### PR TITLE
feat: muting conversation options - pt.2 local (AR-1264)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -233,12 +233,14 @@ class ConversationDataSource(
                 memberUpdateRequest = conversationStatusMapper.toApiModel(mutedStatus, mutedStatusTimestamp),
                 conversationId = idMapper.toApiModel(conversationId)
             )
-        }.map {
-            conversationDAO.updateConversationMutedStatus(
-                conversationId = idMapper.toDaoModel(conversationId),
-                mutedStatus = conversationStatusMapper.toDaoModel(mutedStatus),
-                mutedStatusTimestamp = mutedStatusTimestamp
-            )
+        }.flatMap {
+            wrapStorageRequest {
+                conversationDAO.updateConversationMutedStatus(
+                    conversationId = idMapper.toDaoModel(conversationId),
+                    mutedStatus = conversationStatusMapper.toDaoModel(mutedStatus),
+                    mutedStatusTimestamp = mutedStatusTimestamp
+                )
+            }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatus.kt
@@ -1,7 +1,18 @@
 package com.wire.kalium.logic.data.conversation
 
+/**
+ * ```
+ * 0 -> All notifications are displayed
+ * 1 -> Only mentions are displayed (normal messages muted)
+ * 2 -> Only normal notifications are displayed (mentions are muted) -- legacy, not used
+ * 3 -> No notifications are displayed
+ * ```
+ */
 enum class MutedConversationStatus {
-    ALL_MUTED, ONLY_MENTIONS_ALLOWED, ALL_ALLOWED;
+    ALL_ALLOWED,
+    ONLY_MENTIONS_ALLOWED,
+    MENTIONS_MUTED,
+    ALL_MUTED;
 
     companion object {
         fun fromOrdinal(ordinal: Int): MutedConversationStatus? = values().firstOrNull { ordinal == it.ordinal }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatus.kt
@@ -8,13 +8,10 @@ package com.wire.kalium.logic.data.conversation
  * 3 -> No notifications are displayed
  * ```
  */
-enum class MutedConversationStatus {
-    ALL_ALLOWED,
-    ONLY_MENTIONS_ALLOWED,
-    MENTIONS_MUTED,
-    ALL_MUTED;
-
-    companion object {
-        fun fromOrdinal(ordinal: Int): MutedConversationStatus? = values().firstOrNull { ordinal == it.ordinal }
-    }
+sealed class MutedConversationStatus(open val status: Int = 0) {
+    object AllAllowed : MutedConversationStatus(0)
+    object OnlyMentionsAllowed : MutedConversationStatus(1)
+    @Deprecated("For legacy mapping purpose only, not used")
+    private object MentionsMuted : MutedConversationStatus(2)
+    object AllMuted : MutedConversationStatus(3)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -1,17 +1,28 @@
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.network.api.conversation.MemberUpdateRequest
+import com.wire.kalium.persistence.dao.ConversationEntity
 
 interface ConversationStatusMapper {
-    fun mutedStatusToApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest
+    fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest
+    fun toDaoModel(mutedStatus: MutedConversationStatus): ConversationEntity.MutedStatus
 }
 
 class ConversationStatusMapperImpl : ConversationStatusMapper {
-    override fun mutedStatusToApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest {
+    override fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest {
         return MemberUpdateRequest(
             otrMutedStatus = MemberUpdateRequest.MutedStatus.fromOrdinal(mutedStatus.status),
             otrMutedRef = mutedStatusTimestamp.toString()
         )
+    }
+
+    override fun toDaoModel(mutedStatus: MutedConversationStatus): ConversationEntity.MutedStatus {
+        return when (mutedStatus) {
+            MutedConversationStatus.AllAllowed -> ConversationEntity.MutedStatus.ALL_ALLOWED
+            MutedConversationStatus.OnlyMentionsAllowed -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
+            MutedConversationStatus.AllMuted -> ConversationEntity.MutedStatus.ALL_MUTED
+            else -> ConversationEntity.MutedStatus.MENTIONS_MUTED // legacy, not used
+        }
     }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.network.api.conversation.MemberUpdateRequest
 import com.wire.kalium.persistence.dao.ConversationEntity
+import kotlinx.datetime.Instant
 
 interface ConversationStatusMapper {
     fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest
@@ -12,7 +13,7 @@ class ConversationStatusMapperImpl : ConversationStatusMapper {
     override fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest {
         return MemberUpdateRequest(
             otrMutedStatus = MemberUpdateRequest.MutedStatus.fromOrdinal(mutedStatus.status),
-            otrMutedRef = mutedStatusTimestamp.toString()
+            otrMutedRef = Instant.fromEpochMilliseconds(mutedStatusTimestamp).toString()
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -9,7 +9,7 @@ interface ConversationStatusMapper {
 class ConversationStatusMapperImpl : ConversationStatusMapper {
     override fun mutedStatusToApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest {
         return MemberUpdateRequest(
-            otrMutedStatus = MemberUpdateRequest.MutedStatus.fromOrdinal(mutedStatus.ordinal),
+            otrMutedStatus = MemberUpdateRequest.MutedStatus.fromOrdinal(mutedStatus.status),
             otrMutedRef = mutedStatusTimestamp.toString()
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
@@ -10,7 +10,7 @@ import kotlinx.datetime.Clock
 interface UpdateConversationMutedStatusUseCase {
     /**
      * Use case that allows a conversation to change its muted status to:
-     * [MutedConversationStatus.ALL_MUTED], [MutedConversationStatus.ALL_ALLOWED] or [MutedConversationStatus.ONLY_MENTIONS_ALLOWED]
+     * [MutedConversationStatus.AllMuted], [MutedConversationStatus.AllAllowed] or [MutedConversationStatus.OnlyMentionsAllowed]
      *
      * @param conversationId the id of the conversation where status wants to be changed
      * @param mutedConversationStatus new status to set the given conversation
@@ -34,7 +34,7 @@ internal class UpdateConversationMutedStatusUseCaseImpl(
     ): ConversationUpdateStatusResult = suspending {
         conversationRepository.updateMutedStatus(conversationId, mutedConversationStatus, mutedStatusTimestamp)
             .coFold({
-                kaliumLogger.e("Something went wrong when updating the convId ($conversationId) to (${mutedConversationStatus.name}")
+                kaliumLogger.e("Something went wrong when updating the convId ($conversationId) to (${mutedConversationStatus.status}")
                 ConversationUpdateStatusResult.Failure
             }, {
                 ConversationUpdateStatusResult.Success

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -322,7 +322,7 @@ class ConversationRepositoryTest {
 
         conversationRepository.updateMutedStatus(
             TestConversation.ID,
-            MutedConversationStatus.ALL_MUTED,
+            MutedConversationStatus.AllMuted,
             Clock.System.now().toEpochMilliseconds()
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -198,9 +198,11 @@ class ConversationRepositoryTest {
             .whenInvokedWith(anything(), anything())
             .thenDoNothing()
 
-        val result = conversationRepository.createGroupConversation(GROUP_NAME,
+        val result = conversationRepository.createGroupConversation(
+            GROUP_NAME,
             listOf(Member((TestUser.USER_ID))),
-            ConverationOptions(protocol = ConverationOptions.Protocol.PROTEUS))
+            ConverationOptions(protocol = ConverationOptions.Protocol.PROTEUS)
+        )
 
 
         result.shouldSucceed { }
@@ -240,9 +242,11 @@ class ConversationRepositoryTest {
             .whenInvokedWith(anything(), anything())
             .thenDoNothing()
 
-        val result = conversationRepository.createGroupConversation(GROUP_NAME,
+        val result = conversationRepository.createGroupConversation(
+            GROUP_NAME,
             listOf(Member((TestUser.USER_ID))),
-            ConverationOptions(protocol = ConverationOptions.Protocol.PROTEUS))
+            ConverationOptions(protocol = ConverationOptions.Protocol.PROTEUS)
+        )
 
 
         result.shouldSucceed { }
@@ -288,11 +292,13 @@ class ConversationRepositoryTest {
         given(mlsConversationRepository)
             .suspendFunction(mlsConversationRepository::establishMLSGroup)
             .whenInvokedWith(anything())
-            .then { Either.Right(Unit)}
+            .then { Either.Right(Unit) }
 
-        val result = conversationRepository.createGroupConversation(GROUP_NAME,
+        val result = conversationRepository.createGroupConversation(
+            GROUP_NAME,
             listOf(Member((TestUser.USER_ID))),
-            ConverationOptions(protocol = ConverationOptions.Protocol.MLS))
+            ConverationOptions(protocol = ConverationOptions.Protocol.MLS)
+        )
 
         result.shouldSucceed { }
 
@@ -320,6 +326,11 @@ class ConversationRepositoryTest {
             .whenInvokedWith(any(), any())
             .thenReturn(NetworkResponse.Success(Unit, mapOf(), HttpStatusCode.OK.value))
 
+        given(conversationDAO)
+            .suspendFunction(conversationDAO::updateConversationMutedStatus)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(Unit)
+
         conversationRepository.updateMutedStatus(
             TestConversation.ID,
             MutedConversationStatus.AllMuted,
@@ -329,6 +340,11 @@ class ConversationRepositoryTest {
         verify(conversationApi)
             .suspendFunction(conversationApi::updateConversationMemberState)
             .with(any(), any())
+            .wasInvoked(exactly = once)
+
+        verify(conversationDAO)
+            .suspendFunction(conversationDAO::updateConversationMutedStatus)
+            .with(any(), any(), any())
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
@@ -1,0 +1,39 @@
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.network.api.conversation.MemberUpdateRequest
+import com.wire.kalium.persistence.dao.ConversationEntity
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.mock
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConversationStatusMapperTest {
+    @Mock
+    val idMapper = mock(classOf<IdMapper>())
+
+    private lateinit var conversationStatusMapper: ConversationStatusMapper
+
+    @BeforeTest
+    fun setup() {
+        conversationStatusMapper = ConversationStatusMapperImpl()
+    }
+
+    @Test
+    fun givenAConversationModel_whenMappingToApiModel_thenTheMappingStatusesShouldBeOk() {
+        val result = conversationStatusMapper.toApiModel(MutedConversationStatus.OnlyMentionsAllowed, 1649708697237L)
+
+        assertEquals(MemberUpdateRequest.MutedStatus.ONLY_MENTIONS_ALLOWED, result.otrMutedStatus)
+        assertEquals("2022-04-11T20:24:57.237Z", result.otrMutedRef)
+    }
+
+    @Test
+    fun givenAConversationModel_whenMappingToDaoModel_thenTheMappingStatusesShouldBeOk() {
+        val result = conversationStatusMapper.toDaoModel(MutedConversationStatus.OnlyMentionsAllowed)
+
+        assertEquals(ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED, result)
+    }
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCaseTest.kt
@@ -34,15 +34,15 @@ class UpdateConversationMutedStatusUseCaseTest {
         val conversationId = TestConversation.ID
         given(conversationRepository)
             .suspendFunction(conversationRepository::updateMutedStatus)
-            .whenInvokedWith(any(), eq(MutedConversationStatus.ALL_MUTED), any())
+            .whenInvokedWith(any(), eq(MutedConversationStatus.AllMuted), any())
             .thenReturn(Either.Right(Unit))
 
-        val result = updateConversationMutedStatus(conversationId, MutedConversationStatus.ALL_MUTED)
+        val result = updateConversationMutedStatus(conversationId, MutedConversationStatus.AllMuted)
         assertEquals(ConversationUpdateStatusResult.Success::class, result::class)
 
         verify(conversationRepository)
             .suspendFunction(conversationRepository::updateMutedStatus)
-            .with(any(), eq(MutedConversationStatus.ALL_MUTED), any())
+            .with(any(), eq(MutedConversationStatus.AllMuted), any())
             .wasInvoked(exactly = once)
 
     }
@@ -52,15 +52,15 @@ class UpdateConversationMutedStatusUseCaseTest {
         val conversationId = TestConversation.ID
         given(conversationRepository)
             .suspendFunction(conversationRepository::updateMutedStatus)
-            .whenInvokedWith(any(), eq(MutedConversationStatus.ALL_MUTED), any())
+            .whenInvokedWith(any(), eq(MutedConversationStatus.AllMuted), any())
             .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
 
-        val result = updateConversationMutedStatus(conversationId, MutedConversationStatus.ALL_MUTED)
+        val result = updateConversationMutedStatus(conversationId, MutedConversationStatus.AllMuted)
         assertEquals(ConversationUpdateStatusResult.Failure::class, result::class)
 
         verify(conversationRepository)
             .suspendFunction(conversationRepository::updateMutedStatus)
-            .with(any(), eq(MutedConversationStatus.ALL_MUTED), any())
+            .with(any(), eq(MutedConversationStatus.AllMuted), any())
             .wasInvoked(exactly = once)
 
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MemberUpdateRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MemberUpdateRequest.kt
@@ -12,8 +12,20 @@ data class MemberUpdateRequest(
     @SerialName("otr_muted_ref") val otrMutedRef: String? = null,
     @Serializable(with = MutedStatusSerializer::class) val otrMutedStatus: MutedStatus? = null
 ) {
+
+    /**
+     * ```
+     * 0 -> All notifications are displayed
+     * 1 -> Only mentions are displayed (normal messages muted)
+     * 2 -> Only normal notifications are displayed (mentions are muted) -- legacy, not used
+     * 3 -> No notifications are displayed
+     * ```
+     */
     enum class MutedStatus {
-        ALL_MUTED, ONLY_MENTIONS_ALLOWED, ALL_ALLOWED;
+        ALL_ALLOWED,
+        ONLY_MENTIONS_ALLOWED,
+        MENTIONS_MUTED,
+        ALL_MUTED;
 
         companion object {
             fun fromOrdinal(ordinal: Int): MutedStatus? = values().firstOrNull { ordinal == it.ordinal }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/MemberUpdateRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/MemberUpdateRequestJson.kt
@@ -7,7 +7,7 @@ object MemberUpdateRequestJson {
 
     val valid = ValidJsonProvider(
         MemberUpdateRequest(
-            null, null, null, null, "2022-04-06T14:44:44Z", null
+            null, null, null, null, "2022-04-06T14:44:44Z", MemberUpdateRequest.MutedStatus.ALL_ALLOWED
         )
     ) {
         """

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/MemberUpdateRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/MemberUpdateRequestJson.kt
@@ -7,7 +7,7 @@ object MemberUpdateRequestJson {
 
     val valid = ValidJsonProvider(
         MemberUpdateRequest(
-            null, null, null, null, "2022-04-06T14:44:44Z", MemberUpdateRequest.MutedStatus.ALL_ALLOWED
+            null, null, null, null, "2022-04-11T14:15:48.044Z", MemberUpdateRequest.MutedStatus.ALL_ALLOWED
         )
     ) {
         """

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -65,7 +65,8 @@ actual class UserDatabaseProvider(private val context: Context, userId: UserIDEn
                 qualified_idAdapter = QualifiedIDAdapter(),
                 typeAdapter = EnumColumnAdapter(),
                 mls_group_stateAdapter = EnumColumnAdapter(),
-                protocolAdapter = EnumColumnAdapter()
+                protocolAdapter = EnumColumnAdapter(),
+                muted_statusAdapter = IntColumnAdapter
             ),
             Member.Adapter(userAdapter = QualifiedIDAdapter(), conversationAdapter = QualifiedIDAdapter()),
             Message.Adapter(
@@ -86,7 +87,7 @@ actual class UserDatabaseProvider(private val context: Context, userId: UserIDEn
         get() = UserDAOImpl(database.usersQueries)
 
     actual val conversationDAO: ConversationDAO
-        get() = ConversationDAOImpl(database.converationsQueries, database.usersQueries, database.membersQueries)
+        get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)
 
     actual val metadataDAO: MetadataDAO
         get() = MetadataDAOImpl(database.metadataQueries)

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -66,7 +66,7 @@ actual class UserDatabaseProvider(private val context: Context, userId: UserIDEn
                 typeAdapter = EnumColumnAdapter(),
                 mls_group_stateAdapter = EnumColumnAdapter(),
                 protocolAdapter = EnumColumnAdapter(),
-                muted_statusAdapter = IntColumnAdapter
+                muted_statusAdapter = EnumColumnAdapter()
             ),
             Member.Adapter(userAdapter = QualifiedIDAdapter(), conversationAdapter = QualifiedIDAdapter()),
             Message.Adapter(

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -1,5 +1,6 @@
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
 import com.wire.kalium.persistence.dao.ConversationEntity;
+import kotlin.Int;
 
 CREATE TABLE Conversation (
     qualified_id TEXT AS QualifiedIDEntity NOT NULL PRIMARY KEY,
@@ -8,6 +9,8 @@ CREATE TABLE Conversation (
     team_id TEXT,
     mls_group_id TEXT,
     mls_group_state TEXT AS ConversationEntity.GroupState NOT NULL,
+    muted_status TEXT AS ConversationEntity.MutedStatus DEFAULT "all_allowed",
+    muted_time INTEGER DEFAULT 0,
     protocol TEXT AS ConversationEntity.Protocol NOT NULL
 );
 
@@ -18,7 +21,7 @@ deleteConversation:
 DELETE FROM Conversation WHERE qualified_id = ?;
 
 insertConversation:
-INSERT OR REPLACE INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, protocol) VALUES(?, ?, ?, ?, ?, ?, ?);
+INSERT OR REPLACE INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, protocol, muted_status, muted_time) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateConversation:
 UPDATE Conversation

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -9,9 +9,9 @@ CREATE TABLE Conversation (
     team_id TEXT,
     mls_group_id TEXT,
     mls_group_state TEXT AS ConversationEntity.GroupState NOT NULL,
-    muted_status TEXT AS ConversationEntity.MutedStatus DEFAULT "all_allowed",
-    muted_time INTEGER DEFAULT 0,
-    protocol TEXT AS ConversationEntity.Protocol NOT NULL
+    protocol TEXT AS ConversationEntity.Protocol NOT NULL,
+    muted_status TEXT AS ConversationEntity.MutedStatus DEFAULT "all_allowed" NOT NULL,
+    muted_time INTEGER DEFAULT 0 NOT NULL
 );
 
 deleteAllConversations:
@@ -41,3 +41,8 @@ SELECT * FROM Conversation WHERE qualified_id = ?;
 
 selectByGroupId:
 SELECT * FROM Conversation WHERE mls_group_id = ?;
+
+updateConversationMutingStatus:
+UPDATE Conversation
+SET muted_status = ?, muted_time = ?
+WHERE qualified_id = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -7,7 +7,9 @@ data class ConversationEntity(
     val name: String?,
     val type: Type,
     val teamId: String?,
-    val protocolInfo: ProtocolInfo
+    val protocolInfo: ProtocolInfo,
+    val mutedStatus: MutedStatus = MutedStatus.ALL_ALLOWED,
+    val mutedTime: Long = 0
 ) {
 
     enum class Type { SELF, ONE_ON_ONE, GROUP }
@@ -15,6 +17,10 @@ data class ConversationEntity(
     enum class GroupState { PENDING, PENDING_WELCOME_MESSAGE, ESTABLISHED }
 
     enum class Protocol { PROTEUS, MLS }
+
+    enum class MutedStatus {
+        ALL_ALLOWED, ONLY_MENTIONS_ALLOWED, ALL_MUTED;
+    }
 
     sealed class ProtocolInfo {
         object Proteus: ProtocolInfo()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -18,9 +18,7 @@ data class ConversationEntity(
 
     enum class Protocol { PROTEUS, MLS }
 
-    enum class MutedStatus {
-        ALL_ALLOWED, ONLY_MENTIONS_ALLOWED, ALL_MUTED;
-    }
+    enum class MutedStatus { ALL_ALLOWED, ONLY_MENTIONS_ALLOWED, MENTIONS_MUTED, ALL_MUTED }
 
     sealed class ProtocolInfo {
         object Proteus: ProtocolInfo()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -21,8 +21,8 @@ data class ConversationEntity(
     enum class MutedStatus { ALL_ALLOWED, ONLY_MENTIONS_ALLOWED, MENTIONS_MUTED, ALL_MUTED }
 
     sealed class ProtocolInfo {
-        object Proteus: ProtocolInfo()
-        data class MLS(val groupId: String, val groupState: GroupState): ProtocolInfo()
+        object Proteus : ProtocolInfo()
+        data class MLS(val groupId: String, val groupState: GroupState) : ProtocolInfo()
     }
 }
 
@@ -44,4 +44,9 @@ interface ConversationDAO {
     suspend fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity)
     suspend fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity)
     suspend fun getAllMembers(qualifiedID: QualifiedIDEntity): Flow<List<Member>>
+    suspend fun updateConversationMutedStatus(
+        conversationId: QualifiedIDEntity,
+        mutedStatus: ConversationEntity.MutedStatus,
+        mutedStatusTimestamp: Long
+    )
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -20,9 +20,15 @@ class ConversationMapper {
             conversation.type,
             conversation.team_id,
             protocolInfo = when (conversation.protocol) {
-                ConversationEntity.Protocol.MLS -> ConversationEntity.ProtocolInfo.MLS(conversation.mls_group_id ?: "", conversation.mls_group_state)
+                ConversationEntity.Protocol.MLS -> ConversationEntity.ProtocolInfo.MLS(
+                    conversation.mls_group_id ?: "",
+                    conversation.mls_group_state
+                )
                 ConversationEntity.Protocol.PROTEUS -> ConversationEntity.ProtocolInfo.Proteus
-            })
+            },
+            mutedStatus = conversation.muted_status,
+            mutedTime = conversation.muted_time
+        )
     }
 
 }
@@ -135,5 +141,13 @@ class ConversationDAOImpl(
             .asFlow()
             .mapToList()
             .map { it.map(memberMapper::toModel) }
+    }
+
+    override suspend fun updateConversationMutedStatus(
+        conversationId: QualifiedIDEntity,
+        mutedStatus: ConversationEntity.MutedStatus,
+        mutedStatusTimestamp: Long
+    ) {
+        conversationQueries.updateConversationMutingStatus(mutedStatus, mutedStatusTimestamp, conversationId)
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.persistence.dao
 import com.squareup.sqldelight.runtime.coroutines.asFlow
 import com.squareup.sqldelight.runtime.coroutines.mapToList
 import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
-import com.wire.kalium.persistence.ConverationsQueries
+import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MembersQueries
 import com.wire.kalium.persistence.UsersQueries
 import kotlinx.coroutines.flow.Flow
@@ -34,7 +34,7 @@ class MemberMapper {
 }
 
 class ConversationDAOImpl(
-    private val conversationQueries: ConverationsQueries,
+    private val conversationQueries: ConversationsQueries,
     private val userQueries: UsersQueries,
     private val memberQueries: MembersQueries
 ) : ConversationDAO {
@@ -65,7 +65,9 @@ class ConversationDAOImpl(
             conversationEntity.teamId,
             if (conversationEntity.protocolInfo is ConversationEntity.ProtocolInfo.MLS) conversationEntity.protocolInfo.groupId else null,
             if (conversationEntity.protocolInfo is ConversationEntity.ProtocolInfo.MLS) conversationEntity.protocolInfo.groupState else ConversationEntity.GroupState.ESTABLISHED,
-            if (conversationEntity.protocolInfo is ConversationEntity.ProtocolInfo.MLS) ConversationEntity.Protocol.MLS else ConversationEntity.Protocol.PROTEUS
+            if (conversationEntity.protocolInfo is ConversationEntity.ProtocolInfo.MLS) ConversationEntity.Protocol.MLS else ConversationEntity.Protocol.PROTEUS,
+            conversationEntity.mutedStatus,
+            conversationEntity.mutedTime
         )
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -56,16 +56,24 @@ class ConversationDAOTest : BaseDatabaseTest() {
     @Test
     fun givenExistingConversation_ThenConversationCanBeRetrievedByGroupID() = runTest {
         conversationDAO.insertConversation(conversationEntity2)
-        val result = conversationDAO.getConversationByGroupID((conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId).first()
+        val result =
+            conversationDAO.getConversationByGroupID((conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId)
+                .first()
         assertEquals(conversationEntity2, result)
     }
 
     @Test
     fun givenExistingConversation_ThenConversationGroupStateCanBeUpdated() = runTest {
         conversationDAO.insertConversation(conversationEntity2)
-        conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE, (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId)
+        conversationDAO.updateConversationGroupState(
+            ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
+            (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId
+        )
         val result = conversationDAO.getConversationByQualifiedID(conversationEntity2.id).first()
-        assertEquals((result?.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupState, ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE)
+        assertEquals(
+            (result?.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupState,
+            ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE
+        )
     }
 
     @Test
@@ -100,6 +108,20 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.insertMembers(listOf(member1, member2), conversationEntity1.id)
 
         assertEquals(setOf(member1, member2), conversationDAO.getAllMembers(conversationEntity1.id).first().toSet())
+    }
+
+    @Test
+    fun givenAnExistingConversation_WhenUpdatingTheMutingStatus_ThenConversationShouldBeUpdated() = runTest {
+        conversationDAO.insertConversation(conversationEntity2)
+        conversationDAO.updateConversationMutedStatus(
+            conversationId = conversationEntity2.id,
+            mutedStatus = ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED,
+            mutedStatusTimestamp = 1649702788L
+        )
+
+        val result = conversationDAO.getConversationByQualifiedID(conversationEntity2.id).first()
+
+        assertEquals(ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED, result?.mutedStatus)
     }
 
     private companion object {

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -41,7 +41,8 @@ actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
                 qualified_idAdapter = QualifiedIDAdapter(),
                 typeAdapter = EnumColumnAdapter(),
                 mls_group_stateAdapter = EnumColumnAdapter(),
-                protocolAdapter = EnumColumnAdapter()
+                protocolAdapter = EnumColumnAdapter(),
+                muted_statusAdapter = IntColumnAdapter
             ),
             Member.Adapter(userAdapter = QualifiedIDAdapter(), conversationAdapter = QualifiedIDAdapter()),
             Message.Adapter(
@@ -63,7 +64,7 @@ actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
         get() = UserDAOImpl(database.usersQueries)
 
     actual val conversationDAO: ConversationDAO
-        get() = ConversationDAOImpl(database.converationsQueries, database.usersQueries, database.membersQueries)
+        get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)
 
     actual val metadataDAO: MetadataDAO
         get() = MetadataDAOImpl(database.metadataQueries)

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -42,7 +42,7 @@ actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
                 typeAdapter = EnumColumnAdapter(),
                 mls_group_stateAdapter = EnumColumnAdapter(),
                 protocolAdapter = EnumColumnAdapter(),
-                muted_statusAdapter = IntColumnAdapter
+                muted_statusAdapter = EnumColumnAdapter()
             ),
             Member.Adapter(userAdapter = QualifiedIDAdapter(), conversationAdapter = QualifiedIDAdapter()),
             Message.Adapter(

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -55,7 +55,9 @@ actual class UserDatabaseProvider(private val storePath: File) {
                 qualified_idAdapter = QualifiedIDAdapter(),
                 typeAdapter = EnumColumnAdapter(),
                 mls_group_stateAdapter = EnumColumnAdapter(),
-                protocolAdapter = EnumColumnAdapter()),
+                protocolAdapter = EnumColumnAdapter(),
+                muted_statusAdapter = IntColumnAdapter
+            ),
             Member.Adapter(
                 userAdapter = QualifiedIDAdapter(),
                 conversationAdapter = QualifiedIDAdapter()),
@@ -77,7 +79,7 @@ actual class UserDatabaseProvider(private val storePath: File) {
         get() = UserDAOImpl(database.usersQueries)
 
     actual val conversationDAO: ConversationDAO
-        get() = ConversationDAOImpl(database.converationsQueries, database.usersQueries, database.membersQueries)
+        get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)
 
     actual val metadataDAO: MetadataDAO
         get() = MetadataDAOImpl(database.metadataQueries)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -56,7 +56,7 @@ actual class UserDatabaseProvider(private val storePath: File) {
                 typeAdapter = EnumColumnAdapter(),
                 mls_group_stateAdapter = EnumColumnAdapter(),
                 protocolAdapter = EnumColumnAdapter(),
-                muted_statusAdapter = IntColumnAdapter
+                muted_statusAdapter = EnumColumnAdapter()
             ),
             Member.Adapter(
                 userAdapter = QualifiedIDAdapter(),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Part 1: #376  
- JIRA Ticket: https://wearezeta.atlassian.net/browse/AR-1264
- More info at: https://wearezeta.atlassian.net/wiki/spaces/PROD/pages/1705328/Notifications

### Issues
In this PR, we are adding the capabilities to change the muting status of a conversation, this muting can be:

`ALL_ALLOWED` - User is informed about the conversations every time eg incoming calls, video conferencing, mentions & replies, Etc.
`ONLY_MENTIONS_ALLOWED`- User is Informed about the conversions if he/she is mentioned in the conversions or in replies
`ALL_MUTED` - User is never informed about the conversations

On a layer detail, we are adding:

- The DAO implementation for changing a conversation muting status
- The Repository mapping call to persist locally on success
- Refactor some classes that represent the Muted status
- The unit tests for each layer
- Rename a typo in table `Converations` to `Conversations`

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Later on in Android Reloaded, we will glue this work via the use case to be called and integrated

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
