### PR TITLE
fix: fix ClientApiTest and use the AccessRole enum for conv access response

### DIFF
--- a/src/main/java/com/wire/kalium/api/conversation/ConversationEvent.kt
+++ b/src/main/java/com/wire/kalium/api/conversation/ConversationEvent.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.api.conversation
 
+import com.wire.kalium.models.backend.AccessRole
 import com.wire.kalium.models.backend.ConversationId
 import com.wire.kalium.models.backend.UserId
 import kotlinx.serialization.SerialName
@@ -20,22 +21,22 @@ data class ConversationEvent(
 
 @Serializable
 data class EventData(
-        @SerialName("access") val access: List<String>, // How users can join conversations = ['private', 'invite', 'link', 'code']
+        @SerialName("access") val access: List<AccessRole>, // How users can join conversations = ['private', 'invite', 'link', 'code']
         @SerialName("access_role") val accessRole: String,
         @SerialName("code") val code: String, // Stable conversation identifier ,
         @SerialName("conversation_role") val conversationRole: String?,
-        @SerialName("creator") val creator: String, // 99db9768-04e3-4b5d-9268-831b6a25c4ab
+        @SerialName("creator") val creator: String,
         @SerialName("data") val `data`: String?, // Extra (symmetric) data (i.e. ciphertext, Base64 in JSON) that is common with all other recipients. ,
         @SerialName("email") val email: String?,
         @SerialName("hidden") val hidden: Boolean?,
-        @SerialName("hidden_ref") val hiddenRef: String?, // string
+        @SerialName("hidden_ref") val hiddenRef: String?,
         @SerialName("id") val id: String?,
-        @SerialName("key") val key: String, // Stable conversation identifier ,
+        @SerialName("key") val key: String, // Stable conversation identifier
         @SerialName("last_event") val lastEvent: String?,
         @SerialName("last_event_time") val lastEventTime: String?,
         @SerialName("members") val members: ConversationMembersResponse,
         @SerialName("message") val message: String?,
-        @SerialName("message_timer") val messageTimer: Int?, // Per-conversation message timer (can be null) ,
+        @SerialName("message_timer") val messageTimer: Int?, // Per-conversation message timer (can be null)
         @SerialName("name") val name: String,
         @SerialName("otr_archived") val otrArchived: Boolean?,
         @SerialName("otr_archived_ref") val otrArchivedRef: String?,
@@ -48,7 +49,7 @@ data class EventData(
         @SerialName("receipt_mode") val receiptMode: Int, //Conversation receipt mode
         @SerialName("recipient") val recipient: String,
         @SerialName("sender") val sender: String,
-        @SerialName("status") val status: String, //  ['started', 'stopped'],
+        @SerialName("status") val status: String, //  ['started', 'stopped']
         @SerialName("target") val target: String?,
         @SerialName("team") val team: String?,
         @SerialName("text") val text: String, // The ciphertext for the recipient (Base64 in JSON)

--- a/src/main/java/com/wire/kalium/api/conversation/CreateConversationRequest.kt
+++ b/src/main/java/com/wire/kalium/api/conversation/CreateConversationRequest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.api.conversation
 
+import com.wire.kalium.models.backend.AccessRole
 import com.wire.kalium.models.backend.UserId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -8,7 +9,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CreateConversationRequest(
     @SerialName("access")
-    val access: List<String>,
+    val access: List<AccessRole>,
     @SerialName("access_role")
     val accessRole: String, // How users can join conversations ['private', 'invite', 'link', 'code']
     @SerialName("conversation_role")

--- a/src/test/java/com/wire/kalium/api/user/client/ClientApiTest.kt
+++ b/src/test/java/com/wire/kalium/api/user/client/ClientApiTest.kt
@@ -60,8 +60,8 @@ class ClientApiTest : ApiTest {
 
         val Register_Client_REQUEST = RegisterClientRequest(
                 password = "password",
-                deviceType = "device_type",
-                type = "type",
+                deviceType = DeviceType.Desktop,
+                type = ClientType.Temporary,
                 label = "label",
                 preKeys = listOf(TEST_PRES_KEY_1, TEST_PRES_KEY_2, TEST_PRES_KEY_3),
                 lastKey = TEST_LAST_KEY
@@ -71,8 +71,8 @@ class ClientApiTest : ApiTest {
                 clientId = "client_id",
                 registrationTime = "12.34.56.78",
                 location = LocationResponse(latitude = "1.234", longitude = "5.678"),
-                type = "type",
-                deviceType = "device_type",
+                type = ClientType.Temporary,
+                deviceType = DeviceType.Desktop,
                 label = "label",
                 capabilities = Capabilities(capabilities = listOf())
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

#96 

### Causes (Optional)

forgot to use the AccessRole enum in conversation response

### Solutions

Using the already written enum


#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
