### PR TITLE
fix: login, delete and register client UseCase failures [AR-1207] [AR-1215]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.data.auth.login
 
-import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.session.SessionMapper
@@ -16,14 +15,14 @@ interface LoginRepository {
         password: String,
         shouldPersistClient: Boolean,
         serverConfig: ServerConfig
-    ): Either<CoreFailure, AuthSession>
+    ): Either<NetworkFailure, AuthSession>
 
     suspend fun loginWithHandle(
         handle: String,
         password: String,
         shouldPersistClient: Boolean,
         serverConfig: ServerConfig
-    ): Either<CoreFailure, AuthSession>
+    ): Either<NetworkFailure, AuthSession>
 }
 
 class LoginRepositoryImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -12,12 +12,12 @@ import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.persistence.dao.client.Client as ClientEntity
 
 interface ClientRepository {
-    suspend fun registerClient(param: RegisterClientParam): Either<CoreFailure, Client>
+    suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client>
     suspend fun persistClientId(clientId: ClientId): Either<CoreFailure, Unit>
     suspend fun currentClientId(): Either<CoreFailure, ClientId>
-    suspend fun deleteClient(param: DeleteClientParam): Either<CoreFailure, Unit>
-    suspend fun selfListOfClients(): Either<CoreFailure, List<Client>>
-    suspend fun clientInfo(clientId: ClientId /* = com.wire.kalium.logic.data.id.PlainId */): Either<CoreFailure, Client>
+    suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit>
+    suspend fun selfListOfClients(): Either<NetworkFailure, List<Client>>
+    suspend fun clientInfo(clientId: ClientId /* = com.wire.kalium.logic.data.id.PlainId */): Either<NetworkFailure, Client>
     suspend fun saveNewClients(userId: UserId, clients: List<ClientId>): Either<CoreFailure, Unit>
 }
 
