### PR TITLE
feat: display asset messages on conversation [AR-1150]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfig.kt
@@ -38,7 +38,7 @@ data class ServerConfig(
             websiteUrl = """https://wire.com""",
             title = "Staging"
         )
-        val DEFAULT = STAGING
+        val DEFAULT = PRODUCTION
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfig.kt
@@ -38,7 +38,7 @@ data class ServerConfig(
             websiteUrl = """https://wire.com""",
             title = "Staging"
         )
-        val DEFAULT = PRODUCTION
+        val DEFAULT = STAGING
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
@@ -44,10 +44,11 @@ enum class RetentionType {
     EXPIRING
 }
 
-sealed class AssetType(open val name: String)
-
-sealed class ImageAsset(override val name: String) : AssetType(name) {
-    object JPEG : ImageAsset(name = "image/jpeg")
-    object PNG : ImageAsset(name = "image/png")
+sealed class AssetType(open val name: String) {
+    data class FileAsset(val mimetype: String) : AssetType(mimetype)
+    sealed class ImageAsset(override val name: String) : AssetType(name) {
+        object JPEG : ImageAsset(name = "image/jpeg")
+        object PNG : ImageAsset(name = "image/png")
+    }
 }
 // should put other types of mimetypes, ie: media, audio, etc.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
@@ -44,11 +44,11 @@ enum class RetentionType {
     EXPIRING
 }
 
-sealed class AssetType(open val name: String) {
-    data class FileAsset(val mimetype: String) : AssetType(mimetype)
-    sealed class ImageAsset(override val name: String) : AssetType(name) {
-        object JPEG : ImageAsset(name = "image/jpeg")
-        object PNG : ImageAsset(name = "image/png")
-    }
+sealed class AssetType(open val name: String)
+data class FileAsset(val mimetype: String) : AssetType(mimetype)
+sealed class ImageAsset(override val name: String) : AssetType(name) {
+    object JPEG : ImageAsset(name = "image/jpeg")
+    object PNG : ImageAsset(name = "image/png")
 }
+
 // should put other types of mimetypes, ie: media, audio, etc.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
@@ -62,7 +62,7 @@ class AssetMapperImpl : AssetMapper {
         with(assetContentEntity) {
             return AssetContent(
                 mimeType = assetMimeType,
-                size = assetSize,
+                sizeInBytes = assetSize,
                 name = assetName,
                 metadata = getAssetContentMetadata(assetMimeType, assetContentEntity),
                 remoteData = AssetContent.RemoteData(
@@ -104,7 +104,7 @@ class AssetMapperImpl : AssetMapper {
     override fun fromProtoAssetMessageToAssetContent(protoAssetMessage: Asset): AssetContent {
         with(protoAssetMessage) {
             return AssetContent(
-                size = original?.size?.toInt() ?: 0,
+                sizeInBytes = original?.size?.toInt() ?: 0,
                 name = original?.name,
                 mimeType = original?.mimeType ?: "*/*",
                 metadata = when (val metadataType = original?.metaData) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
@@ -62,7 +62,7 @@ class AssetMapperImpl : AssetMapper {
         with(assetContentEntity) {
             return AssetContent(
                 mimeType = assetMimeType,
-                sizeInBytes = assetSize,
+                sizeInBytes = assetSizeInBytes,
                 name = assetName,
                 metadata = getAssetContentMetadata(assetMimeType, assetContentEntity),
                 remoteData = AssetContent.RemoteData(
@@ -104,7 +104,7 @@ class AssetMapperImpl : AssetMapper {
     override fun fromProtoAssetMessageToAssetContent(protoAssetMessage: Asset): AssetContent {
         with(protoAssetMessage) {
             return AssetContent(
-                sizeInBytes = original?.size?.toInt() ?: 0,
+                sizeInBytes = original?.size ?: 0,
                 name = original?.name,
                 mimeType = original?.mimeType ?: "*/*",
                 metadata = when (val metadataType = original?.metaData) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.data.message
 
 data class AssetContent(
-    val sizeInBytes: Int,
+    val sizeInBytes: Long,
     val name: String? = null,
     val mimeType: String,
     val metadata: AssetMetadata? = null,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.data.message
 
 data class AssetContent(
-    val size: Int,
+    val sizeInBytes: Int,
     val name: String? = null,
     val mimeType: String,
     val metadata: AssetMetadata? = null,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -31,7 +31,7 @@ class MessageMapperImpl(private val idMapper: IdMapper) : MessageMapper {
                 with(message.content.value) {
                     AssetMessageContent(
                         assetMimeType = mimeType,
-                        assetSize = sizeInBytes,
+                        assetSizeInBytes = sizeInBytes,
                         assetName = name,
                         assetImageWidth = metadata?.let { if (it is Image) it.width else null },
                         assetImageHeight = metadata?.let { if (it is Image) it.height else null },

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -31,7 +31,7 @@ class MessageMapperImpl(private val idMapper: IdMapper) : MessageMapper {
                 with(message.content.value) {
                     AssetMessageContent(
                         assetMimeType = mimeType,
-                        assetSize = size,
+                        assetSize = sizeInBytes,
                         assetName = name,
                         assetImageWidth = metadata?.let { if (it is Image) it.width else null },
                         assetImageHeight = metadata?.let { if (it is Image) it.height else null },

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -39,7 +39,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
                         Asset(
                             original = Original(
                                 mimeType = mimeType,
-                                size = size.toLong(),
+                                size = sizeInBytes.toLong(),
                                 name = name,
                                 metaData = when (metadata) {
                                     is AssetContent.AssetMetadata.Image -> Original.MetaData.Image(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -101,7 +101,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             is GenericMessage.Content.Asset -> {
                 if (protoContent.value.uploaded != null) MessageContent.Asset(
                     MapperProvider.assetMapper().fromProtoAssetMessageToAssetContent(protoContent.value)
-                ) else MessageContent.Unknown // Sometimes backend sens preliminar asset messages just with img metadata, so we discard it
+                ) else MessageContent.Unknown // Sometimes backend sends some preview asset messages just with img metadata and no keys or asset id, so we discard it
             }
             is GenericMessage.Content.Availability -> MessageContent.Unknown
             is GenericMessage.Content.ButtonAction -> MessageContent.Unknown

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
@@ -66,7 +66,7 @@ internal class SendAssetMessageUseCaseImpl(
         // Upload the asset encrypted data
         assetDataSource.uploadAndPersistPrivateAsset(FileAsset(assetMimeType), encryptedData.data).flatMap { assetId ->
             // Try to send the Asset Message
-            prepareAndSendAssetMessage(conversationId, assetRawData.size, assetName, assetMimeType, sha256, otrKey, assetId).flatMap {
+            prepareAndSendAssetMessage(conversationId, assetRawData.size.toLong(), assetName, assetMimeType, sha256, otrKey, assetId).flatMap {
                 Either.Right(Unit)
             }
         }.coFold({
@@ -79,7 +79,7 @@ internal class SendAssetMessageUseCaseImpl(
 
     private suspend fun prepareAndSendAssetMessage(
         conversationId: ConversationId,
-        dataSize: Int,
+        dataSize: Long,
         assetName: String?,
         assetMimeType: String,
         sha256: ByteArray,
@@ -120,7 +120,7 @@ internal class SendAssetMessageUseCaseImpl(
     }
 
     private fun provideAssetMessageContent(
-        dataSize: Int,
+        dataSize: Long,
         assetName: String?,
         sha256: ByteArray,
         otrKey: AES256Key,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
@@ -128,7 +128,7 @@ internal class SendAssetMessageUseCaseImpl(
         mimeType: String,
     ): AssetContent {
         return AssetContent(
-            size = dataSize,
+            sizeInBytes = dataSize,
             name = assetName,
             mimeType = mimeType,
             remoteData = AssetContent.RemoteData(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
@@ -8,7 +8,7 @@ import com.wire.kalium.cryptography.utils.encryptDataWithAES256
 import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.asset.AssetType
+import com.wire.kalium.logic.data.asset.FileAsset
 import com.wire.kalium.logic.data.asset.UploadedAssetId
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -64,7 +64,7 @@ internal class SendAssetMessageUseCaseImpl(
         val sha256 = calcSHA256(encryptedData.data)
 
         // Upload the asset encrypted data
-        assetDataSource.uploadAndPersistPrivateAsset(AssetType.FileAsset(assetMimeType), encryptedData.data).flatMap { assetId ->
+        assetDataSource.uploadAndPersistPrivateAsset(FileAsset(assetMimeType), encryptedData.data).flatMap { assetId ->
             // Try to send the Asset Message
             prepareAndSendAssetMessage(conversationId, assetRawData.size, assetName, assetMimeType, sha256, otrKey, assetId).flatMap {
                 Either.Right(Unit)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
@@ -1,10 +1,14 @@
 package com.wire.kalium.logic.feature.asset
 
 import com.benasher44.uuid.uuid4
-import com.wire.kalium.cryptography.utils.*
+import com.wire.kalium.cryptography.utils.AES256Key
+import com.wire.kalium.cryptography.utils.PlainData
+import com.wire.kalium.cryptography.utils.calcSHA256
+import com.wire.kalium.cryptography.utils.encryptDataWithAES256
+import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.asset.ImageAsset
+import com.wire.kalium.logic.data.asset.AssetType
 import com.wire.kalium.logic.data.asset.UploadedAssetId
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -22,10 +26,10 @@ import kotlinx.datetime.Clock
 
 fun interface SendAssetMessageUseCase {
     /**
-     * Function that enables sending an image as a private asset
+     * Function that enables sending an asset message
      *
      * @param conversationId the id of the conversation where the asset wants to be sent
-     * @param assetRawData the raw data of the image to be uploaded to the backend and sent to the given conversation
+     * @param assetRawData the raw data of the asset to be uploaded to the backend and sent to the given conversation
      * @param assetName the name of the original asset file
      * @param assetMimeType the type of the asset file
      * @return an [Either] tuple containing a [CoreFailure] in case anything goes wrong and [Unit] in case everything succeeds
@@ -60,7 +64,7 @@ internal class SendAssetMessageUseCaseImpl(
         val sha256 = calcSHA256(encryptedData.data)
 
         // Upload the asset encrypted data
-        assetDataSource.uploadAndPersistPrivateAsset(ImageAsset.JPEG, encryptedData.data).flatMap { assetId ->
+        assetDataSource.uploadAndPersistPrivateAsset(AssetType.FileAsset(assetMimeType), encryptedData.data).flatMap { assetId ->
             // Try to send the Asset Message
             prepareAndSendAssetMessage(conversationId, assetRawData.size, assetName, assetMimeType, sha256, otrKey, assetId).flatMap {
                 Either.Right(Unit)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
@@ -1,10 +1,14 @@
 package com.wire.kalium.logic.feature.asset
 
 import com.benasher44.uuid.uuid4
-import com.wire.kalium.cryptography.utils.*
+import com.wire.kalium.cryptography.utils.AES256Key
+import com.wire.kalium.cryptography.utils.PlainData
+import com.wire.kalium.cryptography.utils.calcSHA256
+import com.wire.kalium.cryptography.utils.encryptDataWithAES256
+import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.asset.AssetType
+import com.wire.kalium.logic.data.asset.ImageAsset
 import com.wire.kalium.logic.data.asset.UploadedAssetId
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -63,7 +67,7 @@ internal class SendImageMessageUseCaseImpl(
         val sha256 = calcSHA256(encryptedData.data)
 
         // Upload the asset encrypted data
-        assetDataSource.uploadAndPersistPrivateAsset(AssetType.ImageAsset.JPEG, encryptedData.data).flatMap { assetId ->
+        assetDataSource.uploadAndPersistPrivateAsset(ImageAsset.JPEG, encryptedData.data).flatMap { assetId ->
             // Try to send the Image Message
             prepareAndSendImageMessage(conversationId, imageRawData.size, imageName, sha256, otrKey, assetId, imgWidth, imgHeight).flatMap {
                 Either.Right(Unit)
@@ -132,7 +136,7 @@ internal class SendImageMessageUseCaseImpl(
         return AssetContent(
             size = dataSize,
             name = imageName,
-            mimeType = AssetType.ImageAsset.JPEG.name,
+            mimeType = ImageAsset.JPEG.name,
             metadata = AssetContent.AssetMetadata.Image(imgWidth, imgHeight),
             remoteData = AssetContent.RemoteData(
                 otrKey = otrKey.data,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
@@ -4,7 +4,7 @@ import com.benasher44.uuid.uuid4
 import com.wire.kalium.cryptography.utils.*
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.asset.ImageAsset
+import com.wire.kalium.logic.data.asset.AssetType
 import com.wire.kalium.logic.data.asset.UploadedAssetId
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -63,7 +63,7 @@ internal class SendImageMessageUseCaseImpl(
         val sha256 = calcSHA256(encryptedData.data)
 
         // Upload the asset encrypted data
-        assetDataSource.uploadAndPersistPrivateAsset(ImageAsset.JPEG, encryptedData.data).flatMap { assetId ->
+        assetDataSource.uploadAndPersistPrivateAsset(AssetType.ImageAsset.JPEG, encryptedData.data).flatMap { assetId ->
             // Try to send the Image Message
             prepareAndSendImageMessage(conversationId, imageRawData.size, imageName, sha256, otrKey, assetId, imgWidth, imgHeight).flatMap {
                 Either.Right(Unit)
@@ -132,7 +132,7 @@ internal class SendImageMessageUseCaseImpl(
         return AssetContent(
             size = dataSize,
             name = imageName,
-            mimeType = ImageAsset.JPEG.name,
+            mimeType = AssetType.ImageAsset.JPEG.name,
             metadata = AssetContent.AssetMetadata.Image(imgWidth, imgHeight),
             remoteData = AssetContent.RemoteData(
                 otrKey = otrKey.data,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
@@ -134,7 +134,7 @@ internal class SendImageMessageUseCaseImpl(
         imgHeight: Int
     ): AssetContent {
         return AssetContent(
-            size = dataSize,
+            sizeInBytes = dataSize,
             name = imageName,
             mimeType = ImageAsset.JPEG.name,
             metadata = AssetContent.AssetMetadata.Image(imgWidth, imgHeight),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
@@ -69,7 +69,7 @@ internal class SendImageMessageUseCaseImpl(
         // Upload the asset encrypted data
         assetDataSource.uploadAndPersistPrivateAsset(ImageAsset.JPEG, encryptedData.data).flatMap { assetId ->
             // Try to send the Image Message
-            prepareAndSendImageMessage(conversationId, imageRawData.size, imageName, sha256, otrKey, assetId, imgWidth, imgHeight).flatMap {
+            prepareAndSendImageMessage(conversationId, imageRawData.size.toLong(), imageName, sha256, otrKey, assetId, imgWidth, imgHeight).flatMap {
                 Either.Right(Unit)
             }
         }.coFold({
@@ -82,7 +82,7 @@ internal class SendImageMessageUseCaseImpl(
 
     private suspend fun prepareAndSendImageMessage(
         conversationId: ConversationId,
-        dataSize: Int,
+        dataSize: Long,
         imageName: String?,
         sha256: ByteArray,
         otrKey: AES256Key,
@@ -125,7 +125,7 @@ internal class SendImageMessageUseCaseImpl(
     }
 
     private fun provideAssetMessageContent(
-        dataSize: Int,
+        dataSize: Long,
         imageName: String?,
         sha256: ByteArray,
         otrKey: AES256Key,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -12,6 +12,8 @@ import com.wire.kalium.logic.data.prekey.PreKeyRepository
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCaseImpl
+import com.wire.kalium.logic.feature.asset.SendAssetMessageUseCase
+import com.wire.kalium.logic.feature.asset.SendAssetMessageUseCaseImpl
 import com.wire.kalium.logic.feature.asset.SendImageMessageUseCase
 import com.wire.kalium.logic.feature.asset.SendImageMessageUseCaseImpl
 import com.wire.kalium.logic.sync.SyncManager
@@ -65,6 +67,15 @@ class MessageScope(
 
     val sendImageMessage: SendImageMessageUseCase
         get() = SendImageMessageUseCaseImpl(
+            messageRepository,
+            clientRepository,
+            assetRepository,
+            userRepository,
+            messageSender
+        )
+
+    val sendAssetMessage: SendAssetMessageUseCase
+        get() = SendAssetMessageUseCaseImpl(
             messageRepository,
             clientRepository,
             assetRepository,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
@@ -105,7 +105,7 @@ class GetMessageAssetUseCaseTest {
                 id = msgId,
                 content = MessageContent.Asset(
                     AssetContent(
-                        size = 1000,
+                        sizeInBytes = 1000,
                         name = "some_asset.jpg",
                         mimeType = "image/jpeg",
                         metadata = AssetContent.AssetMetadata.Image(width = 100, height = 100),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCaseTest.kt
@@ -15,56 +15,47 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.network.exceptions.KaliumException
-import io.ktor.utils.io.core.toByteArray
-import io.mockative.Mock
-import io.mockative.any
-import io.mockative.classOf
-import io.mockative.given
-import io.mockative.mock
-import io.mockative.once
-import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import io.ktor.utils.io.core.*
+import io.mockative.*
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
-class SendImageUseCaseTest {
+class SendAssetMessageUseCaseTest {
 
     @Test
-    fun givenAValidSendImageMessageRequest_whenSendingImageMessage_thenShouldReturnASuccessResult() = runTest {
+    fun givenAValidSendAssetMessageRequest_whenSendingAssetMessage_thenShouldReturnASuccessResult() = runTest {
         // Given
-        val imageToSend = getMockedImage()
+        val assetToSend = getMockedAsset()
         val conversationId = ConversationId("some-convo-id", "some-domain-id")
-        val (_, sendImageUseCase) = Arrangement()
+        val (_, sendAssetUseCase) = Arrangement()
             .withSuccessfulResponse()
             .arrange()
 
         // When
-        val result = sendImageUseCase.invoke(conversationId, imageToSend, "temp_image.jpg", 1, 1)
+        val result = sendAssetUseCase.invoke(conversationId, assetToSend, "temp_asset.txt", "text/plain")
 
         // Then
-        assertEquals(result, SendImageMessageResult.Success)
+        assertEquals(result, SendAssetMessageResult.Success)
     }
-
 
     @Test
     fun givenAValidSendImageMessageRequest_whenThereIsAnAssetUploadError_thenShouldCallReturnsAFailureResult() = runTest {
         // Given
-        val imageByteArray = getMockedImage()
+        val assetToSend = getMockedAsset()
         val conversationId = ConversationId("some-convo-id", "some-domain-id")
         val unauthorizedException = TestNetworkException.missingAuth
-        val (_, sendImageUseCase) = Arrangement()
+        val (_, sendAssetUseCase) = Arrangement()
             .withUploadAssetErrorResponse(unauthorizedException)
             .arrange()
 
         // When
-        val result = sendImageUseCase.invoke(conversationId, imageByteArray, "temp_image.jpg", 1, 1)
+        val result = sendAssetUseCase.invoke(conversationId, assetToSend, "temp_asset.txt", "text/plain")
 
         // Then
-        assertTrue(result is SendImageMessageResult.Failure)
+        assertTrue(result is SendAssetMessageResult.Failure)
         val exception = result.coreFailure
         assertTrue(exception is NetworkFailure.ServerMiscommunication)
         assertEquals(exception.rootCause, unauthorizedException)
@@ -74,14 +65,14 @@ class SendImageUseCaseTest {
     fun givenASuccessfulSendImageMessageRequest_whenCheckingTheMessageRepository_thenTheAssetIsPersisted() =
         runTest {
             // Given
-            val mockedImg = getMockedImage()
+            val assetToSend = getMockedAsset()
             val conversationId = ConversationId("some-convo-id", "some-domain-id")
-            val (arrangement, sendImageUseCase) = Arrangement()
+            val (arrangement, sendAssetUseCase) = Arrangement()
                 .withSuccessfulResponse()
                 .arrange()
 
             // When
-            sendImageUseCase.invoke(conversationId, mockedImg, "temp_image.jpg", 1, 1)
+            val result = sendAssetUseCase.invoke(conversationId, assetToSend, "temp_asset.txt", "text/plain")
 
             // Then
             verify(arrangement.messageRepository)
@@ -124,8 +115,8 @@ class SendImageUseCaseTest {
             "some_key"
         )
 
-        val sendImageUseCase =
-            SendImageMessageUseCaseImpl(messageRepository, clientRepository, assetDataSource, userRepository, messageSender)
+        val sendAssetUseCase =
+            SendAssetMessageUseCaseImpl(messageRepository, clientRepository, assetDataSource, userRepository, messageSender)
 
         fun withSuccessfulResponse(): Arrangement {
             given(assetDataSource)
@@ -159,9 +150,9 @@ class SendImageUseCaseTest {
             return this
         }
 
-        fun arrange() = this to sendImageUseCase
+        fun arrange() = this to sendAssetUseCase
     }
 
-    private fun getMockedImage(): ByteArray = "some_image".toByteArray()
+    private fun getMockedAsset(): ByteArray =
+        "some VERY long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long asset".toByteArray()
 }
-

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
@@ -19,6 +19,7 @@ import io.ktor.utils.io.core.toByteArray
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
@@ -88,6 +89,10 @@ class SendImageUseCaseTest {
                 .suspendFunction(arrangement.messageRepository::persistMessage)
                 .with(any())
                 .wasInvoked(exactly = once)
+            verify(arrangement.messageSender)
+                .suspendFunction(arrangement.messageSender::trySendingOutgoingMessageById)
+                .with(eq(conversationId), any())
+                .wasInvoked(exactly = once)
         }
 
     private class Arrangement {
@@ -105,7 +110,7 @@ class SendImageUseCaseTest {
         private val userRepository = mock(classOf<UserRepository>())
 
         @Mock
-        private val messageSender = mock(classOf<MessageSender>())
+        val messageSender = mock(classOf<MessageSender>())
 
         val someAssetId = UploadedAssetId("some-asset-id", "some-asset-token")
 

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -73,7 +73,6 @@ actual class UserDatabaseProvider(private val context: Context, userId: UserIDEn
                 statusAdapter = EnumColumnAdapter(),
                 asset_image_widthAdapter = IntColumnAdapter,
                 asset_image_heightAdapter = IntColumnAdapter,
-                asset_sizeAdapter = IntColumnAdapter,
                 content_typeAdapter = ContentTypeAdapter(),
                 visibilityAdapter = EnumColumnAdapter()
             ),

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -11,7 +11,7 @@ CREATE TABLE Message (
 
       -- Asset message fields
       asset_mime_type TEXT,
-      asset_size INTEGER AS Int,
+      asset_size INTEGER,
       asset_name TEXT,
       asset_image_width INTEGER AS Int,
       asset_image_height INTEGER AS Int,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -17,7 +17,7 @@ data class MessageEntity(
         data class TextMessageContent(val messageBody: String) : MessageEntityContent()
         data class AssetMessageContent(
             val assetMimeType: String,
-            val assetSize: Int,
+            val assetSizeInBytes: Long,
             val assetName: String? = null,
             val assetImageWidth: Int? = null,
             val assetImageHeight: Int? = null,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -76,7 +76,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             content_type = contentTypeOf(message.content),
             asset_mime_type = if (message.content is AssetMessageContent) message.content.assetMimeType else null,
             asset_size = if (message.content is AssetMessageContent) message.content.assetSize else null,
-            asset_name = if (message.content is AssetMessageContent) message.content.assetMimeType else null,
+            asset_name = if (message.content is AssetMessageContent) message.content.assetName else null,
             asset_image_width = if (message.content is AssetMessageContent) message.content.assetImageWidth else null,
             asset_image_height = if (message.content is AssetMessageContent) message.content.assetImageHeight else null,
             asset_otr_key = if (message.content is AssetMessageContent) message.content.assetOtrKey else null,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -22,7 +22,7 @@ class MessageMapper {
                 ASSET -> {
                     AssetMessageContent(
                         assetMimeType = msg.asset_mime_type ?: "",
-                        assetSize = msg.asset_size ?: 0,
+                        assetSizeInBytes = msg.asset_size ?: 0,
                         assetName = msg.asset_name ?: "",
                         assetImageWidth = msg.asset_image_width ?: 0,
                         assetImageHeight = msg.asset_image_height ?: 0,
@@ -75,7 +75,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             },
             content_type = contentTypeOf(message.content),
             asset_mime_type = if (message.content is AssetMessageContent) message.content.assetMimeType else null,
-            asset_size = if (message.content is AssetMessageContent) message.content.assetSize else null,
+            asset_size = if (message.content is AssetMessageContent) message.content.assetSizeInBytes else null,
             asset_name = if (message.content is AssetMessageContent) message.content.assetName else null,
             asset_image_width = if (message.content is AssetMessageContent) message.content.assetImageWidth else null,
             asset_image_height = if (message.content is AssetMessageContent) message.content.assetImageHeight else null,
@@ -103,7 +103,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             },
             content_type = contentTypeOf(message.content),
             asset_mime_type = if (message.content is AssetMessageContent) message.content.assetMimeType else null,
-            asset_size = if (message.content is AssetMessageContent) message.content.assetSize else null,
+            asset_size = if (message.content is AssetMessageContent) message.content.assetSizeInBytes else null,
             asset_name = if (message.content is AssetMessageContent) message.content.assetMimeType else null,
             asset_image_width = if (message.content is AssetMessageContent) message.content.assetImageWidth else null,
             asset_image_height = if (message.content is AssetMessageContent) message.content.assetImageHeight else null,

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -51,7 +51,6 @@ actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
                 statusAdapter = EnumColumnAdapter(),
                 asset_image_widthAdapter = IntColumnAdapter,
                 asset_image_heightAdapter = IntColumnAdapter,
-                asset_sizeAdapter = IntColumnAdapter,
                 content_typeAdapter = ContentTypeAdapter(),
                 visibilityAdapter = EnumColumnAdapter()
             ),

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -67,7 +67,6 @@ actual class UserDatabaseProvider(private val storePath: File) {
                 statusAdapter = EnumColumnAdapter(),
                 asset_image_widthAdapter = IntColumnAdapter,
                 asset_image_heightAdapter = IntColumnAdapter,
-                asset_sizeAdapter = IntColumnAdapter,
                 content_typeAdapter = ContentTypeAdapter(),
                 visibilityAdapter = EnumColumnAdapter()
             ),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

So far we only could upload image assets and display them on the chat. With this PR, we will also be able to upload any other file types as generic file assets via the `SendAssetMessageUseCase`


#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
