### PR TITLE
feat: add js implementation of the ProteusClient

### DIFF
--- a/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
+++ b/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
@@ -10,6 +10,7 @@ import com.wire.kalium.cryptography.CryptoClientId
 import com.wire.kalium.cryptography.CryptoSessionId
 import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.cryptography.UserId
+import kotlinx.coroutines.runBlocking
 import java.io.File
 
 class MainActivity : ComponentActivity() {
@@ -18,7 +19,14 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val rootProteusDir = File(this.filesDir, "proteus")
+        val decryptedMessage = encryptAndDecrypt(rootProteusDir)
 
+        setContent {
+            MainLayout(decryptedMessage.toString(Charsets.UTF_8))
+        }
+    }
+
+    fun encryptAndDecrypt(rootProteusDir: File): ByteArray = runBlocking {
         val alice = SampleUser("aliceId", "Alice")
         val aliceFile = File(rootProteusDir, alice.id)
         aliceFile.mkdirs()
@@ -39,9 +47,7 @@ class MainActivity : ComponentActivity() {
         val encryptedMessage = bobClient.encrypt(message.toByteArray(Charsets.UTF_8), aliceSessionId)!!
         val decryptedMessage = aliceClient.decrypt(encryptedMessage, bobSessionId)
 
-        setContent {
-            MainLayout(decryptedMessage.toString(Charsets.UTF_8))
-        }
+        return@runBlocking decryptedMessage
     }
 
     data class SampleUser(val id: String, val name: String)

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -88,6 +88,7 @@ object Dependencies {
         const val logging = "io.ktor:ktor-client-logging:${Versions.ktor}"
         const val auth = "io.ktor:ktor-client-auth:${Versions.ktor}"
         const val webSocket = "io.ktor:ktor-client-websockets:${Versions.ktor}"
+        const val utils = "io.ktor:ktor-utils:${Versions.ktor}"
 
         const val mock = "io.ktor:ktor-client-mock:${Versions.ktor}"
 

--- a/cryptography/build.gradle.kts
+++ b/cryptography/build.gradle.kts
@@ -47,18 +47,26 @@ kotlin {
         }
     }
     android()
+    js(IR) {
+        browser {
+            commonWebpackConfig {
+                cssSupport.enabled = true
+            }
+        }
+    }
 
     sourceSets {
         val commonMain by getting {
             dependencies {
                 // coroutines
                 implementation(Dependencies.Coroutines.core)
-
+                implementation(Dependencies.Ktor.utils)
             }
         }
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(Dependencies.Coroutines.test)
             }
         }
         val jvmMain by getting {
@@ -67,6 +75,13 @@ kotlin {
             }
         }
         val jvmTest by getting
