### PR TITLE
feat: generate and store the DB password in the user preferences

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -19,7 +19,7 @@ actual class UserSessionScope(
 ) : UserSessionScopeCommon(session, authenticatedDataSourceSet) {
 
     override val clientConfig: ClientConfig get() = ClientConfig(applicationContext)
-    override val database: Database get() = Database(applicationContext, "main.db", "123456789")
+    override val database: Database get() = Database(applicationContext, "main.db", userPreferencesSettings)
     override val encryptedSettingsHolder: EncryptedSettingsHolder
         get() = EncryptedSettingsHolder(applicationContext, "$PREFERENCE_FILE_PREFIX-${session.userId}")
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -38,7 +38,7 @@ abstract class UserSessionScopeCommon(
 ) {
 
     protected abstract val encryptedSettingsHolder: EncryptedSettingsHolder
-    private val userPreferencesSettings by lazy { KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings) }
+    protected val userPreferencesSettings by lazy { KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings) }
     private val eventInfoStorage: EventInfoStorage
         get() = EventInfoStorage(userPreferencesSettings)
 

--- a/persistence/src/androidAndroidTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/androidAndroidTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -2,10 +2,13 @@ package com.wire.kalium.persistence
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.russhwolf.settings.MockSettings
 import com.wire.kalium.persistence.db.Database
+import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 
 actual open class BaseDatabaseTest actual constructor() {
     private val name: String = "test.db"
+    private val preferences = KaliumPreferencesSettings(MockSettings())
 
     actual fun deleteDatabase() {
         val context: Context = ApplicationProvider.getApplicationContext()
@@ -13,7 +16,7 @@ actual open class BaseDatabaseTest actual constructor() {
     }
 
     actual fun createDatabase(): Database {
-        return Database(ApplicationProvider.getApplicationContext(), name, "123456789")
+        return Database(ApplicationProvider.getApplicationContext(), name, preferences)
     }
 
 }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/Database.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/Database.kt
@@ -1,20 +1,24 @@
 package com.wire.kalium.persistence.db
 
 import android.content.Context
+import android.os.Build
+import android.util.Base64
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.persistence.dao.ConversationDAOImpl
 import com.wire.kalium.persistence.dao.QualifiedIDAdapter
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.UserDAOImpl
+import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 import net.sqlcipher.database.SupportFactory
+import java.security.SecureRandom
 
-actual class Database(context: Context, name: String, passphrase: String) {
+actual class Database(context: Context, name: String, kaliumPreferences: KaliumPreferences) {
 
     val database: AppDatabase
 
     init {
-        val supportFactory = SupportFactory(passphrase.toByteArray())
+        val supportFactory = SupportFactory(getOrGenerateSecretKey(kaliumPreferences).toByteArray())
         val driver =  AndroidSqliteDriver(AppDatabase.Schema, context, name, factory = supportFactory)
 
         database = AppDatabase(
@@ -29,4 +33,35 @@ actual class Database(context: Context, name: String, passphrase: String) {
 
     actual val conversationDAO: ConversationDAO
         get() = ConversationDAOImpl(database.converationsQueries, database.membersQueries)
+
+    private fun getOrGenerateSecretKey(kaliumPreferences: KaliumPreferences): String {
+        val databaseKey = kaliumPreferences.getString(DATABASE_SECRET_KEY)
+
+        return if (databaseKey == null) {
+            val secretKey = generateSecretKey()
+            kaliumPreferences.putString(DATABASE_SECRET_KEY, secretKey)
+            secretKey
+        } else {
+            databaseKey
+        }
+    }
+
+    private fun generateSecretKey(): String {
+        // TODO review with security
+
+        val random = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            SecureRandom.getInstanceStrong()
+        } else {
+            SecureRandom()
+        }
+        val password = ByteArray(DATABASE_SECRET_LENGTH)
+        random.nextBytes(password)
+
+        return Base64.encodeToString(password, Base64.DEFAULT)
+    }
+
+    companion object {
+        private const val DATABASE_SECRET_KEY = "databaseSecret"
+        private const val DATABASE_SECRET_LENGTH = 48
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We don't the consumer of CoreLib to provide password upon launch.

### Solutions

Generate and store a password for the database in the encrypted user preferences.

### Testing

Base tests class have been updated.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
