### PR TITLE
fix: ValidateUserHandleUseCase returns wrong error state

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -69,7 +69,7 @@ class LoginUseCaseTest {
             val cleanHandle = TEST_HANDLE
             given(validateEmailUseCase).invocation { invoke(cleanHandle) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(cleanHandle) }
-                .then { ValidateUserHandleResult.Valid }
+                .then { ValidateUserHandleResult.Valid(cleanHandle) }
             given(loginRepository).coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }.then {
                 Either.Right(TEST_AUTH_SESSION)
             }
@@ -115,7 +115,7 @@ class LoginUseCaseTest {
             // given
             given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(TEST_HANDLE) }
-                .then { ValidateUserHandleResult.Valid }
+                .then { ValidateUserHandleResult.Valid(TEST_HANDLE) }
             given(loginRepository).coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }.then {
                 Either.Right(TEST_AUTH_SESSION)
             }
@@ -181,7 +181,7 @@ class LoginUseCaseTest {
 
             given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
             given(validateUserHandleUseCase).invocation { invoke(TEST_HANDLE) }
-                .then { ValidateUserHandleResult.Valid }
+                .then { ValidateUserHandleResult.Valid(TEST_HANDLE) }
             given(loginRepository).coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_SERVER_CONFIG) }
                 .then { Either.Left(invalidCredentialsFailure) }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCaseTest.kt
@@ -40,7 +40,13 @@ class ValidateUserHandleUseCaseTest {
     @Test
     fun `given a validUserHandleUseCase is invoked, when handle is invalid, then return handle without invalid chars`() {
         val result = validateUserHandleUseCase("@handle1_A")
-        assertTrue { result is ValidateUserHandleResult.Invalid.InvalidCharacters && result.handleWithoutInvalidCharacters == "handle1_" }
+        assertTrue { result is ValidateUserHandleResult.Invalid.InvalidCharacters && result.handle == "handle1_" }
+    }
+
+    @Test
+    fun `given a validUserHandleUseCase is invoked, when handle is too short and has invaled char, then return handle without invalid chars`() {
+        val result = validateUserHandleUseCase("$")
+        assertTrue { result is ValidateUserHandleResult.Invalid.InvalidCharacters && result.handle == "" }
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
@@ -48,7 +48,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult.Valid }
+            .then { ValidateUserHandleResult.Valid(handle) }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Right(Unit) }
@@ -80,7 +80,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult.Valid }
+            .then { ValidateUserHandleResult.Valid(handle) }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Right(Unit) }
@@ -115,7 +115,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult.Valid }
+            .then { ValidateUserHandleResult.Valid(handle) }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Right(Unit) }
@@ -174,7 +174,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult.Valid }
+            .then { ValidateUserHandleResult.Valid(handle) }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Left(expected) }
@@ -211,7 +211,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult.Valid }
+            .then { ValidateUserHandleResult.Valid(handle) }
         given(userRepository)
             .coroutine { updateSelfHandle(handle) }
             .then { Either.Left(error) }


### PR DESCRIPTION


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ValidateUserHandleUseCase returning the wrong error state when the handle is short/long and has invalid char


### Solutions

1. when invalid char && short/long -> invalid char.
2. ValidateUserHandleResult will always return a handle (to have single source of truth for the handle in the consumer app).


### Testing

New test case added to test  invalid char && short/long -> invalid char.

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
