### PR TITLE
chore: expose list of ongoing calls

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -15,6 +15,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.util.toTimeInMillis
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
@@ -24,7 +25,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -159,12 +159,16 @@ actual class CallManager(
     actual suspend fun onCallingMessageReceived(message: Message, content: MessageContent.Calling) =
         withCalling {
             val msg = content.value.toByteArray()
+
+            val currTime = System.currentTimeMillis()
+            val msgTime = message.date.toTimeInMillis()
+
             wcall_recv_msg(
                 inst = deferredHandle.await(),
                 msg = msg,
                 len = msg.size,
-                curr_time = Uint32_t(value = System.currentTimeMillis() / 1000),
-                msg_time = Uint32_t(value = (System.currentTimeMillis() / 1000) + 10), // TODO: add correct variable
+                curr_time = Uint32_t(value = currTime / 1000),
+                msg_time = Uint32_t(value = msgTime / 1000),
                 convId = message.conversationId.asString(),
                 userId = message.senderUserId.asString(),
                 clientId = message.senderClientId.value

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -19,6 +19,7 @@ actual class GlobalCallManager(
 
     private lateinit var mediaManager: MediaManager
     private lateinit var flowManager: FlowManager
+    private val callManagerHolder = hashMapOf<String, CallManager>()
 
     private val calling by lazy {
         initiateMediaManager()
@@ -37,15 +38,20 @@ actual class GlobalCallManager(
      * Get a [CallManager] for a session, shouldn't be instantiated more than one CallManager for a single session.
      */
     actual fun getCallManagerForClient(
+        userId: String,
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository
-    ): CallManager = CallManager(
-        calling = calling,
-        callRepository = callRepository,
-        userRepository = userRepository,
-        clientRepository = clientRepository
-    )
+    ): CallManager {
+        return callManagerHolder[userId] ?: CallManager(
+            calling = calling,
+            callRepository = callRepository,
+            userRepository = userRepository,
+            clientRepository = clientRepository
+        ).also {
+            callManagerHolder[userId] = it
+        }
+    }
 
     private fun initiateMediaManager() {
         mediaManager = MediaManager.getInstance(appContext)

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -11,6 +11,7 @@ import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.network.api.NonQualifiedUserId
 import com.waz.log.LogHandler as NativeLogHandler
 
 actual class GlobalCallManager(
@@ -38,7 +39,7 @@ actual class GlobalCallManager(
      * Get a [CallManager] for a session, shouldn't be instantiated more than one CallManager for a single session.
      */
     actual fun getCallManagerForClient(
-        userId: String,
+        userId: NonQualifiedUserId,
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/DateTimeUtil.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/DateTimeUtil.kt
@@ -1,0 +1,7 @@
+package com.wire.kalium.logic.util
+
+import java.text.SimpleDateFormat
+
+private val serverDateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+
+fun String.toTimeInMillis(): Long = serverDateTimeFormat.parse(this).time

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -8,3 +8,10 @@ data class QualifiedID(
 typealias ConversationId = QualifiedID
 
 fun QualifiedID.asString() = "$value@$domain"
+
+fun String.toConversationId() = split("@").let {
+    ConversationId(
+        value = it.first(),
+        domain = it.last()
+    )
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -9,7 +9,7 @@ data class QualifiedID(
 
 typealias ConversationId = QualifiedID
 
-fun QualifiedID.asString() = "$value$VALUE_DOMAIN_SEPARATOR$domain"
+fun QualifiedID.asString() = if(domain.isEmpty()) value else "$value$VALUE_DOMAIN_SEPARATOR$domain"
 
 fun String.toConversationId(): ConversationId {
     val (value, domain) = if (contains(VALUE_DOMAIN_SEPARATOR)) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -1,5 +1,7 @@
 package com.wire.kalium.logic.data.id
 
+private const val VALUE_DOMAIN_SEPARATOR = "@"
+
 data class QualifiedID(
     val value: String,
     val domain: String
@@ -7,11 +9,15 @@ data class QualifiedID(
 
 typealias ConversationId = QualifiedID
 
-fun QualifiedID.asString() = "$value@$domain"
+fun QualifiedID.asString() = "$value$VALUE_DOMAIN_SEPARATOR$domain"
 
-fun String.toConversationId() = split("@").let {
-    ConversationId(
-        value = it.first(),
-        domain = it.last()
+fun String.toConversationId(): ConversationId {
+    val (value, domain) = if (contains(VALUE_DOMAIN_SEPARATOR)) {
+        split(VALUE_DOMAIN_SEPARATOR).let { Pair(it.first(), it.last()) }
+    } else { Pair(this@toConversationId, "") }
+
+    return ConversationId(
+        value = value,
+        domain = domain
     )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -30,9 +30,8 @@ import com.wire.kalium.logic.data.team.TeamDataSource
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserDataSource
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
-import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.CallsScope
 import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.conversation.ConversationScope
@@ -173,4 +172,6 @@ abstract class UserSessionScopeCommon(
     val logout: LogoutUseCase get() = LogoutUseCase(logoutRepository, sessionRepository, userId, authenticatedDataSourceSet)
 
     val team: TeamScope get() = TeamScope(userRepository, teamRepository)
+
+    val calls: CallsScope get() = CallsScope(callManager, syncManager)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -131,6 +131,7 @@ abstract class UserSessionScopeCommon(
 
     private val callManager by lazy {
         globalCallManager.getCallManagerForClient(
+            userId = userId,
             callRepository = callRepository,
             userRepository = userRepository,
             clientRepository = clientRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/Call.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/Call.kt
@@ -1,0 +1,6 @@
+package com.wire.kalium.logic.feature.call
+
+data class Call(
+    val conversationId: String,
+    val status: String
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/Call.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/Call.kt
@@ -1,6 +1,16 @@
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.logic.data.id.ConversationId
+
+enum class CallStatus {
+    INCOMING,
+    MISSED,
+    ANSWERED,
+    ESTABLISHED,
+    CLOSED
+}
+
 data class Call(
-    val conversationId: String,
-    val status: String
+    val conversationId: ConversationId,
+    val status: CallStatus
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -2,8 +2,17 @@ package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 
 expect class CallManager {
 
     suspend fun onCallingMessageReceived(message: Message, content: MessageContent.Calling)
+    val allCalls: StateFlow<List<Call>>
+}
+
+val CallManager.ongoingCalls get() = allCalls.map {
+    it.filter { call ->
+        call.status in listOf("incoming", "answered", "established")
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -13,6 +13,6 @@ expect class CallManager {
 
 val CallManager.ongoingCalls get() = allCalls.map {
     it.filter { call ->
-        call.status in listOf("incoming", "answered", "established")
+        call.status in listOf("Incoming", "Answered", "Established")
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -13,6 +13,10 @@ expect class CallManager {
 
 val CallManager.ongoingCalls get() = allCalls.map {
     it.filter { call ->
-        call.status in listOf("Incoming", "Answered", "Established")
+        call.status in listOf(
+            CallStatus.INCOMING,
+            CallStatus.ANSWERED,
+            CallStatus.ESTABLISHED
+        )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -7,7 +7,7 @@ class CallsScope(
     private val syncManager: SyncManager
 ) {
 
-    val getOngoingCallsUseCase: GetOngoingCallsUseCase get() = GetOngoingCallsUseCaseImpl(
+    val getOngoingCalls: GetOngoingCallsUseCase get() = GetOngoingCallsUseCaseImpl(
         callManager = callManager,
         syncManager = syncManager
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -1,0 +1,14 @@
+package com.wire.kalium.logic.feature.call
+
+import com.wire.kalium.logic.sync.SyncManager
+
+class CallsScope(
+    private val callManager: CallManager,
+    private val syncManager: SyncManager
+) {
+
+    val getOngoingCallsUseCase: GetOngoingCallsUseCase get() = GetOngoingCallsUseCaseImpl(
+        callManager = callManager,
+        syncManager = syncManager
+    )
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GetOngoingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GetOngoingCallsUseCase.kt
@@ -14,6 +14,6 @@ internal class GetOngoingCallsUseCaseImpl(
 
     override suspend operator fun invoke(): Flow<List<Call>> {
         syncManager.waitForSlowSyncToComplete()
-        return callManager.ongoingCalls
+        return callManager.allCalls
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GetOngoingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GetOngoingCallsUseCase.kt
@@ -1,0 +1,19 @@
+package com.wire.kalium.logic.feature.call
+
+import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.coroutines.flow.Flow
+
+interface GetOngoingCallsUseCase {
+    suspend operator fun invoke(): Flow<List<Call>>
+}
+
+internal class GetOngoingCallsUseCaseImpl(
+    private val callManager: CallManager,
+    private val syncManager: SyncManager
+): GetOngoingCallsUseCase {
+
+    override suspend operator fun invoke(): Flow<List<Call>> {
+        syncManager.waitForSlowSyncToComplete()
+        return callManager.ongoingCalls
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -3,11 +3,12 @@ package com.wire.kalium.logic.feature.call
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.network.api.NonQualifiedUserId
 
 expect class GlobalCallManager {
 
     fun getCallManagerForClient(
-        userId: String,
+        userId: NonQualifiedUserId,
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.user.UserRepository
 expect class GlobalCallManager {
 
     fun getCallManagerForClient(
+        userId: String,
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -3,8 +3,13 @@ package com.wire.kalium.logic.feature.call
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 actual class CallManager {
+
+    private val _calls = MutableStateFlow(listOf<Call>())
+    actual val allCalls = _calls.asStateFlow()
 
     init {
         kaliumLogger.w("CallManager initialized for JVM but no supported yet.")

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -3,11 +3,12 @@ package com.wire.kalium.logic.feature.call
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.network.api.NonQualifiedUserId
 
 actual class GlobalCallManager {
 
     actual fun getCallManagerForClient(
-        userId: String,
+        userId: NonQualifiedUserId,
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.user.UserRepository
 actual class GlobalCallManager {
 
     actual fun getCallManagerForClient(
+        userId: String,
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With now having a GlobalCallManager providing each session with its instance, we are now able to expose ongoing calls from AVS to all the way to the UI.

### Dependencies (Optional)

This is Part 2 of the epic, tests will come in a later PR.

Needs releases with:

- [X] #322 


### Attachments (Optional)

https://user-images.githubusercontent.com/5890660/160573622-02a40532-947e-4e6c-9a17-95ccc2eb3bfd.mov

