### PR TITLE
feat: Added SyncPendingEventsUseCase

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -62,6 +62,7 @@ import com.wire.kalium.logic.feature.user.UserScope
 import com.wire.kalium.logic.sync.ConversationEventReceiver
 import com.wire.kalium.logic.sync.ListenToEventsUseCase
 import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.logic.sync.SyncPendingEventsUseCase
 import com.wire.kalium.logic.util.TimeParser
 import com.wire.kalium.logic.util.TimeParserImpl
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
@@ -233,6 +234,8 @@ abstract class UserSessionScopeCommon(
     private val logoutRepository: LogoutRepository = LogoutDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.logoutApi)
     val listenToEvents: ListenToEventsUseCase
         get() = ListenToEventsUseCase(syncManager, eventRepository, conversationEventReceiver)
+    val syncPendingEvents: SyncPendingEventsUseCase
+        get() = SyncPendingEventsUseCase(syncManager, eventRepository, conversationEventReceiver)
     val client: ClientScope get() = ClientScope(clientRepository, preKeyRepository, keyPackageRepository, mlsClientProvider)
     val conversations: ConversationScope get() = ConversationScope(conversationRepository, userRepository, syncManager)
     val messages: MessageScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCase.kt
@@ -1,0 +1,43 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventRepository
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.suspending
+import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+
+class SyncPendingEventsUseCase(
+    private val syncManager: SyncManager,
+    private val eventRepository: EventRepository,
+    private val conversationEventReceiver: EventReceiver<Event.Conversation>
+) {
+
+    /**
+     * @return Flow<Unit> that emits only once - when syncing Pending Events was done
+     */
+    suspend operator fun invoke(): Flow<Unit> {
+        syncManager.waitForSlowSyncToComplete()
+
+        return flow {
+            eventRepository.pendingEvents()
+                .onCompletion { emit(Unit) }
+                .collect { either ->
+                    suspending {
+                        either.map { event ->
+                            kaliumLogger.i(message = "Event received: $event")
+                            when (event) {
+                                is Event.Conversation -> conversationEventReceiver.onEvent(event)
+                                else -> kaliumLogger.i(message = "Unhandled event id=${event.id}")
+                            }
+                            eventRepository.updateLastProcessedEventId(event.id)
+                        }
+                    }.onFailure {
+                        kaliumLogger.e(message = "Failure when receiving events: $it")
+                    }
+                }
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCaseTest.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.sync
 
-import app.cash.turbine.test
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.framework.TestConversation
@@ -20,7 +19,6 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @ConfigurationApi
 @ExperimentalCoroutinesApi
@@ -58,34 +56,12 @@ class SyncPendingEventsUseCaseTest {
             .whenInvoked()
             .thenReturn(events.asFlow())
 
-        syncPendingEvents().collect {}
+        syncPendingEvents()
 
         verify(eventRepository)
             .suspendFunction(eventRepository::updateLastProcessedEventId)
             .with(eq(event.id))
             .wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenAnEventIsReceived_whenSyncedPendingEvents_thenFlowEmitsUnit() = runTest {
-        val event = Event.Conversation.MemberJoin(
-            "firstEventId",
-            TestConversation.ID,
-            TestUser.USER_ID,
-            ConversationMembers(listOf(), listOf()),
-            "someFrom"
-        )
-        val events = listOf(Either.Right(event))
-
-        given(eventRepository)
-            .suspendFunction(eventRepository::pendingEvents)
-            .whenInvoked()
-            .thenReturn(events.asFlow())
-
-        syncPendingEvents().test {
-            assertEquals(awaitItem(), Unit)
-            awaitComplete()
-        }
     }
 
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCaseTest.kt
@@ -1,0 +1,91 @@
+package com.wire.kalium.logic.sync
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.network.api.conversation.ConversationMembers
+import io.mockative.ConfigurationApi
+import io.mockative.Mock
+import io.mockative.configure
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@ConfigurationApi
+@ExperimentalCoroutinesApi
+class SyncPendingEventsUseCaseTest {
+
+    @Mock
+    val syncManager = configure(mock(SyncManager::class)) { stubsUnitByDefault = true }
+
+    @Mock
+    val eventRepository = configure(mock(EventRepository::class)) { stubsUnitByDefault = true }
+
+    @Mock
+    val conversationEventReceiver = configure(mock(ConversationEventReceiver::class)) { stubsUnitByDefault = true }
+
+    lateinit var syncPendingEvents: SyncPendingEventsUseCase
+
+    @BeforeTest
+    fun setup() {
+        syncPendingEvents = SyncPendingEventsUseCase(syncManager, eventRepository, conversationEventReceiver)
+    }
+
+    @Test
+    fun givenAnEventIsReceived_whenSyncingPendingEvents_thenTheLastProcessedEventIdIsUpdated() = runTest {
+        val event = Event.Conversation.MemberJoin(
+            "firstEventId",
+            TestConversation.ID,
+            TestUser.USER_ID,
+            ConversationMembers(listOf(), listOf()),
+            "someFrom"
+        )
+        val events = listOf(Either.Right(event))
+
+        given(eventRepository)
+            .suspendFunction(eventRepository::pendingEvents)
+            .whenInvoked()
+            .thenReturn(events.asFlow())
+
+        syncPendingEvents().collect {}
+
+        verify(eventRepository)
+            .suspendFunction(eventRepository::updateLastProcessedEventId)
+            .with(eq(event.id))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAnEventIsReceived_whenSyncedPendingEvents_thenFlowEmitsUnit() = runTest {
+        val event = Event.Conversation.MemberJoin(
+            "firstEventId",
+            TestConversation.ID,
+            TestUser.USER_ID,
+            ConversationMembers(listOf(), listOf()),
+            "someFrom"
+        )
+        val events = listOf(Either.Right(event))
+
+        given(eventRepository)
+            .suspendFunction(eventRepository::pendingEvents)
+            .whenInvoked()
+            .thenReturn(events.asFlow())
+
+        syncPendingEvents().test {
+            assertEquals(awaitItem(), Unit)
+            awaitComplete()
+        }
+    }
+
+}


### PR DESCRIPTION
# What's new in this PR?

Added SyncPendingEventsUseCase
It's needed for 1-time syncing of all the pending events, when the app receives FCM.