### PR TITLE
ci: use Gradle setup caching instead of Java Setup

### DIFF
--- a/.github/workflows/gradle-mobile-tests.yml
+++ b/.github/workflows/gradle-mobile-tests.yml
@@ -22,13 +22,12 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          cache: gradle
+
+      - name: Gradle Setup
+        uses: gradle/gradle-build-action@v2
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
 
       - name: AVD cache
         uses: actions/cache@v2


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

CI is using Setup Java for caching Gradle, instead of the official [gradle-build-action](https://github.com/gradle/gradle-build-action).
The latter is more optimized and has more gradle-specific features if we ever need them.

### Solutions

Replace setup-java's cache with official Gradle caching.

### Testing

;D 

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
