### PR TITLE
fix: running make fails to due to missing target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ libsodium:
 	./configure && \
 	make && make install
 
-cryptobox4j: cryptobox4j-clone cryptobox-compile
+cryptobox4j: cryptobox4j-clone cryptobox4j-compile
 
 cryptobox4j-compile: cryptobox4j-clone
 	cd native/cryptobox4j && \


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Running: `$ make` fails with:
```
make: *** No rule to make target `cryptobox-compile', needed by `cryptobox4j'.  Stop.
```

### Solutions

Fix typo in Makefile.


### Testing

Running: `$ make` should  complete successfully.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
