### PR TITLE
chore: create a way to get unsent messages (AR-1312)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.message
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.failure.SendMessageFailure
 import com.wire.kalium.logic.functional.Either
@@ -42,6 +43,8 @@ interface MessageRepository {
     // TODO: change the return type to Either<CoreFailure, String>
     suspend fun sendEnvelope(conversationId: ConversationId, envelope: MessageEnvelope): Either<SendMessageFailure, String>
     suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, Unit>
+
+    suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>>
 }
 
 class MessageDataSource(
@@ -164,4 +167,9 @@ class MessageDataSource(
         wrapApiRequest {
             mlsMessageApi.sendMessage(message)
         }
+
+    override suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>> = wrapStorageRequest {
+        messageDAO.getAllPendingMessagesFromUser(idMapper.toDaoModel(senderUserId))
+            .map(messageMapper::fromEntityToMessage)
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -9,12 +9,11 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.message.MLSMessageApi
 import com.wire.kalium.network.api.message.MessageApi
-import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.network.api.message.QualifiedSendMessageResponse
 import com.wire.kalium.network.utils.NetworkResponse
-import com.wire.kalium.persistence.dao.message.MessageEntity.Status.SENT
-import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageDAO
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.dao.message.MessageEntity.Status.SENT
 import io.mockative.Mock
 import io.mockative.anything
 import io.mockative.configure
@@ -70,7 +69,7 @@ class MessageRepositoryTest {
         given(messageDAO)
             .suspendFunction(messageDAO::getMessagesByConversation)
             .whenInvokedWith(anything(), anything(), anything())
-            .then { _, _, _-> flowOf(listOf()) }
+            .then { _, _, _ -> flowOf(listOf()) }
 
         given(messageMapper)
             .function(messageMapper::fromEntityToMessage)

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -105,3 +105,6 @@ SELECT * FROM Message WHERE conversation_id = ? ORDER BY Datetime(date) DESC LIM
 
 selectMessagesByConversationIdAfterDate:
 SELECT * FROM Message WHERE conversation_id = ? AND Datetime(date) > Datetime(?) ORDER BY Datetime(date) DESC;
+
+selectMessagesFromUserByStatus:
+SELECT * FROM Message WHERE sender_user_id = ? AND status = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserIDEntity
 import kotlinx.coroutines.flow.Flow
 
 data class MessageEntity(
@@ -63,4 +64,6 @@ interface MessageDAO {
     suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?>
     suspend fun getMessagesByConversation(conversationId: QualifiedIDEntity, limit: Int, offset: Int): Flow<List<MessageEntity>>
     suspend fun getMessagesByConversationAfterDate(conversationId: QualifiedIDEntity, date: String): Flow<List<MessageEntity>>
+
+    suspend fun getAllPendingMessagesFromUser(userId: UserIDEntity): List<MessageEntity>
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -5,6 +5,7 @@ import com.squareup.sqldelight.runtime.coroutines.mapToList
 import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.ASSET
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.TEXT
 import com.wire.kalium.persistence.dao.message.MessageEntity.MessageEntityContent.AssetMessageContent
@@ -158,4 +159,10 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             .asFlow()
             .mapToList()
             .map { entryList -> entryList.map(mapper::toModel) }
+
+    override suspend fun getAllPendingMessagesFromUser(userId: UserIDEntity): List<MessageEntity> {
+        return queries.selectMessagesFromUserByStatus(userId, MessageEntity.Status.PENDING)
+            .executeAsList()
+            .map(mapper::toModel)
+    }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MessageDAOTest.kt
@@ -1,0 +1,116 @@
+package com.wire.kalium.persistence.dao
+
+import com.wire.kalium.persistence.BaseDatabaseTest
+import com.wire.kalium.persistence.dao.message.MessageDAO
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.utils.stubs.newConversationEntity
+import com.wire.kalium.persistence.utils.stubs.newMessageEntity
+import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertTrue
+
+class MessageDAOTest : BaseDatabaseTest() {
+
+    private lateinit var messageDAO: MessageDAO
+    private lateinit var conversationDAO: ConversationDAO
+    private lateinit var userDAO: UserDAO
+
+    private val conversationEntity1 = newConversationEntity()
+    private val userEntity1 = newUserEntity("userEntity1")
+    private val userEntity2 = newUserEntity("userEntity2")
+
+    @BeforeTest
+    fun setUp() {
+        deleteDatabase()
+        val db = createDatabase()
+        messageDAO = db.messageDAO
+        conversationDAO = db.conversationDAO
+        userDAO = db.userDAO
+    }
+
+    @Test
+    fun givenMessagesAreInserted_whenGettingPendingMessagesByUser_thenOnlyRelevantMessagesAreReturned() = runTest {
+        insertInitialData()
+
+        val userInQuestion = userEntity1
+        val otherUser = userEntity2
+
+        val expectedMessages = listOf(
+            newMessageEntity(
+                "1",
+                conversationId = conversationEntity1.id,
+                senderUserId = userInQuestion.id,
+                status = MessageEntity.Status.PENDING
+            ),
+            newMessageEntity(
+                "2",
+                conversationId = conversationEntity1.id,
+                senderUserId = userInQuestion.id,
+                status = MessageEntity.Status.PENDING
+            )
+        )
+
+        val allMessages = expectedMessages + listOf(
+            newMessageEntity(
+                "3",
+                conversationId = conversationEntity1.id,
+                senderUserId = userInQuestion.id,
+                // Different status
+                status = MessageEntity.Status.READ
+            ),
+            newMessageEntity(
+                "4",
+                conversationId = conversationEntity1.id,
+                // Different user
+                senderUserId = otherUser.id,
+                status = MessageEntity.Status.PENDING
+            )
+        )
+
+        messageDAO.insertMessages(allMessages)
+
+        val result = messageDAO.getAllPendingMessagesFromUser(userInQuestion.id)
+
+        assertContentEquals(expectedMessages, result)
+    }
+
+    @Test
+    fun givenMessagesNoRelevantMessagesAreInserted_whenGettingPendingMessagesByUser_thenAnEmptyListIsReturned() = runTest {
+        insertInitialData()
+
+        val userInQuestion = userEntity1
+        val otherUser = userEntity2
+
+        val allMessages = listOf(
+            newMessageEntity(
+                "3",
+                conversationId = conversationEntity1.id,
+                senderUserId = userInQuestion.id,
+                // Different status
+                status = MessageEntity.Status.READ
+            ),
+            newMessageEntity(
+                "4",
+                conversationId = conversationEntity1.id,
+                // Different user
+                senderUserId = otherUser.id,
+                status = MessageEntity.Status.PENDING
+            )
+        )
+
+        messageDAO.insertMessages(allMessages)
+
+        val result = messageDAO.getAllPendingMessagesFromUser(userInQuestion.id)
+
+        assertTrue { result.isEmpty() }
+    }
+
+    private suspend fun insertInitialData() {
+        userDAO.insertUsers(listOf(userEntity1, userEntity2))
+        conversationDAO.insertConversation(conversationEntity1)
+    }
+
+}

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.persistence.dao
 
 import com.wire.kalium.persistence.BaseDatabaseTest
+import com.wire.kalium.persistence.utils.stubs.newConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -13,16 +14,7 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
     private val user1 = newUserEntity(id = "1")
     private val user2 = newUserEntity(id = "2")
 
-    private val conversationEntity1 =
-        ConversationEntity(
-            QualifiedIDEntity("1", "wire.com"),
-            "conversation1",
-            ConversationEntity.Type.ONE_ON_ONE,
-            "teamID",
-            ConversationEntity.ProtocolInfo.Proteus,
-            lastNotificationDate = null,
-            lastModifiedDate = "2022-03-30T15:36:00.000Z"
-        )
+    private val conversationEntity1 = newConversationEntity()
 
     private val member1 = Member(user1.id)
     private val member2 = Member(user2.id)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
@@ -1,0 +1,14 @@
+package com.wire.kalium.persistence.utils.stubs
+
+import com.wire.kalium.persistence.dao.ConversationEntity
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+
+fun newConversationEntity(id: String = "test") = ConversationEntity(
+    QualifiedIDEntity(id, "wire.com"),
+    "conversation1",
+    ConversationEntity.Type.ONE_ON_ONE,
+    "teamID",
+    ConversationEntity.ProtocolInfo.Proteus,
+    lastNotificationDate = null,
+    lastModifiedDate = "2022-03-30T15:36:00.000Z"
+)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
@@ -1,0 +1,15 @@
+package com.wire.kalium.persistence.utils.stubs
+
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.message.MessageEntity
+
+fun newMessageEntity(
+    id: String = "testMessage",
+    content: MessageEntity.MessageEntityContent = MessageEntity.MessageEntityContent.TextMessageContent("Test Text"),
+    conversationId: QualifiedIDEntity = QualifiedIDEntity("convId", "convDomain"),
+    senderUserId: QualifiedIDEntity = QualifiedIDEntity("senderId", "senderDomain"),
+    senderClientId: String = "senderClientId",
+    status: MessageEntity.Status = MessageEntity.Status.PENDING
+) = MessageEntity(
+    id, content, conversationId, date = "date time", senderUserId, senderClientId, status, visibility = MessageEntity.Visibility.VISIBLE
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For AR-1312, I tried one implementation with `WorkManager` and scheduling one worker per message.
However, enqueueing one worker per message may be troublesome in case one fails. All subsequent tries fail too.

### Solutions

In this PR, expose a way to resolve pending messages for a user.
This will enable changing the implementation to enqueue just ONE worker for all pending messages.
This worker will:
- Fetch all pending messages
- Call `MessageSender` for each one of them.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
