### PR TITLE
feat(conversation): observe conversation members (AR-1178)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
 
@@ -39,6 +40,11 @@ sealed class ConversationDetails(open val conversation: Conversation) {
 class MembersInfo(val self: Member, val otherMembers: List<Member>)
 
 class Member(override val id: UserId) : User()
+
+sealed class MemberDetails {
+    data class Self(val selfUser: SelfUser): MemberDetails()
+    data class Other(val otherUser: OtherUser): MemberDetails()
+}
 
 typealias ClientId = PlainId
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MemberMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MemberMapper.kt
@@ -12,6 +12,7 @@ interface MemberMapper {
     fun fromMapOfClientsResponseToRecipients(qualifiedMap: Map<UserId, List<SimpleClientResponse>>): List<Recipient>
     fun fromApiModelToDaoModel(conversationMembersResponse: ConversationMembersResponse): List<PersistedMember>
     fun fromEventToDaoModel(members: List<ConversationMember>): List<PersistedMember>
+    fun fromDaoModel(entity: PersistedMember): Member
 }
 
 internal class MemberMapperImpl(private val idMapper: IdMapper) : MemberMapper {
@@ -44,4 +45,6 @@ internal class MemberMapperImpl(private val idMapper: IdMapper) : MemberMapper {
 
             Recipient(Member(id), clients)
         }
+
+    override fun fromDaoModel(entity: PersistedMember): Member = Member(idMapper.fromDaoModel(entity.user))
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -195,7 +195,7 @@ abstract class UserSessionScopeCommon(
     val listenToEvents: ListenToEventsUseCase
         get() = ListenToEventsUseCase(syncManager, eventRepository, conversationEventReceiver)
     val client: ClientScope get() = ClientScope(clientRepository, preKeyRepository, keyPackageRepository, mlsClientProvider)
-    val conversations: ConversationScope get() = ConversationScope(conversationRepository, syncManager)
+    val conversations: ConversationScope get() = ConversationScope(conversationRepository, userRepository, syncManager)
     val messages: MessageScope
         get() = MessageScope(
             messageRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -1,10 +1,12 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.sync.SyncManager
 
 class ConversationScope(
     private val conversationRepository: ConversationRepository,
+    private val userRepository: UserRepository,
     private val syncManager: SyncManager
 ) {
     val getConversations: GetConversationsUseCase
@@ -15,6 +17,9 @@ class ConversationScope(
 
     val observeConversationListDetails: ObserveConversationListDetailsUseCase
         get() = ObserveConversationListDetailsUseCase(conversationRepository, syncManager)
+
+    val observeConversationMembers: ObserveConversationMembersUseCase
+        get() = ObserveConversationMembersUseCase(conversationRepository, userRepository, syncManager)
 
     val observeConversationDetails: ObserveConversationDetailsUseCase
         get() = ObserveConversationDetailsUseCase(conversationRepository, syncManager)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
@@ -1,0 +1,37 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+
+class ObserveConversationMembersUseCase(
+    private val conversationRepository: ConversationRepository,
+    private val userRepository: UserRepository,
+    private val syncManager: SyncManager
+) {
+
+    suspend operator fun invoke(conversationId: ConversationId): Flow<List<MemberDetails>> {
+        syncManager.waitForSlowSyncToComplete()
+        val selfDetailsFlow = userRepository.getSelfUser()
+        val selfUserID = selfDetailsFlow.first().id
+        return conversationRepository.observeConversationMembers(conversationId).map { members ->
+            members.map {
+                if (it.id == selfUserID) {
+                    selfDetailsFlow.map(MemberDetails::Self)
+                } else {
+                    userRepository.getKnownUser(it.id).filterNotNull().map(MemberDetails::Other)
+                }
+            }
+        }.flatMapLatest { detailsFlows ->
+            combine(detailsFlows) { it.toList() }
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCaseTest.kt
@@ -1,0 +1,57 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.sync.SyncManager
+import io.mockative.Mock
+import io.mockative.mock
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class ObserveConversationMembersUseCaseTest {
+
+    @Mock
+    private val conversationRepository = mock(ConversationRepository::class)
+
+    @Mock
+    private val userRepository = mock(UserRepository::class)
+
+    @Mock
+    private val syncManager = mock(SyncManager::class)
+
+    private lateinit var observeConversationMembers: ObserveConversationMembersUseCase
+
+    @BeforeTest
+    fun setup() {
+        observeConversationMembers = ObserveConversationMembersUseCase(
+            conversationRepository,
+            userRepository,
+            syncManager
+        )
+    }
+
+    @Test
+    fun givenAConversationId_whenObservingMembers_thenTheSyncManagerIsCalled(){
+        TODO()
+    }
+
+    @Test
+    fun givenAConversationId_whenObservingMembers_thenConversationRepositoryIsCalledWithCorrectID(){
+        TODO()
+    }
+
+    @Test
+    fun givenSelfUserUpdates_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow(){
+        TODO()
+    }
+
+    @Test
+    fun givenOtherUserUpdates_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow(){
+        TODO()
+    }
+
+    @Test
+    fun givenANewMemberIsAdded_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow(){
+        TODO()
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCaseTest.kt
@@ -1,12 +1,29 @@
 package com.wire.kalium.logic.feature.conversation
 
+import app.cash.turbine.test
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.SyncManager
 import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.configure
+import io.mockative.eq
+import io.mockative.given
 import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 
 class ObserveConversationMembersUseCaseTest {
 
@@ -17,7 +34,9 @@ class ObserveConversationMembersUseCaseTest {
     private val userRepository = mock(UserRepository::class)
 
     @Mock
-    private val syncManager = mock(SyncManager::class)
+    private val syncManager = configure(mock(SyncManager::class)) {
+        stubsUnitByDefault = true
+    }
 
     private lateinit var observeConversationMembers: ObserveConversationMembersUseCase
 
@@ -31,27 +50,153 @@ class ObserveConversationMembersUseCaseTest {
     }
 
     @Test
-    fun givenAConversationId_whenObservingMembers_thenTheSyncManagerIsCalled(){
-        TODO()
+    fun givenAConversationID_whenObservingMembers_thenTheSyncManagerIsCalled() = runTest {
+        val conversationID = TestConversation.ID
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationMembers)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        observeConversationMembers(conversationID)
+
+        verify(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .wasInvoked(exactly = once)
     }
 
     @Test
-    fun givenAConversationId_whenObservingMembers_thenConversationRepositoryIsCalledWithCorrectID(){
-        TODO()
+    fun givenAConversationID_whenObservingMembers_thenConversationRepositoryIsCalledWithCorrectID() = runTest {
+        val conversationID = TestConversation.ID
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationMembers)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        observeConversationMembers(conversationID)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationMembers)
+            .with(eq(conversationID))
+            .wasInvoked(exactly = once)
     }
 
     @Test
-    fun givenSelfUserUpdates_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow(){
-        TODO()
+    fun givenSelfUserUpdates_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow() = runTest {
+        val conversationID = TestConversation.ID
+        val firstSelfUser = TestUser.SELF
+        val secondSelfUser = firstSelfUser.copy(name = "Updated name")
+        val selfUserUpdates = listOf(firstSelfUser, secondSelfUser)
+        val members = listOf(
+            Member(firstSelfUser.id)
+        )
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(selfUserUpdates.asFlow())
+
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationMembers)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf(members))
+
+        observeConversationMembers(conversationID).test {
+            assertContentEquals(listOf(MemberDetails.Self(firstSelfUser)), awaitItem())
+            assertContentEquals(listOf(MemberDetails.Self(secondSelfUser)), awaitItem())
+            awaitComplete()
+        }
     }
 
     @Test
-    fun givenOtherUserUpdates_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow(){
-        TODO()
+    fun givenOtherUserUpdates_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow() = runTest {
+        val conversationID = TestConversation.ID
+        val firstOtherUser = TestUser.OTHER
+        val secondOtherUser = firstOtherUser.copy(name = "Updated name")
+        val otherUserUpdates = listOf(firstOtherUser, secondOtherUser)
+        val members = listOf(
+            Member(firstOtherUser.id)
+        )
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(anything())
+            .thenReturn(otherUserUpdates.asFlow())
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationMembers)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf(members))
+
+        observeConversationMembers(conversationID).test {
+            assertContentEquals(listOf(MemberDetails.Other(firstOtherUser)), awaitItem())
+            assertContentEquals(listOf(MemberDetails.Other(secondOtherUser)), awaitItem())
+            awaitComplete()
+        }
     }
 
     @Test
-    fun givenANewMemberIsAdded_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow(){
-        TODO()
+    fun givenANewMemberIsAdded_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow() = runTest {
+        val conversationID = TestConversation.ID
+        val otherUser = TestUser.OTHER
+        val selfUser = TestUser.SELF
+        val membersListChannel = Channel<List<Member>>(Channel.UNLIMITED)
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(selfUser))
+
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf(otherUser))
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationMembers)
+            .whenInvokedWith(anything())
+            .thenReturn(membersListChannel.consumeAsFlow())
+
+        observeConversationMembers(conversationID).test {
+            membersListChannel.send(listOf(Member(otherUser.id)))
+            assertContentEquals(listOf(MemberDetails.Other(otherUser)), awaitItem())
+
+            membersListChannel.send(listOf(Member(otherUser.id), Member(selfUser.id)))
+            assertContentEquals(listOf(MemberDetails.Other(otherUser), MemberDetails.Self(selfUser)), awaitItem())
+
+            membersListChannel.close()
+            awaitComplete()
+        }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Consuming apps need to observe the list of conversation members in order to dislpay it.

### Solutions

Add a new UseCase that will get the members of a conversation and merge the flows of each user into a single list of detailed users.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

```kotlin
conversationScope.observeConversationMembers(convId)
```

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
