### PR TITLE
chore: configure the serializer to ignore null values

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/tools/KtxSerializer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/tools/KtxSerializer.kt
@@ -1,11 +1,16 @@
 package com.wire.kalium.network.tools
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 
+@ExperimentalSerializationApi
 object KtxSerializer {
     val json = Json {
         isLenient = true
         ignoreUnknownKeys = true
         encodeDefaults = true
+        // explicitNulls, defines whether null property
+        // values should be included in the serialized JSON string.
+        explicitNulls = false
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

right now the serializer will throw an Exitprion if a value is missing from the json String.
to avoid that i added ```explicitNulls = null``` to the  serializer configration
for more info see [kotlinx.serialization 1.3](https://blog.jetbrains.com/kotlin/2021/09/kotlinx-serialization-1-3-released/)

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