@@ -28,7 +28,7 @@ class ClientDataSource(
     private val clientDAO: ClientDAO,
     private val userMapper: UserMapper
 ) : ClientRepository {
-    override suspend fun registerClient(param: RegisterClientParam): Either<CoreFailure, Client> {
+    override suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client> {
         return clientRemoteRepository.registerClient(param)
     }
 
@@ -43,15 +43,16 @@ class ClientDataSource(
         } ?: Either.Left(CoreFailure.MissingClientRegistration)
     }
 
-    override suspend fun deleteClient(param: DeleteClientParam): Either<CoreFailure, Unit> {
+    override suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit> {
         return clientRemoteRepository.deleteClient(param)
     }
 
-    override suspend fun selfListOfClients(): Either<CoreFailure, List<Client>> {
+    // TODO: after fetch save list of self client in the db
+    override suspend fun selfListOfClients(): Either<NetworkFailure, List<Client>> {
         return clientRemoteRepository.fetchSelfUserClients()
     }
 
-    override suspend fun clientInfo(clientId: ClientId): Either<CoreFailure, Client> {
+    override suspend fun clientInfo(clientId: ClientId): Either<NetworkFailure, Client> {
         return clientRemoteRepository.fetchClientInfo(clientId)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
@@ -7,15 +7,10 @@ import com.wire.kalium.logic.data.client.ClientMapper
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.data.client.RegisterClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.failure.ClientFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.user.client.ClientApi
-import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.network.exceptions.isMissingAuth
-import com.wire.kalium.network.exceptions.isTooManyClients
 
 interface ClientRemoteRepository {
     suspend fun registerClient(param: RegisterClientParam): Either<CoreFailure, Client>
@@ -29,23 +24,12 @@ class ClientRemoteDataSource(
     private val clientMapper: ClientMapper
 ) : ClientRemoteRepository {
 
-    override suspend fun registerClient(param: RegisterClientParam): Either<CoreFailure, Client> =
+    override suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client> =
         wrapApiRequest { clientApi.registerClient(clientMapper.toRegisterClientRequest(param)) }
-            .fold({ networkFailure ->
-                when (networkFailure.kaliumException) {
-                    is KaliumException.InvalidRequestError -> {
-                        if (networkFailure.kaliumException.isTooManyClients())
-                            Either.Left(ClientFailure.TooManyClients)
-                        else if (networkFailure.kaliumException.isMissingAuth())
-                            Either.Left(ClientFailure.WrongPassword)
-                        else
-                            Either.Left(NetworkFailure.ServerMiscommunication(networkFailure.kaliumException))
-                    }
-                    else -> Either.Left(NetworkFailure.ServerMiscommunication(networkFailure.kaliumException))
-                }
-            }, { clientResponse ->
-                Either.Right(clientMapper.fromClientResponse(clientResponse))
-            })
+            .fold(
+                { networkFailure -> Either.Left(networkFailure) },
+                { clientResponse -> Either.Right(clientMapper.fromClientResponse(clientResponse)) }
+            )
 
     override suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit> =
         wrapApiRequest { clientApi.deleteClient(param.password, param.clientId.value) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.data.client.remote
 
-import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientMapper
@@ -13,7 +12,7 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.user.client.ClientApi
 
 interface ClientRemoteRepository {
-    suspend fun registerClient(param: RegisterClientParam): Either<CoreFailure, Client>
+    suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client>
     suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit>
     suspend fun fetchClientInfo(clientId: ClientId): Either<NetworkFailure, Client>
     suspend fun fetchSelfUserClients(): Either<NetworkFailure, List<Client>>

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/AuthenticationFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/AuthenticationFailure.kt
@@ -1,8 +1,0 @@
-package com.wire.kalium.logic.failure
-
-import com.wire.kalium.logic.CoreFailure
-
-sealed class AuthenticationFailure : CoreFailure.FeatureFailure() {
-    object InvalidCredentials: AuthenticationFailure()
-}
-

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/ClientFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/ClientFailure.kt
@@ -1,9 +1,0 @@
-package com.wire.kalium.logic.failure
-
-import com.wire.kalium.logic.CoreFailure
-
-sealed class ClientFailure : CoreFailure.FeatureFailure() {
-    object WrongPassword: ClientFailure()
-    object TooManyClients: ClientFailure()
-}
-

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -1,12 +1,12 @@
 package com.wire.kalium.logic.feature.auth
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.auth.login.LoginRepository
 import com.wire.kalium.logic.data.session.SessionRepository
-import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.suspending
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isInvalidCredentials
 
 sealed class AuthenticationResult {
     data class Success(val userSession: AuthSession) : AuthenticationResult()
@@ -24,34 +24,38 @@ class LoginUseCase(
     private val validateEmailUseCase: ValidateEmailUseCase,
     private val validateUserHandleUseCase: ValidateUserHandleUseCase
 ) {
-    suspend operator fun invoke(userIdentifier: String, password: String, shouldPersistClient: Boolean, serverConfig: ServerConfig): AuthenticationResult {
+    suspend operator fun invoke(
+        userIdentifier: String,
+        password: String,
+        shouldPersistClient: Boolean,
+        serverConfig: ServerConfig
+    ): AuthenticationResult = suspending {
         // remove White Spaces around userIdentifier
         val cleanUserIdentifier = userIdentifier.trim()
 
-        val result = when {
+        when {
             validateEmailUseCase(cleanUserIdentifier) -> {
                 loginRepository.loginWithEmail(cleanUserIdentifier, password, shouldPersistClient, serverConfig)
             }
             validateUserHandleUseCase(cleanUserIdentifier) -> {
                 loginRepository.loginWithHandle(cleanUserIdentifier, password, shouldPersistClient, serverConfig)
             }
-            else -> return AuthenticationResult.Failure.InvalidUserIdentifier
-        }
-
-        return when (result) {
-            is Either.Right -> {
-                sessionRepository.storeSession(result.value)
-                sessionRepository.updateCurrentSession(result.value.userId)
-                AuthenticationResult.Success(result.value)
-            }
-            is Either.Left -> {
-                if (result.value is NetworkFailure.ServerMiscommunication
-                    && result.value.kaliumException is KaliumException.InvalidRequestError) {
-                    AuthenticationResult.Failure.InvalidCredentials
-                } else {
-                    AuthenticationResult.Failure.Generic(result.value)
+            else -> return@suspending AuthenticationResult.Failure.InvalidUserIdentifier
+        }.coFold({
+            when (it.kaliumException) {
+                is KaliumException.InvalidRequestError -> {
+                    if (it.kaliumException.isInvalidCredentials()) {
+                        AuthenticationResult.Failure.InvalidCredentials
+                    } else {
+                        AuthenticationResult.Failure.Generic(it)
+                    }
                 }
+                else -> AuthenticationResult.Failure.Generic(it)
             }
-        }
+        }, {
+            sessionRepository.storeSession(it)
+            sessionRepository.updateCurrentSession(it.userId)
+            AuthenticationResult.Success(it)
+        })
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -1,12 +1,12 @@
 package com.wire.kalium.logic.feature.auth
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.auth.login.LoginRepository
-import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.session.SessionRepository
-import com.wire.kalium.logic.failure.AuthenticationFailure
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.network.exceptions.KaliumException
 
 sealed class AuthenticationResult {
     data class Success(val userSession: AuthSession) : AuthenticationResult()
@@ -45,7 +45,8 @@ class LoginUseCase(
                 AuthenticationResult.Success(result.value)
             }
             is Either.Left -> {
-                if (result.value is AuthenticationFailure.InvalidCredentials) {
+                if (result.value is NetworkFailure.ServerMiscommunication
+                    && result.value.kaliumException is KaliumException.InvalidRequestError) {
                     AuthenticationResult.Failure.InvalidCredentials
                 } else {
                     AuthenticationResult.Failure.Generic(result.value)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.logic.data.user.UserMapper
-import com.wire.kalium.logic.failure.ClientFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -1,11 +1,11 @@
 package com.wire.kalium.logic.data.client
 
+import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.id.PlainId
-import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.logic.data.user.UserMapper
-import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldFail
@@ -256,7 +256,7 @@ class ClientRepositoryTest {
 
     @Test
     fun whenSelfListOfClientsIsFail_thenTheErrorIsPropagated() = runTest {
-        val expected: Either.Left<CoreFailure> = Either.Left(TEST_FAILURE)
+        val expected: Either.Left<NetworkFailure> = Either.Left(TEST_FAILURE)
 
         given(clientRemoteRepository).coroutine { clientRepository.selfListOfClients() }.then { expected }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -1,10 +1,13 @@
 package com.wire.kalium.logic.feature.auth
 
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.auth.login.LoginRepository
 import com.wire.kalium.logic.data.session.SessionRepository
-import com.wire.kalium.logic.failure.AuthenticationFailure
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.TestNetworkException
+import com.wire.kalium.network.api.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
 import io.mockative.ConfigurationApi
 import io.mockative.Mock
 import io.mockative.any
@@ -175,15 +178,16 @@ class LoginUseCaseTest {
     @Test
     fun `given LoginUseCase is invoked, When loginRepository return InvalidCredentials, return InvalidCredentials`() =
         runTest {
+            val invalidCredentialsFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.invalidCredentials)
             given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
             given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }.then { false }
             given(loginRepository).coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
-                .then { Either.Left(AuthenticationFailure.InvalidCredentials) }
+                .then { Either.Left(invalidCredentialsFailure) }
 
             given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(TEST_HANDLE) }.then { true }
             given(loginRepository).coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
-                .then { Either.Left(AuthenticationFailure.InvalidCredentials) }
+                .then { Either.Left(invalidCredentialsFailure) }
 
             // email
             val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCaseTest.kt
@@ -5,6 +5,8 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.TestNetworkException
+import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import io.ktor.utils.io.errors.IOException
 import io.mockative.Mock
@@ -61,6 +63,19 @@ class DeleteClientUseCaseTest {
 
         assertIs<DeleteClientResult.Failure.Generic>(result)
         assertSame(genericFailure, result.genericFailure)
+    }
+
+    @Test
+    fun givenRepositoryDeleteClientFailsDueToWrongPassword_whenDeleting_thenInvalidCredentialsErrorShouldBeReturned() = runTest {
+        val wrongPasswordFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.missingAuth)
+        given(clientRepository)
+            .suspendFunction(clientRepository::deleteClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(wrongPasswordFailure) }
+
+        val result = deleteClient(DELETE_CLIENT_PARAMETERS)
+
+        assertIs<DeleteClientResult.Failure.InvalidCredentials>(result)
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -7,10 +7,11 @@ import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.client.ClientCapability
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.RegisterClientParam
-import com.wire.kalium.logic.failure.ClientFailure
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.TestNetworkException
+import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import io.ktor.utils.io.errors.IOException
 import io.mockative.Mock
@@ -82,7 +83,7 @@ class RegisterClientUseCaseTest {
 
     @Test
     fun givenRepositoryRegistrationFailsDueToWrongPassword_whenRegistering_thenInvalidCredentialsErrorShouldBeReturned() = runTest {
-        val wrongPasswordFailure = ClientFailure.WrongPassword
+        val wrongPasswordFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.missingAuth)
         given(clientRepository)
             .suspendFunction(clientRepository::registerClient)
             .whenInvokedWith(anything())
@@ -118,7 +119,7 @@ class RegisterClientUseCaseTest {
 
     @Test
     fun givenRepositoryRegistrationFailsDueToTooManyClientsRegistered_whenRegistering_thenTooManyClientsErrorShouldBeReturned() = runTest {
-        val tooManyClientsFailure = ClientFailure.TooManyClients
+        val tooManyClientsFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.tooManyClient)
         given(clientRepository)
             .suspendFunction(clientRepository::registerClient)
             .whenInvokedWith(anything())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
@@ -28,4 +28,12 @@ object TestNetworkException {
             label = "missing-auth"
         )
     )
+
+    val invalidCredentials = KaliumException.InvalidRequestError(
+        ErrorResponse(
+            403,
+            message = "invalid credentials",
+            label = "invalid-credentials"
+        )
+    )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -3,7 +3,14 @@ package com.wire.kalium.network.exceptions
 import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.api.message.QualifiedSendMessageResponse
 import com.wire.kalium.network.api.message.SendMessageResponse
-import kotlin.contracts.contract
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.BAD_REQUEST
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.BLACKLISTED_EMAIL
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.DOMAIN_BLOCKED
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_CREDENTIALS
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_EMAIL
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.KEY_EXISTS
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.MISSING_AUTH
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.TOO_MANY_CLIENTS
 
 sealed class KaliumException() : Exception() {
 
@@ -36,13 +43,6 @@ sealed class KaliumException() : Exception() {
         KaliumException()
 
     sealed class FeatureError() : KaliumException()
-
-    internal companion object {
-        const val ERROR_LABEL_TOO_MANY_CLIENTS = "too-many-clients"
-        const val ERROR_LABEL_INVALID_CREDENTIALS = "invalid-credentials"
-        const val ERROR_LABEL_BAD_REQUEST = "bad-request"
-        const val ERROR_LABEL_MISSING_AUTH = "missing-auth"
-    }
 }
 
 sealed class SendMessageError : KaliumException.FeatureError() {
@@ -55,20 +55,35 @@ sealed class QualifiedSendMessageError() : KaliumException.FeatureError() {
     ) : QualifiedSendMessageError()
 }
 
+
+fun KaliumException.InvalidRequestError.isInvalidCredentials(): Boolean {
+    return errorResponse.label == INVALID_CREDENTIALS
+}
+
 fun KaliumException.InvalidRequestError.isTooManyClients(): Boolean {
-    with(this.errorResponse) {
-        return code == 403 && label == KaliumException.ERROR_LABEL_TOO_MANY_CLIENTS
-    }
+    return errorResponse.label == TOO_MANY_CLIENTS
 }
 
 fun KaliumException.InvalidRequestError.isMissingAuth(): Boolean {
-    with(this.errorResponse) {
-        return code == 403 && label == KaliumException.ERROR_LABEL_MISSING_AUTH
-    }
+    return errorResponse.label == MISSING_AUTH
 }
 
 fun KaliumException.InvalidRequestError.isBadRequest(): Boolean {
-    with(this.errorResponse) {
-        return code == 400 && label == KaliumException.ERROR_LABEL_BAD_REQUEST
-    }
+    return errorResponse.label == BAD_REQUEST
+}
+
+fun KaliumException.InvalidRequestError.isDomainBlocked(): Boolean {
+    return errorResponse.label == DOMAIN_BLOCKED
+}
+
+fun KaliumException.InvalidRequestError.isKeyExists(): Boolean {
+    return errorResponse.label == KEY_EXISTS
+}
+
+fun KaliumException.InvalidRequestError.isBlackListedEmail(): Boolean {
+    return errorResponse.label == BLACKLISTED_EMAIL
+}
+
+fun KaliumException.InvalidRequestError.isInvalidEmail(): Boolean {
+    return errorResponse.label == INVALID_EMAIL
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -1,0 +1,12 @@
+package com.wire.kalium.network.exceptions
+
+internal object NetworkErrorLabel {
+    const val TOO_MANY_CLIENTS = "too-many-clients"
+    const val INVALID_CREDENTIALS = "invalid-credentials"
+    const val INVALID_EMAIL = "invalid-email"
+    const val BAD_REQUEST = "bad-request"
+    const val MISSING_AUTH = "missing-auth"
+    const val DOMAIN_BLOCKED = "domain-blocked-for-registration"
+    const val KEY_EXISTS = "key-exists"
+    const val BLACKLISTED_EMAIL = "blacklisted-email"
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When entering wrong password while logging in or deleting client, Generic server error is displayed instead of InvalidCredentials.

### Solutions

Updated UseCases to check failure types properly.

### Testing

UseCase tests updated.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
