### PR TITLE
fix: downgrade from 4.0.0 rc to 3.19.4 as it doesn't support mac m1

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -38,6 +38,10 @@ android {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
 
+    packagingOptions {
+        resources.pickFirsts.add("google/protobuf/*.proto")
+    }
+
 //    sourceSets { map { it.java.srcDir("src/${it.name}/kotlin") } }
 }
 

--- a/protobuf-codegen/build.gradle.kts
+++ b/protobuf-codegen/build.gradle.kts
@@ -17,7 +17,7 @@ version = "0.0.1-SNAPSHOT"
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:4.0.0-rc-2"
+        artifact = "com.google.protobuf:protoc:3.19.4"
     }
     plugins {
         id("pbandk") {

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -20,6 +20,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    packagingOptions {
+        resources.pickFirsts.add("google/protobuf/*.proto")
+    }
 }
 
 val codegenProject = project(":protobuf-codegen")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

protobuf version 4.0.0 rc doesn't support mac m1 chip

### Solutions

Downgraded version to 3.19.4

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
