### PR TITLE
feat: Add dependency container for network module

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     const val coroutines = "1.6.0-RC"
     const val compose = "1.1.0-beta04"
     const val kover = "0.4.2"
-    const val ktor = "1.6.4"
+    const val ktor = "1.6.6"
     const val okHttp = "4.9.3"
     const val kotest = "4.6.3"
 }

--- a/cli/src/main/kotlin/com/wire/kalium/cli/ConversationsApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/ConversationsApplication.kt
@@ -7,7 +7,7 @@ import com.wire.kalium.network.NetworkModule
 import com.wire.kalium.network.api.user.login.LoginWithEmailRequest
 import kotlinx.coroutines.runBlocking
 
-class LoginApplication : CliktCommand() {
+class ConversationsApplication : CliktCommand() {
     private val email: String by option(help = "wire account email").required()
     private val password: String by option(help = "wire account password").required()
 
@@ -21,9 +21,16 @@ class LoginApplication : CliktCommand() {
             false
         ).resultBody
 
-        println("Authenticated: LoginResult = $loginResult")
+        credentialsLedger.onAuthenticate(loginResult.accessToken, "") //TODO extract refresh token from cookie response
+
+        val conversations = networkModule.conversationApi.conversationsByBatch(null, 100).resultBody.conversations
+
+        println("Your conversations:")
+        conversations.forEach {
+            println("ID:${it.id}, Name: ${it.name}")
+        }
     }
 
 }
 
-fun main(args: Array<String>) = LoginApplication().main(args)
+fun main(args: Array<String>) = ConversationsApplication().main(args)

--- a/cli/src/main/kotlin/com/wire/kalium/cli/InMemoryCredentialsLedger.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/InMemoryCredentialsLedger.kt
@@ -1,0 +1,17 @@
+package com.wire.kalium.cli
+
+import com.wire.kalium.network.api.CredentialsProvider
+
+class InMemoryCredentialsLedger : CredentialsProvider {
+    private var accessToken: String? = null
+    private var refreshToken: String? = null
+
+    fun onAuthenticate(accessToken: String, refreshToken: String) {
+        this.accessToken = accessToken
+        this.refreshToken = refreshToken
+    }
+
+    override fun accessToken(): String = accessToken!!
+
+    override fun refreshToken(): String = refreshToken!!
+}

--- a/cli/src/main/kotlin/com/wire/kalium/cli/LoginApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/LoginApplication.kt
@@ -1,0 +1,29 @@
+package com.wire.kalium.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.wire.kalium.network.NetworkModule
+import com.wire.kalium.network.api.user.login.LoginWithEmailRequest
+import kotlinx.coroutines.runBlocking
+
+class LoginApplication : CliktCommand() {
+    private val email: String by option(help = "wire account email").required()
+    private val password: String by option(help = "wire account password").required()
+
+    override fun run(): Unit = runBlocking {
+
+        val credentialsLedger = InMemoryCredentialsLedger()
+        val networkModule = NetworkModule(credentialsLedger)
+
+        val loginResult = networkModule.loginApi.emailLogin(
+            LoginWithEmailRequest(email = email, password = password, label = "ktor"),
+            false
+        ).resultBody
+
+        println("Authenticated: LoginResult = $loginResult")
+    }
+
+}
+
+fun main(args: Array<String>) = LoginApplication().main(args)

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -57,11 +57,14 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
+                implementation(Dependencies.Ktor.okHttp)
             }
         }
         val jvmTest by getting
         val androidMain by getting {
-
+            dependencies {
+                implementation(Dependencies.Ktor.okHttp)
+            }
         }
         val androidTest by getting
     }

