### PR TITLE
feat(conversation): Observe list of conversation details (AR-1177, AR-881)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -11,12 +11,12 @@ data class Conversation(val id: ConversationId, val name: String?, val type: Typ
     enum class Type { SELF, ONE_ON_ONE, GROUP }
 }
 
-sealed class ConversationDetails(val conversation: Conversation) {
+sealed class ConversationDetails(open val conversation: Conversation) {
 
-    class Self(conversation: Conversation) : ConversationDetails(conversation)
+    data class Self(override val conversation: Conversation) : ConversationDetails(conversation)
 
-    class OneOne(
-        conversation: Conversation,
+    data class OneOne(
+        override val conversation: Conversation,
         val otherUser: OtherUser,
         val connectionState: ConnectionState,
         val legalHoldStatus: LegalHoldStatus
@@ -33,7 +33,7 @@ sealed class ConversationDetails(val conversation: Conversation) {
         }
     }
 
-    class Group(conversation: Conversation) : ConversationDetails(conversation)
+    data class Group(override val conversation: Conversation) : ConversationDetails(conversation)
 }
 
 class MembersInfo(val self: Member, val otherMembers: List<Member>)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -29,6 +29,7 @@ interface ConversationRepository {
     suspend fun getSelfConversationId(): ConversationId
     suspend fun fetchConversations(): Either<CoreFailure, Unit>
     suspend fun getConversationList(): Either<StorageFailure, Flow<List<Conversation>>>
+    suspend fun observeConversationList(): Flow<List<Conversation>>
     suspend fun getConversationDetailsById(conversationID: ConversationId): Flow<ConversationDetails>
     suspend fun getConversationDetails(conversationId: ConversationId): Either<StorageFailure, Flow<Conversation>>
     suspend fun getConversationRecipients(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
@@ -67,7 +68,11 @@ class ConversationDataSource(
     override suspend fun getSelfConversationId(): ConversationId = idMapper.fromDaoModel(conversationDAO.getSelfConversationId())
 
     override suspend fun getConversationList(): Either<StorageFailure, Flow<List<Conversation>>> = wrapStorageRequest {
-        conversationDAO.getAllConversations().map { it.map(conversationMapper::fromDaoModel) }
+        observeConversationList()
+    }
+
+    override suspend fun observeConversationList(): Flow<List<Conversation>> {
+        return conversationDAO.getAllConversations().map { it.map(conversationMapper::fromDaoModel) }
     }
 
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -13,6 +13,9 @@ class ConversationScope(
     val getConversationDetails: GetConversationDetailsUseCase
         get() = GetConversationDetailsUseCase(conversationRepository, syncManager)
 
+    val observeConversationListDetails: ObserveConversationListDetailsUseCase
+        get() = ObserveConversationListDetailsUseCase(conversationRepository, syncManager)
+
     val observeConversationDetails: ObserveConversationDetailsUseCase
         get() = ObserveConversationDetailsUseCase(conversationRepository, syncManager)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCase.kt
@@ -1,0 +1,27 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+
+class ObserveConversationListDetailsUseCase(
+    private val conversationRepository: ConversationRepository,
+    private val syncManager: SyncManager
+) {
+
+    suspend operator fun invoke(): Flow<List<ConversationDetails>> {
+        syncManager.waitForSlowSyncToComplete()
+        return conversationRepository.observeConversationList().map { conversations ->
+            conversations.map { conversation ->
+                conversationRepository.getConversationDetailsById(conversation.id)
+            }
+        }.flatMapLatest { flowsOfDetails ->
+            combine(flowsOfDetails) { latestValues -> latestValues.asList() }
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -1,0 +1,224 @@
+package com.wire.kalium.logic.feature.conversation
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.sync.SyncManager
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class ObserveConversationListDetailsUseCaseTest {
+
+    @Mock
+    private val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
+
+    @Mock
+    private val syncManager: SyncManager = mock(SyncManager::class)
+
+    private lateinit var observeConversationsUseCase: ObserveConversationListDetailsUseCase
+
+    @BeforeTest
+    fun setup() {
+        observeConversationsUseCase = ObserveConversationListDetailsUseCase(conversationRepository, syncManager)
+    }
+
+    @Test
+    fun givenSomeConversations_whenObservingDetailsList_thenObserveConversationListShouldBeCalled() = runTest {
+        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
+
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationList)
+            .whenInvoked()
+            .thenReturn(flowOf(conversations))
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        observeConversationsUseCase().collect()
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationList)
+            .wasInvoked(exactly = once)
+
+    }
+
+    @Test
+    fun givenSomeConversations_whenObservingDetailsList_thenSyncManagerShouldBeCalled() = runTest {
+        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
+
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationList)
+            .whenInvoked()
+            .thenReturn(flowOf(conversations))
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        observeConversationsUseCase().collect()
+
+        verify(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .wasInvoked(exactly = once)
+
+    }
+
+    @Test
+    fun givenSomeConversations_whenObservingDetailsList_thenObserveConversationDetailsShouldBeCalledForEachID() = runTest {
+        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
+
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationList)
+            .whenInvoked()
+            .thenReturn(flowOf(conversations))
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        observeConversationsUseCase().collect()
+
+        conversations.forEach { conversation ->
+            verify(conversationRepository)
+                .suspendFunction(conversationRepository::getConversationDetailsById)
+                .with(eq(conversation.id))
+                .wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenSomeConversationsDetailsAreUpdated_whenObservingDetailsList_thenTheUpdateIsPropagatedThroughTheFlow() = runTest {
+        val oneOnOneConversation = TestConversation.ONE_ON_ONE
+        val groupConversation = TestConversation.GROUP
+        val conversations = listOf(groupConversation, oneOnOneConversation)
+
+        val groupConversationUpdates = listOf(ConversationDetails.Group(groupConversation))
+        val firstOneOnOneDetails = ConversationDetails.OneOne(
+            oneOnOneConversation,
+            TestUser.OTHER,
+            ConversationDetails.OneOne.ConnectionState.ACCEPTED,
+            LegalHoldStatus.ENABLED
+        )
+        val secondOneOnOneDetails = ConversationDetails.OneOne(
+            oneOnOneConversation,
+            TestUser.OTHER.copy(name = "New User Name"),
+            ConversationDetails.OneOne.ConnectionState.INCOMING,
+            LegalHoldStatus.DISABLED
+        )
+        val oneOnOneConversationDetailsUpdates = listOf(
+            firstOneOnOneDetails,
+            secondOneOnOneDetails
+        )
+
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationList)
+            .whenInvoked()
+            .thenReturn(flowOf(conversations))
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(eq(groupConversation.id))
+            .thenReturn(groupConversationUpdates.asFlow())
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(eq(oneOnOneConversation.id))
+            .thenReturn(oneOnOneConversationDetailsUpdates.asFlow())
+
+        observeConversationsUseCase().test {
+            assertContentEquals(groupConversationUpdates + firstOneOnOneDetails, awaitItem())
+            assertContentEquals(groupConversationUpdates + secondOneOnOneDetails, awaitItem())
+            awaitComplete()
+        }
+    }
+
+
+    @Test
+    fun givenAConversationIsAddedToTheList_whenObservingDetailsList_thenTheUpdateIsPropagatedThroughTheFlow() = runTest {
+        val groupConversation = TestConversation.GROUP
+        val groupConversationDetails = ConversationDetails.Group(groupConversation)
+
+        val selfConversation = TestConversation.SELF
+        val selfConversationDetails = ConversationDetails.Self(selfConversation)
+
+        val firstConversationsList = listOf(groupConversation)
+        val secondConversationsList = firstConversationsList + selfConversation
+        val conversationListUpdates = Channel<List<Conversation>>(Channel.UNLIMITED)
+        conversationListUpdates.send(firstConversationsList)
+
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationList)
+            .whenInvoked()
+            .thenReturn(conversationListUpdates.consumeAsFlow())
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(eq(groupConversation.id))
+            .thenReturn(flowOf(groupConversationDetails))
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationDetailsById)
+            .whenInvokedWith(eq(selfConversation.id))
+            .thenReturn(flowOf(selfConversationDetails))
+
+        observeConversationsUseCase().test {
+            assertContentEquals(listOf(groupConversationDetails), awaitItem())
+
+            conversationListUpdates.send(secondConversationsList)
+            assertContentEquals(listOf(groupConversationDetails, selfConversationDetails), awaitItem())
+
+            conversationListUpdates.close()
+            awaitComplete()
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -9,9 +9,9 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 object TestConversation {
     val ID = ConversationId("valueConvo", "domainConvo")
 
-    val ONE_ON_ONE = Conversation(ID, "ONE_ON_ONE Name", Conversation.Type.ONE_ON_ONE, TestTeam.TEAM_ID)
-    val SELF = Conversation(ID, "SELF Name", Conversation.Type.SELF, TestTeam.TEAM_ID)
-    val GROUP = Conversation(ID, "GROUP Name", Conversation.Type.GROUP, TestTeam.TEAM_ID)
+    val ONE_ON_ONE = Conversation(ID.copy(value = "1O1 ID"), "ONE_ON_ONE Name", Conversation.Type.ONE_ON_ONE, TestTeam.TEAM_ID)
+    val SELF = Conversation(ID.copy(value = "SELF ID"), "SELF Name", Conversation.Type.SELF, TestTeam.TEAM_ID)
+    val GROUP = Conversation(ID.copy(value = "GROUP ID"), "GROUP Name", Conversation.Type.GROUP, TestTeam.TEAM_ID)
 
     val ENTITY_ID = QualifiedIDEntity("valueConversation", "domainConversation")
     val ENTITY = ConversationEntity(ENTITY_ID, "convo name", ConversationEntity.Type.SELF, "teamId")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need a way to observe details of a whole list of conversations.

### Solutions

Add `ObserveConversationListDetailsUseCase` that will get the list of conversations, and for each conversation, will observe its details, returning back an observable list of details.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

```kotlin
conversationScope.observeConversationListDetails().collect{ listOfConversationDetails ->
    // :D
}
```

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
