### PR TITLE
fix: add call to get getAllNotifications

### DIFF
--- a/src/main/java/com/wire/kalium/api/notification/NotificationApi.kt
+++ b/src/main/java/com/wire/kalium/api/notification/NotificationApi.kt
@@ -7,4 +7,9 @@ interface NotificationApi {
 
     suspend fun notificationsByBatch(querySize: Int, queryClient: String,  querySince: String): KaliumHttpResult<NotificationPageResponse>
 
+    /**
+     * request Notifications from the beginning of time
+     */
+    suspend fun getAllNotifications(querySize: Int, queryClient: String): KaliumHttpResult<NotificationPageResponse>
+
 }

--- a/src/main/java/com/wire/kalium/api/notification/NotificationApiImpl.kt
+++ b/src/main/java/com/wire/kalium/api/notification/NotificationApiImpl.kt
@@ -20,11 +20,20 @@ class NotificationApiImpl(private val httpClient: HttpClient) : NotificationApi{
             querySize: Int,
             queryClient: String,
             querySince: String
+    ): KaliumHttpResult<NotificationPageResponse> = notificationsCall(querySize = querySize, queryClient = queryClient, querySince = querySince)
+
+    override suspend fun getAllNotifications(querySize: Int, queryClient: String): KaliumHttpResult<NotificationPageResponse> =
+    notificationsCall(querySize = querySize, queryClient = queryClient, querySince = null)
+
+    private suspend fun notificationsCall(
+            querySize: Int,
+            queryClient: String,
+            querySince: String?
     ): KaliumHttpResult<NotificationPageResponse> = wrapKaliumResponse{
         httpClient.get<HttpResponse>(path = PATH_NOTIFICATIONS) {
             parameter(SIZE_QUERY_KEY, querySize)
             parameter(CLIENT_QUERY_KEY, queryClient)
-            parameter(SINCE_QUERY_KEY, querySince)
+            querySince?.let { parameter(SINCE_QUERY_KEY, it) }
         }.receive()
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the notificationsByBatch request was not able to call for all notifications


### Solutions

add getAllNotifications and 


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