--- a/network/src/androidMain/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/androidMain/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium.network
+
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+
+actual fun defaultHttpEngine(): HttpClientEngine {
+    return OkHttp.create { }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -1,0 +1,5 @@
+package com.wire.kalium.network
+
+import io.ktor.client.engine.HttpClientEngine
+
+expect fun defaultHttpEngine(): HttpClientEngine

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkModule.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkModule.kt
@@ -49,33 +49,23 @@ class NetworkModule(
 
     private val hostProvider = HostProvider
 
-    val loginApi: LoginApi by lazy {
-        LoginApiImp(anonymousHttpClient)
-    }
-    val authApi: AuthApi by lazy<AuthApi> {
-        AuthApiImp(authenticatedHttpClient)
-    }
-    val logoutApi: LogoutApi by lazy {
-        LogoutImp(authenticatedHttpClient)
-    }
-    val clientApi: ClientApi by lazy {
-        ClientApiImp(authenticatedHttpClient)
-    }
-    val messageApi: MessageApi by lazy {
-        MessageApiImp(authenticatedHttpClient)
-    }
-    val conversationApi: ConversationApi by lazy {
-        ConversationApiImp(authenticatedHttpClient)
-    }
-    val preKeyApi: PreKeyApi by lazy {
-        PreKeyApiImpl(authenticatedHttpClient)
-    }
-    val assetApi: AssetApi by lazy {
-        AssetApiImp(authenticatedHttpClient)
-    }
-    val notificationApi: NotificationApi by lazy {
-        NotificationApiImpl(authenticatedHttpClient)
-    }
+    val loginApi: LoginApi get() = LoginApiImp(anonymousHttpClient)
+
+    val authApi: AuthApi get() = AuthApiImp(authenticatedHttpClient)
+
+    val logoutApi: LogoutApi get() = LogoutImp(authenticatedHttpClient)
+
+    val clientApi: ClientApi get() = ClientApiImp(authenticatedHttpClient)
+
+    val messageApi: MessageApi get() = MessageApiImp(authenticatedHttpClient)
+
+    val conversationApi: ConversationApi get() = ConversationApiImp(authenticatedHttpClient)
+
+    val preKeyApi: PreKeyApi get() = PreKeyApiImpl(authenticatedHttpClient)
+
+    val assetApi: AssetApi get() = AssetApiImp(authenticatedHttpClient)
+
+    val notificationApi: NotificationApi get() = NotificationApiImpl(authenticatedHttpClient)
 
     private val kotlinxSerializer = KotlinxSerializer(KtxSerializer.json)
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkModule.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkModule.kt
@@ -30,6 +30,10 @@ import io.ktor.client.features.auth.providers.bearer
 import io.ktor.client.features.defaultRequest
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.features.logging.Logger
+import io.ktor.client.features.logging.Logging
+import io.ktor.client.features.logging.SIMPLE
 import io.ktor.client.features.websocket.WebSockets
 import io.ktor.client.request.header
 import io.ktor.client.request.host
@@ -39,7 +43,8 @@ import io.ktor.http.URLProtocol
 
 class NetworkModule(
     private val credentialsProvider: CredentialsProvider,
-    private val engine: HttpClientEngine = defaultHttpEngine()
+    private val engine: HttpClientEngine = defaultHttpEngine(),
+    private val isRequestLoggingEnabled: Boolean = false
 ) {
 
     private val hostProvider = HostProvider
@@ -80,10 +85,17 @@ class NetworkModule(
             host = HostProvider.host
             url.protocol = URLProtocol.HTTPS
         }
+        if (isRequestLoggingEnabled) {
+            install(Logging) {
+                logger = Logger.SIMPLE
+                level = LogLevel.ALL
+            }
+        }
         install(JsonFeature) {
             serializer = kotlinxSerializer
             accept(ContentType.Application.Json)
         }
+        config()
     }
 
     internal val anonymousHttpClient by lazy {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkModule.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkModule.kt
@@ -1,0 +1,125 @@
+package com.wire.kalium.network
+
+import com.wire.kalium.network.api.CredentialsProvider
+import com.wire.kalium.network.api.asset.AssetApi
+import com.wire.kalium.network.api.asset.AssetApiImp
+import com.wire.kalium.network.api.auth.AuthApi
+import com.wire.kalium.network.api.auth.AuthApiImp
+import com.wire.kalium.network.api.conversation.ConversationApi
+import com.wire.kalium.network.api.conversation.ConversationApiImp
+import com.wire.kalium.network.api.message.MessageApi
+import com.wire.kalium.network.api.message.MessageApiImp
+import com.wire.kalium.network.api.notification.NotificationApi
+import com.wire.kalium.network.api.notification.NotificationApiImpl
+import com.wire.kalium.network.api.prekey.PreKeyApi
+import com.wire.kalium.network.api.prekey.PreKeyApiImpl
+import com.wire.kalium.network.api.user.client.ClientApi
+import com.wire.kalium.network.api.user.client.ClientApiImp
+import com.wire.kalium.network.api.user.login.LoginApi
+import com.wire.kalium.network.api.user.login.LoginApiImp
+import com.wire.kalium.network.api.user.logout.LogoutApi
+import com.wire.kalium.network.api.user.logout.LogoutImp
+import com.wire.kalium.network.tools.HostProvider
+import com.wire.kalium.network.tools.KtxSerializer
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.features.auth.Auth
+import io.ktor.client.features.auth.providers.BearerTokens
+import io.ktor.client.features.auth.providers.bearer
+import io.ktor.client.features.defaultRequest
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.websocket.WebSockets
+import io.ktor.client.request.header
+import io.ktor.client.request.host
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.URLProtocol
+
+class NetworkModule(
+    private val credentialsProvider: CredentialsProvider,
+    private val engine: HttpClientEngine = defaultHttpEngine()
+) {
+
+    private val hostProvider = HostProvider
+
+    val loginApi: LoginApi by lazy {
+        LoginApiImp(anonymousHttpClient)
+    }
+    val authApi: AuthApi by lazy<AuthApi> {
+        AuthApiImp(authenticatedHttpClient)
+    }
+    val logoutApi: LogoutApi by lazy {
+        LogoutImp(authenticatedHttpClient)
+    }
+    val clientApi: ClientApi by lazy {
+        ClientApiImp(authenticatedHttpClient)
+    }
+    val messageApi: MessageApi by lazy {
+        MessageApiImp(authenticatedHttpClient)
+    }
+    val conversationApi: ConversationApi by lazy {
+        ConversationApiImp(authenticatedHttpClient)
+    }
+    val preKeyApi: PreKeyApi by lazy {
+        PreKeyApiImpl(authenticatedHttpClient)
+    }
+    val assetApi: AssetApi by lazy {
+        AssetApiImp(authenticatedHttpClient)
+    }
+    val notificationApi: NotificationApi by lazy {
+        NotificationApiImpl(authenticatedHttpClient)
+    }
+
+    private val kotlinxSerializer = KotlinxSerializer(KtxSerializer.json)
+
+    private fun provideBaseHttpClient(config: HttpClientConfig<*>.() -> Unit = {}) = HttpClient(engine) {
+        defaultRequest {
+            header("Content-Type", "application/json")
+            host = HostProvider.host
+            url.protocol = URLProtocol.HTTPS
+        }
+        install(JsonFeature) {
+            serializer = kotlinxSerializer
+            accept(ContentType.Application.Json)
+        }
+    }
+
+    internal val anonymousHttpClient by lazy {
+        provideBaseHttpClient()
+    }
+
+    internal val authenticatedHttpClient by lazy {
+        provideBaseHttpClient {
+            installAuth()
+        }
+    }
+
+    private val webSocketClient by lazy {
+        HttpClient(engine) {
+            defaultRequest {
+                host = hostProvider.host
+                url.protocol = URLProtocol.WSS
+            }
+            install(WebSockets)
+            installAuth()
+        }
+    }
+
+    private fun HttpClientConfig<*>.installAuth() {
+        install(Auth) {
+            bearer {
+                loadTokens {
+                    BearerTokens(
+                        accessToken = credentialsProvider.accessToken(),
+                        refreshToken = credentialsProvider.refreshToken()
+                    )
+                }
+                refreshTokens { unauthorizedResponse: HttpResponse ->
+                    TODO("refresh the tokens, interface?")
+                }
+            }
+        }
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/CredentialsProvider.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/CredentialsProvider.kt
@@ -1,6 +1,6 @@
 package com.wire.kalium.network.api
 
-interface AuthenticationManager {
+interface CredentialsProvider {
     fun accessToken(): String
     fun refreshToken(): String
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/KtorHttpClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/KtorHttpClient.kt
@@ -1,86 +1,15 @@
 package com.wire.kalium.network.api
 
-import com.wire.kalium.network.tools.HostProvider
-import com.wire.kalium.network.tools.KtxSerializer
-import io.ktor.client.HttpClient
 import io.ktor.client.call.receive
-import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.ClientRequestException
 import io.ktor.client.features.RedirectResponseException
 import io.ktor.client.features.ResponseException
 import io.ktor.client.features.ServerResponseException
-import io.ktor.client.features.auth.Auth
-import io.ktor.client.features.auth.providers.BearerTokens
-import io.ktor.client.features.auth.providers.bearer
-import io.ktor.client.features.defaultRequest
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.websocket.WebSockets
-import io.ktor.client.request.header
-import io.ktor.client.request.host
 import io.ktor.client.statement.HttpResponse
-import io.ktor.http.ContentType
-import io.ktor.http.URLProtocol
 import io.ktor.util.toMap
 
-class KtorHttpClient(
-    private val hostProvider: HostProvider,
-    private val engine: HttpClientEngine,
-    private val authenticationManager: AuthenticationManager,
-) {
-
-    val provideWebSocketClient by lazy {
-        HttpClient(engine) {
-            defaultRequest {
-                host = hostProvider.host
-                url.protocol = URLProtocol.WSS
-            }
-            install(WebSockets)
-            install(Auth) {
-                bearer {
-                    loadTokens {
-                        BearerTokens(
-                            accessToken = authenticationManager.accessToken(),
-                            refreshToken = authenticationManager.refreshToken()
-                        )
-                    }
-                    refreshTokens { unauthorizedResponse: HttpResponse ->
-                        TODO("refresh the tokens, interface?")
-                    }
-                }
-            }
-        }
-    }
-
-    val provideKtorHttpClient by lazy {
-        HttpClient(engine) {
-            defaultRequest {
-                header("Content-Type", "application/json")
-                host = hostProvider.host
-                url.protocol = URLProtocol.HTTPS
-            }
-            install(Auth) {
-                bearer {
-                    loadTokens {
-                        BearerTokens(
-                            accessToken = authenticationManager.accessToken(),
-                            refreshToken = authenticationManager.refreshToken()
-                        )
-                    }
-                    refreshTokens { unauthorizedResponse: HttpResponse ->
-                        TODO("refresh the tokens, interface?")
-                    }
-                }
-            }
-            install(JsonFeature) {
-                serializer = KotlinxSerializer(KtxSerializer.json)
-                accept(ContentType.Application.Json)
-            }
-        }
-    }
-}
-
-class KaliumKtorResult<BodyType : Any>(private val httpResponse: HttpResponse, private val body: BodyType) : KaliumHttpResult<BodyType> {
+class KaliumKtorResult<BodyType : Any>(private val httpResponse: HttpResponse, private val body: BodyType) :
+    KaliumHttpResult<BodyType> {
     override val httpStatusCode: Int
         get() = httpResponse.status.value
     override val headers: Map<String, List<String>>

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/tools/KtxSerializer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/tools/KtxSerializer.kt
@@ -4,7 +4,8 @@ import kotlinx.serialization.json.Json
 
 object KtxSerializer {
     val json = Json {
-        ignoreUnknownKeys = true
         isLenient = true
+        ignoreUnknownKeys = true
+        encodeDefaults = true
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -1,8 +1,7 @@
 package com.wire.kalium.api
 
-import com.wire.kalium.network.api.AuthenticationManager
-import com.wire.kalium.network.api.KtorHttpClient
-import com.wire.kalium.network.tools.HostProvider
+import com.wire.kalium.network.NetworkModule
+import com.wire.kalium.network.api.CredentialsProvider
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -17,7 +16,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-private class TestAuthManager() : AuthenticationManager {
+private class TestAuthManager() : CredentialsProvider {
     override fun accessToken(): String =
         "eyJhbGciOiJIUzI1AnwarInR5cCI6IkpXVCJ9.eyJsb2dnZWRJbkFzIjoiYWRtaW4iLCJpYXQiOjE0MjI3Nzk2Mz69.gzSraSYS8EXBxLN_oWnFSRgCzcmJmMjLiuyu5CSpyHI"
 
@@ -60,11 +59,10 @@ interface ApiTest {
                 headers = headersOf(HttpHeaders.ContentType, "application/json")
             )
         }
-        return KtorHttpClient(
+        return NetworkModule(
             engine = mockEngine,
-            hostProvider = HostProvider,
-            authenticationManager = TestAuthManager()
-        ).provideKtorHttpClient
+            credentialsProvider = TestAuthManager()
+        ).authenticatedHttpClient
     }
 
     // query params assertions

--- a/network/src/jvmMain/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/jvmMain/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium.network
+
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+
+actual fun defaultHttpEngine(): HttpClientEngine {
+    return OkHttp.create { }
+}


### PR DESCRIPTION
Small sample of utilization in `LoginApplication`

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Closes #154 

### Solutions

A simple dependency container with lazy initialization of API implementations.
Reduced some code cuplication for multiple HttpClientEngine instances.

Check CLI's `ConversationsApplication` for sample on utilization.

### Testing

N/A

We can include some E2E tests or integration later.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
