### PR TITLE
feat: add password validation

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -61,8 +61,9 @@ abstract class AuthenticationScopeCommon(
             sessionMapper
         )
 
-    private val validateEmailUseCase: ValidateEmailUseCase get() = ValidateEmailUseCaseImpl()
-    private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
+    val validateEmailUseCase: ValidateEmailUseCase get() = ValidateEmailUseCaseImpl()
+    val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
+    val validatePasswordUseCase: ValidatePasswordUseCase get() = ValidatePasswordUseCaseImpl()
 
     val login: LoginUseCase
         get() = LoginUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCase.kt
@@ -13,12 +13,20 @@ class ValidateEmailUseCaseImpl : ValidateEmailUseCase {
     }
 
     private fun emailCharactersValid(email: String) =
-        email.contains('@')
+        email.matches(EMAIL_REGEX)
 
     private fun isEmailTooShort(email: String) = email.length < EMAIL_MIN_LENGTH
 
     private companion object {
         private const val EMAIL_MIN_LENGTH = 5
-        private val EMAIL_REGEX = """^[A-Za-z](.*)([@]{1})(.{1,})(\.)(.{1,})""".toRegex()
+        private val EMAIL_REGEX =
+            ("[a-zA-Z0-9\\+\\.\\_\\%\\-\\+]{1,256}" +
+                    "\\@" +
+                    "[a-zA-Z0-9][a-zA-Z0-9\\-]{0,64}" +
+                    "(" +
+                    "\\." +
+                    "[a-zA-Z0-9][a-zA-Z0-9\\-]{0,25}" +
+                    ")+"
+                    ).toRegex()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidatePasswordUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidatePasswordUseCase.kt
@@ -1,0 +1,31 @@
+package com.wire.kalium.logic.feature.auth
+
+interface ValidatePasswordUseCase {
+    operator fun invoke(password: String): Boolean
+}
+
+
+class ValidatePasswordUseCaseImpl : ValidatePasswordUseCase {
+    override operator fun invoke(password: String): Boolean = when {
+        isPasswordTooShort(password) -> false
+        !passwordCharactersValid(password) -> false
+        else -> true
+    }
+
+    private fun passwordCharactersValid(password: String) =
+        password.matches(PASSWORD_REGEX)
+
+    private fun isPasswordTooShort(password: String) = password.length < PASSWORD_MIN_LENGTH
+
+    private companion object {
+        private const val PASSWORD_MIN_LENGTH = 8
+        private val PASSWORD_REGEX = ("^" +
+                "(?=.*[a-z])" +                  // at least one lowercase ASCII letter
+                "(?=.*[A-Z])" +                  // at least one uppercase ASCII letter
+                "(?=.*[0-9])" +                  // at least a digit
+                "(?=.*[^a-zA-Z0-9])" +           // at least a "special character"
+                ".{$PASSWORD_MIN_LENGTH,}" +     //min PASSWORD_MIN_LENGTH characters
+                "$"
+                ).toRegex()
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/register/RequestActivationCodeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/register/RequestActivationCodeUseCase.kt
@@ -3,23 +3,41 @@ package com.wire.kalium.logic.feature.register
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.register.RegisterAccountRepository
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isInvalidEmail
+import com.wire.kalium.network.exceptions.isBlackListedEmail
+import com.wire.kalium.network.exceptions.isKeyExists
+import com.wire.kalium.network.exceptions.isDomainBlockedForRegistration
 
 class RequestActivationCodeUseCase(
     private val registerAccountRepository: RegisterAccountRepository
 ) {
-    suspend operator fun invoke(email: String, serverConfig: ServerConfig): RequestActivationCodeResult =
-        registerAccountRepository.requestEmailActivationCode(email, serverConfig.apiBaseUrl)
+    suspend operator fun invoke(email: String, serverConfig: ServerConfig): RequestActivationCodeResult {
+
+        return registerAccountRepository.requestEmailActivationCode(email, serverConfig.apiBaseUrl)
             .fold({
-                RequestActivationCodeResult.Failure.Generic(it)
+                if(it is NetworkFailure.ServerMiscommunication && it.kaliumException is KaliumException.InvalidRequestError)
+                    when {
+                        it.kaliumException.isInvalidEmail() -> RequestActivationCodeResult.Failure.InvalidEmail
+                        it.kaliumException.isBlackListedEmail() -> RequestActivationCodeResult.Failure.BlacklistedEmail
+                        it.kaliumException.isKeyExists() -> RequestActivationCodeResult.Failure.AlreadyInUse
+                        it.kaliumException.isDomainBlockedForRegistration() -> RequestActivationCodeResult.Failure.DomainBlocked
+                        else -> RequestActivationCodeResult.Failure.Generic(it)
+                    }
+                else RequestActivationCodeResult.Failure.Generic(it)
             }, {
                 RequestActivationCodeResult.Success
             })
-
+    }
 }
 
 sealed class RequestActivationCodeResult {
     object Success : RequestActivationCodeResult()
     sealed class Failure : RequestActivationCodeResult() {
+        object InvalidEmail : Failure()
+        object BlacklistedEmail : Failure()
+        object AlreadyInUse : Failure()
+        object DomainBlocked : Failure()
         class Generic(val failure: NetworkFailure) : Failure()
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCaseTest.kt
@@ -41,11 +41,9 @@ class ValidateEmailUseCaseTest {
 
         val INVALID_EMAILS = listOf(
             "example.com",
-
-            // these values are commented out because of the changes to validateEmailUseCase
-            // to check only if '@' exist somewhere
-            //".test@domain.com",
-            //" email@domain.de",
+            ".test@domain.com",
+            " email@domain.de",
+            "test@domain@domain.com"
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidatePasswordUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidatePasswordUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.wire.kalium.logic.feature.auth
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ValidatePasswordUseCaseTest {
+
+    private val validatePasswordUseCase: ValidatePasswordUseCase = ValidatePasswordUseCaseImpl()
+
+    @Test
+    fun `given a validatePasswordUseCase is invoked, when password is valid, then return true`() {
+        VALID_PASSWORDS.forEach { validPassword ->
+            assertTrue(message = "$validPassword is invalid ") { validatePasswordUseCase(validPassword) }
+        }
+    }
+
+    @Test
+    fun `given a validatePasswordUseCase is invoked, when password is invalid, then return false`() {
+        INVALID_PASSWORDS.forEach { invalidPassword ->
+            assertFalse { validatePasswordUseCase(invalidPassword) }
+        }
+    }
+
+    @Test
+    fun `given a validatePasswordUseCase is invoked, when password is short, then return false`() {
+        assertFalse { validatePasswordUseCase("1@3.") }
+    }
+
+    private companion object {
+        val VALID_PASSWORDS = listOf(
+            "Passw0rd!",            // plain old vanilla password
+            "Pass w0rd!",           // contains space
+            "Päss w0rd!",           // contains umlaut
+            "Päss\uD83D\uDC3Cw0rd!" // contains emoji
+        )
+
+        val INVALID_PASSWORDS = listOf(
+            "aA1!",                 // too short (minimum length here is 8)
+            "A1!A1!A1!A1!",         // no lowercase
+            "a1!a1!a1!a1!",         // no uppercase
+            "aA!aA!aA!aA!",         // no numbers
+            "aA1aA1aA1aA1"          // no symbols
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Validators was private in AuthenticationScope, also there was no validation for password.

### Solutions

- implemented ValidatePasswordUseCase with tests
- changed ValidateEmailUseCase to use regex same as Android uses (Patterns.EMAIL_ADDRESS)
- added error handling for RequestActivationCodeUseCase

### Testing

Added ValidatePasswordUseCaseTest.

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
