### PR TITLE
feat: support for performing long running tasks 

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(Dependencies.Android.activityCompose)
     implementation(Dependencies.Android.composeMaterial)
     implementation(Dependencies.Android.coroutines)
+    implementation(Dependencies.Android.work)
     implementation(Dependencies.Android.ktor)
     implementation(Dependencies.Ktor.okHttp)
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
           package="com.wire.kalium">
+
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
@@ -21,6 +23,19 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <provider
+                android:name="androidx.startup.InitializationProvider"
+                android:authorities="${applicationId}.androidx-startup"
+                android:exported="false"
+                tools:node="merge">
+
+            <meta-data
+                    android:name="androidx.work.WorkManagerInitializer"
+                    android:value="androidx.startup"
+                    tools:node="remove" />
+
+        </provider>
 
     </application>
 </manifest>

--- a/android/src/main/kotlin/com/wire/kalium/KaliumApplication.kt
+++ b/android/src/main/kotlin/com/wire/kalium/KaliumApplication.kt
@@ -1,5 +1,28 @@
 package com.wire.kalium
 
 import android.app.Application
+import androidx.work.*
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.sync.WrapperWorkerFactory
+import java.io.File
 
-class KaliumApplication: Application()
+class KaliumApplication: Application(), Configuration.Provider {
+
+    lateinit var coreLogic: CoreLogic
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val rootProteusDir = File(this.filesDir, "proteus")
+        coreLogic = CoreLogic(applicationContext, "kalium", rootProteusDir.absolutePath)
+    }
+
+    override fun getWorkManagerConfiguration(): Configuration {
+        val myWorkerFactory = WrapperWorkerFactory(coreLogic)
+
+        return Configuration.Builder()
+            .setWorkerFactory(myWorkerFactory)
+            .build()
+    }
+
+}

--- a/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
+++ b/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
@@ -6,10 +6,19 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.lifecycleScope
+import com.wire.kalium.KaliumApplication
 import com.wire.kalium.cryptography.CryptoClientId
 import com.wire.kalium.cryptography.CryptoSessionId
 import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.cryptography.UserId
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.auth.AuthSession
+import com.wire.kalium.logic.feature.auth.AuthenticationResult
+import com.wire.kalium.logic.feature.auth.AuthenticationScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import java.io.File
 
@@ -18,48 +27,41 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val rootProteusDir = File(this.filesDir, "proteus")
-        val decryptedMessage = encryptAndDecrypt(rootProteusDir)
+        loginAndFetchConverationList((application as KaliumApplication).coreLogic)
+    }
 
