### PR TITLE
feat: add usecase for getting ongoingCall

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -10,7 +10,13 @@ import kotlinx.coroutines.flow.map
 
 interface CallManager {
     suspend fun onCallingMessageReceived(message: Message, content: MessageContent.Calling)
-    suspend fun startCall(conversationId: ConversationId, callType: CallType, conversationType: ConversationType, isAudioCbr: Boolean = false) //TODO Audio CBR
+    suspend fun startCall(
+        conversationId: ConversationId,
+        callType: CallType,
+        conversationType: ConversationType,
+        isAudioCbr: Boolean = false
+    ) //TODO Audio CBR
+
     suspend fun answerCall(conversationId: ConversationId)
     suspend fun endCall(conversationId: ConversationId)
     suspend fun rejectCall(conversationId: ConversationId)
@@ -20,10 +26,16 @@ interface CallManager {
 
 expect class CallManagerImpl : CallManager
 
-val CallManager.incomingCalls get() = allCalls.map {
-    it.filter { call ->
-        call.status in listOf(
-            CallStatus.INCOMING
-        )
+val CallManager.incomingCalls
+    get() = allCalls.map {
+        it.filter { call ->
+            call.status in listOf(
+                CallStatus.INCOMING
+            )
+        }
     }
-}
+
+val CallManager.ongoingCall
+    get() = allCalls.map {
+        it.filter { call -> call.status == CallStatus.ESTABLISHED }
+    }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.call
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.GetOngoingCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
@@ -14,11 +15,17 @@ class CallsScope(
     private val syncManager: SyncManager
 ) {
 
+    val onGoingCall: GetOngoingCallUseCase
+        get() = GetOngoingCallUseCase(
+            callManager = callManager,
+            syncManager = syncManager
+        )
+
     val getIncomingCalls: GetIncomingCallsUseCase
         get() = GetIncomingCallsUseCaseImpl(
-        callManager = callManager,
-        syncManager = syncManager
-    )
+            callManager = callManager,
+            syncManager = syncManager
+        )
 
     val startCall: StartCallUseCase get() = StartCallUseCase(callManager)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetOngoingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetOngoingCallsUseCase.kt
@@ -1,0 +1,17 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.ongoingCall
+import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.coroutines.flow.Flow
+
+class GetOngoingCallUseCase(
+    private val callManager: CallManager,
+    private val syncManager: SyncManager
+) {
+    suspend operator fun invoke(): Flow<List<Call>> {
+        syncManager.waitForSlowSyncToComplete()
+        return callManager.ongoingCall
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need a useCase for getting the active call.

### Solutions

Create a new usecase.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing


### Notes (Optional)

This call is considered active when it's established with another client.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
