### PR TITLE
style: prevent wildcard import for specific packages using editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,6 +55,7 @@ ij_kotlin_finally_on_new_line = false
 ij_kotlin_if_rparen_on_new_line = true
 ij_kotlin_import_nested_classes = false
 ij_kotlin_imports_layout = *, java.**, javax.**, kotlin.**, ^
+ij_kotlin_packages_to_use_import_on_demand = ^
 ij_kotlin_insert_whitespaces_in_simple_one_line_method = true
 ij_kotlin_keep_blank_lines_before_right_brace = 2
 ij_kotlin_keep_blank_lines_in_code = 2


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We still have differences in IDE configs regarding wildcard imports, which can lead to unnecessary line-diffs and code conflicts.

### Causes (Optional)

IntelliJ's default settings for wildcard imports under specific packages were not fully covered by `.editorconfig`:
![grafik](https://user-images.githubusercontent.com/9389043/144835041-371b1056-2b15-4821-91c6-51cd2fb10c17.png)

### Solutions

Add `ij_kotlin_packages_to_use_import_on_demand = ^` to .editorconfig.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
