### PR TITLE
fix: delete server config called with title instead of id

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepository.kt
@@ -44,7 +44,7 @@ internal class ServerConfigDataSource(
 
     override fun deleteById(id: String) = wrapStorageRequest { dao.deleteById(id) }
 
-    override fun delete(serverConfig: ServerConfig) = deleteById(serverConfig.title)
+    override fun delete(serverConfig: ServerConfig) = deleteById(serverConfig.id)
 
     override fun storeConfig(serverConfigDTO: ServerConfigDTO): Either<StorageFailure, ServerConfig> = wrapStorageRequest {
         val newId = uuid4().toString()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -101,11 +101,23 @@ class ServerConfigRepositoryTest {
     }
 
     @Test
-    fun givenStoredConfig_thenItCanBeDeleted() = runTest {
+    fun givenStoredConfig_thenItCanBeDeleted() {
         val serverConfig = SERVER_CONFIG
         given(serverConfigDAO).invocation { deleteById(serverConfig.id) }
 
         val actual = serverConfigRepository.deleteById(serverConfig.id)
+
+        actual.shouldSucceed()
+
+        verify(serverConfigDAO).function(serverConfigDAO::deleteById).with(any()).wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenStoredConfig_whenDeleting_thenItCanBeDeleted() {
+        val serverConfig = SERVER_CONFIG
+        given(serverConfigDAO).invocation { deleteById(serverConfig.id) }
+
+        val actual = serverConfigRepository.delete(serverConfig)
 
         actual.shouldSucceed()
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

delete server config called with title instead of id


### Solutions

`config.title` -> `config.id`

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

i did add a unit test to ensure it's called with the right value

- [x] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
