### PR TITLE
fix: login failing

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -18,6 +18,8 @@ sealed class CoreFailure {
 }
 
 sealed class NetworkFailure(internal val kaliumException: KaliumException) : CoreFailure() {
+    // exposed as Throwable to the app if needed for logging
+    val cause: Throwable get() = kaliumException
     /**
      * Failed to establish a connection with the necessary servers in order to pull/push data.
      * Caused by weak - complete lack of - internet connection.

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/LoginApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/LoginApiImpl.kt
@@ -33,7 +33,7 @@ class LoginApiImpl(private val httpClient: HttpClient) : LoginApi {
         @SerialName("token_type") val tokenType: String
     )
 
-    private fun LoginResponse.toSessionCredentials(refreshToken: String): SessionDTO = SessionDTO(
+    private fun LoginResponse.toSessionDto(refreshToken: String): SessionDTO = SessionDTO(
         userIdValue = userId,
         tokenType = tokenType,
         accessToken = accessToken,
@@ -69,7 +69,7 @@ class LoginApiImpl(private val httpClient: HttpClient) : LoginApi {
                 if (refreshToken == null) {
                     NetworkResponse.Error(KaliumException.ServerError(ErrorResponse(500, "no cookie was found", "missing-refreshToken")))
                 } else {
-                    NetworkResponse.Success(result.value.toSessionCredentials(refreshToken), result.headers, result.httpCode)
+                    NetworkResponse.Success(result.value.toSessionDto(refreshToken), result.headers, result.httpCode)
                 }
             }
             is NetworkResponse.Error -> NetworkResponse.Error(result.kException)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkResponse.kt
@@ -16,13 +16,16 @@ sealed class NetworkResponse<out T : Any> {
     ) : NetworkResponse<T>() {
         internal constructor(value: T, httpResponse: HttpResponse) : this(
             value,
+            // small issue here where keys are converted to small case letters
+            // this is an issue for ktor to solve
             httpResponse.headers.toMap()
                 .mapValues { headerEntry -> headerEntry.value.firstOrNull() }, // Ignore header duplication on purpose
             httpResponse.status.value
         )
 
         val cookies: Map<String, String> by lazy {
-            this.headers[HttpHeaders.SetCookie]?.splitSetCookieHeader()?.flatMap { it.splitSetCookieHeader() }
+            // don't use HttpHeaders.SetCookie until the case sensitivity issue is solved
+            this.headers["set-cookie"]?.splitSetCookieHeader()?.flatMap { it.splitSetCookieHeader() }
                 ?.map { parseServerSetCookieHeader(it) }?.associate {
                     it.name to it.value
                 } ?: mapOf()

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -8,9 +8,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.HttpRequestData
-import io.ktor.client.utils.EmptyContent.headers
 import io.ktor.http.ContentType
-import io.ktor.http.Headers
 import io.ktor.http.HeadersImpl
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/LoginApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/LoginApiTest.kt
@@ -2,13 +2,11 @@ package com.wire.kalium.api.tools.json.api.user.login
 
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.tools.json.model.ErrorResponseJson
-import com.wire.kalium.network.api.RefreshTokenProperties
 import com.wire.kalium.network.api.SessionDTO
 import com.wire.kalium.network.api.user.login.LoginApi
 import com.wire.kalium.network.api.user.login.LoginApiImpl
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.isSuccessful
-import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -34,7 +32,7 @@ class LoginApiTest : ApiTest {
                 assertHttps()
                 assertHostEqual(TEST_HOST)
             },
-            headers = mapOf(HttpHeaders.SetCookie to "zuid=$refreshToken")
+            headers = mapOf("set-cookie" to "zuid=$refreshToken")
         )
         val expected = with(VALID_LOGIN_RESPONSE.serializableData) { SessionDTO(userIdValue = userId, accessToken = accessToken, tokenType = tokenType, refreshToken = refreshToken) }
         val loginApi: LoginApi = LoginApiImpl(httpClient)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

kalium not being able to extract the refresh token from headers

### Causes (Optional)

`httpResponse.headers.toMap()` is not case sensitive and will convert the keys to lowercase

### Solutions

get cookie by string key "set-cookie" instead of `HttpHeaders.SetCookie`

Needs releases with:

- [ ] GitHub link to other pull request


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
