### PR TITLE
refactor: remove `Cookie` class from AuthApi interface.

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AuthApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AuthApi.kt
@@ -7,7 +7,7 @@ import com.wire.kalium.network.api.KaliumHttpResult
  */
 interface AuthApi {
 
-    suspend fun renewAccessToken(cookieName: String, cookieValue: String): KaliumHttpResult<RenewAccessTokenResponse>
+    suspend fun renewAccessToken(refreshToken: String): KaliumHttpResult<RenewAccessTokenResponse>
 
     // TODO: move this to user api
     suspend fun removeCookiesByIds(removeCookiesByIdsRequest: RemoveCookiesByIdsRequest): KaliumHttpResult<Unit>

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AuthApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AuthApi.kt
@@ -1,14 +1,13 @@
 package com.wire.kalium.network.api.auth
 
 import com.wire.kalium.network.api.KaliumHttpResult
-import io.ktor.http.Cookie
 
 /**
  *
  */
 interface AuthApi {
 
-    suspend fun renewAccessToken(cookie: Cookie): KaliumHttpResult<RenewAccessTokenResponse>
+    suspend fun renewAccessToken(cookieName: String, cookieValue: String): KaliumHttpResult<RenewAccessTokenResponse>
 
     // TODO: move this to user api
     suspend fun removeCookiesByIds(removeCookiesByIdsRequest: RemoveCookiesByIdsRequest): KaliumHttpResult<Unit>

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AuthApiImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AuthApiImp.kt
@@ -10,7 +10,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Cookie
 
 class AuthApiImp(private val httpClient: HttpClient) : AuthApi {
-    override suspend fun renewAccessToken(cookieName: String, cookieValue: String): KaliumHttpResult<RenewAccessTokenResponse> =
+    override suspend fun renewAccessToken(refreshToken: String): KaliumHttpResult<RenewAccessTokenResponse> =
         wrapKaliumResponse<RenewAccessTokenResponse> {
             httpClient.post<HttpResponse>(path = PATH_ACCESS) {
                 this.cookie(cookieName, cookieValue)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AuthApiImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AuthApiImp.kt
@@ -10,10 +10,10 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Cookie
 
 class AuthApiImp(private val httpClient: HttpClient) : AuthApi {
-    override suspend fun renewAccessToken(cookie: Cookie): KaliumHttpResult<RenewAccessTokenResponse> =
+    override suspend fun renewAccessToken(cookieName: String, cookieValue: String): KaliumHttpResult<RenewAccessTokenResponse> =
         wrapKaliumResponse<RenewAccessTokenResponse> {
             httpClient.post<HttpResponse>(path = PATH_ACCESS) {
-                this.cookie(cookie.name, cookie.value)
+                this.cookie(cookieName, cookieValue)
             }.receive()
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`AuthApi`'s `renewAccessToken` function was exposing Ktor's `Cookie` class to the outside world.
Ideally, we should Ktor and whatever else dependencies used by the underlying modules hidden from the consumer modules.

### Solutions

Re-work the function signature to only get what's actually 

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
