### PR TITLE
fix: missing unique constraint on members table

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -4,11 +4,12 @@ CREATE TABLE Member (
     user TEXT AS QualifiedIDEntity NOT NULL,
     conversation TEXT AS QualifiedIDEntity NOT NULL,
     FOREIGN KEY (user) REFERENCES User(qualified_id),
-    FOREIGN KEY (conversation) REFERENCES Conversation(qualified_id)
+    FOREIGN KEY (conversation) REFERENCES Conversation(qualified_id),
+    CONSTRAINT member_conv UNIQUE (user, conversation) ON CONFLICT IGNORE
 );
 
 insertMember:
-INSERT INTO Member(user, conversation)
+INSERT OR IGNORE INTO Member(user, conversation)
 VALUES (?, ?);
 
 deleteMember:

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -32,7 +32,6 @@ class ConversationMapper {
             lastModifiedDate = conversation.last_modified_date
         )
     }
-
 }
 
 class MemberMapper {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

duplicated conversation members when running sync multiple times

### Causes (Optional)

missing unique constraint  for (userId + convId) in members table

### Solutions

add `CONSTRAINT member_conv UNIQUE (user, conversation) ON CONFLICT IGNORE` to the members table

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

- [x] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
