### PR TITLE
feat: Add session-scoped storage for event processing (AR-915)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -28,6 +28,6 @@ actual class CoreLogic(
                 userScopeStorage[session] = it
             }
         }
-        return UserSessionScope(applicationContext, dataSourceSet)
+        return UserSessionScope(applicationContext, session, dataSourceSet)
     }
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -3,6 +3,8 @@ package com.wire.kalium.logic.feature
 import android.content.Context
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
+import com.wire.kalium.logic.feature.auth.AuthSession
+import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 
 /**
  * This class is only for platform specific variables,
@@ -10,8 +12,15 @@ import com.wire.kalium.logic.configuration.ClientConfig
  */
 actual class UserSessionScope(
     private val applicationContext: Context,
+    private val session: AuthSession,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet
-) : UserSessionScopeCommon(authenticatedDataSourceSet) {
+) : UserSessionScopeCommon(session, authenticatedDataSourceSet) {
 
     override val clientConfig: ClientConfig get() = ClientConfig(applicationContext)
+    override val encryptedSettingsHolder: EncryptedSettingsHolder
+        get() = EncryptedSettingsHolder(applicationContext, "$PREFERENCE_FILE_PREFIX-${session.userId}")
+
+    private companion object {
+        private const val PREFERENCE_FILE_PREFIX = "user-pref"
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -18,15 +18,25 @@ import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.data.location.LocationMapper
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.prekey.PreKeyMapper
+import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.conversation.ConversationScope
 import com.wire.kalium.logic.feature.message.MessageScope
+import com.wire.kalium.persistence.event.EventInfoStorage
+import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
+import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 
 expect class UserSessionScope: UserSessionScopeCommon
 
 abstract class UserSessionScopeCommon(
+    private val session: AuthSession,
     private val authenticatedDataSourceSet: AuthenticatedDataSourceSet
 ) {
+
+    protected abstract val encryptedSettingsHolder: EncryptedSettingsHolder
+    private val userPreferencesSettings = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
+    private val eventInfoStorage = EventInfoStorage(userPreferencesSettings)
+
     private val idMapper: IdMapper get() = IdMapperImpl()
     private val memberMapper: MemberMapper get() = MemberMapperImpl(idMapper)
     private val conversationMapper: ConversationMapper get() = ConversationMapperImpl(idMapper, memberMapper)

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2,9 +2,20 @@ package com.wire.kalium.logic.feature
 
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
+import com.wire.kalium.logic.feature.auth.AuthSession
+import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 
 actual class UserSessionScope(
+    session: AuthSession,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet
-) : UserSessionScopeCommon(authenticatedDataSourceSet) {
+) : UserSessionScopeCommon(session, authenticatedDataSourceSet) {
     override val clientConfig: ClientConfig get() = ClientConfig()
+
+    override val encryptedSettingsHolder: EncryptedSettingsHolder = EncryptedSettingsHolder(
+        "$PREFERENCE_FILE_PREFIX-${session.userId}"
+    )
+
+    private companion object {
+        private const val PREFERENCE_FILE_PREFIX = ".user-pref"
+    }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/event/EventInfoStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/event/EventInfoStorage.kt
@@ -1,0 +1,14 @@
+package com.wire.kalium.persistence.event
+
+import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
+
+class EventInfoStorage(private val kaliumPreferences: KaliumPreferences) {
+
+    var lastProcessedId: String?
+        get() = kaliumPreferences.getString(LAST_PROCESSED_EVENT_ID_KEY)
+        set(value) = kaliumPreferences.putString(LAST_PROCESSED_EVENT_ID_KEY, value)
+
+    private companion object {
+        const val LAST_PROCESSED_EVENT_ID_KEY = "last_processed_event_id"
+    }
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmm_settings/KaliumPreferences.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmm_settings/KaliumPreferences.kt
@@ -9,8 +9,8 @@ import kotlinx.serialization.KSerializer
 interface KaliumPreferences {
     fun remove(key: String)
     fun hasValue(key: String): Boolean
-    fun putString(key: String, value: String)
-    fun putString(key: String, value: () -> String) = putString(key, value())
+    fun putString(key: String, value: String?)
+    fun putString(key: String, value: () -> String?) = putString(key, value())
     fun getString(key: String): String?
 
     fun <T> putSerializable(key: String, value: T, kSerializer: KSerializer<T>)
@@ -26,7 +26,7 @@ class KaliumPreferencesSettings(
 
     override fun hasValue(key: String) = encryptedSettings.keys.contains(key)
 
-    override fun putString(key: String, value: String) {
+    override fun putString(key: String, value: String?) {
         encryptedSettings[key] = value
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/event/EventInfoStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/event/EventInfoStorageTest.kt
@@ -1,0 +1,60 @@
+package com.wire.kalium.persistence.event
+
+import com.russhwolf.settings.MockSettings
+import com.russhwolf.settings.Settings
+import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EventInfoStorageTest {
+
+    private val mockSettings: Settings = MockSettings()
+    private val kaliumPreferences = KaliumPreferencesSettings(mockSettings)
+
+    private lateinit var eventInfoStorage: EventInfoStorage
+
+    @BeforeTest
+    fun setup(){
+        mockSettings.clear()
+        eventInfoStorage = EventInfoStorage(kaliumPreferences)
+    }
+
+    @Test
+    fun givenNoEventIdWasSaved_whenGettingTheLastEventId_thenResultShouldBeNull(){
+        assertNull(eventInfoStorage.lastProcessedId)
+    }
+
+    @Test
+    fun givenAnEventIdWasSaved_whenGettingTheLastEventId_thenTheSavedIdShouldBeReturned(){
+        val testId = "😎EventId"
+        eventInfoStorage.lastProcessedId = testId
+
+        val result = eventInfoStorage.lastProcessedId
+
+        assertEquals(testId, result)
+    }
+
+    @Test
+    fun givenTheLastIdWasUpdatedMultipleTimes_whenGettingTheLastEventId_thenTheLatestIdShouldBeReturned(){
+        val latestId = "sold"
+        eventInfoStorage.lastProcessedId = "give it once"
+        eventInfoStorage.lastProcessedId = "give it twice"
+        eventInfoStorage.lastProcessedId = latestId
+
+        val result = eventInfoStorage.lastProcessedId
+
+        assertEquals(latestId, result)
+    }
+
+    @Test
+    fun givenTheLastIdExisted_andWasUpdatedToNull_whenGettingTheLastEventId_thenNullShouldBeReturned(){
+        eventInfoStorage.lastProcessedId = "give it once"
+        eventInfoStorage.lastProcessedId = null
+
+        val result = eventInfoStorage.lastProcessedId
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Even though we already have a global preferences/storage to store the multiple sessions, we also need one storage PER session. 
For example, when dealing with processing of events, we need to store info about the latest event that was processed.

### Solutions

Expanded on @MohamadJaara's work for settings/preferences and created one instance of `KaliumSettings` per `UserScope`.
Based on it, created an `EventInfoStorage` that can hold an ID of the latest processed event.

### Testing

Added tests for the new `EventInfoStorage`.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
