### PR TITLE
fix: remove merge conflict artefacts in licence file.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -645,11 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-<<<<<<< HEAD
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
-=======
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
->>>>>>> c586a4d (Add maven deployment on release (#8))
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -668,19 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<<<<<<< HEAD
 <https://www.gnu.org/licenses/>.
-=======
-<http://www.gnu.org/licenses/>.
->>>>>>> c586a4d (Add maven deployment on release (#8))
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<<<<<<< HEAD
 <https://www.gnu.org/licenses/why-not-lgpl.html>.
-=======
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
->>>>>>> c586a4d (Add maven deployment on release (#8))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The LICENSE file in the project root contained merge conflict markers, which appear to have been accidentally committed into `develop` instead of being removed when the merge conflict was resolved.

### Solutions

This commit removes the merge conflict markers.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
