### PR TITLE
fix: decode group ID before passing it to CoreCrypto

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -4,6 +4,8 @@ import com.wire.crypto.CiphersuiteName
 import com.wire.crypto.ConversationConfiguration
 import com.wire.crypto.CoreCrypto
 import com.wire.crypto.Invitee
+import io.ktor.util.decodeBase64Bytes
+import io.ktor.util.encodeBase64
 import java.time.Duration
 
 @OptIn(ExperimentalUnsignedTypes::class)
@@ -41,13 +43,11 @@ actual class MLSClientImpl actual constructor(
             keyRotationDuration
         )
 
-        val messages = coreCrypto.createConversation(toUByteList(conversationId), conf)
-
+        val messages = coreCrypto.createConversation(toUByteList(conversationId.decodeBase64Bytes()), conf)
         return messages?.let { Pair(toByteArray(it.message), toByteArray(it.welcome)) }
     }
 
     override fun processWelcomeMessage(message: WelcomeMessage): MLSGroupId {
-
         // TODO currently generating a dummy ConversationConfiguration, this should be removed when API is updated.
         val conf = ConversationConfiguration(
             emptyList(),
@@ -57,16 +57,16 @@ actual class MLSClientImpl actual constructor(
         )
 
         val conversationId = coreCrypto.processWelcomeMessage(toUByteList(message), conf)
-        return String(toByteArray(conversationId))
+        return toByteArray(conversationId).encodeBase64()
     }
 
     override fun encryptMessage(groupId: MLSGroupId, message: PlainMessage): ApplicationMessage {
-        val applicationMessage = coreCrypto.encryptMessage(toUByteList(groupId), toUByteList(message))
+        val applicationMessage = coreCrypto.encryptMessage(toUByteList(groupId.decodeBase64Bytes()), toUByteList(message))
         return toByteArray(applicationMessage)
     }
 
     override fun decryptMessage(groupId: MLSGroupId, message: ApplicationMessage): PlainMessage? {
-        return coreCrypto.decryptMessage(toUByteList(groupId), toUByteList(message))?.let { toByteArray(it) }
+        return coreCrypto.decryptMessage(toUByteList(groupId.decodeBase64Bytes()), toUByteList(message))?.let { toByteArray(it) }
     }
 
     override fun addMember(
@@ -76,8 +76,7 @@ actual class MLSClientImpl actual constructor(
             Invitee(toUByteList(it.first.toString()), toUByteList(it.second))
         }
 
-        val messages = coreCrypto.addClientsToConversation(toUByteList(conversationId), invitees)
-
+        val messages = coreCrypto.addClientsToConversation(toUByteList(conversationId.decodeBase64Bytes()), invitees)
         return messages?.let { Pair(toByteArray(it.message), toByteArray(it.welcome)) }
     }
 
@@ -90,7 +89,7 @@ actual class MLSClientImpl actual constructor(
             Invitee(toUByteList(it.toString()), toUByteList(generateKeyPackages(1).first()))
         }
 
-        val handshake = coreCrypto.removeClientsFromConversation(toUByteList(groupId), invitees)
+        val handshake = coreCrypto.removeClientsFromConversation(toUByteList(groupId.decodeBase64Bytes()), invitees)
         return handshake?.let { toByteArray(it) }
     }
 

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
@@ -113,7 +113,7 @@ class MLSClientTest: BaseMLSClientTest() {
     }
 
     companion object {
-        const val MLS_CONVERSATION_ID = "12e823ds99ab922"
+        const val MLS_CONVERSATION_ID = "JfflcPtUivbg+1U3Iyrzsh5D2ui/OGS5Rvf52ipH5KY="
         const val PLAIN_TEXT = "Hello World"
         val ALICE = SampleUser(
             CryptoQualifiedID("837655f7-b448-465a-b4b2-93f0919b38f0", "wire.com"),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sending the handshake message for creating a group conversation results in 404 "no-conversation" error by the BE.

### Causes

Group IDs returned by the BE are base64 encoded and CoreCrypto expects the decode bytes but we were passing the raw string.

### Solutions

Decode group IDs inside the MLSClient before given them to CoreCrypto.

### Testing

- [x] I have added automated test to this contribution

#### How to Test

```
> cli login create-group
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
