### PR TITLE
fix: prevent proguard from minifying UserSessionWorker constructor

### DIFF
--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -14,6 +14,7 @@ android {
     defaultConfig {
         minSdk = Android.Sdk.min
         targetSdk = Android.Sdk.target
+        consumerProguardFiles("consumer-proguard-rules.pro")
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/logic/consumer-proguard-rules.pro
+++ b/logic/consumer-proguard-rules.pro
@@ -1,0 +1,26 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+# Keep all classes that extend UserSessionWorker for scheduled workers
+-keep class * extends com.wire.kalium.logic.sync.UserSessionWorker {
+   <init>(...);
+}


### PR DESCRIPTION
…serSessionWorker`s constructors

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Android apps consuming Kalium are crashing on production when starting sync.

### Causes (Optional)

Proguard is removing the constructor of classes extending `UserSessionWorker`, as it is only invoked using Reflection.

### Solutions

Add a consumer proguard file to `logic` that keeps the constructor of such classes.

### Testing

Using Android Reloaded:
* It no longer crashes due to method not being found.
* By inspecting the built `.apk` file, I can see the constructor in question.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
