### PR TITLE
chore: Rename OngoingCallsUseCase to IncomingCallsUseCase

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -20,12 +20,10 @@ interface CallManager {
 
 expect class CallManagerImpl : CallManager
 
-val CallManager.ongoingCalls get() = allCalls.map {
+val CallManager.incomingCalls get() = allCalls.map {
     it.filter { call ->
         call.status in listOf(
-            CallStatus.INCOMING,
-            CallStatus.ANSWERED,
-            CallStatus.ESTABLISHED
+            CallStatus.INCOMING
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -1,8 +1,8 @@
 package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.GetOngoingCallsUseCase
-import com.wire.kalium.logic.feature.call.usecase.GetOngoingCallsUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
@@ -14,8 +14,8 @@ class CallsScope(
     private val syncManager: SyncManager
 ) {
 
-    val getOngoingCalls: GetOngoingCallsUseCase
-        get() = GetOngoingCallsUseCaseImpl(
+    val getIncomingCalls: GetIncomingCallsUseCase
+        get() = GetIncomingCallsUseCaseImpl(
         callManager = callManager,
         syncManager = syncManager
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -2,20 +2,21 @@ package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.incomingCalls
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.Flow
 
-interface GetOngoingCallsUseCase {
+interface GetIncomingCallsUseCase {
     suspend operator fun invoke(): Flow<List<Call>>
 }
 
-internal class GetOngoingCallsUseCaseImpl(
+internal class GetIncomingCallsUseCaseImpl(
     private val callManager: CallManager,
     private val syncManager: SyncManager
-) : GetOngoingCallsUseCase {
+) : GetIncomingCallsUseCase {
 
     override suspend operator fun invoke(): Flow<List<Call>> {
         syncManager.waitForSlowSyncToComplete()
-        return callManager.allCalls
+        return callManager.incomingCalls
     }
 }


### PR DESCRIPTION
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently there was no real use of ongoing calls and thus renaming it to be correctly used as IncomingCalls

### Solutions

Renamed the usecase to `IncomingCallsUseCase`