### PR TITLE
chore: add database and network layers for user connection status

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.network.api.teams.TeamsApi
 import com.wire.kalium.network.api.teams.TeamsApiImp
 import com.wire.kalium.network.api.user.client.ClientApi
 import com.wire.kalium.network.api.user.client.ClientApiImpl
+import com.wire.kalium.network.api.user.connection.ConnectionApi
+import com.wire.kalium.network.api.user.connection.ConnectionApiImpl
 import com.wire.kalium.network.api.user.details.UserDetailsApi
 import com.wire.kalium.network.api.user.details.UserDetailsApiImp
 import com.wire.kalium.network.api.user.logout.LogoutApi
@@ -70,6 +72,8 @@ class AuthenticatedNetworkContainer(
     val userSearchApi: UserSearchApi get() = UserSearchApiImpl(authenticatedHttpClient)
 
     val callApi: CallApi get() = CallApiImpl(authenticatedHttpClient)
+
+    val connectionApi: ConnectionApi get() = ConnectionApiImpl(authenticatedHttpClient)
 
     internal val authenticatedHttpClient by lazy {
         provideBaseHttpClient(engine, HttpClientOptions.DefaultHost(backendConfig)) {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
@@ -1,0 +1,27 @@
+package com.wire.kalium.network.api.user.connection
+
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import kotlinx.serialization.json.buildJsonObject
+
+interface ConnectionApi {
+
+    suspend fun fetchSelfUserConnections(): NetworkResponse<ConnectionResponse>
+}
+
+class ConnectionApiImpl(private val httpClient: HttpClient) : ConnectionApi {
+
+    override suspend fun fetchSelfUserConnections(): NetworkResponse<ConnectionResponse> =
+        wrapKaliumResponse {
+            httpClient.post(PATH_CONNECTIONS) {
+                setBody(buildJsonObject {  })
+            }
+        }
+
+    private companion object {
+        const val PATH_CONNECTIONS = "/list-connections"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
@@ -9,15 +9,21 @@ import kotlinx.serialization.json.buildJsonObject
 
 interface ConnectionApi {
 
-    suspend fun fetchSelfUserConnections(): NetworkResponse<ConnectionResponse>
+    suspend fun fetchSelfUserConnections(pagingState: String?): NetworkResponse<ConnectionResponse>
 }
 
 class ConnectionApiImpl(private val httpClient: HttpClient) : ConnectionApi {
 
-    override suspend fun fetchSelfUserConnections(): NetworkResponse<ConnectionResponse> =
+    override suspend fun fetchSelfUserConnections(pagingState: String?): NetworkResponse<ConnectionResponse> =
         wrapKaliumResponse {
             httpClient.post(PATH_CONNECTIONS) {
-                setBody(buildJsonObject {  })
+                setBody(
+                    buildJsonObject {
+                        pagingState?.let {
+                            "paging_state" to it
+                        }
+                    }
+                )
             }
         }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
@@ -1,0 +1,55 @@
+package com.wire.kalium.network.api.user.connection
+
+import com.wire.kalium.network.api.ConversationId
+import com.wire.kalium.network.api.UserId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConnectionResponse(
+    @SerialName("connections") val connections: List<Connection>,
+    @SerialName("has_more") val hasMore: Boolean,
+    @SerialName("paging_state") val pagingState: String
+)
+
+@Serializable
+data class Connection(
+    @SerialName("conversation") val conversationId: String,
+    @SerialName("from") val from: String,
+    @SerialName("last_update") val lastUpdate: String,
+    @SerialName("qualified_conversation") val qualifiedConversationId: ConversationId,
+    @SerialName("qualified_to") val qualifiedToId: UserId,
+    @SerialName("status") val status: ConnectionState,
+    @SerialName("to") val toId: String
+)
+
+@Serializable
+enum class ConnectionState {
+    // The other user has sent a connection request to this one
+    @SerialName("pending")
+    PENDING,
+
+    // This user has sent a connection request to another user
+    @SerialName("sent")
+    SENT,
+
+    // The user has been blocked
+    @SerialName("blocked")
+    BLOCKED,
+
+    // The connection has been ignored
+    @SerialName("ignored")
+    IGNORED,
+
+    // The connection has been cancelled
+    @SerialName("cancelled")
+    CANCELLED,
+
+    // The connection is missing legal hold consent
+    @SerialName("missing-legalhold-consent")
+    MISSING_LEGALHOLD_CONSENT,
+
+    // The connection is complete and the conversation is in its normal state
+    @SerialName("accepted")
+    ACCEPTED
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
@@ -25,31 +25,31 @@ data class Connection(
 
 @Serializable
 enum class ConnectionState {
-    // The other user has sent a connection request to this one
+    /** The other user has sent a connection request to this one */
     @SerialName("pending")
     PENDING,
 
-    // This user has sent a connection request to another user
+    /** This user has sent a connection request to another user */
     @SerialName("sent")
     SENT,
 
-    // The user has been blocked
+    /** The user has been blocked */
     @SerialName("blocked")
     BLOCKED,
 
-    // The connection has been ignored
+    /** The connection has been ignored */
     @SerialName("ignored")
     IGNORED,
 
-    // The connection has been cancelled
+    /** The connection has been cancelled */
     @SerialName("cancelled")
     CANCELLED,
 
-    // The connection is missing legal hold consent
+    /** The connection is missing legal hold consent  */
     @SerialName("missing-legalhold-consent")
     MISSING_LEGALHOLD_CONSENT,
 
-    // The connection is complete and the conversation is in its normal state
+    /** The connection is complete and the conversation is in its normal state */
     @SerialName("accepted")
     ACCEPTED
 }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/Database.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/Database.kt
@@ -67,7 +67,11 @@ actual class Database(private val context: Context, userId: UserIDEntity, kalium
                 content_typeAdapter = ContentTypeAdapter(),
                 visibilityAdapter = EnumColumnAdapter()
             ),
-            User.Adapter(qualified_idAdapter = QualifiedIDAdapter(), IntColumnAdapter)
+            User.Adapter(
+                qualified_idAdapter = QualifiedIDAdapter(),
+                accent_idAdapter = IntColumnAdapter,
+                connection_statusAdapter = EnumColumnAdapter(),
+            )
         )
     }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -27,7 +27,7 @@ interface ConversationDAO {
     suspend fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity)
     suspend fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity)
     suspend fun getAllMembers(qualifiedID: QualifiedIDEntity): Flow<List<Member>>
-    suspend fun insertOrUpdateOneOneMemberWithConnectionStatus(
+    suspend fun insertOrUpdateOneToOneMemberWithConnectionStatus(
         userId: UserIDEntity,
         status: UserEntity.ConnectionState,
         conversationID: QualifiedIDEntity

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -27,7 +27,7 @@ interface ConversationDAO {
     suspend fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity)
     suspend fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity)
     suspend fun getAllMembers(qualifiedID: QualifiedIDEntity): Flow<List<Member>>
-    suspend fun insertOrUpdateOneToOneMemberWithConnectionStatus(
+    suspend fun insertOrUpdateOneOnOneMemberWithConnectionStatus(
         userId: UserIDEntity,
         status: UserEntity.ConnectionState,
         conversationID: QualifiedIDEntity

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -27,4 +27,9 @@ interface ConversationDAO {
     suspend fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity)
     suspend fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity)
     suspend fun getAllMembers(qualifiedID: QualifiedIDEntity): Flow<List<Member>>
+    suspend fun insertOrUpdateOneOneMemberWithConnectionStatus(
+        userId: UserIDEntity,
+        status: UserEntity.ConnectionState,
+        conversationID: QualifiedIDEntity
+    )
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -101,7 +101,7 @@ class ConversationDAOImpl(
 
     }
 
-    override suspend fun insertOrUpdateOneOneMemberWithConnectionStatus(
+    override suspend fun insertOrUpdateOneToOneMemberWithConnectionStatus(
         userId: UserIDEntity,
         status: UserEntity.ConnectionState,
         conversationID: QualifiedIDEntity

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -101,7 +101,7 @@ class ConversationDAOImpl(
 
     }
 
-    override suspend fun insertOrUpdateOneToOneMemberWithConnectionStatus(
+    override suspend fun insertOrUpdateOneOnOneMemberWithConnectionStatus(
         userId: UserIDEntity,
         status: UserEntity.ConnectionState,
         conversationID: QualifiedIDEntity

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -101,6 +101,17 @@ class ConversationDAOImpl(
 
     }
 
+    override suspend fun insertOrUpdateOneOneMemberWithConnectionStatus(
+        userId: UserIDEntity,
+        status: UserEntity.ConnectionState,
+        conversationID: QualifiedIDEntity
+    ) {
+        memberQueries.transaction {
+            userQueries.insertOrIgnoreUserIdWithConnectionStatus(userId, status)
+            memberQueries.insertMember(userId, conversationID)
+        }
+    }
+
     override suspend fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity) {
         memberQueries.deleteMember(conversationID, userID)
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -19,9 +19,37 @@ data class UserEntity(
     val phone: String?,
     val accentId: Int,
     val team: String?,
+    val connectionStatus: ConnectionState = ConnectionState.NOT_CONNECTED,
     val previewAssetId: UserAssetIdEntity?,
     val completeAssetId: UserAssetIdEntity?
-)
+) {
+    enum class ConnectionState {
+        // Default - No connection state
+        NOT_CONNECTED,
+
+        // The other user has sent a connection request to this one
+        PENDING,
+
+        // This user has sent a connection request to another user
+        SENT,
+
+        // The user has been blocked
+        BLOCKED,
+
+        // The connection has been ignored
+        IGNORED,
+
+        // The connection has been cancelled
+        CANCELLED,
+
+        // The connection is missing legal hold consent
+        MISSING_LEGALHOLD_CONSENT,
+
+        // The connection is complete and the conversation is in its normal state
+        ACCEPTED
+    }
+}
+
 internal typealias UserAssetIdEntity = String
 
 interface UserDAO {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -24,28 +24,28 @@ data class UserEntity(
     val completeAssetId: UserAssetIdEntity?
 ) {
     enum class ConnectionState {
-        // Default - No connection state
+        /** Default - No connection state */
         NOT_CONNECTED,
 
-        // The other user has sent a connection request to this one
+        /** The other user has sent a connection request to this one */
         PENDING,
 
-        // This user has sent a connection request to another user
+        /** This user has sent a connection request to another user */
         SENT,
 
-        // The user has been blocked
+        /** The user has been blocked */
         BLOCKED,
 
-        // The connection has been ignored
+        /** The connection has been ignored */
         IGNORED,
 
-        // The connection has been cancelled
+        /** The connection has been cancelled */
         CANCELLED,
 
-        // The connection is missing legal hold consent
+        /** The connection is missing legal hold consent */
         MISSING_LEGALHOLD_CONSENT,
 
-        // The connection is complete and the conversation is in its normal state
+        /** The connection is complete and the conversation is in its normal state */
         ACCEPTED
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -11,15 +11,16 @@ import com.wire.kalium.persistence.db.User as SQLDelightUser
 class UserMapper {
     fun toModel(user: SQLDelightUser): UserEntity {
         return UserEntity(
-            user.qualified_id,
-            user.name,
-            user.handle,
-            user.email,
-            user.phone,
-            user.accent_id,
-            user.team,
-            user.preview_asset_id,
-            user.complete_asset_id
+            id = user.qualified_id,
+            name = user.name,
+            handle = user.handle,
+            email = user.email,
+            phone = user.phone,
+            accentId = user.accent_id,
+            team = user.team,
+            connectionStatus = user.connection_status,
+            previewAssetId = user.preview_asset_id,
+            completeAssetId = user.complete_asset_id
         )
     }
 }
@@ -37,6 +38,7 @@ class UserDAOImpl(private val queries: UsersQueries) : UserDAO {
             user.phone,
             user.accentId,
             user.team,
+            user.connectionStatus,
             user.previewAssetId,
             user.completeAssetId
         )
@@ -53,6 +55,7 @@ class UserDAOImpl(private val queries: UsersQueries) : UserDAO {
                     user.phone,
                     user.accentId,
                     user.team,
+                    user.connectionStatus,
                     user.previewAssetId,
                     user.completeAssetId
                 )

--- a/persistence/src/commonMain/sqldelight/com/wire/kalium/persistence/db/Users.sq
+++ b/persistence/src/commonMain/sqldelight/com/wire/kalium/persistence/db/Users.sq
@@ -1,4 +1,5 @@
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+import com.wire.kalium.persistence.dao.UserEntity.ConnectionState;
 import kotlin.Int;
 
 CREATE TABLE User (
@@ -9,6 +10,7 @@ CREATE TABLE User (
     phone TEXT,
     accent_id INTEGER AS Int NOT NULL DEFAULT 0,
     team TEXT,
+    connection_status TEXT AS ConnectionState NOT NULL DEFAULT 'NOT_CONNECTED',
     preview_asset_id TEXT,
     complete_asset_id TEXT
 );
@@ -20,8 +22,8 @@ deleteUser:
 DELETE FROM User WHERE qualified_id = ?;
 
 insertUser:
-INSERT OR REPLACE INTO User(qualified_id, name, handle, email, phone, accent_id, team, preview_asset_id, complete_asset_id)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT OR REPLACE INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 insertOrIgnoreUserId:
 INSERT OR IGNORE INTO User(qualified_id)
@@ -31,6 +33,10 @@ updateUser:
 UPDATE User
 SET name = ?, handle = ?, email = ?, accent_id = ?, preview_asset_id = ?, complete_asset_id = ?
 WHERE qualified_id = ?;
+
+insertOrIgnoreUserIdWithConnectionStatus:
+INSERT OR REPLACE INTO User(qualified_id, connection_status)
+VALUES(?, ?);
 
 selectAllUsers:
 SELECT * FROM User;

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -57,7 +57,8 @@ class UserDAOTest : BaseDatabaseTest() {
     fun givenExistingUser_ThenUserCanBeUpdated() = runTest {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
-            user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team", UserAssetIdEntity(), UserAssetIdEntity()
+            user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
+            UserEntity.ConnectionState.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity()
         )
         db.userDAO.updateUser(updatedUser1)
         val result = db.userDAO.getUserByQualifiedID(user1.id).first()
@@ -68,7 +69,8 @@ class UserDAOTest : BaseDatabaseTest() {
     fun givenListOfUsers_ThenUserCanBeQueriedByName() = runTest {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
-            user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team", UserAssetIdEntity(), UserAssetIdEntity()
+            user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
+            UserEntity.ConnectionState.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity()
         )
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
@@ -81,7 +83,8 @@ class UserDAOTest : BaseDatabaseTest() {
     @Test
     fun givenRetrievedUser_ThenUpdatesArePropagatedThroughFlow() = runTest {
         db.userDAO.insertUser(user1)
-        val updatedUser1 = UserEntity(user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team", null, null)
+        val updatedUser1 = UserEntity(user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
+            UserEntity.ConnectionState.ACCEPTED, null, null)
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
         assertEquals(user1, result.first())
@@ -151,6 +154,7 @@ class UserDAOTest : BaseDatabaseTest() {
                     phone = "testPhone4",
                     accentId = 4,
                     team = "testTeam4",
+                    UserEntity.ConnectionState.ACCEPTED,
                     null, null
                 ),
                 UserEntity(
@@ -161,6 +165,7 @@ class UserDAOTest : BaseDatabaseTest() {
                     phone = "testPhone5",
                     accentId = 5,
                     team = "testTeam5",
+                    UserEntity.ConnectionState.ACCEPTED,
                     null, null
                 )
             )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
@@ -12,6 +12,7 @@ fun newUserEntity(id: String = "test") =
         phone = "phone$id",
         accentId = 1,
         team = "team",
+        UserEntity.ConnectionState.ACCEPTED,
         null, null
     )
 
@@ -24,6 +25,7 @@ fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
         phone = "phone$id",
         accentId = 1,
         team = "team",
+        UserEntity.ConnectionState.ACCEPTED,
         null, null
     )
 
@@ -35,6 +37,7 @@ fun newUserEntity(
     phone: String = "testPhone",
     accentId: Int = 1,
     team: String = "testTeam",
+    connectionStatus: UserEntity.ConnectionState = UserEntity.ConnectionState.ACCEPTED,
     previewAssetId: String = "previewAssetId",
     completeAssetId: String = "completeAssetId",
 ): UserEntity {
@@ -46,6 +49,7 @@ fun newUserEntity(
         phone = phone,
         accentId = accentId,
         team = team,
+        connectionStatus = connectionStatus,
         previewAssetId = previewAssetId,
         completeAssetId = completeAssetId
     )

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/Database.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/Database.kt
@@ -43,7 +43,11 @@ actual class Database(userId: UserIDEntity, passphrase: String) {
                 content_typeAdapter = ContentTypeAdapter(),
                 visibilityAdapter = EnumColumnAdapter()
             ),
-            User.Adapter(qualified_idAdapter = QualifiedIDAdapter(), IntColumnAdapter)
+            User.Adapter(
+                qualified_idAdapter = QualifiedIDAdapter(),
+                accent_idAdapter = IntColumnAdapter,
+                connection_statusAdapter = EnumColumnAdapter()
+            )
         )
         driver.execute(null, "PRAGMA foreign_keys=ON", 0)
     }

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/Database.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/Database.kt
@@ -34,7 +34,11 @@ actual class Database {
                 content_typeAdapter = ContentTypeAdapter(),
                 visibilityAdapter = EnumColumnAdapter()
             ),
-            User.Adapter(qualified_idAdapter = QualifiedIDAdapter(), IntColumnAdapter)
+            User.Adapter(
+                qualified_idAdapter = QualifiedIDAdapter(),
+                accent_idAdapter = IntColumnAdapter,
+                connection_statusAdapter = EnumColumnAdapter()
+            )
         )
         driver.execute(null, "PRAGMA foreign_keys=ON", 0)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-1333 - Fetch and store connection status during Sync](https://wearezeta.atlassian.net/browse/AR-1333)

### Issues

Currently there was no status about the connection between the self user and another user (even if it were from the same team).

### Solutions

This PR starts with the Database and Api layers will later be implemented in the logic module in another PR.

PS: Tests will fail and some classes will be missing some new parameters, the "fix" or rather the correct implementation will be in the next PR, this PR is only to hold database and api layers.

PS.2: We are aware that `ConnectionState` and its way of mapping around is duplicated, we will soon handle this issue with something more `global` for model classes and some enums or classes that we are globally using.

### Dependencies (Optional)

Other PRs will follow soon.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

Tests will be done in the last PR (probably part 3)
