### PR TITLE
chore: identify lack of connection failures (AR-1312)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/core_failure/WrapApiRequestTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/core_failure/WrapApiRequestTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.utils.io.errors.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -28,5 +29,15 @@ class WrapApiRequestTest {
 
         assertIs<Either.Left<NetworkFailure.ServerMiscommunication>>(actual)
         assertEquals(expected.kException, actual.value.kaliumException)
+    }
+
+    @Test
+    fun whenApiRequestReturnAnIOException_thenALackOfConnectionIsPropagated() {
+        val exception = KaliumException.GenericError(IOException("Oops doopsie"))
+
+        val actual = wrapApiRequest { NetworkResponse.Error(exception) }
+
+        assertIs<Either.Left<NetworkFailure.NoNetworkConnection>>(actual)
+        assertEquals(exception, actual.value.cause)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
@@ -71,7 +71,7 @@ class GetMessageAssetUseCaseTest {
         // Given
         val someConversationId = ConversationId("some-conversation-id", "some-domain.com")
         val someMessageId = "some-message-id"
-        val connectionFailure = NetworkFailure.NoNetworkConnection
+        val connectionFailure = NetworkFailure.NoNetworkConnection(null)
         val (_, getMessageAsset) = Arrangement()
             .withDownloadAssetErrorResponse(connectionFailure)
             .arrange()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We currently don't identify when an API request fails because we're unable to reach the server.

### Solutions

Ktor will throw `IOException` when we can't reach the server due to any reason.
Handle `IOException` independently from generic `Exception`, mapping it to the current `NoNetworkConnection` failure.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
