### PR TITLE
refactor: remove suspend modifier from DAOs

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -1,6 +1,5 @@
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
 import com.wire.kalium.persistence.dao.ConversationEntity;
-import kotlin.Int;
 
 CREATE TABLE Conversation (
     qualified_id TEXT AS QualifiedIDEntity NOT NULL PRIMARY KEY,
@@ -46,3 +45,6 @@ updateConversationMutingStatus:
 UPDATE Conversation
 SET muted_status = ?, muted_time = ?
 WHERE qualified_id = ?;
+
+selectConversationByType:
+SELECT * FROM Conversation WHERE type = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -31,25 +31,27 @@ data class Member(
 )
 
 interface ConversationDAO {
-    suspend fun getSelfConversationId(): QualifiedIDEntity
-    suspend fun insertConversation(conversationEntity: ConversationEntity)
-    suspend fun insertConversations(conversationEntities: List<ConversationEntity>)
-    suspend fun updateConversation(conversationEntity: ConversationEntity)
-    suspend fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String)
-    suspend fun getAllConversations(): Flow<List<ConversationEntity>>
-    suspend fun getConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
-    suspend fun getConversationByGroupID(groupID: String): Flow<ConversationEntity?>
-    suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity)
-    suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity)
-    suspend fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity)
-    suspend fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity)
-    suspend fun getAllMembers(qualifiedID: QualifiedIDEntity): Flow<List<Member>>
-    suspend fun insertOrUpdateOneOnOneMemberWithConnectionStatus(
+    fun getSelfConversationId(): QualifiedIDEntity?
+    fun insertConversation(conversationEntity: ConversationEntity)
+    fun insertConversations(conversationEntities: List<ConversationEntity>)
+    fun updateConversation(conversationEntity: ConversationEntity)
+    fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String)
+    fun getAllConversationsFlow(): Flow<List<ConversationEntity>>
+    fun getConversationByQualifiedIDFlow(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
+    fun getConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity?
+    fun getConversationByGroupID(groupID: String): ConversationEntity?
+    fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity)
+    fun insertMember(member: Member, conversationID: QualifiedIDEntity)
+    fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity)
+    fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity)
+    fun getAllMembersFlow(qualifiedID: QualifiedIDEntity): Flow<List<Member>>
+    fun getAllMembers(qualifiedID: QualifiedIDEntity): List<Member>
+    fun insertOrUpdateOneOnOneMemberWithConnectionStatus(
         userId: UserIDEntity,
         status: UserEntity.ConnectionState,
         conversationID: QualifiedIDEntity
     )
