### PR TITLE
feat(conversation): handle new converation events

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.conversation.ConversationMembers
+import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationUsers
 
 sealed class Event(open val id: String) {
@@ -18,6 +19,13 @@ sealed class Event(open val id: String) {
             val senderClientId: ClientId,
             val time: String,
             val content: String
+        ) : Conversation(id, conversationId)
+
+        data class NewConversation(
+            override val id: String,
+            override val conversationId: ConversationId,
+            val time: String,
+            val conversation: ConversationResponse
         ) : Conversation(id, conversationId)
 
         data class MemberJoin(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -13,6 +13,7 @@ class EventMapper(private val idMapper: IdMapper) {
         return eventResponse.payload?.map { eventContentDTO ->
             when (eventContentDTO) {
                 is EventContentDTO.Conversation.NewMessageDTO -> newMessage(id, eventContentDTO)
+                is EventContentDTO.Conversation.NewConversationDTO -> newConversation(id, eventContentDTO)
                 is EventContentDTO.Conversation.MemberJoinDTO -> memberJoin(id, eventContentDTO)
                 is EventContentDTO.Conversation.MemberLeaveDTO -> memberLeave(id, eventContentDTO)
                 is EventContentDTO.Conversation.MLSWelcomeDTO -> welcomeMessage(id, eventContentDTO)
@@ -40,6 +41,16 @@ class EventMapper(private val idMapper: IdMapper) {
         ClientId(eventContentDTO.data.sender),
         eventContentDTO.time,
         eventContentDTO.data.text
+    )
+
+    private fun newConversation(
+        id: String,
+        eventContentDTO: EventContentDTO.Conversation.NewConversationDTO
+    ) = Event.Conversation.NewConversation(
+        id,
+        idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+        eventContentDTO.time,
+        eventContentDTO.data
     )
 
     private fun memberJoin(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.network.api.notification
 import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.conversation.ConversationMembers
+import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationUsers
 import com.wire.kalium.network.api.message.MLSMessageApi
 import com.wire.kalium.network.api.notification.conversation.MessageEventData
@@ -22,6 +23,16 @@ sealed class EventContentDTO {
 
     @Serializable
     sealed class Conversation : EventContentDTO() {
+
+        @Serializable
+        @SerialName("conversation.create")
+        data class NewConversationDTO(
+            @SerialName("qualified_conversation")
+            val qualifiedConversation: ConversationId,
+            @SerialName("qualified_from") val qualifiedFrom: UserId,
+            val time: String,
+            @SerialName("data") val data: ConversationResponse,
+        ) : Conversation()
 
         @Serializable
         @SerialName("conversation.otr-message-add")

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -10,22 +10,7 @@ import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
 
 object ConversationResponseJson {
 
-    val validGroup = ValidJsonProvider(
-        ConversationResponse(
-            "fdf23116-42a5-472c-8316-e10655f5d11e",
-            ConversationMembersResponse(
-                ConversationSelfMemberResponse(QualifiedIDSamples.one),
-                listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
-            ),
-            "group name",
-            QualifiedIDSamples.one,
-            "groupID",
-            ConversationResponse.Type.GROUP,
-            null,
-            "teamID",
-            ConvProtocol.PROTEUS
-        )
-    ) {
+    val conversationResponseSerializer = { it: ConversationResponse ->
         """
         |{
         |   "creator": "${it.creator}",
@@ -59,4 +44,21 @@ object ConversationResponseJson {
         |}
         """.trimMargin()
     }
+
+    val validGroup = ValidJsonProvider(
+        ConversationResponse(
+            "fdf23116-42a5-472c-8316-e10655f5d11e",
+            ConversationMembersResponse(
+                ConversationSelfMemberResponse(QualifiedIDSamples.one),
+                listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
+            ),
+            "group name",
+            QualifiedIDSamples.one,
+            "groupID",
+            ConversationResponse.Type.GROUP,
+            null,
+            "teamID",
+            ConvProtocol.PROTEUS
+        ), conversationResponseSerializer
+    )
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationApiTest.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.api.tools.json.api.notification
 
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.TEST_BACKEND_CONFIG
+import com.wire.kalium.api.tools.json.api.conversation.ConversationResponseJson
 import com.wire.kalium.network.api.notification.EventContentDTO
 import com.wire.kalium.network.api.notification.NotificationApiImpl
 import com.wire.kalium.network.utils.isSuccessful
@@ -32,7 +33,7 @@ class NotificationApiTest : ApiTest {
             }
         )
         val notificationsApi = NotificationApiImpl(httpClient, TEST_BACKEND_CONFIG)
-
+        
         notificationsApi.notificationsByBatch(limit, clientId, since)
     }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationEventsResponseJson.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.QualifiedID
 import com.wire.kalium.network.api.notification.EventContentDTO
 import com.wire.kalium.network.api.notification.user.NewClientEventData
+import com.wire.kalium.api.tools.json.api.conversation.ConversationResponseJson
 
 object NotificationEventsResponseJson {
     private val newClientSerializer = { eventData: EventContentDTO.User.NewClientDTO ->
@@ -63,6 +64,34 @@ object NotificationEventsResponseJson {
         ), mlsWelcomeSerializer
     )
 
+    private val newConversationSerializer = { eventData: EventContentDTO.Conversation.NewConversationDTO ->
+        """
+        |{
+        |  "from" : "fdf23116-42a5-472c-8316-e10655f5d11e",
+        |  "qualified_conversation" : {
+        |    "id" : "${eventData.qualifiedConversation.value}",
+        |    "domain" : "${eventData.qualifiedConversation.domain}"
+        |  },
+        |  "qualified_from" : {
+        |     "id" : "${eventData.qualifiedFrom.value}",
+        |     "domain" : "${eventData.qualifiedFrom.domain}"
+        |  }, 
+        |  "data" : ${ConversationResponseJson.conversationResponseSerializer(eventData.data)},
+        |  "time" : "2022-04-12T13:57:02.414Z",
+        |  "type" : "conversation.create"
+        |}
+        """.trimMargin()
+    }
+
+    private val newConversation = ValidJsonProvider(
+        EventContentDTO.Conversation.NewConversationDTO(
+            ConversationId("e16babfa-308b-414e-b6e0-c59517f723db", "staging.zinfra.io"),
+            QualifiedID("76ebeb16-a849-4be4-84a7-157654b492cf","staging.zinfra.io"),
+            "2022-04-12T13:57:02.414Z",
+            ConversationResponseJson.validGroup.serializableData
+        ), newConversationSerializer
+    )
+    
     val notificationsWithUnknownEventAtFirstPosition = """
         {
           "time": "2022-02-15T12:54:30Z",
@@ -87,6 +116,12 @@ object NotificationEventsResponseJson {
                 ${mlsWelcome.rawJson}
               ],
               "id": "7e676173-b715-11ec-8001-22000a252765"
+            },
+            {
+              "payload": [
+                ${newConversation.rawJson}
+              ],
+              "id": "6dd9dfd9-ba68-11ec-8001-22000a09a242"
             },
             {
               "payload": [


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Conversations created after the slow sync is completed never appear.

### Causes

We don't handle the `conversation.create` event.

### Solutions

Persist conversation when receiving an `conversation.create` event.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

1. Login with User A and wait or slow sync to complete
2. On the web app, create a new conversation with User A
->  New conversation should appear in the conversation list.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
