### PR TITLE
feat: add UserDetailsApi (part of AR-1030)

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/Handles.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/Handles.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.network.api
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QualifiedHandle(
+    @SerialName("domain") val domain: String,
+    @SerialName("handle") val handle: String
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/LegalHoldStatusResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/LegalHoldStatusResponse.kt
@@ -1,0 +1,16 @@
+package com.wire.kalium.network.api.user
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class LegalHoldStatusResponse {
+    @SerialName("enabled")
+    ENABLED,
+    @SerialName("pending")
+    PENDING,
+    @SerialName("disabled")
+    DISABLED,
+    @SerialName("no_consent")
+    NO_CONSENT
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/details/ListUserRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/details/ListUserRequest.kt
@@ -1,0 +1,25 @@
+package com.wire.kalium.network.api.user.details
+
+import com.wire.kalium.network.api.QualifiedHandle
+import com.wire.kalium.network.api.QualifiedID
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+sealed class ListUserRequest {
+    companion object
+}
+
+fun ListUserRequest.Companion.qualifiedIds(qualifiedIDs: List<QualifiedID>) = QualifiedUserIdListRequest(qualifiedIDs)
+
+@Serializable
+data class QualifiedUserIdListRequest(
+    @SerialName("qualified_ids") val qualifiedIds: List<QualifiedID>
+) : ListUserRequest()
+
+
+fun ListUserRequest.Companion.qualifiedHandles(qualifiedHandles: List<QualifiedHandle>) = QualifiedHandleListRequest(qualifiedHandles)
+
+@Serializable
+data class QualifiedHandleListRequest(
+    @SerialName("qualified_handles") val qualifiedHandles: List<QualifiedHandle>
+) : ListUserRequest()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/details/UserDetailsApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/details/UserDetailsApi.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium.network.api.user.details
+
+import com.wire.kalium.network.utils.NetworkResponse
+
+interface UserDetailsApi {
+
+    suspend fun getMultipleUsers(users: ListUserRequest): NetworkResponse<List<UserDetailsResponse>>
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/details/UserDetailsApiImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/details/UserDetailsApiImp.kt
@@ -1,0 +1,20 @@
+package com.wire.kalium.network.api.user.details
+
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+
+class UserDetailsApiImp(private val httpClient: HttpClient) : UserDetailsApi {
+
+    override suspend fun getMultipleUsers(users: ListUserRequest): NetworkResponse<List<UserDetailsResponse>> = wrapKaliumResponse {
+        httpClient.post(PATH_LIST_USERS) {
+            setBody(users)
+        }
+    }
+
+    private companion object {
+        const val PATH_LIST_USERS = "list-users"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/details/UserDetailsResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/details/UserDetailsResponse.kt
@@ -1,0 +1,18 @@
+package com.wire.kalium.network.api.user.details
+
+import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.model.Asset
+import com.wire.kalium.network.api.user.LegalHoldStatusResponse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserDetailsResponse(
+    @SerialName("qualified_id") val id: UserId,
+    @SerialName("name") val name: String,
+    @SerialName("handle") val handle: String,
+    @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatusResponse,
+    @SerialName("team") val team: String?,
+    @SerialName("accent_id") val accentId: Int,
+    @SerialName("assets") val assets: List<Asset>
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/tools/KtxSerializer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/tools/KtxSerializer.kt
@@ -12,5 +12,9 @@ object KtxSerializer {
         // explicitNulls, defines whether null property
         // values should be included in the serialized JSON string.
         explicitNulls = false
+
+        // If API returns null or unknown values for Enums, we can use default constructor parameter to override it
+        // https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/json.md#coercing-input-values
+        coerceInputValues = true
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -13,11 +13,13 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLProtocol
+import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 interface ApiTest {
@@ -158,13 +160,23 @@ interface ApiTest {
         assertContains(this.body.contentType?.contentType ?: "", contentType.contentType)
 
     // path
-    fun HttpRequestData.assertPathEqual(path: String) = assertEquals(this.url.encodedPath, path)
+    fun HttpRequestData.assertPathEqual(path: String) = assertEquals(path, this.url.encodedPath)
+
+    // body
+    fun HttpRequestData.assertBodyContent(content: String) {
+        assertIs<TextContent>(body)
+        assertEquals(content, (body as TextContent).text)
+    }
 
     // host
     fun HttpRequestData.assertHostEqual(expectedHost: String) = assertEquals(expected = expectedHost, actual = this.url.host)
     fun HttpRequestData.assertHttps() = assertEquals(expected = URLProtocol.HTTPS, actual = this.url.protocol)
 
     private companion object {
-        val TEST_BACKEND_CONFIG = BackendConfig("test.api.com", "test.account.com", "test.ws.com",  "test.blacklist",  "test.teams.com", "test.wire.com")
+        val TEST_BACKEND_CONFIG =
+            BackendConfig(
+                "test.api.com", "test.account.com", "test.ws.com",
+                "test.blacklist", "test.teams.com", "test.wire.com"
+            )
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/details/ListUsersRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/details/ListUsersRequestJson.kt
@@ -1,0 +1,34 @@
+package com.wire.kalium.api.tools.json.api.user.details
+
+import com.wire.kalium.api.tools.json.ValidJsonProvider
+import com.wire.kalium.network.api.QualifiedID
+import com.wire.kalium.network.api.user.details.QualifiedHandleListRequest
+import com.wire.kalium.network.api.user.details.QualifiedUserIdListRequest
+
+object ListUsersRequestJson {
+
+    private val qualifiedIdsProvider = { serializable: QualifiedUserIdListRequest ->
+        val idsArrayContent = serializable.qualifiedIds.joinToString(",") {
+            """{"domain": "${it.domain}", "id":"${it.value}""""
+        }
+        """{"qualified_ids": [$idsArrayContent]}"""
+    }
+    private val qualifiedHandlesProvider = { serializable: QualifiedHandleListRequest ->
+        val handlesArrayContent = serializable.qualifiedHandles.joinToString(",") {
+            """{"domain": "${it.domain}", "handle":"${it.handle}""""
+        }
+        """{"qualified_ids": [$handlesArrayContent]}"""
+    }
+
+    val validIdsJsonProvider = ValidJsonProvider(QualifiedUserIdListRequest(listOf(
+        QualifiedID("id1","domain1"),
+        QualifiedID("id11","domain1"),
+        QualifiedID("id2","domain2")
+    )), qualifiedIdsProvider)
+
+    val validHandlesJsonProvider = ValidJsonProvider(QualifiedUserIdListRequest(listOf(
+        QualifiedID("id1","domain1"),
+        QualifiedID("id11","domain1"),
+        QualifiedID("id2","domain2")
+    )), qualifiedIdsProvider)
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/details/UserDetailsApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/details/UserDetailsApiTest.kt
@@ -1,0 +1,77 @@
+package com.wire.kalium.api.tools.json.api.user.details
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.api.tools.json.model.QualifiedHandleSample
+import com.wire.kalium.api.tools.json.model.QualifiedIDSamples
+import com.wire.kalium.network.api.user.details.ListUserRequest
+import com.wire.kalium.network.api.user.details.UserDetailsApi
+import com.wire.kalium.network.api.user.details.UserDetailsApiImp
+import com.wire.kalium.network.api.user.details.qualifiedHandles
+import com.wire.kalium.network.api.user.details.qualifiedIds
+import com.wire.kalium.network.tools.KtxSerializer
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class UserDetailsApiTest : ApiTest {
+
+    @Test
+    fun givenListOfQualifiedIds_whenGettingListOfUsers_thenBodyShouldSerializeCorrectly() = runTest {
+        val params = ListUserRequest.qualifiedIds(listOf(QualifiedIDSamples.one, QualifiedIDSamples.two))
+        val expectedRequestBody = KtxSerializer.json.encodeToString(params)
+        val httpClient = mockAuthenticatedHttpClient(
+            ListUsersRequestJson.validIdsJsonProvider.rawJson,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertPost()
+                assertJson()
+                assertNoQueryParams()
+                assertPathEqual(PATH_LIST_USERS)
+                assertBodyContent(expectedRequestBody)
+            }
+        )
+        val userDetailsApi: UserDetailsApi = UserDetailsApiImp(httpClient)
+
+        userDetailsApi.getMultipleUsers(params)
+    }
+
+    @Test
+    fun givenListOfQualifiedHandles_whenGettingListOfUsers_thenBodyShouldSerializeCorrectly() = runTest {
+        val params = ListUserRequest.qualifiedHandles(listOf(QualifiedHandleSample.one, QualifiedHandleSample.two))
+        val expectedRequestBody = KtxSerializer.json.encodeToString(params)
+        val httpClient = mockAuthenticatedHttpClient(
+            ListUsersRequestJson.validIdsJsonProvider.rawJson,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertBodyContent(expectedRequestBody)
+            }
+        )
+        val userDetailsApi: UserDetailsApi = UserDetailsApiImp(httpClient)
+
+        userDetailsApi.getMultipleUsers(params)
+    }
+
+    @Test
+    fun givenAValidRequest_whenGettingListOfUsers_thenCorrectHttpHeadersAndMethodShouldBeUsed() = runTest {
+        val httpClient = mockAuthenticatedHttpClient(
+            ListUsersRequestJson.validIdsJsonProvider.rawJson,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertPost()
+                assertJson()
+                assertNoQueryParams()
+                assertPathEqual(PATH_LIST_USERS)
+            }
+        )
+        val userDetailsApi: UserDetailsApi = UserDetailsApiImp(httpClient)
+
+        userDetailsApi.getMultipleUsers(ListUserRequest.qualifiedIds(listOf()))
+    }
+
+    private companion object{
+        const val PATH_LIST_USERS = "/list-users"
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/model/IDSample.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/model/IDSample.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium.api.tools.json.model
+
+import com.wire.kalium.network.api.QualifiedID
+
+object QualifiedIDSamples {
+    val one = QualifiedID("someValue", "someDomain")
+    val two = QualifiedID("anotherValue", "anotherDomain")
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/model/QualifiedHandleSample.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/model/QualifiedHandleSample.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium.api.tools.json.model
+
+import com.wire.kalium.network.api.QualifiedHandle
+
+object QualifiedHandleSample {
+    val one = QualifiedHandle("someDomain", "someHandle")
+    val two = QualifiedHandle("anotherDomain", "anotherHandle")
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to sync/store user details (like name, for example), we need to fetch them first. And we currently don't have an API to fetch it.

### Solutions

In this PR, implemented a `UserDetailsApi` that allows us to get user details.
The next will follow with sync and inserting into storage.

### Testing

Cover the API with tests in `UserDetailsApiTest`.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