-    suspend fun updateConversationMutedStatus(
+    fun updateConversationMutedStatus(
         conversationId: QualifiedIDEntity,
         mutedStatus: ConversationEntity.MutedStatus,
         mutedStatusTimestamp: Long

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -7,7 +7,6 @@ import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MembersQueries
 import com.wire.kalium.persistence.UsersQueries
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import com.wire.kalium.persistence.Conversation as SQLDelightConversation
 import com.wire.kalium.persistence.Member as SQLDelightMember
@@ -48,15 +47,15 @@ class ConversationDAOImpl(
     private val memberMapper = MemberMapper()
     private val conversationMapper = ConversationMapper()
 
-    override suspend fun getSelfConversationId() = getAllConversations().first().first { it.type == ConversationEntity.Type.SELF }.id
+    override fun getSelfConversationId() =
+        conversationQueries.selectConversationByType(ConversationEntity.Type.SELF).executeAsOneOrNull()?.qualified_id
 
-    override suspend fun insertConversation(conversationEntity: ConversationEntity) {
+    override fun insertConversation(conversationEntity: ConversationEntity) {
         nonSuspendingInsertConversation(conversationEntity)
     }
 
-    override suspend fun insertConversations(conversationEntities: List<ConversationEntity>) {
+    override fun insertConversations(conversationEntities: List<ConversationEntity>) {
         conversationQueries.transaction {
-
             for (conversationEntity: ConversationEntity in conversationEntities) {
                 nonSuspendingInsertConversation(conversationEntity)
             }
@@ -77,7 +76,7 @@ class ConversationDAOImpl(
         )
     }
 
-    override suspend fun updateConversation(conversationEntity: ConversationEntity) {
+    override fun updateConversation(conversationEntity: ConversationEntity) {
         conversationQueries.updateConversation(
             conversationEntity.name,
             conversationEntity.type,
@@ -86,53 +85,51 @@ class ConversationDAOImpl(
         )
     }
 
-    override suspend fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String) {
+    override fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String) {
         conversationQueries.updateConversationGroupState(groupState, groupId)
     }
 
-    override suspend fun getAllConversations(): Flow<List<ConversationEntity>> {
+    override fun getAllConversationsFlow(): Flow<List<ConversationEntity>> {
         return conversationQueries.selectAllConversations()
             .asFlow()
             .mapToList()
             .map { it.map(conversationMapper::toModel) }
     }
 
-    override suspend fun getConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?> {
+    override fun getConversationByQualifiedIDFlow(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?> {
         return conversationQueries.selectByQualifiedId(qualifiedID)
             .asFlow()
             .mapToOneOrNull()
             .map { it?.let { conversationMapper.toModel(it) } }
     }
 
-    override suspend fun getConversationByGroupID(groupID: String): Flow<ConversationEntity?> {
-        return conversationQueries.selectByGroupId(groupID)
-            .asFlow()
-            .mapToOneOrNull()
-            .map { it?.let { conversationMapper.toModel(it) } }
-    }
+    override fun getConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity? =
+        conversationQueries.selectByQualifiedId(qualifiedID).executeAsOneOrNull()?.let { conversationMapper.toModel(it) }
 
-    override suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity) {
+    override fun getConversationByGroupID(groupID: String): ConversationEntity? =
+        conversationQueries.selectByGroupId(groupID).executeAsOneOrNull()?.let { conversationMapper.toModel(it) }
+
+    override fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity) {
         conversationQueries.deleteConversation(qualifiedID)
     }
 
-    override suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity) {
+    override fun insertMember(member: Member, conversationID: QualifiedIDEntity) {
         memberQueries.transaction {
             userQueries.insertOrIgnoreUserId(member.user)
             memberQueries.insertMember(member.user, conversationID)
         }
     }
 
-    override suspend fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity) {
+    override fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity) {
         memberQueries.transaction {
             for (member: Member in memberList) {
                 userQueries.insertOrIgnoreUserId(member.user)
                 memberQueries.insertMember(member.user, conversationID)
             }
         }
-
     }
 
-    override suspend fun insertOrUpdateOneOnOneMemberWithConnectionStatus(
+    override fun insertOrUpdateOneOnOneMemberWithConnectionStatus(
         userId: UserIDEntity,
         status: UserEntity.ConnectionState,
         conversationID: QualifiedIDEntity
@@ -143,18 +140,21 @@ class ConversationDAOImpl(
         }
     }
 
-    override suspend fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity) {
+    override fun deleteMemberByQualifiedID(conversationID: QualifiedIDEntity, userID: QualifiedIDEntity) {
         memberQueries.deleteMember(conversationID, userID)
     }
 
-    override suspend fun getAllMembers(qualifiedID: QualifiedIDEntity): Flow<List<Member>> {
+    override fun getAllMembersFlow(qualifiedID: QualifiedIDEntity): Flow<List<Member>> {
         return memberQueries.selectAllMembersByConversation(qualifiedID)
             .asFlow()
             .mapToList()
             .map { it.map(memberMapper::toModel) }
     }
 
-    override suspend fun updateConversationMutedStatus(
+    override fun getAllMembers(qualifiedID: QualifiedIDEntity): List<Member> =
+        memberQueries.selectAllMembersByConversation(qualifiedID).executeAsList().map(memberMapper::toModel)
+
+    override fun updateConversationMutedStatus(
         conversationId: QualifiedIDEntity,
         mutedStatus: ConversationEntity.MutedStatus,
         mutedStatusTimestamp: Long

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAO.kt
@@ -1,8 +1,6 @@
 package com.wire.kalium.persistence.dao
 
-import kotlinx.coroutines.flow.Flow
-
 interface MetadataDAO {
-    suspend fun insertValue(value: String, key: String)
-    suspend fun valueByKey(key: String): Flow<String?>
+    fun insertValue(value: String, key: String)
+    fun valueByKey(key: String): String?
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
@@ -1,18 +1,11 @@
 package com.wire.kalium.persistence.dao
 
-import com.squareup.sqldelight.runtime.coroutines.asFlow
-import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.MetadataQueries
-import kotlinx.coroutines.flow.Flow
 
 // TODO: suggestion implement with preference
 class MetadataDAOImpl(private val metadataQueries: MetadataQueries): MetadataDAO {
 
-    override suspend fun insertValue(value: String, key: String) {
-        metadataQueries.insertValue(key, value)
-    }
+    override fun insertValue(value: String, key: String) = metadataQueries.insertValue(key, value)
 
-    override suspend fun valueByKey(key: String): Flow<String?> {
-        return metadataQueries.selectValueByKey(key).asFlow().mapToOneOrNull()
-    }
+    override fun valueByKey(key: String): String? = metadataQueries.selectValueByKey(key).executeAsOneOrNull()
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/TeamDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/TeamDAO.kt
@@ -1,14 +1,12 @@
 package com.wire.kalium.persistence.dao
 
-import kotlinx.coroutines.flow.Flow
-
 data class TeamEntity(
     val id: String,
     val name: String?
 )
 
 interface TeamDAO {
-    suspend fun insertTeam(team: TeamEntity)
-    suspend fun insertTeams(teams: List<TeamEntity>)
-    suspend fun getTeamById(teamId: String): Flow<TeamEntity?>
+    fun insertTeam(team: TeamEntity)
+    fun insertTeams(teams: List<TeamEntity>)
+    fun getTeamById(teamId: String): TeamEntity?
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/TeamDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/TeamDAOImpl.kt
@@ -1,9 +1,6 @@
 package com.wire.kalium.persistence.dao
 
-import com.squareup.sqldelight.runtime.coroutines.asFlow
-import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.TeamsQueries
-import kotlinx.coroutines.flow.map
 import com.wire.kalium.persistence.Team as SQLDelightTeam
 
 class TeamMapper {
@@ -19,12 +16,12 @@ class TeamDAOImpl(private val queries: TeamsQueries) : TeamDAO {
 
     val mapper = TeamMapper()
 
-    override suspend fun insertTeam(team: TeamEntity) = queries.insertTeam(
+    override fun insertTeam(team: TeamEntity) = queries.insertTeam(
         id = team.id,
         name = team.name
     )
 
-    override suspend fun insertTeams(teams: List<TeamEntity>) = queries.transaction {
+    override fun insertTeams(teams: List<TeamEntity>) = queries.transaction {
         for (team: TeamEntity in teams) {
             queries.insertTeam(
                 id = team.id,
@@ -33,8 +30,5 @@ class TeamDAOImpl(private val queries: TeamsQueries) : TeamDAO {
         }
     }
 
-    override suspend fun getTeamById(teamId: String) = queries.selectTeamById(id = teamId)
-        .asFlow()
-        .mapToOneOrNull()
-        .map { it?.let { mapper.toModel(team = it) } }
+    override fun getTeamById(teamId: String): TeamEntity? = queries.selectTeamById(teamId).executeAsOneOrNull()?.let { mapper.toModel(it) }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -53,12 +53,14 @@ data class UserEntity(
 internal typealias UserAssetIdEntity = String
 
 interface UserDAO {
-    suspend fun insertUser(user: UserEntity)
-    suspend fun insertUsers(users: List<UserEntity>)
-    suspend fun updateUser(user: UserEntity)
-    suspend fun getAllUsers(): Flow<List<UserEntity>>
-    suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?>
-    suspend fun getUserByNameOrHandleOrEmail(searchQuery: String): Flow<List<UserEntity>>
-    suspend fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity)
-    suspend fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String)
+    fun insertUser(user: UserEntity)
+    fun insertUsers(users: List<UserEntity>)
+    fun updateUser(user: UserEntity)
+    fun getAllUsersFlow(): Flow<List<UserEntity>>
+    fun getAllUsers(): List<UserEntity>
+    fun getUserByQualifiedIDFlow(qualifiedID: QualifiedIDEntity): Flow<UserEntity?>
+    fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntity?
+    fun getUserByNameOrHandleOrEmailFlow(searchQuery: String): Flow<List<UserEntity>>
+    fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity)
+    fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -29,7 +29,7 @@ class UserDAOImpl(private val queries: UsersQueries) : UserDAO {
 
     val mapper = UserMapper()
 
-    override suspend fun insertUser(user: UserEntity) {
+    override fun insertUser(user: UserEntity) {
         queries.insertUser(
             user.id,
             user.name,
@@ -44,7 +44,7 @@ class UserDAOImpl(private val queries: UsersQueries) : UserDAO {
         )
     }
 
-    override suspend fun insertUsers(users: List<UserEntity>) {
+    override fun insertUsers(users: List<UserEntity>) {
         queries.transaction {
             for (user: UserEntity in users) {
                 queries.insertUser(
@@ -63,34 +63,40 @@ class UserDAOImpl(private val queries: UsersQueries) : UserDAO {
         }
     }
 
-    override suspend fun updateUser(user: UserEntity) {
+    override fun updateUser(user: UserEntity) =
         queries.updateUser(user.name, user.handle, user.email, user.accentId, user.previewAssetId, user.completeAssetId, user.id)
-    }
 
-    override suspend fun getAllUsers(): Flow<List<UserEntity>> = queries.selectAllUsers()
+
+    override fun getAllUsersFlow(): Flow<List<UserEntity>> = queries.selectAllUsers()
         .asFlow()
         .mapToList()
         .map { entryList -> entryList.map(mapper::toModel) }
 
-    override suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?> {
+    override fun getAllUsers(): List<UserEntity> =
+        queries.selectAllUsers().executeAsList().map(mapper::toModel)
+
+    override fun getUserByQualifiedIDFlow(qualifiedID: QualifiedIDEntity): Flow<UserEntity?> {
         return queries.selectByQualifiedId(qualifiedID)
             .asFlow()
             .mapToOneOrNull()
             .map { it?.let { mapper.toModel(it) } }
     }
 
-    override suspend fun getUserByNameOrHandleOrEmail(searchQuery: String): Flow<List<UserEntity>> {
+    override fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntity? =
+        queries.selectByQualifiedId(qualifiedID).executeAsOneOrNull()?.let { mapper.toModel(it) }
+
+    override fun getUserByNameOrHandleOrEmailFlow(searchQuery: String): Flow<List<UserEntity>> {
         return queries.selectByNameOrHandleOrEmail(searchQuery)
             .asFlow()
             .mapToList()
             .map { entryList -> entryList.map(mapper::toModel) }
     }
 
-    override suspend fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity) {
+    override fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity) {
         queries.deleteUser(qualifiedID)
     }
 
-    override suspend fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String) {
+    override fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String) {
         queries.updateUserhandle(handle, qualifiedID)
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/asset/AssetDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/asset/AssetDAO.kt
@@ -1,7 +1,5 @@
 package com.wire.kalium.persistence.dao.asset
 
-import kotlinx.coroutines.flow.Flow
-
 data class AssetEntity(
     val key: String,
     val domain: String,
@@ -36,8 +34,8 @@ data class AssetEntity(
 }
 
 interface AssetDAO {
-    suspend fun insertAsset(assetEntity: AssetEntity)
-    suspend fun insertAssets(assetsEntity: List<AssetEntity>)
-    suspend fun getAssetByKey(assetKey: String): Flow<AssetEntity?>
-    suspend fun updateAsset(assetEntity: AssetEntity)
+    fun insertAsset(assetEntity: AssetEntity)
+    fun insertAssets(assetsEntity: List<AssetEntity>)
+    fun getAssetByKey(assetKey: String): AssetEntity?
+    fun updateAsset(assetEntity: AssetEntity)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/asset/AssetDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/asset/AssetDAOImpl.kt
@@ -1,10 +1,6 @@
 package com.wire.kalium.persistence.dao.asset
 
-import com.squareup.sqldelight.runtime.coroutines.asFlow
-import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.AssetsQueries
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import com.wire.kalium.persistence.Asset as SQLDelightAsset
 
 class AssetMapper {
@@ -23,7 +19,7 @@ class AssetDAOImpl(private val queries: AssetsQueries) : AssetDAO {
 
     val mapper by lazy { AssetMapper() }
 
-    override suspend fun insertAsset(assetEntity: AssetEntity) {
+    override fun insertAsset(assetEntity: AssetEntity) {
         queries.insertAsset(
             assetEntity.key,
             assetEntity.domain,
@@ -33,7 +29,7 @@ class AssetDAOImpl(private val queries: AssetsQueries) : AssetDAO {
         )
     }
 
-    override suspend fun insertAssets(assetsEntity: List<AssetEntity>) {
+    override fun insertAssets(assetsEntity: List<AssetEntity>) {
         queries.transaction {
             assetsEntity.forEach { asset ->
                 queries.insertAsset(
@@ -47,18 +43,10 @@ class AssetDAOImpl(private val queries: AssetsQueries) : AssetDAO {
         }
     }
 
-    override suspend fun getAssetByKey(assetKey: String): Flow<AssetEntity?> {
-        return queries.selectByKey(assetKey)
-            .asFlow()
-            .mapToOneOrNull()
-            .map {
-                it?.let {
-                    return@map mapper.toModel(it)
-                }
-            }
-    }
+    override fun getAssetByKey(assetKey: String): AssetEntity? =
+        queries.selectByKey(assetKey).executeAsOneOrNull()?.let { mapper.toModel(it) }
 
-    override suspend fun updateAsset(assetEntity: AssetEntity) {
+    override fun updateAsset(assetEntity: AssetEntity) {
         queries.updateAsset(assetEntity.downloadedDate, assetEntity.rawData, assetEntity.mimeType, assetEntity.key)
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
@@ -1,7 +1,6 @@
 package com.wire.kalium.persistence.dao.client
 
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
-import kotlinx.coroutines.flow.Flow
 
 data class Client(
     val userId: QualifiedIDEntity,
@@ -9,9 +8,9 @@ data class Client(
 )
 
 interface ClientDAO {
-    suspend fun insertClient(client: Client)
-    suspend fun insertClients(clients: List<Client>)
-    suspend fun getClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<List<Client>>
-    suspend fun deleteClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity)
-    suspend fun deleteClient(userId: QualifiedIDEntity, clientId: String)
+    fun insertClient(client: Client)
+    fun insertClients(clients: List<Client>)
+    fun getClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): List<Client>
+    fun deleteClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity)
+    fun deleteClient(userId: QualifiedIDEntity, clientId: String)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -1,11 +1,7 @@
 package com.wire.kalium.persistence.dao.client
 
-import com.squareup.sqldelight.runtime.coroutines.asFlow
-import com.squareup.sqldelight.runtime.coroutines.mapToList
 import com.wire.kalium.persistence.ClientsQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import com.wire.kalium.persistence.Client as SQLDelightClient
 
 internal class ClientMapper {
@@ -15,25 +11,20 @@ internal class ClientMapper {
 internal class ClientDAOImpl(private val clientsQueries: ClientsQueries) : ClientDAO {
     val mapper = ClientMapper()
 
-    override suspend fun insertClient(client: Client): Unit =
+    override fun insertClient(client: Client): Unit =
         clientsQueries.insertClient(client.userId, client.id)
 
-    override suspend fun insertClients(clients: List<Client>) = clientsQueries.transaction {
+    override fun insertClients(clients: List<Client>) = clientsQueries.transaction {
         clients.forEach { client ->
             clientsQueries.insertClient(client.userId, client.id)
         }
     }
 
-    override suspend fun getClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<List<Client>> =
-        clientsQueries.selectAllClientsByUserId(qualifiedID)
-            .asFlow()
-            .mapToList()
-            .map { listOfEntries ->
-                listOfEntries.map(mapper::toModel)
-            }
+    override fun getClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): List<Client> =
+        clientsQueries.selectAllClientsByUserId(qualifiedID).executeAsList().map(mapper::toModel)
 
-    override suspend fun deleteClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): Unit = clientsQueries.deleteClientsOfUser(qualifiedID)
+    override fun deleteClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): Unit = clientsQueries.deleteClientsOfUser(qualifiedID)
 
-    override suspend fun deleteClient(userId: QualifiedIDEntity, clientId: String) = clientsQueries.deleteClient(userId, clientId)
+    override fun deleteClient(userId: QualifiedIDEntity, clientId: String) = clientsQueries.deleteClient(userId, clientId)
     
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -49,15 +49,15 @@ data class MessageEntity(
 }
 
 interface MessageDAO {
-    suspend fun deleteMessage(id: String, conversationsId: QualifiedIDEntity)
-    suspend fun deleteMessage(id: String)
-    suspend fun updateMessageVisibility(visibility: MessageEntity.Visibility, id: String, conversationId: QualifiedIDEntity)
-    suspend fun deleteAllMessages()
-    suspend fun insertMessage(message: MessageEntity)
-    suspend fun insertMessages(messages: List<MessageEntity>)
-    suspend fun updateMessage(message: MessageEntity)
-    suspend fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity)
-    suspend fun getAllMessages(): Flow<List<MessageEntity>>
-    suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?>
-    suspend fun getMessageByConversation(conversationId: QualifiedIDEntity, limit: Int): Flow<List<MessageEntity>>
+    fun deleteMessage(id: String, conversationsId: QualifiedIDEntity)
+    fun deleteMessage(id: String)
+    fun updateMessageVisibility(visibility: MessageEntity.Visibility, id: String, conversationId: QualifiedIDEntity)
+    fun deleteAllMessages()
+    fun insertMessage(message: MessageEntity)
+    fun insertMessages(messages: List<MessageEntity>)
+    fun updateMessage(message: MessageEntity)
+    fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity)
+    fun getAllMessagesFlow(): Flow<List<MessageEntity>>
+    fun getMessageById(id: String, conversationId: QualifiedIDEntity): MessageEntity?
+    fun getMessageByConversationFlow(conversationId: QualifiedIDEntity, limit: Int): Flow<List<MessageEntity>>
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MetadataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MetadataDAOTest.kt
@@ -2,8 +2,6 @@ package com.wire.kalium.persistence.dao
 
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.db.UserDatabaseProvider
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -11,11 +9,11 @@ import kotlin.test.assertNull
 
 class MetadataDAOTest: BaseDatabaseTest() {
 
-    val value1 = "value1"
+    private val value1 = "value1"
     val value2 = "value2"
 
-    val key1 = "key1"
-    val key2 = "key2"
+    private val key1 = "key1"
+    private val key2 = "key2"
 
     lateinit var db: UserDatabaseProvider
 
@@ -26,27 +24,27 @@ class MetadataDAOTest: BaseDatabaseTest() {
     }
 
     @Test
-    fun givenNonExistingKey_thenValueCanBeStored() = runTest {
+    fun givenNonExistingKey_thenValueCanBeStored() {
         db.metadataDAO.insertValue(value1, key1)
-        assertEquals(value1, db.metadataDAO.valueByKey(key1).first())
+        assertEquals(value1, db.metadataDAO.valueByKey(key1))
     }
 
     @Test
-    fun givenExistingKey_thenExistingValueCanBeOverwritten() = runTest {
+    fun givenExistingKey_thenExistingValueCanBeOverwritten() {
         db.metadataDAO.insertValue(value1, key1)
         db.metadataDAO.insertValue(value2, key1)
-        assertEquals(value2, db.metadataDAO.valueByKey(key1).first())
+        assertEquals(value2, db.metadataDAO.valueByKey(key1))
     }
 
     @Test
-    fun givenExistingKey_thenValueCanBeRetrieved() = runTest {
+    fun givenExistingKey_thenValueCanBeRetrieved() {
         db.metadataDAO.insertValue(value1, key1)
-        assertEquals(value1, db.metadataDAO.valueByKey(key1).first())
+        assertEquals(value1, db.metadataDAO.valueByKey(key1))
     }
 
     @Test
-    fun giveNonExistingKey_thenNullValueWillBeReturned() = runTest {
+    fun giveNonExistingKey_thenNullValueWillBeReturned() {
         db.metadataDAO.insertValue(value1, key1)
-        assertNull(db.metadataDAO.valueByKey(key2).first())
+        assertNull(db.metadataDAO.valueByKey(key2))
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/TeamDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/TeamDAOTest.kt
@@ -1,13 +1,14 @@
 package com.wire.kalium.persistence.dao
 
 import com.wire.kalium.persistence.BaseDatabaseTest
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TeamDAOTest : BaseDatabaseTest() {
 
     private lateinit var teamDAO: TeamDAO
@@ -22,7 +23,7 @@ class TeamDAOTest : BaseDatabaseTest() {
     @Test
     fun givenNoTeamsAreInserted_whenFetchingByTeamId_thenTheResultIsNull() = runTest {
         val result = teamDAO.getTeamById(teamId = teamId)
-        assertNull(result.first())
+        assertNull(result)
     }
 
     @Test
@@ -31,7 +32,7 @@ class TeamDAOTest : BaseDatabaseTest() {
         teamDAO.insertTeam(insertedTeam)
 
         val result = teamDAO.getTeamById(teamId = teamId)
-        assertEquals(insertedTeam.id, result.first()?.id)
+        assertEquals(insertedTeam.id, result?.id)
     }
 
     @Test
@@ -43,8 +44,8 @@ class TeamDAOTest : BaseDatabaseTest() {
         val resultTeam1 = teamDAO.getTeamById(teamId = "teamId 1")
         val resultTeam2 = teamDAO.getTeamById(teamId = "teamId 2")
 
-        assertEquals(insertedTeam1.id, resultTeam1.first()?.id)
-        assertEquals(insertedTeam2.id, resultTeam2.first()?.id)
+        assertEquals(insertedTeam1.id, resultTeam1?.id)
+        assertEquals(insertedTeam2.id, resultTeam2?.id)
     }
 
     private companion object {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserClientDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserClientDAOIntegrationTest.kt
@@ -4,13 +4,14 @@ import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.client.Client
 import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFails
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class UserClientDAOIntegrationTest : BaseDatabaseTest() {
 
     private lateinit var clientDAO: ClientDAO
@@ -31,7 +32,7 @@ class UserClientDAOIntegrationTest : BaseDatabaseTest() {
 
         userDAO.deleteUserByQualifiedID(user.id)
 
-        val result = clientDAO.getClientsOfUserByQualifiedID(user.id).first()
+        val result = clientDAO.getClientsOfUserByQualifiedID(user.id)
         assertTrue(result.isEmpty())
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
@@ -2,12 +2,14 @@ package com.wire.kalium.persistence.dao
 
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
 
     private val user1 = newUserEntity(id = "1")
@@ -43,7 +45,7 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
         conversationDAO.insertConversation(conversationEntity1)
         conversationDAO.insertMember(member1, conversationEntity1.id)
 
-        val result = userDAO.getUserByQualifiedID(user1.id).first()
+        val result = userDAO.getUserByQualifiedIDFlow(user1.id).first()
         assertEquals(user1, result)
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.persistence.dao
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -13,6 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class UserDAOTest : BaseDatabaseTest() {
 
     private val user1 = newUserEntity(id = "1")
@@ -30,16 +32,16 @@ class UserDAOTest : BaseDatabaseTest() {
     @Test
     fun givenUser_ThenUserCanBeInserted() = runTest {
         db.userDAO.insertUser(user1)
-        val result = db.userDAO.getUserByQualifiedID(user1.id).first()
+        val result = db.userDAO.getUserByQualifiedIDFlow(user1.id).first()
         assertEquals(result, user1)
     }
 
     @Test
     fun givenListOfUsers_ThenMultipleUsersCanBeInsertedAtOnce() = runTest {
         db.userDAO.insertUsers(listOf(user1, user2, user3))
-        val result1 = db.userDAO.getUserByQualifiedID(user1.id).first()
-        val result2 = db.userDAO.getUserByQualifiedID(user2.id).first()
-        val result3 = db.userDAO.getUserByQualifiedID(user3.id).first()
+        val result1 = db.userDAO.getUserByQualifiedIDFlow(user1.id).first()
+        val result2 = db.userDAO.getUserByQualifiedIDFlow(user2.id).first()
+        val result3 = db.userDAO.getUserByQualifiedIDFlow(user3.id).first()
         assertEquals(result1, user1)
         assertEquals(result2, user2)
         assertEquals(result3, user3)
@@ -49,7 +51,7 @@ class UserDAOTest : BaseDatabaseTest() {
     fun givenExistingUser_ThenUserCanBeDeleted() = runTest {
         db.userDAO.insertUser(user1)
         db.userDAO.deleteUserByQualifiedID(user1.id)
-        val result = db.userDAO.getUserByQualifiedID(user1.id).first()
+        val result = db.userDAO.getUserByQualifiedIDFlow(user1.id).first()
         assertNull(result)
     }
 
@@ -61,7 +63,7 @@ class UserDAOTest : BaseDatabaseTest() {
             UserEntity.ConnectionState.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity()
         )
         db.userDAO.updateUser(updatedUser1)
-        val result = db.userDAO.getUserByQualifiedID(user1.id).first()
+        val result = db.userDAO.getUserByQualifiedIDFlow(user1.id).first()
         assertEquals(result, updatedUser1)
     }
 
@@ -73,7 +75,7 @@ class UserDAOTest : BaseDatabaseTest() {
             UserEntity.ConnectionState.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity()
         )
 
-        val result = db.userDAO.getUserByQualifiedID(user1.id)
+        val result = db.userDAO.getUserByQualifiedIDFlow(user1.id)
         assertEquals(user1, result.first())
 
         db.userDAO.updateUser(updatedUser1)
@@ -86,7 +88,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val updatedUser1 = UserEntity(user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
             UserEntity.ConnectionState.ACCEPTED, null, null)
 
-        val result = db.userDAO.getUserByQualifiedID(user1.id)
+        val result = db.userDAO.getUserByQualifiedIDFlow(user1.id)
         assertEquals(user1, result.first())
 
         db.userDAO.updateUser(updatedUser1)
@@ -101,7 +103,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val user3 = USER_ENTITY_3
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(user2.email!!).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(user2.email!!).first()
         //then
         assertEquals(searchResult, listOf(user2))
     }
@@ -115,7 +117,7 @@ class UserDAOTest : BaseDatabaseTest() {
             val user3 = USER_ENTITY_3.copy(handle = "uniqueHandlForUser3")
             db.userDAO.insertUsers(listOf(user1, user2, user3))
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(user3.handle!!).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(user3.handle!!).first()
             //then
             assertEquals(searchResult, listOf(user3))
         }
@@ -129,7 +131,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val user3 = USER_ENTITY_3
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(user1.name!!).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(user1.name!!).first()
         //then
         assertEquals(searchResult, listOf(user1))
     }
@@ -173,7 +175,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
             db.userDAO.insertUsers(mockUsers)
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonEmailPrefix).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(commonEmailPrefix).first()
             //then
             assertEquals(searchResult, commonEmailUsers)
         }
@@ -187,7 +189,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
         val nonExistingEmailQuery = "doesnotexist@wire.com"
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(nonExistingEmailQuery).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(nonExistingEmailQuery).first()
         //then
         assertTrue { searchResult.isEmpty() }
     }
@@ -200,7 +202,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonEmailPrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(commonEmailPrefix).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.email!!, commonEmailPrefix)
@@ -216,7 +218,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonHandlePrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(commonHandlePrefix).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.handle!!, commonHandlePrefix)
@@ -231,7 +233,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonNamePrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(commonNamePrefix).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.name!!, commonNamePrefix)
@@ -251,7 +253,7 @@ class UserDAOTest : BaseDatabaseTest() {
             )
             db.userDAO.insertUsers(mockUsers)
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonPrefix).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailFlow(commonPrefix).first()
             //then
             assertEquals(mockUsers, searchResult)
         }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -4,8 +4,6 @@ import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,31 +23,31 @@ class ClientDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenNoClientsAreInserted_whenFetchingClientsByUserId_thenTheResultIsEmpty() = runTest {
-        val result = clientDAO.getClientsOfUserByQualifiedID(userId).first()
+    fun givenNoClientsAreInserted_whenFetchingClientsByUserId_thenTheResultIsEmpty() {
+        val result = clientDAO.getClientsOfUserByQualifiedID(userId)
         assertTrue(result.isEmpty())
     }
 
     @Test
-    fun givenClientIsInserted_whenFetchingClientsByUserId_thenTheRelevantClientIsReturned() = runTest {
+    fun givenClientIsInserted_whenFetchingClientsByUserId_thenTheRelevantClientIsReturned() {
         val insertedClient = Client(user.id, "id1")
         userDAO.insertUser(user)
         clientDAO.insertClient(insertedClient)
 
-        val result = clientDAO.getClientsOfUserByQualifiedID(userId).first()
+        val result = clientDAO.getClientsOfUserByQualifiedID(userId)
 
         assertEquals(1, result.size)
         assertEquals(insertedClient, result.first())
     }
 
     @Test
-    fun givenMultipleClientsAreInserted_whenFetchingClientsByUserId_thenTheRelevantClientIsReturned() = runTest {
+    fun givenMultipleClientsAreInserted_whenFetchingClientsByUserId_thenTheRelevantClientIsReturned() {
         val insertedClient = Client(user.id, "id1")
         val insertedClient2 = Client(user.id, "id2")
         userDAO.insertUser(user)
         clientDAO.insertClients(listOf(insertedClient, insertedClient2))
 
-        val result = clientDAO.getClientsOfUserByQualifiedID(userId).first()
+        val result = clientDAO.getClientsOfUserByQualifiedID(userId)
 
         assertEquals(2, result.size)
         assertEquals(insertedClient, result[0])
@@ -57,7 +55,7 @@ class ClientDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenClientsAreInsertedForMultipleUsers_whenFetchingClientsByUserId_thenOnlyTheRelevantClientsAreReturned() = runTest {
+    fun givenClientsAreInsertedForMultipleUsers_whenFetchingClientsByUserId_thenOnlyTheRelevantClientsAreReturned() {
         val insertedClient = Client(user.id, "id1")
         val insertedClient2 = Client(user.id, "id2")
         userDAO.insertUser(user)
@@ -69,26 +67,26 @@ class ClientDAOTest : BaseDatabaseTest() {
         userDAO.insertUser(unrelatedUser)
         clientDAO.insertClient(unrelatedInsertedClient)
 
-        val result = clientDAO.getClientsOfUserByQualifiedID(userId).first()
+        val result = clientDAO.getClientsOfUserByQualifiedID(userId)
 
         assertEquals(2, result.size)
         assertEquals(insertedClient, result.first())
     }
 
     @Test
-    fun givenClientIsInserted_whenDeletingItSpecifically_thenItShouldNotBeReturnedAnymoreOnNextFetch() = runTest {
+    fun givenClientIsInserted_whenDeletingItSpecifically_thenItShouldNotBeReturnedAnymoreOnNextFetch() {
         val insertedClient = Client(user.id, "id1")
         userDAO.insertUser(user)
         clientDAO.insertClient(insertedClient)
 
         clientDAO.deleteClient(insertedClient.userId, insertedClient.id)
 
-        val result = clientDAO.getClientsOfUserByQualifiedID(userId).first()
+        val result = clientDAO.getClientsOfUserByQualifiedID(userId)
         assertTrue(result.isEmpty())
     }
 
     @Test
-    fun givenClientsAreInserted_whenDeletingClientsOfUser_thenTheyShouldNotBeReturnedAnymoreOnNextFetch() = runTest {
+    fun givenClientsAreInserted_whenDeletingClientsOfUser_thenTheyShouldNotBeReturnedAnymoreOnNextFetch() {
         val insertedClient = Client(user.id, "id1")
         val insertedClient2 = Client(user.id, "id2")
         userDAO.insertUser(user)
@@ -96,7 +94,7 @@ class ClientDAOTest : BaseDatabaseTest() {
 
         clientDAO.deleteClientsOfUserByQualifiedID(insertedClient.userId)
 
-        val result = clientDAO.getClientsOfUserByQualifiedID(userId).first()
+        val result = clientDAO.getClientsOfUserByQualifiedID(userId)
         assertTrue(result.isEmpty())
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. `suspend` modifier is used by default in all DAOs functions, which lead to unnecessary compile/run time overhead.
2. using `flow` to fetch only list from the DB with `flow.fitst()` 


### Solutions

1. remove the ´suspend´ modifier.
2. replace `query.asFlow()` with `query.executeAsList()` and using `.asFlow()` only when it's really needed (e.g. observing a list of conversations)

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

- [x] I have added automated test to this contribution


### Notes (Optional)

this PR is not supposed to pass CI since the changes here requires refactoring some repositories and UseCases in ´logic´ (the logic refactor will come in a later PR)

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
