### PR TITLE
feat(mls): handle incoming mls messages

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -57,8 +57,6 @@ class MLSConversationDataSource(
         mlsClientProvider.getMLSClient().flatMap { client ->
             val groupID = client.processWelcomeMessage(welcomeEvent.message.decodeBase64Bytes())
 
-            client.encryptMessage(groupID, "hello world".encodeToByteArray())
-
             wrapStorageRequest {
                 if (conversationDAO.getConversationByGroupID(groupID).first() == null) {
                     // Welcome arrived before the conversation create event, insert empty conversation.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -21,6 +21,13 @@ sealed class Event(open val id: String) {
             val content: String
         ) : Conversation(id, conversationId)
 
+        data class NewMLSMessage(
+            override val id: String, override val conversationId: ConversationId,
+            val senderUserId: UserId,
+            val time: String,
+            val content: String
+        ) : Conversation(id, conversationId)
+
         data class NewConversation(
             override val id: String,
             override val conversationId: ConversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -17,6 +17,7 @@ class EventMapper(private val idMapper: IdMapper) {
                 is EventContentDTO.Conversation.MemberJoinDTO -> memberJoin(id, eventContentDTO)
                 is EventContentDTO.Conversation.MemberLeaveDTO -> memberLeave(id, eventContentDTO)
                 is EventContentDTO.Conversation.MLSWelcomeDTO -> welcomeMessage(id, eventContentDTO)
+                is EventContentDTO.Conversation.NewMLSMessageDTO -> newMLSMessage(id, eventContentDTO)
                 is EventContentDTO.User.NewClientDTO, EventContentDTO.Unknown -> Event.Unknown(id)
             }
         } ?: listOf()
@@ -42,6 +43,17 @@ class EventMapper(private val idMapper: IdMapper) {
         eventContentDTO.time,
         eventContentDTO.data.text
     )
+    private fun newMLSMessage(
+        id: String,
+        eventContentDTO: EventContentDTO.Conversation.NewMLSMessageDTO
+    ) = Event.Conversation.NewMLSMessage(
+        id,
+        idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+        idMapper.fromApiModel(eventContentDTO.qualifiedFrom),
+        eventContentDTO.time,
+        eventContentDTO.message
+    )
+
 
     private fun newConversation(
         id: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
@@ -28,7 +28,7 @@ class MLSMessageCreatorImpl(
         return mlsClientProvider.getMLSClient().flatMap { client ->
             kaliumLogger.i("Creating outgoing MLS message (groupID = $groupId)")
             val content = protoContentMapper.encodeToProtobuf(ProtoContent(message.id, message.content))
-            val encryptedContent = client.encryptMessage(groupId, content.data)
+            val encryptedContent = client.encryptMessage(groupId, content.data) // TODO handle MLS errors
             Either.Right(MLSMessageApi.Message(encryptedContent))
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.network.api.message.MLSMessageApi
 
 interface MLSMessageCreator {
@@ -25,6 +26,7 @@ class MLSMessageCreatorImpl(
 
     override suspend fun createOutgoingMLSMessage(groupId: String, message: Message): Either<CoreFailure, MLSMessageApi.Message> {
         return mlsClientProvider.getMLSClient().flatMap { client ->
+            kaliumLogger.i("Creating outgoing MLS message (groupID = $groupId)")
             val content = protoContentMapper.encodeToProtobuf(ProtoContent(message.id, message.content))
             val encryptedContent = client.encryptMessage(groupId, content.data)
             Either.Right(MLSMessageApi.Message(encryptedContent))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -26,7 +26,6 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.thenDoNothing
 import io.mockative.verify
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -90,6 +89,11 @@ class MLSConversationRepositoryTest {
             .whenInvokedWith(anything())
             .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
 
+        given(mlsMessageApi)
+            .suspendFunction(mlsMessageApi::sendMessage)
+            .whenInvokedWith(anything())
+            .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
+
         given(conversationDAO)
             .suspendFunction(conversationDAO::updateConversationGroupState)
             .whenInvokedWith(anything(), anything())
@@ -105,6 +109,9 @@ class MLSConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(mlsMessageApi).coroutine { sendWelcomeMessage(MLSMessageApi.WelcomeMessage(WELCOME)) }
+            .wasInvoked(once)
+
+        verify(mlsMessageApi).coroutine { sendMessage(MLSMessageApi.Message(HANDSHAKE)) }
             .wasInvoked(once)
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
@@ -74,6 +74,15 @@ sealed class EventContentDTO {
             @SerialName("data") val message: String,
             @SerialName("from") val from: String
         ) : Conversation()
+
+        @Serializable
+        @SerialName("conversation.mls-message-add")
+        data class NewMLSMessageDTO(
+            @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
+            @SerialName("qualified_from") val qualifiedFrom: UserId,
+            val time: String,
+            @SerialName("data") val message: String,
+        ) : Conversation()
     }
 
     @Serializable

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationEventsResponseJson.kt
@@ -64,6 +64,33 @@ object NotificationEventsResponseJson {
         ), mlsWelcomeSerializer
     )
 
+    private val newMlsMessageSerializer = { eventData: EventContentDTO.Conversation.NewMLSMessageDTO ->
+        """
+        |{
+        |  "data": "${eventData.message}",
+        |  "qualified_conversation": {
+        |    "domain": "${eventData.qualifiedConversation.domain}",
+        |    "id": "${eventData.qualifiedConversation.value}"
+        |  },
+        |  "qualified_from": {
+        |    "domain": "${eventData.qualifiedFrom.domain}",
+        |    "id": "${eventData.qualifiedFrom.value}"
+        |  },
+        |  "time": "${eventData.time}",
+        |  "type": "conversation.mls-message-add"
+        |}    
+        """.trimMargin()
+    }
+
+    private val newMlsMessage = ValidJsonProvider(
+        EventContentDTO.Conversation.NewMLSMessageDTO(
+            ConversationId("e16babfa-308b-414e-b6e0-c59517f723db", "staging.zinfra.io"),
+            QualifiedID("76ebeb16-a849-4be4-84a7-157654b492cf","staging.zinfra.io"),
+            "2022-04-12T13:57:02.414Z",
+            "AiDyKXJ/yTKaq4fIO2SXXkQIBVhU0uOiDHIfVP3Yb6HoWAAAAAAAAAABAQAAAAAo6sj3pAQr7tXmljXYG4+sRsnR2IKQVhhUIOSopJZ7N2wIVH3nh1Az0AAAAJBQsRZJea8cnIeR/DKmixvos3AHWHchXr5PvXModBjxTVx7wcbT4wCTBVXtZqcYJwySIoKxokYhUUE2+zMKGg96+CV7jdQvqYG/fxk/dSm4TdQypanbSuu7VsYXZSPKPV0E1wChqpLitX5luW7smQPNcmPwwbrK0MDIq3PVhYwI4Cfi1eO1Ii94zM5IfVApyR4="
+        ), newMlsMessageSerializer
+    )
+
     private val newConversationSerializer = { eventData: EventContentDTO.Conversation.NewConversationDTO ->
         """
         |{
@@ -122,6 +149,12 @@ object NotificationEventsResponseJson {
                 ${newConversation.rawJson}
               ],
               "id": "6dd9dfd9-ba68-11ec-8001-22000a09a242"
+            },
+            {
+              "payload": [
+                ${newMlsMessage.rawJson}
+              ],
+              "id": "855fc5f1-bc01-11ec-8001-22000ac2309b"
             },
             {
               "payload": [


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Handle decrypt incoming MLS messages by decrypting and processing the message protobuf.

This implements: [Use case: receive message (MLS)](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/557154491/Use+case+receive+message+MLS)

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

Login as User B so this it has an MLS client
```
> cli login
```

Login as User A and create a group with user B and send a message
```
> cli login create-group listen-group
```

Login as User B and receive the message
```
> cli login listen-group
```

### Notes

- Testing is broken due to some bugs in MLS client.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
