### PR TITLE
fix: add legal hold status also to group conversation details

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -25,7 +25,10 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         val legalHoldStatus: LegalHoldStatus
     ) : ConversationDetails(conversation)
 
-    data class Group(override val conversation: Conversation) : ConversationDetails(conversation)
+    data class Group(
+        override val conversation: Conversation,
+        val legalHoldStatus: LegalHoldStatus
+    ) : ConversationDetails(conversation)
 }
 
 class MembersInfo(val self: Member, val otherMembers: List<Member>)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -165,7 +165,13 @@ class ConversationDataSource(
     private suspend fun getDetailsFlowConversation(conversation: Conversation): Flow<ConversationDetails> =
         when (conversation.type) {
             ConversationEntity.Type.SELF -> flowOf(ConversationDetails.Self(conversation))
-            ConversationEntity.Type.GROUP -> flowOf(ConversationDetails.Group(conversation))
+            ConversationEntity.Type.GROUP ->
+                flowOf(
+                    ConversationDetails.Group(
+                        conversation,
+                        LegalHoldStatus.DISABLED //TODO get actual legal hold status
+                    )
+                )
             ConversationEntity.Type.ONE_ON_ONE -> {
                 suspending {
                     val selfUserId = userRepository.getSelfUser().map { it.id }.first()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.conversation
 import app.cash.turbine.test
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.sync.SyncManager
 import io.mockative.Mock
@@ -80,8 +81,8 @@ class ObserveConversationDetailsUseCaseTest {
     fun givenTheConversationIsUpdated_whenObservingConversationUseCase_thenThisUpdateIsPropagatedInTheFlow() = runTest {
         val conversation = TestConversation.GROUP
         val conversationDetailsValues = listOf(
-            ConversationDetails.Group(conversation),
-            ConversationDetails.Group(conversation.copy(name = "New Name"))
+            ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED),
+            ConversationDetails.Group(conversation.copy(name = "New Name"), LegalHoldStatus.DISABLED)
         )
 
         given(syncManager)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -130,7 +130,7 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversation = TestConversation.GROUP
         val conversations = listOf(groupConversation, oneOnOneConversation)
 
-        val groupConversationUpdates = listOf(ConversationDetails.Group(groupConversation))
+        val groupConversationUpdates = listOf(ConversationDetails.Group(groupConversation, LegalHoldStatus.DISABLED))
         val firstOneOnOneDetails = ConversationDetails.OneOne(
             oneOnOneConversation,
             TestUser.OTHER,
@@ -179,7 +179,7 @@ class ObserveConversationListDetailsUseCaseTest {
     @Test
     fun givenAConversationIsAddedToTheList_whenObservingDetailsList_thenTheUpdateIsPropagatedThroughTheFlow() = runTest {
         val groupConversation = TestConversation.GROUP
-        val groupConversationDetails = ConversationDetails.Group(groupConversation)
+        val groupConversationDetails = ConversationDetails.Group(groupConversation, LegalHoldStatus.DISABLED)
 
         val selfConversation = TestConversation.SELF
         val selfConversationDetails = ConversationDetails.Self(selfConversation)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently only 1to1 conversations have the legal hold status, but according to the documentation:
> A conversation is under legal hold if any participant is under legal hold. 

so also group conversations should have such indicator. 

### Solutions

Added legal hold status also to group conversation details.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
