### PR TITLE
chore: add tests for the upload asset api

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/asset/AssetApiImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/asset/AssetApiImp.kt
@@ -16,7 +16,7 @@ import io.ktor.utils.io.core.toByteArray
 class AssetApiImp(private val httpClient: HttpClient) : AssetApi {
 
     /**
-     * download an asset
+     * Downloads an asset
      * @param assetKey the asset identifier
      * @param assetToken the asset token, can be null in case of public assets
      */
@@ -26,6 +26,10 @@ class AssetApiImp(private val httpClient: HttpClient) : AssetApi {
         }
     }
 
+    /** Uploads an already encrypted asset
+     * @param metadata the metadata associated to the asset that wants to be uploaded
+     * @param encryptedData the encrypted data on a ByteArray shape
+     */
     override suspend fun uploadAsset(metadata: AssetMetadata, encryptedData: ByteArray): NetworkResponse<Asset> = wrapKaliumResponse {
         httpClient.post(PATH_PUBLIC_ASSETS) {
             contentType(ContentType.MultiPart.Mixed)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
@@ -23,6 +23,7 @@ class AssetApiTest : ApiTest {
         // Given
         val assetMetadata = AssetMetadata("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
         val encryptedData = ByteArray(16)
+        Random.nextBytes(encryptedData)
         val httpClient = mockAuthenticatedHttpClient(
             VALID_ASSET_UPLOAD_RESPONSE.rawJson,
             statusCode = HttpStatusCode.Created,
@@ -49,6 +50,7 @@ class AssetApiTest : ApiTest {
         // Given
         val assetMetadata = AssetMetadata("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
         val encryptedData = ByteArray(16)
+        Random.nextBytes(encryptedData)
         val httpClient = mockAuthenticatedHttpClient(
             VALID_ASSET_UPLOAD_RESPONSE.rawJson,
             statusCode = HttpStatusCode.Created,

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
@@ -11,6 +11,7 @@ import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -74,6 +75,7 @@ class AssetApiTest : ApiTest {
         // Given
         val assetMetadata = AssetMetadata("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
         val encryptedData = ByteArray(16)
+        Random.nextBytes(encryptedData)
         val httpClient = mockAuthenticatedHttpClient(
             INVALID_ASSET_UPLOAD_RESPONSE.rawJson,
             statusCode = HttpStatusCode.BadRequest,
@@ -99,6 +101,7 @@ class AssetApiTest : ApiTest {
     fun givenAValidAssetDownloadApiRequest_whenCallingTheAssetDownloadApiEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
         // Given
         val downloadedAsset = ByteArray(16)
+        Random.nextBytes(downloadedAsset)
         val assetKey = "3-1-e7788668-1b22-488a-b63c-acede42f771f"
         val assetToken = "assetToken"
         val apiPath = "$PATH_PUBLIC_ASSETS/$assetKey"
@@ -120,11 +123,7 @@ class AssetApiTest : ApiTest {
 
         // Then
         assertTrue(response.isSuccessful())
-
-        // We can't assert that the response object is exactly the same object as the provided on the Mocked HttpClient because MockEngine
-        // from Ktor seems to copy internally the content of the original ByteArray into a different ByteArray, therefore they are not
-        // technically the same object. That's why we are just doing a simple array size check
-        assertEquals(response.value.size, downloadedAsset.size)
+        assertEquals(response.value.decodeToString(), downloadedAsset.decodeToString())
     }
 
     @Test

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
@@ -1,0 +1,162 @@
+package com.wire.kalium.api.tools.json.api.asset
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.network.api.asset.AssetApi
+import com.wire.kalium.network.api.asset.AssetApiImp
+import com.wire.kalium.network.api.model.AssetMetadata
+import com.wire.kalium.network.api.model.AssetRetentionType
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.isSuccessful
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class AssetApiTest : ApiTest {
+    @Test
+    fun givenAValidAssetUploadApiRequest_whenCallingTheAssetUploadApiEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
+        // Given
+        val assetMetadata = AssetMetadata("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
+        val encryptedData = ByteArray(16)
+        val httpClient = mockAuthenticatedHttpClient(
+            VALID_ASSET_UPLOAD_RESPONSE.rawJson,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertPost()
+                assertJson()
+                assertNoQueryParams()
+                assertAuthorizationHeaderExist()
+                assertPathEqual(PATH_PUBLIC_ASSETS)
+            }
+        )
+
+        // When
+        val assetApi: AssetApi = AssetApiImp(httpClient)
+        val response = assetApi.uploadAsset(assetMetadata, encryptedData)
+
+        // Then
+        assertTrue(response.isSuccessful())
+        assertEquals(response.value, VALID_ASSET_UPLOAD_RESPONSE.serializableData)
+    }
+
+    @Test
+    fun givenAValidAssetUploadApiRequest_whenCallingTheAssetUploadApiEndpoint_theRequestHeaderShouldContainTheAssetToken() = runTest {
+        // Given
+        val assetMetadata = AssetMetadata("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
+        val encryptedData = ByteArray(16)
+        val httpClient = mockAuthenticatedHttpClient(
+            VALID_ASSET_UPLOAD_RESPONSE.rawJson,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertPost()
+                assertJson()
+                assertNoQueryParams()
+                assertAuthorizationHeaderExist()
+                assertPathEqual(PATH_PUBLIC_ASSETS)
+            }
+        )
+
+        // When
+        val assetApi: AssetApi = AssetApiImp(httpClient)
+        val response = assetApi.uploadAsset(assetMetadata, encryptedData)
+
+        // Then
+        assertTrue(response.isSuccessful())
+        assertEquals(response.value, VALID_ASSET_UPLOAD_RESPONSE.serializableData)
+    }
+
+    @Test
+    fun givenAnInvalidAssetUploadApiRequest_whenCallingTheAssetUploadApiEndpoint_theRequestShouldContainAnError() = runTest {
+        // Given
+        val assetMetadata = AssetMetadata("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
+        val encryptedData = ByteArray(16)
+        val httpClient = mockAuthenticatedHttpClient(
+            INVALID_ASSET_UPLOAD_RESPONSE.rawJson,
+            statusCode = HttpStatusCode.BadRequest,
+            assertion = {
+                assertPost()
+                assertJson()
+                assertNoQueryParams()
+                assertAuthorizationHeaderExist()
+                assertPathEqual(PATH_PUBLIC_ASSETS)
+            }
+        )
+
+        // When
+        val assetApi: AssetApi = AssetApiImp(httpClient)
+        val response = assetApi.uploadAsset(assetMetadata, encryptedData)
+
+        // Then
+        assertTrue(response is NetworkResponse.Error)
+        assertTrue(response.kException is KaliumException.InvalidRequestError)
+    }
+
+    @Test
+    fun givenAValidAssetDownloadApiRequest_whenCallingTheAssetDownloadApiEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
+        // Given
+        val downloadedAsset = ByteArray(16)
+        val assetKey = "3-1-e7788668-1b22-488a-b63c-acede42f771f"
+        val assetToken = "assetToken"
+        val apiPath = "$PATH_PUBLIC_ASSETS/$assetKey"
+        val httpClient = mockAuthenticatedHttpClient(
+            responseBody = downloadedAsset,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertNoQueryParams()
+                assertAuthorizationHeaderExist()
+                assertHeaderExist(HEADER_ASSET_TOKEN)
+                assertPathEqual(apiPath)
+            }
+        )
+
+        // When
+        val assetApi: AssetApi = AssetApiImp(httpClient)
+        val response = assetApi.downloadAsset(assetKey, assetToken)
+
+        // Then
+        assertTrue(response.isSuccessful())
+
+        // We can't assert that the response object is exactly the same object as the provided on the Mocked HttpClient because MockEngine
+        // from Ktor seems to copy internally the content of the original ByteArray into a different ByteArray, therefore they are not
+        // technically the same object. That's why we are just doing a simple array size check
+        assertEquals(response.value.size, downloadedAsset.size)
+    }
+
+    @Test
+    fun givenAnInvalidAssetDownloadApiRequest_whenCallingTheAssetDownloadApiEndpoint_theResponseShouldContainAnError() = runTest {
+        // Given
+        val assetKey = "3-1-e7788668-1b22-488a-b63c-acede42f771f"
+        val assetToken = "assetToken"
+        val apiPath = "$PATH_PUBLIC_ASSETS/$assetKey"
+        val httpClient = mockAuthenticatedHttpClient(
+            responseBody = AssetDownloadResponseJson.invalid.rawJson,
+            statusCode = HttpStatusCode.BadRequest,
+            assertion = {
+                assertGet()
+                assertNoQueryParams()
+                assertAuthorizationHeaderExist()
+                assertPathEqual(apiPath)
+            }
+        )
+
+        // When
+        val assetApi: AssetApi = AssetApiImp(httpClient)
+        val response = assetApi.downloadAsset(assetKey, assetToken)
+
+        // Then
+        assertTrue(response is NetworkResponse.Error)
+        assertTrue(response.kException is KaliumException.InvalidRequestError)
+    }
+
+    companion object {
+        val VALID_ASSET_UPLOAD_RESPONSE = AssetUploadResponseJson.valid
+        val INVALID_ASSET_UPLOAD_RESPONSE = AssetUploadResponseJson.invalid
+        const val PATH_PUBLIC_ASSETS = "/assets/v3/"
+        const val HEADER_ASSET_TOKEN = "Asset-Token"
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetDownloadResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetDownloadResponseJson.kt
@@ -1,0 +1,21 @@
+package com.wire.kalium.api.tools.json.api.asset
+
+import com.wire.kalium.api.tools.json.ValidJsonProvider
+import com.wire.kalium.network.api.ErrorResponse
+
+object AssetDownloadResponseJson {
+    private val invalidJsonProvider = { serializable: ErrorResponse ->
+        """
+        |{
+        |   "code": "${serializable.code}",
+        |   "message": "${serializable.message}",
+        |   "label": "${serializable.label}"
+        |}
+        """.trimMargin()
+    }
+
+    val invalid = ValidJsonProvider(
+        ErrorResponse(401, "Invalid Asset Token", "invalid_asset_token"),
+        invalidJsonProvider
+    )
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetUploadResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetUploadResponseJson.kt
@@ -1,0 +1,40 @@
+package com.wire.kalium.api.tools.json.api.asset
+
+import com.wire.kalium.api.tools.json.ValidJsonProvider
+import com.wire.kalium.network.api.ErrorResponse
+import com.wire.kalium.network.api.model.Asset
+
+object AssetUploadResponseJson {
+    private val validJsonProvider = { serializable: Asset ->
+        """
+        |{
+        |   "key": "${serializable.key}",
+        |   "expires": "${serializable.expires}",
+        |   "token": "${serializable.token}"
+        |}
+        """.trimMargin()
+    }
+    private val invalidJsonProvider = { serializable: ErrorResponse ->
+        """
+        |{
+        |   "code": "${serializable.code}",
+        |   "message": "${serializable.message}",
+        |   "label": "${serializable.label}"
+        |}
+        """.trimMargin()
+    }
+
+    val valid = ValidJsonProvider(
+        Asset(
+            key = "3-1-e7788668-1b22-488a-b63c-acede42f771f",
+            expires = "expiration_date",
+            token = "asset_token"
+        ),
+        validJsonProvider
+    )
+
+    val invalid = ValidJsonProvider(
+        ErrorResponse(401, "Invalid Asset Token", "invalid_asset_token"),
+        invalidJsonProvider
+    )
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/message/MessageApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/message/MessageApiTest.kt
@@ -5,9 +5,7 @@ import com.wire.kalium.api.tools.json.ValidJsonProvider
 import com.wire.kalium.network.api.message.MessageApi
 import com.wire.kalium.network.api.message.MessageApiImp
 import com.wire.kalium.network.api.message.SendMessageResponse
-import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.SendMessageError
-import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,7 +21,7 @@ class MessageApiTest : ApiTest {
     @Test
     fun givenAValidIgnoreAlloption_whenSendingAMessage_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 SUCCESS_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.Created,
                 assertion =
@@ -48,7 +46,7 @@ class MessageApiTest : ApiTest {
     @Test
     fun givenAValidReportAll_whenSendingAMessage_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 SUCCESS_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.Created,
                 assertion =
@@ -73,7 +71,7 @@ class MessageApiTest : ApiTest {
     @Test
     fun givenAValidIgnoreSome_whenSendingAMessage_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 SUCCESS_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.Created,
                 assertion =
@@ -98,7 +96,7 @@ class MessageApiTest : ApiTest {
     @Test
     fun givenAValidReportSome_whenSendingAMessage_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 SUCCESS_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.Created,
                 assertion =
@@ -132,7 +130,7 @@ class MessageApiTest : ApiTest {
 
     private fun errorCaseTest(errorResponse: ValidJsonProvider<SendMessageResponse.MissingDevicesResponse>) =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 errorResponse.rawJson,
                 statusCode = HttpStatusCode.PreconditionFailed
             )

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/prekey/PrekeyApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/prekey/PrekeyApiTest.kt
@@ -21,7 +21,7 @@ class PrekeyApiTest : ApiTest {
 
     @Test
     fun givenAValidDomainToUserIdToClientsMap_whenCallingGetUsersPrekeyEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
-        val httpClient = mockHttpClient(
+        val httpClient = mockAuthenticatedHttpClient(
             VALID_GET_USERS_PREKEY_RESPONSE.rawJson,
             statusCode = HttpStatusCode.OK,
             assertion = {
@@ -39,7 +39,7 @@ class PrekeyApiTest : ApiTest {
 
     @Test
     fun givenTheServerReturnsAnError_whenCallingGetUsersPrekeyEndpoint_theCorrectExceptionIsThrown() = runTest {
-        val httpClient = mockHttpClient(
+        val httpClient = mockAuthenticatedHttpClient(
             ErrorResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.Forbidden,
         )

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/teams/TeamsApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/teams/TeamsApiTest.kt
@@ -15,7 +15,7 @@ class TeamsApiTest: ApiTest {
     fun givenAValidListOfTeamsIds_whenCallingGetTeamsLimitedTo_theRequestShouldBeConfiguredCorrectly() =
         runTest {
             val commaSeparatedListOfIds = LIST_OF_TEAM_IDS.joinToString(",")
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 GET_LIMIT_TO_CLIENT_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.OK,
                 assertion = {
@@ -33,7 +33,7 @@ class TeamsApiTest: ApiTest {
     @Test
     fun givenAValidGetTeamsRequest_whenCallingGetTeamsStartFrom_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 GET_START_FROM_CLIENT_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.OK,
                 assertion = {
@@ -51,7 +51,7 @@ class TeamsApiTest: ApiTest {
     @Test
     fun givenAValidGetTeamsFirstPageRequest_whenGettingTeamsMembers_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 GET_TEAM_MEMBER_CLIENT_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.OK,
                 assertion = {
@@ -69,7 +69,7 @@ class TeamsApiTest: ApiTest {
     fun givenADeleteConversationForTeamRequest_whenDeletingATeamConversationWithSuccess_theRequestShouldBeConfiguredCorrectly() =
         runTest {
             val conversationId = "96a6e8e4-6420-49db-aa83-2711edf7580d"
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 "",
                 statusCode = HttpStatusCode.OK,
                 assertion = {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/ClientApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/ClientApiTest.kt
@@ -19,7 +19,7 @@ class ClientApiTest : ApiTest {
     @Test
     fun givenAValidRegisterClientRequest_whenCallingTheRegisterClientEndpoint_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 VALID_REGISTER_CLIENT_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.Created,
                 assertion = {
@@ -37,7 +37,7 @@ class ClientApiTest : ApiTest {
 
     @Test
     fun givenTheServerReturnsAnError_whenCallingTheRegisterClientEndpoint_theCorrectExceptionIsThrown() = runTest {
-        val httpClient = mockHttpClient(
+        val httpClient = mockAuthenticatedHttpClient(
             ErrorResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.Unauthorized
         )

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/LoginApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/LoginApiTest.kt
@@ -19,7 +19,7 @@ class LoginApiTest : ApiTest {
 
     @Test
     fun givenAValidLoginRequest_whenCallingTheLoginEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
-        val httpClient = mockHttpClient(
+        val httpClient = mockUnauthenticatedHttpClient(
             VALID_LOGIN_RESPONSE.rawJson,
             statusCode = HttpStatusCode.OK,
             assertion = {
@@ -38,7 +38,7 @@ class LoginApiTest : ApiTest {
 
     @Test
     fun givenTheServerReturnsAnError_whenCallingTheLoginEndpoint_theCorrectExceptionIsThrown() = runTest {
-        val httpClient = mockHttpClient(
+        val httpClient = mockUnauthenticatedHttpClient(
             ErrorResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.Unauthorized
         )

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/logout/LogoutApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/logout/LogoutApiTest.kt
@@ -1,7 +1,6 @@
 package com.wire.kalium.api.tools.json.api.user.logout
 
 import com.wire.kalium.api.ApiTest
-import com.wire.kalium.api.tools.json.api.user.client.RegisterClientResponseJson
 import com.wire.kalium.api.tools.json.model.ErrorResponseJson
 import com.wire.kalium.network.api.user.logout.LogoutApi
 import com.wire.kalium.network.api.user.logout.LogoutImp
@@ -21,7 +20,7 @@ class LogoutApiTest : ApiTest {
     @Test
     fun givenAValidRegisterLogoutRequest_whenCallingTheRegisterLogoutEndpoint_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 "",
                 statusCode = HttpStatusCode.Created,
                 assertion = {
@@ -37,7 +36,7 @@ class LogoutApiTest : ApiTest {
 
     @Test
     fun givenTheServerReturnsAnError_whenCallingTheLogoutEndpoint_theCorrectExceptionIsThrown() = runTest {
-        val httpClient = mockHttpClient(
+        val httpClient = mockAuthenticatedHttpClient(
             ERROR_RESPONSE.rawJson,
             statusCode = HttpStatusCode.Unauthorized
         )

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/self/SelfApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/self/SelfApiTest.kt
@@ -18,7 +18,7 @@ class SelfApiTest : ApiTest {
     @Test
     fun givenAValidRegisterLogoutRequest_whenCallingTheRegisterLogoutEndpoint_theRequestShouldBeConfiguredCorrectly() =
         runTest {
-            val httpClient = mockHttpClient(
+            val httpClient = mockAuthenticatedHttpClient(
                 VALID_SELF_RESPONSE.rawJson,
                 statusCode = HttpStatusCode.Created,
                 assertion = {
@@ -35,7 +35,7 @@ class SelfApiTest : ApiTest {
 
     @Test
     fun givenTheServerReturnsAnError_whenCallingTheGetSelfEndpoint_theCorrectExceptionIsThrown() = runTest {
-        val httpClient = mockHttpClient(
+        val httpClient = mockAuthenticatedHttpClient(
             ErrorResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.Unauthorized
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The asset upload api feature was still missing a batch of tests. Also rewrote the `ApiTest` class to make a difference between authenticated an unauthenticated Http clients.
