### PR TITLE
feat(teams): split teams API from legacy client to modular client

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkModule.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkModule.kt
@@ -13,6 +13,8 @@ import com.wire.kalium.network.api.notification.NotificationApi
 import com.wire.kalium.network.api.notification.NotificationApiImpl
 import com.wire.kalium.network.api.prekey.PreKeyApi
 import com.wire.kalium.network.api.prekey.PreKeyApiImpl
+import com.wire.kalium.network.api.teams.TeamsApi
+import com.wire.kalium.network.api.teams.TeamsApiImp
 import com.wire.kalium.network.api.user.client.ClientApi
 import com.wire.kalium.network.api.user.client.ClientApiImp
 import com.wire.kalium.network.api.user.login.LoginApi
@@ -66,6 +68,8 @@ class NetworkModule(
     val assetApi: AssetApi get() = AssetApiImp(authenticatedHttpClient)
 
     val notificationApi: NotificationApi get() = NotificationApiImpl(authenticatedHttpClient)
+
+    val teamsApi: TeamsApi get() = TeamsApiImp(authenticatedHttpClient)
 
     private val kotlinxSerializer = KotlinxSerializer(KtxSerializer.json)
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/IDs.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/IDs.kt
@@ -4,7 +4,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 typealias ConversationId = QualifiedID
+typealias NonQualifiedConversationId = String
 typealias UserId = QualifiedID
+typealias NonQualifiedUserId = String
+typealias TeamId = String
+typealias AssetId = String
 
 @Serializable
 data class QualifiedID(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/CreateConversationRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/CreateConversationRequest.kt
@@ -34,5 +34,5 @@ data class Team(
     @SerialName("managed")
     val managed: Boolean,
     @SerialName("teamid")
-    val teamid: String
+    val teamId: String
 )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApiImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApiImp.kt
@@ -45,7 +45,7 @@ class MessageApiImp(private val httpClient: HttpClient) : MessageApi {
         ): KaliumHttpResult<SendMessageResponse> {
             try {
                 return wrapKaliumResponse<SendMessageResponse.MessageSent> {
-                    httpClient.post<HttpResponse>(path = "$PATH_CONVERSATIONS/$conversationId$PATH_OTR_MESSAGE") {
+                    httpClient.post<HttpResponse>(path = "/$PATH_CONVERSATIONS/$conversationId/$PATH_OTR_MESSAGE") {
                         if (queryParameter != null) {
                             parameter(queryParameter, queryParameterValue)
                         }
@@ -85,8 +85,8 @@ class MessageApiImp(private val httpClient: HttpClient) : MessageApi {
     }
 
     private companion object {
-        const val PATH_OTR_MESSAGE = "/otr/messages"
-        const val PATH_CONVERSATIONS = "/conversations"
+        const val PATH_OTR_MESSAGE = "otr/messages"
+        const val PATH_CONVERSATIONS = "conversations"
         const val QUERY_IGNORE_MISSING = "ignore_missing"
         const val QUERY_REPORT_MISSING = "report_missing"
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/teams/TeamsApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/teams/TeamsApi.kt
@@ -1,0 +1,83 @@
+package com.wire.kalium.network.api.teams
+
+import com.wire.kalium.network.api.AssetId
+import com.wire.kalium.network.api.ConversationId
+import com.wire.kalium.network.api.KaliumHttpResult
+import com.wire.kalium.network.api.NonQualifiedConversationId
+import com.wire.kalium.network.api.TeamId
+import com.wire.kalium.network.api.NonQualifiedUserId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+interface TeamsApi {
+
+    @Serializable
+    data class TeamsResponse(
+        @SerialName("has_more") val hasMore: Boolean,
+        val teams: List<Team>
+    )
+
+    @Serializable
+    data class Team(
+        val creator: String,
+        val icon: AssetId,
+        val name: String,
+        val id: TeamId,
+        @SerialName("icon_key") val iconKey: String?,
+        val binding: Boolean
+    )
+
+    @Serializable
+    data class TeamMemberList(
+        // Please note that this is intentionally cased differently form the has_more in TeamsResponse
+        // because the backend response contains a different casing
+        @SerialName("hasMore") val hasMore: Boolean,
+        val members: List<TeamMember>
+    )
+
+    @Serializable
+    data class TeamMember(
+        @SerialName("user") val nonQualifiedUserId: NonQualifiedUserId,
+        @SerialName("created_by") val createdBy: NonQualifiedUserId?,
+        @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatus?,
+        @SerialName("created_at") val createdAt: String?,
+        val permissions: Permissions?
+    )
+
+    @Serializable
+    enum class LegalHoldStatus {
+        @SerialName("enabled")
+        ENABLED,
+        @SerialName("pending")
+        PENDING,
+        @SerialName("disabled")
+        DISABLED,
+        @SerialName("no_consent")
+        NO_CONSENT
+    }
+
+    @Serializable
+    data class Permissions(
+        val copy: Int,
+        @SerialName("self") val own: Int
+    )
+
+    sealed interface GetTeamsOptionsInterface
+    sealed class GetTeamsOption : GetTeamsOptionsInterface {
+        /**
+         * StartFrom parameters
+         * @param teamId the id of the team to continue the query from
+         */
+        data class StartFrom(val teamId: TeamId) : GetTeamsOption()
+
+        /**
+         * LimitTo parameters
+         * @param teamIds a list of max 32 team ids to limit the query to
+         */
+        data class LimitTo(val teamIds: List<TeamId>) : GetTeamsOption()
+    }
+
+    suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): KaliumHttpResult<Unit>
+    suspend fun getTeams(size: Int?, option: GetTeamsOption?): KaliumHttpResult<TeamsResponse>
+    suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?): KaliumHttpResult<TeamMemberList>
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/teams/TeamsApiImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/teams/TeamsApiImp.kt
@@ -1,0 +1,58 @@
+package com.wire.kalium.network.api.teams
+
+import com.wire.kalium.network.api.ConversationId
+import com.wire.kalium.network.api.KaliumHttpResult
+import com.wire.kalium.network.api.NonQualifiedConversationId
+import com.wire.kalium.network.api.TeamId
+import com.wire.kalium.network.api.wrapKaliumResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.receive
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.HttpResponse
+
+class TeamsApiImp(private val httpClient: HttpClient) : TeamsApi {
+
+    override suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): KaliumHttpResult<Unit> =
+        wrapKaliumResponse {
+            httpClient.delete<HttpResponse>(
+                path = "/$PATH_TEAMS/$teamId/$PATH_CONVERSATIONS/$conversationId"
+            ).receive()
+        }
+
+    override suspend fun getTeams(size: Int?, option: TeamsApi.GetTeamsOption?): KaliumHttpResult<TeamsApi.TeamsResponse> =
+        wrapKaliumResponse {
+            when (option) {
+                is TeamsApi.GetTeamsOption.StartFrom ->
+                    httpClient.get<HttpResponse>(path = "/$PATH_TEAMS") {
+                        size?.let { parameter(QUERY_KEY_SIZE, it) }
+                        option?.let { parameter(QUERY_KEY_START, it.teamId) }
+                    }.receive()
+                is TeamsApi.GetTeamsOption.LimitTo ->
+                    httpClient.get<HttpResponse>(path = "/$PATH_TEAMS") {
+                        size?.let { parameter(QUERY_KEY_SIZE, it) }
+                        option?.let { parameter(QUERY_KEY_IDS, it.teamIds.joinToString(",")) }
+                    }.receive()
+                null ->
+                    httpClient.get<HttpResponse>(path = "/$PATH_TEAMS").receive()
+            }
+        }
+
+    override suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?): KaliumHttpResult<TeamsApi.TeamMemberList> =
+        wrapKaliumResponse {
+            httpClient.get<HttpResponse>(path = "/$PATH_TEAMS/$teamId/$PATH_MEMBERS") {
+                limitTo?.let { parameter("maxResults", it) }
+            }.receive()
+        }
+
+    private companion object {
+        const val PATH_TEAMS = "teams"
+        const val PATH_CONVERSATIONS = "conversations"
+        const val PATH_MEMBERS = "members"
+
+        const val QUERY_KEY_START = "start"
+        const val QUERY_KEY_SIZE = "size"
+        const val QUERY_KEY_IDS = "ids"
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -71,7 +71,17 @@ interface ApiTest {
      * @param name name of the query parameter
      */
     fun HttpRequestData.assertQueryExist(name: String) = assertFalse(this.url.parameters[name].isNullOrBlank())
-
+    /**
+     * assert the request url does not have query parameter value
+     * @param name name of the query parameter
+     */
+    fun HttpRequestData.assertQueryDoesNotExist(name: String) = assertTrue(this.url.parameters[name].isNullOrBlank())
+    /**
+     * assert the request url has query parameter value
+     * @param name name of the query parameter
+     * @param hasValue the value of the parameter
+     */
+    fun HttpRequestData.assertQueryParameter(name: String, hasValue: String) = assertEquals(this.url.parameters[name], hasValue)
     /**
      * assert the request url has no query params
      */

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/ValidSingleJsonObjectProvider.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/ValidSingleJsonObjectProvider.kt
@@ -12,3 +12,10 @@ data class ValidJsonProvider<Serializable : Any>(
 ) : JsonProvider {
     override val rawJson: String = jsonProvider(serializableData).replace("\\s".toRegex(), "")
 }
+
+data class AnyResponseProvider<T>(
+    val data: T,
+    private val jsonProvider: (T) -> String
+): JsonProvider {
+    override val rawJson: String = jsonProvider(data).replace("\\s".toRegex(), "")
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/teams/TeamsApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/teams/TeamsApiTest.kt
@@ -1,0 +1,94 @@
+package com.wire.kalium.api.tools.json.api.teams
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.network.api.teams.TeamsApi
+import com.wire.kalium.network.api.teams.TeamsApiImp
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class TeamsApiTest: ApiTest {
+
+    @Test
+    fun givenAValidListOfTeamsIds_whenCallingGetTeamsLimitedTo_theRequestShouldBeConfiguredCorrectly() =
+        runTest {
+            val commaSeparatedListOfIds = LIST_OF_TEAM_IDS.joinToString(",")
+            val httpClient = mockHttpClient(
+                GET_LIMIT_TO_CLIENT_RESPONSE.rawJson,
+                statusCode = HttpStatusCode.OK,
+                assertion = {
+                    assertGet()
+                    assertQueryExist("size")
+                    assertQueryExist("ids")
+                    assertQueryParameter("ids", hasValue = commaSeparatedListOfIds)
+                    assertPathEqual("/$PATH_TEAMS")
+                }
+            )
+            val teamsApi: TeamsApi = TeamsApiImp(httpClient)
+            teamsApi.getTeams(size = 10, option = TeamsApi.GetTeamsOption.LimitTo(LIST_OF_TEAM_IDS))
+        }
+
+    @Test
+    fun givenAValidGetTeamsRequest_whenCallingGetTeamsStartFrom_theRequestShouldBeConfiguredCorrectly() =
+        runTest {
+            val httpClient = mockHttpClient(
+                GET_START_FROM_CLIENT_RESPONSE.rawJson,
+                statusCode = HttpStatusCode.OK,
+                assertion = {
+                    assertGet()
+                    assertQueryExist("size")
+                    assertQueryDoesNotExist("ids")
+                    assertQueryParameter("start", hasValue = DUMMY_TEAM_ID)
+                    assertPathEqual("/$PATH_TEAMS")
+                }
+            )
+            val teamsApi: TeamsApi = TeamsApiImp(httpClient)
+            teamsApi.getTeams(size = 10, option = TeamsApi.GetTeamsOption.StartFrom(DUMMY_TEAM_ID))
+        }
+
+    @Test
+    fun givenAValidGetTeamsFirstPageRequest_whenGettingTeamsMembers_theRequestShouldBeConfiguredCorrectly() =
+        runTest {
+            val httpClient = mockHttpClient(
+                GET_TEAM_MEMBER_CLIENT_RESPONSE.rawJson,
+                statusCode = HttpStatusCode.OK,
+                assertion = {
+                    assertGet()
+                    assertQueryExist("maxResults")
+                    assertQueryParameter("maxResults", hasValue = "10")
+                    assertPathEqual("/$PATH_TEAMS/$DUMMY_TEAM_ID/$PATH_MEMBERS")
+                }
+            )
+            val teamsApi: TeamsApi = TeamsApiImp(httpClient)
+            teamsApi.getTeamMembers(DUMMY_TEAM_ID, limitTo = 10)
+        }
+
+    @Test
+    fun givenADeleteConversationForTeamRequest_whenDeletingATeamConversationWithSuccess_theRequestShouldBeConfiguredCorrectly() =
+        runTest {
+            val conversationId = "96a6e8e4-6420-49db-aa83-2711edf7580d"
+            val httpClient = mockHttpClient(
+                "",
+                statusCode = HttpStatusCode.OK,
+                assertion = {
+                    assertDelete()
+                    assertPathEqual("/$PATH_TEAMS/$DUMMY_TEAM_ID/$PATH_CONVERSATIONS/$conversationId")
+                }
+            )
+            val teamsApi: TeamsApi = TeamsApiImp(httpClient)
+            teamsApi.deleteConversation(conversationId, teamId = DUMMY_TEAM_ID)
+        }
+
+    private companion object {
+        const val PATH_TEAMS = "teams"
+        const val PATH_CONVERSATIONS = "conversations"
+        const val PATH_MEMBERS = "members"
+        const val DUMMY_TEAM_ID = "770b0623-ffd5-4e08-8092-7a6b9b9ca3b4"
+        val LIST_OF_TEAM_IDS = listOf(DUMMY_TEAM_ID)
+        val GET_LIMIT_TO_CLIENT_RESPONSE = TeamsResponsesJson.GetTeams.validGetTeamsLimitTo(LIST_OF_TEAM_IDS)
+        val GET_START_FROM_CLIENT_RESPONSE = TeamsResponsesJson.GetTeams.validGetTeamsStartFrom(DUMMY_TEAM_ID)
+        val GET_TEAM_MEMBER_CLIENT_RESPONSE = TeamsResponsesJson.GetTeamsMembers.validGetTeamsMembers
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/teams/TeamsResponsesJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/teams/TeamsResponsesJson.kt
@@ -1,0 +1,79 @@
+package com.wire.kalium.api.tools.json.api.teams
+
+import com.wire.kalium.api.tools.json.AnyResponseProvider
+import com.wire.kalium.network.api.teams.TeamsApi
+
+object TeamsResponsesJson {
+
+    object GetTeams {
+        private val jsonProvider = { option: TeamsApi.GetTeamsOption ->
+            when (option) {
+                is TeamsApi.GetTeamsOption.LimitTo ->
+                    """
+                |{
+                |  "has_more": false,
+                |  "teams": [
+                |       {
+                |           "creator": "33f1df6b-0bed-4a72-bd09-61b871178b9d",
+                |           "icon": "default",
+                |           "name": "Gonzo",
+                |           "id": "770b0623-ffd5-4e08-8092-7a6b9b9ca3b4",
+                |           "binding": true
+                |       }
+                |  ]
+                |}
+                """.trimMargin()
+                is TeamsApi.GetTeamsOption.StartFrom ->
+                    """
+                |{
+                |   "has_more": false,
+                |   "teams": []
+                |}
+                """.trimMargin()
+            }
+        }
+
+        val validGetTeamsLimitTo = { listOfTeamIds: List<String> ->
+            AnyResponseProvider(data = TeamsApi.GetTeamsOption.LimitTo(listOfTeamIds), jsonProvider)
+        }
+
+        val validGetTeamsStartFrom = { startFromTeamId: String ->
+            AnyResponseProvider(data = TeamsApi.GetTeamsOption.StartFrom(startFromTeamId), jsonProvider)
+        }
+    }
+
+    object GetTeamsMembers {
+        private val jsonProvider = { _: String ->
+            """
+        |{
+        |   "members": [
+        |       {
+        |           "user": "33f1df6b-0bed-4a72-bd09-61b871178b9d",
+        |           "created_by": null,
+        |           "legalhold_status": "no_consent",
+        |           "created_at": null,
+        |           "permissions": {
+        |               "copy": 8191,
+        |               "self": 8191
+        |           }
+        |       },
+        |       {
+        |           "user": "57b0f4d8-657f-4730-a8fa-a8b1456f6b4c",
+        |           "created_by": "33f1df6b-0bed-4a72-bd09-61b871178b9d",
+        |           "legalhold_status": "no_consent",
+        |           "created_at": "2021-12-09T14:11:09.246Z",
+        |           "permissions": {
+        |               "copy": 1587,
+        |               "self": 1587
+        |           }
+        |       }
+        |   ],
+        |   "hasMore": false
+        |}
+        """.trimMargin()
+        }
+
+        val validGetTeamsMembers = AnyResponseProvider(data = "", jsonProvider)
+    }
+}
+


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The parts of the `/teams` api that were already mapped, still were not modularized in the new api client. Closes #129 

### Solutions

Implemented a TeamApi that contains the methods we already had

### Testing

Added `TeamsApiTest` to our test suit

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
