### PR TITLE
feat: update call status when starting a call

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -200,6 +200,10 @@ actual class CallManagerImpl(
 
     override suspend fun startCall(conversationId: ConversationId, callType: CallType, conversationType: ConversationType, isAudioCbr: Boolean) {
         callingLogger.d("$TAG -> starting call..")
+        updateCallStatusById(
+            conversationId = conversationId.asString(),
+            status = CallStatus.STARTED
+        )
         withCalling {
             val avsCallType = callMapper.toCallTypeCalling(callType)
             val avsConversationType = callMapper.toConversationTypeCalling(conversationType)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/Call.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/Call.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.call
 import com.wire.kalium.logic.data.id.ConversationId
 
 enum class CallStatus {
+    STARTED,
     INCOMING,
     MISSED,
     ANSWERED,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issue

We need to capture different status of a call and based on that, we update the UI.
Currently there is no way to know if a started call has been accepted or not as we don't have this status.

### solution
I've added the STARTED status and for every call initiated we change the status of that call to STARTED

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
