### PR TITLE
fix: workaround code gen compiling issues

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/DateTimeUtil.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/DateTimeUtil.kt
@@ -2,6 +2,6 @@ package com.wire.kalium.logic.util
 
 import java.text.SimpleDateFormat
 
-private val serverDateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+private val serverDateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
 
 fun String.toTimeInMillis(): Long = serverDateTimeFormat.parse(this).time

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/DateTimeUtil.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/DateTimeUtil.kt
@@ -2,6 +2,6 @@ package com.wire.kalium.logic.util
 
 import java.text.SimpleDateFormat
 
-private val serverDateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+private val serverDateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
 
 fun String.toTimeInMillis(): Long = serverDateTimeFormat.parse(this).time

--- a/protobuf-codegen/build.gradle.kts
+++ b/protobuf-codegen/build.gradle.kts
@@ -3,9 +3,9 @@ import com.google.protobuf.gradle.generateProtoTasks
 import com.google.protobuf.gradle.id
 import com.google.protobuf.gradle.ofSourceSet
 import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.remove
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
+import com.google.protobuf.gradle.remove
 
 plugins {
     Plugins.jvm(this)
@@ -33,5 +33,16 @@ protobuf {
                 id("pbandk")
             }
         }
+    }
+}
+
+// Workaround to avoid compiling kotlin and java, since we are only using the generated code output
+// https://github.com/streem/pbandk/blob/master/examples/gradle-and-jvm/build.gradle.kts
+tasks {
+    compileJava {
+        enabled = false
+    }
+    compileKotlin {
+        enabled = false
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, on M1 Macbooks @MohammedMokresh and I had some issues when the module `protobuf-codegen` was building. As @saleniuk suggested and using the example from https://github.com/streem/pbandk/blob/master/examples/gradle-and-jvm/build.gradle.kts we are now skipping the `compileJava` and `CompileKotlin` tasks, since are not required for code generation purposes

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
