### PR TITLE
fix: encode SSO initiate request

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/SSOLoginApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/SSOLoginApi.kt
@@ -9,6 +9,7 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.head
 import io.ktor.client.request.header
+import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.statement.request
 import io.ktor.http.ContentType

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/SSOLoginApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/SSOLoginApi.kt
@@ -34,13 +34,12 @@ interface SSOLoginApi {
 
 class SSOLoginApiImpl(private val httpClient: HttpClient) : SSOLoginApi {
     override suspend fun initiate(param: SSOLoginApi.InitiateParam, apiBaseUrl: Url): NetworkResponse<String> {
-        val path = when (param) {
-            is SSOLoginApi.InitiateParam.WithoutRedirect -> "$PATH_SSO/$PATH_INITIATE/${param.uuid}"
-            // ktor will encode the query param as URL so a way around it to append the query to the path string
-            is SSOLoginApi.InitiateParam.WithRedirect -> "$PATH_SSO/$PATH_INITIATE/${param.uuid}?$QUERY_SUCCESS_REDIRECT=${param.success}&$QUERY_ERROR_REDIRECT=${param.error}"
-        }
         val response = httpClient.head {
-            setUrl(apiBaseUrl, path)
+            setUrl(apiBaseUrl, "$PATH_SSO/$PATH_INITIATE/${param.uuid}")
+            if(param is SSOLoginApi.InitiateParam.WithRedirect) {
+                parameter(QUERY_SUCCESS_REDIRECT, param.success)
+                parameter(QUERY_ERROR_REDIRECT, param.error)
+            }
             accept(ContentType.Text.Plain)
         }
         return if (response.status.isSuccess()) {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -235,6 +235,9 @@ interface ApiTest {
     // path
     fun HttpRequestData.assertPathEqual(path: String) = assertEquals(path, this.url.encodedPath)
 
+    // path and query
+    fun HttpRequestData.assertPathAndQueryEqual(pathAndQuery: String) = assertEquals(pathAndQuery, this.url.encodedPathAndQuery)
+
     // body
     fun HttpRequestData.assertBodyContent(content: String) {
         assertIs<TextContent>(body)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/SSOLoginApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/SSOLoginApiTest.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
+import io.ktor.http.protocolWithAuthority
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -20,39 +21,41 @@ class SSOLoginApiTest: ApiTest {
     fun givenBEResponseSuccess_whenCallingInitiateSSOEndpointWithNoRedirect_thenRequestConfiguredCorrectly() = runTest{
         val uuid = "uuid"
         val param = SSOLoginApi.InitiateParam.WithoutRedirect(uuid)
+        val expectedPath = "$PATH_SSO_INITIATE/$uuid"
         val httpClient = mockAuthenticatedHttpClient(
             "",
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertHead()
                 assertNoQueryParams()
-                assertPathEqual("$PATH_SSO_INITIATE/$uuid")
+                assertPathEqual(expectedPath)
             }
         )
         val ssoApi: SSOLoginApi = SSOLoginApiImpl(httpClient)
         val actual = ssoApi.initiate(param, TEST_HOST)
 
         assertIs<NetworkResponse.Success<String>>(actual)
-        assertEquals("${TEST_HOST}sso/initiate-login/$uuid", actual.value)
+        assertEquals("${TEST_HOST.protocolWithAuthority}$expectedPath", actual.value)
     }
 
     @Test
     fun givenBEResponseSuccess_whenCallingInitiateSSOEndpointWithRedirect_thenRequestConfiguredCorrectly() = runTest {
         val uuid = "uuid"
         val param = SSOLoginApi.InitiateParam.WithRedirect(uuid = uuid, success = "wire://success", error = "wire://error")
+        val expectedPathAndQuery = "$PATH_SSO_INITIATE/$uuid?success_redirect=wire%3A%2F%2Fsuccess&error_redirect=wire%3A%2F%2Ferror"
         val httpClient = mockAuthenticatedHttpClient(
             "",
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertHead()
-                assertPathEqual("$PATH_SSO_INITIATE/$uuid%3Fsuccess_redirect=${param.success}&error_redirect=${param.error}")
+                assertPathAndQueryEqual(expectedPathAndQuery)
             }
         )
         val ssoApi: SSOLoginApi = SSOLoginApiImpl(httpClient)
         val actual = ssoApi.initiate(param, TEST_HOST)
 
         assertIs<NetworkResponse.Success<String>>(actual)
-        assertEquals("${TEST_HOST}sso/initiate-login/$uuid%3Fsuccess_redirect=${param.success}&error_redirect=${param.error}", actual.value)
+        assertEquals("${TEST_HOST.protocolWithAuthority}$expectedPathAndQuery", actual.value)
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Without encoding, when using redirects like `wire://` we get 404 response.

### Causes (Optional)

That's because we don't encode the parameters.

### Solutions

Encode the parameters.

### Testing

#### How to Test

Execute the `initiate` request by using `SSOInitiateLoginUseCase` or directly from `SSOLoginApi`.

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
