### PR TITLE
feat: constructor injection MapperProvider

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.session.SessionDataSource
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.session.local.SessionLocalDataSource
 import com.wire.kalium.logic.data.session.local.SessionLocalRepository
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.auth.AuthenticationScope
@@ -34,7 +35,7 @@ actual class CoreLogic(
         val sessionPreferences =
             KaliumPreferencesSettings(EncryptedSettingsHolder(appContext, SHARED_PREFERENCE_FILE_NAME).encryptedSettings)
         val sessionStorage: SessionStorage = SessionStorageImpl(sessionPreferences)
-        val sessionLocalRepository: SessionLocalRepository = SessionLocalDataSource(sessionStorage, sessionMapper)
+        val sessionLocalRepository: SessionLocalRepository = SessionLocalDataSource(sessionStorage)
         return SessionDataSource(sessionLocalRepository)
     }
 
@@ -44,8 +45,8 @@ actual class CoreLogic(
     override fun getSessionScope(session: AuthSession): UserSessionScope {
         val dataSourceSet = userScopeStorage[session] ?: run {
             val networkContainer = AuthenticatedNetworkContainer(
-                sessionDTO = sessionMapper.toSessionDTO(session),
-                backendConfig = serverConfigMapper.toBackendConfig(serverConfig = session.serverConfig)
+                sessionDTO = MapperProvider.sessionMapper().toSessionDTO(session),
+                backendConfig = MapperProvider.serverConfigMapper().toBackendConfig(serverConfig = session.serverConfig)
             )
 
             val proteusClient: ProteusClient = ProteusClientImpl(rootProteusDirectoryPath, session.userId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -1,9 +1,5 @@
 package com.wire.kalium.logic
 
-import com.wire.kalium.logic.configuration.ServerConfigMapper
-import com.wire.kalium.logic.configuration.ServerConfigMapperImpl
-import com.wire.kalium.logic.data.session.SessionMapper
-import com.wire.kalium.logic.data.session.SessionMapperImpl
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.AuthSession
@@ -16,9 +12,6 @@ abstract class CoreLogicCommon(
     protected val clientLabel: String,
     protected val rootProteusDirectoryPath: String
 ) {
-
-    protected val serverConfigMapper: ServerConfigMapper get() = ServerConfigMapperImpl()
-    protected val sessionMapper: SessionMapper get() = SessionMapperImpl(serverConfigMapper)
 
     val sessionRepository: SessionRepository by lazy {
         getSessionRepo()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfigRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfigRemoteRepository.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.configuration
 
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
@@ -12,7 +13,7 @@ interface ServerConfigRemoteRepository {
 
 class ServerConfigRemoteDataSource(
     private val remoteConfigApi: ServerConfigApi,
-    private val serverConfigMapper: ServerConfigMapper
+    private val serverConfigMapper: ServerConfigMapper = MapperProvider.serverConfigMapper()
 ) : ServerConfigRemoteRepository {
 
     override suspend fun fetchServerConfig(remoteConfigUrl: String): Either<NetworkFailure, ServerConfig> = wrapApiRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -21,7 +21,7 @@ interface AssetRepository {
 internal class AssetDataSource(
     private val assetApi: AssetApi,
     private val assetDao: AssetDAO,
-    private val assetMapper: AssetMapper = MapperProvider.assetMapper(),
+    private val assetMapper: AssetMapper = MapperProvider.assetMapper()
     ) : AssetRepository {
 
     override suspend fun uploadAndPersistPublicAsset(mimeType: AssetType, assetData: ByteArray): Either<NetworkFailure, UploadedAssetId> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.asset
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.user.UserAssetId
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
 import com.wire.kalium.logic.wrapApiRequest
@@ -19,9 +20,9 @@ interface AssetRepository {
 
 internal class AssetDataSource(
     private val assetApi: AssetApi,
-    private val assetMapper: AssetMapper,
-    private val assetDao: AssetDAO
-) : AssetRepository {
+    private val assetDao: AssetDAO,
+    private val assetMapper: AssetMapper = MapperProvider.assetMapper(),
+    ) : AssetRepository {
 
     override suspend fun uploadAndPersistPublicAsset(mimeType: AssetType, assetData: ByteArray): Either<NetworkFailure, UploadedAssetId> {
         val uploadAssetData = UploadAssetData(assetData, mimeType, true, RetentionType.ETERNAL)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.auth.login
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.session.SessionMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
@@ -28,7 +29,7 @@ interface LoginRepository {
 class LoginRepositoryImpl(
     private val loginApi: LoginApi,
     private val clientLabel: String,
-    private val sessionMapper: SessionMapper
+    private val sessionMapper: SessionMapper = MapperProvider.sessionMapper()
 ) : LoginRepository {
 
     override suspend fun loginWithEmail(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
 import com.wire.kalium.persistence.dao.client.ClientDAO
@@ -26,7 +27,7 @@ class ClientDataSource(
     private val clientRemoteRepository: ClientRemoteRepository,
     private val clientRegistrationStorage: ClientRegistrationStorage,
     private val clientDAO: ClientDAO,
-    private val userMapper: UserMapper
+    private val userMapper: UserMapper = MapperProvider.userMapper()
 ) : ClientRepository {
     override suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client> {
         return clientRemoteRepository.registerClient(param)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
@@ -1,11 +1,13 @@
 package com.wire.kalium.logic.data.client.remote
 
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientMapper
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.data.client.RegisterClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
@@ -20,7 +22,8 @@ interface ClientRemoteRepository {
 
 class ClientRemoteDataSource(
     private val clientApi: ClientApi,
-    private val clientMapper: ClientMapper
+    private val clientConfig: ClientConfig,
+    private val clientMapper: ClientMapper= MapperProvider.clientMapper(clientConfig)
 ) : ClientRemoteRepository {
 
     override suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
@@ -23,7 +23,7 @@ interface ClientRemoteRepository {
 class ClientRemoteDataSource(
     private val clientApi: ClientApi,
     private val clientConfig: ClientConfig,
-    private val clientMapper: ClientMapper= MapperProvider.clientMapper(clientConfig)
+    private val clientMapper: ClientMapper = MapperProvider.clientMapper(clientConfig)
 ) : ClientRemoteRepository {
 
     override suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.suspending
@@ -31,9 +32,9 @@ class ConversationDataSource(
     private val conversationDAO: ConversationDAO,
     private val conversationApi: ConversationApi,
     private val clientApi: ClientApi,
-    private val idMapper: IdMapper,
-    private val conversationMapper: ConversationMapper,
-    private val memberMapper: MemberMapper
+    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(),
+    private val memberMapper: MemberMapper = MapperProvider.memberMapper()
 ) : ConversationRepository {
 
     // TODO: this need a review after the new wrapApiRequest

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.event
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
 import com.wire.kalium.network.api.notification.NotificationApi
@@ -29,7 +30,7 @@ class EventDataSource(
     private val notificationApi: NotificationApi,
     private val eventInfoStorage: EventInfoStorage,
     private val clientRepository: ClientRepository,
-    private val eventMapper: EventMapper
+    private val eventMapper: EventMapper = MapperProvider.eventMapper()
 ) : EventRepository {
 
     override suspend fun events(): Flow<Either<CoreFailure, Event>> = suspending {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -3,10 +3,10 @@ package com.wire.kalium.logic.data.message
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.failure.SendMessageFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
-import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.network.api.message.MessageApi
 import com.wire.kalium.network.api.message.MessagePriority
 import com.wire.kalium.network.exceptions.QualifiedSendMessageError
@@ -29,9 +29,9 @@ interface MessageRepository {
 class MessageDataSource(
     private val messageApi: MessageApi,
     private val messageDAO: MessageDAO,
-    private val messageMapper: MessageMapper,
-    private val idMapper: IdMapper,
-    private val sendMessageFailureMapper: SendMessageFailureMapper
+    private val messageMapper: MessageMapper = MapperProvider.messageMapper(),
+    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val sendMessageFailureMapper: SendMessageFailureMapper = MapperProvider.sendMessageFailureMapper()
 ) : MessageRepository {
 
     override suspend fun getMessagesForConversation(conversationId: ConversationId, limit: Int): Flow<List<Message>> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/remote/PreKeyRemoteDataSource.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/remote/PreKeyRemoteDataSource.kt
@@ -1,12 +1,10 @@
 package com.wire.kalium.logic.data.prekey.remote
 
-import com.wire.kalium.cryptography.PreKeyCrypto
-import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.prekey.QualifiedUserPreKeyInfo
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
@@ -20,7 +18,7 @@ interface PreKeyRemoteRepository {
 
 class PreKeyRemoteDataSource(
     private val preKeyApi: PreKeyApi,
-    private val preKeyListMapper: PreKeyListMapper
+    private val preKeyListMapper: PreKeyListMapper = MapperProvider.preKeyListMapper()
 ) : PreKeyRemoteRepository {
 
     //TODO unit test to be created later

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserRepository.kt
@@ -3,8 +3,8 @@ package com.wire.kalium.logic.data.publicuser
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.publicuser.model.PublicUserSearchResult
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.mapLeft
 import com.wire.kalium.logic.functional.suspending
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.contact.search.ContactSearchApi
@@ -25,7 +25,7 @@ interface PublicUserRepository {
 class PublicUserRepositoryImpl(
     private val contactSearchApi: ContactSearchApi,
     private val userApi: UserDetailsApi,
-    private val publicUserMapper: PublicUserMapper,
+    private val publicUserMapper: PublicUserMapper = MapperProvider.publicUserMapper()
 ) : PublicUserRepository {
 
     override suspend fun searchPublicContact(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepository.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
@@ -21,8 +22,8 @@ interface RegisterAccountRepository {
 
 class RegisterAccountDataSource(
     private val registerApi: RegisterApi,
-    private val userMapper: UserMapper,
-    private val sessionMapper: SessionMapper
+    private val userMapper: UserMapper = MapperProvider.userMapper(),
+    private val sessionMapper: SessionMapper = MapperProvider.sessionMapper()
 ) : RegisterAccountRepository {
     override suspend fun requestEmailActivationCode(email: String, baseApiHost: String): Either<NetworkFailure, Unit> =
         requestActivation(RegisterApi.RequestActivationCodeParam.Email(email), baseApiHost)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/local/SessionLocalRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/local/SessionLocalRepository.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.session.local
 
 import com.wire.kalium.logic.data.session.SessionMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.failure.SessionFailure
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.functional.Either
@@ -17,7 +18,7 @@ interface SessionLocalRepository {
 
 class SessionLocalDataSource(
     private val sessionStorage: SessionStorage,
-    private val sessionMapper: SessionMapper
+    private val sessionMapper: SessionMapper = MapperProvider.sessionMapper()
 ) : SessionLocalRepository {
 
     override fun storeSession(autSession: AuthSession) =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.data.team
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.user.UserMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
 import com.wire.kalium.logic.wrapApiRequest
@@ -20,7 +21,7 @@ internal class TeamDataSource(
     private val teamDAO: TeamDAO,
     private val teamMapper: TeamMapper,
     private val teamsApi: TeamsApi,
-    private val userMapper: UserMapper
+    private val userMapper: UserMapper = MapperProvider.userMapper()
 ) : TeamRepository {
 
     override suspend fun fetchTeamById(teamId: TeamId): Either<CoreFailure, Unit> = suspending {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -19,9 +19,9 @@ interface TeamRepository {
 internal class TeamDataSource(
     private val userDAO: UserDAO,
     private val teamDAO: TeamDAO,
-    private val teamMapper: TeamMapper,
     private val teamsApi: TeamsApi,
-    private val userMapper: UserMapper = MapperProvider.userMapper()
+    private val userMapper: UserMapper = MapperProvider.userMapper(),
+    private val teamMapper: TeamMapper = MapperProvider.teamMapper(),
 ) : TeamRepository {
 
     override suspend fun fetchTeamById(teamId: TeamId): Either<CoreFailure, Unit> = suspending {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
 import com.wire.kalium.logic.wrapApiRequest
@@ -43,9 +44,9 @@ class UserDataSource(
     private val metadataDAO: MetadataDAO,
     private val selfApi: SelfApi,
     private val userApi: UserDetailsApi,
-    private val idMapper: IdMapper,
-    private val userMapper: UserMapper,
-    private val assetRepository: AssetRepository
+    private val assetRepository: AssetRepository,
+    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val userMapper: UserMapper = MapperProvider.userMapper()
 ) : UserRepository {
 
     private suspend fun getSelfUserId(): QualifiedIDEntity {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.logic.data.team.TeamMapperImpl
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.data.user.UserMapperImpl
 
-object MapperProvider {
+internal object MapperProvider {
     fun idMapper(): IdMapper = IdMapperImpl()
     fun serverConfigMapper(): ServerConfigMapper = ServerConfigMapperImpl()
     fun sessionMapper(): SessionMapper = SessionMapperImpl(serverConfigMapper())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -1,9 +1,11 @@
 package com.wire.kalium.logic.di
 
+import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.configuration.ServerConfigMapper
 import com.wire.kalium.logic.configuration.ServerConfigMapperImpl
 import com.wire.kalium.logic.data.asset.AssetMapper
 import com.wire.kalium.logic.data.asset.AssetMapperImpl
+import com.wire.kalium.logic.data.client.ClientMapper
 import com.wire.kalium.logic.data.conversation.ConversationMapper
 import com.wire.kalium.logic.data.conversation.ConversationMapperImpl
 import com.wire.kalium.logic.data.conversation.MemberMapper
@@ -11,10 +13,14 @@ import com.wire.kalium.logic.data.conversation.MemberMapperImpl
 import com.wire.kalium.logic.data.event.EventMapper
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
+import com.wire.kalium.logic.data.location.LocationMapper
 import com.wire.kalium.logic.data.message.MessageMapper
 import com.wire.kalium.logic.data.message.MessageMapperImpl
 import com.wire.kalium.logic.data.message.SendMessageFailureMapper
 import com.wire.kalium.logic.data.message.SendMessageFailureMapperImpl
+import com.wire.kalium.logic.data.prekey.PreKeyMapper
+import com.wire.kalium.logic.data.prekey.PreKeyMapperImpl
+import com.wire.kalium.logic.data.prekey.remote.PreKeyListMapper
 import com.wire.kalium.logic.data.publicuser.PublicUserMapper
 import com.wire.kalium.logic.data.publicuser.PublicUserMapperImpl
 import com.wire.kalium.logic.data.session.SessionMapper
@@ -37,4 +43,8 @@ object MapperProvider {
     fun sendMessageFailureMapper(): SendMessageFailureMapper = SendMessageFailureMapperImpl()
     fun assetMapper(): AssetMapper = AssetMapperImpl()
     fun eventMapper(): EventMapper = EventMapper(idMapper())
+    fun preyKeyMapper(): PreKeyMapper = PreKeyMapperImpl()
+    fun preKeyListMapper(): PreKeyListMapper = PreKeyListMapper(preyKeyMapper())
+    fun locationMapper(): LocationMapper = LocationMapper()
+    fun clientMapper(clientConfig: ClientConfig): ClientMapper = ClientMapper(preyKeyMapper(), locationMapper(), clientConfig)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -1,0 +1,40 @@
+package com.wire.kalium.logic.di
+
+import com.wire.kalium.logic.configuration.ServerConfigMapper
+import com.wire.kalium.logic.configuration.ServerConfigMapperImpl
+import com.wire.kalium.logic.data.asset.AssetMapper
+import com.wire.kalium.logic.data.asset.AssetMapperImpl
+import com.wire.kalium.logic.data.conversation.ConversationMapper
+import com.wire.kalium.logic.data.conversation.ConversationMapperImpl
+import com.wire.kalium.logic.data.conversation.MemberMapper
+import com.wire.kalium.logic.data.conversation.MemberMapperImpl
+import com.wire.kalium.logic.data.event.EventMapper
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.id.IdMapperImpl
+import com.wire.kalium.logic.data.message.MessageMapper
+import com.wire.kalium.logic.data.message.MessageMapperImpl
+import com.wire.kalium.logic.data.message.SendMessageFailureMapper
+import com.wire.kalium.logic.data.message.SendMessageFailureMapperImpl
+import com.wire.kalium.logic.data.publicuser.PublicUserMapper
+import com.wire.kalium.logic.data.publicuser.PublicUserMapperImpl
+import com.wire.kalium.logic.data.session.SessionMapper
+import com.wire.kalium.logic.data.session.SessionMapperImpl
+import com.wire.kalium.logic.data.team.TeamMapper
+import com.wire.kalium.logic.data.team.TeamMapperImpl
+import com.wire.kalium.logic.data.user.UserMapper
+import com.wire.kalium.logic.data.user.UserMapperImpl
+
+object MapperProvider {
+    fun idMapper(): IdMapper = IdMapperImpl()
+    fun serverConfigMapper(): ServerConfigMapper = ServerConfigMapperImpl()
+    fun sessionMapper(): SessionMapper = SessionMapperImpl(serverConfigMapper())
+    fun userMapper(): UserMapper = UserMapperImpl(idMapper())
+    fun teamMapper(): TeamMapper = TeamMapperImpl()
+    fun messageMapper(): MessageMapper = MessageMapperImpl(idMapper())
+    fun memberMapper(): MemberMapper = MemberMapperImpl(idMapper())
+    fun conversationMapper(): ConversationMapper = ConversationMapperImpl(idMapper(), memberMapper())
+    fun publicUserMapper(): PublicUserMapper = PublicUserMapperImpl()
+    fun sendMessageFailureMapper(): SendMessageFailureMapper = SendMessageFailureMapperImpl()
+    fun assetMapper(): AssetMapper = AssetMapperImpl()
+    fun eventMapper(): EventMapper = EventMapper(idMapper())
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -3,8 +3,6 @@ package com.wire.kalium.logic.feature
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.data.asset.AssetDataSource
-import com.wire.kalium.logic.data.asset.AssetMapper
-import com.wire.kalium.logic.data.asset.AssetMapperImpl
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientDataSource
 import com.wire.kalium.logic.data.client.ClientMapper
@@ -12,26 +10,15 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.remote.ClientRemoteDataSource
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.conversation.ConversationDataSource
-import com.wire.kalium.logic.data.conversation.ConversationMapper
-import com.wire.kalium.logic.data.conversation.ConversationMapperImpl
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.MemberMapper
-import com.wire.kalium.logic.data.conversation.MemberMapperImpl
 import com.wire.kalium.logic.data.event.EventDataSource
-import com.wire.kalium.logic.data.event.EventMapper
 import com.wire.kalium.logic.data.event.EventRepository
-import com.wire.kalium.logic.data.id.IdMapper
-import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.data.location.LocationMapper
 import com.wire.kalium.logic.data.logout.LogoutDataSource
 import com.wire.kalium.logic.data.logout.LogoutRepository
 import com.wire.kalium.logic.data.message.MessageDataSource
-import com.wire.kalium.logic.data.message.MessageMapper
-import com.wire.kalium.logic.data.message.MessageMapperImpl
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.ProtoContentMapper
-import com.wire.kalium.logic.data.message.SendMessageFailureMapper
-import com.wire.kalium.logic.data.message.SendMessageFailureMapperImpl
 import com.wire.kalium.logic.data.prekey.PreKeyDataSource
 import com.wire.kalium.logic.data.prekey.PreKeyMapper
 import com.wire.kalium.logic.data.prekey.PreKeyMapperImpl
@@ -39,16 +26,13 @@ import com.wire.kalium.logic.data.prekey.PreKeyRepository
 import com.wire.kalium.logic.data.prekey.remote.PreKeyListMapper
 import com.wire.kalium.logic.data.prekey.remote.PreKeyRemoteDataSource
 import com.wire.kalium.logic.data.prekey.remote.PreKeyRemoteRepository
+import com.wire.kalium.logic.data.publicuser.PublicUserRepository
+import com.wire.kalium.logic.data.publicuser.PublicUserRepositoryImpl
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.team.TeamDataSource
 import com.wire.kalium.logic.data.team.TeamMapperImpl
 import com.wire.kalium.logic.data.team.TeamRepository
-import com.wire.kalium.logic.data.publicuser.PublicUserMapper
-import com.wire.kalium.logic.data.publicuser.PublicUserMapperImpl
-import com.wire.kalium.logic.data.publicuser.PublicUserRepository
-import com.wire.kalium.logic.data.publicuser.PublicUserRepositoryImpl
 import com.wire.kalium.logic.data.user.UserDataSource
-import com.wire.kalium.logic.data.user.UserMapperImpl
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
@@ -80,11 +64,7 @@ abstract class UserSessionScopeCommon(
     private val eventInfoStorage: EventInfoStorage
         get() = EventInfoStorageImpl(userPreferencesSettings)
 
-    private val idMapper: IdMapper get() = IdMapperImpl()
-    private val memberMapper: MemberMapper get() = MemberMapperImpl(idMapper)
-    private val conversationMapper: ConversationMapper get() = ConversationMapperImpl(idMapper, memberMapper)
-    private val userMapper = UserMapperImpl(idMapper)
-    private val publicUserMapper: PublicUserMapper = PublicUserMapperImpl()
+
     private val database: Database = authenticatedDataSourceSet.database
     private val teamMapper = TeamMapperImpl()
 
@@ -92,20 +72,13 @@ abstract class UserSessionScopeCommon(
         get() = ConversationDataSource(
             database.conversationDAO,
             authenticatedDataSourceSet.authenticatedNetworkContainer.conversationApi,
-            authenticatedDataSourceSet.authenticatedNetworkContainer.clientApi, idMapper, conversationMapper, memberMapper
+            authenticatedDataSourceSet.authenticatedNetworkContainer.clientApi
         )
 
-    private val messageMapper: MessageMapper get() = MessageMapperImpl(idMapper)
-
-    private val sendMessageFailureMapper: SendMessageFailureMapper get() = SendMessageFailureMapperImpl()
 
     private val messageRepository: MessageRepository
         get() = MessageDataSource(
-            authenticatedDataSourceSet.authenticatedNetworkContainer.messageApi,
-            database.messageDAO,
-            messageMapper,
-            idMapper,
-            sendMessageFailureMapper
+            authenticatedDataSourceSet.authenticatedNetworkContainer.messageApi, database.messageDAO
         )
 
     private val userRepository: UserRepository
@@ -114,8 +87,6 @@ abstract class UserSessionScopeCommon(
             database.metadataDAO,
             authenticatedDataSourceSet.authenticatedNetworkContainer.selfApi,
             authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi,
-            idMapper,
-            userMapper,
             assetRepository
         )
 
@@ -124,15 +95,13 @@ abstract class UserSessionScopeCommon(
             userDAO = database.userDAO,
             teamDAO = database.teamDAO,
             teamMapper = teamMapper,
-            teamsApi = authenticatedDataSourceSet.authenticatedNetworkContainer.teamsApi,
-            userMapper = userMapper
+            teamsApi = authenticatedDataSourceSet.authenticatedNetworkContainer.teamsApi
         )
 
     private val publicUserRepository: PublicUserRepository
         get() = PublicUserRepositoryImpl(
             authenticatedDataSourceSet.authenticatedNetworkContainer.contactSearchApi,
-            authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi,
-            publicUserMapper
+            authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi
         )
 
     protected abstract val clientConfig: ClientConfig
@@ -144,59 +113,44 @@ abstract class UserSessionScopeCommon(
 
     private val clientRemoteRepository: ClientRemoteRepository
         get() = ClientRemoteDataSource(
-            authenticatedDataSourceSet.authenticatedNetworkContainer.clientApi,
-            clientMapper
+            authenticatedDataSourceSet.authenticatedNetworkContainer.clientApi, clientMapper
         )
 
     private val clientRegistrationStorage: ClientRegistrationStorage
         get() = ClientRegistrationStorageImpl(userPreferencesSettings)
 
     private val clientRepository: ClientRepository
-        get() = ClientDataSource(clientRemoteRepository, clientRegistrationStorage, database.clientDAO, userMapper)
+        get() = ClientDataSource(clientRemoteRepository, clientRegistrationStorage, database.clientDAO)
 
-    private val assetMapper: AssetMapper get() = AssetMapperImpl()
     private val assetRepository: AssetRepository
-        get() = AssetDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.assetApi, assetMapper, database.assetDAO)
+        get() = AssetDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.assetApi, database.assetDAO)
 
     val syncManager: SyncManager get() = authenticatedDataSourceSet.syncManager
 
-    private val eventMapper: EventMapper get() = EventMapper(idMapper)
     private val eventRepository: EventRepository
         get() = EventDataSource(
-            authenticatedDataSourceSet.authenticatedNetworkContainer.notificationApi,
-            eventInfoStorage,
-            clientRepository,
-            eventMapper
+            authenticatedDataSourceSet.authenticatedNetworkContainer.notificationApi, eventInfoStorage, clientRepository
         )
 
     protected abstract val protoContentMapper: ProtoContentMapper
     private val conversationEventReceiver: ConversationEventReceiver
         get() = ConversationEventReceiver(
-            authenticatedDataSourceSet.proteusClient,
-            messageRepository,
-            conversationRepository,
-            protoContentMapper,
-            memberMapper,
-            idMapper
+            authenticatedDataSourceSet.proteusClient, messageRepository, conversationRepository, protoContentMapper
         )
 
     private val preKeyRemoteRepository: PreKeyRemoteRepository
         get() = PreKeyRemoteDataSource(
-            authenticatedDataSourceSet.authenticatedNetworkContainer.preKeyApi,
-            preKeyListMapper
+            authenticatedDataSourceSet.authenticatedNetworkContainer.preKeyApi, preKeyListMapper
         )
     private val preKeyRepository: PreKeyRepository
         get() = PreKeyDataSource(
-            preKeyRemoteRepository,
-            authenticatedDataSourceSet.proteusClient
+            preKeyRemoteRepository, authenticatedDataSourceSet.proteusClient
         )
 
     private val logoutRepository: LogoutRepository = LogoutDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.logoutApi)
     val listenToEvents: ListenToEventsUseCase
         get() = ListenToEventsUseCase(
-            syncManager = syncManager,
-            eventRepository = eventRepository,
-            conversationEventReceiver = conversationEventReceiver
+            syncManager = syncManager, eventRepository = eventRepository, conversationEventReceiver = conversationEventReceiver
         )
     val client: ClientScope get() = ClientScope(clientRepository, preKeyRepository)
     val conversations: ConversationScope get() = ConversationScope(conversationRepository, syncManager)
@@ -210,17 +164,9 @@ abstract class UserSessionScopeCommon(
             userRepository,
             syncManager
         )
-    val users: UserScope
-        get() = UserScope(
-            userRepository = userRepository,
-            publicUserRepository, syncManager = syncManager,
-            assetRepository = assetRepository
-        )
+    val users: UserScope get() = UserScope(userRepository, publicUserRepository, syncManager, assetRepository)
     val logout: LogoutUseCase get() = LogoutUseCase(logoutRepository, sessionRepository, session.userId, authenticatedDataSourceSet)
 
-    val team: TeamScope get() = TeamScope(
-        userRepository = userRepository,
-        teamRepository = teamRepository
-    )
+    val team: TeamScope get() = TeamScope(userRepository, teamRepository)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -2,22 +2,14 @@ package com.wire.kalium.logic.feature.auth
 
 import com.wire.kalium.logic.configuration.GetServerConfigUseCase
 import com.wire.kalium.logic.configuration.ServerConfigDataSource
-import com.wire.kalium.logic.configuration.ServerConfigMapper
-import com.wire.kalium.logic.configuration.ServerConfigMapperImpl
 import com.wire.kalium.logic.configuration.ServerConfigRemoteDataSource
 import com.wire.kalium.logic.configuration.ServerConfigRemoteRepository
 import com.wire.kalium.logic.configuration.ServerConfigRepository
 import com.wire.kalium.logic.data.auth.login.LoginRepository
 import com.wire.kalium.logic.data.auth.login.LoginRepositoryImpl
-import com.wire.kalium.logic.data.id.IdMapper
-import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.data.register.RegisterAccountDataSource
 import com.wire.kalium.logic.data.register.RegisterAccountRepository
-import com.wire.kalium.logic.data.session.SessionMapper
-import com.wire.kalium.logic.data.session.SessionMapperImpl
 import com.wire.kalium.logic.data.session.SessionRepository
-import com.wire.kalium.logic.data.user.UserMapper
-import com.wire.kalium.logic.data.user.UserMapperImpl
 import com.wire.kalium.logic.feature.register.RegisterScope
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.session.SessionScope
@@ -29,8 +21,7 @@ import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 expect class AuthenticationScope : AuthenticationScopeCommon
 
 abstract class AuthenticationScopeCommon(
-    private val clientLabel: String,
-    private val sessionRepository: SessionRepository
+    private val clientLabel: String, private val sessionRepository: SessionRepository
 ) {
 
     protected val loginNetworkContainer: LoginNetworkContainer by lazy {
@@ -40,25 +31,15 @@ abstract class AuthenticationScopeCommon(
     protected abstract val encryptedSettingsHolder: EncryptedSettingsHolder
     private val kaliumPreferences: KaliumPreferences get() = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
 
-    private val serverConfigMapper: ServerConfigMapper get() = ServerConfigMapperImpl()
-    private val serverConfigRemoteRepository: ServerConfigRemoteRepository
-        get() = ServerConfigRemoteDataSource(
-            loginNetworkContainer.serverConfigApi,
-            serverConfigMapper
-        )
+    private val serverConfigRemoteRepository: ServerConfigRemoteRepository get() = ServerConfigRemoteDataSource(loginNetworkContainer.serverConfigApi)
     private val serverConfigRepository: ServerConfigRepository get() = ServerConfigDataSource(serverConfigRemoteRepository)
 
-    private val sessionMapper: SessionMapper get() = SessionMapperImpl(serverConfigMapper)
-    private val idMapper: IdMapper get() = IdMapperImpl()
-    private val userMapper: UserMapper get() = UserMapperImpl(idMapper)
 
-    private val loginRepository: LoginRepository get() = LoginRepositoryImpl(loginNetworkContainer.loginApi, clientLabel, sessionMapper)
+    private val loginRepository: LoginRepository get() = LoginRepositoryImpl(loginNetworkContainer.loginApi, clientLabel)
 
     private val registerAccountRepository: RegisterAccountRepository
         get() = RegisterAccountDataSource(
-            loginNetworkContainer.registerApi,
-            userMapper,
-            sessionMapper
+            loginNetworkContainer.registerApi
         )
 
     val validateEmailUseCase: ValidateEmailUseCase get() = ValidateEmailUseCaseImpl()
@@ -67,10 +48,7 @@ abstract class AuthenticationScopeCommon(
 
     val login: LoginUseCase
         get() = LoginUseCaseImpl(
-            loginRepository,
-            sessionRepository,
-            validateEmailUseCase,
-            validateUserHandleUseCase
+            loginRepository, sessionRepository, validateEmailUseCase, validateUserHandleUseCase
         )
 
     val getSessions: GetSessionsUseCase get() = GetSessionsUseCase(sessionRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -46,11 +46,7 @@ abstract class AuthenticationScopeCommon(
     val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
     val validatePasswordUseCase: ValidatePasswordUseCase get() = ValidatePasswordUseCaseImpl()
 
-    val login: LoginUseCase
-        get() = LoginUseCaseImpl(
-            loginRepository, sessionRepository, validateEmailUseCase, validateUserHandleUseCase
-        )
-
+    val login: LoginUseCase get() = LoginUseCaseImpl(loginRepository, sessionRepository, validateEmailUseCase, validateUserHandleUseCase)
     val getSessions: GetSessionsUseCase get() = GetSessionsUseCase(sessionRepository)
     val getServerConfig: GetServerConfigUseCase get() = GetServerConfigUseCase(serverConfigRepository)
     val session: SessionScope get() = SessionScope(sessionRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.PlainMessageBlob
 import com.wire.kalium.logic.data.message.ProtoContentMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.suspending
 import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.logic.wrapCryptoRequest
@@ -22,8 +23,8 @@ class ConversationEventReceiver(
     private val messageRepository: MessageRepository,
     private val conversationRepository: ConversationRepository,
     private val protoContentMapper: ProtoContentMapper,
-    private val memberMapper: MemberMapper,
-    private val idMapper: IdMapper
+    private val memberMapper: MemberMapper = MapperProvider.memberMapper(),
+    private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : EventReceiver<Event.Conversation> {
     override suspend fun onEvent(event: Event.Conversation) {
         when (event) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -43,7 +43,7 @@ class AssetRepositoryTest {
 
     @BeforeTest
     fun setUp() {
-        assetRepository = AssetDataSource(assetApi, assetMapper, assetDAO)
+        assetRepository = AssetDataSource(assetApi, assetDAO, assetMapper)
     }
 
     @Test

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.cryptography.ProteusClientImpl
 import com.wire.kalium.logic.data.session.SessionDataSource
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.session.local.SessionLocalDataSource
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.auth.AuthenticationScope
@@ -25,7 +26,7 @@ actual class CoreLogic(clientLabel: String, rootProteusDirectoryPath: String) :
     override fun getSessionRepo(): SessionRepository {
         val kaliumPreferences = KaliumPreferencesSettings(EncryptedSettingsHolder(".pref").encryptedSettings)
         val sessionStorage = SessionStorageImpl(kaliumPreferences)
-        val sessionLocalRepository = SessionLocalDataSource(sessionStorage, sessionMapper)
+        val sessionLocalRepository = SessionLocalDataSource(sessionStorage)
         return SessionDataSource(sessionLocalRepository)
     }
 
@@ -36,8 +37,8 @@ actual class CoreLogic(clientLabel: String, rootProteusDirectoryPath: String) :
     override fun getSessionScope(session: AuthSession): UserSessionScope {
         val dataSourceSet = userScopeStorage[session] ?: run {
             val networkContainer = AuthenticatedNetworkContainer(
-                sessionDTO = sessionMapper.toSessionDTO(session),
-                backendConfig = serverConfigMapper.toBackendConfig(serverConfig = session.serverConfig)
+                sessionDTO = MapperProvider.sessionMapper().toSessionDTO(session),
+                backendConfig = MapperProvider.serverConfigMapper().toBackendConfig(serverConfig = session.serverConfig)
             )
 
             val proteusClient: ProteusClient = ProteusClientImpl(rootProteusDirectoryPath, session.userId)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Excessively many mappers are created inside `UserSessionScope`, `AuthenticationScope` and `CoreLogic` and some are actually duplicated 

### Solutions

```kotlin 
object MapperProvider {
    fun idMapper(): IdMapper = IdMapperImpl()
.....
}
```
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
