### PR TITLE
fix: ServerConfigRemoteDataSource not using wrapApiRequest

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfigRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfigRemoteRepository.kt
@@ -1,22 +1,22 @@
 package com.wire.kalium.logic.configuration
 
-import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.configuration.ServerConfigApi
-import com.wire.kalium.network.utils.isSuccessful
 
 interface ServerConfigRemoteRepository {
-    suspend fun fetchServerConfig(remoteConfigUrl: String): Either<CoreFailure, ServerConfig>
+    suspend fun fetchServerConfig(remoteConfigUrl: String): Either<NetworkFailure, ServerConfig>
 }
+
 class ServerConfigRemoteDataSource(
     private val remoteConfigApi: ServerConfigApi,
     private val serverConfigMapper: ServerConfigMapper
 ) : ServerConfigRemoteRepository {
-    override suspend fun fetchServerConfig(remoteConfigUrl: String): Either<CoreFailure, ServerConfig> {
-        val response = remoteConfigApi.fetchServerConfig(remoteConfigUrl)
-        return if (response.isSuccessful())
-            Either.Right(serverConfigMapper.fromBackendConfig(response.value))
-        else
-            Either.Left(CoreFailure.Unknown(response.kException))
-    }
+
+    override suspend fun fetchServerConfig(remoteConfigUrl: String): Either<NetworkFailure, ServerConfig> = wrapApiRequest {
+        remoteConfigApi.fetchServerConfig(remoteConfigUrl)
+    }.map { serverConfigMapper.fromBackendConfig(it) }
+
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ServerConfigRemoteDataSource not using wrapApiRequest

### Solutions

wrapApiRequest

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
