### PR TITLE
fix: store jvm preferences in a more discoverable place

### DIFF
--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/PackagePathProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/PackagePathProvider.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium;
+
+/**
+ * IMPORTANT: this class only exist to provide a permanent package path for
+ * the Java Preferences API and must **NOT** be moved to a different package.
+ * Doing so will result in data loss for users.
+ */
+internal class PackagePathProvider

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
@@ -13,7 +13,7 @@ import java.util.prefs.Preferences
 actual class EncryptedSettingsHolder(
     options: SettingOptions
 ) {
-    private val preferences: Preferences = Preferences.userRoot().node(options.fileName)
+    private val preferences: Preferences = Preferences.userNodeForPackage(EncryptedSettingsHolder::class.java).node(options.fileName)
     // TODO: JvmPreferencesSettings is not encrypted
     actual val encryptedSettings: Settings = JvmPreferencesSettings(preferences)
 }

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.persistence.kmm_settings
 import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.JvmPreferencesSettings
 import com.russhwolf.settings.Settings
+import com.wire.kalium.PackagePathProvider
 import java.util.prefs.Preferences
 
 /**
@@ -13,7 +14,7 @@ import java.util.prefs.Preferences
 actual class EncryptedSettingsHolder(
     options: SettingOptions
 ) {
-    private val preferences: Preferences = Preferences.userNodeForPackage(EncryptedSettingsHolder::class.java).node(options.fileName)
+    private val preferences: Preferences = Preferences.userNodeForPackage(PackagePathProvider::class.java).node(options.fileName)
     // TODO: JvmPreferencesSettings is not encrypted
     actual val encryptedSettings: Settings = JvmPreferencesSettings(preferences)
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Finding and deleting the data stored in `KaliumPreferences` when running the JVM target is really hard annoying.

### Solutions

Use `userNodeForPackage(EncryptedSettingsHolder::class.java)` instead of `userRoot()` which on macOS at least save the preferences in `~/Library/Preferences/com.wire.kalium.plist` instead of some obscure java plist file. 

### Testing

#### How to Test

CLI app still works.

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
