### PR TITLE
feat: add self user info request

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/Asset.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/Asset.kt
@@ -1,0 +1,36 @@
+package com.wire.kalium.network.api.model
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Asset(
+    @SerialName("key")
+    val key: String,
+    @SerialName("size")
+    val size: AssetSize?,
+    @SerialName("type")
+    val type: AssetType
+)
+
+@Serializable
+enum class AssetSize {
+    @SerialName("preview")
+    Preview,
+
+    @SerialName("complete")
+    Complete;
+
+    override fun toString(): String {
+        return this.name.lowercase()
+    }
+}
+
+@Serializable
+enum class AssetType {
+    @SerialName("image")
+    Image;
+
+    override fun toString(): String {
+        return this.name.lowercase()
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/Service.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/Service.kt
@@ -1,0 +1,11 @@
+package com.wire.kalium.network.api.model
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Service(
+    @SerialName("id")
+    val id: String?,
+    @SerialName("provider")
+    val provider: String?
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/SelfApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/SelfApi.kt
@@ -1,0 +1,20 @@
+package com.wire.kalium.network.api.user.self
+
+import com.wire.kalium.network.api.KaliumHttpResult
+import com.wire.kalium.network.api.wrapKaliumResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.receive
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+
+class SelfApi(private val httpClient: HttpClient) {
+
+    suspend fun getSelfInfo(): KaliumHttpResult<SelfUserInfoResponse> =
+        wrapKaliumResponse {
+        httpClient.get<HttpResponse>(path = PATH_SELF).receive()
+    }
+
+    private companion object {
+        const val PATH_SELF = "self"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/SelfApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/SelfApi.kt
@@ -11,8 +11,8 @@ class SelfApi(private val httpClient: HttpClient) {
 
     suspend fun getSelfInfo(): KaliumHttpResult<SelfUserInfoResponse> =
         wrapKaliumResponse {
-        httpClient.get<HttpResponse>(path = PATH_SELF).receive()
-    }
+            httpClient.get<HttpResponse>(path = PATH_SELF).receive()
+        }
 
     private companion object {
         const val PATH_SELF = "self"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/SelfUserInfoResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/SelfUserInfoResponse.kt
@@ -1,4 +1,5 @@
 package com.wire.kalium.network.api.user.self
+
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.model.Asset
 import com.wire.kalium.network.api.model.Service
@@ -41,11 +42,11 @@ data class SelfUserInfoResponse(
     val managedBy: ManagedBy // 'wire', 'scim'
 )
 
-
 @Serializable
 enum class ManagedBy {
     @SerialName("wire")
     Wire,
+
     @SerialName("scim")
     Scim;
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/SelfUserInfoResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/SelfUserInfoResponse.kt
@@ -1,0 +1,58 @@
+package com.wire.kalium.network.api.user.self
+import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.model.Asset
+import com.wire.kalium.network.api.model.Service
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SelfUserInfoResponse(
+    @SerialName("email")
+    val email: String?,
+    @SerialName("phone")
+    val phone: String?,
+    @SerialName("sso_id")
+    val userSsoId: UserSsoId?,
+    @SerialName("id")
+    val id: String,
+    @SerialName("qualified_id")
+    val qualifiedId: UserId,
+    @SerialName("name")
+    val name: String,
+    @SerialName("picture")
+    val picture: List<Picture>,
+    @SerialName("accent_id")
+    val accentId: Int,
+    @SerialName("deleted")
+    val deleted: Boolean?,
+    @SerialName("assets")
+    val assets: List<Asset>,
+    @SerialName("locale")
+    val locale: String,
+    @SerialName("service")
+    val service: Service?,
+    @SerialName("expires_at")
+    val expiresAt: String?, // Time of sending message. ,
+    @SerialName("handle")
+    val handle: String?,
+    @SerialName("team")
+    val team: String,
+    @SerialName("managed_by")
+    val managedBy: ManagedBy // 'wire', 'scim'
+)
+
+
+@Serializable
+enum class ManagedBy {
+    @SerialName("wire")
+    Wire,
+    @SerialName("scim")
+    Scim;
+
+    override fun toString(): String {
+        return this.name.lowercase()
+    }
+}
+
+@Serializable
+class Picture

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/UserSsoId.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/UserSsoId.kt
@@ -1,0 +1,13 @@
+package com.wire.kalium.network.api.user.self
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserSsoId(
+    @SerialName("scim_external_id")
+    val scimExternalId: String?,
+    @SerialName("subjecßt")
+    val subject: String,
+    @SerialName("tenant")
+    val tenant: String?
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/UserSsoId.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/self/UserSsoId.kt
@@ -1,4 +1,5 @@
 package com.wire.kalium.network.api.user.self
+
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/self/SelfApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/self/SelfApiTest.kt
@@ -1,0 +1,52 @@
+package com.wire.kalium.api.tools.json.api.user.self
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.api.tools.json.model.ErrorResponseJson
+import com.wire.kalium.network.api.ErrorResponse
+import com.wire.kalium.network.api.user.self.SelfApi
+import io.ktor.client.call.receive
+import io.ktor.client.features.ClientRequestException
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@ExperimentalCoroutinesApi
+class SelfApiTest : ApiTest {
+    @Test
+    fun givenAValidRegisterLogoutRequest_whenCallingTheRegisterLogoutEndpoint_theRequestShouldBeConfiguredCorrectly() =
+        runTest {
+            val httpClient = mockHttpClient(
+                VALID_SELF_RESPONSE.rawJson,
+                statusCode = HttpStatusCode.Created,
+                assertion = {
+                    assertGet()
+                    assertNoQueryParams()
+                    assertPathEqual(PATH_SELF)
+                }
+            )
+            val selfApi: SelfApi = SelfApi(httpClient)
+            val response = selfApi.getSelfInfo()
+            assertEquals(response.resultBody, VALID_SELF_RESPONSE.serializableData)
+        }
+
+    @Test
+    fun givenTheServerReturnsAnError_whenCallingTheGetSelfEndpoint_theCorrectExceptionIsThrown() = runTest {
+        val httpClient = mockHttpClient(
+            ErrorResponseJson.valid.rawJson,
+            statusCode = HttpStatusCode.Unauthorized
+        )
+        val selfApi: SelfApi = SelfApi(httpClient)
+        val error = assertFailsWith<ClientRequestException> { selfApi.getSelfInfo() }
+        assertEquals(error.response.receive<ErrorResponse>(), ERROR_RESPONSE)
+    }
+
+
+    private companion object {
+        const val PATH_SELF = "self"
+        val VALID_SELF_RESPONSE = SelfUserInfoResponseJson.valid
+        val ERROR_RESPONSE = ErrorResponseJson.valid.serializableData
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/self/SelfUserInfoResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/self/SelfUserInfoResponseJson.kt
@@ -1,0 +1,53 @@
+package com.wire.kalium.api.tools.json.api.user.self
+
+import com.wire.kalium.api.tools.json.ValidJsonProvider
+import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.user.self.ManagedBy
+import com.wire.kalium.network.api.user.self.SelfUserInfoResponse
+
+object SelfUserInfoResponseJson {
+    private val jsonProvider = { serializable: SelfUserInfoResponse ->
+        """
+        |{
+        |  "id": ${serializable.id},
+        |  "qualified_id": "${serializable.qualifiedId}",
+        |  "name": "${serializable.name}",
+        |  "picture": [
+        |       {}
+        |  ]
+        |  "accent_id": ${serializable.accentId},
+        |  "assets": [
+        |       {
+        |           "key": "${serializable.assets[0].key}",
+        |           "type": "${serializable.assets[0].type}"
+        |       }
+        |  ],
+        |  "local": "${serializable.locale}",
+        |  "team": "${serializable.team}",
+        |  "managed_by": "${serializable.managedBy}"
+        |}
+        """.trimMargin()
+    }
+
+    val valid = ValidJsonProvider(
+        SelfUserInfoResponse(
+            email = null,
+            phone = null,
+            userSsoId = null,
+            id = "id",
+            qualifiedId = UserId(value = "99db9768-04e3-4b5d-9268-831b6a25c4ab", domain = "domain"),
+            name = "cool_name",
+            picture = listOf(),
+            accentId = 0,
+            deleted = null,
+            assets = listOf(),
+            locale = "user_local",
+            service = null,
+            expiresAt = null,
+            handle = null,
+            team = "99db9768-04e3-4b5d-9268-831b6a25c4ab",
+            managedBy = ManagedBy.Wire
+        ),
+        jsonProvider
+    )
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

#128 



### Testing

givenAValidRegisterLogoutRequest_whenCallingTheRegisterLogoutEndpoint_theRequestShouldBeConfiguredCorrectly
givenTheServerReturnsAnError_whenCallingTheGetSelfEndpoint_theCorrectExceptionIsThrown

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
