### PR TITLE
chore: add callType and ConversationType in logic module

### DIFF
--- a/calling/src/androidMain/kotlin/com/wire/kalium/calling/Platform.kt
+++ b/calling/src/androidMain/kotlin/com/wire/kalium/calling/Platform.kt
@@ -1,5 +1,0 @@
-package com.wire.kalium.calling
-
-actual class Platform actual constructor() {
-    actual val platform: String = "Android ${android.os.Build.VERSION.SDK_INT}"
-}

--- a/calling/src/commonMain/kotlin/com/wire/kalium/calling/CallTypeCalling.kt
+++ b/calling/src/commonMain/kotlin/com/wire/kalium/calling/CallTypeCalling.kt
@@ -4,7 +4,7 @@ package com.wire.kalium.calling
  * [AUDIO] for audio call
  * [VIDEO] for video cal
  */
-enum class CallType(val avsValue: Int) {
+enum class CallTypeCalling(val avsValue: Int) {
     AUDIO(avsValue = 0),
     VIDEO(avsValue = 1),
 }

--- a/calling/src/commonMain/kotlin/com/wire/kalium/calling/ConversationTypeCalling.kt
+++ b/calling/src/commonMain/kotlin/com/wire/kalium/calling/ConversationTypeCalling.kt
@@ -1,6 +1,6 @@
 package com.wire.kalium.calling
 
-enum class CallingConversationType(val avsValue: Int) {
+enum class ConversationTypeCalling(val avsValue: Int) {
     OneOnOne(avsValue = 0),
     Group(avsValue = 1),
     Conference(avsValue = 2)

--- a/calling/src/commonMain/kotlin/com/wire/kalium/calling/Platform.kt
+++ b/calling/src/commonMain/kotlin/com/wire/kalium/calling/Platform.kt
@@ -1,5 +1,0 @@
-package com.wire.kalium.calling
-
-expect class Platform() {
-    val platform: String
-}

--- a/calling/src/jvmMain/kotlin/com/wire/kalium/calling/Platform.kt
+++ b/calling/src/jvmMain/kotlin/com/wire/kalium/calling/Platform.kt
@@ -1,6 +1,0 @@
-package com.wire.kalium.calling
-
-actual class Platform actual constructor() {
-    actual val platform = "JVM"
-}
-

--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.types.Handle
+import com.wire.kalium.logic.data.call.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -40,6 +41,9 @@ class CallManagerTest {
     @Mock
     private val messageSender = mock(classOf<MessageSender>())
 
+    @Mock
+    private val callMapper = mock(classOf<CallMapper>())
+
     private lateinit var callManagerImpl: CallManagerImpl
 
     @BeforeTest
@@ -49,6 +53,7 @@ class CallManagerTest {
             callRepository = callRepository,
             userRepository = userRepository,
             clientRepository = clientRepository,
+            callMapper = callMapper,
             messageSender = messageSender
         )
     }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -7,6 +7,7 @@ import com.waz.media.manager.MediaManager
 import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.ENVIRONMENT_DEFAULT
 import com.wire.kalium.calling.callbacks.LogHandler
+import com.wire.kalium.logic.data.call.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -44,6 +45,7 @@ actual class GlobalCallManager(
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository,
+        callMapper: CallMapper,
         messageSender: MessageSender
     ): CallManager {
         return callManagerHolder[userId] ?: CallManagerImpl(
@@ -51,6 +53,7 @@ actual class GlobalCallManager(
             callRepository = callRepository,
             userRepository = userRepository,
             clientRepository = clientRepository,
+            callMapper = callMapper,
             messageSender = messageSender
         ).also {
             callManagerHolder[userId] = it

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMapper.kt
@@ -1,0 +1,21 @@
+package com.wire.kalium.logic.data.call
+
+import com.wire.kalium.calling.CallTypeCalling
+import com.wire.kalium.calling.ConversationTypeCalling
+
+class CallMapper {
+
+    fun toCallTypeCalling(callType: CallType) : CallTypeCalling {
+        return when(callType) {
+            CallType.AUDIO -> CallTypeCalling.AUDIO
+            CallType.VIDEO -> CallTypeCalling.VIDEO
+        }
+    }
+
+    fun toConversationTypeCalling(conversationType: ConversationType) : ConversationTypeCalling {
+        return when(conversationType) {
+            ConversationType.OneOnOne -> ConversationTypeCalling.OneOnOne
+            ConversationType.Conference -> ConversationTypeCalling.Conference
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallType.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallType.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.logic.data.call
+
+/**
+ * [AUDIO] for audio call
+ * [VIDEO] for video cal
+ */
+enum class CallType {
+    AUDIO,
+    VIDEO,
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/ConversationType.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/ConversationType.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.logic.data.call
+
+/**
+ * [OneOnOne] for a 1:1 call
+ * [Conference] for a group cal
+ */
+enum class ConversationType {
+    OneOnOne,
+    Conference
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.data.asset.AssetDataSource
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.call.CallDataSource
+import com.wire.kalium.logic.data.call.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.client.ClientDataSource
 import com.wire.kalium.logic.data.client.ClientRepository
@@ -169,12 +170,16 @@ abstract class UserSessionScopeCommon(
             authenticatedDataSourceSet.authenticatedNetworkContainer.notificationApi, eventInfoStorage, clientRepository
         )
 
+    private val callMapper: CallMapper
+        get() = CallMapper()
+
     private val callManager by lazy {
         globalCallManager.getCallManagerForClient(
             userId = userId,
             callRepository = callRepository,
             userRepository = userRepository,
             clientRepository = clientRepository,
+            callMapper = callMapper,
             messageSender = messageSender
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.feature.call
 
-import com.wire.kalium.calling.CallType
-import com.wire.kalium.calling.CallingConversationType
+import com.wire.kalium.logic.data.call.CallType
+import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.map
 
 interface CallManager {
     suspend fun onCallingMessageReceived(message: Message, content: MessageContent.Calling)
-    suspend fun startCall(conversationId: ConversationId, callType: CallType, conversationType: CallingConversationType, isAudioCbr: Boolean = false) //TODO Audio CBR
+    suspend fun startCall(conversationId: ConversationId, callType: CallType, conversationType: ConversationType, isAudioCbr: Boolean = false) //TODO Audio CBR
     suspend fun answerCall(conversationId: ConversationId)
     val allCalls: StateFlow<List<Call>>
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.logic.data.call.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -13,6 +14,7 @@ expect class GlobalCallManager {
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository,
+        callMapper: CallMapper,
         messageSender: MessageSender
     ): CallManager
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
@@ -1,13 +1,17 @@
 package com.wire.kalium.logic.feature.call.usecase
 
-import com.wire.kalium.calling.CallType
-import com.wire.kalium.calling.CallingConversationType
+import com.wire.kalium.logic.data.call.CallType
+import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
 
 class StartCallUseCase(private val callManager: CallManager) {
 
-    suspend operator fun invoke(conversationId: ConversationId, callType: CallType, callingConversationType: CallingConversationType) {
-        callManager.startCall(conversationId, callType, callingConversationType)
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        callType: CallType = CallType.AUDIO,
+        conversationType: ConversationType = ConversationType.OneOnOne
+    ) {
+        callManager.startCall(conversationId, callType, conversationType)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/StartCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/StartCallUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.feature.call
 
-import com.wire.kalium.calling.CallType
-import com.wire.kalium.calling.CallingConversationType
+import com.wire.kalium.logic.data.call.CallType
+import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
 import io.mockative.Mock
@@ -34,14 +34,14 @@ class StartCallUseCaseTest {
 
         given(callManager)
             .suspendFunction(callManager::startCall)
-            .whenInvokedWith(eq(conversationId), eq(CallType.AUDIO), eq(CallingConversationType.OneOnOne), eq(false))
+            .whenInvokedWith(eq(conversationId), eq(CallType.AUDIO), eq(ConversationType.OneOnOne), eq(false))
             .thenDoNothing()
 
-        startCall.invoke(conversationId, CallType.AUDIO, CallingConversationType.OneOnOne)
+        startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
 
         verify(callManager)
             .suspendFunction(callManager::startCall)
-            .with(eq(conversationId), eq(CallType.AUDIO), eq(CallingConversationType.OneOnOne), eq(false))
+            .with(eq(conversationId), eq(CallType.AUDIO), eq(ConversationType.OneOnOne), eq(false))
             .wasInvoked(once)
     }
 

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.feature.call
 
-import com.wire.kalium.calling.CallType
-import com.wire.kalium.calling.CallingConversationType
+import com.wire.kalium.logic.data.call.CallType
+import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -22,7 +22,7 @@ actual class CallManagerImpl : CallManager {
         kaliumLogger.w("onCallingMessageReceived for JVM but not supported yet.")
     }
 
-    override suspend fun startCall(conversationId: ConversationId, callType: CallType, conversationType: CallingConversationType, isAudioCbr: Boolean) {
+    override suspend fun startCall(conversationId: ConversationId, callType: CallType, conversationType: ConversationType, isAudioCbr: Boolean) {
         kaliumLogger.w("startCall for JVM but no supported yet.")
     }
 

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.logic.data.call.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -13,6 +14,7 @@ actual class GlobalCallManager {
         callRepository: CallRepository,
         userRepository: UserRepository,
         clientRepository: ClientRepository,
+        callMapper: CallMapper,
         messageSender: MessageSender
     ): CallManager = CallManagerImpl()
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We can not use `CallType` and `ConversationType` in app module

### Solutions

Create these two types in `logic` module and map them with `CallMapper`

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
