### PR TITLE
fix: remove line breaks from PreKeys Base64 encoding/decoding on Android

### DIFF
--- a/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -36,7 +36,7 @@ actual class ProteusClientImpl actual constructor(rootDir: String, userId: Strin
         return wrapException { box.localFingerprint }
     }
 
-    override suspend  fun newPreKeys(from: Int, count: Int): ArrayList<PreKey> {
+    override suspend fun newPreKeys(from: Int, count: Int): ArrayList<PreKey> {
         return wrapException { box.newPreKeys(from, count).map { toPreKey(it) } as ArrayList<PreKey> }
     }
 
@@ -87,10 +87,10 @@ actual class ProteusClientImpl actual constructor(rootDir: String, userId: Strin
 
     companion object {
         private fun toPreKey(preKey: PreKey): com.wire.cryptobox.PreKey =
-            com.wire.cryptobox.PreKey(preKey.id, Base64.decode(preKey.encodedData, Base64.DEFAULT))
+            com.wire.cryptobox.PreKey(preKey.id, Base64.decode(preKey.encodedData, Base64.NO_WRAP))
 
         private fun toPreKey(preKey: com.wire.cryptobox.PreKey): PreKey =
-            PreKey(preKey.id, Base64.encodeToString(preKey.data, Base64.DEFAULT))
+            PreKey(preKey.id, Base64.encodeToString(preKey.data, Base64.NO_WRAP))
 
         private fun createId(userId: UUID?, clientId: String?): String? {
             return String.format("%s_%s", userId, clientId)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When encoding PreKeys on Android to Base64, a `\n` is being added at the end of the string. Backend does not accept prekeys with this format.

### Causes (Optional)

Use of `DEFAULT` instead of `NO_WRAP`

### Solutions

`NO_WRAP` 😃 

### Testing

Not yet in place.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
