### PR TITLE
feat: send connection repository work - part 2 (AR-1483)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.connection
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.isRight
@@ -18,6 +19,7 @@ import com.wire.kalium.persistence.dao.UserEntity
 
 interface ConnectionRepository {
     suspend fun fetchSelfUserConnections(): Either<CoreFailure, Unit>
+    suspend fun sendUserConnection(userId: UserId): Either<CoreFailure, Unit>
 }
 
 internal class ConnectionDataSource(
@@ -45,6 +47,14 @@ internal class ConnectionDataSource(
         }
 
         latestResult
+    }
+
+    override suspend fun sendUserConnection(userId: UserId): Either<CoreFailure, Unit> = suspending {
+        wrapApiRequest {
+            connectionApi.createConnection(idMapper.toApiModel(userId))
+        }.map { connection ->
+            updateUserConnectionStatus(listOf(connection))
+        }
     }
 
     private fun connectionStateToDao(state: ConnectionState): UserEntity.ConnectionState = when (state) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -136,7 +136,7 @@ class ConnectionRepositoryTest {
     @Test
     fun givenAConnectionRequest_WhenSendingAConnectionAndPersistingReturnsAnError_thenTheConnectionShouldNotBePersisted() = runTest {
         // given
-        val userId = UserId("user_id", "domain_id")
+        val userId = NetworkUserId("user_id", "domain_id")
         given(connectionApi)
             .suspendFunction(connectionApi::createConnection)
             .whenInvokedWith(eq(userId))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -88,7 +88,7 @@ class ConnectionRepositoryTest {
             .then { _, _, _ -> return@then }
 
         // when
-        val result = connectionRepository.sendUserConnection(com.wire.kalium.logic.data.user.UserId("user_id", "domain_id"))
+        val result = connectionRepository.sendUserConnection(com.wire.kalium.logic.data.user.UserId(userId.value, userId.domain))
 
         // then
         result.shouldSucceed()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

https://wearezeta.atlassian.net/browse/AR-1483

### Issues

This work it's related to the creation of a connection of a user, "Send a connection request" in detail this PR takes care of the repo layer, namely: Calling the Network layer and persisting locally the response.

You could see prev. PR implemented here -> #468 

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
