### PR TITLE
fix: issues with image asset encryption flow [AR-1307]

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/CryptoUtils.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/CryptoUtils.kt
@@ -10,10 +10,9 @@ actual fun calcMd5(bytes: ByteArray): String = bytes.let {
     return hash.encodeBase64()
 }
 
-actual fun calcSHA256(bytes: ByteArray): String {
+actual fun calcSHA256(bytes: ByteArray): ByteArray {
     val md = MessageDigest.getInstance("SHA-256")
-    val digest = md.digest(bytes)
-    return digest.fold("") { str, it -> str + "%02x".format(it) }
+    return md.digest(bytes)
 }
 
 actual fun encryptDataWithAES256(data: PlainData, key: AES256Key): EncryptedData = AESEncrypt().encrypt(data, key)

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
@@ -4,7 +4,7 @@ import kotlin.jvm.JvmInline
 
 expect fun calcMd5(bytes: ByteArray): String
 
-expect fun calcSHA256(bytes: ByteArray): String
+expect fun calcSHA256(bytes: ByteArray): ByteArray
 
 /**
  * Method used to encrypt an array of bytes using the AES256 encryption algorithm

--- a/cryptography/src/iosX64Main/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
+++ b/cryptography/src/iosX64Main/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
@@ -17,7 +17,7 @@ actual fun calcMd5(bytes: ByteArray): String {
     return toData(digestData.asByteArray()).base64Encoding()
 }
 
-actual fun calcSHA256(bytes: ByteArray): String {
+actual fun calcSHA256(bytes: ByteArray): ByteArray {
     TODO("Not yet implemented")
 }
 

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
@@ -4,7 +4,7 @@ actual fun calcMd5(bytes: ByteArray): String {
     TODO("Not yet implemented")
 }
 
-actual fun calcSHA256(bytes: ByteArray): String {
+actual fun calcSHA256(bytes: ByteArray): ByteArray {
     TODO("Not yet implemented")
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
@@ -1,6 +1,6 @@
 package com.wire.kalium.logic.data.asset
 
-data class UploadedAssetId(val key: String)
+data class UploadedAssetId(val key: String, val assetToken: String? = null)
 
 /**
  * On creation of this model, the use case should "calculate" the logic.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
@@ -112,8 +112,8 @@ class AssetMapperImpl : AssetMapper {
                     null -> null
                     else -> null
                 },
-                remoteData = status?.run {
-                    with((this as? Asset.Status.Uploaded)?.value) {
+                remoteData = status.run {
+                    with((this as Asset.Status.Uploaded).value) {
                         AssetContent.RemoteData(
                             otrKey = otrKey.array,
                             sha256 = sha256.array,
@@ -127,7 +127,7 @@ class AssetMapperImpl : AssetMapper {
                             }
                         )
                     }
-                } ?: null
+                }
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
@@ -36,7 +36,7 @@ class AssetMapperImpl : AssetMapper {
     }
 
     override fun fromApiUploadResponseToDomainModel(asset: AssetResponse) =
-        UploadedAssetId(asset.key)
+        UploadedAssetId(asset.key, assetToken = asset.token)
 
     override fun fromUploadedAssetToDaoModel(uploadAssetData: UploadAssetData, uploadedAssetResponse: AssetResponse): AssetEntity {
         return AssetEntity(
@@ -112,20 +112,22 @@ class AssetMapperImpl : AssetMapper {
                     null -> null
                     else -> null
                 },
-                remoteData = with((status as Asset.Status.Uploaded).value) {
-                    AssetContent.RemoteData(
-                        otrKey = otrKey.array,
-                        sha256 = sha256.array,
-                        assetId = assetId ?: "",
-                        assetDomain = assetDomain,
-                        assetToken = assetToken,
-                        encryptionAlgorithm = when (encryption) {
-                            EncryptionAlgorithm.AES_CBC -> AES_CBC
-                            EncryptionAlgorithm.AES_GCM -> AES_GCM
-                            else -> null
-                        }
-                    )
-                }
+                remoteData = status?.run {
+                    with((this as? Asset.Status.Uploaded)?.value) {
+                        AssetContent.RemoteData(
+                            otrKey = otrKey.array,
+                            sha256 = sha256.array,
+                            assetId = assetId ?: "",
+                            assetDomain = assetDomain,
+                            assetToken = assetToken,
+                            encryptionAlgorithm = when (encryption) {
+                                EncryptionAlgorithm.AES_CBC -> AES_CBC
+                                EncryptionAlgorithm.AES_GCM -> AES_GCM
+                                else -> null
+                            }
+                        )
+                    }
+                } ?: null
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -43,6 +43,7 @@ class MessageMapperImpl(private val idMapper: IdMapper) : MessageMapper {
                         assetOtrKey = remoteData.otrKey,
                         assetSha256Key = remoteData.sha256,
                         assetId = remoteData.assetId,
+                        assetToken = remoteData.assetToken,
                         assetEncryptionAlgorithm = remoteData.encryptionAlgorithm?.name
                     )
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -184,6 +184,7 @@ abstract class UserSessionScopeCommon(
             authenticatedDataSourceSet.proteusClient,
             preKeyRepository,
             userRepository,
+            assetRepository,
             syncManager
         )
     val users: UserScope get() = UserScope(userRepository, publicUserRepository, syncManager, assetRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -1,14 +1,16 @@
 package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.cryptography.ProteusClient
+import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.message.ProtoContentMapperImpl
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.asset.SendImageMessageUseCase
+import com.wire.kalium.logic.feature.asset.SendImageMessageUseCaseImpl
 import com.wire.kalium.logic.sync.SyncManager
 
 class MessageScope(
@@ -18,6 +20,7 @@ class MessageScope(
     private val proteusClient: ProteusClient,
     private val preKeyRepository: PreKeyRepository,
     private val userRepository: UserRepository,
+    private val assetRepository: AssetRepository,
     private val syncManager: SyncManager
 ) {
 
@@ -46,6 +49,16 @@ class MessageScope(
             syncManager,
             messageSender
         )
+
+    val sendImageMessage: SendImageMessageUseCase
+        get() = SendImageMessageUseCaseImpl(
+            messageRepository,
+            clientRepository,
+            assetRepository,
+            userRepository,
+            messageSender
+        )
+
     val getRecentMessages: GetRecentMessagesUseCase get() = GetRecentMessagesUseCase(messageRepository)
 
     val deleteMessage: DeleteMessageUseCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -256,5 +256,5 @@ class AssetRepositoryTest {
     }
 
     private fun stubAssetEntity(assetKey: String, rawData: ByteArray) =
-        AssetEntity(assetKey, "some_domain", null, rawData, 1)
+        AssetEntity(assetKey, "some_domain", null, rawData, null, 1)
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
@@ -108,7 +108,7 @@ private class Arrangement {
     @Mock
     private val messageSender = mock(classOf<MessageSender>())
 
-    val someAssetId = UploadedAssetId("some-asset-id")
+    val someAssetId = UploadedAssetId("some-asset-id", "some-asset-token")
 
     val someClientId = ClientId("some-client-id")
 
@@ -124,7 +124,7 @@ private class Arrangement {
         "some_key"
     )
 
-    val sendImageUseCase = SendImageUseCaseImpl(messageRepository, clientRepository, assetDataSource, userRepository, messageSender)
+    val sendImageUseCase = SendImageMessageUseCaseImpl(messageRepository, clientRepository, assetDataSource, userRepository, messageSender)
 
     fun withSuccessfulResponse(): Arrangement {
         given(assetDataSource)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
@@ -42,7 +42,7 @@ class SendImageUseCaseTest {
             .arrange()
 
         // When
-        val result = sendImageUseCase.invoke(conversationId, imageToSend)
+        val result = sendImageUseCase.invoke(conversationId, imageToSend, 1, 1)
 
         // Then
         assertEquals(result, SendImageMessageResult.Success)
@@ -61,7 +61,7 @@ class SendImageUseCaseTest {
             .arrange()
 
         // When
-        val result = sendImageUseCase.invoke(conversationId, imageByteArray)
+        val result = sendImageUseCase.invoke(conversationId, imageByteArray, 1, 1)
 
         // Then
         assertTrue(result is SendImageMessageResult.Failure)
@@ -81,7 +81,7 @@ class SendImageUseCaseTest {
                 .arrange()
 
             // When
-            sendImageUseCase.invoke(conversationId, mockedImg)
+            sendImageUseCase.invoke(conversationId, mockedImg, 1, 1)
 
             // Then
             verify(arrangement.messageRepository)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/asset/AssetDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/asset/AssetDAO.kt
@@ -7,6 +7,7 @@ data class AssetEntity(
     val domain: String,
     val mimeType: String?,
     val rawData: ByteArray,
+    val assetToken: String? = null,
     val downloadedDate: Long?
 ) {
     override fun equals(other: Any?): Boolean {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/asset/AssetDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/asset/AssetDAOImpl.kt
@@ -10,11 +10,11 @@ import com.wire.kalium.persistence.db.Asset as SQLDelightAsset
 class AssetMapper {
     fun toModel(asset: SQLDelightAsset): AssetEntity {
         return AssetEntity(
-            asset.key,
-            asset.domain,
-            asset.mime_type,
-            asset.raw_data,
-            asset.downloaded_date
+            key = asset.key,
+            domain = asset.domain,
+            mimeType = asset.mime_type,
+            rawData = asset.raw_data,
+            downloadedDate = asset.downloaded_date
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On the previously merged PR #327 , there was a latent issue on the way of calculating the SHA256 digestion of the encrypted data. It was transforming it to hex value and then transforming it to byte array. This PR fixes this.
The field `status.uploaded` returned by the backend upon asset upload seems to be sometimes null, so added a nullability check for that as well to avoid undesired crashes.


### Dependencies (Optional)

A following PR will come wiring the app logic with the use case so that the image can be directly uploaded as a private asset from the app.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
