### PR TITLE
feat: support client register with optional password

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
@@ -1,14 +1,18 @@
 package com.wire.kalium.logic.data.client
 
+import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.location.Location
-import com.wire.kalium.cryptography.PreKeyCrypto
 
 data class RegisterClientParam(
-    val password: String,
+    val password: String?,
     val preKeys: List<PreKeyCrypto>,
     val lastKey: PreKeyCrypto,
-    val capabilities: List<ClientCapability>?
+    val deviceType: DeviceType?,
+    //val type: ClientType,
+    val label: String?,
+    val capabilities: List<ClientCapability>?,
+    val model: String?
 )
 
 data class DeleteClientParam(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -92,7 +92,10 @@ class RegisterClientUseCaseImpl(
                     password = password,
                     capabilities = capabilities,
                     preKeys = preKeys,
-                    lastKey = lastKey
+                    lastKey = lastKey,
+                    deviceType = null,
+                    label = null,
+                    model = null
                 )
             )
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -267,7 +267,9 @@ class ClientRepositoryTest {
     }
 
     private companion object {
-        val REGISTER_CLIENT_PARAMS = RegisterClientParam("pass", listOf(), PreKeyCrypto(2, "2"), listOf())
+        val REGISTER_CLIENT_PARAMS = RegisterClientParam(
+            "pass", listOf(), PreKeyCrypto(2, "2"), null, null, listOf(), null
+        )
         val CLIENT_ID = TestClient.CLIENT_ID
         val CLIENT_RESULT = TestClient.CLIENT
         val TEST_FAILURE = NetworkFailure.ServerMiscommunication(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -169,7 +169,7 @@ class RegisterClientUseCaseTest {
         given(MLS_CLIENT)
             .function(MLS_CLIENT::getPublicKey)
             .whenInvoked()
-            .thenReturn( MLS_PUBLIC_KEY )
+            .thenReturn(MLS_PUBLIC_KEY)
 
         given(clientRepository)
             .suspendFunction(clientRepository::registerMLSClient)
@@ -200,7 +200,7 @@ class RegisterClientUseCaseTest {
         given(MLS_CLIENT)
             .function(MLS_CLIENT::getPublicKey)
             .whenInvoked()
-            .thenReturn( MLS_PUBLIC_KEY )
+            .thenReturn(MLS_PUBLIC_KEY)
 
         given(clientRepository)
             .suspendFunction(clientRepository::registerMLSClient)
@@ -210,7 +210,7 @@ class RegisterClientUseCaseTest {
         given(keyPackageRepository)
             .suspendFunction(keyPackageRepository::uploadNewKeyPackages)
             .whenInvokedWith(anything(), eq(100))
-            .thenReturn( Either.Left(TEST_FAILURE))
+            .thenReturn(Either.Left(TEST_FAILURE))
 
         registerClient(TEST_PASSWORD, TEST_CAPABILITIES)
 
@@ -236,7 +236,7 @@ class RegisterClientUseCaseTest {
         given(MLS_CLIENT)
             .function(MLS_CLIENT::getPublicKey)
             .whenInvoked()
-            .thenReturn( MLS_PUBLIC_KEY )
+            .thenReturn(MLS_PUBLIC_KEY)
 
         given(clientRepository)
             .suspendFunction(clientRepository::registerMLSClient)
@@ -246,7 +246,7 @@ class RegisterClientUseCaseTest {
         given(keyPackageRepository)
             .suspendFunction(keyPackageRepository::uploadNewKeyPackages)
             .whenInvokedWith(anything(), eq(100))
-            .thenReturn( Either.Right(Unit))
+            .thenReturn(Either.Right(Unit))
 
         given(clientRepository)
             .suspendFunction(clientRepository::persistClientId)
@@ -276,7 +276,7 @@ class RegisterClientUseCaseTest {
         given(MLS_CLIENT)
             .function(MLS_CLIENT::getPublicKey)
             .whenInvoked()
-            .thenReturn( MLS_PUBLIC_KEY )
+            .thenReturn(MLS_PUBLIC_KEY)
 
         given(clientRepository)
             .suspendFunction(clientRepository::registerMLSClient)
@@ -286,7 +286,7 @@ class RegisterClientUseCaseTest {
         given(keyPackageRepository)
             .suspendFunction(keyPackageRepository::uploadNewKeyPackages)
             .whenInvokedWith(anything(), eq(100))
-            .thenReturn( Either.Right(Unit))
+            .thenReturn(Either.Right(Unit))
 
         val persistFailure = TEST_FAILURE
         given(clientRepository)
@@ -316,7 +316,7 @@ class RegisterClientUseCaseTest {
         given(MLS_CLIENT)
             .function(MLS_CLIENT::getPublicKey)
             .whenInvoked()
-            .thenReturn( MLS_PUBLIC_KEY )
+            .thenReturn(MLS_PUBLIC_KEY)
 
         given(clientRepository)
             .suspendFunction(clientRepository::registerMLSClient)
@@ -326,7 +326,7 @@ class RegisterClientUseCaseTest {
         given(keyPackageRepository)
             .suspendFunction(keyPackageRepository::uploadNewKeyPackages)
             .whenInvokedWith(anything(), eq(100))
-            .thenReturn( Either.Right(Unit))
+            .thenReturn(Either.Right(Unit))
 
         given(clientRepository)
             .suspendFunction(clientRepository::persistClientId)
@@ -382,7 +382,10 @@ class RegisterClientUseCaseTest {
             password = TEST_PASSWORD,
             preKeys = PRE_KEYS,
             lastKey = LAST_KEY,
-            capabilities = TEST_CAPABILITIES
+            capabilities = TEST_CAPABILITIES,
+            deviceType = null,
+            label = null,
+            model = null
         )
         val CLIENT = TestClient.CLIENT
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientRequest.kt
@@ -8,14 +8,14 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RegisterClientRequest(
-    @SerialName("password") val password: String,
+    @SerialName("password") val password: String?,
     @SerialName("prekeys") val preKeys: List<PreKeyDTO>,
     @SerialName("lastkey") val lastKey: PreKeyDTO,
-    @SerialName("class") val deviceType: DeviceTypeDTO,
+    @SerialName("class") val deviceType: DeviceTypeDTO?,
     @SerialName("type") val type: ClientTypeDTO, // 'temporary', 'permanent', 'legalhold'
-    @SerialName("label") val label: String,
+    @SerialName("label") val label: String?,
     @SerialName("capabilities") val capabilities: List<ClientCapabilityDTO>?,
-    @SerialName("model") val model: String
+    @SerialName("model") val model: String?
 )
 
 @Serializable


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In kalium the password is mandatory to register client, but it's not in swagger

### Solutions

password is now optional

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

- [x] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
