### PR TITLE
feat: add delete client usecase (AR-979)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
@@ -1,0 +1,15 @@
+package com.wire.kalium.logic.feature.client
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.client.DeleteClientParam
+import com.wire.kalium.logic.functional.Either
+
+interface DeleteClientUseCase {
+    suspend operator fun invoke(param: DeleteClientParam): Either<CoreFailure, Unit>
+}
+
+class DeleteClientUseCaseImpl(private val clientRepository: ClientRepository) : DeleteClientUseCase {
+    override suspend operator fun invoke(param: DeleteClientParam) =
+        clientRepository.deleteClient(param)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
@@ -3,13 +3,26 @@ package com.wire.kalium.logic.feature.client
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.DeleteClientParam
-import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.suspending
 
 interface DeleteClientUseCase {
-    suspend operator fun invoke(param: DeleteClientParam): Either<CoreFailure, Unit>
+    suspend operator fun invoke(param: DeleteClientParam): DeleteClientResult
 }
 
 class DeleteClientUseCaseImpl(private val clientRepository: ClientRepository) : DeleteClientUseCase {
-    override suspend operator fun invoke(param: DeleteClientParam) =
+    override suspend operator fun invoke(param: DeleteClientParam): DeleteClientResult = (suspending {
         clientRepository.deleteClient(param)
+    }.fold({ failure ->
+        DeleteClientResult.Failure.Generic(failure)
+    }, {
+        DeleteClientResult.Success
+    }))!!
+}
+
+sealed class DeleteClientResult {
+    object Success : DeleteClientResult()
+
+    sealed class Failure : DeleteClientResult() {
+        class Generic(val genericFailure: CoreFailure) : Failure()
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
@@ -16,7 +16,7 @@ class DeleteClientUseCaseImpl(private val clientRepository: ClientRepository) : 
         DeleteClientResult.Failure.Generic(failure)
     }, {
         DeleteClientResult.Success
-    }))!!
+    }))
 }
 
 sealed class DeleteClientResult {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCaseTest.kt
@@ -1,0 +1,68 @@
+package com.wire.kalium.logic.feature.client
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.client.DeleteClientParam
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+class DeleteClientUseCaseTest {
+
+    @Mock
+    private val clientRepository = mock(classOf<ClientRepository>())
+
+    private lateinit var deleteClient: DeleteClientUseCase
+
+    @BeforeTest
+    fun setup() {
+        deleteClient = DeleteClientUseCaseImpl(clientRepository)
+    }
+
+    @Test
+    fun givenDeleteClientParams_whenDeleting_thenTheRepositoryShouldBeCalledWithCorrectParameters() = runTest {
+        val params = DELETE_CLIENT_PARAMETERS
+        given(clientRepository)
+            .suspendFunction(clientRepository::deleteClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(CoreFailure.ServerMiscommunication) }
+
+        deleteClient(params)
+
+        verify(clientRepository)
+            .suspendFunction(clientRepository::deleteClient)
+            .with(eq(params))
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenRepositoryDeleteClientFailsDueToGenericError_whenDeleting_thenGenericErrorShouldBeReturned() = runTest {
+        val genericFailure = CoreFailure.NoNetworkConnection
+        given(clientRepository)
+            .suspendFunction(clientRepository::deleteClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(genericFailure) }
+
+        val result = deleteClient(DELETE_CLIENT_PARAMETERS)
+
+        assertIs<DeleteClientResult.Failure.Generic>(result)
+        assertSame(genericFailure, result.genericFailure)
+    }
+
+    private companion object {
+        val CLIENT = TestClient.CLIENT
+        val DELETE_CLIENT_PARAMETERS = DeleteClientParam("pass", CLIENT.clientId)
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

### Issues
[AR-979]

### Solutions
Add DeleteClientUseCase to call the related API to delete a client.

Needs releases with:

- [x] Depends on [feat: SelfClientsUseCase]

### Testing

Tested Params passing and Generic Failure.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

[feat: SelfClientsUseCase]: https://github.com/wireapp/kalium/pull/211
[AR-979]: https://wearezeta.atlassian.net/browse/AR-979