-        setContent {
-            MainLayout(decryptedMessage.toString(Charsets.UTF_8))
+    fun loginAndFetchConverationList(coreLogic: CoreLogic) = lifecycleScope.launchWhenCreated {
+        login(coreLogic.getAuthenticationScope())?.let {
+            val conversations = fetchConversations(coreLogic.getSessionScope(it), it)
+
+            setContent {
+                MainLayout(conversations)
+            }
         }
     }
 
-    fun encryptAndDecrypt(rootProteusDir: File): ByteArray = runBlocking {
-        val alice = SampleUser("aliceId", "Alice")
-        val aliceFile = File(rootProteusDir, alice.id)
-        aliceFile.mkdirs()
-        val aliceClient = ProteusClient(rootProteusDir.absolutePath, alice.id)
-        aliceClient.open()
-        val aliceSessionId = CryptoSessionId(UserId(alice.id), CryptoClientId("aliceClient"))
-        val aliceKey = aliceClient.newPreKeys(0, 10).first()
+    suspend fun login(authenticationScope: AuthenticationScope): AuthSession? {
+        val result = authenticationScope.loginUsingEmail("jacob.persson+summer1@wire.com", "hepphepp", false)
 
-        val bob = SampleUser("bobId", "Bob")
-        val bobFile = File(rootProteusDir, bob.id)
-        bobFile.mkdirs()
-        val bobClient = ProteusClient(rootProteusDir.absolutePath, bob.id)
-        val bobSessionId = CryptoSessionId(UserId(bob.id), CryptoClientId("bobClient"))
-        bobClient.open()
+        if (result !is AuthenticationResult.Success) {
+            throw RuntimeException(
+                "There was an error on the login :(" +
+                        "Check the credentials and the internet connection and try again"
+            )
+        }
 
-        bobClient.createSession(aliceKey, aliceSessionId)
-        val message = "Oi Alice!"
-        val encryptedMessage = bobClient.encrypt(message.toByteArray(Charsets.UTF_8), aliceSessionId)!!
-        val decryptedMessage = aliceClient.decrypt(encryptedMessage, bobSessionId)
-
-        return@runBlocking decryptedMessage
+        return result.userSession
     }
 
-    data class SampleUser(val id: String, val name: String)
+    suspend fun fetchConversations(userSessionScope: UserSessionScope, session: AuthSession): List<Conversation> {
+        return userSessionScope.conversations.getConversations().first()
+    }
 }
 
-data class SampleUser(val id: String, val name: String)
-
-
 @Composable
-fun MainLayout(messageFromBob: String) {
+fun MainLayout(conversations: List<Conversation>) {
     Column {
-        Text("Bob said:")
-        Text(messageFromBob)
+        Text("Conversation count:")
+        Text("${conversations.size}")
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -18,6 +18,7 @@ object Versions {
     const val okHttp = "4.9.3"
     const val kotest = "4.6.3"
     const val mockative = "1.1.4"
+    const val androidWork = "2.7.1"
     const val androidTestRunner = "1.4.0"
     const val androidTestRules = "1.4.0"
     const val androidTestCore = "1.4.0"
@@ -71,6 +72,7 @@ object Dependencies {
     object Android {
         const val appCompat = "androidx.appcompat:appcompat:${Versions.appCompat}"
         const val activityCompose = "androidx.activity:activity-compose:${Versions.activityCompose}"
+        const val work = "androidx.work:work-runtime-ktx:${Versions.androidWork}"
         const val composeMaterial = "androidx.compose.material:material:${Versions.compose}"
         const val composeTooling = "androidx.compose.ui:ui-tooling:${Versions.compose}"
         const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
                     }
                 }
                 implementation(Dependencies.Coroutines.core)
+                implementation(Dependencies.Kotlinx.serialization)
                 // the Dependency is duplicated between here and persistence build.gradle.kts
                 implementation(Dependencies.MultiplatformSettings.settings)
             }
@@ -62,11 +63,16 @@ kotlin {
         }
         val jvmMain by getting
         val jvmTest by getting
-        val androidMain by getting
+        val androidMain by getting {
+            dependencies {
+                implementation(Dependencies.Android.work)
+            }
+        }
         val androidTest by getting
     }
 }
 
 dependencies {
+    implementation("androidx.work:work-runtime-ktx:2.5.0")
     ksp(Dependencies.Test.mockativeProcessor)
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -7,6 +7,8 @@ import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.UserSessionScopeCommon
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.auth.AuthenticationScope
+import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.logic.sync.WorkScheduler
 import com.wire.kalium.network.AuthenticatedNetworkContainer
 
 /**
@@ -24,10 +26,12 @@ actual class CoreLogic(
         val dataSourceSet = userScopeStorage[session] ?: run {
             val networkContainer = AuthenticatedNetworkContainer(sessionMapper.toSessionCredentials(session))
             val proteusClient = ProteusClient(rootProteusDirectoryPath, session.userId)
-            AuthenticatedDataSourceSet(networkContainer, proteusClient).also {
+            val workScheduler = WorkScheduler(applicationContext, session)
+            val syncManager = SyncManager(workScheduler)
+            AuthenticatedDataSourceSet(networkContainer, proteusClient, workScheduler, syncManager).also {
                 userScopeStorage[session] = it
             }
         }
-        return UserSessionScope(applicationContext, dataSourceSet)
+        return UserSessionScope(applicationContext, session, dataSourceSet)
     }
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -3,6 +3,8 @@ package com.wire.kalium.logic.feature
 import android.content.Context
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
+import com.wire.kalium.logic.feature.auth.AuthSession
+import com.wire.kalium.logic.sync.WorkScheduler
 import com.wire.kalium.persistence.db.Database
 
 /**
@@ -11,9 +13,9 @@ import com.wire.kalium.persistence.db.Database
  */
 actual class UserSessionScope(
     private val applicationContext: Context,
+    private val session: AuthSession,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet
 ) : UserSessionScopeCommon(authenticatedDataSourceSet) {
-
     override val clientConfig: ClientConfig get() = ClientConfig(applicationContext)
     override val database: Database get() = Database(applicationContext, "main.db", "123456789")
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
@@ -1,0 +1,79 @@
+package com.wire.kalium.logic.sync
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ListenableWorker
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.auth.AuthSession
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.reflect.KClass
+
+
+class WrapperWorker(private val innerWorker: UserSessionWorker, appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        return when (innerWorker.doWork()) {
+            is com.wire.kalium.logic.sync.Result.Success -> {
+                return Result.success()
+            }
+            is com.wire.kalium.logic.sync.Result.Failure -> {
+                return Result.failure()
+            }
+            is com.wire.kalium.logic.sync.Result.Retry -> {
+                return Result.retry()
+            }
+        }
+    }
+
+}
+
+class WrapperWorkerFactory(private val coreLogic: CoreLogic): WorkerFactory() {
+
+    override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters): ListenableWorker? {
+        val userSessionEncoded = workerParameters.inputData.getString(WrapperWorkerFactory.SESSION_KEY)
+        val innerWorkerClassName = workerParameters.inputData.getString(WrapperWorkerFactory.WORKER_CLASS_KEY)
+
+        if (userSessionEncoded == null || innerWorkerClassName == null) {
+            throw RuntimeException("No session was specified")
+        }
+
+        val userSession: AuthSession = Json.decodeFromString(userSessionEncoded)
+        val constructor = Class.forName(innerWorkerClassName).getDeclaredConstructor(UserSessionScope::class.java)
+        val innerWorker = constructor.newInstance(coreLogic.getSessionScope(userSession))
+        return WrapperWorker(innerWorker as UserSessionWorker, appContext, workerParameters)
+    }
+
+    companion object {
+        const val WORKER_CLASS_KEY = "worker_class"
+        const val SESSION_KEY = "session" +
+                ""
+    }
+
+}
+
+actual class WorkScheduler(private val context: Context, private val session: AuthSession) {
+
+    actual fun schedule(work: KClass<out UserSessionWorker>, name: String) {
+        val inputData = Data.Builder()
+            .putString(WrapperWorkerFactory.WORKER_CLASS_KEY, work.java.canonicalName)
+            .putString(WrapperWorkerFactory.SESSION_KEY, Json.encodeToString(session))
+            .build()
+        val request = OneTimeWorkRequest.Builder(WrapperWorker::class.java).setInputData(inputData).build()
+
+        WorkManager.getInstance(context).beginUniqueWork(
+            name,
+            ExistingWorkPolicy.REPLACE,
+            request
+        ).enqueue()
+    }
+
+}

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
@@ -39,6 +39,10 @@ class WrapperWorker(private val innerWorker: UserSessionWorker, appContext: Cont
 class WrapperWorkerFactory(private val coreLogic: CoreLogic): WorkerFactory() {
 
     override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters): ListenableWorker? {
+        if (WrapperWorker::class.java.canonicalName != workerClassName) {
+            return null // delegate to default factory
+        }
+
         val userSessionEncoded = workerParameters.inputData.getString(WrapperWorkerFactory.SESSION_KEY)
         val innerWorkerClassName = workerParameters.inputData.getString(WrapperWorkerFactory.WORKER_CLASS_KEY)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/AuthenticatedDataSourceSet.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/AuthenticatedDataSourceSet.kt
@@ -1,9 +1,13 @@
 package com.wire.kalium.logic
 
 import com.wire.kalium.cryptography.ProteusClient
+import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.logic.sync.WorkScheduler
 import com.wire.kalium.network.AuthenticatedNetworkContainer
 
 class AuthenticatedDataSourceSet(
     val authenticatedNetworkContainer: AuthenticatedNetworkContainer,
-    val proteusClient: ProteusClient
+    val proteusClient: ProteusClient,
+    val workScheduler: WorkScheduler,
+    val syncManager: SyncManager
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.data.prekey.PreKeyMapper
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.conversation.ConversationScope
 import com.wire.kalium.logic.feature.message.MessageScope
+import com.wire.kalium.logic.sync.WorkScheduler
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.persistence.db.Database
 
@@ -32,7 +33,6 @@ abstract class UserSessionScopeCommon(
     private val idMapper: IdMapper get() = IdMapperImpl()
     private val memberMapper: MemberMapper get() = MemberMapperImpl(idMapper)
     private val conversationMapper: ConversationMapper get() = ConversationMapperImpl(idMapper, memberMapper)
-    private val syncManager: SyncManager get() = SyncManager(conversations.syncConversations)
     protected abstract val database: Database
 
     private val conversationRepository: ConversationRepository
@@ -60,7 +60,8 @@ abstract class UserSessionScopeCommon(
     private val clientRepository: ClientRepository
         get() = ClientRepositoryImpl(clientRemoteDataSource)
 
+    val syncManager: SyncManager get() = authenticatedDataSourceSet.syncManager
     val client: ClientScope get() = ClientScope(clientRepository)
-    val conversations: ConversationScope get() = ConversationScope(conversationRepository, syncManager)
+    val conversations: ConversationScope get() = ConversationScope(conversationRepository, authenticatedDataSourceSet.syncManager)
     val messages: MessageScope get() = MessageScope(messageRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthSession.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthSession.kt
@@ -1,5 +1,8 @@
 package com.wire.kalium.logic.feature.auth
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class AuthSession(
     val userId: String,
     val accessToken: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
@@ -1,0 +1,28 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.suspending
+
+class SlowSyncWorker(userSessionScope: UserSessionScope) : UserSessionWorker(userSessionScope) {
+
+    override suspend fun doWork(): Result = suspending {
+
+        val result = userSessionScope.conversations.syncConversations()
+            .onSuccess { userSessionScope.syncManager.completeSlowSync() }
+
+        when ( result ) {
+            is Either.Left -> {
+                return@suspending Result.Failure
+            }
+            is Either.Right -> {
+                return@suspending Result.Success
+            }
+        }
+    }
+
+    companion object {
+        const val name: String = "SLOW_SYNC"
+    }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -1,58 +1,39 @@
 package com.wire.kalium.logic.sync
 
-import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.feature.conversation.SyncConversationsUseCase
-import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.onSuccess
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.updateAndGet
 
 enum class SyncState {
     WAITING,
     SLOW_SYNC,
-    FETCHING_CONVERSATIONS,
     COMPLETED,
 }
 
-class SyncManager(private val syncConversationsUseCase: SyncConversationsUseCase) {
+class SyncManager(private val workScheduler: WorkScheduler) {
 
     private val internalSyncState = MutableStateFlow(SyncState.WAITING)
-    private var syncJob: Job? = null
 
-    suspend fun performSlowSync(): Either<CoreFailure, Unit> {
-        internalSyncState.update { SyncState.FETCHING_CONVERSATIONS }
-
-        return syncConversationsUseCase()
-            .onSuccess { internalSyncState.update { SyncState.COMPLETED } }
+    fun completeSlowSync() {
+        internalSyncState.update { SyncState.COMPLETED }
     }
 
     suspend fun waitForSlowSyncToComplete() {
-        startSyncJobIfNotAlreadyRunning()
         startSlowSyncIfNotAlreadyCompletedOrRunning()
-
         internalSyncState.first { it == SyncState.COMPLETED }
     }
 
-    private suspend fun startSyncJobIfNotAlreadyRunning() {
-        if (syncJob != null) {
-            return
-        }
-
-        // TODO should be executed by the WorkerManager(Android) / BackgroundTask(iOS)
-        syncJob = GlobalScope.launch {
-            internalSyncState.filter { it == SyncState.SLOW_SYNC }.collect {
-                performSlowSync()
+    private fun startSlowSyncIfNotAlreadyCompletedOrRunning() {
+        val syncState = internalSyncState.updateAndGet {
+            when (it) {
+                SyncState.WAITING -> SyncState.SLOW_SYNC
+                else -> it
             }
         }
-    }
 
-    private fun startSlowSyncIfNotAlreadyCompletedOrRunning() {
-        internalSyncState.compareAndSet(SyncState.WAITING, SyncState.SLOW_SYNC)
+        if (syncState == SyncState.SLOW_SYNC) {
+            workScheduler.schedule(SlowSyncWorker::class, SlowSyncWorker.name)
+        }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/UserSessionWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/UserSessionWorker.kt
@@ -1,0 +1,15 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logic.feature.UserSessionScope
+
+sealed class Result {
+    object Success : Result()
+    object Failure : Result()
+    object Retry : Result()
+}
+
+abstract class UserSessionWorker(val userSessionScope: UserSessionScope) {
+
+    abstract suspend fun doWork(): Result
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logic.feature.auth.AuthSession
+import kotlin.reflect.KClass
+
+expect class WorkScheduler {
+
+    fun schedule(work: KClass<out UserSessionWorker>, name: String)
+
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -11,6 +11,4 @@ actual class UserSessionScope(
     override val clientConfig: ClientConfig get() = ClientConfig()
     override val database: Database
         get() = Database()
-    override val workScheduler: WorkScheduler
-        get() = WorkScheduler()
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.feature
 
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
+import com.wire.kalium.logic.sync.WorkScheduler
 import com.wire.kalium.persistence.db.Database
 
 actual class UserSessionScope(
@@ -10,4 +11,6 @@ actual class UserSessionScope(
     override val clientConfig: ClientConfig get() = ClientConfig()
     override val database: Database
         get() = Database()
+    override val workScheduler: WorkScheduler
+        get() = WorkScheduler()
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
@@ -1,0 +1,16 @@
+package com.wire.kalium.logic.sync
+
+import kotlin.reflect.KClass
+
+actual class WorkScheduler {
+
+    actual fun schedule(
+        work: KClass<out UserSessionWorker>,
+        name: String,
+        sessionId: String
+    ) {
+        val worker = work.java.getDeclaredConstructor().newInstance()
+        worker.doWork()
+    }
+
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/sync/WorkScheduler.kt
@@ -1,16 +1,23 @@
 package com.wire.kalium.logic.sync
 
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.auth.AuthSession
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
-actual class WorkScheduler {
+actual class WorkScheduler(private val coreLogic: CoreLogic, private val session: AuthSession) {
 
     actual fun schedule(
         work: KClass<out UserSessionWorker>,
-        name: String,
-        sessionId: String
+        name: String
     ) {
-        val worker = work.java.getDeclaredConstructor().newInstance()
-        worker.doWork()
+        GlobalScope.launch {
+            val constructor = work::class.java.getDeclaredConstructor(UserSessionScope::class.java)
+            val worker = constructor.newInstance(coreLogic.getSessionScope(session)) as UserSessionWorker
+            worker.doWork()
+        }
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Certain operations like performing the slow sync / quick sync / sending messages needs to be continue running in the background after the user has closed the Wire application.

### Solutions

Performing a long running operation on Android can be achieved by using the `WorkManager` to schedule a work item which gets executed independently from activity which scheduled it. 

On iOS you request for the application to continue running in the background by [creating a background task](https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtaskwithexpiratio). A background task doesn't necessarily need to run in a separate thread. 

On the web "application" doesn't get put in the background so this is not an issue here. 

---

The API with the most constraints come from the WorkManager so I started by trying to abstract it in way a that we can keep 
the operation logic in the common. Since the WorkManager doesn't let you instantiate the work classes yourself it's annoying to inject dependencies.  My solution is surely not the best so I'm very open for other suggestions.

### Dependencies (Optional)

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/192

### Testing

Not yet implemented

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
