### PR TITLE
chore: prepare recipients for sending message (AR-971)

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -16,7 +16,6 @@ object Versions {
     const val ktor = "1.6.7"
     const val ktor2 = "2.0.0-beta-1"
     const val okHttp = "4.9.3"
-    const val kotest = "4.6.3"
     const val mockative = "1.1.4"
     const val androidWork = "2.7.1"
     const val androidTestRunner = "1.4.0"
@@ -27,6 +26,8 @@ object Versions {
     const val multiplatformSettings = "0.8.1"
     const val androidSecurity = "1.0.0"
     const val sqlDelight = "2.0.0-SNAPSHOT"
+    const val wireJvmMessageProto = "1.36.0"
+    const val protobufLite = "3.19.4"
 }
 
 object Plugins {
@@ -132,14 +133,13 @@ object Dependencies {
         const val jsDriver = "app.cash.sqldelight:sqljs-driver:${Versions.sqlDelight}"
     }
 
-    object Kotest {
-        const val junit5Runner = "io.kotest:kotest-runner-junit5:${Versions.kotest}"
-        const val assertions = "io.kotest:kotest-assertions-core:${Versions.kotest}"
-        const val property = "io.kotest:kotest-property:${Versions.kotest}"
-    }
-
     object Test {
         const val mockative = "io.mockative:mockative:${Versions.mockative}"
         const val mockativeProcessor = "io.mockative:mockative-processor:${Versions.mockative}"
+    }
+
+    object Protobuf {
+        const val wireJvmMessageProto = "com.wire:generic-message-proto:${Versions.wireJvmMessageProto}"
+        const val protobufLite = "com.google.protobuf:protobuf-javalite:${Versions.protobufLite}"
     }
 }

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -41,6 +41,9 @@ interface ProteusClient {
     fun newLastPreKey(): PreKey
 
     @Throws(ProteusException::class)
+    suspend fun doesSessionExist(sessionId: CryptoSessionId): Boolean
+
+    @Throws(ProteusException::class)
     suspend fun createSession(preKey: PreKey, sessionId: CryptoSessionId)
 
     @Throws(ProteusException::class)

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -13,7 +13,7 @@ import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
 
-actual class ProteusClientImpl actual constructor(rootDir: String, userId: String): ProteusClient {
+actual class ProteusClientImpl actual constructor(rootDir: String, userId: String) : ProteusClient {
 
     private val userId: String
     private lateinit var box: Cryptobox
@@ -56,6 +56,14 @@ actual class ProteusClientImpl actual constructor(rootDir: String, userId: Strin
         } else {
             throw ProteusException("Local identity doesn't exist", ProteusException.Code.UNKNOWN_ERROR)
         }
+    }
+
+    override suspend fun doesSessionExist(sessionId: CryptoSessionId): Boolean = try {
+        box.session_load(sessionId.value).await()
+        true
+        // TODO check the internals of cryptobox.js to see what happens if the session doesn't exist
+    } catch (e: Exception) {
+        false
     }
 
     @OptIn(InternalAPI::class)

--- a/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -45,6 +45,10 @@ actual class ProteusClientImpl actual constructor(rootDir: String, userId: Strin
         return wrapException { box.newPreKeys(from, count).map { toPreKey(it) } as ArrayList<PreKey> }
     }
 
+    override suspend fun doesSessionExist(sessionId: CryptoSessionId): Boolean {
+        TODO("Nope. Can't do this using cryptobox4j.")
+    }
+
     override suspend fun createSession(preKey: PreKey, sessionId: CryptoSessionId) {
         wrapException { box.encryptFromPreKeys(sessionId.value, toPreKey(preKey), ByteArray(0)) }
     }

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -89,6 +89,5 @@ kotlin {
 }
 
 dependencies {
-    implementation("androidx.work:work-runtime-ktx:2.5.0")
     ksp(Dependencies.Test.mockativeProcessor)
 }

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+
 plugins {
     Plugins.androidLibrary(this)
     Plugins.multiplatform(this)
@@ -61,11 +63,25 @@ kotlin {
                 implementation(Dependencies.Test.mockative)
             }
         }
-        val jvmMain by getting
+        fun KotlinSourceSet.addCommonKotlinJvmSourceDir() {
+            kotlin.srcDir("src/commonJvmAndroid/kotlin")
+        }
+        val jvmMain by getting {
+            addCommonKotlinJvmSourceDir()
+            dependencies {
+                implementation(Dependencies.Protobuf.wireJvmMessageProto)
+            }
+        }
         val jvmTest by getting
         val androidMain by getting {
+            addCommonKotlinJvmSourceDir()
             dependencies {
                 implementation(Dependencies.Android.work)
+                implementation(Dependencies.Protobuf.wireJvmMessageProto) {
+                    // Don't use the runtime Protobuf included in wire. We can use Protobuf Lite instead
+                    exclude(module = "protobuf-java")
+                }
+                implementation(Dependencies.Protobuf.protobufLite)
             }
         }
         val androidTest by getting

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature
 import android.content.Context
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
+import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.persistence.db.Database
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
@@ -21,6 +22,8 @@ actual class UserSessionScope(
     override val database: Database get() = Database(applicationContext, "main.db", userPreferencesSettings)
     override val encryptedSettingsHolder: EncryptedSettingsHolder
         get() = EncryptedSettingsHolder(applicationContext, "$PREFERENCE_FILE_PREFIX-${session.userId}")
+
+    override val protoContentMapper: ProtoContentMapper = ProtoContentMapper()
 
     private companion object {
         private const val PREFERENCE_FILE_PREFIX = "user-pref"

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/Base64.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/Base64.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium.logic.util
+
+import android.util.Base64
+
+actual object Base64 {
+    actual fun encodeToBase64(originalString: ByteArray): ByteArray = Base64.encode(originalString, Base64.NO_WRAP)
+    actual fun decodeFromBase64(encoded: ByteArray): ByteArray = Base64.decode(encoded, Base64.NO_WRAP)
+}

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -5,7 +5,8 @@ import com.waz.model.Messages.GenericMessage
 
 actual class ProtoContentMapper {
 
-    actual fun encodeToProtobuf(messageUid: String, messageContent: MessageContent): PlainMessageBlob {
+    actual fun encodeToProtobuf(protoContent: ProtoContent): PlainMessageBlob {
+        val (messageUid, messageContent) = protoContent
         val builder = GenericMessage.newBuilder()
             .setMessageId(messageUid)
 
@@ -23,14 +24,15 @@ actual class ProtoContentMapper {
         return PlainMessageBlob(builder.build().toByteArray())
     }
 
-    actual fun decodeFromProtobuf(encodedContent: PlainMessageBlob): MessageContent {
+    actual fun decodeFromProtobuf(encodedContent: PlainMessageBlob): ProtoContent {
         val genericMessage = GenericMessage.parseFrom(encodedContent.data)
 
         //TODO Handle other message types
-        return if (genericMessage.hasText()) {
+        val content = if (genericMessage.hasText()) {
             MessageContent.Text(genericMessage.text.content)
         } else {
             MessageContent.Unknown
         }
+        return ProtoContent(genericMessage.messageId, content)
     }
 }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -1,0 +1,36 @@
+package com.wire.kalium.logic.data.message
+
+import com.waz.model.Messages
+import com.waz.model.Messages.GenericMessage
+
+actual class ProtoContentMapper {
+
+    actual fun encodeToProtobuf(messageUid: String, messageContent: MessageContent): PlainMessageBlob {
+        val builder = GenericMessage.newBuilder()
+            .setMessageId(messageUid)
+
+        when (messageContent) {
+            is MessageContent.Text -> {
+                val text = Messages.Text.newBuilder()
+                    .setContent(messageContent.value)
+                    .build()
+                builder.text = text
+            }
+            else -> {
+                throw IllegalArgumentException("Unexpected message content type: $messageContent")
+            }
+        }
+        return PlainMessageBlob(builder.build().toByteArray())
+    }
+
+    actual fun decodeFromProtobuf(encodedContent: PlainMessageBlob): MessageContent {
+        val genericMessage = GenericMessage.parseFrom(encodedContent.data)
+
+        //TODO Handle other message types
+        return if (genericMessage.hasText()) {
+            MessageContent.Text(genericMessage.text.content)
+        } else {
+            MessageContent.Unknown
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -1,0 +1,19 @@
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+
+data class Message(
+    val id: String,
+    val content: MessageContent,
+    val conversationId: ConversationId,
+    val date: String,
+    val senderUserId: UserId,
+    val senderClientId: ClientId,
+    val status: Status
+) {
+    enum class Status {
+        PENDING, SENT, READ, FAILED
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageBlob.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageBlob.kt
@@ -1,0 +1,19 @@
+package com.wire.kalium.logic.data.message
+
+import kotlin.jvm.JvmInline
+
+/**
+ * [EncryptedMessageBlob] and [PlainMessageBlob] wrappers exist to avoid confusion and provide an easier to use development environment.
+ * Functions like `encrypt` can take a [PlainMessageBlob] as input and output an [EncryptedMessageBlob].
+ * And a `decrypt` function could do the reverse.
+ */
+@JvmInline
+value class EncryptedMessageBlob(val data: ByteArray)
+
+/**
+ * [EncryptedMessageBlob] and [PlainMessageBlob] wrappers exist to avoid confusion and provide an easier to use development environment.
+ * Functions like `encrypt` can take a [PlainMessageBlob] as input and output an [EncryptedMessageBlob].
+ * And a `decrypt` function could do the reverse.
+ */
+@JvmInline
+value class PlainMessageBlob(val data: ByteArray)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium.logic.data.message
+
+sealed class MessageContent {
+
+    data class Text(val value: String): MessageContent()
+
+    object Unknown: MessageContent()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -1,0 +1,56 @@
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.persistence.dao.message.MessageRecord
+
+interface MessageMapper {
+    fun fromMessageToRecord(message: Message): MessageRecord
+    fun fromRecordToMessage(message: MessageRecord): Message
+}
+
+class MessageMapperImpl(private val idMapper: IdMapper) : MessageMapper {
+    override fun fromMessageToRecord(message: Message): MessageRecord {
+        val stringContent = when (val content = message.content) {
+            is MessageContent.Text -> content.value
+            MessageContent.Unknown -> null
+        }
+        val status = when (message.status) {
+            Message.Status.PENDING -> MessageRecord.Status.PENDING
+            Message.Status.SENT -> MessageRecord.Status.SENT
+            Message.Status.READ -> MessageRecord.Status.READ
+            Message.Status.FAILED -> MessageRecord.Status.FAILED
+        }
+        return MessageRecord(
+            message.id,
+            stringContent,
+            idMapper.toDaoModel(message.conversationId),
+            message.date,
+            idMapper.toDaoModel(message.senderUserId),
+            message.senderClientId.value,
+            status
+        )
+    }
+
+    override fun fromRecordToMessage(message: MessageRecord): Message {
+        val content = when (val stringContent = message.content) {
+            null -> MessageContent.Unknown
+            else -> MessageContent.Text(stringContent)
+        }
+        val status = when (message.status) {
+            MessageRecord.Status.PENDING -> Message.Status.PENDING
+            MessageRecord.Status.SENT -> Message.Status.SENT
+            MessageRecord.Status.READ -> Message.Status.READ
+            MessageRecord.Status.FAILED -> Message.Status.FAILED
+        }
+        return Message(
+            message.id,
+            content,
+            idMapper.fromDaoModel(message.conversationId),
+            message.date,
+            idMapper.fromDaoModel(message.senderUserId),
+            ClientId(message.senderClientId),
+            status
+        )
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -4,13 +4,13 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.api.message.MessageApi
 import com.wire.kalium.persistence.dao.QualifiedID
-import com.wire.kalium.persistence.dao.message.Message
+import com.wire.kalium.persistence.dao.message.MessageRecord
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import kotlinx.coroutines.flow.Flow
 
 interface MessageRepository {
-    suspend fun getMessagesForConversation(conversationId: QualifiedID, limit: Int): Flow<List<Message>>
-    suspend fun persistMessage(message: Message): Either<CoreFailure, Unit>
+    suspend fun getMessagesForConversation(conversationId: QualifiedID, limit: Int): Flow<List<MessageRecord>>
+    suspend fun persistMessage(message: MessageRecord): Either<CoreFailure, Unit>
 }
 
 class MessageDataSource(
@@ -18,11 +18,11 @@ class MessageDataSource(
     private val messageDAO: MessageDAO
 ) : MessageRepository {
 
-    override suspend fun getMessagesForConversation(conversationId: QualifiedID, limit: Int): Flow<List<Message>> {
+    override suspend fun getMessagesForConversation(conversationId: QualifiedID, limit: Int): Flow<List<MessageRecord>> {
         return messageDAO.getMessageByConversation(conversationId, limit)
     }
 
-    override suspend fun persistMessage(message: Message): Either<CoreFailure, Unit> {
+    override suspend fun persistMessage(message: MessageRecord): Either<CoreFailure, Unit> {
         messageDAO.insertMessage(message)
         return Either.Right(Unit)
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -1,36 +1,35 @@
 package com.wire.kalium.logic.data.message
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ConversationId
+import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.api.message.MessageApi
-import com.wire.kalium.persistence.dao.QualifiedID
-import com.wire.kalium.persistence.dao.message.MessageRecord
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 interface MessageRepository {
-    suspend fun getMessagesForConversation(conversationId: QualifiedID, limit: Int): Flow<List<MessageRecord>>
-    suspend fun persistMessage(message: MessageRecord): Either<CoreFailure, Unit>
+    suspend fun getMessagesForConversation(conversationId: ConversationId, limit: Int): Flow<List<Message>>
+    suspend fun persistMessage(message: Message): Either<CoreFailure, Unit>
 }
 
 class MessageDataSource(
     private val messageApi: MessageApi,
-    private val messageDAO: MessageDAO
+    private val messageDAO: MessageDAO,
+    private val messageMapper: MessageMapper,
+    private val idMapper: IdMapper
 ) : MessageRepository {
 
-    override suspend fun getMessagesForConversation(conversationId: QualifiedID, limit: Int): Flow<List<MessageRecord>> {
-        return messageDAO.getMessageByConversation(conversationId, limit)
+    override suspend fun getMessagesForConversation(conversationId: ConversationId, limit: Int): Flow<List<Message>> {
+        return messageDAO.getMessageByConversation(idMapper.toDaoModel(conversationId), limit).map { messageList ->
+            messageList.map(messageMapper::fromRecordToMessage)
+        }
     }
 
-    override suspend fun persistMessage(message: MessageRecord): Either<CoreFailure, Unit> {
-        messageDAO.insertMessage(message)
+    override suspend fun persistMessage(message: Message): Either<CoreFailure, Unit> {
+        messageDAO.insertMessage(messageMapper.fromMessageToRecord(message))
         return Either.Right(Unit)
     }
-
-    //TODO Rework after NetworkResponse in PR #151
-    // Either response maybe?
-//    suspend fun sendEnvelope(envelope: MessageEnvelope) {
-//
-//    }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
@@ -1,0 +1,3 @@
+package com.wire.kalium.logic.data.message
+
+data class ProtoContent(val messageUid: String, val messageContent: MessageContent)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -1,0 +1,7 @@
+package com.wire.kalium.logic.data.message
+
+// IDE is currently complaining that it's not implemented on JVM. The compiler builds it correctly. The IDE is wrong.
+expect class ProtoContentMapper {
+    fun encodeToProtobuf(messageUid: String, messageContent: MessageContent): PlainMessageBlob
+    fun decodeFromProtobuf(encodedContent: PlainMessageBlob): MessageContent
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -2,6 +2,6 @@ package com.wire.kalium.logic.data.message
 
 // IDE is currently complaining that it's not implemented on JVM. The compiler builds it correctly. The IDE is wrong.
 expect class ProtoContentMapper {
-    fun encodeToProtobuf(messageUid: String, messageContent: MessageContent): PlainMessageBlob
-    fun decodeFromProtobuf(encodedContent: PlainMessageBlob): MessageContent
+    fun encodeToProtobuf(protoContent: ProtoContent): PlainMessageBlob
+    fun decodeFromProtobuf(encodedContent: PlainMessageBlob): ProtoContent
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -9,8 +9,8 @@ import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientDataSource
 import com.wire.kalium.logic.data.client.ClientMapper
 import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.client.remote.ClientRemoteDataSource
+import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.conversation.ConversationDataSource
 import com.wire.kalium.logic.data.conversation.ConversationMapper
 import com.wire.kalium.logic.data.conversation.ConversationMapperImpl
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.data.location.LocationMapper
 import com.wire.kalium.logic.data.message.MessageDataSource
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.prekey.PreKeyMapper
 import com.wire.kalium.logic.data.prekey.PreKeyMapperImpl
 import com.wire.kalium.logic.data.user.UserDataSource
@@ -35,6 +36,7 @@ import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.conversation.ConversationScope
 import com.wire.kalium.logic.feature.message.MessageScope
 import com.wire.kalium.logic.feature.user.UserScope
+import com.wire.kalium.logic.sync.ConversationEventReceiver
 import com.wire.kalium.logic.sync.ListenToEventsUseCase
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
@@ -116,7 +118,14 @@ abstract class UserSessionScopeCommon(
             eventMapper
         )
 
-    val listenToEvents: ListenToEventsUseCase get() = ListenToEventsUseCase(syncManager, eventRepository)
+    protected abstract val protoContentMapper: ProtoContentMapper
+    private val conversationEventReceiver: ConversationEventReceiver
+        get() = ConversationEventReceiver(
+            authenticatedDataSourceSet.proteusClient,
+            messageRepository,
+            protoContentMapper
+        )
+    val listenToEvents: ListenToEventsUseCase get() = ListenToEventsUseCase(syncManager, eventRepository, conversationEventReceiver)
     val client: ClientScope get() = ClientScope(clientRepository, authenticatedDataSourceSet.proteusClient)
     val conversations: ConversationScope get() = ConversationScope(conversationRepository, syncManager)
     val messages: MessageScope get() = MessageScope(messageRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.RegisterClientParam
 import com.wire.kalium.logic.failure.ClientFailure
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase.Companion.FIRST_KEY_ID
+import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.suspending
 
 interface RegisterClientUseCase {
@@ -32,6 +33,9 @@ class RegisterClientUseCaseImpl(
         capabilities: List<ClientCapability>?,
         preKeysToSend: Int
     ): RegisterClientResult = suspending {
+        if(clientRepository.currentClientId().isRight()){
+            return@suspending RegisterClientResult.Failure.TooManyClients
+        }
         //TODO Should we fail here if the client is already registered?
         try {
             val param = RegisterClientParam(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -33,9 +33,6 @@ class RegisterClientUseCaseImpl(
         capabilities: List<ClientCapability>?,
         preKeysToSend: Int
     ): RegisterClientResult = suspending {
-        if(clientRepository.currentClientId().isRight()){
-            return@suspending RegisterClientResult.Failure.TooManyClients
-        }
         //TODO Should we fail here if the client is already registered?
         try {
             val param = RegisterClientParam(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
@@ -1,13 +1,13 @@
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logic.data.conversation.ConversationId
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.persistence.dao.QualifiedID
-import com.wire.kalium.persistence.dao.message.MessageRecord
 import kotlinx.coroutines.flow.Flow
 
 class GetRecentMessagesUseCase(private val messageRepository: MessageRepository) {
 
-    suspend operator fun invoke(conversationId: QualifiedID, limit: Int = 100): Flow<List<MessageRecord>> {
+    suspend operator fun invoke(conversationId: ConversationId, limit: Int = 100): Flow<List<Message>> {
         return messageRepository.getMessagesForConversation(conversationId, limit)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
@@ -2,12 +2,12 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.persistence.dao.QualifiedID
-import com.wire.kalium.persistence.dao.message.Message
+import com.wire.kalium.persistence.dao.message.MessageRecord
 import kotlinx.coroutines.flow.Flow
 
 class GetRecentMessagesUseCase(private val messageRepository: MessageRepository) {
 
-    suspend operator fun invoke(conversationId: QualifiedID, limit: Int = 100): Flow<List<Message>> {
+    suspend operator fun invoke(conversationId: QualifiedID, limit: Int = 100): Flow<List<MessageRecord>> {
         return messageRepository.getMessagesForConversation(conversationId, limit)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -1,12 +1,16 @@
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.user.UserId
 
 class MessageScope(
-    private val messageRepository: MessageRepository
+    private val messageRepository: MessageRepository,
+    private val clientRepository: ClientRepository,
+    private val userId: UserId
     // cryptography things
 ) {
 
-    val sendTextMessage: SendTextMessageUseCase get() = SendTextMessageUseCase(messageRepository)
+    val sendTextMessage: SendTextMessageUseCase get() = SendTextMessageUseCase(messageRepository, userId, clientRepository)
     val getRecentMessages: GetRecentMessagesUseCase get() = GetRecentMessagesUseCase(messageRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/OutgoingMessageRecipientsRetriever.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/OutgoingMessageRecipientsRetriever.kt
@@ -1,0 +1,87 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.cryptography.CryptoClientId
+import com.wire.kalium.cryptography.CryptoSessionId
+import com.wire.kalium.cryptography.ProteusClient
+import com.wire.kalium.cryptography.exceptions.ProteusException
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Recipient
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.suspending
+import com.wire.kalium.cryptography.UserId as CryptoUserId
+
+interface OutgoingMessageRecipientsRetriever {
+
+    /**
+     * Verifies if this client can send messages to all the client recipients.
+     * Will fetch PreKeys and establish cryptographic sessions if needed.
+     */
+    suspend fun prepareRecipientsForNewOutgoingMessage(
+        recipients: List<Recipient>
+    ): Either<CoreFailure, Unit>
+}
+
+class OutgoingMessageRecipientsRetrieverImpl(
+    private val proteusClient: ProteusClient
+) : OutgoingMessageRecipientsRetriever {
+    override suspend fun prepareRecipientsForNewOutgoingMessage(
+        recipients: List<Recipient>
+    ): Either<CoreFailure, Unit> =
+        suspending {
+            getAllMissingClients(recipients).flatMap {
+                establishMissingSessions(it)
+            }
+        }
+
+    private suspend fun establishMissingSessions(
+        missingContactClients: Map<UserId, List<ClientId>>
+    ): Either<CoreFailure, Unit> = suspending {
+        if (missingContactClients.isEmpty()) {
+            return@suspending Either.Right(Unit)
+        }
+
+        TODO("fetch prekeys using preKeyRepository and establish session")
+    }
+
+    private suspend fun getAllMissingClients(
+        detailedContacts: List<Recipient>
+    ): Either<CoreFailure, Map<UserId, List<ClientId>>> = suspending {
+        detailedContacts.foldToEitherWhileRight(mutableMapOf<UserId, List<ClientId>>()) { recipient, userAccumulator ->
+            getMissingClientsForRecipients(recipient).map { missingClients ->
+                if (missingClients.isNotEmpty()) {
+                    userAccumulator[recipient.member.id] = missingClients
+                }
+                userAccumulator
+            }
+        }
+    }
+
+    private suspend fun getMissingClientsForRecipients(
+        recipient: Recipient
+    ): Either<CoreFailure, List<ClientId>> =
+        suspending {
+            recipient.clients.foldToEitherWhileRight(mutableListOf<ClientId>()) { client, clientIdAccumulator ->
+                //TODO Use domain too
+                doesSessionExist(recipient.member.id.value, client).map { sessionExists ->
+                    if (!sessionExists) {
+                        clientIdAccumulator += client
+                    }
+                    clientIdAccumulator
+                }
+            }
+        }
+
+    private suspend fun doesSessionExist(
+        recipientUserId: String,
+        client: ClientId
+    ): Either<CoreFailure, Boolean> {
+        return try {
+            val cryptoSessionID = CryptoSessionId(CryptoUserId(recipientUserId), CryptoClientId(client.value))
+            Either.Right(proteusClient.doesSessionExist(cryptoSessionID))
+        } catch (proteusException: ProteusException) {
+            Either.Left(CoreFailure.Unknown(proteusException))
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -2,20 +2,20 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.persistence.dao.QualifiedID
-import com.wire.kalium.persistence.dao.message.Message
+import com.wire.kalium.persistence.dao.message.MessageRecord
 
 class SendTextMessageUseCase(private val messageRepository: MessageRepository) {
 
     suspend operator fun invoke(conversationId: QualifiedID, text: String) {
         //TODO
-        val message = Message(
+        val message = MessageRecord(
             id = "someUUID",
             content = text,
             conversationId = conversationId,
             date = "25 Jan 2022 13:30:00 GMT",
             senderUserId = QualifiedID("sender_id", "domain"),
             senderClientId = "someSenderClientId",
-            status = Message.Status.READ
+            status = MessageRecord.Status.READ
         )
 
         messageRepository.persistMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -1,21 +1,27 @@
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.conversation.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.persistence.dao.QualifiedID
-import com.wire.kalium.persistence.dao.message.MessageRecord
+import com.wire.kalium.logic.data.user.UserId
 
-class SendTextMessageUseCase(private val messageRepository: MessageRepository) {
+class SendTextMessageUseCase(
+    private val messageRepository: MessageRepository,
+    private val userId: UserId,
+    private val clientRepository: ClientRepository
+) {
 
-    suspend operator fun invoke(conversationId: QualifiedID, text: String) {
-        //TODO
-        val message = MessageRecord(
+    suspend operator fun invoke(conversationId: ConversationId, text: String) {
+        val message = Message(
             id = "someUUID",
-            content = text,
+            content = MessageContent.Text(text),
             conversationId = conversationId,
             date = "25 Jan 2022 13:30:00 GMT",
-            senderUserId = QualifiedID("sender_id", "domain"),
-            senderClientId = "someSenderClientId",
-            status = MessageRecord.Status.READ
+            senderUserId = userId,
+            senderClientId = clientRepository.currentClientId().fold({ TODO("Fix me") }, { it }),
+            status = Message.Status.PENDING
         )
 
         messageRepository.persistMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -1,0 +1,40 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.cryptography.CryptoClientId
+import com.wire.kalium.cryptography.CryptoSessionId
+import com.wire.kalium.cryptography.ProteusClient
+import com.wire.kalium.cryptography.UserId
+import com.wire.kalium.cryptography.exceptions.ProteusException
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.PlainMessageBlob
+import com.wire.kalium.logic.data.message.ProtoContentMapper
+import com.wire.kalium.logic.util.Base64
+import io.ktor.utils.io.core.toByteArray
+
+class ConversationEventReceiver(
+    private val proteusClient: ProteusClient,
+    private val messageRepository: MessageRepository,
+    private val protoContentMapper: ProtoContentMapper
+) : EventReceiver<Event.Conversation> {
+    override suspend fun onEvent(event: Event.Conversation) {
+        when (event) {
+            is Event.Conversation.NewMessage -> handleNewMessage(event)
+        }
+    }
+
+    private suspend fun handleNewMessage(event: Event.Conversation.NewMessage) {
+        val decodedContentBytes = Base64.decodeFromBase64(event.content.toByteArray())
+
+        //TODO Use domain when creating CryptoSession too
+        val cryptoSessionId = CryptoSessionId(UserId(event.senderUserId.value), CryptoClientId(event.senderClientId.value))
+        val decryptedContentBytes = try {
+            proteusClient.decrypt(decodedContentBytes, cryptoSessionId)
+        } catch (e: ProteusException){
+            //TODO: Insert a failed message into the database to notify user that encryption is kaputt
+            return
+        }
+        val content = protoContentMapper.decodeFromProtobuf(PlainMessageBlob(decryptedContentBytes))
+
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/EventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/EventReceiver.kt
@@ -1,0 +1,7 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logic.data.event.Event
+
+fun interface EventReceiver<T : Event> {
+    suspend fun onEvent(event: T)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCase.kt
@@ -7,7 +7,8 @@ import com.wire.kalium.logic.functional.onFailure
 
 class ListenToEventsUseCase(
     private val syncManager: SyncManager,
-    private val eventRepository: EventRepository
+    private val eventRepository: EventRepository,
+    private val conversationEventReceiver: EventReceiver<Event.Conversation>
 ) {
 
     /**
@@ -21,8 +22,8 @@ class ListenToEventsUseCase(
             either.map { event ->
                 println("Event received: $event")
                 when (event) {
-                    is Event.Conversation.NewMessage -> {
-                        //TODO Handle messages!
+                    is Event.Conversation -> {
+                        conversationEventReceiver.onEvent(event)
                     }
                     else -> {
                         //TODO: Multiplatform logging

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/Base64.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/Base64.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.logic.util
+
+/**
+ *
+ * TODO: Move to a utils module?
+ */
+expect object Base64 {
+    fun encodeToBase64(originalString: ByteArray): ByteArray
+    fun decodeFromBase64(encoded: ByteArray): ByteArray
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1,10 +1,10 @@
 package com.wire.kalium.logic.feature
 
-import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
-import com.wire.kalium.persistence.db.Database
+import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.feature.auth.AuthSession
+import com.wire.kalium.persistence.db.Database
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 
 actual class UserSessionScope(
@@ -18,6 +18,8 @@ actual class UserSessionScope(
     override val encryptedSettingsHolder: EncryptedSettingsHolder = EncryptedSettingsHolder(
         "$PREFERENCE_FILE_PREFIX-${session.userId}"
     )
+
+    override val protoContentMapper: ProtoContentMapper = ProtoContentMapper()
 
     private companion object {
         private const val PREFERENCE_FILE_PREFIX = ".user-pref"

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/util/Base64.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/util/Base64.kt
@@ -1,0 +1,9 @@
+package com.wire.kalium.logic.util
+
+import java.util.Base64
+
+actual object Base64 {
+    actual fun encodeToBase64(originalString: ByteArray): ByteArray = Base64.getEncoder().encode(originalString)
+
+    actual fun decodeFromBase64(encoded: ByteArray): ByteArray = Base64.getDecoder().decode(encoded)
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.persistence.dao.message
 import com.wire.kalium.persistence.dao.QualifiedID
 import kotlinx.coroutines.flow.Flow
 
-data class Message(
+data class MessageRecord(
     val id: String,
     val content: String?,
     val conversationId: QualifiedID,
@@ -20,10 +20,10 @@ data class Message(
 interface MessageDAO {
     suspend fun deleteMessage(id: String, conversationsId: QualifiedID)
     suspend fun deleteAllMessages()
-    suspend fun insertMessage(message: Message)
-    suspend fun insertMessages(messages: List<Message>)
-    suspend fun updateMessage(message: Message)
-    suspend fun getAllMessages(): Flow<List<Message>>
-    suspend fun getMessageById(id: String, conversationId: QualifiedID): Flow<Message?>
-    suspend fun getMessageByConversation(conversationId: QualifiedID, limit: Int): Flow<List<Message>>
+    suspend fun insertMessage(message: MessageRecord)
+    suspend fun insertMessages(messages: List<MessageRecord>)
+    suspend fun updateMessage(message: MessageRecord)
+    suspend fun getAllMessages(): Flow<List<MessageRecord>>
+    suspend fun getMessageById(id: String, conversationId: QualifiedID): Flow<MessageRecord?>
+    suspend fun getMessageByConversation(conversationId: QualifiedID, limit: Int): Flow<List<MessageRecord>>
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.flow.map
 import com.wire.kalium.persistence.db.Message as SQLDelightMessage
 
 class MessageMapper {
-    fun toModel(msg: SQLDelightMessage): Message {
-        return Message(
+    fun toModel(msg: SQLDelightMessage): MessageRecord {
+        return MessageRecord(
             id = msg.id,
             content = msg.content,
             conversationId = msg.conversation_id,
@@ -30,7 +30,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
 
     override suspend fun deleteAllMessages() = queries.deleteAllMessages()
 
-    override suspend fun insertMessage(message: Message) =
+    override suspend fun insertMessage(message: MessageRecord) =
         queries.insertMessage(
             message.id,
             message.content,
@@ -41,7 +41,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             message.status
         )
 
-    override suspend fun insertMessages(messages: List<Message>) =
+    override suspend fun insertMessages(messages: List<MessageRecord>) =
         queries.transaction {
             messages.forEach { message ->
                 queries.insertMessage(
@@ -56,7 +56,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             }
         }
 
-    override suspend fun updateMessage(message: Message) =
+    override suspend fun updateMessage(message: MessageRecord) =
         queries.updateMessages(
             message.content,
             message.date,
@@ -67,19 +67,19 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             message.conversationId
         )
 
-    override suspend fun getAllMessages(): Flow<List<Message>> =
+    override suspend fun getAllMessages(): Flow<List<MessageRecord>> =
         queries.selectAllMessages()
             .asFlow()
             .mapToList()
             .map { entryList -> entryList.map(mapper::toModel) }
 
-    override suspend fun getMessageById(id: String, conversationId: QualifiedID): Flow<Message?> =
+    override suspend fun getMessageById(id: String, conversationId: QualifiedID): Flow<MessageRecord?> =
         queries.selectById(id, conversationId)
             .asFlow()
             .mapToOneOrNull()
             .map { msg -> msg?.let(mapper::toModel) }
 
-    override suspend fun getMessageByConversation(conversationId: QualifiedID, limit: Int): Flow<List<Message>> =
+    override suspend fun getMessageByConversation(conversationId: QualifiedID, limit: Int): Flow<List<MessageRecord>> =
         queries.selectByConversationId(conversationId, limit.toLong())
             .asFlow()
             .mapToList()

--- a/persistence/src/commonMain/sqldelight/com/wire/kalium/persistence/db/Messages.sq
+++ b/persistence/src/commonMain/sqldelight/com/wire/kalium/persistence/db/Messages.sq
@@ -1,5 +1,5 @@
 import com.wire.kalium.persistence.dao.QualifiedID;
-import com.wire.kalium.persistence.dao.message.Message;
+import com.wire.kalium.persistence.dao.message.MessageRecord;
 
 CREATE TABLE Message (
       id TEXT NOT NULL,
@@ -8,7 +8,7 @@ CREATE TABLE Message (
       date TEXT NOT NULL,
       sender_user_id TEXT AS QualifiedID NOT NULL,
       sender_client_id TEXT NOT NULL,
-      status TEXT AS Message.Status NOT NULL,
+      status TEXT AS MessageRecord.Status NOT NULL,
       FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id),
       FOREIGN KEY (sender_user_id) REFERENCES User(qualified_id),
       PRIMARY KEY (id, conversation_id)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When sending a message, we need to make sure we have cryptographic session with all the recipients. If we don't, then we need to fetch PreKeys for each missing session and establish them.

### Solutions

Created a `OutgoingMessageRecipientsRetriever` which needs a better name.

### Dependencies (Optional)

* Needs `PreKeyRepository`, which is not in place yet. Hence the big `TODO`.

### Testing

[W.I.P]


----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
