### PR TITLE
fix: replace decodeFromStream

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/websocket/EventApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/websocket/EventApi.kt
@@ -7,10 +7,11 @@ import io.ktor.client.features.websocket.webSocket
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpMethod
 import io.ktor.http.cio.websocket.Frame
-import io.ktor.util.Identity.decode
+import io.ktor.utils.io.core.String
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
 
 class EventApi(private val httpClient: HttpClient) {
     /**
@@ -27,10 +28,10 @@ class EventApi(private val httpClient: HttpClient) {
             while (true) {
                 when (val frame = incoming.receive()) {
                     is Frame.Binary -> {
-                        //TODO: replace "decodeFromStream" with something else
-                        // decodeFromStream only works on JVM
-//                        val event = KtxSerializer.json.decodeFromStream<EventResponse>(frame.data)
-//                        emit(event)
+                        // assuming here the byteArray is an ASCII character set
+                        val jsonString = String(frame.data)
+                        val event = KtxSerializer.json.decodeFromString<EventResponse>(jsonString)
+                        emit(event)
                     }
                 }
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

we were using ```Json.decodeFromStream()``` to desrialize incoming frames from websocket but it's a jvm only fumction


### Solutions

casting the incoming byteArray to string and using decodeFromString

#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
