### PR TITLE
feat: add the logout api implementation details

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/LoginApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/LoginApi.kt
@@ -4,8 +4,5 @@ import com.wire.kalium.network.api.KaliumHttpResult
 
 
 interface LoginApi {
-    suspend fun emailLogin(
-        loginWithEmailRequest: LoginWithEmailRequest,
-        persist: Boolean
-    ): KaliumHttpResult<LoginWithEmailResponse>
+    suspend fun emailLogin(loginWithEmailRequest: LoginWithEmailRequest, persist: Boolean): KaliumHttpResult<LoginWithEmailResponse>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/logout/Cookie.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/logout/Cookie.kt
@@ -1,9 +1,0 @@
-package com.wire.kalium.network.api.user.logout
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class Cookie(
-    var name: String,
-    var value: String
-)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/logout/LogoutApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/logout/LogoutApi.kt
@@ -1,9 +1,8 @@
 package com.wire.kalium.network.api.user.logout
 
-interface LogoutApi {
-    fun logout(cookie: Cookie)
+import com.wire.kalium.network.api.KaliumHttpResult
+import com.wire.kalium.network.api.user.login.LoginWithEmailResponse
 
-    companion object {
-        protected val PATH_LOGOUT = "logout"
-    }
+interface LogoutApi {
+    suspend fun logout(cookie: String): KaliumHttpResult<LoginWithEmailResponse>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/logout/LogoutImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/logout/LogoutImp.kt
@@ -1,8 +1,21 @@
 package com.wire.kalium.network.api.user.logout
 
+import com.wire.kalium.network.api.KaliumHttpResult
+import com.wire.kalium.network.api.user.login.LoginWithEmailResponse
+import com.wire.kalium.network.api.wrapKaliumResponse
+import io.ktor.client.*
+import io.ktor.client.request.*
 
-class LogoutImp : LogoutApi {
-    override fun logout(cookie: Cookie) {
-        TODO("Not yet implemented")
+
+class LogoutImp(private val httpClient: HttpClient) : LogoutApi {
+    override suspend fun logout(cookie: String): KaliumHttpResult<LoginWithEmailResponse> = wrapKaliumResponse {
+        httpClient.post(path = PATH_LOGOUT) {
+            header(QUERY_COOKIE, cookie)
+        }
+    }
+
+    private companion object {
+        const val PATH_LOGOUT = "logout"
+        const val QUERY_COOKIE = "cookie"
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/logout/LogoutImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/logout/LogoutImp.kt
@@ -6,7 +6,6 @@ import com.wire.kalium.network.api.wrapKaliumResponse
 import io.ktor.client.*
 import io.ktor.client.request.*
 
-
 class LogoutImp(private val httpClient: HttpClient) : LogoutApi {
     override suspend fun logout(cookie: String): KaliumHttpResult<LoginWithEmailResponse> = wrapKaliumResponse {
         httpClient.post(path = PATH_LOGOUT) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
It adds the logout functionality by injecting the `zuid` cookie on the http request header.

It closes issue #113 

#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
