### PR TITLE
feat: add usecases for muting/unmuting calls

### DIFF
--- a/calling/src/androidMain/kotlin/com/wire/kalium/calling/Calling.kt
+++ b/calling/src/androidMain/kotlin/com/wire/kalium/calling/Calling.kt
@@ -60,7 +60,7 @@ interface Calling : Library {
 
     fun wcall_close()
 
-    fun wcall_get_mute(inst: Int): Int
+    fun wcall_set_mute(inst: Handle, muted: Int)
 
     fun wcall_recv_msg(
         inst: Handle,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -226,6 +226,11 @@ actual class CallManagerImpl(
         wcall_reject(inst = deferredHandle.await(), conversationId = conversationId.asString())
     }
 
+    override suspend fun muteCall(shouldMute: Boolean) = withCalling {
+        kaliumLogger.d("$TAG -> muting call..")
+        wcall_set_mute(deferredHandle.await(), muted =  shouldMute.toInt())
+    }
+
     override fun onConfigRequest(inst: Handle, arg: Pointer?): Int {
         scope.launch {
             val config = callRepository.getCallConfigResponse(limit = null)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -14,6 +14,7 @@ interface CallManager {
     suspend fun answerCall(conversationId: ConversationId)
     suspend fun endCall(conversationId: ConversationId)
     suspend fun rejectCall(conversationId: ConversationId)
+    suspend fun muteCall(shouldMute: Boolean)
     val allCalls: StateFlow<List<Call>>
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -3,8 +3,10 @@ package com.wire.kalium.logic.feature.call
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetOngoingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetOngoingCallsUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.sync.SyncManager
 
 class CallsScope(
@@ -25,4 +27,8 @@ class CallsScope(
     val endCall: EndCallUseCase get() = EndCallUseCase(callManager)
 
     val rejectCall: RejectCallUseCase get() = RejectCallUseCase(callManager)
+
+    val muteCall: MuteCallUseCase get() = MuteCallUseCase(callManager)
+
+    val unMuteCall: UnMuteCallUseCase get() = UnMuteCallUseCase(callManager)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCase.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.feature.call.CallManager
+
+class MuteCallUseCase(private val callManager: CallManager) {
+
+    suspend operator fun invoke() {
+        callManager.muteCall(true)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.feature.call.CallManager
+
+class UnMuteCallUseCase(private val callManager: CallManager) {
+
+    suspend operator fun invoke() {
+        callManager.muteCall(false)
+    }
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -37,4 +37,8 @@ actual class CallManagerImpl : CallManager {
     override suspend fun rejectCall(conversationId: ConversationId) {
         kaliumLogger.w("rejectCall for JVM but not supported yet.")
     }
+
+    override suspend fun muteCall(shouldMute: Boolean) {
+        kaliumLogger.w("muteCall for JVM but not supported yet.")
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

New feature

### Solutions

In this PR, I prepared two useCases for muting and un-muting calls


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
