### PR TITLE
fix(network): handle unknown device class type when getting clients of users

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -65,6 +65,7 @@ class ClientMapper(
         DeviceType.Tablet -> DeviceTypeDTO.Tablet
         DeviceType.Desktop -> DeviceTypeDTO.Desktop
         DeviceType.LegalHold -> DeviceTypeDTO.LegalHold
+        DeviceType.Unknown -> DeviceTypeDTO.Unknown
     }
 
     private fun fromDeviceTypeDTO(deviceTypeDTO: DeviceTypeDTO): DeviceType = when (deviceTypeDTO) {
@@ -72,5 +73,6 @@ class ClientMapper(
         DeviceTypeDTO.Tablet -> DeviceType.Tablet
         DeviceTypeDTO.Desktop -> DeviceType.Desktop
         DeviceTypeDTO.LegalHold -> DeviceType.LegalHold
+        DeviceTypeDTO.Unknown -> DeviceType.Unknown
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
@@ -46,7 +46,8 @@ enum class DeviceType {
     Phone,
     Tablet,
     Desktop,
-    LegalHold;
+    LegalHold,
+    Unknown;
 }
 
 enum class ClientCapability {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/IdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/IdMapperTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.id
 
+import com.wire.kalium.network.api.user.client.DeviceTypeDTO
 import com.wire.kalium.network.api.user.client.SimpleClientResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -30,7 +31,7 @@ class IdMapperTest {
 
     @Test
     fun givenASimpleClientResponse_whenMappingFromSimpleClientResponse_thenTheIDShouldBeMappedCorrectly() {
-        val simpleClientResponse = SimpleClientResponse("an ID", "it doesn't matter")
+        val simpleClientResponse = SimpleClientResponse("an ID", DeviceTypeDTO.Desktop)
 
         val clientID = idMapper.fromSimpleClientResponse(simpleClientResponse)
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientRequest.kt
@@ -39,6 +39,10 @@ enum class ClientTypeDTO {
     }
 }
 
+/**
+ * The type of device where the client is running.
+ * In case the backend returns null, nothing, or any other unknown value, [Unknown] is used.
+ */
 @Serializable
 enum class DeviceTypeDTO {
     @SerialName("phone")
@@ -51,7 +55,10 @@ enum class DeviceTypeDTO {
     Desktop,
 
     @SerialName("legalhold")
-    LegalHold;
+    LegalHold,
+
+    @SerialName("unknown")
+    Unknown;
 
     override fun toString(): String {
         return this.name.lowercase()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientResponse.kt
@@ -38,6 +38,6 @@ data class ClientsOfUsersResponse(
 @Serializable
 data class SimpleClientResponse(
     @SerialName("id") val id: String,
-    @SerialName("class") val deviceClass: String? = "unknown"
+    @SerialName("class") val deviceClass: DeviceTypeDTO? = DeviceTypeDTO.Unknown
 )
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientResponse.kt
@@ -38,6 +38,6 @@ data class ClientsOfUsersResponse(
 @Serializable
 data class SimpleClientResponse(
     @SerialName("id") val id: String,
-    @SerialName("class") val deviceClass: String
+    @SerialName("class") val deviceClass: String? = "unknown"
 )
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/client/ClientResponse.kt
@@ -12,7 +12,7 @@ data class ClientResponse(
     @SerialName("model") val model: String?,
     @SerialName("id") val clientId: String,
     @SerialName("type") val type: ClientTypeDTO,
-    @SerialName("class") val deviceType: DeviceTypeDTO?,
+    @SerialName("class") val deviceType: DeviceTypeDTO = DeviceTypeDTO.Unknown,
     @SerialName("capabilities") val capabilities: Capabilities?,
     @SerialName("label") val label: String?
 )
@@ -38,6 +38,6 @@ data class ClientsOfUsersResponse(
 @Serializable
 data class SimpleClientResponse(
     @SerialName("id") val id: String,
-    @SerialName("class") val deviceClass: DeviceTypeDTO? = DeviceTypeDTO.Unknown
+    @SerialName("class") val deviceClass: DeviceTypeDTO = DeviceTypeDTO.Unknown
 )
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseJson.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.api.tools.json.api.user.client
 
 import com.wire.kalium.api.tools.json.ValidJsonProvider
 import com.wire.kalium.network.api.user.client.ClientResponse
+import com.wire.kalium.network.api.user.client.DeviceTypeDTO
 import com.wire.kalium.network.api.user.client.SimpleClientResponse
 
 object SimpleClientResponseJson {
@@ -9,6 +10,14 @@ object SimpleClientResponseJson {
         """
         |{
         |   "id": "${serializable.id}"
+        |}
+        """.trimMargin()
+    }
+    private val gibberishClassJsonProvider = { serializable: SimpleClientResponse ->
+        """
+        |{
+        |   "id": "${serializable.id}",
+        |   "class": "198237juf9"
         |}
         """.trimMargin()
     }
@@ -24,7 +33,7 @@ object SimpleClientResponseJson {
     val valid = ValidJsonProvider(
         SimpleClientResponse(
             id = "3b3a54c770f5e1a4",
-            deviceClass = "desktop"
+            deviceClass = DeviceTypeDTO.Phone
         ),
         jsonProvider
     )
@@ -34,6 +43,13 @@ object SimpleClientResponseJson {
             id = "3b3a54c770f5e1a4"
         ),
         missingClassJsonProvider
+    )
+
+    val validGibberishClass = ValidJsonProvider(
+        SimpleClientResponse(
+            id = "3b3a54c770f5e1a4"
+        ),
+        gibberishClassJsonProvider
     )
 
     fun createValid(clientResponse: SimpleClientResponse) = ValidJsonProvider(clientResponse, jsonProvider)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseJson.kt
@@ -1,0 +1,40 @@
+package com.wire.kalium.api.tools.json.api.user.client
+
+import com.wire.kalium.api.tools.json.ValidJsonProvider
+import com.wire.kalium.network.api.user.client.ClientResponse
+import com.wire.kalium.network.api.user.client.SimpleClientResponse
+
+object SimpleClientResponseJson {
+    private val missingClassJsonProvider = { serializable: SimpleClientResponse ->
+        """
+        |{
+        |   "id": "${serializable.id}"
+        |}
+        """.trimMargin()
+    }
+    private val jsonProvider = { serializable: SimpleClientResponse ->
+        """
+        |{
+        |   "id": "${serializable.id}",
+        |   "class": "${serializable.deviceClass}"
+        |}
+        """.trimMargin()
+    }
+
+    val valid = ValidJsonProvider(
+        SimpleClientResponse(
+            id = "3b3a54c770f5e1a4",
+            deviceClass = "desktop"
+        ),
+        jsonProvider
+    )
+
+    val validMissingClass = ValidJsonProvider(
+        SimpleClientResponse(
+            id = "3b3a54c770f5e1a4"
+        ),
+        missingClassJsonProvider
+    )
+
+    fun createValid(clientResponse: SimpleClientResponse) = ValidJsonProvider(clientResponse, jsonProvider)
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseTest.kt
@@ -1,0 +1,22 @@
+package com.wire.kalium.api.tools.json.api.user.client
+
+import com.wire.kalium.network.api.user.client.SimpleClientResponse
+import com.wire.kalium.network.tools.KtxSerializer
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SimpleClientResponseTest {
+
+
+    @Test
+    fun givenAJsonWithMissingClass_whenDeserializingIt_thenHandleItByPuttingUnknownClass() = runTest {
+        val jsonString = SimpleClientResponseJson.validMissingClass.rawJson
+
+        val result = KtxSerializer.json.decodeFromString<SimpleClientResponse>(jsonString)
+
+        assertEquals("unknown", result.deviceClass)
+        assertEquals(SimpleClientResponseJson.validMissingClass.serializableData, result)
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.assertEquals
 
 class SimpleClientResponseTest {
 
-
     @Test
     fun givenAJsonWithMissingClass_whenDeserializingIt_thenHandleItByPuttingUnknownClass() = runTest {
         val jsonString = SimpleClientResponseJson.validMissingClass.rawJson

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/client/SimpleClientResponseTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.api.tools.json.api.user.client
 
+import com.wire.kalium.network.api.user.client.DeviceTypeDTO
 import com.wire.kalium.network.api.user.client.SimpleClientResponse
 import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.coroutines.test.runTest
@@ -15,7 +16,16 @@ class SimpleClientResponseTest {
 
         val result = KtxSerializer.json.decodeFromString<SimpleClientResponse>(jsonString)
 
-        assertEquals("unknown", result.deviceClass)
+        assertEquals(DeviceTypeDTO.Unknown, result.deviceClass)
         assertEquals(SimpleClientResponseJson.validMissingClass.serializableData, result)
+    }
+    @Test
+    fun givenAJsonWithGibberishClass_whenDeserializingIt_thenHandleItByPuttingUnknownClass() = runTest {
+        val jsonString = SimpleClientResponseJson.validGibberishClass.rawJson
+
+        val result = KtxSerializer.json.decodeFromString<SimpleClientResponse>(jsonString)
+
+        assertEquals(DeviceTypeDTO.Unknown, result.deviceClass)
+        assertEquals(SimpleClientResponseJson.validGibberishClass.serializableData, result)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When getting list of clients from users, we were expecting the `class` to be always present. Leading to crashes.
But the API doesn't always incldue that data.

### Solutions

When nothing comes up, replace with "unknown".

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

### Notes

We currently' don't use this field for anything. So just putting in a String is fine.
Once we start using it, we should probably replace it with an enum or similar.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
