### PR TITLE
feat: add filtering to the search result by only the accepted connection status

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.network.api.user.details.ListUserRequest
 import com.wire.kalium.network.api.user.details.UserDetailsApi
 import com.wire.kalium.network.api.user.details.qualifiedIds
 import com.wire.kalium.persistence.dao.UserDAO
+import com.wire.kalium.persistence.dao.UserEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -32,7 +33,7 @@ class SearchUserRepositoryImpl(
 ) : SearchUserRepository {
 
     override suspend fun searchKnownUsers(searchQuery: String) =
-        userDAO.getUserByNameOrHandleOrEmail(searchQuery)
+        userDAO.getUserByNameOrHandleOrEmailAndConnectionState(searchQuery, UserEntity.ConnectionState.ACCEPTED)
             .map {
                 UserSearchResult(it.map { userEntity -> publicUserMapper.fromDaoModelToPublicUser(userEntity) })
             }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -47,11 +47,12 @@ SELECT * FROM User WHERE connection_status = ?;
 selectByQualifiedId:
 SELECT * FROM User WHERE qualified_id = ?;
 
-selectByNameOrHandleOrEmail:
+selectByNameOrHandleOrEmailAndConnectionState:
 SELECT * FROM User
 WHERE name LIKE ('%' || :searchQuery || '%')
 OR  handle LIKE  ('%' || :searchQuery || '%')
-OR  email LIKE  ('%' || :searchQuery || '%');
+OR  email LIKE  ('%' || :searchQuery || '%')
+AND connection_status = :connectionStatus;
 
 updateUserhandle:
 UPDATE User SET handle = ? WHERE qualified_id = ?;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -49,9 +49,9 @@ SELECT * FROM User WHERE qualified_id = ?;
 
 selectByNameOrHandleOrEmailAndConnectionState:
 SELECT * FROM User
-WHERE name LIKE ('%' || :searchQuery || '%')
+WHERE (name LIKE ('%' || :searchQuery || '%')
 OR  handle LIKE  ('%' || :searchQuery || '%')
-OR  email LIKE  ('%' || :searchQuery || '%')
+OR  email LIKE  ('%' || :searchQuery || '%'))
 AND connection_status = :connectionStatus;
 
 updateUserhandle:

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -57,9 +57,13 @@ interface UserDAO {
     suspend fun insertUsers(users: List<UserEntity>)
     suspend fun updateUser(user: UserEntity)
     suspend fun getAllUsers(): Flow<List<UserEntity>>
-    suspend fun getAllUsersByConnectionStatus(connectionState: UserEntity.ConnectionState) : List<UserEntity>
+    suspend fun getAllUsersByConnectionStatus(connectionState: UserEntity.ConnectionState): List<UserEntity>
     suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?>
-    suspend fun getUserByNameOrHandleOrEmail(searchQuery: String): Flow<List<UserEntity>>
+    suspend fun getUserByNameOrHandleOrEmailAndConnectionState(
+        searchQuery: String,
+        connectionState: UserEntity.ConnectionState
+    ): Flow<List<UserEntity>>
+
     suspend fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity)
     suspend fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -79,8 +79,11 @@ class UserDAOImpl(private val queries: UsersQueries) : UserDAO {
             .map { it?.let { mapper.toModel(it) } }
     }
 
-    override suspend fun getUserByNameOrHandleOrEmail(searchQuery: String): Flow<List<UserEntity>> {
-        return queries.selectByNameOrHandleOrEmail(searchQuery)
+    override suspend fun getUserByNameOrHandleOrEmailAndConnectionState(
+        searchQuery: String,
+        connectionState: UserEntity.ConnectionState
+    ): Flow<List<UserEntity>> {
+        return queries.selectByNameOrHandleOrEmailAndConnectionState(searchQuery, UserEntity.ConnectionState.ACCEPTED)
             .asFlow()
             .mapToList()
             .map { entryList -> entryList.map(mapper::toModel) }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -101,7 +101,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val user3 = USER_ENTITY_3
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(user2.email!!).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user2.email!!).first()
         //then
         assertEquals(searchResult, listOf(user2))
     }
@@ -115,7 +115,7 @@ class UserDAOTest : BaseDatabaseTest() {
             val user3 = USER_ENTITY_3.copy(handle = "uniqueHandlForUser3")
             db.userDAO.insertUsers(listOf(user1, user2, user3))
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(user3.handle!!).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user3.handle!!).first()
             //then
             assertEquals(searchResult, listOf(user3))
         }
@@ -129,7 +129,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val user3 = USER_ENTITY_3
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(user1.name!!).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user1.name!!).first()
         //then
         assertEquals(searchResult, listOf(user1))
     }
@@ -173,7 +173,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
             db.userDAO.insertUsers(mockUsers)
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonEmailPrefix).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix).first()
             //then
             assertEquals(searchResult, commonEmailUsers)
         }
@@ -187,7 +187,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
         val nonExistingEmailQuery = "doesnotexist@wire.com"
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(nonExistingEmailQuery).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(nonExistingEmailQuery).first()
         //then
         assertTrue { searchResult.isEmpty() }
     }
