### PR TITLE
feat: extend API for creating groups to handle MLS conversations

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.conversation.ConvProtocol
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
@@ -114,9 +115,11 @@ class ConversationMapperTest {
             MEMBERS_RESPONSE,
             "name",
             ORIGINAL_CONVERSATION_ID,
+            null,
             ConversationResponse.Type.GROUP,
             null,
-            null
+            null,
+            ConvProtocol.PROTEUS
         )
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
@@ -10,6 +10,8 @@ import com.wire.kalium.network.api.conversation.ConversationApi
 import com.wire.kalium.network.api.conversation.ConversationApiImp
 import com.wire.kalium.network.api.keypackage.KeyPackageApi
 import com.wire.kalium.network.api.keypackage.KeyPackageApiImpl
+import com.wire.kalium.network.api.message.MLSMessageApi
+import com.wire.kalium.network.api.message.MLSMessageApiImpl
 import com.wire.kalium.network.api.message.MessageApi
 import com.wire.kalium.network.api.message.MessageApiImp
 import com.wire.kalium.network.api.message.provideEnvelopeProtoMapper
@@ -46,6 +48,8 @@ class AuthenticatedNetworkContainer(
     val clientApi: ClientApi get() = ClientApiImpl(authenticatedHttpClient)
 
     val messageApi: MessageApi get() = MessageApiImp(authenticatedHttpClient, provideEnvelopeProtoMapper())
+
+    val mlsMessageApi: MLSMessageApi get() = MLSMessageApiImpl(authenticatedHttpClient)
 
     val conversationApi: ConversationApi get() = ConversationApiImp(authenticatedHttpClient)
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -20,6 +20,9 @@ data class ConversationResponse(
     @SerialName("qualified_id")
     val id: ConversationId,
 
+    @SerialName("group_id")
+    val groupId: String?,
+
     @Serializable(with = ConversationTypeSerializer::class)
     val type: Type,
 
@@ -27,7 +30,10 @@ data class ConversationResponse(
     val messageTimer: Int?,
 
     @SerialName("team")
-    val teamId: TeamId?
+    val teamId: TeamId?,
+
+    @SerialName("protocol")
+    val protocol: ConvProtocol
 ){
 
     val isOneOnOneConversation: Boolean

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/CreateConversationRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/CreateConversationRequest.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.network.api.conversation
 import com.wire.kalium.network.api.TeamId
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.model.ConversationAccess
+import com.wire.kalium.network.api.model.ConversationAccessRole
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -17,18 +18,31 @@ data class CreateConversationRequest(
     val name: String,
     @SerialName("access")
     val access: List<ConversationAccess>,
-    @SerialName("access_role")
-    val conversationAccess: ConversationAccess,
+    @SerialName("access_role_v2")
+    val accessRole: List<ConversationAccessRole>,
     @SerialName("team")
-    val convTeamInfo: ConvTeamInfo,
+    val convTeamInfo: ConvTeamInfo?,
     @SerialName("message_timer")
     val messageTimer: Int?, // Per-conversation message time
     @SerialName("receipt_mode")
     val receiptMode: Int,
+    // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles
+    // designed by Wire (i.e., no custom roles can have the same prefix)
     @SerialName("conversation_role")
-    val conversationRole: String, // Role name, between 2 and 128 chars, 'wire_' prefix is reserved
-    // for roles designed by Wire (i.e., no custom roles can have the same prefix)
+    val conversationRole: String,
+    @SerialName("protocol")
+    val protocol: ConvProtocol?
 )
+
+@Serializable
+enum class ConvProtocol {
+    @SerialName("proteus") PROTEUS,
+    @SerialName("mls") MLS;
+
+    override fun toString(): String {
+        return this.name.lowercase()
+    }
+}
 
 @Serializable
 data class ConvTeamInfo(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/ConversationAccessRole.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/ConversationAccessRole.kt
@@ -1,0 +1,18 @@
+package com.wire.kalium.network.api.model
+
+import kotlinx.serialization.SerialName
+
+enum class ConversationAccessRole {
+    @SerialName("team_member")
+    TEAM_MEMBER,
+    @SerialName("non_team_member")
+    NON_TEAM_MEMBER,
+    @SerialName("guest")
+    GUEST,
+    @SerialName("service")
+    SERVICE;
+
+    override fun toString(): String {
+        return this.name.lowercase()
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 class ConversationApiTest: ApiTest {
 
     @Test
-    fun given_whenCallingCreateNewConversation_thenTheRequestShouldBeConfiguredCorrectly() = runTest {
+    fun givenACreateNewConversationRequest_whenCallingCreateNewConversation_thenTheRequestShouldBeConfiguredCorrectly() = runTest {
         val httpClient = mockAuthenticatedHttpClient(
             CREATE_CONVERSATION_RESPONSE,
             statusCode = HttpStatusCode.Created,

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
@@ -1,0 +1,37 @@
+package com.wire.kalium.api.tools.json.api.conversation
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.network.api.conversation.ConversationApi
+import com.wire.kalium.network.api.conversation.ConversationApiImp
+import com.wire.kalium.network.utils.isSuccessful
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ConversationApiTest: ApiTest {
+
+    @Test
+    fun given_whenCallingCreateNewConversation_thenTheRequestShouldBeConfiguredCorrectly() = runTest {
+        val httpClient = mockAuthenticatedHttpClient(
+            CREATE_CONVERSATION_RESPONSE,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertJson()
+                assertPost()
+                assertPathEqual(PATH_CONVERSATIONS)
+                assertBodyContent(CREATE_CONVERSATION_REQUEST.rawJson)
+            }
+        )
+        val conversationApi: ConversationApi = ConversationApiImp(httpClient)
+        val result = conversationApi.createNewConversation(CREATE_CONVERSATION_REQUEST.serializableData)
+
+        assertTrue(result.isSuccessful())
+    }
+
+    private companion object {
+        const val PATH_CONVERSATIONS = "/conversations"
+        val CREATE_CONVERSATION_RESPONSE = ConversationResponseJson.validGroup.rawJson
+        val CREATE_CONVERSATION_REQUEST = CreateConversationRequestJson.valid
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -1,0 +1,62 @@
+package com.wire.kalium.api.tools.json.api.conversation
+
+import com.wire.kalium.api.tools.json.ValidJsonProvider
+import com.wire.kalium.api.tools.json.model.QualifiedIDSamples
+import com.wire.kalium.network.api.conversation.ConvProtocol
+import com.wire.kalium.network.api.conversation.ConversationMembersResponse
+import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
+import com.wire.kalium.network.api.conversation.ConversationResponse
+import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
+
+object ConversationResponseJson {
+
+    val validGroup = ValidJsonProvider(
+        ConversationResponse(
+            "fdf23116-42a5-472c-8316-e10655f5d11e",
+            ConversationMembersResponse(
+                ConversationSelfMemberResponse(QualifiedIDSamples.one),
+                listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
+            ),
+            "group name",
+            QualifiedIDSamples.one,
+            "groupID",
+            ConversationResponse.Type.GROUP,
+            null,
+            "teamID",
+            ConvProtocol.PROTEUS
+        )
+    ) {
+        """
+        |{
+        |   "creator": "${it.creator}",
+        |   "group_id": "${it.groupId}",
+        |   "id": "99db9768-04e3-4b5d-9268-831b6a25c4ab",
+        |   "members": {
+        |       "others": [
+        |           {
+        |               "qualified_id": {
+        |                   "domain": "${it.members.otherMembers[0].userId.domain}",
+        |                   "id": "${it.members.otherMembers[0].userId.value}"
+        |               }
+        |           }
+        |       ],
+        |       "self": {
+        |           "qualified_id": {
+        |               "domain": "${it.members.self.userId.domain}",
+        |               "id": "${it.members.self.userId.value}"
+        |           }
+        |       }
+        |   },
+        |   "message_timer": ${it.messageTimer},
+        |   "name": "${it.name}",
+        |   "protocol": "${it.protocol}",
+        |   "qualified_id": {
+        |       "domain": "${it.id.domain}",
+        |       "id": "${it.id.value}"
+        |   },
+        |   "team": "${it.teamId}",
+        |   "type": ${it.type.ordinal}
+        |}
+        """.trimMargin()
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/CreateConversationRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/CreateConversationRequestJson.kt
@@ -1,0 +1,52 @@
+package com.wire.kalium.api.tools.json.api.conversation
+
+import com.wire.kalium.api.tools.json.ValidJsonProvider
+import com.wire.kalium.api.tools.json.model.QualifiedIDSamples
+import com.wire.kalium.network.api.conversation.ConvProtocol
+import com.wire.kalium.network.api.conversation.ConvTeamInfo
+import com.wire.kalium.network.api.conversation.CreateConversationRequest
+import com.wire.kalium.network.api.model.ConversationAccess
+import com.wire.kalium.network.api.model.ConversationAccessRole
+
+object CreateConversationRequestJson {
+
+    val valid = ValidJsonProvider(
+        CreateConversationRequest(
+        listOf(QualifiedIDSamples.one),
+        "group name",
+        listOf(ConversationAccess.PRIVATE),
+        listOf(ConversationAccessRole.TEAM_MEMBER),
+        ConvTeamInfo(false, "teamID"),
+        0,
+        0,
+        "WIRE_MEMBER",
+        ConvProtocol.PROTEUS)
+    ) {
+        """
+        |{
+        |   "access": [
+        |       "${it.access[0]}"
+        |   ],
+        |   "access_role_v2": [
+        |       "${it.accessRole[0]}}"
+        |   ],
+        |   "conversation_role": "${it.conversationRole}",
+        |   "message_timer": ${it.messageTimer},
+        |   "name": "${it.name}",
+        |   "protocol": "${it.protocol}",
+        |   "qualified_users": [
+        |       {
+        |           "domain": "${it.qualifiedUsers[0].domain}",
+        |           "id": "${it.qualifiedUsers[0].value}"
+        |       }
+        |   ],
+        |   "receipt_mode": ${it.receiptMode},
+        |   "team": {
+        |       "managed": "false",
+        |       "teamid": "${it.convTeamInfo?.teamId}"
+        |   }
+        |}
+        """.trimIndent()
+        }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to create MLS group we need support for the  the `protocol` and `group_id` fields.

### Solutions

- Add support for `protocol` field which controls if we are creating a proteus or a MLS group.
- Add support for `group_id` which holds a MLS specific identifier for conversations.
- Replace the usage of deprecated `access_role` with the `access_role_v2`

### Testing

Unit tests

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
