### PR TITLE
feat: generate SSO success/error in SSOInitiateLoginUseCase

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sso/SSOUtil.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sso/SSOUtil.kt
@@ -1,10 +1,8 @@
 package com.wire.kalium.logic.data.sso
 
-import com.wire.kalium.logic.configuration.ServerConfig
-
 object SSOUtil {
-    internal fun generateSuccessRedirect(serverConfig: ServerConfig) =
-        "wire://$SUCCESS_HOST/?\$cookie&$QUERY_USER_ID=\$user\$$QUERY_SERVER_CONFIG=${serverConfig.title}"
+    internal fun generateSuccessRedirect(serverConfigId: String) =
+        "wire://$SUCCESS_HOST/?\$cookie&$QUERY_USER_ID=\$user\$$QUERY_SERVER_CONFIG=${serverConfigId}"
 
     internal fun generateErrorRedirect() = "wire://$ERROR_HOST/?\$label"
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCase.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.auth.login.SSOLoginRepository
+import com.wire.kalium.logic.data.sso.SSOUtil
 import com.wire.kalium.network.exceptions.KaliumException
 import io.ktor.http.HttpStatusCode
 
@@ -17,7 +18,9 @@ sealed class SSOInitiateLoginResult {
     }
 }
 
-data class SSORedirects(val success: String, val error: String)
+data class SSORedirects(val success: String, val error: String) {
+    constructor(serverConfigId: String) : this(SSOUtil.generateSuccessRedirect(serverConfigId), SSOUtil.generateErrorRedirect())
+}
 
 interface SSOInitiateLoginUseCase {
     sealed class Param {
@@ -25,7 +28,11 @@ interface SSOInitiateLoginUseCase {
         abstract val serverConfig: ServerConfig
 
         data class WithoutRedirect(override val ssoCode: String, override val serverConfig: ServerConfig) : Param()
-        data class WithRedirect(override val ssoCode: String, val redirects: SSORedirects, override val serverConfig: ServerConfig) :
+        data class WithRedirect(
+            override val ssoCode: String,
+            override val serverConfig: ServerConfig,
+            val redirects: SSORedirects = SSORedirects(serverConfig.id)
+        ) :
             Param()
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCaseTest.kt
@@ -95,9 +95,9 @@ class SSOInitiateLoginUseCaseTest {
             val result = ssoInitiateLoginUseCase(
                 SSOInitiateLoginUseCase.Param.WithRedirect(
                     TEST_CODE,
-                    SSORedirects(TEST_SUCCESS, TEST_ERROR),
-                    TEST_SERVER_CONFIG
-                )
+                    TEST_SERVER_CONFIG,
+                    SSORedirects(TEST_SUCCESS, TEST_ERROR)
+                    )
             )
             assertEquals(result, SSOInitiateLoginResult.Success(TEST_RESPONSE))
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

SSOInitiateLoginUseCase is not generating the success/error redirects

### Solutions
add a secondary constructor to `SSORedirects` that will generate the redirects from `SSOUtil`

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