@@ -200,7 +200,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonEmailPrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.email!!, commonEmailPrefix)
@@ -216,7 +216,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonHandlePrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonHandlePrefix).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.handle!!, commonHandlePrefix)
@@ -231,7 +231,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonNamePrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.name!!, commonNamePrefix)
@@ -251,7 +251,7 @@ class UserDAOTest : BaseDatabaseTest() {
             )
             db.userDAO.insertUsers(mockUsers)
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmail(commonPrefix).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix).first()
             //then
             assertEquals(mockUsers, searchResult)
         }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -187,7 +187,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
         val nonExistingEmailQuery = "doesnotexist@wire.com"
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(nonExistingEmailQuery).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(nonExistingEmailQuery,UserEntity.ConnectionState.ACCEPTED).first()
         //then
         assertTrue { searchResult.isEmpty() }
     }
@@ -255,6 +255,21 @@ class UserDAOTest : BaseDatabaseTest() {
             //then
             assertEquals(mockUsers, searchResult)
         }
+
+    @Test
+    fun givenAExistingUsers_whenQueried_ThenResultsUsersAreConnected() = runTest {
+        //given
+        val commonNamePrefix = "commonName"
+
+        val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
+        db.userDAO.insertUsers(mockUsers)
+        //when
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix, UserEntity.ConnectionState.ACCEPTED).first()
+        //then
+        searchResult.forEach { userEntity ->
+            assertEquals(UserEntity.ConnectionState.ACCEPTED,userEntity.connectionStatus)
+        }
+    }
 
     private companion object {
         val USER_ENTITY_1  = newUserEntity(QualifiedIDEntity("1", "wire.com"))

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -83,8 +83,10 @@ class UserDAOTest : BaseDatabaseTest() {
     @Test
     fun givenRetrievedUser_ThenUpdatesArePropagatedThroughFlow() = runTest {
         db.userDAO.insertUser(user1)
-        val updatedUser1 = UserEntity(user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
-            UserEntity.ConnectionState.ACCEPTED, null, null)
+        val updatedUser1 = UserEntity(
+            user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
+            UserEntity.ConnectionState.ACCEPTED, null, null
+        )
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
         assertEquals(user1, result.first())
@@ -101,7 +103,8 @@ class UserDAOTest : BaseDatabaseTest() {
         val user3 = USER_ENTITY_3
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user2.email!!, UserEntity.ConnectionState.ACCEPTED).first()
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user2.email!!, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         assertEquals(searchResult, listOf(user2))
     }
@@ -115,7 +118,8 @@ class UserDAOTest : BaseDatabaseTest() {
             val user3 = USER_ENTITY_3.copy(handle = "uniqueHandlForUser3")
             db.userDAO.insertUsers(listOf(user1, user2, user3))
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user3.handle!!, UserEntity.ConnectionState.ACCEPTED).first()
+            val searchResult =
+                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user3.handle!!, UserEntity.ConnectionState.ACCEPTED).first()
             //then
             assertEquals(searchResult, listOf(user3))
         }
@@ -129,7 +133,8 @@ class UserDAOTest : BaseDatabaseTest() {
         val user3 = USER_ENTITY_3
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user1.name!!, UserEntity.ConnectionState.ACCEPTED).first()
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user1.name!!, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         assertEquals(searchResult, listOf(user1))
     }
@@ -173,7 +178,8 @@ class UserDAOTest : BaseDatabaseTest() {
 
             db.userDAO.insertUsers(mockUsers)
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+            val searchResult =
+                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED).first()
             //then
             assertEquals(searchResult, commonEmailUsers)
         }
@@ -187,7 +193,8 @@ class UserDAOTest : BaseDatabaseTest() {
 
         val nonExistingEmailQuery = "doesnotexist@wire.com"
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(nonExistingEmailQuery,UserEntity.ConnectionState.ACCEPTED).first()
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(nonExistingEmailQuery, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         assertTrue { searchResult.isEmpty() }
     }
@@ -200,13 +207,13 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.email!!, commonEmailPrefix)
         }
     }
-
 
     @Test
     fun givenAExistingUsers_whenQueriedWithCommonHandlePrefix_ThenResultsUsersHandleContainsThatPrefix() = runTest {
@@ -216,7 +223,8 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonHandlePrefix, UserEntity.ConnectionState.ACCEPTED).first()
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonHandlePrefix, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.handle!!, commonHandlePrefix)
@@ -231,7 +239,8 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix, UserEntity.ConnectionState.ACCEPTED).first()
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.name!!, commonNamePrefix)
@@ -251,7 +260,8 @@ class UserDAOTest : BaseDatabaseTest() {
             )
             db.userDAO.insertUsers(mockUsers)
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix,UserEntity.ConnectionState.ACCEPTED).first()
+            val searchResult =
+                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED).first()
             //then
             assertEquals(mockUsers, searchResult)
         }
