### PR TITLE
fix: Add correct ISO message date for parsing

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/SendCallingMessage.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/SendCallingMessage.kt
@@ -5,12 +5,12 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
-import java.util.Date
+import kotlinx.datetime.Clock
 import java.util.UUID
 
 suspend fun CallManagerImpl.sendCallingMessage(conversationId: ConversationId, userId: UserId, clientId: ClientId, data: String) {
-    val messageContent =  MessageContent.Calling(data)
-    val date = Date().toString()
-    val message =  Message(UUID.randomUUID().toString(), messageContent, conversationId, date, userId, clientId, Message.Status.SENT)
+    val messageContent = MessageContent.Calling(data)
+    val date = Clock.System.now().toString()
+    val message = Message(UUID.randomUUID().toString(), messageContent, conversationId, date, userId, clientId, Message.Status.SENT)
     messageSender.trySendingOutgoingMessage(conversationId, message)
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

As we are now parsing the message date for diff when updating pending messages, when a message of type Calling was being passed, the date was in wrong format.

### Solutions

Add correct creation of calling message type with correct ISO.
