### PR TITLE
feat: update ValidateUserHandleUseCase to return also handleWithoutInvalidChars

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -45,7 +45,7 @@ internal class LoginUseCaseImpl(
             validateEmailUseCase(cleanUserIdentifier) -> {
                 loginRepository.loginWithEmail(cleanUserIdentifier, password, shouldPersistClient, serverConfig)
             }
-            validateUserHandleUseCase(cleanUserIdentifier) -> {
+            validateUserHandleUseCase(cleanUserIdentifier).isValid -> {
                 loginRepository.loginWithHandle(cleanUserIdentifier, password, shouldPersistClient, serverConfig)
             }
             else -> return@suspending AuthenticationResult.Failure.InvalidUserIdentifier

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCase.kt
@@ -1,24 +1,21 @@
 package com.wire.kalium.logic.feature.auth
 
 interface ValidateUserHandleUseCase {
-    operator fun invoke(handle: String): Boolean
+    operator fun invoke(handle: String): ValidateUserHandleResult
 }
 class ValidateUserHandleUseCaseImpl: ValidateUserHandleUseCase  {
-    override operator fun invoke(handle: String): Boolean {
-        return when {
-            isHandleTooShort(handle) -> false
-            !validateHandle(handle) -> false
-            else -> true
-        }
+    override operator fun invoke(handle: String): ValidateUserHandleResult {
+        val handleWithoutInvalidChars = handle.replace(Regex(HANDLE_FORBIDDEN_CHARACTERS_REGEX), "")
+        val hasValidChars = handle == handleWithoutInvalidChars
+        val hasValidLength = handleWithoutInvalidChars.length in HANDLE_MIN_LENGTH..HANDLE_MAX_LENGTH
+        return ValidateUserHandleResult(hasValidChars && hasValidLength, handleWithoutInvalidChars)
     }
-
-    private fun validateHandle(handle: String) =
-        handle.matches(HANDLE_REGEX)
-
-    private fun isHandleTooShort(handle: String) = handle.length < HANDEL_MIN_LENGTH
 
     private companion object {
-        private const val HANDEL_MIN_LENGTH = 2
-        private val HANDLE_REGEX = """^[a-z0-9_]*$""".toRegex()
+        private const val HANDLE_FORBIDDEN_CHARACTERS_REGEX = "[^a-z0-9_]"
+        private const val HANDLE_MIN_LENGTH = 2
+        private const val HANDLE_MAX_LENGTH = 255
     }
 }
+
+data class ValidateUserHandleResult(val isValid: Boolean, val handleWithoutInvalidChars: String)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCase.kt
@@ -21,7 +21,7 @@ sealed class SetUserHandleResult {
 class SetUserHandleUseCase(
     private val userRepository: UserRepository, private val validateUserHandleUseCase: ValidateUserHandleUseCase
 ) {
-    suspend operator fun invoke(handle: String): SetUserHandleResult = when (validateUserHandleUseCase(handle)) {
+    suspend operator fun invoke(handle: String): SetUserHandleResult = when (validateUserHandleUseCase(handle).isValid) {
         true -> userRepository.updateSelfHandle(handle).fold({
             if (it is NetworkFailure.ServerMiscommunication && it.kaliumException is KaliumException.InvalidRequestError) {
                 handleSpecificError(it.kaliumException)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -46,7 +46,7 @@ class LoginUseCaseTest {
             val cleanEmail = TEST_EMAIL
             given(validateEmailUseCase).invocation { invoke(cleanEmail) }.then { true }
             given(validateUserHandleUseCase).invocation { invoke(cleanEmail) }
-                .then { ValidateUserHandleResult(false, "") }
+                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("") }
             given(loginRepository).coroutine { loginWithEmail(cleanEmail, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }.then {
                 Either.Right(TEST_AUTH_SESSION)
             }
@@ -69,7 +69,7 @@ class LoginUseCaseTest {
             val cleanHandle = TEST_HANDLE
             given(validateEmailUseCase).invocation { invoke(cleanHandle) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(cleanHandle) }
-                .then { ValidateUserHandleResult(true, "") }
+                .then { ValidateUserHandleResult.Valid }
             given(loginRepository).coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }.then {
                 Either.Right(TEST_AUTH_SESSION)
             }
@@ -92,7 +92,7 @@ class LoginUseCaseTest {
         runTest {
             given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
             given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult(false, "") }
+                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("") }
             given(loginRepository).coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }.then {
                 Either.Right(TEST_AUTH_SESSION)
             }
@@ -115,7 +115,7 @@ class LoginUseCaseTest {
             // given
             given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(TEST_HANDLE) }
-                .then { ValidateUserHandleResult(true, "") }
+                .then { ValidateUserHandleResult.Valid }
             given(loginRepository).coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }.then {
                 Either.Right(TEST_AUTH_SESSION)
             }
@@ -145,7 +145,7 @@ class LoginUseCaseTest {
         runTest {
             given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
             given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult(false, "") }
+                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("") }
             given(loginRepository).coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
                 .then { Either.Right(TEST_AUTH_SESSION) }
 
@@ -159,7 +159,7 @@ class LoginUseCaseTest {
         runTest {
             given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult(false, "") }
+                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("") }
 
             val loginUserCaseResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG)
 
@@ -175,13 +175,13 @@ class LoginUseCaseTest {
             val invalidCredentialsFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.invalidCredentials)
             given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
             given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult(false, "") }
+                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("") }
             given(loginRepository).coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
                 .then { Either.Left(invalidCredentialsFailure) }
 
             given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(TEST_HANDLE) }
-                .then { ValidateUserHandleResult(true, "") }
+                .then { ValidateUserHandleResult.Valid }
             given(loginRepository).coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
                 .then { Either.Left(invalidCredentialsFailure) }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCaseTest.kt
@@ -9,22 +9,38 @@ class ValidateUserHandleUseCaseTest {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase = ValidateUserHandleUseCaseImpl()
 
     @Test
-    fun `given a validUserHandleUseCase is invoked, when handel is valid , then return true`() {
+    fun `given a validUserHandleUseCase is invoked, when handle is valid, then return true`() {
         VALID_HANDLES.forEach { validUserHandle ->
-            assertTrue { validateUserHandleUseCase(validUserHandle) }
+            assertTrue { validateUserHandleUseCase(validUserHandle).isValid }
         }
     }
 
     @Test
-    fun `given a validUserHandleUseCase is invoked, when handel is invalid, then return false`() {
+    fun `given a validUserHandleUseCase is invoked, when handle is invalid, then return false`() {
         INVALID_HANDLES.forEach { inValidUserHandle ->
-            assertFalse { validateUserHandleUseCase(inValidUserHandle) }
+            assertFalse { validateUserHandleUseCase(inValidUserHandle).isValid }
         }
     }
 
     @Test
-    fun `given a validUserHandleUseCase is invoked, when handel is short, then return false`() {
-        assertFalse { validateUserHandleUseCase("a") }
+    fun `given a validUserHandleUseCase is invoked, when handle is too short, then return false`() {
+        assertFalse { validateUserHandleUseCase("a").isValid }
+    }
+
+    @Test
+    fun `given a validUserHandleUseCase is invoked, when handle is too long, then return false`() {
+        assertFalse {
+            validateUserHandleUseCase(
+            "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890" +
+                    "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890" +
+                    "123456789012345678901234567890123456789012345678901234567890"
+        ).isValid }
+    }
+
+    @Test
+    fun `given a validUserHandleUseCase is invoked, when handle is invalid, then return handle without invalid chars`() {
+        val result = validateUserHandleUseCase("@handle1_A")
+        assertTrue { !result.isValid && result.handleWithoutInvalidChars == "handle1_" }
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCaseTest.kt
@@ -23,24 +23,24 @@ class ValidateUserHandleUseCaseTest {
     }
 
     @Test
-    fun `given a validUserHandleUseCase is invoked, when handle is too short, then return false`() {
-        assertFalse { validateUserHandleUseCase("a").isValid }
+    fun `given a validUserHandleUseCase is invoked, when handle is too short, then return TooShort`() {
+        assertTrue { validateUserHandleUseCase("a") is ValidateUserHandleResult.Invalid.TooShort }
     }
 
     @Test
-    fun `given a validUserHandleUseCase is invoked, when handle is too long, then return false`() {
-        assertFalse {
+    fun `given a validUserHandleUseCase is invoked, when handle is too long, then return TooLong`() {
+        assertTrue {
             validateUserHandleUseCase(
             "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890" +
                     "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890" +
                     "123456789012345678901234567890123456789012345678901234567890"
-        ).isValid }
+        )  is ValidateUserHandleResult.Invalid.TooLong }
     }
 
     @Test
     fun `given a validUserHandleUseCase is invoked, when handle is invalid, then return handle without invalid chars`() {
         val result = validateUserHandleUseCase("@handle1_A")
-        assertTrue { !result.isValid && result.handleWithoutInvalidChars == "handle1_" }
+        assertTrue { result is ValidateUserHandleResult.Invalid.InvalidCharacters && result.handleWithoutInvalidCharacters == "handle1_" }
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.auth.ValidateUserHandleResult
 import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
@@ -41,7 +42,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { true }
+            .then { ValidateUserHandleResult(true, "") }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Right(Unit) }
@@ -65,7 +66,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { false }
+            .then { ValidateUserHandleResult(false, "") }
 
         val actual = setUserHandleUseCase(handle)
 
@@ -88,7 +89,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { true }
+            .then { ValidateUserHandleResult(true, "") }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Left(expected) }
@@ -120,7 +121,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { true }
+            .then { ValidateUserHandleResult(true, "") }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Left(error) }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
@@ -42,7 +42,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult(true, "") }
+            .then { ValidateUserHandleResult.Valid }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Right(Unit) }
@@ -66,7 +66,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult(false, "") }
+            .then { ValidateUserHandleResult.Invalid.InvalidCharacters("") }
 
         val actual = setUserHandleUseCase(handle)
 
@@ -89,7 +89,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult(true, "") }
+            .then { ValidateUserHandleResult.Valid }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Left(expected) }
@@ -121,7 +121,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult(true, "") }
+            .then { ValidateUserHandleResult.Valid }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Left(error) }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Right now ValidateUserHandleUseCase returns boolean which determines whether the specific handle is valid, but in order to execute the "shake" animation when the user enters invalid character and not allow the invalid ones to be added to the text field, we need to also get the handle string with invalid chars filtered out.

### Solutions

Update ValidateUserHandleUseCase to return ValidateUserHandleResult which contains both boolean and string with invalid chars filtered out.

### Testing

Added tests to ValidateUserHandleUseCaseTest and updated others that use this usecase.

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
