### PR TITLE
chore: remove android lib dependency from JVM source set

### DIFF
--- a/cryptography/build.gradle.kts
+++ b/cryptography/build.gradle.kts
@@ -98,7 +98,6 @@ kotlin {
             addCommonKotlinJvmSourceDir()
             dependencies {
                 implementation(Dependencies.Cryptography.cryptobox4j)
-                implementation(Dependencies.Cryptography.javaxCrypto)
                 implementation(Dependencies.Cryptography.mlsClientJvm)
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Failure to build CLI target:

`:cli:test: Could not resolve androidx.security:security-crypto-ktx:1.1.0-alpha03.`

### Causes

We're wrongly including an Android library as a JVM dependency in `:cryptography`.

### Solutions

Remove it. It was not being used inside `cryptography/jvmMain`.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
