### PR TITLE
feat: Move DB initializations into CoreLogic to have a Singleton

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -43,7 +43,15 @@ actual class CoreLogic(
             val encryptedSettingsHolder = EncryptedSettingsHolder(applicationContext, "${PREFERENCE_FILE_PREFIX}-${session.userId}")
             val userPreferencesSettings = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
             val database = Database(applicationContext, "main.db", userPreferencesSettings)
-            AuthenticatedDataSourceSet(networkContainer, proteusClient, workScheduler, syncManager, database, userPreferencesSettings, encryptedSettingsHolder).also {
+            AuthenticatedDataSourceSet(
+                networkContainer,
+                proteusClient,
+                workScheduler,
+                syncManager,
+                database,
+                userPreferencesSettings,
+                encryptedSettingsHolder
+            ).also {
                 userScopeStorage[session] = it
             }
         }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -19,13 +19,7 @@ actual class UserSessionScope(
 ) : UserSessionScopeCommon(session, authenticatedDataSourceSet) {
 
     override val clientConfig: ClientConfig get() = ClientConfig(applicationContext)
-    override val database: Database get() = Database(applicationContext, "main.db", userPreferencesSettings)
-    override val encryptedSettingsHolder: EncryptedSettingsHolder
-        get() = EncryptedSettingsHolder(applicationContext, "$PREFERENCE_FILE_PREFIX-${session.userId}")
 
     override val protoContentMapper: ProtoContentMapper get() = ProtoContentMapper()
 
-    private companion object {
-        private const val PREFERENCE_FILE_PREFIX = "user-pref"
-    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/AuthenticatedDataSourceSet.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/AuthenticatedDataSourceSet.kt
@@ -4,10 +4,16 @@ import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.sync.WorkScheduler
 import com.wire.kalium.network.AuthenticatedNetworkContainer
+import com.wire.kalium.persistence.db.Database
+import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
+import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 
 class AuthenticatedDataSourceSet(
     val authenticatedNetworkContainer: AuthenticatedNetworkContainer,
     val proteusClient: ProteusClient,
     val workScheduler: WorkScheduler,
-    val syncManager: SyncManager
+    val syncManager: SyncManager,
+    val database: Database,
+    val kaliumPreferencesSettings: KaliumPreferencesSettings,
+    val encryptedSettingsHolder: EncryptedSettingsHolder
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -47,7 +47,6 @@ import com.wire.kalium.persistence.db.Database
 import com.wire.kalium.persistence.event.EventInfoStorage
 import com.wire.kalium.persistence.event.EventInfoStorageImpl
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
-import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 
 expect class UserSessionScope : UserSessionScopeCommon
 
@@ -56,8 +55,8 @@ abstract class UserSessionScopeCommon(
     private val authenticatedDataSourceSet: AuthenticatedDataSourceSet,
 ) {
 
-    protected abstract val encryptedSettingsHolder: EncryptedSettingsHolder
-    protected val userPreferencesSettings by lazy { KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings) }
+    private val encryptedSettingsHolder: EncryptedSettingsHolder = authenticatedDataSourceSet.encryptedSettingsHolder
+    private val userPreferencesSettings = authenticatedDataSourceSet.kaliumPreferencesSettings
     private val eventInfoStorage: EventInfoStorage
         get() = EventInfoStorageImpl(userPreferencesSettings)
 
@@ -65,7 +64,7 @@ abstract class UserSessionScopeCommon(
     private val memberMapper: MemberMapper get() = MemberMapperImpl(idMapper)
     private val conversationMapper: ConversationMapper get() = ConversationMapperImpl(idMapper, memberMapper)
     private val userMapper = UserMapperImpl(idMapper)
-    protected abstract val database: Database
+    private val database: Database = authenticatedDataSourceSet.database
 
     private val conversationRepository: ConversationRepository
         get() = ConversationDataSource(

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -12,16 +12,7 @@ actual class UserSessionScope(
     authenticatedDataSourceSet: AuthenticatedDataSourceSet,
 ) : UserSessionScopeCommon(session, authenticatedDataSourceSet) {
     override val clientConfig: ClientConfig get() = ClientConfig()
-    override val database: Database
-        get() = Database()
-
-    override val encryptedSettingsHolder: EncryptedSettingsHolder = EncryptedSettingsHolder(
-        "$PREFERENCE_FILE_PREFIX-${session.userId}"
-    )
 
     override val protoContentMapper: ProtoContentMapper get() = ProtoContentMapper()
 
-    private companion object {
-        private const val PREFERENCE_FILE_PREFIX = ".user-pref"
-    }
 }


### PR DESCRIPTION
### Issues

prev. DB was inited in UseCase, because of it we had different DB instances for each request.

### Solutions

Move DB init into CoreLogic, so it will be invited once and passed to necessary places (UserScope, etc.)
