### PR TITLE
chore: rename ServerConfig

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfig.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.configuration
 
-import com.wire.kalium.network.tools.BackendConfig
-import com.wire.kalium.persistence.model.NetworkConfig
+import com.wire.kalium.network.tools.ServerConfigDTO
+import com.wire.kalium.persistence.model.ServerConfigEntity
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -38,27 +38,27 @@ data class ServerConfig(
 }
 
 interface ServerConfigMapper {
-    fun toBackendConfig(serverConfig: ServerConfig): BackendConfig
-    fun fromBackendConfig(backendConfig: BackendConfig): ServerConfig
-    fun toNetworkConfig(serverConfig: ServerConfig): NetworkConfig
-    fun fromNetworkConfig(networkConfig: NetworkConfig): ServerConfig
+    fun toDTO(serverConfig: ServerConfig): ServerConfigDTO
+    fun fromDTO(serverConfigDTO: ServerConfigDTO): ServerConfig
+    fun toEntity(serverConfig: ServerConfig): ServerConfigEntity
+    fun fromEntity(serverConfigEntity: ServerConfigEntity): ServerConfig
 }
 
 class ServerConfigMapperImpl : ServerConfigMapper {
     // TODO: url validation check e.g. remove https:// since ktor will control the http protocol
-    override fun toBackendConfig(serverConfig: ServerConfig): BackendConfig =
-        with(serverConfig) { BackendConfig(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
+    override fun toDTO(serverConfig: ServerConfig): ServerConfigDTO =
+        with(serverConfig) { ServerConfigDTO(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
 
-    override fun fromBackendConfig(backendConfig: BackendConfig): ServerConfig =
-        with(backendConfig) { ServerConfig(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
+    override fun fromDTO(serverConfigDTO: ServerConfigDTO): ServerConfig =
+        with(serverConfigDTO) { ServerConfig(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
 
-    override fun toNetworkConfig(serverConfig: ServerConfig): NetworkConfig =
+    override fun toEntity(serverConfig: ServerConfig): ServerConfigEntity =
         with(serverConfig) {
-            NetworkConfig(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, serverConfig.title)
+            ServerConfigEntity(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, serverConfig.title)
         }
 
-    override fun fromNetworkConfig(networkConfig: NetworkConfig): ServerConfig =
-        with(networkConfig) {
+    override fun fromEntity(serverConfigEntity: ServerConfigEntity): ServerConfig =
+        with(serverConfigEntity) {
             ServerConfig(
                 apiBaseUrl,
                 accountBaseUrl,
@@ -66,7 +66,7 @@ class ServerConfigMapperImpl : ServerConfigMapper {
                 blackListUrl,
                 teamsUrl,
                 websiteUrl,
-                networkConfig.title
+                serverConfigEntity.title
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfigRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfigRemoteRepository.kt
@@ -18,6 +18,6 @@ class ServerConfigRemoteDataSource(
 
     override suspend fun fetchServerConfig(remoteConfigUrl: String): Either<NetworkFailure, ServerConfig> = wrapApiRequest {
         remoteConfigApi.fetchServerConfig(remoteConfigUrl)
-    }.map { serverConfigMapper.fromBackendConfig(it) }
+    }.map { serverConfigMapper.fromDTO(it) }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
@@ -33,7 +33,7 @@ internal class SessionMapperImpl(
         accessToken = persistenceSession.accessToken,
         refreshToken = persistenceSession.refreshToken,
         tokenType = persistenceSession.tokenType,
-        serverConfig = serverConfigMapper.fromNetworkConfig(persistenceSession.networkConfig)
+        serverConfig = serverConfigMapper.fromEntity(persistenceSession.serverConfigEntity)
     )
 
     override fun toPersistenceSession(authSession: AuthSession): PersistenceSession = PersistenceSession(
@@ -41,7 +41,7 @@ internal class SessionMapperImpl(
         accessToken = authSession.accessToken,
         refreshToken = authSession.refreshToken,
         tokenType = authSession.tokenType,
-        networkConfig = serverConfigMapper.toNetworkConfig(authSession.serverConfig)
+        serverConfigEntity = serverConfigMapper.toEntity(authSession.serverConfig)
     )
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -10,7 +10,7 @@ import com.wire.kalium.network.api.SessionDTO
 import com.wire.kalium.network.api.model.AccessTokenDTO
 import com.wire.kalium.network.api.model.RefreshTokenDTO
 import com.wire.kalium.network.session.SessionManager
-import com.wire.kalium.network.tools.BackendConfig
+import com.wire.kalium.network.tools.ServerConfigDTO
 
 class SessionManagerImpl(
     private val sessionRepository: SessionRepository,
@@ -18,10 +18,10 @@ class SessionManagerImpl(
     private val sessionMapper: SessionMapper = MapperProvider.sessionMapper(),
     private val serverConfigMapper: ServerConfigMapper = MapperProvider.serverConfigMapper()
 ) : SessionManager {
-    override fun session(): Pair<SessionDTO, BackendConfig> = sessionRepository.userSession(userId).fold({
+    override fun session(): Pair<SessionDTO, ServerConfigDTO> = sessionRepository.userSession(userId).fold({
         TODO("no session is stored to the user")
     }, { session ->
-        Pair(sessionMapper.toSessionDTO(session), serverConfigMapper.toBackendConfig(session.serverConfig))
+        Pair(sessionMapper.toSessionDTO(session), serverConfigMapper.toDTO(session.serverConfig))
     })
 
     override fun updateSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.configuration
 
-import com.wire.kalium.network.tools.BackendConfig
-import com.wire.kalium.persistence.model.NetworkConfig
+import com.wire.kalium.network.tools.ServerConfigDTO
+import com.wire.kalium.persistence.model.ServerConfigEntity
 import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -18,53 +18,53 @@ class ServerConfigMapperTest {
 
     @Test
     fun givenABackendConfig_whenMappingFromBackendConfig_thenValuesAreMappedCorrectly() {
-        val backendConfig: BackendConfig = randomBackendConfig()
+        val serverConfigDTO: ServerConfigDTO = randomBackendConfig()
         val acuteValue: ServerConfig =
-            with(backendConfig) { ServerConfig(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
+            with(serverConfigDTO) { ServerConfig(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
 
-        val expectedValue: ServerConfig = serverConfigMapper.fromBackendConfig(backendConfig)
+        val expectedValue: ServerConfig = serverConfigMapper.fromDTO(serverConfigDTO)
         assertEquals(expectedValue, acuteValue)
     }
 
     @Test
     fun givenAServerConfig_whenMappingToBackendConfig_thenValuesAreMappedCorrectly() {
         val serverConfig: ServerConfig = randomServerConfig()
-        val acuteValue: BackendConfig =
-            with(serverConfig) { BackendConfig(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
+        val acuteValue: ServerConfigDTO =
+            with(serverConfig) { ServerConfigDTO(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
 
-        val expectedValue: BackendConfig = serverConfigMapper.toBackendConfig(serverConfig)
+        val expectedValue: ServerConfigDTO = serverConfigMapper.toDTO(serverConfig)
         assertEquals(expectedValue, acuteValue)
     }
 
     @Test
     fun givenANetworkConfigEntity_whenMappingFromNetworkConfig_thenValuesAreMappedCorrectly() {
-        val networkConfig: NetworkConfig = randomNetworkConfig()
+        val serverConfigEntity: ServerConfigEntity = randomNetworkConfig()
         val acuteValue: ServerConfig =
-            with(networkConfig) { ServerConfig(apiBaseUrl, accountBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
+            with(serverConfigEntity) { ServerConfig(apiBaseUrl, accountBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
 
-        val expectedValue: ServerConfig = serverConfigMapper.fromNetworkConfig(networkConfig)
+        val expectedValue: ServerConfig = serverConfigMapper.fromEntity(serverConfigEntity)
         assertEquals(expectedValue, acuteValue)
     }
 
     @Test
     fun givenAServerConfig_whenMappingToNetworkConfig_thenValuesAreMappedCorrectly() {
         val serverConfig: ServerConfig = randomServerConfig()
-        val acuteValue: NetworkConfig =
-            with(serverConfig) { NetworkConfig(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
+        val acuteValue: ServerConfigEntity =
+            with(serverConfig) { ServerConfigEntity(apiBaseUrl, accountsBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title) }
 
-        val expectedValue: NetworkConfig = serverConfigMapper.toNetworkConfig(serverConfig)
+        val expectedValue: ServerConfigEntity = serverConfigMapper.toEntity(serverConfig)
         assertEquals(expectedValue, acuteValue)
     }
 
     private companion object {
         val randomString get() = Random.nextBytes(64).decodeToString()
-        fun randomBackendConfig(): BackendConfig =
-            BackendConfig(randomString, randomString, randomString, randomString, randomString, randomString, randomString)
+        fun randomBackendConfig(): ServerConfigDTO =
+            ServerConfigDTO(randomString, randomString, randomString, randomString, randomString, randomString, randomString)
 
         fun randomServerConfig(): ServerConfig =
             ServerConfig(randomString, randomString, randomString, randomString, randomString, randomString, randomString)
 
-        fun randomNetworkConfig(): NetworkConfig =
-            NetworkConfig(randomString, randomString, randomString, randomString, randomString, randomString, randomString)
+        fun randomNetworkConfig(): ServerConfigEntity =
+            ServerConfigEntity(randomString, randomString, randomString, randomString, randomString, randomString, randomString)
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/HttpClientProvider.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/HttpClientProvider.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.network
 
-import com.wire.kalium.network.tools.BackendConfig
 import com.wire.kalium.network.tools.KtxSerializer
+import com.wire.kalium.network.tools.ServerConfigDTO
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
@@ -21,7 +21,7 @@ import io.ktor.serialization.kotlinx.json.json
 
 sealed class HttpClientOptions {
     object NoDefaultHost : HttpClientOptions()
-    data class DefaultHost(val backendConfig: BackendConfig) : HttpClientOptions()
+    data class DefaultHost(val serverConfigDTO: ServerConfigDTO) : HttpClientOptions()
 }
 
 internal fun provideBaseHttpClient(
@@ -39,7 +39,7 @@ internal fun provideBaseHttpClient(
             HttpClientOptions.NoDefaultHost -> {/* do nothing */ }
 
             is HttpClientOptions.DefaultHost -> {
-                host = options.backendConfig.apiBaseUrl
+                host = options.serverConfigDTO.apiBaseUrl
                 // the UrlProtocol is intentionally here and not default for both options
                 // since any url configuration here will get overwritten by the request configuration
                 url.protocol = URLProtocol.HTTPS

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/configuration/ServerConfigApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/configuration/ServerConfigApi.kt
@@ -1,6 +1,6 @@
 package com.wire.kalium.network.api.configuration
 
-import com.wire.kalium.network.tools.BackendConfig
+import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse
@@ -8,7 +8,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 
 interface ServerConfigApi {
-    suspend fun fetchServerConfig(serverConfigUrl: String): NetworkResponse<BackendConfig>
+    suspend fun fetchServerConfig(serverConfigUrl: String): NetworkResponse<ServerConfigDTO>
 }
 
 class ServerConfigApiImp(private val httpClient: HttpClient) : ServerConfigApi {
@@ -18,11 +18,11 @@ class ServerConfigApiImp(private val httpClient: HttpClient) : ServerConfigApi {
      * @param serverConfigUrl the remote config url
      */
     // TODO: use wrapApiRequest once PR #226 is merged
-    override suspend fun fetchServerConfig(serverConfigUrl: String): NetworkResponse<BackendConfig> =
+    override suspend fun fetchServerConfig(serverConfigUrl: String): NetworkResponse<ServerConfigDTO> =
         wrapKaliumResponse<ServerConfigResponse> {
             httpClient.get(serverConfigUrl)
         }.mapSuccess {
-            BackendConfig(
+            ServerConfigDTO(
                 apiBaseUrl = it.endpoints.apiBaseUrl,
                 accountsBaseUrl = it.endpoints.accountsBaseUrl,
                 webSocketBaseUrl = it.endpoints.webSocketBaseUrl,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApiImpl.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.network.api.notification
 
-import com.wire.kalium.network.tools.BackendConfig
 import com.wire.kalium.network.tools.KtxSerializer
+import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.HttpClient
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
 
-class NotificationApiImpl(private val httpClient: HttpClient, private val backendConfig: BackendConfig) : NotificationApi {
+class NotificationApiImpl(private val httpClient: HttpClient, private val serverConfigDTO: ServerConfigDTO) : NotificationApi {
     override suspend fun lastNotification(
         queryClient: String
     ): NetworkResponse<EventResponse> = wrapKaliumResponse {
@@ -56,7 +56,7 @@ class NotificationApiImpl(private val httpClient: HttpClient, private val backen
         path = PATH_AWAIT
     ) {
         url {
-            host = backendConfig.webSocketBaseUrl
+            host = serverConfigDTO.webSocketBaseUrl
             protocol = URLProtocol.WSS
             port = URLProtocol.WSS.defaultPort
         }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.network.api.model.AccessTokenDTO
 import com.wire.kalium.network.api.model.RefreshTokenDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isInvalidCredentials
-import com.wire.kalium.network.tools.BackendConfig
+import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.auth.Auth
@@ -14,7 +14,7 @@ import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 
 interface SessionManager {
-    fun session(): Pair<SessionDTO, BackendConfig>
+    fun session(): Pair<SessionDTO, ServerConfigDTO>
     fun updateSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO
     fun onSessionExpired()
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/tools/ServerConfigDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/tools/ServerConfigDTO.kt
@@ -1,6 +1,6 @@
 package com.wire.kalium.network.tools
 
-data class BackendConfig(
+data class ServerConfigDTO(
     val apiBaseUrl: String,
     val accountsBaseUrl: String,
     val webSocketBaseUrl: String,

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -7,7 +7,7 @@ import com.wire.kalium.network.api.SessionDTO
 import com.wire.kalium.network.api.model.AccessTokenDTO
 import com.wire.kalium.network.api.model.RefreshTokenDTO
 import com.wire.kalium.network.session.SessionManager
-import com.wire.kalium.network.tools.BackendConfig
+import com.wire.kalium.network.tools.ServerConfigDTO
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -32,7 +32,7 @@ class TestSessionManager : SessionManager {
     private val serverConfig = TEST_BACKEND_CONFIG
     private var session = testCredentials
 
-    override fun session(): Pair<SessionDTO, BackendConfig> = Pair(session, serverConfig)
+    override fun session(): Pair<SessionDTO, ServerConfigDTO> = Pair(session, serverConfig)
 
     override fun updateSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO =
         SessionDTO(
@@ -48,7 +48,7 @@ class TestSessionManager : SessionManager {
 
     companion object {
         val TEST_BACKEND_CONFIG =
-            BackendConfig(
+            ServerConfigDTO(
                 "test.api.com", "test.account.com", "test.ws.com",
                 "test.blacklist", "test.teams.com", "test.wire.com", "Test Title"
             )

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationApiTest.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.api.tools.json.api.notification
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.network.api.notification.EventContentDTO
 import com.wire.kalium.network.api.notification.NotificationApiImpl
-import com.wire.kalium.network.tools.BackendConfig
+import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
@@ -89,7 +89,7 @@ class NotificationApiTest : ApiTest {
     }
 
     private companion object {
-        val BACKEND_CONFIG = BackendConfig(
+        val BACKEND_CONFIG = ServerConfigDTO(
             "apiBaseUrl", "accountsUrl",
             "websocketUrl", "blacklist", "teams", "website", "title"
         )

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/model/PersistenceSession.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/model/PersistenceSession.kt
@@ -4,7 +4,7 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class NetworkConfig(
+data class ServerConfigEntity(
     val apiBaseUrl: String,
     val accountBaseUrl: String,
     val webSocketBaseUrl: String,
@@ -20,5 +20,5 @@ data class PersistenceSession(
     val tokenType: String,
     val accessToken: String,
     val refreshToken: String,
-    val networkConfig: NetworkConfig
+    val serverConfigEntity: ServerConfigEntity
 )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/SessionStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/SessionStorageTest.kt
@@ -5,8 +5,8 @@ import com.russhwolf.settings.Settings
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
-import com.wire.kalium.persistence.model.NetworkConfig
 import com.wire.kalium.persistence.model.PersistenceSession
+import com.wire.kalium.persistence.model.ServerConfigEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.random.Random
@@ -115,8 +115,8 @@ class SessionDAOTest {
 
     private companion object {
         val randomString get() = Random.nextBytes(64).decodeToString()
-        fun randomNetworkConfig(): NetworkConfig =
-            NetworkConfig(randomString, randomString, randomString, randomString, randomString, randomString, "test_network_config")
+        fun randomNetworkConfig(): ServerConfigEntity =
+            ServerConfigEntity(randomString, randomString, randomString, randomString, randomString, randomString, "test_network_config")
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ServerConfig class has multiple confusing names in each module 


### Solutions

logic -> ServerConfig
network -> ServerConfigDTO
persistence -> ServerConfigEntitiy

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
