### PR TITLE
fix: events received through websocket being re-processed durying sync

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCase.kt
@@ -32,6 +32,7 @@ class ListenToEventsUseCase(
                                 kaliumLogger.i(message = "Unhandled event id=${event.id}")
                             }
                         }
+                        eventRepository.updateLastProcessedEventId(event.id)
                     }
                 }.onFailure {
                     kaliumLogger.e(message = "Failure when receiving events: $it")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -50,9 +50,7 @@ class ConversationRepositoryTest {
     private val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
 
     @Mock
-    private val conversationDAO = configure(mock(ConversationDAO::class)) {
-        stubsUnitByDefault = true
-    }
+    private val conversationDAO = configure(mock(ConversationDAO::class)) { stubsUnitByDefault = true }
 
     @Mock
     private val conversationApi = mock(ConversationApi::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -1,19 +1,35 @@
 package com.wire.kalium.logic.data.event
 
+import app.cash.turbine.test
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.IdMapperImpl
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.notification.EventContentDTO
+import com.wire.kalium.network.api.notification.EventResponse
 import com.wire.kalium.network.api.notification.NotificationApi
+import com.wire.kalium.network.api.notification.NotificationPageResponse
+import com.wire.kalium.network.api.notification.conversation.MessageEventData
+import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.event.EventInfoStorage
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
 import io.mockative.configure
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class EventRepositoryTest {
 
@@ -38,22 +54,128 @@ class EventRepositoryTest {
         eventRepository = EventDataSource(notificationApi, eventInfoStorage, clientRepository, eventMapper)
     }
 
-    @Ignore
     @Test
     fun givenNoEventWasProcessedBefore_whenGettingEvents_thenGetAllNotificationsIsCalled() = runTest {
+        val firstPage = EventResponse(
+            "eventId",
+            listOf()
+        )
+        val notificationsPageResponse = NotificationPageResponse("time", false, listOf(firstPage))
+
         given(eventInfoStorage)
             .getter(eventInfoStorage::lastProcessedId)
             .whenInvoked()
-            .then { null }
+            .thenReturn(null)
 
-//        given(notificationApi)
-//            .suspendFunction(notificationApi::getAllNotifications)
-//            .whenInvokedWith(any(), any())
-//            .then {
-////                NetworkResponse.Success() TODO: Can't mock Network Response!
-//            }
+        given(notificationApi)
+            .suspendFunction(notificationApi::getAllNotifications)
+            .whenInvokedWith(any(), any())
+            .thenReturn(NetworkResponse.Success(notificationsPageResponse, mapOf(), 200))
 
-//        eventRepository.events()
+        given(notificationApi)
+            .suspendFunction(notificationApi::listenToLiveEvents)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf())
 
+        val clientId = TestClient.CLIENT_ID
+        given(clientRepository)
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
+            .thenReturn(Either.Right(clientId))
+
+        eventRepository.events().collect()
+
+        verify(notificationApi)
+            .suspendFunction(notificationApi::getAllNotifications)
+            .with(any(), eq(clientId.value))
+            .wasInvoked(exactly = once)
+    }
+    @Test
+    fun givenSomeEventWasProcessedBefore_whenGettingEvents_thenGetByBatchStartingOnLastProcessedID() = runTest {
+        val lastProcessedEventId = "someNotificationID"
+        val firstPage = EventResponse(
+            "eventId",
+            listOf(
+                EventContentDTO.Conversation.NewMessageDTO(
+                    TestConversation.NETWORK_ID,
+                    UserId("value", "domain"),
+                    "eventTime",
+                    MessageEventData("text", "senderId", "recipient")
+                )
+            )
+        )
+        val notificationsPageResponse = NotificationPageResponse("time", false, listOf(firstPage))
+
+        given(eventInfoStorage)
+            .getter(eventInfoStorage::lastProcessedId)
+            .whenInvoked()
+            .thenReturn(lastProcessedEventId)
+
+        given(notificationApi)
+            .suspendFunction(notificationApi::notificationsByBatch)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(NetworkResponse.Success(notificationsPageResponse, mapOf(), 200))
+
+        given(notificationApi)
+            .suspendFunction(notificationApi::listenToLiveEvents)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf())
+
+        val clientId = TestClient.CLIENT_ID
+        given(clientRepository)
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
+            .thenReturn(Either.Right(clientId))
+
+        eventRepository.events().collect()
+
+        verify(notificationApi)
+            .suspendFunction(notificationApi::notificationsByBatch)
+            .with(any(), eq(clientId.value), eq(lastProcessedEventId))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenPendingEventsAndLiveEvents_whenGettingEvents_thenReturnPendingFirstFollowedByLive() = runTest {
+        val pendingEventPayload = EventContentDTO.Conversation.NewMessageDTO(
+            TestConversation.NETWORK_ID,
+            UserId("value", "domain"),
+            "eventTime",
+            MessageEventData("text", "senderId", "recipient")
+        )
+        val pendingEvent = EventResponse("pendingEventId", listOf(pendingEventPayload))
+        val liveEvent = pendingEvent.copy(id = "liveEventId")
+        val notificationsPageResponse = NotificationPageResponse("time", false, listOf(pendingEvent))
+
+        given(eventInfoStorage)
+            .getter(eventInfoStorage::lastProcessedId)
+            .whenInvoked()
+            .thenReturn("someNotificationId")
+
+        given(notificationApi)
+            .suspendFunction(notificationApi::notificationsByBatch)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(NetworkResponse.Success(notificationsPageResponse, mapOf(), 200))
+
+        given(notificationApi)
+            .suspendFunction(notificationApi::listenToLiveEvents)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(liveEvent))
+
+        val clientId = TestClient.CLIENT_ID
+        given(clientRepository)
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
+            .thenReturn(Either.Right(clientId))
+
+        eventRepository.events().test {
+            awaitItem().shouldSucceed {
+                assertEquals(pendingEvent.id, it.id)
+            }
+            awaitItem().shouldSucceed {
+                assertEquals(liveEvent.id, it.id)
+            }
+            awaitComplete()
+        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCaseTest.kt
@@ -1,0 +1,65 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.network.api.conversation.ConversationMembers
+import io.mockative.Mock
+import io.mockative.configure
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+interface ConversationEventReceiver : EventReceiver<Event.Conversation>
+
+class ListenToEventsUseCaseTest {
+
+    @Mock
+    val syncManager = configure(mock(SyncManager::class)) { stubsUnitByDefault = true }
+
+    @Mock
+    val eventRepository = configure(mock(EventRepository::class)) { stubsUnitByDefault = true }
+
+    @Mock
+    val conversationEventReceiver = configure(mock(ConversationEventReceiver::class)) { stubsUnitByDefault = true }
+
+    lateinit var listenToEvents: ListenToEventsUseCase
+
+    @BeforeTest
+    fun setup() {
+        listenToEvents = ListenToEventsUseCase(syncManager, eventRepository, conversationEventReceiver)
+    }
+
+    @Test
+    fun givenAnEventIsReceived_whenListeningToEvents_thenTheLastProcessedEventIdIsUpdated() = runTest {
+        val event = Event.Conversation.MemberJoin(
+            "firstEventId",
+            TestConversation.ID,
+            TestUser.USER_ID,
+            ConversationMembers(listOf(), listOf()),
+            "someFrom"
+        )
+        val events = listOf(Either.Right(event))
+
+        given(eventRepository)
+            .suspendFunction(eventRepository::events)
+            .whenInvoked()
+            .thenReturn(events.asFlow())
+
+        listenToEvents()
+
+        verify(eventRepository)
+            .suspendFunction(eventRepository::updateLastProcessedEventId)
+            .with(eq(event.id))
+            .wasInvoked(exactly = once)
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

@borichellow noticed that we were receiving some events twice. First in real-time and then when doing sync.

Easy to reproduce:
1. Receive an event through the Websocket
2. Close the app
3. Open the app
4. Event will be received again through the notification API


### Causes

I remembered a crucial flaw when doing the receiving of events, that right now the "last processed ID" is only updated when receiving events through the API.

So *all* the events received through the Websocket are not being considered as processed, making the app request for them again when opening the app.

### Solutions

Change the current implementation, so:
- Remove the updating of the last ID from the repository, as it has two sources (REST and Websocket);
- Centralise this logic by making `ListenToEventsUseCase` responsible for updating the processed ID and always **after** processing the event.

`ListenToEventsUseCase` is completely agnostic about the source of the events, it doesn't know if the event has come through the Websocket or through the REST API. So it stays like this:
1. Event is emited
2. Event is processed
3. Last ID is updated

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
