### PR TITLE
feat: added get Conversation Details UseCase

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -1,9 +1,10 @@
 package com.wire.kalium.logic.data.message
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.api.message.MessageApi
-import com.wire.kalium.persistence.dao.QualifiedID
 import com.wire.kalium.persistence.dao.message.Message
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import kotlinx.coroutines.flow.Flow
@@ -14,12 +15,13 @@ interface MessageRepository {
 }
 
 class MessageDataSource(
+    private val idMapper: IdMapper,
     private val messageApi: MessageApi,
     private val messageDAO: MessageDAO
 ) : MessageRepository {
 
     override suspend fun getMessagesForConversation(conversationId: QualifiedID, limit: Int): Flow<List<Message>> {
-        return messageDAO.getMessageByConversation(conversationId, limit)
+        return messageDAO.getMessageByConversation(idMapper.toDaoModel(conversationId), limit)
     }
 
     override suspend fun persistMessage(message: Message): Either<CoreFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -9,14 +9,9 @@ import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientDataSource
 import com.wire.kalium.logic.data.client.ClientMapper
 import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.client.remote.ClientRemoteDataSource
-import com.wire.kalium.logic.data.conversation.ConversationDataSource
-import com.wire.kalium.logic.data.conversation.ConversationMapper
-import com.wire.kalium.logic.data.conversation.ConversationMapperImpl
-import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.MemberMapper
-import com.wire.kalium.logic.data.conversation.MemberMapperImpl
+import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
+import com.wire.kalium.logic.data.conversation.*
 import com.wire.kalium.logic.data.event.EventDataSource
 import com.wire.kalium.logic.data.event.EventMapper
 import com.wire.kalium.logic.data.event.EventRepository
@@ -71,7 +66,11 @@ abstract class UserSessionScopeCommon(
         )
 
     private val messageRepository: MessageRepository
-        get() = MessageDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.messageApi, database.messageDAO)
+        get() = MessageDataSource(
+            idMapper,
+            authenticatedDataSourceSet.authenticatedNetworkContainer.messageApi,
+            database.messageDAO
+        )
 
     private val userRepository: UserRepository
         get() = UserDataSource(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -9,5 +9,6 @@ class ConversationScope(
 ) {
     // TODO: get()
     val getConversations: GetConversationsUseCase = GetConversationsUseCase(conversationRepository, syncManager)
+    val getConversationDetails: GetConversationDetailsUseCase = GetConversationDetailsUseCase(conversationRepository, syncManager)
     val syncConversations: SyncConversationsUseCase = SyncConversationsUseCase(conversationRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationDetailsUseCase.kt
@@ -1,0 +1,18 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.coroutines.flow.Flow
+
+class GetConversationDetailsUseCase(
+    private val conversationRepository: ConversationRepository,
+    private val syncManager: SyncManager
+) {
+
+    suspend operator fun invoke(conversationId: QualifiedID): Flow<Conversation> {
+        syncManager.waitForSlowSyncToComplete()
+        return conversationRepository.getConversationDetailsFromDB(conversationId)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.persistence.dao.QualifiedID
 import com.wire.kalium.persistence.dao.message.Message
 import kotlinx.coroutines.flow.Flow
 


### PR DESCRIPTION
# What's new in this PR?

- added `GetConversationDetailsUseCase` for getting details for single Conversations by ID
- fixed IDs problem in `MessageScope`

### Issues

1. prev. `MessageRepository.getMessagesForConversation` was accepting `QualifiedID` from `persistence` as a param. 
But that QualifiedID is not accessible from the other modules.
2. there was no option to get just single Conversations details by ID

### Causes (Optional)

1. I didn't know there are so many `QualifiedID` :) 

### Solutions

1. made `MessageRepository.getMessagesForConversation`to  accept `QualifiedID` from `logic` module as a param and added `idMapper`.
