### PR TITLE
feat(conversations): observe details of a conversation (AR-1177, AR-881)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -4,11 +4,18 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.sync.SyncManager
 
 class ConversationScope(
-    conversationRepository: ConversationRepository,
-    syncManager: SyncManager
+    private val conversationRepository: ConversationRepository,
+    private val syncManager: SyncManager
 ) {
-    // TODO: get()
-    val getConversations: GetConversationsUseCase = GetConversationsUseCase(conversationRepository, syncManager)
-    val getConversationDetails: GetConversationDetailsUseCase = GetConversationDetailsUseCase(conversationRepository, syncManager)
-    val syncConversations: SyncConversationsUseCase = SyncConversationsUseCase(conversationRepository)
+    val getConversations: GetConversationsUseCase
+        get() = GetConversationsUseCase(conversationRepository, syncManager)
+
+    val getConversationDetails: GetConversationDetailsUseCase
+        get() = GetConversationDetailsUseCase(conversationRepository, syncManager)
+
+    val observeConversationDetails: ObserveConversationDetailsUseCase
+        get() = ObserveConversationDetailsUseCase(conversationRepository, syncManager)
+
+    val syncConversations: SyncConversationsUseCase
+        get() = SyncConversationsUseCase(conversationRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
@@ -1,0 +1,18 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.coroutines.flow.Flow
+
+class ObserveConversationDetailsUseCase(
+    private val conversationRepository: ConversationRepository,
+    private val syncManager: SyncManager
+) {
+
+    suspend operator fun invoke(conversationId: ConversationId): Flow<ConversationDetails> {
+        syncManager.waitForSlowSyncToComplete()
+        return conversationRepository.getConversationDetailsById(conversationId)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -1,0 +1,103 @@
+package com.wire.kalium.logic.feature.conversation
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.sync.SyncManager
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObserveConversationDetailsUseCaseTest {
+
+    @Mock
+    private val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
+
+    @Mock
+    private val syncManager: SyncManager = mock(SyncManager::class)
+
+    private lateinit var observeConversationsUseCase: ObserveConversationDetailsUseCase
+
+    @BeforeTest
+    fun setup() {
+        observeConversationsUseCase = ObserveConversationDetailsUseCase(conversationRepository, syncManager)
+    }
+
+    @Test
+    fun givenAConversationId_whenObservingConversationUseCase_thenTheConversationRepositoryShouldBeCalledWithTheCorrectID() = runTest {
+        val conversationId = TestConversation.ID
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(anything())
+            .then { flowOf() }
+
+        observeConversationsUseCase(conversationId)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .with(eq(conversationId))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAConversationID_whenObservingConversationUseCase_thenSyncManagerShouldBeCalled() = runTest {
+        val conversationId = TestConversation.ID
+
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(anything())
+            .then { flowOf() }
+
+        observeConversationsUseCase(conversationId)
+
+        verify(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenTheConversationIsUpdated_whenObservingConversationUseCase_thenThisUpdateIsPropagatedInTheFlow() = runTest {
+        val conversation = TestConversation.GROUP
+        val conversationDetailsValues = listOf(
+            ConversationDetails.Group(conversation),
+            ConversationDetails.Group(conversation.copy(name = "New Name"))
+        )
+
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(anything())
+            .then { conversationDetailsValues.asFlow() }
+
+        observeConversationsUseCase(TestConversation.ID).test {
+            assertEquals(conversationDetailsValues[0], awaitItem())
+            assertEquals(conversationDetailsValues[1], awaitItem())
+            awaitComplete()
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -1,11 +1,17 @@
 package com.wire.kalium.logic.framework
 
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 
 object TestConversation {
     val ID = ConversationId("valueConvo", "domainConvo")
+
+    val ONE_ON_ONE = Conversation(ID, "ONE_ON_ONE Name", Conversation.Type.ONE_ON_ONE, TestTeam.TEAM_ID)
+    val SELF = Conversation(ID, "SELF Name", Conversation.Type.SELF, TestTeam.TEAM_ID)
+    val GROUP = Conversation(ID, "GROUP Name", Conversation.Type.GROUP, TestTeam.TEAM_ID)
 
     val ENTITY_ID = QualifiedIDEntity("valueConversation", "domainConversation")
     val ENTITY = ConversationEntity(ENTITY_ID, "convo name", ConversationEntity.Type.SELF, "teamId")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestTeam.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestTeam.kt
@@ -1,0 +1,7 @@
+package com.wire.kalium.logic.framework
+
+import com.wire.kalium.logic.data.id.TeamId
+
+object TestTeam {
+    val TEAM_ID = TeamId("Some-Team")
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to a way to observe details of a conversation as they are updated, so it can be displayed by consumer apps.

### Solutions

Leverage the new `ConversationDetails` class and the implementation of that in `ConversationRepository`.

### Testing

✅

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
