### PR TITLE
chore: cleanup useless serialization annotations for inbound models.

### DIFF
--- a/src/main/java/com/wire/kalium/models/inbound/AudioPreviewMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/AudioPreviewMessage.kt
@@ -17,25 +17,21 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.waz.model.Messages.Asset.Original
 import java.util.UUID
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class AudioPreviewMessage @JsonCreator constructor(
-    @JsonProperty("duration") val duration: Long,
-    @JsonProperty("levels") val levels: ByteArray,
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") convId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String,
-    @JsonProperty("mimeType") mimeType: String,
-    @JsonProperty("size") size: Long,
-    @JsonProperty("name") name: String
+class AudioPreviewMessage(
+    val duration: Long,
+    val levels: ByteArray,
+    eventId: UUID,
+    messageId: UUID,
+    convId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String,
+    mimeType: String,
+    size: Long,
+    name: String
 ) : OriginMessage(
     mimeType = mimeType,
     name = name,

--- a/src/main/java/com/wire/kalium/models/inbound/CallingMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/CallingMessage.kt
@@ -17,20 +17,16 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class CallingMessage @JsonCreator constructor(
-    @JsonProperty val content: String,
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") convId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String
+class CallingMessage(
+    val content: String,
+    eventId: UUID,
+    messageId: UUID,
+    convId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String
 ) : MessageBase(eventId = eventId, messageId = messageId, conversationId = convId, clientId = clientId, userId = userId, time = time) {
 
     constructor(content: String, msgBase: MessageBase) :

--- a/src/main/java/com/wire/kalium/models/inbound/ConfirmationMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/ConfirmationMessage.kt
@@ -17,21 +17,17 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class ConfirmationMessage @JsonCreator constructor(
-    @JsonProperty val confirmationMessageId: UUID,
-    @JsonProperty val type: Type,
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") convId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String
+class ConfirmationMessage(
+    val confirmationMessageId: UUID,
+    val type: Type,
+    eventId: UUID,
+    messageId: UUID,
+    convId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String
 ) : MessageBase(eventId = eventId, messageId = messageId, conversationId = convId, clientId = clientId, userId = userId, time = time) {
 
 

--- a/src/main/java/com/wire/kalium/models/inbound/DeletedTextMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/DeletedTextMessage.kt
@@ -17,20 +17,16 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class DeletedTextMessage @JsonCreator constructor(
-    @JsonProperty val deletedMessageId: UUID,
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") convId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String
+class DeletedTextMessage(
+    val deletedMessageId: UUID,
+    eventId: UUID,
+    messageId: UUID,
+    convId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String
 ) : MessageBase(eventId = eventId, messageId = messageId, conversationId = convId, clientId = clientId, userId = userId, time = time) {
 
     constructor(_deletedMessageId: UUID, msgBase: MessageBase) :

--- a/src/main/java/com/wire/kalium/models/inbound/EditedTextMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/EditedTextMessage.kt
@@ -19,8 +19,8 @@ package com.wire.kalium.models.inbound
 
 import java.util.UUID
 
-//@JsonIgnoreProperties(ignoreUnknown = true)
-//@JsonCreator constructor(...
+
+//constructor(...
 class EditedTextMessage(
 //        @JsonProperty
     val replacingMessageId: UUID,

--- a/src/main/java/com/wire/kalium/models/inbound/EphemeralTextMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/EphemeralTextMessage.kt
@@ -19,27 +19,15 @@ package com.wire.kalium.models.inbound
 
 import java.util.UUID
 
-
-//@JsonIgnoreProperties(ignoreUnknown = true)
-//@JsonCreator constructor EphemeralTextMessage(...
 class EphemeralTextMessage(
-//        @JsonProperty("expireAfterMillis")
     val expireAfterMillis: Long,
-//        @JsonProperty("eventId")
     eventId: UUID,
-//        @JsonProperty("messageId")
     messageId: UUID,
-//        @JsonProperty("conversationId")
     conversationId: UUID,
-//        @JsonProperty("clientId")
     clientId: String,
-//        @JsonProperty("userId")
     userId: UUID,
-//        @JsonProperty("time")
     time: String,
-//        @JsonProperty
     mentions: ArrayList<Mention>,
-//        @JsonProperty
     text: String?
 
 ) : TextMessage(

--- a/src/main/java/com/wire/kalium/models/inbound/FilePreviewMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/FilePreviewMessage.kt
@@ -17,24 +17,20 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.waz.model.Messages.Asset.Original
 import java.util.UUID
 
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class FilePreviewMessage @JsonCreator constructor(
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") conversationId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String,
-    @JsonProperty("mimeType") mimeType: String,
-    @JsonProperty("size") size: Long,
-    @JsonProperty("name") name: String
+class FilePreviewMessage(
+    eventId: UUID,
+    messageId: UUID,
+    conversationId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String,
+    mimeType: String,
+    size: Long,
+    name: String
 ) : OriginMessage(
     mimeType = mimeType,
     name = name,

--- a/src/main/java/com/wire/kalium/models/inbound/PhotoPreviewMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/PhotoPreviewMessage.kt
@@ -17,28 +17,22 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.waz.model.Messages.Asset.Original
 import java.util.UUID
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(JsonInclude.Include.NON_NULL)
-class PhotoPreviewMessage @JsonCreator constructor(
+class PhotoPreviewMessage(
     // TODO: dimension data class ?
-    @JsonProperty("width") val height: Int,
-    @JsonProperty("height") val width: Int,
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") convId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String,
-    @JsonProperty("mimeType") mimeType: String,
-    @JsonProperty("size") size: Long,
-    @JsonProperty("name") name: String
+    val height: Int,
+    val width: Int,
+    eventId: UUID,
+    messageId: UUID,
+    convId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String,
+    mimeType: String,
+    size: Long,
+    name: String
 ) : OriginMessage(
     mimeType = mimeType,
     name = name,

--- a/src/main/java/com/wire/kalium/models/inbound/PingMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/PingMessage.kt
@@ -17,19 +17,15 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class PingMessage @JsonCreator constructor(
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") convId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String
+class PingMessage(
+    eventId: UUID,
+    messageId: UUID,
+    convId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String
 ) : MessageBase(eventId, messageId, convId, clientId, userId, time) {
 
 

--- a/src/main/java/com/wire/kalium/models/inbound/ReactionMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/ReactionMessage.kt
@@ -17,21 +17,17 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class ReactionMessage @JsonCreator constructor(
-    @JsonProperty val emoji: String,
-    @JsonProperty val reactionMessageId: UUID,
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") convId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String
+class ReactionMessage(
+    val emoji: String,
+    val reactionMessageId: UUID,
+    eventId: UUID,
+    messageId: UUID,
+    convId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String
 ) : MessageBase(eventId, messageId, convId, clientId, userId, time) {
 
     constructor(_emoji: String, _reactionMessageId: UUID, msgBase: MessageBase) : this(

--- a/src/main/java/com/wire/kalium/models/inbound/RemoteMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/RemoteMessage.kt
@@ -17,22 +17,20 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.waz.model.Messages.Asset.RemoteData
 import java.util.UUID
 
-class RemoteMessage @JsonCreator constructor(
-    @JsonProperty("assetId") val assetId: String,
-    @JsonProperty("assetToken") val assetToken: String,
-    @JsonProperty("otrKey") val otrKey: ByteArray,
-    @JsonProperty("sha256") val sha256: ByteArray,
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") convId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String
+class RemoteMessage(
+    val assetId: String,
+    val assetToken: String,
+    val otrKey: ByteArray,
+    val sha256: ByteArray,
+    eventId: UUID,
+    messageId: UUID,
+    convId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String
 ) : MessageBase(eventId = eventId, messageId = messageId, conversationId = convId, clientId = clientId, userId = userId, time = time) {
 
     constructor(msg: MessageBase, uploaded: RemoteData) : this(

--- a/src/main/java/com/wire/kalium/models/inbound/TextMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/TextMessage.kt
@@ -20,20 +20,12 @@ package com.wire.kalium.models.inbound
 import com.waz.model.Messages
 import java.util.UUID
 
-//@JsonIgnoreProperties(ignoreUnknown = true)
-//@JsonInclude(JsonInclude.Include.NON_NULL)
-open class TextMessage constructor(
-//        @JsonProperty("eventId")
+open class TextMessage(
     eventId: UUID,
-//        @JsonProperty("messageId")
     messageId: UUID,
-//        @JsonProperty("conversationId")
     convId: UUID,
-//        @JsonProperty("clientId")
     clientId: String,
-//        @JsonProperty("userId")
     userId: UUID,
-//        @JsonProperty("time")
     time: String
 ) : MessageBase(eventId = eventId, messageId = messageId, conversationId = convId, clientId = clientId, userId = userId, time = time) {
 

--- a/src/main/java/com/wire/kalium/models/inbound/VideoPreviewMessage.kt
+++ b/src/main/java/com/wire/kalium/models/inbound/VideoPreviewMessage.kt
@@ -17,26 +17,22 @@
 //
 package com.wire.kalium.models.inbound
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.waz.model.Messages.Asset.Original
 import java.util.UUID
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class VideoPreviewMessage @JsonCreator constructor(
-    @JsonProperty("width") val width: Int,
-    @JsonProperty("height") val height: Int,
-    @JsonProperty("duration") val duration: Long,
-    @JsonProperty("eventId") eventId: UUID,
-    @JsonProperty("messageId") messageId: UUID,
-    @JsonProperty("conversationId") conversationId: UUID,
-    @JsonProperty("clientId") clientId: String,
-    @JsonProperty("userId") userId: UUID,
-    @JsonProperty("time") time: String,
-    @JsonProperty("mimeType") mimeType: String,
-    @JsonProperty("size") size: Long,
-    @JsonProperty("name") name: String
+class VideoPreviewMessage(
+    val width: Int,
+    val height: Int,
+    val duration: Long,
+    eventId: UUID,
+    messageId: UUID,
+    conversationId: UUID,
+    clientId: String,
+    userId: UUID,
+    time: String,
+    mimeType: String,
+    size: Long,
+    name: String
 ) : OriginMessage(
     mimeType = mimeType,
     name = name,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The models in `models.inbound` had useless serialization annotations, probably caused during the Java → Kotlin convertion.

### Solutions

Delete them!
These classes are probably getting replaced soon too, but it's easier to read and understand when re-implementing without garbage in the way.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