+        val jsMain by getting {
+            dependencies {
+                implementation(npm("@wireapp/cryptobox", "12.7.1", generateExternals = false))
+                implementation(npm("@wireapp/store-engine", "4.9.7", generateExternals = false))
+            }
+        }
+        val jsTest by getting
         val androidMain by getting {
             dependencies {
                 implementation(Dependencies.Cryptography.cryptoboxAndroid)

--- a/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
+++ b/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
@@ -17,7 +17,7 @@ actual class ProteusClient actual constructor(rootDir: String, userId: String) {
         path = String.format("%s/%s", rootDir, userId)
     }
 
-    actual fun open() {
+    actual suspend fun open() {
         box = wrapException {
             File(path).mkdirs()
             CryptoBox.open(path)
@@ -36,7 +36,7 @@ actual class ProteusClient actual constructor(rootDir: String, userId: String) {
         return wrapException { box.localFingerprint }
     }
 
-    actual fun newPreKeys(from: Int, count: Int): ArrayList<PreKey> {
+    actual suspend  fun newPreKeys(from: Int, count: Int): ArrayList<PreKey> {
         return wrapException { box.newPreKeys(from, count).map { toPreKey(it) } as ArrayList<PreKey> }
     }
 
@@ -44,11 +44,11 @@ actual class ProteusClient actual constructor(rootDir: String, userId: String) {
         return wrapException { toPreKey(box.newLastPreKey()) }
     }
 
-    actual fun createSession(preKey: PreKey, sessionId: CryptoSessionId) {
+    actual suspend fun createSession(preKey: PreKey, sessionId: CryptoSessionId) {
         wrapException { box.initSessionFromPreKey(sessionId.value, toPreKey(preKey)) }
     }
 
-    actual fun decrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray {
+    actual suspend fun decrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray {
         val session = box.tryGetSession(sessionId.value)
 
         return wrapException {
@@ -60,11 +60,11 @@ actual class ProteusClient actual constructor(rootDir: String, userId: String) {
         }
     }
 
-    actual fun encrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray? {
+    actual suspend fun encrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray? {
         return wrapException { box.getSession(sessionId.value)?.encrypt(message) }
     }
 
-    actual fun encryptWithPreKey(
+    actual suspend fun encryptWithPreKey(
         message: ByteArray,
         preKey: PreKey,
         sessionId: CryptoSessionId

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
@@ -23,7 +23,7 @@ data class PreKey(
 expect class ProteusClient(rootDir: String, userId: String) {
 
     @Throws(ProteusException::class)
-    fun open()
+    suspend fun open()
     @Throws(ProteusException::class)
     fun close()
 
@@ -33,24 +33,24 @@ expect class ProteusClient(rootDir: String, userId: String) {
     fun getLocalFingerprint(): ByteArray
 
     @Throws(ProteusException::class)
-    fun newPreKeys(from: Int, count: Int): ArrayList<PreKey>
+    suspend fun newPreKeys(from: Int, count: Int): ArrayList<PreKey>
     @Throws(ProteusException::class)
     fun newLastPreKey(): PreKey
 
     @Throws(ProteusException::class)
-    fun createSession(preKey: PreKey, sessionId: CryptoSessionId)
+    suspend fun createSession(preKey: PreKey, sessionId: CryptoSessionId)
 
     @Throws(ProteusException::class)
-    fun decrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray
+    suspend fun decrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray
 
     @Throws(ProteusException::class)
-    fun encrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray?
+    suspend fun encrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray?
 
     @Throws(ProteusException::class)
-    fun encryptWithPreKey(message: ByteArray, preKey: PreKey, sessionId: CryptoSessionId): ByteArray
+    suspend fun encryptWithPreKey(message: ByteArray, preKey: PreKey, sessionId: CryptoSessionId): ByteArray
 }
 
-fun ProteusClient.createSessions(preKeys: Map<String, Map<String, PreKey>>) {
+suspend fun ProteusClient.createSessions(preKeys: Map<String, Map<String, PreKey>>) {
     for (userId in preKeys.keys) {
         val clients = preKeys.getValue(userId)
         for (clientId in clients.keys) {

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
@@ -1,9 +1,12 @@
 package com.wire.kalium.cryptography
 
+import kotlin.js.ExperimentalJsExport
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
+@ExperimentalJsExport
 class ProteusClientTest: BaseProteusClientTest() {
 
     data class SampleUser(val id: UserId, val name: String)
@@ -14,7 +17,7 @@ class ProteusClientTest: BaseProteusClientTest() {
     val bobSessionId = CryptoSessionId(alice.id, CryptoClientId("aliceClient"))
 
     @Test
-    fun givenProteusClient_whenCallingNewLastKey_thenItReturnsALastPreKey() {
+    fun givenProteusClient_whenCallingNewLastKey_thenItReturnsALastPreKey() = runTest {
         val aliceClient = createProteusClient(alice.id)
         aliceClient.open()
         val lastPreKey = aliceClient.newLastPreKey()
@@ -22,7 +25,7 @@ class ProteusClientTest: BaseProteusClientTest() {
     }
 
     @Test
-    fun givenProteusClient_whenCallingNewPreKeys_thenItReturnsAListOfPreKeys() {
+    fun givenProteusClient_whenCallingNewPreKeys_thenItReturnsAListOfPreKeys() = runTest {
         val aliceClient = createProteusClient(alice.id)
         aliceClient.open()
         val preKeyList = aliceClient.newPreKeys(0, 10)
@@ -30,7 +33,7 @@ class ProteusClientTest: BaseProteusClientTest() {
     }
 
     @Test
-    fun givenIncomingPreKeyMessage_whenCallingDecrypt_thenMessageIsDecrypted() {
+    fun givenIncomingPreKeyMessage_whenCallingDecrypt_thenMessageIsDecrypted() = runTest {
         val aliceClient = createProteusClient(alice.id)
         aliceClient.open()
 
@@ -45,7 +48,7 @@ class ProteusClientTest: BaseProteusClientTest() {
     }
 
     @Test
-    fun givenSessionAlreadyExists_whenCallingDecrypt_thenMessageIsDecrypted() {
+    fun givenSessionAlreadyExists_whenCallingDecrypt_thenMessageIsDecrypted() = runTest {
         val aliceClient = createProteusClient(alice.id)
         aliceClient.open()
 
@@ -53,7 +56,6 @@ class ProteusClientTest: BaseProteusClientTest() {
         bobClient.open()
 
         val aliceKey = aliceClient.newPreKeys(0, 10).first()
-        bobClient.createSession(aliceKey, aliceSessionId)
         val message1 = "Hi Alice!"
         val encryptedMessage1 = bobClient.encryptWithPreKey(message1.encodeToByteArray(), aliceKey, aliceSessionId)
         aliceClient.decrypt(encryptedMessage1, bobSessionId)
@@ -66,7 +68,7 @@ class ProteusClientTest: BaseProteusClientTest() {
     }
 
     @Test
-    fun givenNoSessionExists_whenCallingCreateSession_thenSessionIsCreated() {
+    fun givenNoSessionExists_whenCallingCreateSession_thenSessionIsCreated() = runTest {
         val aliceClient = createProteusClient(alice.id)
         aliceClient.open()
 

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
@@ -90,8 +90,8 @@ actual class ProteusClient actual constructor(rootDir: String, userId: String) {
         sessionId: CryptoSessionId
     ): ByteArray {
         val preKeyBundle = preKey.encodedData.decodeBase64Bytes()
-        val foo = box.encrypt(sessionId.value, payload = message.toUint8Array(), preKeyBundle = preKeyBundle.toArrayBuffer())
-        return Int8Array(foo.await()).unsafeCast<ByteArray>()
+        val encryptedMessage = box.encrypt(sessionId.value, payload = message.toUint8Array(), preKeyBundle = preKeyBundle.toArrayBuffer())
+        return Int8Array(encryptedMessage.await()).unsafeCast<ByteArray>()
     }
 
     fun ByteArray.toUint8Array(): Uint8Array {

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
@@ -1,0 +1,115 @@
+package com.wire.kalium.cryptography
+
+import com.wire.kalium.cryptography.exceptions.ProteusException
+import com.wire.kalium.cryptography.externals.Cryptobox
+import com.wire.kalium.cryptography.externals.IdentityKey
+import com.wire.kalium.cryptography.externals.MemoryEngine
+import com.wire.kalium.cryptography.externals.PreKeyBundle
+import io.ktor.util.InternalAPI
+import io.ktor.util.decodeBase64Bytes
+import io.ktor.util.encodeBase64
+import kotlinx.coroutines.await
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Int8Array
+import org.khronos.webgl.Uint8Array
+
+actual class ProteusClient actual constructor(rootDir: String, userId: String) {
+
+    private val userId: String
+    private lateinit var box: Cryptobox
+
+    init {
+        this.userId = userId
+    }
+
+    actual suspend fun open() {
+        val engine = MemoryEngine()
+        engine.init(userId).await()
+
+        box = Cryptobox(engine)
+        box.create().await()
+    }
+
+    actual fun close() {}
+
+    actual fun getIdentity(): ByteArray {
+        val encodedIdentity = box.getIdentity().serialise()
+        return Int8Array(encodedIdentity).unsafeCast<ByteArray>()
+    }
+
+    actual fun getLocalFingerprint(): ByteArray {
+        return box.identity.public_key.fingerprint().encodeToByteArray()
+    }
+
+    actual suspend fun newPreKeys(
+        from: Int,
+        count: Int
+    ): ArrayList<PreKey> {
+        val preKeys = box.new_prekeys(from, count).await()
+        return preKeys.map { toPreKey(box.getIdentity().public_key, it) } as ArrayList<PreKey>
+    }
+
+    actual fun newLastPreKey(): PreKey {
+        val preKey = box.lastResortPreKey
+        if (preKey != null) {
+            return toPreKey(box.getIdentity().public_key, preKey)
+        } else {
+            throw ProteusException("Local identity doesn't exist", ProteusException.Code.UNKNOWN_ERROR)
+        }
+    }
+
+    @OptIn(InternalAPI::class)
+    actual suspend fun createSession(
+        preKey: PreKey,
+        sessionId: CryptoSessionId
+    ) {
+        val preKeyBundle = preKey.encodedData.decodeBase64Bytes()
+        box.session_from_prekey(sessionId.value, preKeyBundle.toArrayBuffer()).await()
+    }
+
+    actual suspend fun decrypt(
+        message: ByteArray,
+        sessionId: CryptoSessionId
+    ): ByteArray {
+        val decryptedMessage = box.decrypt(sessionId.value, message.toArrayBuffer()).await()
+        return Int8Array(decryptedMessage.buffer).unsafeCast<ByteArray>()
+    }
+
+    actual suspend fun encrypt(
+        message: ByteArray,
+        sessionId: CryptoSessionId
+    ): ByteArray? {
+        val encryptedMessage = box.encrypt(sessionId.value, payload = message.toUint8Array())
+        return Int8Array(encryptedMessage.await()).unsafeCast<ByteArray>()
+    }
+
+    @OptIn(InternalAPI::class)
+    actual suspend fun encryptWithPreKey(
+        message: ByteArray,
+        preKey: PreKey,
+        sessionId: CryptoSessionId
+    ): ByteArray {
+        val preKeyBundle = preKey.encodedData.decodeBase64Bytes()
+        val foo = box.encrypt(sessionId.value, payload = message.toUint8Array(), preKeyBundle = preKeyBundle.toArrayBuffer())
+        return Int8Array(foo.await()).unsafeCast<ByteArray>()
+    }
+
+    fun ByteArray.toUint8Array(): Uint8Array {
+        val int8Array = this.unsafeCast<Int8Array>()
+        return Uint8Array(int8Array.buffer)
+    }
+
+    fun ByteArray.toArrayBuffer(): ArrayBuffer {
+        val int8Array = this.unsafeCast<Int8Array>()
+        return int8Array.buffer
+    }
+
+    companion object {
+        @OptIn(InternalAPI::class)
+        private fun toPreKey(localIdentityKey: IdentityKey, preKey: com.wire.kalium.cryptography.externals.PreKey): PreKey {
+            val preKeyBundle = PreKeyBundle(localIdentityKey, preKey)
+            val encodedData = Uint8Array(preKeyBundle.serialise()).unsafeCast<ByteArray>().encodeBase64()
+            return PreKey(preKey.key_id.toInt(), encodedData)
+        }
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/CRUDEngine.module_@wireapp_store-engine.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/CRUDEngine.module_@wireapp_store-engine.kt
@@ -1,0 +1,38 @@
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface CRUDEngineBase {
+    fun <EntityType, PrimaryKey> create(tableName: String, primaryKey: PrimaryKey, entity: EntityType): Promise<PrimaryKey>
+    fun <EntityType, PrimaryKey> read(tableName: String, primaryKey: PrimaryKey): Promise<EntityType>
+    fun <PrimaryKey, ChangesType> update(tableName: String, primaryKey: PrimaryKey, changes: ChangesType): Promise<PrimaryKey>
+    fun <PrimaryKey> delete(tableName: String, primaryKey: PrimaryKey): Promise<PrimaryKey>
+}
+
+external interface CRUDEngineBaseCollection : CRUDEngineBase {
+    fun <EntityType> readAll(tableName: String): Promise<Array<EntityType>>
+    fun readAllPrimaryKeys(tableName: String): Promise<Array<String>>
+    fun deleteAll(tableName: String): Promise<Boolean>
+}
+
+external interface CRUDEngine : CRUDEngineBaseCollection {
+    fun clearTables(): Promise<Unit>
+    fun isSupported(): Promise<Unit>
+    fun purge(): Promise<Unit>
+    var storeName: String
+    fun <PrimaryKey, ChangesType> updateOrCreate(tableName: String, primaryKey: PrimaryKey, changes: ChangesType): Promise<PrimaryKey>
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/Cryptobox.module_@wireapp_cryptobox.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/Cryptobox.module_@wireapp_cryptobox.kt
@@ -1,0 +1,80 @@
+@file:JsModule("@wireapp/cryptobox")
+@file:JsNonModule
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external enum class TOPIC {
+    NEW_PREKEYS /* = "new-prekeys" */,
+    NEW_SESSION /* = "new-session" */
+}
+
+external interface `T$0` {
+    var id: Number
+    var key: String
+}
+
+external open class Cryptobox(engine: CRUDEngineBaseCollection, minimumAmountOfPreKeys: Number = definedExternally)  {
+    open fun on(event: TOPIC, listener: (prekeys: Array<PreKey>) -> Unit): Cryptobox /* this */
+    open fun on(event: TOPIC, listener: (session: String) -> Unit): Cryptobox /* this */
+    open var cachedSessions: Any
+    open var queues: Any
+    open var minimumAmountOfPreKeys: Any
+    open var store: Any
+    open var identity: IdentityKeyPair
+    open var lastResortPreKey: PreKey?
+    open var get_session_queue: Any
+    open var save_session_in_cache: Any
+    open var load_session_from_cache: Any
+    open var remove_session_from_cache: Any
+    open fun create(): Promise<Array<PreKey>>
+    open fun getIdentity(): IdentityKeyPair
+    open fun load(): Promise<Array<PreKey>>
+    open var init: Any
+    open fun get_serialized_last_resort_prekey(): Promise<`T$0`>
+    open var get_prekey: Any
+    open fun get_prekey_bundle(preKeyId: Number = definedExternally): Promise<PreKeyBundle>
+    open fun get_serialized_standard_prekeys(): Promise<Array<`T$0`>>
+    open var publish_event: Any
+    open var publish_prekeys: Any
+    open var publish_session_id: Any
+    open var refill_prekeys: Any
+    open var create_new_identity: Any
+    open var save_identity: Any
+    open fun session_from_prekey(sessionId: String, preKeyBundle: ArrayBuffer): Promise<CryptoboxSession>
+    open var session_from_message: Any
+    open fun session_load(sessionId: String): Promise<CryptoboxSession>
+    open var session_save: Any
+    open var session_update: Any
+    open fun session_delete(sessionId: String): Promise<String>
+    open var create_last_resort_prekey: Any
+    open fun serialize_prekey(prekey: PreKey): `T$0`
+    open fun new_prekeys(start: Number, size: Number): Promise<Array<PreKey>>
+    open fun encrypt(sessionId: String, payload: String, preKeyBundle: ArrayBuffer = definedExternally): Promise<ArrayBuffer>
+    open fun encrypt(sessionId: String, payload: String): Promise<ArrayBuffer>
+    open fun encrypt(sessionId: String, payload: Uint8Array, preKeyBundle: ArrayBuffer = definedExternally): Promise<ArrayBuffer>
+    open fun encrypt(sessionId: String, payload: Uint8Array): Promise<ArrayBuffer>
+    open fun decrypt(sessionId: String, ciphertext: ArrayBuffer): Promise<Uint8Array>
+    open var deleteData: Any
+    open var importIdentity: Any
+    open var importPreKeys: Any
+    open var importSessions: Any
+
+    companion object {
+        var VERSION: String
+        var TOPIC: Any
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/CryptoboxCRUDStore.module_@wireapp_cryptobox.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/CryptoboxCRUDStore.module_@wireapp_cryptobox.kt
@@ -1,0 +1,36 @@
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class CryptoboxCRUDStore(engine: CRUDEngineBaseCollection) : PreKeyStore {
+    open var engine: Any
+    open var from_store: Any
+    open var to_store: Any
+    open fun delete_all(): Promise<Boolean>
+    override fun delete_prekey(prekeyId: Number): Promise<Number>
+    open fun load_identity(): Promise<IdentityKeyPair?>
+    override open fun load_prekey(prekeyId: Number): Promise<PreKey?>
+    open fun load_prekeys(): Promise<Array<PreKey>>
+    open fun save_identity(identity: IdentityKeyPair): Promise<IdentityKeyPair>
+    open fun save_prekey(preKey: PreKey): Promise<PreKey>
+    open fun save_prekeys(preKeys: Array<PreKey>): Promise<Array<PreKey>>
+
+    companion object {
+        var KEYS: Any
+        var STORES: Any
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/CryptoboxSession.module_@wireapp_cryptobox.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/CryptoboxSession.module_@wireapp_cryptobox.kt
@@ -1,0 +1,27 @@
+@file:JsModule("@wireapp/cryptobox")
+@file:JsNonModule
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class CryptoboxSession {
+    open var id: String
+    open fun decrypt(ciphertext: ArrayBuffer, pk_store: CryptoboxCRUDStore): Promise<Uint8Array>
+    open fun encrypt(plaintext: String): ArrayBuffer
+    open fun encrypt(plaintext: Uint8Array): ArrayBuffer
+    open fun fingerprint_local(): String
+    open fun fingerprint_remote(): String
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/Decoder.module_@wireapp_cbor.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/Decoder.module_@wireapp_cbor.kt
@@ -1,0 +1,71 @@
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface DecoderConfig {
+    var max_array_length: Number
+    var max_bytes_length: Number
+    var max_nesting: Number
+    var max_object_size: Number
+    var max_text_length: Number
+}
+
+external open class Decoder(buffer: ArrayBuffer, config: DecoderConfig = definedExternally) {
+    open var buffer: Any
+    open var config: Any
+    open var view: Any
+    open var _advance: Any
+    open var _read: Any
+    open var _u8: Any
+    open var _u16: Any
+    open var _u32: Any
+    open var _u64: Any
+    open var _f32: Any
+    open var _f64: Any
+    open var _read_length: Any
+    open var _bytes: Any
+    open var _read_type_info: Any
+    open var _type_info_with_assert: Any
+    open var _read_unsigned: Any
+    open var _read_signed: Any
+    open var _skip_until_break: Any
+    open var _skip_value: Any
+    open fun u8(): Number
+    open fun u16(): Number
+    open fun u32(): Number
+    open fun u64(): Number
+    open fun i8(): Number
+    open fun i16(): Number
+    open fun i32(): Number
+    open fun i64(): Number
+    open fun unsigned(): Number
+    open fun int(): Number
+    open fun f16(): Number
+    open fun f32(): Number
+    open fun f64(): Number
+    open fun bool(): Boolean
+    open fun bytes(): ArrayBuffer
+    open fun text(): String
+    open fun <T> optional(closure: () -> T): T?
+    open fun array(): Number
+    open fun `object`(): Number
+    open fun skip(): Boolean
+
+    companion object {
+        var _check_overflow: Any
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/Encoder.module_@wireapp_cbor.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/Encoder.module_@wireapp_cbor.kt
@@ -1,0 +1,58 @@
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class Encoder {
+    open var buffer: Any
+    open var view: Any
+    open fun get_buffer(): ArrayBuffer
+    open var _new_buffer_length: Any
+    open var _grow_buffer: Any
+    open var _ensure: Any
+    open var _advance: Any
+    open var _write: Any
+    open var _write_type_and_len: Any
+    open var _u8: Any
+    open var _u16: Any
+    open var _u32: Any
+    open var _u64: Any
+    open var _f32: Any
+    open var _f64: Any
+    open var _bytes: Any
+    open fun u8(value: Number): Encoder
+    open fun u16(value: Number): Encoder
+    open fun u32(value: Number): Encoder
+    open fun u64(value: Number): Encoder
+    open fun i8(value: Number): Encoder
+    open fun i16(value: Number): Encoder
+    open fun i32(value: Number): Encoder
+    open fun i64(value: Number): Encoder
+    open fun f32(value: Number): Encoder
+    open fun f64(value: Number): Encoder
+    open fun bool(value: Boolean): Encoder
+    open fun bytes(value: ArrayBuffer): Encoder
+    open fun bytes(value: Uint8Array): Encoder
+    open fun text(value: String): Encoder
+    open fun `null`(): Encoder
+    open fun undefined(): Encoder
+    open fun array(len: Number): Encoder
+    open fun array_begin(): Encoder
+    open fun array_end(): Encoder
+    open fun `object`(len: Number): Encoder
+    open fun object_begin(): Encoder
+    open fun object_end(): Encoder
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/IdentityKey.module_@wireapp_proteus.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/IdentityKey.module_@wireapp_proteus.kt
@@ -1,0 +1,30 @@
+@file:JsModule("@wireapp/proteus")
+@file:JsNonModule
+@file:JsQualifier("keys")
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class IdentityKey(publicKey: PublicKey) {
+    open var public_key: PublicKey
+    open fun fingerprint(): String
+
+    companion object {
+        var propertiesLength: Any
+        fun encode(encoder: Encoder, identityKey: IdentityKey): Encoder
+        fun decode(decoder: Decoder): IdentityKey
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/IdentityKeyPair.module_@wireapp_proteus.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/IdentityKeyPair.module_@wireapp_proteus.kt
@@ -1,0 +1,33 @@
+@file:JsModule("@wireapp/proteus")
+@file:JsNonModule
+@file:JsQualifier("keys")
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class IdentityKeyPair(publicKey: IdentityKey = definedExternally, secretKey: SecretKey = definedExternally, version: Number = definedExternally) {
+    open var public_key: IdentityKey
+    open var secret_key: SecretKey
+    open var version: Number
+    open fun serialise(): ArrayBuffer
+
+    companion object {
+        var propertiesLength: Any
+        fun deserialise(buf: ArrayBuffer): IdentityKeyPair
+        fun encode(encoder: Encoder, identityKeyPair: IdentityKeyPair): Encoder
+        fun decode(decoder: Decoder): IdentityKeyPair
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/KeyPair.module_@wireapp_proteus.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/KeyPair.module_@wireapp_proteus.kt
@@ -1,0 +1,34 @@
+@file:JsModule("@wireapp/proteus")
+@file:JsNonModule
+@file:JsQualifier("keys")
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class KeyPair {
+    open var public_key: PublicKey
+    open var secret_key: SecretKey
+    constructor()
+    constructor(publicKey: PublicKey, secretKey: SecretKey)
+
+    companion object {
+        var propertiesLength: Any
+        fun construct_private_key(ed25519_key_pair: KeyPair): SecretKey
+        fun construct_public_key(ed25519_key_pair: KeyPair): PublicKey
+        fun encode(encoder: Encoder, keyPair: KeyPair): Encoder
+        fun decode(decoder: Decoder): KeyPair
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/MemoryEngine.module_@wireapp_store-engine.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/MemoryEngine.module_@wireapp_store-engine.kt
@@ -1,0 +1,39 @@
+@file:JsModule("@wireapp/store-engine")
+@file:JsNonModule
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class MemoryEngine : CRUDEngine {
+    override var storeName: String
+    open var stores: Any
+    open var autoIncrementedPrimaryKey: Any
+    override fun <EntityType, PrimaryKey> create(tableName: String, primaryKey: PrimaryKey, entity: EntityType): Promise<PrimaryKey>
+    override fun clearTables(): Promise<Unit>
+    override fun <PrimaryKey> delete(tableName: String, primaryKey: PrimaryKey): Promise<PrimaryKey>
+    override fun deleteAll(tableName: String): Promise<Boolean>
+    open fun init(storeName: String): Promise<Any>
+    open fun <ObjectType> initWithObject(storeName: String, obj: ObjectType): Promise<Any>
+    open var assignDb: Any
+    override fun isSupported(): Promise<Unit>
+    override fun purge(): Promise<Unit>
+    override fun <EntityType, PrimaryKey> read(tableName: String, primaryKey: PrimaryKey): Promise<EntityType>
+    override fun <T> readAll(tableName: String): Promise<Array<T>>
+    override fun readAllPrimaryKeys(tableName: String): Promise<Array<String>>
+    override fun <PrimaryKey, ChangesType> update(tableName: String, primaryKey: PrimaryKey, changes: ChangesType): Promise<PrimaryKey>
+    override fun <PrimaryKey, ChangesType> updateOrCreate(tableName: String, primaryKey: PrimaryKey, changes: ChangesType): Promise<PrimaryKey>
+    open var prepareTable: Any
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/PreKey.module_@wireapp_proteus.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/PreKey.module_@wireapp_proteus.kt
@@ -1,0 +1,36 @@
+@file:JsModule("@wireapp/proteus")
+@file:JsNonModule
+@file:JsQualifier("keys")
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class PreKey(keyId: Number = definedExternally, keyPair: KeyPair = definedExternally, version: Number = definedExternally) {
+    open var key_id: Number
+    open var key_pair: KeyPair
+    open var version: Number
+    open fun serialise(): ArrayBuffer
+
+    companion object {
+        var MAX_PREKEY_ID: Any = definedExternally
+        var propertiesLength: Any
+        fun last_resort(): PreKey
+        fun generate_prekeys(start: Number, size: Number): Array<PreKey>
+        fun deserialise(buf: ArrayBuffer): PreKey
+        fun encode(encoder: Encoder, preKey: PreKey): Encoder
+        fun decode(decoder: Decoder): PreKey
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/PreKeyBundle.module_@wireapp_proteus.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/PreKeyBundle.module_@wireapp_proteus.kt
@@ -1,0 +1,45 @@
+@file:JsModule("@wireapp/proteus")
+@file:JsNonModule
+@file:JsQualifier("keys")
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface SerialisedJSON {
+    var id: Number
+    var key: String
+}
+
+external open class PreKeyBundle {
+    open var identity_key: IdentityKey
+    open var prekey_id: Number
+    open var public_key: PublicKey
+    open var signature: Uint8Array?
+    open var version: Number
+    constructor(publicIdentityKey: IdentityKey, preKey: PreKey)
+    constructor(publicIdentityKey: IdentityKey, preKeyId: Number, publicKey: PublicKey, signature: Uint8Array? = definedExternally, version: Number = definedExternally)
+    constructor(publicIdentityKey: IdentityKey, preKeyId: Number, publicKey: PublicKey)
+    constructor(publicIdentityKey: IdentityKey, preKeyId: Number, publicKey: PublicKey, signature: Uint8Array? = definedExternally)
+    open fun serialise(): ArrayBuffer
+    open fun serialised_json(): SerialisedJSON
+
+    companion object {
+        var propertiesLength: Any
+        fun deserialise(buf: ArrayBuffer): PreKeyBundle
+        fun encode(encoder: Encoder, preKeyBundle: PreKeyBundle): Encoder
+        fun decode(decoder: Decoder): PreKeyBundle
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/PreKeyStore.module_@wireapp_proteus.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/PreKeyStore.module_@wireapp_proteus.kt
@@ -1,0 +1,22 @@
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class PreKeyStore {
+    open fun load_prekey(prekeyId: Number): Promise<PreKey?>
+    open fun delete_prekey(prekeyId: Number): Promise<Number>
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/PublicKey.module_@wireapp_proteus.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/PublicKey.module_@wireapp_proteus.kt
@@ -1,0 +1,33 @@
+@file:JsModule("@wireapp/proteus")
+@file:JsNonModule
+@file:JsQualifier("keys")
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class PublicKey(pubEdward: Uint8Array, pubCurve: Uint8Array) {
+    open var pub_edward: Uint8Array
+    open var pub_curve: Uint8Array
+    open fun verify(signature: Uint8Array, message: Uint8Array): Boolean
+    open fun verify(signature: Uint8Array, message: String): Boolean
+    open fun fingerprint(): String
+
+    companion object {
+        var propertiesLength: Any
+        fun encode(encoder: Encoder, publicKey: PublicKey): Encoder
+        fun decode(decoder: Decoder): PublicKey
+    }
+}

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/SecretKey.module_@wireapp_proteus.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/externals/SecretKey.module_@wireapp_proteus.kt
@@ -1,0 +1,33 @@
+@file:JsModule("@wireapp/proteus")
+@file:JsNonModule
+@file:JsQualifier("keys")
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+package com.wire.kalium.cryptography.externals
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class SecretKey(secEdward: Uint8Array, secCurve: Uint8Array) {
+    open var sec_curve: Uint8Array
+    open var sec_edward: Uint8Array
+    open fun sign(message: Uint8Array): Uint8Array
+    open fun sign(message: String): Uint8Array
+
+    companion object {
+        var propertiesLength: Any
+        fun shared_secret(publicKey: PublicKey, secretKey: SecretKey): Uint8Array
+        fun encode(encoder: Encoder, secretKey: SecretKey): Encoder
+        fun decode(decoder: Decoder): SecretKey
+    }
+}

--- a/cryptography/src/jsTest/kotlin/com/wire/kalium/cryptography/BaseProteusClientTest.kt
+++ b/cryptography/src/jsTest/kotlin/com/wire/kalium/cryptography/BaseProteusClientTest.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.cryptography
+
+actual open class BaseProteusClientTest actual constructor() {
+
+    actual fun createProteusClient(userId: UserId): ProteusClient {
+        // TODO currently expects an in memory proteus client
+        return ProteusClient("foo/bar", userId.value)
+    }
+
+}

--- a/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
+++ b/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
@@ -17,7 +17,7 @@ actual class ProteusClient actual constructor(rootDir: String, userId: String) {
         path = String.format("%s/%s", rootDir, userId)
     }
 
-    actual fun open() {
+    actual suspend fun open() {
         val directory = File(path)
         box = wrapException {
             directory.mkdirs()
@@ -41,23 +41,23 @@ actual class ProteusClient actual constructor(rootDir: String, userId: String) {
         return wrapException { toPreKey(box.newLastPreKey()) }
     }
 
-    actual fun newPreKeys(from: Int, count: Int): ArrayList<PreKey> {
+    actual suspend fun newPreKeys(from: Int, count: Int): ArrayList<PreKey> {
         return wrapException { box.newPreKeys(from, count).map { toPreKey(it) } as ArrayList<PreKey> }
     }
 
-    actual fun createSession(preKey: PreKey, sessionId: CryptoSessionId) {
+    actual suspend fun createSession(preKey: PreKey, sessionId: CryptoSessionId) {
         wrapException { box.encryptFromPreKeys(sessionId.value, toPreKey(preKey), ByteArray(0)) }
     }
 
-    actual fun decrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray {
+    actual suspend fun decrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray {
         return wrapException { box.decrypt(sessionId.value, message) }
     }
 
-    actual fun encrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray? {
+    actual suspend fun encrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray? {
         return wrapException { box.encryptFromSession(sessionId.value, message) }
     }
 
-    actual fun encryptWithPreKey(
+    actual suspend fun encryptWithPreKey(
         message: ByteArray,
         preKey: PreKey,
         sessionId: CryptoSessionId

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx2g
 android.useAndroidX=true
 kotlin.native.binary.memoryModel=experimental
+kotlin.js.generate.executable.default=false


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We want validate the KMP when targeting JS to assure us that it will also be possible to integrate the library on the web.

### Solutions

- Configure JS target in the cryptography module
- Implement the ProteusClient for JS using the existing [@wireapp/cryptobox](https://www.npmjs.com/search?q=%40wireapp%2Fcryptobox) implementation 

### Testing

The common ProteusClient tests pass when running against the JS target.

### Notes (Optional)

- For simplicity is the JS ProteusClient using the in-memory engine which doesn't support any persistence.
- I've annotated many of ProteusClient methods with `suspend` since the JS cryptobox based on promises.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
