### PR TITLE
chore: bump SQLDelight version to 2.0.0-alpha01

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.android.build.gradle.internal.tasks.factory.dependsOn
 buildscript {
     val kotlinVersion = "1.6.10"
     val dokkaVersion = "1.6.10"
-    val sqlDelightVersion = "2.0.0-SNAPSHOT"
+    val sqlDelightVersion = "2.0.0-alpha01"
     val protobufCodegenVersion = "0.8.18"
     val carthageVersion = "0.0.1"
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val ktxSerialization = "1.3.2"
     const val multiplatformSettings = "0.8.1"
     const val androidSecurity = "1.0.0"
-    const val sqlDelight = "2.0.0-SNAPSHOT"
+    const val sqlDelight = "2.0.0-alpha01"
     @Deprecated("A new implementation is available. Use the protobuf project instead.")
     const val wireJvmMessageProto = "1.36.0"
     @Deprecated("A new implementation is available. Use the protobuf project instead.")

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 
 sqldelight {
     database("AppDatabase") {
-        dialect = "sqlite:3.24"
+        dialect = "app.cash.sqldelight:sqlite-3-24-dialect:${Versions.sqlDelight}"
         packageName = "com.wire.kalium.persistence.db"
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Develop is not buildable:

``` 
       > Could not find sqlite:3.24:.
6 actionable tasks: 6 executed
        Required by:
            project :persistence
```

### Causes

We were using a Snapshot version of SQLDelight 2.0.0, that was updated and broke some stuff.
[SQLDelight 2.0.0-alpha01](https://github.com/cashapp/sqldelight/releases/tag/2.0.0-alpha01) has just been released.

### Solutions

This PR bumps SQLDelight to `2.0.0-alpha01` and accomodates the required dialect definition change in order to keep the project building.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
