### PR TITLE
fix: fetching access token from a cookie

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
@@ -37,7 +37,7 @@ class AuthenticatedNetworkContainer(
     private val engine: HttpClientEngine = defaultHttpEngine(),
 //    private val onTokenUpdate: (newTokenInfo: Pair<String, String>) -> Unit // Idea to let the network handle the refresh token automatically
 ) {
-    private val accessTokenApi: AccessTokenApi get() = AccessTokenApiImpl(authenticatedHttpClient)
+    val accessTokenApi: AccessTokenApi get() = AccessTokenApiImpl(authenticatedHttpClient)
 
     val logoutApi: LogoutApi get() = LogoutImpl(authenticatedHttpClient, sessionDTO.refreshToken)
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/LoginNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/LoginNetworkContainer.kt
@@ -1,7 +1,5 @@
 package com.wire.kalium.network
 
-import com.wire.kalium.network.api.auth.AccessTokenApi
-import com.wire.kalium.network.api.auth.AccessTokenApiImpl
 import com.wire.kalium.network.api.configuration.ServerConfigApi
 import com.wire.kalium.network.api.configuration.ServerConfigApiImp
 import com.wire.kalium.network.api.user.login.LoginApi
@@ -16,12 +14,7 @@ class LoginNetworkContainer(
 
     val loginApi: LoginApi get() = LoginApiImpl(anonymousHttpClient)
     val serverConfigApi: ServerConfigApi get() = ServerConfigApiImp(anonymousHttpClient)
-    // AccessTokenApi is private here because it's a bit special since getToken
-    // can be called with and without the Authorization header and
-    // in LoginNetworkContainer it only needed to generate a token after register
-    // and no consumer of kalium should call getToken without the Authorization header
-    private val accessTokenApi: AccessTokenApi get() = AccessTokenApiImpl(anonymousHttpClient)
-    val registerApi: RegisterApi get() = RegisterApiImpl(anonymousHttpClient, accessTokenApi)
+    val registerApi: RegisterApi get() = RegisterApiImpl(anonymousHttpClient)
 
     internal val anonymousHttpClient by lazy {
         provideBaseHttpClient(engine, HttpClientOptions.NoDefaultHost)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AccessTokenApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/auth/AccessTokenApi.kt
@@ -5,8 +5,9 @@ import com.wire.kalium.network.api.model.AccessTokenDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.HttpClient
-import io.ktor.client.request.cookie
+import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.http.HttpHeaders
 
 interface AccessTokenApi {
     suspend fun getToken(refreshToken: String): NetworkResponse<AccessTokenDTO>
@@ -15,7 +16,7 @@ interface AccessTokenApi {
 internal class AccessTokenApiImpl(private val httpClient: HttpClient) : AccessTokenApi {
     override suspend fun getToken(refreshToken: String): NetworkResponse<AccessTokenDTO> = wrapKaliumResponse {
         httpClient.post(PATH_ACCESS) {
-            this.cookie(RefreshTokenProperties.COOKIE_NAME, refreshToken)
+            header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$refreshToken")
         }
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/AccessTokenDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/AccessTokenDTO.kt
@@ -1,15 +1,19 @@
 package com.wire.kalium.network.api.model
 
+import com.wire.kalium.network.api.NonQualifiedUserId
+import com.wire.kalium.network.api.SessionDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 
 @Serializable
-data class AccessTokenDTO (
-    @SerialName("access_token")
-    val value: String,
-    @SerialName("expires_in")
-    val expiresIn: Int,
-    @SerialName("token_type")
-    val tokenType: String
+data class AccessTokenDTO(
+    @SerialName("user") val userId: NonQualifiedUserId,
+    @SerialName("access_token") val value: String,
+    @SerialName("expires_in") val expiresIn: Int,
+    @SerialName("token_type") val tokenType: String
+)
+
+internal fun AccessTokenDTO.toSessionDto(refreshToken: String): SessionDTO = SessionDTO(
+    userIdValue = userId, tokenType = tokenType, accessToken = value, refreshToken = refreshToken
 )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/AccessTokenDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/AccessTokenDTO.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 
 
 @Serializable
-data class AccessTokenDTO(
+internal data class AccessTokenDTO(
     @SerialName("user") val userId: NonQualifiedUserId,
     @SerialName("access_token") val value: String,
     @SerialName("expires_in") val expiresIn: Int,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/AccessTokenDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/AccessTokenDTO.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 
 
 @Serializable
-internal data class AccessTokenDTO(
+data class AccessTokenDTO(
     @SerialName("user") val userId: NonQualifiedUserId,
     @SerialName("access_token") val value: String,
     @SerialName("expires_in") val expiresIn: Int,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -12,4 +12,8 @@ internal object NetworkErrorLabel {
     const val INVALID_CODE = "invalid-code"
     const val USER_CREATION_RESTRICTED = "user-creation-restricted"
     const val TOO_MANY_MEMBERS = "too-many-team-members"
+
+    object KaliumCustom {
+        const val MISSING_REFRESH_TOKEN = "missing-refresh_token"
+    }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/CustomErrors.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/CustomErrors.kt
@@ -1,0 +1,9 @@
+package com.wire.kalium.network.utils
+
+import com.wire.kalium.network.api.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
+
+object CustomErrors {
+    val MISSING_REFRESH_TOKEN =
+        NetworkResponse.Error(KaliumException.ServerError(ErrorResponse(500, "no cookie was found", "missing-refreshToken")))
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/CustomErrors.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/CustomErrors.kt
@@ -2,8 +2,17 @@ package com.wire.kalium.network.utils
 
 import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.NetworkErrorLabel
 
 object CustomErrors {
     val MISSING_REFRESH_TOKEN =
-        NetworkResponse.Error(KaliumException.ServerError(ErrorResponse(500, "no cookie was found", "missing-refreshToken")))
+        NetworkResponse.Error(
+            KaliumException.ServerError(
+                ErrorResponse(
+                    500,
+                    "no cookie was found",
+                    NetworkErrorLabel.KaliumCustom.MISSING_REFRESH_TOKEN
+                )
+            )
+        )
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/AccessTokenDTOJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/AccessTokenDTOJson.kt
@@ -2,23 +2,23 @@ package com.wire.kalium.api.tools.json.api.user.login
 
 import com.wire.kalium.api.tools.json.FaultyJsonProvider
 import com.wire.kalium.api.tools.json.ValidJsonProvider
-import com.wire.kalium.network.api.user.login.LoginApiImpl
+import com.wire.kalium.network.api.model.AccessTokenDTO
 
-object LoginResponseJson {
-    private val jsonProvider = { serializable: LoginApiImpl.LoginResponse ->
+object AccessTokenDTOJson {
+    private val jsonProvider = { serializable: AccessTokenDTO ->
         """
         |{
         |  "expires_in": ${serializable.expiresIn},
-        |  "access_token": "${serializable.accessToken}",
+        |  "access_token": "${serializable.value}",
         |  "user": "${serializable.userId}",
         |  "token_type": "${serializable.tokenType}"
         |}
         """.trimMargin()
     }
     val valid = ValidJsonProvider(
-        LoginApiImpl.LoginResponse(
+        AccessTokenDTO(
             userId = "user_id",
-            accessToken = "Nlrhltkj-NgJUjEVevHz8Ilgy_pyWCT2b0kQb-GlnamyswanghN9DcC3an5RUuA7sh1_nC3hv2ZzMRlIhPM7Ag==.v=1.k=1.d=1637254939." +
+            value = "Nlrhltkj-NgJUjEVevHz8Ilgy_pyWCT2b0kQb-GlnamyswanghN9DcC3an5RUuA7sh1_nC3hv2ZzMRlIhPM7Ag==.v=1.k=1.d=1637254939." +
                     "t=a.l=.u=75ebeb16-a860-4be4-84a7-157654b492cf.c=18401233206926541098",
             expiresIn = 900,
             tokenType = "Bearer"

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/LoginApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/LoginApiTest.kt
@@ -34,7 +34,7 @@ class LoginApiTest : ApiTest {
             },
             headers = mapOf("set-cookie" to "zuid=$refreshToken")
         )
-        val expected = with(VALID_LOGIN_RESPONSE.serializableData) { SessionDTO(userIdValue = userId, accessToken = accessToken, tokenType = tokenType, refreshToken = refreshToken) }
+        val expected = with(VALID_LOGIN_RESPONSE.serializableData) { SessionDTO(userIdValue = userId, accessToken = value, tokenType = tokenType, refreshToken = refreshToken) }
         val loginApi: LoginApi = LoginApiImpl(httpClient)
 
         val response = loginApi.login(LOGIN_WITH_EMAIL_REQUEST.serializableData, false, TEST_HOST)
@@ -58,7 +58,7 @@ class LoginApiTest : ApiTest {
 
     private companion object {
         val LOGIN_WITH_EMAIL_REQUEST = LoginWithEmailRequestJson.validLoginWithEmail
-        val VALID_LOGIN_RESPONSE = LoginResponseJson.valid
+        val VALID_LOGIN_RESPONSE = AccessTokenDTOJson.valid
         val ERROR_RESPONSE = ErrorResponseJson.valid.serializableData
         const val QUERY_PERSIST = "persist"
         const val PATH_LOGIN = "/login"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
1. when using ```
cookie(coockie_name, cookie_value)
``` ktor will encode the value and by default it's `URI` encoded, e.g., a cookie with the value `my_cookie.u=some_text` will become `my_cookie.u%3Dsome_text`.
2. when calling `AccessTokenAPI.getToken()` after registration (http client with no host URL) ktor will default to localhost.
 


### Solutions

1. replace  
```kotlin
cookie(coockie_name, cookie_value)
```
with  
```kotlin
header(HttpHeaders.Cookie, "$cookie_name=$cookie_value")
```
2. calling AccessTokenApi with authenticated http client only and adding 
```kotlin
    private suspend fun getToken(refreshToken: String, apiBaseUrl: String): NetworkResponse<AccessTokenDTO> = wrapKaliumResponse {
        httpClient.post {
            url {
                host = apiBaseUrl
                pathSegments = listOf(PATH_ACCESS)
                protocol = URLProtocol.HTTPS
            }
            header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$refreshToken")
        }
    }
```
to `RegisterApi`

3. yet, I deleted another model from network `LoginResponse` since it's just a good old `AccessTokenDTO`


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
