### PR TITLE
feat: add useCase for rejecting call [AR-1253]

### DIFF
--- a/calling/src/androidMain/kotlin/com/wire/kalium/calling/Calling.kt
+++ b/calling/src/androidMain/kotlin/com/wire/kalium/calling/Calling.kt
@@ -46,6 +46,8 @@ interface Calling : Library {
 
     fun wcall_answer(inst: Handle, conversationId: String, callType: Int, cbrEnabled: Boolean)
 
+    fun wcall_reject(inst: Handle, conversationId: String)
+
     fun wcall_config_update(inst: Handle, error: Int, jsonString: String)
 
     fun wcall_library_version(): String

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -215,6 +215,11 @@ actual class CallManagerImpl(
         )
     }
 
+    override suspend fun rejectCall(conversationId: ConversationId) = withCalling {
+        kaliumLogger.d("$TAG -> rejecting call..")
+        wcall_reject(inst = deferredHandle.await(), conversationId = conversationId.asString())
+    }
+
     override fun onConfigRequest(inst: Handle, arg: Pointer?): Int {
         scope.launch {
             val config = callRepository.getCallConfigResponse(limit = null)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -12,6 +12,7 @@ interface CallManager {
     suspend fun onCallingMessageReceived(message: Message, content: MessageContent.Calling)
     suspend fun startCall(conversationId: ConversationId, callType: CallType, conversationType: ConversationType, isAudioCbr: Boolean = false) //TODO Audio CBR
     suspend fun answerCall(conversationId: ConversationId)
+    suspend fun rejectCall(conversationId: ConversationId)
     val allCalls: StateFlow<List<Call>>
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.logic.feature.call.usecase.GetOngoingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetOngoingCallsUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
 import com.wire.kalium.logic.sync.SyncManager
 
@@ -19,4 +20,6 @@ class CallsScope(
     val startCall: StartCallUseCase get() = StartCallUseCase(callManager)
 
     val answerCall: AnswerCallUseCase get() = AnswerCallUseCaseImpl(callManager)
+
+    val rejectCall: RejectCallUseCase get() = RejectCallUseCase(callManager)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/RejectCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/RejectCallUseCase.kt
@@ -1,0 +1,11 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.CallManager
+
+class RejectCallUseCase(private val callManager: CallManager) {
+
+    suspend operator fun invoke(conversationId: ConversationId) {
+        callManager.rejectCall(conversationId)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/RejectCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/RejectCallUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.wire.kalium.logic.feature.call
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.thenDoNothing
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class RejectCallUseCaseTest {
+
+    @Mock
+    private val callManager = mock(classOf<CallManager>())
+
+    private lateinit var rejectCallUseCase: RejectCallUseCase
+
+    @BeforeTest
+    fun setup() {
+        rejectCallUseCase = RejectCallUseCase(callManager)
+    }
+
+    @Test
+    fun givenCallingParams_whenRunningUseCase_thenInvokeRejectCallOnce() = runTest {
+        val conversationId = ConversationId("someone", "wire.com")
+
+        given(callManager)
+            .suspendFunction(callManager::rejectCall)
+            .whenInvokedWith(eq(conversationId))
+            .thenDoNothing()
+
+        rejectCallUseCase.invoke(conversationId)
+
+        verify(callManager)
+            .suspendFunction(callManager::rejectCall)
+            .with(eq(conversationId))
+            .wasInvoked(once)
+    }
+
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -29,4 +29,8 @@ actual class CallManagerImpl : CallManager {
     override suspend fun answerCall(conversationId: ConversationId) {
         kaliumLogger.w("answerCall for JVM but not supported yet.")
     }
+
+    override suspend fun rejectCall(conversationId: ConversationId) {
+        kaliumLogger.w("rejectCall for JVM but not supported yet.")
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

No useCase for rejecting call

### Solutions

Create a useCase to allow the use to reject a call

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### How to Test

Unit test 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
