### PR TITLE
feat: handle message sending failures update status

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.failure.SendMessageFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.message.MLSMessageApi
 import com.wire.kalium.network.api.message.MessageApi
 import com.wire.kalium.network.api.message.MessagePriority
@@ -24,7 +25,7 @@ interface MessageRepository {
     suspend fun persistMessage(message: Message): Either<CoreFailure, Unit>
     suspend fun deleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun deleteMessage(messageUuid: String): Either<CoreFailure, Unit>
-    suspend fun updateMessage(message:Message): Either<CoreFailure,Unit>
+    suspend fun updateMessage(message: Message): Either<CoreFailure, Unit>
     suspend fun softDeleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun hideMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun markMessageAsSent(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit>
@@ -70,9 +71,9 @@ class MessageDataSource(
     }
 
     override suspend fun updateMessage(message: Message): Either<CoreFailure, Unit> {
-        messageDAO.updateMessage(messageMapper.fromMessageToEntity(message))
-        //TODO: Handle failures
-        return Either.Right(Unit)
+        return wrapStorageRequest {
+            messageDAO.updateMessage(messageMapper.fromMessageToEntity(message))
+        }
     }
 
     override suspend fun softDeleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -24,6 +24,7 @@ interface MessageRepository {
     suspend fun persistMessage(message: Message): Either<CoreFailure, Unit>
     suspend fun deleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun deleteMessage(messageUuid: String): Either<CoreFailure, Unit>
+    suspend fun updateMessage(message:Message): Either<CoreFailure,Unit>
     suspend fun softDeleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun hideMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun markMessageAsSent(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit>
@@ -64,6 +65,12 @@ class MessageDataSource(
 
     override suspend fun deleteMessage(messageUuid: String): Either<CoreFailure, Unit> {
         messageDAO.deleteMessage(messageUuid)
+        //TODO: Handle failures
+        return Either.Right(Unit)
+    }
+
+    override suspend fun updateMessage(message: Message): Either<CoreFailure, Unit> {
+        messageDAO.updateMessage(messageMapper.fromMessageToEntity(message))
         //TODO: Handle failures
         return Either.Right(Unit)
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -1,16 +1,13 @@
 package com.wire.kalium.logic.feature.message
 
 import com.benasher44.uuid.uuid4
-import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
-import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
@@ -20,18 +17,17 @@ class SendTextMessageUseCase(
     private val userRepository: UserRepository,
     private val clientRepository: ClientRepository,
     private val syncManager: SyncManager,
-    private val messageSender: MessageSender
+    private val messageSender: MessageSender,
 ) {
 
-    suspend operator fun invoke(conversationId: ConversationId, text: String): Either<CoreFailure, Unit> {
+    suspend operator fun invoke(conversationId: ConversationId, text: String): SendTextMessageResult {
         syncManager.waitForSlowSyncToComplete()
         val selfUser = userRepository.getSelfUser().first()
+        val generatedMessageUuid = uuid4().toString()
 
         return suspending {
-            val generatedMessageUuid = uuid4().toString()
-
-            clientRepository.currentClientId().flatMap { currentClientId ->
-                val message = Message(
+            clientRepository.currentClientId().map { currentClientId ->
+                Message(
                     id = generatedMessageUuid,
                     content = MessageContent.Text(text),
                     conversationId = conversationId,
@@ -40,16 +36,24 @@ class SendTextMessageUseCase(
                     senderClientId = currentClientId,
                     status = Message.Status.PENDING
                 )
+            }.flatMap { message ->
                 messageRepository.persistMessage(message)
-            }.flatMap {
-                messageSender.trySendingOutgoingMessageById(conversationId, generatedMessageUuid)
-            }.onFailure {
-                kaliumLogger.e("There was an error trying to send the message $it")
-                if (it is CoreFailure.Unknown) {
-                    //TODO Did I write multiplatform logging today?
-                    it.rootCause?.printStackTrace()
-                }
-            }
+                    .flatMap {
+                        messageSender.trySendingOutgoingMessageById(conversationId, generatedMessageUuid)
+                    }.flatMap {
+                        messageRepository.persistMessage(message.copy(status = Message.Status.SENT))
+                    }
+            }.onFailure { SendTextMessageResult.Failure("test") }
+                .onSuccess { SendTextMessageResult.Success }
+                .coFold(
+                    { SendTextMessageResult.Failure("test") },
+                    { SendTextMessageResult.Success }
+                )
         }
     }
+}
+
+sealed class SendTextMessageResult {
+    object Success : SendTextMessageResult()
+    data class Failure(val messageId: String) : SendTextMessageResult()
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCaseTest.kt
@@ -9,9 +9,11 @@ import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.SyncManager
+import io.mockative.ConfigurationApi
 import io.mockative.Mock
 import io.mockative.Times
 import io.mockative.anything
+import io.mockative.configure
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.verify
@@ -21,6 +23,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertIs
 
+@OptIn(ConfigurationApi::class)
 class SendTextMessageUseCaseTest {
 
     @Mock
@@ -33,7 +36,7 @@ class SendTextMessageUseCaseTest {
     private val clientRepository = mock(ClientRepository::class)
 
     @Mock
-    private val syncManager = mock(SyncManager::class)
+    private val syncManager = configure(mock(SyncManager::class)) { stubsUnitByDefault = true }
 
     @Mock
     private val messageSender: MessageSender = mock(MessageSender::class)
@@ -52,13 +55,8 @@ class SendTextMessageUseCaseTest {
     }
 
     @Test
-    fun givenRecipients_whenCreatingAnEnvelope_thenProteusClientShouldBeUsedToEncryptForEachClient() = runTest {
+    fun givenGettingClientIdFails_WhenSendingTextMessage_FailureIsPropagatedImmediately() = runTest {
         //given
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSlowSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
-
         given(userRepository)
             .suspendFunction(userRepository::getSelfUser)
             .whenInvoked()
@@ -86,13 +84,8 @@ class SendTextMessageUseCaseTest {
     }
 
     @Test
-    fun givenRecipients_whenCreatingAnEnvelope_thenProteusClientShouldBeUsedToEncryptForEachClient123() = runTest {
+    fun givenPersistingMessageFails_WhenSendingTextMessage_FailureIsPropagatedImmediately() = runTest {
         //given
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSlowSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
-
         given(userRepository)
             .suspendFunction(userRepository::getSelfUser)
             .whenInvoked()
@@ -139,13 +132,8 @@ class SendTextMessageUseCaseTest {
     }
 
     @Test
-    fun givenRecipients_whenCreatingAnEnvelope_thenProteusClientShouldBeUsedToEncryptForEachClient1234() = runTest {
+    fun givenSendingOutgoingMessageFails_WhenSendingTextMessage_FailureIsPropagatedImmediately() = runTest {
         //given
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSlowSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
-
         given(userRepository)
             .suspendFunction(userRepository::getSelfUser)
             .whenInvoked()
@@ -190,13 +178,8 @@ class SendTextMessageUseCaseTest {
     }
 
     @Test
-    fun givenRecipients_whenCreatingAnEnvelope_thenProteusClientShouldBeUsedToEncryptForEachClient12345() = runTest {
+    fun givenSendingTextMessageSucceeds_whenSendingTextMessage_SuccessIsPropagatedCorrectly() = runTest {
         //given
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSlowSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
-
         given(userRepository)
             .suspendFunction(userRepository::getSelfUser)
             .whenInvoked()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCaseTest.kt
@@ -1,0 +1,234 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.PlainId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.SyncManager
+import io.mockative.Mock
+import io.mockative.Times
+import io.mockative.anything
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class SendTextMessageUseCaseTest {
+
+    @Mock
+    private val messageRepository = mock(MessageRepository::class)
+
+    @Mock
+    private val userRepository = mock(UserRepository::class)
+
+    @Mock
+    private val clientRepository = mock(ClientRepository::class)
+
+    @Mock
+    private val syncManager = mock(SyncManager::class)
+
+    @Mock
+    private val messageSender: MessageSender = mock(MessageSender::class)
+
+    lateinit var sendTextMessageUseCase: SendTextMessageUseCase
+
+    @BeforeTest
+    fun setup() {
+        sendTextMessageUseCase = SendTextMessageUseCase(
+            messageRepository = messageRepository,
+            userRepository = userRepository,
+            clientRepository = clientRepository,
+            syncManager = syncManager,
+            messageSender = messageSender
+        )
+    }
+
+    @Test
+    fun givenRecipients_whenCreatingAnEnvelope_thenProteusClientShouldBeUsedToEncryptForEachClient() = runTest {
+        //given
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(clientRepository)
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
+            .thenReturn(Either.Left(CoreFailure.Unknown(IllegalArgumentException())))
+        //when
+        val result = sendTextMessageUseCase(ConversationId("test", "test"), "text")
+
+        //then
+        verify(messageRepository)
+            .suspendFunction(messageRepository::persistMessage)
+            .with(anything())
+            .wasNotInvoked()
+
+        verify(messageSender)
+            .suspendFunction(messageSender::trySendingOutgoingMessageById)
+            .with(anything(), anything())
+            .wasNotInvoked()
+
+        assertIs<SendTextMessageResult.Failure>(result)
+    }
+
+    @Test
+    fun givenRecipients_whenCreatingAnEnvelope_thenProteusClientShouldBeUsedToEncryptForEachClient123() = runTest {
+        //given
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(clientRepository)
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
+            .thenReturn(Either.Right(PlainId("test")))
+
+        given(messageRepository)
+            .suspendFunction(messageRepository::persistMessage)
+            .whenInvokedWith(anything())
+            .thenReturn(Either.Left(CoreFailure.Unknown(IllegalArgumentException())))
+        //when
+        val result = sendTextMessageUseCase(ConversationId("test", "test"), "text")
+
+        //then
+        verify(messageRepository)
+            .suspendFunction(messageRepository::persistMessage)
+            .with(anything())
+            .wasInvoked(Times(1))
+
+        verify(messageSender)
+            .suspendFunction(messageSender::trySendingOutgoingMessageById)
+            .with(anything(), anything())
+            .wasNotInvoked()
+
+        assertIs<SendTextMessageResult.Failure>(result)
+    }
+
+    @Test
+    fun givenRecipients_whenCreatingAnEnvelope_thenProteusClientShouldBeUsedToEncryptForEachClient1234() = runTest {
+        //given
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(clientRepository)
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
+            .thenReturn(Either.Right(PlainId("test")))
+
+        given(messageRepository)
+            .suspendFunction(messageRepository::persistMessage)
+            .whenInvokedWith(anything())
+            .thenReturn(Either.Right(Unit))
+
+        given(messageSender)
+            .suspendFunction(messageSender::trySendingOutgoingMessageById)
+            .whenInvokedWith(anything(), anything())
+            .thenReturn(Either.Left(CoreFailure.Unknown(IllegalArgumentException())))
+        //when
+        val result = sendTextMessageUseCase(ConversationId("test", "test"), "text")
+
+        //then
+        verify(messageRepository)
+            .suspendFunction(messageRepository::persistMessage)
+            .with(anything())
+            .wasInvoked(Times(1))
+
+        verify(messageSender)
+            .suspendFunction(messageSender::trySendingOutgoingMessageById)
+            .with(anything(), anything())
+            .wasInvoked(Times(1))
+
+        assertIs<SendTextMessageResult.Failure>(result)
+    }
+
+    @Test
+    fun givenRecipients_whenCreatingAnEnvelope_thenProteusClientShouldBeUsedToEncryptForEachClient12345() = runTest {
+        //given
+        given(syncManager)
+            .suspendFunction(syncManager::waitForSlowSyncToComplete)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(clientRepository)
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
+            .thenReturn(Either.Right(PlainId("test")))
+
+        given(messageRepository)
+            .suspendFunction(messageRepository::persistMessage)
+            .whenInvokedWith(anything())
+            .thenReturn(Either.Right(Unit))
+
+        given(messageSender)
+            .suspendFunction(messageSender::trySendingOutgoingMessageById)
+            .whenInvokedWith(anything(), anything())
+            .thenReturn(Either.Right(Unit))
+        //when
+        val result = sendTextMessageUseCase(ConversationId("test", "test"), "text")
+
+        //then
+        verify(messageRepository)
+            .suspendFunction(messageRepository::persistMessage)
+            .with(eq(TEST_MESSAGE))
+            .wasInvoked(Times(3))
+
+
+        verify(messageSender)
+            .suspendFunction(messageSender::trySendingOutgoingMessageById)
+            .with(anything(), anything())
+            .wasInvoked(Times(1))
+
+        assertIs<SendTextMessageResult.Success>(result)
+    }
+
+    companion object {
+        val TEST_MESSAGE = Message(
+            id = "test",
+            content = MessageContent.Text("test"),
+            conversationId = ConversationId("test", "test"),
+            date = Clock.System.now().toString(),
+            senderUserId = UserId("test", "test"),
+            senderClientId = ClientId("test"),
+            status = Message.Status.PENDING
+        )
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- In order to correctly display the status of messages being sent I adjusted the behaviour of SendTextMessageUseCase
- Now it correctly updates the status inside the DAO on failure or when it is successfully has been sent.
- I also returns the result with a given failure in case we could not even create a message inside the DAO
- Add a update method to MessageRepository

### Testing

- Unit tests


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
