### PR TITLE
fix: app crashing on 401 response [AR-1135]

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/HttpClientProvider.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/HttpClientProvider.kt
@@ -13,6 +13,8 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.SIMPLE
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
 
@@ -32,7 +34,7 @@ internal fun provideBaseHttpClient(
 
         // since error response are application/json
         // this header is added by default to all requests
-        header("Content-Type", "application/json")
+        header(HttpHeaders.ContentType, ContentType.Application.Json)
 
         when (options) {
             HttpClientOptions.NoDefaultHost -> {/* do nothing */ }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -3,8 +3,10 @@ package com.wire.kalium.network.exceptions
 import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.api.message.QualifiedSendMessageResponse
 import com.wire.kalium.network.api.message.SendMessageResponse
+import io.ktor.http.HttpStatusCode
 
 sealed class KaliumException(val errorCode: Int) : Exception() {
+    object Unauthorized: KaliumException(HttpStatusCode.Unauthorized.value)
     class RedirectError(val errorResponse: ErrorResponse) : KaliumException(errorCode = errorResponse.code)
     class InvalidRequestError(val errorResponse: ErrorResponse) : KaliumException(errorCode = errorResponse.code)
     class ServerError(val errorResponse: ErrorResponse) : KaliumException(errorCode = errorResponse.code)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.network.api.message.SendMessageResponse
 import io.ktor.http.HttpStatusCode
 
 sealed class KaliumException(val errorCode: Int) : Exception() {
-    object Unauthorized: KaliumException(HttpStatusCode.Unauthorized.value)
+    class Unauthorized(errorCode: Int): KaliumException(errorCode)
     class RedirectError(val errorResponse: ErrorResponse) : KaliumException(errorCode = errorResponse.code)
     class InvalidRequestError(val errorResponse: ErrorResponse) : KaliumException(errorCode = errorResponse.code)
     class ServerError(val errorResponse: ErrorResponse) : KaliumException(errorCode = errorResponse.code)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkUtils.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkUtils.kt
@@ -71,7 +71,7 @@ suspend inline fun <reified BodyType> wrapKaliumResponse(performRequest: () -> H
                     // TODO: log if 401 got to this step, since it need to be handled by the http client
                     // for 401 error the BE return response with content-type: text/html which our ktor client
                     // has no idea how to parse -> app crash
-                    HttpStatusCode.Unauthorized -> NetworkResponse.Error(KaliumException.Unauthorized)
+                    HttpStatusCode.Unauthorized -> NetworkResponse.Error(KaliumException.Unauthorized(e.response.status.value))
 
                     // TODO: try catch the parsing of error body
                     else -> NetworkResponse.Error(kException = KaliumException.InvalidRequestError(e.response.body()))

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkUtils.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkUtils.kt
@@ -8,6 +8,7 @@ import io.ktor.client.plugins.RedirectResponseException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.setCookie
 import io.ktor.util.toMap
 import io.ktor.utils.io.errors.IOException
@@ -66,7 +67,15 @@ suspend inline fun <reified BodyType> wrapKaliumResponse(performRequest: () -> H
             }
             is ClientRequestException -> {
                 // 400 .. 499
-                NetworkResponse.Error(kException = KaliumException.InvalidRequestError(e.response.body()))
+                when(e.response.status) {
+                    // TODO: log if 401 got to this step, since it need to be handled by the http client
+                    // for 401 error the BE return response with content-type: text/html which our ktor client
+                    // has no idea how to parse -> app crash
+                    HttpStatusCode.Unauthorized -> NetworkResponse.Error(KaliumException.Unauthorized)
+
+                    // TODO: try catch the parsing of error body
+                    else -> NetworkResponse.Error(kException = KaliumException.InvalidRequestError(e.response.body()))
+                }
             }
             is ServerResponseException -> {
                 // 500 .. 599

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/ClientApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/ClientApiTest.kt
@@ -36,10 +36,10 @@ class ClientApiTest : ApiTest {
         }
 
     @Test
-    fun givenTheServerReturnsAnError_whenCallingTheRegisterClientEndpoint_theCorrectExceptionIsThrown() = runTest {
+    fun givenTheServerReturnsAnError_whenCallingTheRegisterClientEndpoint_thenExceptionIsPropagated() = runTest {
         val httpClient = mockAuthenticatedHttpClient(
             ErrorResponseJson.valid.rawJson,
-            statusCode = HttpStatusCode.Unauthorized
+            statusCode = HttpStatusCode.BadRequest
         )
         val clientApi: ClientApi = ClientApiImpl(httpClient)
         val errorResponse = clientApi.registerClient(REGISTER_CLIENT_REQUEST.serializableData)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/LoginApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/LoginApiTest.kt
@@ -39,10 +39,10 @@ class LoginApiTest : ApiTest {
     }
 
     @Test
-    fun givenTheServerReturnsAnError_whenCallingTheLoginEndpoint_theCorrectExceptionIsThrown() = runTest {
+    fun givenTheServerReturnsAnError_whenCallingTheLoginEndpoint_thenExceptionIsPropagated() = runTest {
         val httpClient = mockUnauthenticatedHttpClient(
             ErrorResponseJson.valid.rawJson,
-            statusCode = HttpStatusCode.Unauthorized
+            statusCode = HttpStatusCode.BadRequest
         )
         val loginApi: LoginApi = LoginApiImpl(httpClient)
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/logout/LogoutApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/logout/LogoutApiTest.kt
@@ -35,10 +35,10 @@ class LogoutApiTest : ApiTest {
         }
 
     @Test
-    fun givenTheServerReturnsAnError_whenCallingTheLogoutEndpoint_theCorrectExceptionIsThrown() = runTest {
+    fun givenTheServerReturnsAnError_whenCallingTheLogoutEndpoint_thenExceptionIsPropagated() = runTest {
         val httpClient = mockAuthenticatedHttpClient(
             ERROR_RESPONSE.rawJson,
-            statusCode = HttpStatusCode.Unauthorized
+            statusCode = HttpStatusCode.BadRequest
         )
         val logout: LogoutApi = LogoutImp(httpClient)
         val errorResponse = logout.logout(TEST_COOKIE)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/self/SelfApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/self/SelfApiTest.kt
@@ -34,10 +34,10 @@ class SelfApiTest : ApiTest {
         }
 
     @Test
-    fun givenTheServerReturnsAnError_whenCallingTheGetSelfEndpoint_theCorrectExceptionIsThrown() = runTest {
+    fun givenTheServerReturnsAnError_whenCallingTheGetSelfEndpoint_thenExceptionIsPropagated() = runTest {
         val httpClient = mockAuthenticatedHttpClient(
             ErrorResponseJson.valid.rawJson,
-            statusCode = HttpStatusCode.Unauthorized
+            statusCode = HttpStatusCode.BadRequest
         )
         val selfApi = SelfApi(httpClient)
         val response = selfApi.getSelfInfo()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

BE send 401 -> app crash 

### Causes (Optional)

on 401 unauthorized the BE sends error response with `content-type: text/html` and the ktor client does not speak html, so when trying to parse the body it throw `NoTransformationFoundException`
### Solutions

ez just don't parse it 


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

manually


----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
