### PR TITLE
fix: remove content-type hack

### DIFF
--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -10,25 +10,11 @@ actual fun defaultHttpEngine(): HttpClientEngine {
     return OkHttp.create {
         addInterceptor(object : Interceptor {
             override fun intercept(chain: Interceptor.Chain): Response {
-                return chain.call().request().handleProtoHeader()
-                    .let { checkedRequest -> chain.proceed(checkedRequest) }.handleUnauthorizedResponse()
+                return chain.request().let { checkedRequest -> chain.proceed(checkedRequest) }.handleUnauthorizedResponse()
             }
         })
     }
 }
-
-/**
- * This is a hack
- *
- * As seen here: https://github.com/ktorio/ktor/issues/1127
- * Ktor is pretty has `application/protobuf` but not `application/x-protobuf`
- * and it doesn't support custom content types!
- */
-private fun Request.handleProtoHeader(): Request =
-    when (headers["Content-Type"] == "application/octet-stream") {
-        true -> this.newBuilder().header("Content-Type", "application/x-protobuf").build()
-        false -> this
-    }
 
 /**
  * Ktor need "WWW-Authenticate" to be set by BE in-order for the tokens refresh to work

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
@@ -27,9 +27,12 @@ import com.wire.kalium.network.api.user.logout.LogoutApi
 import com.wire.kalium.network.api.user.logout.LogoutImpl
 import com.wire.kalium.network.api.user.self.SelfApi
 import com.wire.kalium.network.api.user.self.SelfApiImpl
+import com.wire.kalium.network.serialization.mls
+import com.wire.kalium.network.serialization.xprotobuf
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.session.installAuth
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.ContentNegotiation
 
 class AuthenticatedNetworkContainer(
     private val sessionManager: SessionManager,
@@ -67,6 +70,10 @@ class AuthenticatedNetworkContainer(
     internal val authenticatedHttpClient by lazy {
         provideBaseHttpClient(engine, HttpClientOptions.DefaultHost(backendConfig)) {
             installAuth(sessionManager)
+            install(ContentNegotiation) {
+                mls()
+                xprotobuf()
+            }
         }
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApiImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApiImp.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.QualifiedSendMessageError
 import com.wire.kalium.network.exceptions.SendMessageError
+import com.wire.kalium.network.serialization.XProtoBuf
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.HttpClient
@@ -111,9 +112,7 @@ class MessageApiImp(
         return try {
             val response = httpClient.post("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}$PATH_PROTEUS_MESSAGE") {
                 setBody(envelopeProtoMapper.encodeToProtobuf(parameters))
-                // This technically doesn't work, Ktor will replace with application/octet-stream anyway
-                // But if this ever gets improved, we're already on the right track
-                contentType(ContentType.Application.ProtoBuf)
+                contentType(ContentType.Application.XProtoBuf)
             }
             NetworkResponse.Success(httpResponse = response, value = response.body<QualifiedSendMessageResponse.MessageSent>())
         } catch (e: ResponseException) {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/serialization/ByteArrayConverter.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/serialization/ByteArrayConverter.kt
@@ -1,0 +1,41 @@
+package com.wire.kalium.network.serialization
+
+import io.ktor.http.ContentType
+import io.ktor.http.content.ByteArrayContent
+import io.ktor.http.content.OutgoingContent
+import io.ktor.serialization.Configuration
+import io.ktor.serialization.ContentConverter
+import io.ktor.util.reflect.TypeInfo
+import io.ktor.util.toByteArray
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.charsets.Charset
+
+/**
+ * A ContentConverter which does nothing, it simply passes byte arrays through as they are. This is useful
+ * if you want to register your own custom binary content type with the ContentNegotiation plugin.
+ */
+class ByteArrayConverter: ContentConverter {
+
+    override suspend fun deserialize(charset: Charset, typeInfo: TypeInfo, content: ByteReadChannel): Any? {
+        return content.toByteArray()
+    }
+
+    override suspend fun serialize(contentType: ContentType, charset: Charset, typeInfo: TypeInfo, value: Any): OutgoingContent? {
+        return ByteArrayContent(value as ByteArray, contentType)
+    }
+
+}
+
+public val ContentType.Message.Mls: ContentType
+    get() = ContentType("message", "mls")
+
+public val ContentType.Application.XProtoBuf: ContentType
+    get() = ContentType("application", "x-protobuf")
+
+public fun Configuration.mls(contentType: ContentType = ContentType.Message.Mls) {
+    register(contentType, ByteArrayConverter())
+}
+
+public fun Configuration.xprotobuf(contentType: ContentType = ContentType.Application.XProtoBuf) {
+    register(contentType, ByteArrayConverter())
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are sending our messages as protobuf and the server requires the content type to be set to `application/x-protobuf`. Ktor however doesn't respect overriding the content-type on a request and will always send binary data as `application/octet-stream`.

We hacked around this on the Android/JVM by installing a http interceptor which re-writes the content type. This has some drawbacks: 
1. It only fixes the problem on Android,
2. The moment we need to send another binary content type the hack doesn't work anymore.

And that moment is now because I need to send binary data with content type `message/mls` when I send MLS messages.

### Solutions

Install the `ContentNegotiation` plugin which can be used to serialise/deserialise requests based on the content-type. We'll only use it to register our missing binary content-types with a dummy converter which simply passes the binary data through as is.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
