### PR TITLE
feat: persist client id after registration

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -15,7 +15,7 @@ sealed class CoreFailure {
     object ServerMiscommunication : CoreFailure()
 
     /**
-     * The operation in attempt requires that this client is registered.
+     * The attempted operation requires that this client is registered.
      */
     object MissingClientRegistration : CoreFailure()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -14,6 +14,11 @@ sealed class CoreFailure {
      */
     object ServerMiscommunication : CoreFailure()
 
+    /**
+     * The operation in attempt requires that this client is registered.
+     */
+    object MissingClientRegistration : CoreFailure()
+
     class Unknown(val rootCause: Throwable?) : CoreFailure()
 
     abstract class FeatureFailure : CoreFailure()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.client
 
 import com.wire.kalium.logic.configuration.ClientConfig
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.location.LocationMapper
 import com.wire.kalium.logic.data.prekey.PreKeyMapper
 import com.wire.kalium.network.api.user.client.ClientCapabilityDTO
@@ -27,7 +28,7 @@ class ClientMapper(
     )
 
     fun fromRegisterClientResponse(response: RegisterClientResponse): Client = Client(
-        clientId = response.clientId,
+        clientId = ClientId(response.clientId),
         type = fromClientTypeDTO(response.type),
         registrationTime = response.registrationTime,
         location = locationMapper.fromLocationDTO(response.location),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.client
 
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.location.Location
 import com.wire.kalium.logic.data.prekey.PreKey
 
@@ -11,7 +12,7 @@ data class RegisterClientParam(
 )
 
 data class Client(
-    val clientId: String,
+    val clientId: ClientId,
     val type: ClientType,
     val registrationTime: String, // yyyy-mm-ddThh:MM:ss.qqq
     val location: Location?,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -1,8 +1,11 @@
 package com.wire.kalium.logic.data.client
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.functional.Either
 
 interface ClientRepository {
     suspend fun registerClient(param: RegisterClientParam): Either<CoreFailure, Client>
+    suspend fun persistClientId(clientId: ClientId): Either<CoreFailure, Unit>
+    suspend fun currentClientId(): Either<CoreFailure, ClientId>
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryImpl.kt
@@ -2,11 +2,25 @@ package com.wire.kalium.logic.data.client
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.remote.ClientRemoteDataSource
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.persistence.client.ClientRegistrationStorage
 
 class ClientRepositoryImpl(
-    private val clientRemoteDataSource: ClientRemoteDataSource
+    private val clientRemoteDataSource: ClientRemoteDataSource,
+    private val clientRegistrationStorage: ClientRegistrationStorage
 ) : ClientRepository {
     override suspend fun registerClient(param: RegisterClientParam): Either<CoreFailure, Client> =
         clientRemoteDataSource.registerClient(param)
+
+    override suspend fun persistClientId(clientId: ClientId): Either<CoreFailure, Unit> {
+        clientRegistrationStorage.registeredClientId = clientId.value
+        return Either.Right(Unit)
+    }
+
+    override suspend fun currentClientId(): Either<CoreFailure, ClientId> {
+        return clientRegistrationStorage.registeredClientId?.let { clientId ->
+            Either.Right(ClientId(clientId))
+        } ?: Either.Left(CoreFailure.MissingClientRegistration)
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -28,7 +28,7 @@ import com.wire.kalium.persistence.event.EventInfoStorage
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 
-expect class UserSessionScope : UserSessionScopeCommon
+expect class UserSessionScope: UserSessionScopeCommon
 
 abstract class UserSessionScopeCommon(
     private val session: AuthSession,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -22,10 +22,9 @@ import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.conversation.ConversationScope
 import com.wire.kalium.logic.feature.message.MessageScope
+import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
 import com.wire.kalium.persistence.client.ClientRegistrationStorageImpl
-import com.wire.kalium.logic.sync.WorkScheduler
-import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.persistence.db.Database
 import com.wire.kalium.persistence.event.EventInfoStorage
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -28,7 +28,7 @@ import com.wire.kalium.persistence.event.EventInfoStorage
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 
-expect class UserSessionScope: UserSessionScopeCommon
+expect class UserSessionScope : UserSessionScopeCommon
 
 abstract class UserSessionScopeCommon(
     private val session: AuthSession,
@@ -37,7 +37,8 @@ abstract class UserSessionScopeCommon(
 
     protected abstract val encryptedSettingsHolder: EncryptedSettingsHolder
     private val userPreferencesSettings = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
-    private val eventInfoStorage = EventInfoStorage(userPreferencesSettings)
+    private val eventInfoStorage: EventInfoStorage
+        get() = EventInfoStorage(userPreferencesSettings)
 
     private val idMapper: IdMapper get() = IdMapperImpl()
     private val memberMapper: MemberMapper get() = MemberMapperImpl(idMapper)
@@ -64,7 +65,8 @@ abstract class UserSessionScopeCommon(
             clientMapper
         )
 
-    private val clientRegistrationStorage: ClientRegistrationStorage = ClientRegistrationStorageImpl(userPreferencesSettings)
+    private val clientRegistrationStorage: ClientRegistrationStorage
+        get() = ClientRegistrationStorageImpl(userPreferencesSettings)
 
     private val clientRepository: ClientRepository
         get() = ClientRepositoryImpl(clientRemoteDataSource, clientRegistrationStorage)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -22,11 +22,13 @@ import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.conversation.ConversationScope
 import com.wire.kalium.logic.feature.message.MessageScope
+import com.wire.kalium.persistence.client.ClientRegistrationStorage
+import com.wire.kalium.persistence.client.ClientRegistrationStorageImpl
 import com.wire.kalium.persistence.event.EventInfoStorage
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 
-expect class UserSessionScope: UserSessionScopeCommon
+expect class UserSessionScope : UserSessionScopeCommon
 
 abstract class UserSessionScopeCommon(
     private val session: AuthSession,
@@ -62,8 +64,10 @@ abstract class UserSessionScopeCommon(
             clientMapper
         )
 
+    private val clientRegistrationStorage: ClientRegistrationStorage = ClientRegistrationStorageImpl(userPreferencesSettings)
+
     private val clientRepository: ClientRepository
-        get() = ClientRepositoryImpl(clientRemoteDataSource)
+        get() = ClientRepositoryImpl(clientRemoteDataSource, clientRegistrationStorage)
 
     val client: ClientScope get() = ClientScope(clientRepository)
     val conversations: ConversationScope get() = ConversationScope(conversationRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.RegisterClientParam
 import com.wire.kalium.logic.failure.AuthenticationFailure
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.suspending
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -12,8 +13,16 @@ class RegisterClientUseCase(
     private val clientRepository: ClientRepository
 ) {
     suspend operator fun invoke(param: RegisterClientParam): Flow<RegisterClientResult> = flow {
+        //TODO Should we fail here if the client is already registered?
         when (val result = clientRepository.registerClient(param)) {
-            is Either.Right -> emit(RegisterClientResult.Success(result.value))
+            is Either.Right -> {
+                suspending {
+                    result.flatMap {
+                        clientRepository.persistClientId(it.clientId)
+                    }
+                }
+                emit(RegisterClientResult.Success(result.value))
+            }
 
             is Either.Left -> {
                 if (result.value is AuthenticationFailure)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -3,33 +3,25 @@ package com.wire.kalium.logic.feature.client
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.RegisterClientParam
 import com.wire.kalium.logic.failure.AuthenticationFailure
-import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 
 
-class RegisterClientUseCase(
-    private val clientRepository: ClientRepository
-) {
-    suspend operator fun invoke(param: RegisterClientParam): Flow<RegisterClientResult> = flow {
+class RegisterClientUseCase(private val clientRepository: ClientRepository) {
+
+    suspend operator fun invoke(param: RegisterClientParam): RegisterClientResult = suspending {
         //TODO Should we fail here if the client is already registered?
-        when (val result = clientRepository.registerClient(param)) {
-            is Either.Right -> {
-                suspending {
-                    result.flatMap {
-                        clientRepository.persistClientId(it.clientId)
-                    }
-                }
-                emit(RegisterClientResult.Success(result.value))
-            }
-
-            is Either.Left -> {
-                if (result.value is AuthenticationFailure)
-                    emit(RegisterClientResult.Failure.InvalidCredentials)
-                else
-                    emit(RegisterClientResult.Failure.Generic(result.value))
+        clientRepository.registerClient(param).flatMap { client ->
+            clientRepository.persistClientId(client.clientId).map {
+                client
             }
         }
-    }
+    }.fold({ failure ->
+        if (failure is AuthenticationFailure)
+            RegisterClientResult.Failure.InvalidCredentials
+        else
+            RegisterClientResult.Failure.Generic(failure)
+    }, { client ->
+        RegisterClientResult.Success(client)
+    })!!
+
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -2,7 +2,7 @@ package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.RegisterClientParam
-import com.wire.kalium.logic.failure.AuthenticationFailure
+import com.wire.kalium.logic.failure.WrongPassword
 import com.wire.kalium.logic.functional.suspending
 
 
@@ -16,7 +16,7 @@ class RegisterClientUseCase(private val clientRepository: ClientRepository) {
             }
         }
     }.fold({ failure ->
-        if (failure is AuthenticationFailure)
+        if (failure is WrongPassword)
             RegisterClientResult.Failure.InvalidCredentials
         else
             RegisterClientResult.Failure.Generic(failure)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryImplTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryImplTest.kt
@@ -2,8 +2,8 @@ package com.wire.kalium.logic.data.client
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.remote.ClientRemoteDataSource
-import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.prekey.PreKey
+import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
@@ -128,10 +128,7 @@ class ClientRepositoryImplTest {
 
     private companion object {
         val REGISTER_CLIENT_PARAMS = RegisterClientParam("pass", listOf(), PreKey(2, "2"), listOf())
-        val CLIENT_ID = ClientId("test")
-        val CLIENT_RESULT = Client(
-            CLIENT_ID, ClientType.Permanent, "time", null,
-            null, "label", "cookie", null, "model"
-        )
+        val CLIENT_ID = TestClient.CLIENT_ID
+        val CLIENT_RESULT = TestClient.CLIENT
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryImplTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryImplTest.kt
@@ -1,0 +1,137 @@
+package com.wire.kalium.logic.data.client
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.remote.ClientRemoteDataSource
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.prekey.PreKey
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.persistence.client.ClientRegistrationStorage
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.configure
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+class ClientRepositoryImplTest {
+
+    @Mock
+    private val clientRemoteDataSource = mock(classOf<ClientRemoteDataSource>())
+
+    @Mock
+    private val clientRegistrationStorage = configure(mock(classOf<ClientRegistrationStorage>())) {
+        stubsUnitByDefault = true
+    }
+
+    private lateinit var clientRepository: ClientRepositoryImpl
+
+    @BeforeTest
+    fun setup() {
+        clientRepository = ClientRepositoryImpl(clientRemoteDataSource, clientRegistrationStorage)
+    }
+
+    @Test
+    fun givenClientParams_whenRegisteringClient_thenParamsShouldBePassedCorrectly() = runTest {
+        given(clientRemoteDataSource)
+            .suspendFunction(clientRemoteDataSource::registerClient)
+            .whenInvokedWith(any())
+            .then { Either.Right(CLIENT_RESULT) }
+
+        clientRepository.registerClient(REGISTER_CLIENT_PARAMS)
+
+        verify(clientRemoteDataSource)
+            .suspendFunction(clientRemoteDataSource::registerClient)
+            .with(eq(REGISTER_CLIENT_PARAMS))
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givingRemoteDataSourceFails_whenRegisteringClient_thenTheFailureShouldBePropagated() = runTest {
+        val failure = Either.Left(CoreFailure.NoNetworkConnection)
+        given(clientRemoteDataSource)
+            .suspendFunction(clientRemoteDataSource::registerClient)
+            .whenInvokedWith(any())
+            .then { failure }
+
+        val result = clientRepository.registerClient(REGISTER_CLIENT_PARAMS)
+
+        result.shouldFail {
+            assertSame(failure.value, it)
+        }
+    }
+
+    @Test
+    fun givenRemoteDataSourceSucceed_whenRegisteringClient_thenTheSuccessShouldBePropagated() = runTest {
+        val clientResult = Either.Right(CLIENT_RESULT)
+        given(clientRemoteDataSource)
+            .suspendFunction(clientRemoteDataSource::registerClient)
+            .whenInvokedWith(any())
+            .then { clientResult }
+
+        val result = clientRepository.registerClient(REGISTER_CLIENT_PARAMS)
+
+        result.shouldSucceed {
+            assertSame(clientResult.value, it)
+        }
+    }
+
+    @Test
+    fun givenAClientId_whenPersistingClientId_thenTheStorageShouldBeCalledWithRightParameter() = runTest {
+        val clientId = CLIENT_ID
+
+        clientRepository.persistClientId(clientId)
+
+        verify(clientRegistrationStorage)
+            .setter(clientRegistrationStorage::registeredClientId)
+            .with(eq(clientRepository))
+    }
+
+    @Test
+    fun givenAClientIdIsStored_whenGettingRegisteredClientId_thenTheStoredValueShouldBeReturned() = runTest {
+        val clientId = CLIENT_ID
+        given(clientRegistrationStorage)
+            .getter(clientRegistrationStorage::registeredClientId)
+            .whenInvoked()
+            .then { clientId.value }
+
+        val result = clientRepository.currentClientId()
+
+        result.shouldSucceed {
+            assertEquals(clientId, it)
+        }
+    }
+
+    @Test
+    fun givenNoClientIdIsStored_whenGettingRegisteredClientId_thenShouldFailWithMissingRegistration() = runTest {
+        given(clientRegistrationStorage)
+            .getter(clientRegistrationStorage::registeredClientId)
+            .whenInvoked()
+            .then { null }
+
+        val result = clientRepository.currentClientId()
+
+        result.shouldFail {
+            assertIs<CoreFailure.MissingClientRegistration>(it)
+        }
+    }
+
+    private companion object {
+        val REGISTER_CLIENT_PARAMS = RegisterClientParam("pass", listOf(), PreKey(2, "2"), listOf())
+        val CLIENT_ID = ClientId("test")
+        val CLIENT_RESULT = Client(
+            CLIENT_ID, ClientType.Permanent, "time", null,
+            null, "label", "cookie", null, "model"
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -1,13 +1,26 @@
 package com.wire.kalium.logic.feature.client
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.RegisterClientParam
 import com.wire.kalium.logic.data.prekey.PreKey
+import com.wire.kalium.logic.failure.WrongPassword
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
+import io.mockative.anything
 import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
 import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
 
 class RegisterClientUseCaseTest {
 
@@ -22,39 +35,124 @@ class RegisterClientUseCaseTest {
     }
 
     @Test
-    fun givenRegistrationParams_whenRegistering_thenTheRepositoryShouldBeCalledWithCorrectParameters(){
+    fun givenRegistrationParams_whenRegistering_thenTheRepositoryShouldBeCalledWithCorrectParameters() = runTest {
         val params = REGISTER_PARAMETERS
+        given(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(CoreFailure.ServerMiscommunication) }
 
-        TODO()
+        registerClient(params)
+
+        verify(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .with(eq(params))
+            .wasInvoked(once)
     }
 
     @Test
-    fun givenRepositoryRegistrationFailsDueToWrongCredentials_whenRegistering_thenInvalidCredentialsErrorShouldBeReturned(){
-        TODO()
+    fun givenRepositoryRegistrationFailsDueToWrongPassword_whenRegistering_thenInvalidCredentialsErrorShouldBeReturned() = runTest {
+        val wrongPasswordFailure = WrongPassword
+        given(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(wrongPasswordFailure) }
+
+        val result = registerClient(REGISTER_PARAMETERS)
+
+        assertIs<RegisterClientResult.Failure.InvalidCredentials>(result)
     }
 
     @Test
-    fun givenRepositoryRegistrationFailsDueToGenericError_whenRegistering_thenGenericErrorShouldBeReturned(){
-        TODO()
+    fun givenRepositoryRegistrationFailsDueToGenericError_whenRegistering_thenGenericErrorShouldBeReturned() = runTest {
+        val genericFailure = CoreFailure.NoNetworkConnection
+        given(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(genericFailure) }
+
+        val result = registerClient(REGISTER_PARAMETERS)
+
+        assertIs<RegisterClientResult.Failure.Generic>(result)
+        assertSame(genericFailure, result.genericFailure)
     }
 
     @Test
-    fun givenRepositoryRegistrationFails_whenRegistering_thenNoPersistenceShouldBeDone(){
-        TODO()
+    fun givenRepositoryRegistrationFails_whenRegistering_thenNoPersistenceShouldBeDone() = runTest {
+        given(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(CoreFailure.ServerMiscommunication) }
+
+        registerClient(REGISTER_PARAMETERS)
+
+        verify(clientRepository)
+            .suspendFunction(clientRepository::persistClientId)
+            .with(anything())
+            .wasNotInvoked()
     }
 
     @Test
-    fun givenPersistingClientIdFails_whenRegistering_thenTheFailureShouldBePropagated(){
-        TODO()
+    fun givenRegisteringSucceeds_whenRegistering_thenThePersistenceShouldBeCalledWithCorrectId() = runTest {
+        val registeredClient = CLIENT
+        given(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .whenInvokedWith(anything())
+            .then { Either.Right(registeredClient) }
+
+        given(clientRepository)
+            .suspendFunction(clientRepository::persistClientId)
+            .whenInvokedWith(anything())
+            .then { Either.Right(Unit) }
+
+        registerClient(REGISTER_PARAMETERS)
+
+        verify(clientRepository)
+            .suspendFunction(clientRepository::persistClientId)
+            .with(eq(registeredClient.clientId))
+            .wasInvoked(once)
     }
 
     @Test
-    fun givenRegisteringSucceedsAndPersistingClientIdSucceeds_whenRegistering_thenTheFailureShouldBePropagated(){
-        TODO()
+    fun givenRegisteringSucceedsAndPersistingClientIdFails_whenRegistering_thenTheFailureShouldBePropagated() = runTest {
+        given(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .whenInvokedWith(anything())
+            .then { Either.Right(CLIENT) }
+
+        val persistFailure = CoreFailure.ServerMiscommunication
+        given(clientRepository)
+            .suspendFunction(clientRepository::persistClientId)
+            .whenInvokedWith(anything())
+            .then { Either.Left(persistFailure) }
+
+        val result = registerClient(REGISTER_PARAMETERS)
+
+        assertIs<RegisterClientResult.Failure.Generic>(result)
+        assertEquals(persistFailure, result.genericFailure)
     }
 
+    @Test
+    fun givenRegisteringSucceedsAndPersistingClientIdSucceeds_whenRegistering_thenSuccessShouldBePropagated() = runTest {
+        val registeredClient = CLIENT
+        given(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .whenInvokedWith(anything())
+            .then { Either.Right(CLIENT) }
 
-    private companion object{
+        given(clientRepository)
+            .suspendFunction(clientRepository::persistClientId)
+            .whenInvokedWith(anything())
+            .then { Either.Right(Unit) }
+
+        val result = registerClient(REGISTER_PARAMETERS)
+
+        assertIs<RegisterClientResult.Success>(result)
+        assertEquals(registeredClient, result.client)
+    }
+
+    private companion object {
         val REGISTER_PARAMETERS = RegisterClientParam("pass", listOf(), PreKey(2, "42"), null)
+        val CLIENT = TestClient.CLIENT
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -1,0 +1,60 @@
+package com.wire.kalium.logic.feature.client
+
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.client.RegisterClientParam
+import com.wire.kalium.logic.data.prekey.PreKey
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.mock
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class RegisterClientUseCaseTest {
+
+    @Mock
+    private val clientRepository = mock(classOf<ClientRepository>())
+
+    private lateinit var registerClient: RegisterClientUseCase
+
+    @BeforeTest
+    fun setup() {
+        registerClient = RegisterClientUseCase(clientRepository)
+    }
+
+    @Test
+    fun givenRegistrationParams_whenRegistering_thenTheRepositoryShouldBeCalledWithCorrectParameters(){
+        val params = REGISTER_PARAMETERS
+
+        TODO()
+    }
+
+    @Test
+    fun givenRepositoryRegistrationFailsDueToWrongCredentials_whenRegistering_thenInvalidCredentialsErrorShouldBeReturned(){
+        TODO()
+    }
+
+    @Test
+    fun givenRepositoryRegistrationFailsDueToGenericError_whenRegistering_thenGenericErrorShouldBeReturned(){
+        TODO()
+    }
+
+    @Test
+    fun givenRepositoryRegistrationFails_whenRegistering_thenNoPersistenceShouldBeDone(){
+        TODO()
+    }
+
+    @Test
+    fun givenPersistingClientIdFails_whenRegistering_thenTheFailureShouldBePropagated(){
+        TODO()
+    }
+
+    @Test
+    fun givenRegisteringSucceedsAndPersistingClientIdSucceeds_whenRegistering_thenTheFailureShouldBePropagated(){
+        TODO()
+    }
+
+
+    private companion object{
+        val REGISTER_PARAMETERS = RegisterClientParam("pass", listOf(), PreKey(2, "42"), null)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestClient.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestClient.kt
@@ -1,0 +1,14 @@
+package com.wire.kalium.logic.framework
+
+import com.wire.kalium.logic.data.client.Client
+import com.wire.kalium.logic.data.client.ClientType
+import com.wire.kalium.logic.data.conversation.ClientId
+
+object TestClient {
+    val CLIENT_ID = ClientId("test")
+
+    val CLIENT = Client(
+        CLIENT_ID, ClientType.Permanent, "time", null,
+        null, "label", "cookie", null, "model"
+    )
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
@@ -1,0 +1,18 @@
+package com.wire.kalium.persistence.client
+
+import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
+
+interface ClientRegistrationStorage {
+    var registeredClientId: String?
+}
+
+class ClientRegistrationStorageImpl(private val kaliumPreferences: KaliumPreferences): ClientRegistrationStorage {
+
+    override var registeredClientId: String?
+        get() = kaliumPreferences.getString(REGISTERED_CLIENT_ID_KEY)
+        set(value) = kaliumPreferences.putString(REGISTERED_CLIENT_ID_KEY, value)
+
+    private companion object {
+        const val REGISTERED_CLIENT_ID_KEY = "registered_client_id"
+    }
+}

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageTest.kt
@@ -1,0 +1,60 @@
+package com.wire.kalium.persistence.client
+
+import com.russhwolf.settings.MockSettings
+import com.russhwolf.settings.Settings
+import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ClientRegistrationStorageTest {
+
+    private val mockSettings: Settings = MockSettings()
+    private val kaliumPreferences = KaliumPreferencesSettings(mockSettings)
+
+    private lateinit var clientRegistrationStorage: ClientRegistrationStorageImpl
+
+    @BeforeTest
+    fun setup(){
+        mockSettings.clear()
+        clientRegistrationStorage = ClientRegistrationStorageImpl(kaliumPreferences)
+    }
+
+    @Test
+    fun givenNoClientIdWasSaved_whenGettingTheLastClientId_thenResultShouldBeNull(){
+        assertNull(clientRegistrationStorage.registeredClientId)
+    }
+
+    @Test
+    fun givenAnClientIdWasSaved_whenGettingTheLastClientId_thenTheSavedIdShouldBeReturned(){
+        val testId = "😎ClientId"
+        clientRegistrationStorage.registeredClientId = testId
+
+        val result = clientRegistrationStorage.registeredClientId
+
+        assertEquals(testId, result)
+    }
+
+    @Test
+    fun givenTheLastIdWasUpdatedMultipleTimes_whenGettingTheLastClientId_thenTheLatestIdShouldBeReturned(){
+        val latestId = "sold"
+        clientRegistrationStorage.registeredClientId = "give it once"
+        clientRegistrationStorage.registeredClientId = "give it twice"
+        clientRegistrationStorage.registeredClientId = latestId
+
+        val result = clientRegistrationStorage.registeredClientId
+
+        assertEquals(latestId, result)
+    }
+
+    @Test
+    fun givenTheLastIdExisted_andWasUpdatedToNull_whenGettingTheLastClientId_thenNullShouldBeReturned(){
+        clientRegistrationStorage.registeredClientId = "give it once"
+        clientRegistrationStorage.registeredClientId = null
+
+        val result = clientRegistrationStorage.registeredClientId
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need the ClientId for a lot of operations, and after successfully calling `registerClient`, we don't store its value anywhere.

### Solutions

* Created key/value `ClientRegistrationStorage` for persist the client id.
* Perform storage after registering in `RegisterClientUseCase`

### Testing

Full coverage for all the layers changed: 
* `ClientRegistrationStorage`
* `ClientRepository`
* `RegisterClientUseCase` (WIP)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
