### PR TITLE
feat(messages): retry sending after reconnecting (PART-3): fix worker initialization

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ScheduledMessageWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ScheduledMessageWorker.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.sync
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.kaliumLogger
 
 /**
  * Given [conversationId] and [messageUuid], this worker will
@@ -20,6 +21,7 @@ internal class ScheduledMessageWorker(
      * Does **not** return [Result.Retry]. The retry logic is handled by [MessageSender].
      */
     override suspend fun doWork(): Result {
+        kaliumLogger.i("Scheduled sending of message. ConversationId=$conversationId; Message UUID=$messageUuid")
         return userSessionScope.messages.messageSender.trySendingOutgoingMessageById(
             conversationId, messageUuid
         ).fold({


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Scheduler was not being invoked as it was expecting a `ServerMiscomunication` failure instead of `NoNetworkConnection`
- `MissingMethodException` when initializing the Worker.

### Causes

The generic Worker constructor via reflection was being called instead.

### Solutions

Check the class of the worker being initialized and pass the correct arguments for the new `ScheduledMessageWorker`

Also: add some logs to make it easier to understand in the future.

### Testing

#### How to Test

On Reloaded, with these changes:
- Turn off internet connection
- Send a Message
- Close the app
- Turn on the internet connection

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
