### PR TITLE
fix: part-1 refresh session: token refresh header workaround

### DIFF
--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -31,5 +31,19 @@ actual fun defaultHttpEngine(): HttpClientEngine {
                 }
             }
         })
+        addInterceptor(RefreshTokenWorkAround())
+    }
+}
+
+class RefreshTokenWorkAround : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.call().request().let { request ->
+            chain.proceed(request)
+        }.let { response ->
+            when (response.code) {
+                401 -> response.newBuilder().addHeader("WWW-Authenticate", "Bearer").build()
+                else -> response
+            }
+        }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

while attempting to refresh the token, we are running into this [issue](https://youtrack.jetbrains.com/issue/KTOR-2806)

### Causes (Optional)

missing WWW-Authenticate header on 401 responses

### Solutions

JVM/Android only: intercept response → is 401 → add header ("WWW-Authenticate", "Bearer")


Needs releases with:

- [ ] GitHub link to other pull request


----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
