### PR TITLE
feat(messages): retry sending after reconnecting - PART-1: Schedule when failing

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingSchedulerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingSchedulerImpl.kt
@@ -1,0 +1,13 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.kaliumLogger
+
+actual class MessageSendingSchedulerImpl : MessageSendingScheduler {
+    override suspend fun scheduleSendingOfPersistedMessage(conversationID: ConversationId, messageUuid: String) {
+        kaliumLogger.w(
+            "Scheduling of messages is not supported on Android. " +
+                    "Message of Conversation=$conversationID and UUID=$messageUuid won't be scheduled for sending."
+        )
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -54,6 +54,8 @@ import com.wire.kalium.logic.feature.message.MessageScope
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.MessageSenderImpl
+import com.wire.kalium.logic.feature.message.MessageSendingScheduler
+import com.wire.kalium.logic.feature.message.MessageSendingSchedulerImpl
 import com.wire.kalium.logic.feature.message.SessionEstablisher
 import com.wire.kalium.logic.feature.message.SessionEstablisherImpl
 import com.wire.kalium.logic.feature.team.TeamScope
@@ -89,14 +91,15 @@ abstract class UserSessionScopeCommon(
             "${authenticatedDataSourceSet.authenticatedRootDir}/mls",
             userId,
             clientRepository,
-            authenticatedDataSourceSet.kaliumPreferencesSettings)
+            authenticatedDataSourceSet.kaliumPreferencesSettings
+        )
 
     private val mlsConversationRepository: MLSConversationRepository
-    get() = MLSConversationDataSource(
-        keyPackageRepository,
-        mlsClientProvider,authenticatedDataSourceSet.authenticatedNetworkContainer.mlsMessageApi,
-        userDatabaseProvider.conversationDAO
-    )
+        get() = MLSConversationDataSource(
+            keyPackageRepository,
+            mlsClientProvider, authenticatedDataSourceSet.authenticatedNetworkContainer.mlsMessageApi,
+            userDatabaseProvider.conversationDAO
+        )
 
     private val conversationRepository: ConversationRepository
         get() = ConversationDataSource(
@@ -173,9 +176,21 @@ abstract class UserSessionScopeCommon(
     private val mlsMessageCreator: MLSMessageCreator
         get() = MLSMessageCreatorImpl(mlsClientProvider, protoContentMapper)
 
+    private val messageSendingScheduler: MessageSendingScheduler
+        get() = MessageSendingSchedulerImpl()
+
     // TODO code duplication, can't we get the MessageSender from the message scope?
     private val messageSender: MessageSender
-        get() = MessageSenderImpl(messageRepository, conversationRepository, syncManager, messageSendFailureHandler, sessionEstablisher, messageEnvelopeCreator, mlsMessageCreator)
+        get() = MessageSenderImpl(
+            messageRepository,
+            conversationRepository,
+            syncManager,
+            messageSendFailureHandler,
+            sessionEstablisher,
+            messageEnvelopeCreator,
+            mlsMessageCreator,
+            messageSendingScheduler
+        )
 
     private val assetRepository: AssetRepository
         get() = AssetDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.assetApi, userDatabaseProvider.assetDAO)
@@ -243,7 +258,15 @@ abstract class UserSessionScopeCommon(
             syncManager
         )
     val users: UserScope get() = UserScope(userRepository, publicUserRepository, syncManager, assetRepository)
-    val logout: LogoutUseCase get() = LogoutUseCase(logoutRepository, sessionRepository, userId, authenticatedDataSourceSet, clientRepository, mlsClientProvider)
+    val logout: LogoutUseCase
+        get() = LogoutUseCase(
+            logoutRepository,
+            sessionRepository,
+            userId,
+            authenticatedDataSourceSet,
+            clientRepository,
+            mlsClientProvider
+        )
 
     val team: TeamScope get() = TeamScope(userRepository, teamRepository)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -45,6 +45,9 @@ class MessageScope(
     private val mlsMessageCreator: MLSMessageCreator
         get() = MLSMessageCreatorImpl(mlsClientProvider, protoContentMapper)
 
+    private val messageSendingScheduler: MessageSendingScheduler
+        get() = MessageSendingSchedulerImpl()
+
     private val messageSender: MessageSender
         get() = MessageSenderImpl(
             messageRepository,
@@ -53,7 +56,8 @@ class MessageScope(
             messageSendFailureHandler,
             sessionEstablisher,
             messageEnvelopeCreator,
-            mlsMessageCreator
+            mlsMessageCreator,
+            messageSendingScheduler
         )
 
     val sendTextMessage: SendTextMessageUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingScheduler.kt
@@ -1,0 +1,24 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.data.id.ConversationId
+
+/**
+ * Responsible for [scheduleSendingOfPersistedMessage].
+ */
+interface MessageSendingScheduler {
+
+    /**
+     *  Given [conversationID] and [messageUuid] of a persisted message, schedule the sending/retry.
+     *
+     *  **When** it's gonna to be executed may vary depending on the platform and/or implementation.
+     *
+     *  One of the criteria in order to attempt sending a message is that there's
+     *  an established internet connection. So the scheduler *may* take this into consideration.
+     *
+     *  If the implementation is unable to schedule (due to platform limitations for example),
+     *  it's OK to just don't do anything, ideally logging a warning about the lack of implementation.
+     */
+    suspend fun scheduleSendingOfPersistedMessage(conversationID: ConversationId, messageUuid: String)
+}
+
+expect class MessageSendingSchedulerImpl: MessageSendingScheduler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingScheduler.kt
@@ -21,4 +21,4 @@ interface MessageSendingScheduler {
     suspend fun scheduleSendingOfPersistedMessage(conversationID: ConversationId, messageUuid: String)
 }
 
-expect class MessageSendingSchedulerImpl: MessageSendingScheduler
+expect class MessageSendingSchedulerImpl(): MessageSendingScheduler

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingSchedulerImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingSchedulerImpl.kt
@@ -1,0 +1,13 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.kaliumLogger
+
+actual class MessageSendingSchedulerImpl : MessageSendingScheduler {
+    override suspend fun scheduleSendingOfPersistedMessage(conversationID: ConversationId, messageUuid: String) {
+        kaliumLogger.w(
+            "Scheduling of messages is not supported on JVM. " +
+                    "Message of Conversation=$conversationID and UUID=$messageUuid won't be scheduled for sending."
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Part 1 of the epic. Once a sending of messages fails due to lack of connection, we need to be able to schedule a retry in the future.

### Solutions

1. Define a `MessageSendingScheduler` that should be implemented on a platform-basis.
2. Call this `MessageSendingScheduler` from the `MessageSender` if a `NoNetworkAvailable` causes a failure.

### Testing

#### Test Coverage

I'll add tests to the next PR.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
