### PR TITLE
fix: weird Type mismatch error

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -8,7 +8,6 @@ import com.wire.kalium.logic.data.message.MessageEnvelope
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.failure.SendMessageFailure
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.suspending
 import com.wire.kalium.logic.sync.SyncManager
 
@@ -68,19 +67,16 @@ class MessageSenderImpl(
         envelope: MessageEnvelope,
         messageUuid: Message,
     ): Either<CoreFailure, Unit> = suspending {
-        val sendResult = messageRepository.sendEnvelope(conversationId, envelope)
-
-        if (sendResult.isRight()) {
-            return@suspending Either.Right(Unit)
-        }
-
-        when (val failure = sendResult.value) {
-            is SendMessageFailure.ClientsHaveChanged -> {
-                messageSendFailureHandler.handleClientsHaveChangedFailure(failure).flatMap {
-                    getRecipientsAndAttemptSend(conversationId, messageUuid)
+        messageRepository.sendEnvelope(conversationId, envelope).coFold(
+            {
+                when (it) {
+                    is SendMessageFailure.Unknown -> Either.Left(it)
+                    is SendMessageFailure.ClientsHaveChanged -> messageSendFailureHandler.handleClientsHaveChangedFailure(it).flatMap {
+                        getRecipientsAndAttemptSend(conversationId, messageUuid)
+                    }
                 }
-            }
-            else -> Either.Left(failure)
-        }
+            }, {
+                Either.Right(Unit)
+            })
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

weird kotlin compile error 
```
e: /Users/mohamad.jaara/Desktop/work/wire-android-reloaded/kalium/logic/src
/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt: (70, 36): 
Type mismatch: inferred type is Either<Any, Unit> but Either<CoreFailure, Unit> was expected
```
I think it's related to kotlin contract but can't verify
```kotlin
@OptIn(ExperimentalContracts::class)
fun <L, R> Either<L, R>.isRight(): Boolean {
    contract {
        returns(true) implies (this@isRight is Right<R>)
        returns(false) implies (this@isRight is Left<L>)
    }
    return this is Right<R>
}
```

the error message usually disappears after `clean project`, but I'm just tired of it

### Solutions

using 'coFold` instead of kotlin contract 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
