### PR TITLE
feat: muting conversation status mapping for fetching (AR-1446)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -9,7 +9,9 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
 
-data class Conversation(val id: ConversationId, val name: String?, val type: Type, val teamId: TeamId?) {
+data class Conversation(
+    val id: ConversationId, val name: String?, val type: Type, val teamId: TeamId?, val mutedStatus: MutedConversationStatus
+) {
     enum class Type { SELF, ONE_ON_ONE, GROUP }
 }
 
@@ -32,8 +34,8 @@ class MembersInfo(val self: Member, val otherMembers: List<Member>)
 class Member(override val id: UserId) : User()
 
 sealed class MemberDetails {
-    data class Self(val selfUser: SelfUser): MemberDetails()
-    data class Other(val otherUser: OtherUser): MemberDetails()
+    data class Self(val selfUser: SelfUser) : MemberDetails()
+    data class Other(val otherUser: OtherUser) : MemberDetails()
 }
 
 typealias ClientId = PlainId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -13,6 +13,8 @@ import com.wire.kalium.network.api.model.ConversationAccessRole
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.ConversationEntity.GroupState
 import com.wire.kalium.persistence.dao.ConversationEntity.ProtocolInfo
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import com.wire.kalium.persistence.dao.ConversationEntity as PersistedConversation
 import com.wire.kalium.persistence.dao.ConversationEntity.Protocol as PersistedProtocol
 
@@ -44,7 +46,7 @@ internal class ConversationMapperImpl(
             apiModel.teamId,
             apiModel.getProtocolInfo(groupCreation),
             conversationStatusMapper.fromApiToDaoModel(apiModel.members.self.otrMutedStatus),
-            apiModel.members.self.otrMutedRef?.toLong() ?: 0
+            apiModel.members.self.otrMutedRef?.let { Instant.parse(it) }?.toEpochMilliseconds() ?: 0
         )
 
     override fun fromApiModelToDaoModel(apiModel: ConvProtocol): PersistedProtocol = when (apiModel) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -44,7 +44,7 @@ internal class ConversationMapperImpl(
             apiModel.teamId,
             apiModel.getProtocolInfo(groupCreation),
             conversationStatusMapper.fromApiToDaoModel(apiModel.members.self.otrMutedStatus),
-            apiModel.members.self.otrMutedReference?.toLong() ?: 0
+            apiModel.members.self.otrMutedRef?.toLong() ?: 0
         )
 
     override fun fromApiModelToDaoModel(apiModel: ConvProtocol): PersistedProtocol = when (apiModel) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -9,7 +9,6 @@ interface ConversationStatusMapper {
     fun toDaoModel(mutedStatus: MutedConversationStatus): ConversationEntity.MutedStatus
     fun fromDaoModel(mutedStatus: ConversationEntity.MutedStatus): MutedConversationStatus
     fun fromApiToDaoModel(mutedStatus: MemberUpdateDTO.MutedStatus?): ConversationEntity.MutedStatus
-    fun fromApiToDaoModel(mutedStatus: Int?): ConversationEntity.MutedStatus
 }
 
 class ConversationStatusMapperImpl : ConversationStatusMapper {
@@ -43,15 +42,6 @@ class ConversationStatusMapperImpl : ConversationStatusMapper {
             MemberUpdateDTO.MutedStatus.ALL_ALLOWED -> ConversationEntity.MutedStatus.ALL_ALLOWED
             MemberUpdateDTO.MutedStatus.ONLY_MENTIONS_ALLOWED -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
             MemberUpdateDTO.MutedStatus.ALL_MUTED -> ConversationEntity.MutedStatus.ALL_MUTED
-            else -> ConversationEntity.MutedStatus.ALL_ALLOWED
-        }
-    }
-
-    override fun fromApiToDaoModel(mutedStatus: Int?): ConversationEntity.MutedStatus {
-        return when(mutedStatus) {
-            0 -> ConversationEntity.MutedStatus.ALL_ALLOWED
-            1 -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
-            3 -> ConversationEntity.MutedStatus.ALL_MUTED
             else -> ConversationEntity.MutedStatus.ALL_ALLOWED
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -9,6 +9,7 @@ interface ConversationStatusMapper {
     fun toDaoModel(mutedStatus: MutedConversationStatus): ConversationEntity.MutedStatus
     fun fromDaoModel(mutedStatus: ConversationEntity.MutedStatus): MutedConversationStatus
     fun fromApiToDaoModel(mutedStatus: MemberUpdateDTO.MutedStatus?): ConversationEntity.MutedStatus
+    fun fromApiToDaoModel(mutedStatus: Int?): ConversationEntity.MutedStatus
 }
 
 class ConversationStatusMapperImpl : ConversationStatusMapper {
@@ -42,6 +43,15 @@ class ConversationStatusMapperImpl : ConversationStatusMapper {
             MemberUpdateDTO.MutedStatus.ALL_ALLOWED -> ConversationEntity.MutedStatus.ALL_ALLOWED
             MemberUpdateDTO.MutedStatus.ONLY_MENTIONS_ALLOWED -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
             MemberUpdateDTO.MutedStatus.ALL_MUTED -> ConversationEntity.MutedStatus.ALL_MUTED
+            else -> ConversationEntity.MutedStatus.ALL_ALLOWED
+        }
+    }
+
+    override fun fromApiToDaoModel(mutedStatus: Int?): ConversationEntity.MutedStatus {
+        return when(mutedStatus) {
+            0 -> ConversationEntity.MutedStatus.ALL_ALLOWED
+            1 -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
+            3 -> ConversationEntity.MutedStatus.ALL_MUTED
             else -> ConversationEntity.MutedStatus.ALL_ALLOWED
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -1,18 +1,20 @@
 package com.wire.kalium.logic.data.conversation
 
-import com.wire.kalium.network.api.conversation.MemberUpdateRequest
+import com.wire.kalium.network.api.conversation.MemberUpdateDTO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import kotlinx.datetime.Instant
 
 interface ConversationStatusMapper {
-    fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest
+    fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateDTO
     fun toDaoModel(mutedStatus: MutedConversationStatus): ConversationEntity.MutedStatus
+    fun fromDaoModel(mutedStatus: ConversationEntity.MutedStatus): MutedConversationStatus
+    fun fromApiToDaoModel(mutedStatus: MemberUpdateDTO.MutedStatus?): ConversationEntity.MutedStatus
 }
 
 class ConversationStatusMapperImpl : ConversationStatusMapper {
-    override fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateRequest {
-        return MemberUpdateRequest(
-            otrMutedStatus = MemberUpdateRequest.MutedStatus.fromOrdinal(mutedStatus.status),
+    override fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateDTO {
+        return MemberUpdateDTO(
+            otrMutedStatus = MemberUpdateDTO.MutedStatus.fromOrdinal(mutedStatus.status),
             otrMutedRef = Instant.fromEpochMilliseconds(mutedStatusTimestamp).toString()
         )
     }
@@ -22,7 +24,25 @@ class ConversationStatusMapperImpl : ConversationStatusMapper {
             MutedConversationStatus.AllAllowed -> ConversationEntity.MutedStatus.ALL_ALLOWED
             MutedConversationStatus.OnlyMentionsAllowed -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
             MutedConversationStatus.AllMuted -> ConversationEntity.MutedStatus.ALL_MUTED
-            else -> ConversationEntity.MutedStatus.MENTIONS_MUTED // legacy, not used
+            else -> ConversationEntity.MutedStatus.ALL_ALLOWED
+        }
+    }
+
+    override fun fromDaoModel(mutedStatus: ConversationEntity.MutedStatus): MutedConversationStatus {
+        return when (mutedStatus) {
+            ConversationEntity.MutedStatus.ALL_ALLOWED -> MutedConversationStatus.AllAllowed
+            ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED -> MutedConversationStatus.OnlyMentionsAllowed
+            ConversationEntity.MutedStatus.ALL_MUTED -> MutedConversationStatus.AllMuted
+            else -> MutedConversationStatus.AllAllowed
+        }
+    }
+
+    override fun fromApiToDaoModel(mutedStatus: MemberUpdateDTO.MutedStatus?): ConversationEntity.MutedStatus {
+        return when (mutedStatus) {
+            MemberUpdateDTO.MutedStatus.ALL_ALLOWED -> ConversationEntity.MutedStatus.ALL_ALLOWED
+            MemberUpdateDTO.MutedStatus.ONLY_MENTIONS_ALLOWED -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
+            MemberUpdateDTO.MutedStatus.ALL_MUTED -> ConversationEntity.MutedStatus.ALL_MUTED
+            else -> ConversationEntity.MutedStatus.ALL_ALLOWED
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.network.api.conversation.MemberUpdateDTO
+import com.wire.kalium.network.api.conversation.MutedStatus
 import com.wire.kalium.persistence.dao.ConversationEntity
 import kotlinx.datetime.Instant
 
@@ -8,13 +9,13 @@ interface ConversationStatusMapper {
     fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateDTO
     fun toDaoModel(mutedStatus: MutedConversationStatus): ConversationEntity.MutedStatus
     fun fromDaoModel(mutedStatus: ConversationEntity.MutedStatus): MutedConversationStatus
-    fun fromApiToDaoModel(mutedStatus: MemberUpdateDTO.MutedStatus?): ConversationEntity.MutedStatus
+    fun fromApiToDaoModel(mutedStatus: MutedStatus?): ConversationEntity.MutedStatus
 }
 
 class ConversationStatusMapperImpl : ConversationStatusMapper {
     override fun toApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateDTO {
         return MemberUpdateDTO(
-            otrMutedStatus = MemberUpdateDTO.MutedStatus.fromOrdinal(mutedStatus.status),
+            otrMutedStatus = MutedStatus.fromOrdinal(mutedStatus.status),
             otrMutedRef = Instant.fromEpochMilliseconds(mutedStatusTimestamp).toString()
         )
     }
@@ -37,11 +38,11 @@ class ConversationStatusMapperImpl : ConversationStatusMapper {
         }
     }
 
-    override fun fromApiToDaoModel(mutedStatus: MemberUpdateDTO.MutedStatus?): ConversationEntity.MutedStatus {
+    override fun fromApiToDaoModel(mutedStatus: MutedStatus?): ConversationEntity.MutedStatus {
         return when (mutedStatus) {
-            MemberUpdateDTO.MutedStatus.ALL_ALLOWED -> ConversationEntity.MutedStatus.ALL_ALLOWED
-            MemberUpdateDTO.MutedStatus.ONLY_MENTIONS_ALLOWED -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
-            MemberUpdateDTO.MutedStatus.ALL_MUTED -> ConversationEntity.MutedStatus.ALL_MUTED
+            MutedStatus.ALL_ALLOWED -> ConversationEntity.MutedStatus.ALL_ALLOWED
+            MutedStatus.ONLY_MENTIONS_ALLOWED -> ConversationEntity.MutedStatus.ONLY_MENTIONS_ALLOWED
+            MutedStatus.ALL_MUTED -> ConversationEntity.MutedStatus.ALL_MUTED
             else -> ConversationEntity.MutedStatus.ALL_ALLOWED
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -40,7 +40,7 @@ internal object MapperProvider {
     fun teamMapper(): TeamMapper = TeamMapperImpl()
     fun messageMapper(): MessageMapper = MessageMapperImpl(idMapper())
     fun memberMapper(): MemberMapper = MemberMapperImpl(idMapper())
-    fun conversationMapper(): ConversationMapper = ConversationMapperImpl(idMapper())
+    fun conversationMapper(): ConversationMapper = ConversationMapperImpl(idMapper(), ConversationStatusMapperImpl())
     fun publicUserMapper(): PublicUserMapper = PublicUserMapperImpl(idMapper())
     fun sendMessageFailureMapper(): SendMessageFailureMapper = SendMessageFailureMapperImpl()
     fun assetMapper(): AssetMapper = AssetMapperImpl()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
@@ -1,9 +1,6 @@
 package com.wire.kalium.logic.sync
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.ProteusFailure
-import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
@@ -26,18 +23,6 @@ class SlowSyncWorker(
             is Either.Left -> {
                 val failure = result.value
                 kaliumLogger.e("SLOW SYNC FAILED $failure")
-
-
-                when(failure) {
-                    CoreFailure.MissingClientRegistration -> kaliumLogger.e("SLOW SYNC FAILED MissingClientRegistration $failure")
-                    is CoreFailure.Unknown -> kaliumLogger.e("SLOW SYNC FAILED Unknown ${failure.rootCause}")
-                    is CoreFailure.FeatureFailure ->kaliumLogger.e("SLOW SYNC FAILED FeatureFailure $failure")
-                    NetworkFailure.NoNetworkConnection -> kaliumLogger.e("SLOW SYNC FAILED NoNetworkConnection $failure")
-                    is NetworkFailure.ServerMiscommunication -> kaliumLogger.e("SLOW SYNC FAILED ServerMiscommunication ${failure.rootCause}")
-                    is ProteusFailure ->kaliumLogger.e("SLOW SYNC FAILED ProteusFailure ${failure.rootCause}")
-                    StorageFailure.DataNotFound -> kaliumLogger.e("SLOW SYNC FAILED DataNotFound $failure")
-                    is StorageFailure.Generic -> kaliumLogger.e("SLOW SYNC FAILED Generic ${failure.rootCause}")
-                }
                 (failure as? CoreFailure.Unknown)?.let {
                     it.rootCause?.printStackTrace()
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
@@ -1,6 +1,9 @@
 package com.wire.kalium.logic.sync
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.ProteusFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.suspending
@@ -23,6 +26,18 @@ class SlowSyncWorker(
             is Either.Left -> {
                 val failure = result.value
                 kaliumLogger.e("SLOW SYNC FAILED $failure")
+
+
+                when(failure) {
+                    CoreFailure.MissingClientRegistration -> kaliumLogger.e("SLOW SYNC FAILED MissingClientRegistration $failure")
+                    is CoreFailure.Unknown -> kaliumLogger.e("SLOW SYNC FAILED Unknown ${failure.rootCause}")
+                    is CoreFailure.FeatureFailure ->kaliumLogger.e("SLOW SYNC FAILED FeatureFailure $failure")
+                    NetworkFailure.NoNetworkConnection -> kaliumLogger.e("SLOW SYNC FAILED NoNetworkConnection $failure")
+                    is NetworkFailure.ServerMiscommunication -> kaliumLogger.e("SLOW SYNC FAILED ServerMiscommunication ${failure.rootCause}")
+                    is ProteusFailure ->kaliumLogger.e("SLOW SYNC FAILED ProteusFailure ${failure.rootCause}")
+                    StorageFailure.DataNotFound -> kaliumLogger.e("SLOW SYNC FAILED DataNotFound $failure")
+                    is StorageFailure.Generic -> kaliumLogger.e("SLOW SYNC FAILED Generic ${failure.rootCause}")
+                }
                 (failure as? CoreFailure.Unknown)?.let {
                     it.rootCause?.printStackTrace()
                 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -153,7 +153,7 @@ class ConversationMapperTest {
         val SELF_USER_TEAM_ID = TeamId("teamID")
         val SELF_MEMBER_RESPONSE =
             ConversationSelfMemberResponse(
-                UserId("selfId", "selfDomain"), "111111", MutedStatus.ALL_ALLOWED
+                UserId("selfId", "selfDomain"), "2022-04-11T20:24:57.237Z", MutedStatus.ALL_ALLOWED
             )
         val OTHER_MEMBERS = listOf(ConversationOtherMembersResponse(null, UserId("other1", "domain1")))
         val MEMBERS_RESPONSE = ConversationMembersResponse(SELF_MEMBER_RESPONSE, OTHER_MEMBERS)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -9,6 +9,7 @@ import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
+import com.wire.kalium.network.api.conversation.MemberUpdateDTO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import io.mockative.Mock
@@ -27,11 +28,14 @@ class ConversationMapperTest {
     @Mock
     val idMapper = mock(classOf<IdMapper>())
 
+    @Mock
+    val conversationStatusMapper = mock(classOf<ConversationStatusMapper>())
+
     private lateinit var conversationMapper: ConversationMapper
 
     @BeforeTest
     fun setup() {
-        conversationMapper = ConversationMapperImpl(idMapper)
+        conversationMapper = ConversationMapperImpl(idMapper, conversationStatusMapper)
     }
 
     @Test
@@ -43,6 +47,16 @@ class ConversationMapperTest {
             .function(idMapper::fromApiToDao)
             .whenInvokedWith(any())
             .then { transformedConversationId }
+
+        given(conversationStatusMapper)
+            .function(conversationStatusMapper::fromDaoModel)
+            .whenInvokedWith(any())
+            .then { MutedConversationStatus.AllAllowed }
+
+        given(conversationStatusMapper)
+            .function(conversationStatusMapper::fromApiToDaoModel)
+            .whenInvokedWith(any())
+            .then { ConversationEntity.MutedStatus.ALL_ALLOWED }
 
         val mappedResponse = conversationMapper.fromApiModelToDaoModel(response, groupCreation = false, SELF_USER_TEAM_ID)
 
@@ -59,6 +73,16 @@ class ConversationMapperTest {
             .function(idMapper::fromApiToDao)
             .whenInvokedWith(any())
             .then { transformedConversationId }
+
+        given(conversationStatusMapper)
+            .function(conversationStatusMapper::fromDaoModel)
+            .whenInvokedWith(any())
+            .then { MutedConversationStatus.AllAllowed }
+
+        given(conversationStatusMapper)
+            .function(conversationStatusMapper::fromApiToDaoModel)
+            .whenInvokedWith(any())
+            .then { ConversationEntity.MutedStatus.ALL_ALLOWED }
 
         conversationMapper.fromApiModelToDaoModel(response, groupCreation = false, SELF_USER_TEAM_ID)
 
@@ -85,6 +109,16 @@ class ConversationMapperTest {
             .whenInvokedWith(any())
             .then { QualifiedIDEntity("transformed", "tDomain") }
 
+        given(conversationStatusMapper)
+            .function(conversationStatusMapper::fromDaoModel)
+            .whenInvokedWith(any())
+            .then { MutedConversationStatus.AllAllowed }
+
+        given(conversationStatusMapper)
+            .function(conversationStatusMapper::fromApiToDaoModel)
+            .whenInvokedWith(any())
+            .then { ConversationEntity.MutedStatus.ALL_ALLOWED }
+
         val result = conversationMapper.fromApiModelToDaoModel(response, groupCreation = false, SELF_USER_TEAM_ID)
 
         assertEquals(ConversationEntity.Type.ONE_ON_ONE, result.type)
@@ -99,6 +133,16 @@ class ConversationMapperTest {
             .whenInvokedWith(any())
             .then { QualifiedIDEntity("transformed", "tDomain") }
 
+        given(conversationStatusMapper)
+            .function(conversationStatusMapper::fromDaoModel)
+            .whenInvokedWith(any())
+            .then { MutedConversationStatus.AllAllowed }
+
+        given(conversationStatusMapper)
+            .function(conversationStatusMapper::fromApiToDaoModel)
+            .whenInvokedWith(any())
+            .then { ConversationEntity.MutedStatus.ALL_ALLOWED }
+
         val result = conversationMapper.fromApiModelToDaoModel(response, groupCreation = false, SELF_USER_TEAM_ID)
 
         assertEquals(ConversationEntity.Type.GROUP, result.type)
@@ -107,7 +151,10 @@ class ConversationMapperTest {
     private companion object {
         val ORIGINAL_CONVERSATION_ID = ConversationId("original", "oDomain")
         val SELF_USER_TEAM_ID = TeamId("teamID")
-        val SELF_MEMBER_RESPONSE = ConversationSelfMemberResponse(UserId("selfId", "selfDomain"))
+        val SELF_MEMBER_RESPONSE =
+            ConversationSelfMemberResponse(
+                UserId("selfId", "selfDomain"), "111111", MemberUpdateDTO.MutedStatus.ALL_ALLOWED
+            )
         val OTHER_MEMBERS = listOf(ConversationOtherMembersResponse(null, UserId("other1", "domain1")))
         val MEMBERS_RESPONSE = ConversationMembersResponse(SELF_MEMBER_RESPONSE, OTHER_MEMBERS)
         val CONVERSATION_RESPONSE = ConversationResponse(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -9,7 +9,7 @@ import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
-import com.wire.kalium.network.api.conversation.MemberUpdateDTO
+import com.wire.kalium.network.api.conversation.MutedStatus
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import io.mockative.Mock
@@ -153,7 +153,7 @@ class ConversationMapperTest {
         val SELF_USER_TEAM_ID = TeamId("teamID")
         val SELF_MEMBER_RESPONSE =
             ConversationSelfMemberResponse(
-                UserId("selfId", "selfDomain"), "111111", MemberUpdateDTO.MutedStatus.ALL_ALLOWED
+                UserId("selfId", "selfDomain"), "111111", MutedStatus.ALL_ALLOWED
             )
         val OTHER_MEMBERS = listOf(ConversationOtherMembersResponse(null, UserId("other1", "domain1")))
         val MEMBERS_RESPONSE = ConversationMembersResponse(SELF_MEMBER_RESPONSE, OTHER_MEMBERS)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.logic.data.id.IdMapper
-import com.wire.kalium.network.api.conversation.MemberUpdateRequest
+import com.wire.kalium.network.api.conversation.MemberUpdateDTO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import io.mockative.Mock
 import io.mockative.classOf
@@ -25,7 +25,7 @@ class ConversationStatusMapperTest {
     fun givenAConversationModel_whenMappingToApiModel_thenTheMappingStatusesShouldBeOk() {
         val result = conversationStatusMapper.toApiModel(MutedConversationStatus.OnlyMentionsAllowed, 1649708697237L)
 
-        assertEquals(MemberUpdateRequest.MutedStatus.ONLY_MENTIONS_ALLOWED, result.otrMutedStatus)
+        assertEquals(MemberUpdateDTO.MutedStatus.ONLY_MENTIONS_ALLOWED, result.otrMutedStatus)
         assertEquals("2022-04-11T20:24:57.237Z", result.otrMutedRef)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.logic.data.id.IdMapper
-import com.wire.kalium.network.api.conversation.MemberUpdateDTO
+import com.wire.kalium.network.api.conversation.MutedStatus
 import com.wire.kalium.persistence.dao.ConversationEntity
 import io.mockative.Mock
 import io.mockative.classOf
@@ -25,7 +25,7 @@ class ConversationStatusMapperTest {
     fun givenAConversationModel_whenMappingToApiModel_thenTheMappingStatusesShouldBeOk() {
         val result = conversationStatusMapper.toApiModel(MutedConversationStatus.OnlyMentionsAllowed, 1649708697237L)
 
-        assertEquals(MemberUpdateDTO.MutedStatus.ONLY_MENTIONS_ALLOWED, result.otrMutedStatus)
+        assertEquals(MutedStatus.ONLY_MENTIONS_ALLOWED, result.otrMutedStatus)
         assertEquals("2022-04-11T20:24:57.237Z", result.otrMutedRef)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -80,7 +81,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         val USER_ID = UserId(value = "userId", domain = "domainId")
         val MEMBER = listOf(Member(USER_ID))
         val CONVERSATION_ID = ConversationId(value = "userId", domain = "domainId")
-        val CONVERSATION = Conversation(id = CONVERSATION_ID, name = null, type = Conversation.Type.ONE_ON_ONE, teamId = null)
+        val CONVERSATION = Conversation(id = CONVERSATION_ID, name = null, type = Conversation.Type.ONE_ON_ONE, teamId = null, MutedConversationStatus.AllAllowed)
         val OTHER_USER = OtherUser(
             id =
             USER_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.framework
 
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.network.api.QualifiedID
 import com.wire.kalium.persistence.dao.ConversationEntity
@@ -10,9 +11,9 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 object TestConversation {
     val ID = ConversationId("valueConvo", "domainConvo")
 
-    val ONE_ON_ONE = Conversation(ID.copy(value = "1O1 ID"), "ONE_ON_ONE Name", Conversation.Type.ONE_ON_ONE, TestTeam.TEAM_ID)
-    val SELF = Conversation(ID.copy(value = "SELF ID"), "SELF Name", Conversation.Type.SELF, TestTeam.TEAM_ID)
-    val GROUP = Conversation(ID.copy(value = "GROUP ID"), "GROUP Name", Conversation.Type.GROUP, TestTeam.TEAM_ID)
+    val ONE_ON_ONE = Conversation(ID.copy(value = "1O1 ID"), "ONE_ON_ONE Name", Conversation.Type.ONE_ON_ONE, TestTeam.TEAM_ID, MutedConversationStatus.AllAllowed)
+    val SELF = Conversation(ID.copy(value = "SELF ID"), "SELF Name", Conversation.Type.SELF, TestTeam.TEAM_ID, MutedConversationStatus.AllAllowed)
+    val GROUP = Conversation(ID.copy(value = "GROUP ID"), "GROUP Name", Conversation.Type.GROUP, TestTeam.TEAM_ID, MutedConversationStatus.AllAllowed)
 
     val NETWORK_ID = QualifiedID("valueConversation", "domainConversation")
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApi.kt
@@ -24,7 +24,7 @@ interface ConversationApi {
     ): NetworkResponse<AddParticipantResponse>
 
     suspend fun updateConversationMemberState(
-        memberUpdateRequest: MemberUpdateRequest,
+        memberUpdateRequest: MemberUpdateDTO,
         conversationId: ConversationId
     ): NetworkResponse<Unit>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
@@ -87,7 +87,7 @@ class ConversationApiImpl(private val httpClient: HttpClient) : ConversationApi 
     }
 
     override suspend fun updateConversationMemberState(
-        memberUpdateRequest: MemberUpdateRequest,
+        memberUpdateRequest: MemberUpdateDTO,
         conversationId: ConversationId,
     ): NetworkResponse<Unit> = wrapKaliumResponse {
         httpClient.put("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}$PATH_SELF") {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -63,12 +63,9 @@ data class ConversationMembersResponse(
 
 @Serializable
 data class ConversationSelfMemberResponse(
-
     @SerialName("qualified_id") override val userId: UserId,
-    @SerialName("otr_muted_ref") val otrMutedReference: String? = null,
-    @SerialName("otr_muted_status") // FIXME
-    @Serializable(with = MutedStatusSerializer::class)
-    val otrMutedStatus: MutedStatus? = null
+    @SerialName("otr_muted_ref") val otrMutedRef: String? = null,
+    @SerialName("otr_muted_status") val otrMutedStatus: MutedStatus? = null
     /*
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed
     // by Wire (i.e., no custom roles can have the same prefix)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -67,7 +67,8 @@ data class ConversationSelfMemberResponse(
     @SerialName("qualified_id") override val userId: UserId,
     @SerialName("otr_muted_ref") val otrMutedReference: String? = null,
     @SerialName("otr_muted_status")
-    val otrMutedStatus: Int? = null
+    @Serializable(with = MutedStatusSerializer::class)
+    val otrMutedStatus: MemberUpdateDTO.MutedStatus? = null
     /*
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed
     // by Wire (i.e., no custom roles can have the same prefix)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -65,7 +65,7 @@ data class ConversationMembersResponse(
 data class ConversationSelfMemberResponse(
     @SerialName("qualified_id") override val userId: UserId,
     @SerialName("otr_muted_ref") val otrMutedRef: String? = null,
-    @SerialName("otr_muted_status") val otrMutedStatus: MutedStatus? = null
+    @SerialName("otr_muted_status") @Serializable(with = MutedStatusSerializer::class) val otrMutedStatus: MutedStatus? = null
     /*
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed
     // by Wire (i.e., no custom roles can have the same prefix)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -34,7 +34,7 @@ data class ConversationResponse(
 
     @SerialName("protocol")
     val protocol: ConvProtocol
-){
+) {
 
     val isOneOnOneConversation: Boolean
         get() = type in setOf(
@@ -65,6 +65,10 @@ data class ConversationMembersResponse(
 data class ConversationSelfMemberResponse(
 
     @SerialName("qualified_id") override val userId: UserId,
+    @SerialName("otr_muted_ref") val otrMutedReference: String? = null,
+    @SerialName("otr_muted_status")
+    @Serializable(with = MutedStatusSerializer::class)
+    val otrMutedStatus: MemberUpdateDTO.MutedStatus? = null
     /*
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed
     // by Wire (i.e., no custom roles can have the same prefix)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -67,8 +67,7 @@ data class ConversationSelfMemberResponse(
     @SerialName("qualified_id") override val userId: UserId,
     @SerialName("otr_muted_ref") val otrMutedReference: String? = null,
     @SerialName("otr_muted_status")
-    @Serializable(with = MutedStatusSerializer::class)
-    val otrMutedStatus: MemberUpdateDTO.MutedStatus? = null
+    val otrMutedStatus: Int? = null
     /*
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed
     // by Wire (i.e., no custom roles can have the same prefix)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -66,9 +66,9 @@ data class ConversationSelfMemberResponse(
 
     @SerialName("qualified_id") override val userId: UserId,
     @SerialName("otr_muted_ref") val otrMutedReference: String? = null,
-    @SerialName("otr_muted_status")
+    @SerialName("otr_muted_status") // FIXME
     @Serializable(with = MutedStatusSerializer::class)
-    val otrMutedStatus: MemberUpdateDTO.MutedStatus? = null
+    val otrMutedStatus: MutedStatus? = null
     /*
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed
     // by Wire (i.e., no custom roles can have the same prefix)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MemberUpdateDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MemberUpdateDTO.kt
@@ -11,33 +11,30 @@ data class MemberUpdateDTO(
     @SerialName("otr_archived_ref") val otrArchivedRef: String? = null,
     @SerialName("otr_muted_ref") val otrMutedRef: String? = null,
     @SerialName("otr_muted_status") @Serializable(with = MutedStatusSerializer::class) val otrMutedStatus: MutedStatus? = null
-) {
+)
 
-    enum class MutedStatus {
-        /**
-         * 0 -> All notifications are displayed
-         */
-        ALL_ALLOWED,
+enum class MutedStatus {
+    /**
+     * 0 -> All notifications are displayed
+     */
+    ALL_ALLOWED,
 
-        /**
-         * 1 -> Only mentions are displayed (normal messages muted)
-         */
-        ONLY_MENTIONS_ALLOWED,
+    /**
+     * 1 -> Only mentions are displayed (normal messages muted)
+     */
+    ONLY_MENTIONS_ALLOWED,
 
-        /**
-         * 2 -> Only normal notifications are displayed (mentions are muted) -- legacy, not used
-         */
-        MENTIONS_MUTED,
+    /**
+     * 2 -> Only normal notifications are displayed (mentions are muted) -- legacy, not used
+     */
+    MENTIONS_MUTED,
 
-        /**
-         * 3 -> No notifications are displayed
-         */
-        ALL_MUTED;
+    /**
+     * 3 -> No notifications are displayed
+     */
+    ALL_MUTED;
 
-        companion object {
-            fun fromOrdinal(ordinal: Int): MutedStatus? = values().firstOrNull { ordinal == it.ordinal }
-        }
+    companion object {
+        fun fromOrdinal(ordinal: Int): MutedStatus? = values().firstOrNull { ordinal == it.ordinal }
     }
 }
-
-

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MemberUpdateDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MemberUpdateDTO.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MemberUpdateRequest(
+data class MemberUpdateDTO(
     @SerialName("hidden") val hidden: Boolean? = null,
     @SerialName("hidden_ref") val hiddenRef: String? = null,
     @SerialName("otr_archived") val otrArchived: Boolean? = null,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MutedStatusSerializer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MutedStatusSerializer.kt
@@ -17,7 +17,6 @@ class MutedStatusSerializer : KSerializer<MutedStatus?> {
         } else {
             encoder.encodeInt(value.ordinal)
         }
-
     }
 
     override fun deserialize(decoder: Decoder): MutedStatus? {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MutedStatusSerializer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MutedStatusSerializer.kt
@@ -7,11 +7,11 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-@Serializer(MemberUpdateRequest.MutedStatus::class)
-class MutedStatusSerializer : KSerializer<MemberUpdateRequest.MutedStatus?> {
+@Serializer(MemberUpdateDTO.MutedStatus::class)
+class MutedStatusSerializer : KSerializer<MemberUpdateDTO.MutedStatus?> {
     override val descriptor = PrimitiveSerialDescriptor("otr_muted_status", PrimitiveKind.INT)
 
-    override fun serialize(encoder: Encoder, value: MemberUpdateRequest.MutedStatus?) {
+    override fun serialize(encoder: Encoder, value: MemberUpdateDTO.MutedStatus?) {
         if (value == null) {
             encoder.encodeNull()
         } else {
@@ -20,8 +20,8 @@ class MutedStatusSerializer : KSerializer<MemberUpdateRequest.MutedStatus?> {
 
     }
 
-    override fun deserialize(decoder: Decoder): MemberUpdateRequest.MutedStatus? {
+    override fun deserialize(decoder: Decoder): MemberUpdateDTO.MutedStatus? {
         val rawValue = decoder.decodeInt()
-        return MemberUpdateRequest.MutedStatus.fromOrdinal(rawValue)
+        return MemberUpdateDTO.MutedStatus.fromOrdinal(rawValue)
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MutedStatusSerializer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/MutedStatusSerializer.kt
@@ -7,11 +7,11 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-@Serializer(MemberUpdateDTO.MutedStatus::class)
-class MutedStatusSerializer : KSerializer<MemberUpdateDTO.MutedStatus?> {
+@Serializer(MutedStatus::class)
+class MutedStatusSerializer : KSerializer<MutedStatus?> {
     override val descriptor = PrimitiveSerialDescriptor("otr_muted_status", PrimitiveKind.INT)
 
-    override fun serialize(encoder: Encoder, value: MemberUpdateDTO.MutedStatus?) {
+    override fun serialize(encoder: Encoder, value: MutedStatus?) {
         if (value == null) {
             encoder.encodeNull()
         } else {
@@ -20,8 +20,8 @@ class MutedStatusSerializer : KSerializer<MemberUpdateDTO.MutedStatus?> {
 
     }
 
-    override fun deserialize(decoder: Decoder): MemberUpdateDTO.MutedStatus? {
+    override fun deserialize(decoder: Decoder): MutedStatus? {
         val rawValue = decoder.decodeInt()
-        return MemberUpdateDTO.MutedStatus.fromOrdinal(rawValue)
+        return MutedStatus.fromOrdinal(rawValue)
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -55,7 +55,7 @@ object ConversationResponseJson {
                 ConversationSelfMemberResponse(
                     QualifiedIDSamples.one,
                     "2022-04-11T14:15:48.044Z",
-                    1
+                    MemberUpdateDTO.MutedStatus.ALL_MUTED
                 ),
                 listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
             ),

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -53,8 +53,9 @@ object ConversationResponseJson {
             "fdf23116-42a5-472c-8316-e10655f5d11e",
             ConversationMembersResponse(
                 ConversationSelfMemberResponse(
-                    QualifiedIDSamples.one, "2022-04-11T14:15:48.044Z",
-                    MemberUpdateDTO.MutedStatus.ALL_ALLOWED
+                    QualifiedIDSamples.one,
+                    "2022-04-11T14:15:48.044Z",
+                    1
                 ),
                 listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
             ),

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -7,7 +7,7 @@ import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
-import com.wire.kalium.network.api.conversation.MemberUpdateDTO
+import com.wire.kalium.network.api.conversation.MutedStatus
 
 object ConversationResponseJson {
 
@@ -55,7 +55,7 @@ object ConversationResponseJson {
                 ConversationSelfMemberResponse(
                     QualifiedIDSamples.one,
                     "2022-04-11T14:15:48.044Z",
-                    MemberUpdateDTO.MutedStatus.ALL_MUTED
+                    MutedStatus.ALL_MUTED
                 ),
                 listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
             ),

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -31,8 +31,8 @@ object ConversationResponseJson {
         |               "domain": "${it.members.self.userId.domain}",
         |               "id": "${it.members.self.userId.value}"
         |           },
-        |           "otr_muted_ref": "${it.members.self.otrMutedRef}",
-        |           "otr_muted_status": ${it.members.self.otrMutedStatus}
+        |           "otr_muted_ref": "2022-04-11T14:15:48.044Z",
+        |           "otr_muted_status": 0
         |       }
         |   },
         |   "message_timer": ${it.messageTimer},
@@ -53,9 +53,7 @@ object ConversationResponseJson {
             "fdf23116-42a5-472c-8316-e10655f5d11e",
             ConversationMembersResponse(
                 ConversationSelfMemberResponse(
-                    QualifiedIDSamples.one,
-                    "2022-04-11T14:15:48.044Z",
-                    MutedStatus.ALL_MUTED
+                    QualifiedIDSamples.one
                 ),
                 listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
             ),

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
+import com.wire.kalium.network.api.conversation.MemberUpdateDTO
 
 object ConversationResponseJson {
 
@@ -29,7 +30,9 @@ object ConversationResponseJson {
         |           "qualified_id": {
         |               "domain": "${it.members.self.userId.domain}",
         |               "id": "${it.members.self.userId.value}"
-        |           }
+        |           },
+        |           "otr_muted_ref": "${it.members.self.otrMutedReference}",
+        |           "otr_muted_status": ${it.members.self.otrMutedStatus}
         |       }
         |   },
         |   "message_timer": ${it.messageTimer},
@@ -49,7 +52,10 @@ object ConversationResponseJson {
         ConversationResponse(
             "fdf23116-42a5-472c-8316-e10655f5d11e",
             ConversationMembersResponse(
-                ConversationSelfMemberResponse(QualifiedIDSamples.one),
+                ConversationSelfMemberResponse(
+                    QualifiedIDSamples.one, "2022-04-11T14:15:48.044Z",
+                    MemberUpdateDTO.MutedStatus.ALL_ALLOWED
+                ),
                 listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
             ),
             "group name",

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -31,7 +31,7 @@ object ConversationResponseJson {
         |               "domain": "${it.members.self.userId.domain}",
         |               "id": "${it.members.self.userId.value}"
         |           },
-        |           "otr_muted_ref": "${it.members.self.otrMutedReference}",
+        |           "otr_muted_ref": "${it.members.self.otrMutedRef}",
         |           "otr_muted_status": ${it.members.self.otrMutedStatus}
         |       }
         |   },

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/MemberUpdateRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/MemberUpdateRequestJson.kt
@@ -1,13 +1,13 @@
 package com.wire.kalium.api.tools.json.api.conversation
 
 import com.wire.kalium.api.tools.json.ValidJsonProvider
-import com.wire.kalium.network.api.conversation.MemberUpdateRequest
+import com.wire.kalium.network.api.conversation.MemberUpdateDTO
 
 object MemberUpdateRequestJson {
 
     val valid = ValidJsonProvider(
-        MemberUpdateRequest(
-            null, null, null, null, "2022-04-11T14:15:48.044Z", MemberUpdateRequest.MutedStatus.ALL_ALLOWED
+        MemberUpdateDTO(
+            null, null, null, null, "2022-04-11T14:15:48.044Z", MemberUpdateDTO.MutedStatus.ALL_ALLOWED
         )
     ) {
         """

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/MemberUpdateRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/MemberUpdateRequestJson.kt
@@ -2,12 +2,13 @@ package com.wire.kalium.api.tools.json.api.conversation
 
 import com.wire.kalium.api.tools.json.ValidJsonProvider
 import com.wire.kalium.network.api.conversation.MemberUpdateDTO
+import com.wire.kalium.network.api.conversation.MutedStatus
 
 object MemberUpdateRequestJson {
 
     val valid = ValidJsonProvider(
         MemberUpdateDTO(
-            null, null, null, null, "2022-04-11T14:15:48.044Z", MemberUpdateDTO.MutedStatus.ALL_ALLOWED
+            null, null, null, null, "2022-04-11T14:15:48.044Z", MutedStatus.ALL_ALLOWED
         )
     ) {
         """

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -56,6 +56,7 @@ class ConversationDAOImpl(
 
     override suspend fun insertConversations(conversationEntities: List<ConversationEntity>) {
         conversationQueries.transaction {
+
             for (conversationEntity: ConversationEntity in conversationEntities) {
                 nonSuspendingInsertConversation(conversationEntity)
             }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -56,7 +56,6 @@ class ConversationDAOImpl(
 
     override suspend fun insertConversations(conversationEntities: List<ConversationEntity>) {
         conversationQueries.transaction {
-
             for (conversationEntity: ConversationEntity in conversationEntities) {
                 nonSuspendingInsertConversation(conversationEntity)
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Additional PR that allows the mapping for the muting status in a conversation, when fetching/syncing.

- Epic: #405 

- JIRA Ticket: https://wearezeta.atlassian.net/browse/AR-1446
- More info at: https://wearezeta.atlassian.net/wiki/spaces/PROD/pages/1705328/Notifications

### Issues
In this PR, we are adding the missing mapping from the conversation details muted status, so we can get it and display it on Android Reloaded

### Solutions

Since the field creation on the Conversation table was already done in a previous PR #405 Here we are only mapping/persisting when the sync is performed

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
