### PR TITLE
feat: add Either classes for internal usage in `logic` module

### DIFF
--- a/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
+++ b/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.feature.auth.LoginUsingEmailUseCase
+import com.wire.kalium.logic.feature.auth.AuthenticationResult
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
@@ -28,7 +28,7 @@ class MainActivity : ComponentActivity() {
                         email = "username@example.com", //TODO Form or something to get user input
                         password = "password",
                         shouldPersistClient = false
-                    ) as LoginUsingEmailUseCase.Result.Success // assuming success
+                    ) as AuthenticationResult.Success // assuming success
                 }.userSession
 
                 val conversationList = core.sessionScope(session) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -1,19 +1,20 @@
 package com.wire.kalium.logic
 
-sealed class GenericFailure {
+sealed class CoreFailure {
     /**
      * Failed to establish a connection with the necessary servers in order to pull/push data.
      * Caused by weak - complete lack of - internet connection.
      */
-    object NoNetworkConnection : GenericFailure()
+    object NoNetworkConnection : CoreFailure()
 
     /**
      * Server internal error, or we can't parse the response,
      * or anything API-related that is out of control from the user.
      * Either fix our app or our backend.
      */
-    object ServerMiscommunication : GenericFailure()
+    object ServerMiscommunication : CoreFailure()
 
-    class UnknownFailure(val rootCause: Throwable?): GenericFailure()
+    class Unknown(val rootCause: Throwable?) : CoreFailure()
 
+    abstract class FeatureFailure : CoreFailure()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/AuthenticationFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/AuthenticationFailure.kt
@@ -1,0 +1,7 @@
+package com.wire.kalium.logic.failure
+
+import com.wire.kalium.logic.CoreFailure
+
+sealed class AuthenticationFailure : CoreFailure.FeatureFailure()
+
+object InvalidCredentials: AuthenticationFailure()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationResult.kt
@@ -1,0 +1,12 @@
+package com.wire.kalium.logic.feature.auth
+
+import com.wire.kalium.logic.CoreFailure
+
+sealed class AuthenticationResult {
+    class Success(val userSession: AuthSession) : AuthenticationResult()
+
+    sealed class Failure : AuthenticationResult() {
+        object InvalidCredentials : Failure()
+        class Generic(val genericFailure: CoreFailure) : Failure()
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUsingEmailUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUsingEmailUseCase.kt
@@ -1,27 +1,26 @@
 package com.wire.kalium.logic.feature.auth
 
-import com.wire.kalium.logic.GenericFailure
 import com.wire.kalium.logic.data.login.LoginRepository
 import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.failure.AuthenticationFailure
+import com.wire.kalium.logic.functional.isRight
 
 class LoginUsingEmailUseCase(
     private val loginRepository: LoginRepository,
     private val sessionRepository: SessionRepository
 ) {
-    suspend operator fun invoke(email: String, password: String, shouldPersistClient: Boolean): Result {
+    suspend operator fun invoke(email: String, password: String, shouldPersistClient: Boolean): AuthenticationResult {
         val result = loginRepository.loginWithEmail(email, password, shouldPersistClient)
-        if (result is Result.Success) {
-            sessionRepository.storeSession(result.userSession)
-        }
-        return result
-    }
-
-    sealed class Result {
-        class Success(val userSession: AuthSession) : Result()
-
-        sealed class Failure : Result() {
-            object InvalidCredentials : Failure()
-            class Generic(val genericFailure: GenericFailure) : Failure()
+        return if (result.isRight()) {
+            sessionRepository.storeSession(result.value)
+            AuthenticationResult.Success(result.value)
+        } else {
+            if (result.value is AuthenticationFailure) {
+                AuthenticationResult.Failure.InvalidCredentials
+            } else {
+                AuthenticationResult.Failure.Generic(result.value)
+            }
         }
     }
+
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Either.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Either.kt
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2019 Fernando Cejas Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.wire.kalium.logic.functional
+
+import com.wire.kalium.logic.functional.Either.Left
+import com.wire.kalium.logic.functional.Either.Right
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Represents a value of one of two possible types (a disjoint union).
+ * Instances of [Either] are either an instance of [Left] or [Right].
+ * FP Convention dictates that [Left] is used for "failure"
+ * and [Right] is used for "success".
+ *
+ * @see Left
+ * @see Right
+ */
+sealed class Either<out L, out R> {
+    /** * Represents the left side of [Either] class which by convention is a "Failure". */
+    data class Left<out L>(val value: L) : Either<L, Nothing>()
+
+    /** * Represents the right side of [Either] class which by convention is a "Success". */
+    data class Right<out R>(val value: R) : Either<Nothing, R>()
+
+
+    /**
+     * Creates a Left type.
+     * @see Left
+     */
+    fun <L> left(a: L) = Left(a)
+
+    /**
+     * Creates a Left type.
+     * @see Right
+     */
+    fun <R> right(b: R) = Right(b)
+
+    /**
+     * Applies fnL if this is a Left or fnR if this is a Right.
+     * @see Left
+     * @see Right
+     */
+    fun <T> fold(fnL: (L) -> T?, fnR: (R) -> T?): T? =
+        when (this) {
+            is Left -> fnL(value)
+            is Right -> fnR(value)
+        }
+}
+
+
+/**
+ * Returns true if this is a Right, false otherwise.
+ * @see Right
+ */
+@OptIn(ExperimentalContracts::class)
+fun <L, R> Either<L, R>.isRight(): Boolean {
+    contract {
+        returns(true) implies (this@isRight is Right<R>)
+        returns(false) implies (this@isRight is Left<L>)
+    }
+    return this is Right<R>
+}
+
+/**
+ * Returns true if this is a Left, false otherwise.
+ * @see Left
+ */
+@OptIn(ExperimentalContracts::class)
+fun <L, R> Either<L, R>.isLeft(): Boolean {
+    contract {
+        returns(true) implies (this@isLeft is Left<L>)
+        returns(false) implies (this@isLeft is Right<R>)
+    }
+    return this is Left<L>
+}
+
+/**
+ * Composes 2 functions
+ * See <a href="https://proandroiddev.com/kotlins-nothing-type-946de7d464fb">Credits to Alex Hart.</a>
+ */
+fun <A, B, C> ((A) -> B).c(f: (B) -> C): (A) -> C = {
+    f(this(it))
+}
+
+/**
+ * Right-biased flatMap() FP convention which means that Right is assumed to be the default case
+ * to operate on. If it is Left, operations like map, flatMap, ... return the Left value unchanged.
+ */
+fun <T, L, R> Either<L, R>.flatMap(fn: (R) -> Either<L, T>): Either<L, T> =
+    when (this) {
+        is Either.Left -> Either.Left(value)
+        is Either.Right -> fn(value)
+    }
+
+/**
+ * Left-biased onFailure() FP convention dictates that when this class is Left, it'll perform
+ * the onFailure functionality passed as a parameter, but, overall will still return an either
+ * object so you chain calls.
+ */
+fun <L, R> Either<L, R>.onFailure(fn: (failure: L) -> Unit): Either<L, R> =
+    this.apply { if (this is Either.Left) fn(value) }
+
+/**
+ * Right-biased onSuccess() FP convention dictates that when this class is Right, it'll perform
+ * the onSuccess functionality passed as a parameter, but, overall will still return an either
+ * object so you chain calls.
+ */
+fun <L, R> Either<L, R>.onSuccess(fn: (success: R) -> Unit): Either<L, R> =
+    this.apply { if (this is Either.Right) fn(value) }
+
+/**
+ * Right-biased map() FP convention which means that Right is assumed to be the default case
+ * to operate on. If it is Left, operations like map, flatMap, ... return the Left value unchanged.
+ */
+fun <T, L, R> Either<L, R>.map(fn: (R) -> (T)): Either<L, T> = this.flatMap(fn.c(::right))
+
+/**
+ * Returns the value from this `Right` or the given argument if this is a `Left`.
+ * Right(12).getOrElse(17) RETURNS 12 and Left(12).getOrElse(17) RETURNS 17
+ */
+fun <L, R> Either<L, R>.getOrElse(value: R): R =
+    when (this) {
+        is Either.Left -> value
+        is Either.Right -> this.value
+    }
+
+/**
+ * Folds a list into an Either while it doesn't go Left.
+ * Allows for accumulation of value through iterations.
+ * @return the final accumulated value if there are NO Left results, or the first Left result otherwise.
+ */
+fun <T, L, R> Iterable<T>.foldToEitherWhileRight(initialValue: R, fn: (item: T, accumulated: R) -> Either<L, R>): Either<L, R> {
+    return this.fold<T, Either<L, R>>(Either.Right(initialValue)) { acc, item ->
+        acc.flatMap { accumulatedValue -> fn(item, accumulatedValue) }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/SuspendableEitherScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/SuspendableEitherScope.kt
@@ -1,0 +1,77 @@
+package com.wire.kalium.logic.functional
+
+import com.wire.kalium.logic.functional.Either.Left
+import com.wire.kalium.logic.functional.Either.Right
+
+/**
+ * Helper class that extends [Either] to be compatible with suspend functions. The extension methods created in this class
+ * are only visible inside a scope that belongs to this class. The scope can be created by [suspending] method.
+ *
+ * ```
+ * suspend fun save() {
+ *    ...
+ * }
+ *
+ * suspend fun saveResult() {
+ *     either.flatMap {
+ *        save()        // compile time error: cannot call suspend function here
+ *     }
+ * }
+ *
+ *
+ * suspend fun saveResult() {
+ *     suspending {             // this: SuspendableEitherScope
+ *         either.flatMap {     // resolves "flatMap" in SuspendableEitherScope
+ *             save()           // we can now call a suspend function here
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @see Either
+ */
+class SuspendableEitherScope {
+
+    /**
+     * @see [Either.fold]
+     */
+    suspend fun <L, R, T> Either<L, R>.fold(fnL: suspend (L) -> T?, fnR: suspend (R) -> T?): T? =
+        when (this) {
+            is Left -> fnL(value)
+            is Right -> fnR(value)
+        }
+
+    suspend fun <L, R, T> Either<L, R>.flatMap(fn: suspend (R) -> Either<L, T>): Either<L, T> =
+        when (this) {
+            is Left -> Left(value)
+            is Right -> fn(value)
+        }
+
+    suspend fun <L, R> Either<L, R>.onFailure(fn: suspend (failure: L) -> Unit): Either<L, R> =
+        this.apply { if (this is Left) fn(value) }
+
+    suspend fun <L, R> Either<L, R>.onSuccess(fn: suspend (success: R) -> Unit): Either<L, R> =
+        this.apply { if (this is Right) fn(value) }
+
+    suspend fun <L, R, T> Either<L, R>.map(fn: suspend (R) -> (T)): Either<L, T> =
+        when (this) {
+            is Left -> Left(value)
+            is Right -> Right(fn(value))
+        }
+
+    /**
+     * Folds a list into an Either while it doesn't go Left.
+     * Allows for accumulation of value through iterations.
+     * @return the final accumulated value if there are NO Left results, or the first Left result otherwise.
+     */
+    suspend fun <T, L, R> Iterable<T>.foldToEitherWhileRight(
+        initialValue: R,
+        fn: suspend (item: T, accumulated: R) -> Either<L, R>
+    ): Either<L, R> {
+        return this.fold<T, Either<L, R>>(Right(initialValue)) { acc, item ->
+            acc.flatMap { accumulatedValue -> fn(item, accumulatedValue) }
+        }
+    }
+}
+
+suspend fun <T> suspending(block: suspend SuspendableEitherScope.() -> T): T = SuspendableEitherScope().block()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/functional/EitherTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/functional/EitherTest.kt
@@ -1,0 +1,177 @@
+package com.wire.kalium.logic.functional
+
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.exceptions.KaliumException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class EitherTest {
+
+    @Test
+    fun `given fold is called, when either is Right, applies fnR and returns its result`() {
+        val either = Either.Right("Success")
+        val result = either.fold({ fail("Shouldn't be executed") }) { 5 }
+
+        assertSame(result, 5)
+    }
+
+    @Test
+    fun `given fold is called, when either is Left, applies fnL and returns its result`() {
+        val either = Either.Left(12)
+
+        val foldResult = "Fold Result"
+        val result = either.fold({ foldResult }) { fail("Shouldn't be executed") }
+
+        assertSame(result, foldResult)
+    }
+
+    @Test
+    fun `given flatMap is called, when either is Right, applies function and returns new Either`() {
+        val either = Either.Right("Success")
+
+        val mapped = Either.Left(KaliumException.GenericError(null, null))
+        val result = either.flatMap {
+            assertSame(it, "Success")
+            mapped
+        }
+
+        assertTrue(result.isLeft())
+        assertEquals<Either<KaliumException.GenericError, Int>>(result, mapped)
+    }
+
+    @Test
+    fun `given flatMap is called, when either is Left, doesn't invoke function and returns original Either`() {
+        val either = Either.Left(12)
+
+        val result: Either<Int, Int> = either.flatMap {
+            fail("Shouldn't be executed")
+        }
+
+        assertTrue(result.isLeft())
+        assertEquals<Either<Int, Int>>(result, either)
+    }
+
+    @Test
+    fun `given onFailure is called, when either is Right, doesn't invoke function and returns original Either`() {
+        val success = "Success"
+        val either = Either.Right(success)
+
+        val result = either.onFailure { fail("Shouldn't be executed") }
+
+        assertSame(result, either)
+        assertSame(either.getOrElse("Failure"), success)
+    }
+
+    @Test
+    fun `given onFailure is called, when either is Left, invokes function with left value and returns original Either`() {
+        val either = Either.Left(12)
+
+        var methodCalled = false
+        val result = either.onFailure {
+            assertEquals(it, 12)
+            methodCalled = true
+        }
+
+        assertSame(result, either)
+        assertTrue(methodCalled)
+    }
+
+    @Test
+    fun `given onSuccess is called, when either is Right, invokes function with right value and returns original Either`() {
+        val success = "Success"
+        val either = Either.Right(success)
+
+        var methodCalled = false
+        val result = either.onSuccess {
+            assertEquals(it, success)
+            methodCalled = true
+        }
+
+        assertSame(result, either)
+        assertSame(methodCalled, true)
+    }
+
+    @Test
+    fun `given onSuccess is called, when either is Left, doesn't invoke function and returns original Either`() {
+        val either = Either.Left(12)
+
+        val result = either.onSuccess {
+            fail("Shouldn't be executed")
+        }
+
+        assertSame(result, either)
+    }
+
+    @Test
+    fun `given map is called, when either is Right, invokes function with right value and returns a new Either`() {
+        val success = "Success"
+        val resultValue = "Result"
+        val either = Either.Right(success)
+
+        val result = either.map {
+            assertSame(it, success)
+            resultValue
+        }
+
+        assertEquals(result, Either.Right(resultValue))
+    }
+
+    @Test
+    fun `given map is called, when either is Left, doesn't invoke function and returns original Either`() {
+        val either: Either<Int, Int> = Either.Left(12)
+
+        val result = either.map {
+            fail("Shouldn't be executed")
+        }
+
+        assertTrue(result.isLeft())
+        assertEquals(result, either)
+    }
+
+    @Test
+    fun `given a list and a mapper to either that succeeds, when folding to either while right, then accumulate values until the end`() {
+        val items = listOf(1, 1, 1)
+
+        val result = items.foldToEitherWhileRight(0) { item, acc ->
+            Either.Right(acc + item)
+        }
+
+        result shouldSucceed {
+            assertEquals(it, 3)
+        }
+    }
+
+    @Test
+    fun `given a list and a mapper to either that fails, when folding to either while right, then return first Left`() {
+        val items = listOf(1, 2, 3)
+
+        val result = items.foldToEitherWhileRight(0) { _, _ ->
+            Either.Left(-1)
+        }
+
+        result shouldFail {
+            assertEquals(it, -1)
+        }
+    }
+
+    @Test
+    fun `given a list and a mapper to either that fails, when folding to either while right, mappers after left should not be called`() {
+        var callCount = 0
+        val mapFunction: () -> Either<Int, Int> = {
+            callCount++
+            fail("Shouldn't be executed")
+        }
+        val expectedFailure = -1
+        val items = listOf(1 to { Either.Left(expectedFailure) }, 2 to mapFunction, 3 to mapFunction)
+
+        items.foldToEitherWhileRight(0) { item, _ ->
+            item.second()
+        }
+
+        assertEquals(callCount, 0)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/functional/SuspendableEitherScopeTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/functional/SuspendableEitherScopeTest.kt
@@ -1,0 +1,228 @@
+package com.wire.kalium.logic.functional
+
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.exceptions.KaliumException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class SuspendableEitherScopeTest {
+
+    private lateinit var suspendableEitherScope: SuspendableEitherScope
+
+    @BeforeTest
+    fun setUp() {
+        suspendableEitherScope = SuspendableEitherScope()
+    }
+
+    @Test
+    fun `given either is right, when folding, applies fnR and returns its result`() = runTest {
+        val either = Either.Right("Success")
+
+        val result = with(suspendableEitherScope) {
+            either.fold({ fail("Shouldn't be executed") }) { 5 }
+        }
+
+        assertEquals(result, 5)
+    }
+
+    @Test
+    fun `given either is left, when folding, applies fnL and returns its result`() = runTest {
+        val either = Either.Left(12)
+        val foldResult = "Fold Result"
+
+        val result = with(suspendableEitherScope) {
+            either.fold({ foldResult }) { fail("Shouldn't be executed") }
+        }
+
+        assertSame(result, foldResult)
+    }
+
+    @Test
+    fun `given either is Right, when flatMapping, applies function and returns new Either`() = runTest {
+        val either = Either.Right("Success")
+
+        val mapped = Either.Left(KaliumException.GenericError(null, null))
+        val result = with(suspendableEitherScope) {
+            either.flatMap {
+                assertSame(it, "Success")
+                mapped
+            }
+        }
+
+        assertEquals(result, mapped)
+        assertTrue(result.isLeft())
+    }
+
+    @Test
+    fun `given either is Left, when flatMapping, doesn't invoke function and returns original Either`() = runTest {
+        val either = Either.Left(12)
+
+        val result: Either<Int, Int> = with(suspendableEitherScope) {
+            either.flatMap { fail("Shouldn't be executed") }
+        }
+
+        assertTrue(result.isLeft())
+        assertEquals<Either<Int, Int>>(result, either)
+    }
+
+    @Test
+    fun `given either is right, when onFailure is called, doesn't invoke function and returns original Either`() = runTest {
+        val success = "Success"
+        val either = Either.Right(success)
+
+        val result = with(suspendableEitherScope) {
+            either.onFailure { fail("Shouldn't be executed") }
+        }
+
+        assertSame(result, either)
+        assertSame(either.getOrElse("Failure"), success)
+    }
+
+    @Test
+    fun `given either is left, when onFailure is called, invokes function with left value and returns original Either`() =
+        runTest {
+            val either = Either.Left(12)
+            var methodCalled = false
+
+            val result = with(suspendableEitherScope) {
+
+                either.onFailure {
+                    assertEquals(it, 12)
+                    methodCalled = true
+                }
+            }
+
+            assertSame(result, either)
+            assertSame(methodCalled, true)
+        }
+
+    @Test
+    fun `given either is right, when onSuccess is called, invokes function with right value and returns original Either`() =
+        runTest {
+            val success = "Success"
+            val either = Either.Right(success)
+            var methodCalled = false
+
+            val result = with(suspendableEitherScope) {
+                either.onSuccess {
+                    assertEquals(it, success)
+                    methodCalled = true
+                }
+            }
+
+            assertSame(result, either)
+            assertSame(methodCalled, true)
+        }
+
+    @Test
+    fun `given either is left, when onSuccess is called, doesn't invoke function and returns original Either`() = runTest {
+        val either = Either.Left(12)
+
+        val result = with(suspendableEitherScope) {
+            either.onSuccess { fail("Shouldn't be executed") }
+        }
+
+        assertSame(result, either)
+    }
+
+    @Test
+    fun `given either is right, when mapping, invokes function with right value and returns a new Either`() = runTest {
+        val success = "Success"
+        val resultValue = "Result"
+        val either = Either.Right(success)
+
+        val result = with(suspendableEitherScope) {
+
+            either.map {
+                assertSame(it, success)
+                resultValue
+            }
+        }
+
+        assertEquals(result, Either.Right(resultValue))
+    }
+
+    @Test
+    fun `given either is left, when mapping, doesn't invoke function and returns original Either`() = runTest {
+        val either = Either.Left(12)
+
+        val result = with(suspendableEitherScope) {
+            either.map { fail("Shouldn't be executed") }
+        }
+
+        assertTrue(result.isLeft())
+        assertEquals<Either<Int, Int>>(result, either)
+    }
+
+    @Test
+    fun `given a block, when suspending is called, then creates a new SuspendableEitherScope and executes block on it`() {
+        var callCount = 0
+        val block: SuspendableEitherScope.() -> Unit = { callCount++ }
+
+        runTest {
+            suspending {
+                assertIs<SuspendableEitherScope>(this)
+                block()
+            }
+        }
+
+        assertEquals(callCount, 1)
+    }
+
+    @Test
+    fun `given a list and a mapper to either that succeeds, when folding to either while right, then accumulate values until the end`() =
+        runTest {
+            val items = listOf(1, 1, 1)
+
+            val result =
+                suspending {
+                    items.foldToEitherWhileRight(0) { item, acc ->
+                        Either.Right(acc + item)
+                    }
+                }
+
+            result shouldSucceed {
+                assertEquals(it, 3)
+            }
+        }
+
+    @Test
+    fun `given a list and a mapper to either that fails, when folding to either while right, then return first Left`() = runTest {
+        val items = listOf(1, 2, 3)
+
+        val result = suspending {
+            items.foldToEitherWhileRight(0) { _, _ ->
+                Either.Left(-1)
+            }
+        }
+
+        result shouldFail {
+            assertEquals(it, -1)
+        }
+    }
+
+    @Test
+    fun `given a list and a mapper to either that fails, when folding to either while right, mappers after left should not be called`() =
+        runTest {
+            var callCount = 0
+            val mapFunction: () -> Either<Int, Int> = {
+                callCount++
+                fail("Shouldn't be executed")
+            }
+            val expectedFailure = -1
+            val items = listOf(1 to { Either.Left(expectedFailure) }, 2 to mapFunction, 3 to mapFunction)
+
+            items.foldToEitherWhileRight(0) { item, _ ->
+                item.second()
+            }
+
+            assertEquals(callCount, 0)
+        }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/EitherAssertions.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/EitherAssertions.kt
@@ -1,0 +1,12 @@
+package com.wire.kalium.logic.util
+
+import com.wire.kalium.logic.functional.Either
+import kotlin.test.fail
+
+inline infix fun <L, R> Either<L, R>.shouldSucceed(crossinline successAssertion: (R) -> Unit) =
+    this.fold({ fail("Expected a Right value but got Left") }) { successAssertion(it) }!!
+
+inline infix fun <L, R> Either<L, R>.shouldFail(crossinline failAssertion: (L) -> Unit) =
+    this.fold({ failAssertion(it) }) { fail("Expected a Left value but got Right") }!!
+
+fun <L> Either<L, Unit>.shouldFail() = shouldFail { }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For splicit success/failure return values and easy mapping of results, the something like `Either` can be employed, at least internally in the `logic` module.
It can assist us to tie the different pieces / data sources together in a strongly typed way.

### Solutions

Brought up the `Either` class from Android Reloaded, with a small tweak: `isLeft` and `isRight` are not functions and benefit from the kotlin contracts.

### Testing

Included

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
