### PR TITLE
fix: unresolved references when importing classes generated from proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ libs/
 
 # CLI working diretory
 .proteus
+
+# kotlin files generated from proto
+generated/

--- a/protobuf-codegen/build.gradle.kts
+++ b/protobuf-codegen/build.gradle.kts
@@ -16,6 +16,7 @@ group = "com.wire.kalium"
 version = "0.0.1-SNAPSHOT"
 
 protobuf {
+    generatedFilesBaseDir = "$projectDir/generated"
     protoc {
         artifact = "com.google.protobuf:protoc:3.19.4"
     }

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
 
     sourceSets {
         val commonMain by getting {
-            kotlin.srcDir(codegenProject.file("build/generated/source/proto/main/pbandk"))
+            kotlin.srcDir(codegenProject.file("generated"))
             dependencies {
                 api("pro.streem.pbandk:pbandk-runtime:${Versions.pbandk}")
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was a "unresolved references" issue with classes generated from proto. It wasn't breaking the build but making it difficult to use them in code.

<img width="553" alt="image" src="https://user-images.githubusercontent.com/30429749/161765853-7a646649-8d3a-47af-b7e8-65b298449b70.png">

### Causes (Optional)

It probably was because the same path that was supposed to be the source for `protobuf` module was also the "generated source root" for `protobuf-codegen` and probably Android Studio doesn't like that.

<img width="442" alt="image" src="https://user-images.githubusercontent.com/30429749/161766563-e574b765-b855-453b-9bd9-408c1388a602.png">

### Solutions

Fortunately there is a parameter `generatedFilesBaseDir` that can be used to determine the directory where the generated files are placed. It had to be outside of the `build` directory, because it looks like the pbandk searches for such directory in `build` and marks it as a "generated source root" for the module so separate `generated` folder is created, which is ignored by git, and access to the generated classes is easier.

### Testing

Tested manually.

#### How to Test

Check if the generated classes are accessible in the `kalium` and there are no "unresolved references".

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
