### PR TITLE
ci: generate Dokka docs on Mac runners

### DIFF
--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     publish:
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         steps:
             - name: Checkout project
               uses: actions/checkout@v2.3.4


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

CD of Dokka docs is failing: https://github.com/wireapp/kalium/runs/5560210086?check_suite_focus=true#step:5:62

### Causes

It is failing because our Carthage plugin is trying to run Carthage on a Linux machine.

### Solutions

Short term: run on Mac.
Long term: investigate if we can update the Carthage plugin to behave a nicer on non-Mac machines.

### Testing

🤷🏼 

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