@@ -259,22 +269,74 @@ class UserDAOTest : BaseDatabaseTest() {
     @Test
     fun givenAExistingUsers_whenQueried_ThenResultsUsersAreConnected() = runTest {
         //given
-        val commonNamePrefix = "commonName"
+        val commonPrefix = "common"
 
-        val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
+        val mockUsers = listOf(
+            USER_ENTITY_1.copy(name = commonPrefix + "u1"),
+            USER_ENTITY_2.copy(handle = commonPrefix + "u2"),
+            USER_ENTITY_3.copy(email = commonPrefix + "u3")
+        )
+
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix, UserEntity.ConnectionState.ACCEPTED).first()
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         searchResult.forEach { userEntity ->
-            assertEquals(UserEntity.ConnectionState.ACCEPTED,userEntity.connectionStatus)
+            assertEquals(UserEntity.ConnectionState.ACCEPTED, userEntity.connectionStatus)
         }
     }
 
+    @Test
+    fun givenAConnectedExistingUsersAndNonConnected_whenQueried_ThenResultsUsersAreConnected() = runTest {
+        //given
+        val commonPrefix = "common"
+
+        val mockUsers = listOf(
+            USER_ENTITY_1.copy(name = commonPrefix + "u1"),
+            USER_ENTITY_2.copy(handle = commonPrefix + "u2"),
+            USER_ENTITY_3.copy(email = commonPrefix + "u3", connectionStatus = UserEntity.ConnectionState.NOT_CONNECTED),
+            USER_ENTITY_4.copy(email = commonPrefix + "u4", connectionStatus = UserEntity.ConnectionState.NOT_CONNECTED)
+        )
+
+        db.userDAO.insertUsers(mockUsers)
+        //when
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+        //then
+        assertTrue(searchResult.size == 2)
+        searchResult.forEach { userEntity ->
+            assertEquals(UserEntity.ConnectionState.ACCEPTED, userEntity.connectionStatus)
+        }
+    }
+
+    @Test
+    fun givenAConnectedExistingUserAndNonConnected_whenQueried_ThenResultIsTheConnectedUser() = runTest {
+        //given
+        val commonPrefix = "common"
+
+        val expectedResult = listOf(USER_ENTITY_1.copy(name = commonPrefix + "u1"))
+
+        val mockUsers = listOf(
+            USER_ENTITY_1.copy(name = commonPrefix + "u1"),
+            USER_ENTITY_2.copy(handle = commonPrefix + "u2", connectionStatus = UserEntity.ConnectionState.NOT_CONNECTED),
+            USER_ENTITY_3.copy(name = commonPrefix + "u3", connectionStatus = UserEntity.ConnectionState.NOT_CONNECTED),
+            USER_ENTITY_4.copy(email = commonPrefix + "u4", connectionStatus = UserEntity.ConnectionState.NOT_CONNECTED)
+        )
+
+        db.userDAO.insertUsers(mockUsers)
+        //when
+        val searchResult =
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+        //then
+        assertEquals(expectedResult, searchResult)
+    }
+
     private companion object {
-        val USER_ENTITY_1  = newUserEntity(QualifiedIDEntity("1", "wire.com"))
+        val USER_ENTITY_1 = newUserEntity(QualifiedIDEntity("1", "wire.com"))
         val USER_ENTITY_2 = newUserEntity(QualifiedIDEntity("2", "wire.com"))
         val USER_ENTITY_3 = newUserEntity(QualifiedIDEntity("3", "wire.com"))
+        val USER_ENTITY_4 = newUserEntity(QualifiedIDEntity("4", "wire.com"))
     }
 
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -101,7 +101,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val user3 = USER_ENTITY_3
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user2.email!!).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user2.email!!, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         assertEquals(searchResult, listOf(user2))
     }
@@ -115,7 +115,7 @@ class UserDAOTest : BaseDatabaseTest() {
             val user3 = USER_ENTITY_3.copy(handle = "uniqueHandlForUser3")
             db.userDAO.insertUsers(listOf(user1, user2, user3))
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user3.handle!!).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user3.handle!!, UserEntity.ConnectionState.ACCEPTED).first()
             //then
             assertEquals(searchResult, listOf(user3))
         }
@@ -129,7 +129,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val user3 = USER_ENTITY_3
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user1.name!!).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user1.name!!, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         assertEquals(searchResult, listOf(user1))
     }
@@ -173,7 +173,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
             db.userDAO.insertUsers(mockUsers)
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED).first()
             //then
             assertEquals(searchResult, commonEmailUsers)
         }
@@ -200,7 +200,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.email!!, commonEmailPrefix)
@@ -216,7 +216,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonHandlePrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonHandlePrefix, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.handle!!, commonHandlePrefix)
@@ -231,7 +231,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.insertUsers(mockUsers)
         //when
-        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix).first()
+        val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix, UserEntity.ConnectionState.ACCEPTED).first()
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.name!!, commonNamePrefix)
@@ -251,7 +251,7 @@ class UserDAOTest : BaseDatabaseTest() {
             )
             db.userDAO.insertUsers(mockUsers)
             //when
-            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix).first()
+            val searchResult = db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix,UserEntity.ConnectionState.ACCEPTED).first()
             //then
             assertEquals(mockUsers, searchResult)
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- the search query from the DAO returned the contacts that also had the status as not accepted 

### Solution

- extended the user dao method to query by additional ConnectionState argument 
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
