### PR TITLE
feat: update current session after a new login

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
@@ -2,7 +2,7 @@ package com.wire.kalium.logic.data.auth.login
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.configuration.ServerConfig
-import com.wire.kalium.logic.failure.InvalidCredentials
+import com.wire.kalium.logic.failure.AuthenticationFailure
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.api.RefreshTokenProperties
@@ -49,7 +49,7 @@ class LoginRepositoryImpl(
 
     private fun handleFailedApiResponse(response: NetworkResponse.Error<*>) =
         when (response.kException) {
-            is KaliumException.InvalidRequestError -> Either.Left(InvalidCredentials)
+            is KaliumException.InvalidRequestError -> Either.Left(AuthenticationFailure.InvalidCredentials)
             is KaliumException.NetworkUnavailableError -> Either.Left(CoreFailure.NoNetworkConnection)
             else -> Either.Left(CoreFailure.Unknown(response.kException))
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
@@ -10,21 +10,7 @@ interface SessionRepository {
     suspend fun storeSession(autSession: AuthSession)
     suspend fun getSessions(): Either<CoreFailure, List<AuthSession>>
     suspend fun doesSessionExist(userId: UserId): Either<CoreFailure, Boolean>
-}
-
-@Deprecated("Use the SessionRepositoryImpl", replaceWith = ReplaceWith("SessionRepositoryImpl"))
-class InMemorySessionRepository : SessionRepository {
-    private val sessions = hashMapOf<String, AuthSession>()
-
-    override suspend fun storeSession(autSession: AuthSession) {
-        sessions[autSession.userId] = autSession
-    }
-
-    override suspend fun getSessions(): Either<CoreFailure, List<AuthSession>> = Either.Right(sessions.values.toList())
-    override suspend fun doesSessionExist(userId: UserId): Either<CoreFailure, Boolean> {
-        TODO("Not yet implemented")
-    }
-
+    suspend fun updateCurrentSession(userIdValue: String)
 }
 
 class SessionDataSource(
@@ -47,6 +33,8 @@ class SessionDataSource(
                 Either.Right(false)
             }
         }
+
+    override suspend fun updateCurrentSession(userIdValue: String) = sessionLocalRepository.updateCurrentSession(userIdValue)
 }
 
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/local/SessionLocalRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/local/SessionLocalRepository.kt
@@ -2,31 +2,34 @@ package com.wire.kalium.logic.data.session.local
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.session.SessionMapper
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.failure.SessionFailure
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.persistence.client.SessionDAO
+import com.wire.kalium.persistence.client.SessionStorage
 import com.wire.kalium.persistence.model.PreferencesResult
 
 interface SessionLocalRepository {
     suspend fun storeSession(autSession: AuthSession)
     suspend fun getSessions(): Either<CoreFailure, List<AuthSession>>
+    suspend fun updateCurrentSession(userIdValue: String)
 }
 
 class SessionLocalDataSource(
-    private val sessionLocalDataSource: SessionDAO,
+    private val sessionStorage: SessionStorage,
     private val sessionMapper: SessionMapper
 ) : SessionLocalRepository {
-    override suspend fun storeSession(autSession: AuthSession) =
-        sessionLocalDataSource.addSession(sessionMapper.toPersistenceSession(autSession))
 
+    override suspend fun storeSession(autSession: AuthSession) =
+        sessionStorage.addSession(sessionMapper.toPersistenceSession(autSession))
 
     override suspend fun getSessions(): Either<CoreFailure, List<AuthSession>> =
-        when (val result = sessionLocalDataSource.allSessions()) {
+        when (val result = sessionStorage.allSessions()) {
             is PreferencesResult.Success -> Either.Right(
-                result.data.values.toList().map { sessionMapper.fromPersistenceSession(it) })
-
+                result.data.values.toList().map { sessionMapper.fromPersistenceSession(it) }
+            )
             is PreferencesResult.DataNotFound -> Either.Left(SessionFailure.NoSessionFound)
         }
 
+    override suspend fun updateCurrentSession(userIdValue: String) = sessionStorage.updateCurrentSession(userIdValue)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/AuthenticationFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/AuthenticationFailure.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.failure
 
 import com.wire.kalium.logic.CoreFailure
 
-sealed class AuthenticationFailure : CoreFailure.FeatureFailure()
+sealed class AuthenticationFailure : CoreFailure.FeatureFailure() {
+    object InvalidCredentials: AuthenticationFailure()
+}
 
-object InvalidCredentials: AuthenticationFailure()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -12,8 +12,8 @@ import com.wire.kalium.logic.data.session.local.SessionLocalDataSource
 import com.wire.kalium.logic.data.session.local.SessionLocalRepository
 import com.wire.kalium.logic.feature.session.SessionScope
 import com.wire.kalium.network.LoginNetworkContainer
-import com.wire.kalium.persistence.client.SessionDAOImpl
-import com.wire.kalium.persistence.client.SessionDAO
+import com.wire.kalium.persistence.client.SessionStorageImpl
+import com.wire.kalium.persistence.client.SessionStorage
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
@@ -30,14 +30,14 @@ abstract class AuthenticationScopeCommon(
 
     protected abstract val encryptedSettingsHolder: EncryptedSettingsHolder
     private val kaliumPreferences: KaliumPreferences get() = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
-    private val sessionDao: SessionDAO get() = SessionDAOImpl(kaliumPreferences)
+    private val sessionStorage: SessionStorage get() = SessionStorageImpl(kaliumPreferences)
 
     private val serverConfigMapper: ServerConfigMapper get() = ServerConfigMapperImpl()
     private val sessionMapper: SessionMapper get() = SessionMapperImpl(serverConfigMapper)
 
     private val loginRepository: LoginRepository get() = LoginRepositoryImpl(loginNetworkContainer.loginApi, clientLabel)
 
-    private val sessionLocalRepository: SessionLocalRepository get() = SessionLocalDataSource(sessionDao, sessionMapper)
+    private val sessionLocalRepository: SessionLocalRepository get() = SessionLocalDataSource(sessionStorage, sessionMapper)
     private val sessionRepository: SessionRepository
         get() = SessionDataSource(sessionLocalRepository)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -40,10 +40,11 @@ class LoginUseCase(
         return when (result) {
             is Either.Right -> {
                 sessionRepository.storeSession(result.value)
+                sessionRepository.updateCurrentSession(result.value.userId)
                 AuthenticationResult.Success(result.value)
             }
             is Either.Left -> {
-                if (result.value is AuthenticationFailure) {
+                if (result.value is AuthenticationFailure.InvalidCredentials) {
                     AuthenticationResult.Failure.InvalidCredentials
                 } else {
                     AuthenticationResult.Failure.Generic(result.value)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.prekey.PreKeyMapper
 
 class ClientScope(
     private val clientRepository: ClientRepository,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.logic.feature.auth
 import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.auth.login.LoginRepository
 import com.wire.kalium.logic.data.session.SessionRepository
-import com.wire.kalium.logic.failure.InvalidCredentials
+import com.wire.kalium.logic.failure.AuthenticationFailure
 import com.wire.kalium.logic.functional.Either
 import io.mockative.ConfigurationApi
 import io.mockative.Mock
@@ -44,7 +44,7 @@ class LoginUseCaseTest {
     }
 
     @Test
-    fun givenLoginUserCaseIsInvoked_whenEmailHasLeadingOrTrailingSpaces_thenACCleanSUUserIdentifierIsUsedToAuthenticate() =
+    fun givenLoginUserCaseIsInvoked_whenEmailHasLeadingOrTrailingSpaces_thenCleanUserIdentifierIsUsedToAuthenticate() =
         runTest {
             val cleanEmail = "user@email.de"
             val password = "password"
@@ -70,7 +70,7 @@ class LoginUseCaseTest {
         }
 
     @Test
-    fun givenLoginUserCaseIsInvoked_whenUserHandleHasLeadingOrTrailingSpaces_thenACCleanSUUserIdentifierIsUsedToAuthenticate() =
+    fun givenLoginUserCaseIsInvoked_whenUserHandleHasLeadingOrTrailingSpaces_thenCleanUserIdentifierIsUsedToAuthenticate() =
         runTest {
             val cleanHandle = "usere"
             val password = "password"
@@ -138,13 +138,24 @@ class LoginUseCaseTest {
             // then
             assertEquals(loginUserCaseResult, AuthenticationResult.Success(TEST_AUTH_SESSION))
 
-            verify(validateEmailUseCase).invocation { invoke(TEST_HANDEL) }.wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase).invocation { invoke(TEST_HANDEL) }.wasInvoked(exactly = once)
-            verify(loginRepository).coroutine {
-                loginWithHandle(TEST_HANDEL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG)
-            }.wasInvoked(exactly = once)
-            verify(loginRepository).suspendFunction(loginRepository::loginWithEmail).with(any(), any(), any(), any()).wasNotInvoked()
-            verify(sessionRepository).coroutine { storeSession(TEST_AUTH_SESSION) }.wasInvoked(exactly = once)
+            verify(validateEmailUseCase)
+                .invocation { invoke(TEST_HANDEL) }
+                .wasInvoked(exactly = once)
+            verify(validateUserHandleUseCase)
+                .invocation { invoke(TEST_HANDEL) }
+                .wasInvoked(exactly = once)
+            verify(loginRepository)
+                .coroutine { loginWithHandle(TEST_HANDEL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
+                .wasInvoked(exactly = once)
+            verify(loginRepository)
+                .suspendFunction(loginRepository::loginWithEmail).with(any(), any(), any(), any())
+                .wasNotInvoked()
+            verify(sessionRepository)
+                .coroutine { storeSession(TEST_AUTH_SESSION) }
+                .wasInvoked(exactly = once)
+            verify(sessionRepository)
+                .coroutine { updateCurrentSession(TEST_AUTH_SESSION.userId) }
+                .wasInvoked(exactly = once)
         }
 
     @Test
@@ -167,35 +178,64 @@ class LoginUseCaseTest {
             given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
             given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }.then { false }
             given(loginRepository).coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
-                .then { Either.Left(InvalidCredentials) }
+                .then { Either.Left(AuthenticationFailure.InvalidCredentials) }
 
             given(validateEmailUseCase).invocation { invoke(TEST_HANDEL) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(TEST_HANDEL) }.then { true }
             given(loginRepository).coroutine { loginWithHandle(TEST_HANDEL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
-                .then { Either.Left(InvalidCredentials) }
+                .then { Either.Left(AuthenticationFailure.InvalidCredentials) }
 
             // email
             val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG)
             assertEquals(loginEmailResult, AuthenticationResult.Failure.InvalidCredentials)
-            verify(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase).function(validateUserHandleUseCase::invoke).with(any()).wasNotInvoked()
+
+            verify(validateEmailUseCase)
+                .invocation { invoke(TEST_EMAIL) }
+                .wasInvoked(exactly = once)
+            verify(validateUserHandleUseCase)
+                .function(validateUserHandleUseCase::invoke)
+                .with(any()).wasNotInvoked()
             verify(loginRepository).coroutine {
                 loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG)
             }.wasInvoked(exactly = once)
-            verify(loginRepository).suspendFunction(loginRepository::loginWithHandle).with(any(), any(), any(), any()).wasNotInvoked()
-
+            verify(loginRepository)
+                .suspendFunction(loginRepository::loginWithHandle)
+                .with(any(), any(), any(), any())
+                .wasNotInvoked()
+            verify(sessionRepository)
+                .suspendFunction(sessionRepository::storeSession)
+                .with(any())
+                .wasNotInvoked()
+            verify(sessionRepository)
+                .suspendFunction(sessionRepository::updateCurrentSession)
+                .with(any())
+                .wasNotInvoked()
 
             // user handle
             val loginHandelResult = loginUseCase(TEST_HANDEL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG)
             assertEquals(loginHandelResult, AuthenticationResult.Failure.InvalidCredentials)
-            verify(validateEmailUseCase).invocation { invoke(TEST_HANDEL) }.wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase).invocation { invoke(TEST_HANDEL) }.wasInvoked(exactly = once)
+
+            verify(validateEmailUseCase)
+                .invocation { invoke(TEST_HANDEL) }
+                .wasInvoked(exactly = once)
+            verify(validateUserHandleUseCase)
+                .invocation { invoke(TEST_HANDEL) }
+                .wasInvoked(exactly = once)
             verify(loginRepository).coroutine {
                 loginWithHandle(TEST_HANDEL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG)
             }.wasInvoked(exactly = once)
-            verify(loginRepository).suspendFunction(loginRepository::loginWithEmail).with(any(), any(), any(), any()).wasNotInvoked()
-
-
+            verify(loginRepository)
+                .suspendFunction(loginRepository::loginWithEmail)
+                .with(any(), any(), any(), any())
+                .wasNotInvoked()
+            verify(sessionRepository)
+                .suspendFunction(sessionRepository::storeSession)
+                .with(any())
+                .wasNotInvoked()
+            verify(sessionRepository)
+                .suspendFunction(sessionRepository::updateCurrentSession)
+                .with(any())
+                .wasNotInvoked()
         }
 
     private companion object {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/SessionStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/SessionStorage.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.persistence.model.PersistenceSession
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
-interface SessionDAO {
+interface SessionStorage {
     /**
      * store a session locally
      */
@@ -38,9 +38,9 @@ interface SessionDAO {
     suspend fun sessionsExist(): Boolean
 }
 
-class SessionDAOImpl(
+class SessionStorageImpl(
     private val kaliumPreferences: KaliumPreferences
-) : SessionDAO {
+) : SessionStorage {
     override suspend fun addSession(persistenceSession: PersistenceSession) =
         when (val result = allSessions()) {
             is PreferencesResult.Success -> {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/SessionDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/SessionDAOTest.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.persistence.client
 
 import com.russhwolf.settings.MockSettings
 import com.russhwolf.settings.Settings
-import com.wire.kalium.persistence.dao.UserId
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 import com.wire.kalium.persistence.model.NetworkConfig
@@ -20,7 +19,7 @@ class SessionDAOTest {
     private val settings: Settings = MockSettings()
 
     private val kaliumPreferences: KaliumPreferences = KaliumPreferencesSettings(settings)
-    private val sessionDAO: SessionDAO = SessionDAOImpl(kaliumPreferences)
+    private val sessionStorage: SessionStorage = SessionStorageImpl(kaliumPreferences)
 
     @BeforeTest
     fun setUp() {
@@ -38,9 +37,9 @@ class SessionDAOTest {
                 randomNetworkConfig()
             )
         val sessionsMap = mapOf(persistenceSession.userId to persistenceSession)
-        sessionDAO.addSession(persistenceSession)
+        sessionStorage.addSession(persistenceSession)
 
-        assertEquals(PreferencesResult.Success(sessionsMap), sessionDAO.allSessions())
+        assertEquals(PreferencesResult.Success(sessionsMap), sessionStorage.allSessions())
     }
 
     @Test
@@ -70,18 +69,18 @@ class SessionDAOTest {
             )
         val afterDeleteExpectedValue = PreferencesResult.Success(mapOf(session1.userId to session1))
 
-        sessionDAO.addSession(session1)
-        sessionDAO.addSession(sessionToDelete)
+        sessionStorage.addSession(session1)
+        sessionStorage.addSession(sessionToDelete)
 
-        assertEquals(sessionsMapExpectedValue, sessionDAO.allSessions())
+        assertEquals(sessionsMapExpectedValue, sessionStorage.allSessions())
         // delete session
-        sessionDAO.deleteSession(sessionToDelete.userId)
-        assertEquals(afterDeleteExpectedValue, sessionDAO.allSessions())
+        sessionStorage.deleteSession(sessionToDelete.userId)
+        assertEquals(afterDeleteExpectedValue, sessionStorage.allSessions())
     }
 
     @Test
     fun givenAUserId_WhenCallingUpdateCurrentSession_ThenItWillBeStoredLocally() = runTest {
-        assertNull(sessionDAO.currentSession())
+        assertNull(sessionStorage.currentSession())
         val session1 =
             PersistenceSession(
                 "user_id_1",
@@ -100,12 +99,12 @@ class SessionDAOTest {
                 randomNetworkConfig()
             )
 
-        sessionDAO.addSession(session1)
-        sessionDAO.addSession(session2)
+        sessionStorage.addSession(session1)
+        sessionStorage.addSession(session2)
 
-        sessionDAO.updateCurrentSession("user_id_1")
+        sessionStorage.updateCurrentSession("user_id_1")
 
-        assertEquals(session1, sessionDAO.currentSession())
+        assertEquals(session1, sessionStorage.currentSession())
     }
 
     private companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

current session is not apdated after login



### Solutions

updating the current session in `LoginuseCase`

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

update `LoginUseCaseTest` to check if the updateCurrentSession is called

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
