### PR TITLE
fix(android): prevent minification of protobuf models

### DIFF
--- a/logic/consumer-proguard-rules.pro
+++ b/logic/consumer-proguard-rules.pro
@@ -24,3 +24,6 @@
 -keep class * extends com.wire.kalium.logic.sync.UserSessionWorker {
    <init>(...);
 }
+
+# protobuf
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }

--- a/network/consumer-proguard-rules.pro
+++ b/network/consumer-proguard-rules.pro
@@ -42,3 +42,6 @@
 -keepclassmembers class <1>.<2> {
   <1>.<2>$Companion Companion;
 }
+
+# protobuf
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Android devices are crashing on release builds

### Causes (Optional)

Proguard is minifying Protobuf classes

### Solutions

Add consumer rule to prevent consumer apps from doing this when building a release artifact.

### Testing

Tested manually on Android-Reloaded by building a minified `.apk`

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
