### PR TITLE
chore: bump ktor to 2.0.1 and make the project compatible

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -14,7 +14,7 @@ object Versions {
     const val cryptoboxAndroid = "1.1.3"
     const val javaxCrypto = "1.1.0-alpha03"
     const val kover = "0.4.4"
-    const val ktor2 = "2.0.0-beta-1"
+    const val ktor = "2.0.1"
     const val okHttp = "4.9.3"
     const val mockative = "1.1.4"
     const val androidWork = "2.7.1"
@@ -94,7 +94,7 @@ object Dependencies {
         const val composeMaterial = "androidx.compose.material:material:${Versions.compose}"
         const val composeTooling = "androidx.compose.ui:ui-tooling:${Versions.compose}"
         const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
-        const val ktor = "io.ktor:ktor-client-android:${Versions.ktor2}"
+        const val ktor = "io.ktor:ktor-client-android:${Versions.ktor}"
         const val securityCrypto = "androidx.security:security-crypto:${Versions.androidSecurity}"
         const val desugarJdkLibs = "com.android.tools:desugar_jdk_libs:${Versions.desugarJdk}"
     }
@@ -133,17 +133,17 @@ object Dependencies {
     }
 
     object Ktor {
-        const val core = "io.ktor:ktor-client-core:${Versions.ktor2}"
-        const val json = "io.ktor:ktor-client-json:${Versions.ktor2}"
-        const val serialization = "io.ktor:ktor-serialization-kotlinx-json:${Versions.ktor2}"
-        const val logging = "io.ktor:ktor-client-logging:${Versions.ktor2}"
-        const val authClient = "io.ktor:ktor-client-auth:${Versions.ktor2}"
-        const val contentNegotiation = "io.ktor:ktor-client-content-negotiation:${Versions.ktor2}"
-        const val webSocket = "io.ktor:ktor-client-websockets:${Versions.ktor2}"
-        const val utils = "io.ktor:ktor-utils:${Versions.ktor2}"
-        const val mock = "io.ktor:ktor-client-mock:${Versions.ktor2}"
-        const val okHttp = "io.ktor:ktor-client-okhttp:${Versions.ktor2}"
-        const val iosHttp = "io.ktor:ktor-client-ios:${Versions.ktor2}"
+        const val core = "io.ktor:ktor-client-core:${Versions.ktor}"
+        const val json = "io.ktor:ktor-client-json:${Versions.ktor}"
+        const val serialization = "io.ktor:ktor-serialization-kotlinx-json:${Versions.ktor}"
+        const val logging = "io.ktor:ktor-client-logging:${Versions.ktor}"
+        const val authClient = "io.ktor:ktor-client-auth:${Versions.ktor}"
+        const val contentNegotiation = "io.ktor:ktor-client-content-negotiation:${Versions.ktor}"
+        const val webSocket = "io.ktor:ktor-client-websockets:${Versions.ktor}"
+        const val utils = "io.ktor:ktor-utils:${Versions.ktor}"
+        const val mock = "io.ktor:ktor-client-mock:${Versions.ktor}"
+        const val okHttp = "io.ktor:ktor-client-okhttp:${Versions.ktor}"
+        const val iosHttp = "io.ktor:ktor-client-ios:${Versions.ktor}"
     }
 
     object SqlDelight {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -62,7 +62,7 @@ class EventRepositoryTest {
             "eventId",
             listOf()
         )
-        val notificationsPageResponse = NotificationResponse.CompleteList("time", false, listOf(firstPage))
+        val notificationsPageResponse = NotificationResponse("time", false, listOf(firstPage))
 
         given(eventInfoStorage)
             .getter(eventInfoStorage::lastProcessedId)
@@ -106,7 +106,7 @@ class EventRepositoryTest {
                 )
             )
         )
-        val notificationsPageResponse = NotificationResponse.CompleteList("time", false, listOf(firstPage))
+        val notificationsPageResponse = NotificationResponse("time", false, listOf(firstPage))
 
         given(eventInfoStorage)
             .getter(eventInfoStorage::lastProcessedId)
@@ -147,7 +147,7 @@ class EventRepositoryTest {
         )
         val pendingEvent = EventResponse("pendingEventId", listOf(pendingEventPayload))
         val liveEvent = pendingEvent.copy(id = "liveEventId")
-        val notificationsPageResponse = NotificationResponse.CompleteList("time", false, listOf(pendingEvent))
+        val notificationsPageResponse = NotificationResponse("time", false, listOf(pendingEvent))
 
         given(eventInfoStorage)
             .getter(eventInfoStorage::lastProcessedId)
@@ -190,7 +190,7 @@ class EventRepositoryTest {
             MessageEventData("text", "senderId", "recipient")
         )
         val pendingEvent = EventResponse("pendingEventId", listOf(pendingEventPayload))
-        val notificationsPageResponse = NotificationResponse.CompleteList("time", false, listOf(pendingEvent))
+        val notificationsPageResponse = NotificationResponse("time", false, listOf(pendingEvent))
 
         given(eventInfoStorage)
             .getter(eventInfoStorage::lastProcessedId)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/AuthenticatedNetworkContainer.kt
@@ -36,7 +36,7 @@ import com.wire.kalium.network.serialization.xprotobuf
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.session.installAuth
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.plugins.ContentNegotiation
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 
 class AuthenticatedNetworkContainer(
     private val sessionManager: SessionManager,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/HttpClientProvider.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/HttpClientProvider.kt
@@ -5,7 +5,7 @@ import com.wire.kalium.network.tools.ServerConfigDTO
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.plugins.ContentNegotiation
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApiImp.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApiImp.kt
@@ -1,7 +1,6 @@
 package com.wire.kalium.network.api.message
 
 import com.wire.kalium.network.api.ConversationId
-import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.ProteusClientsChangedError
 import com.wire.kalium.network.exceptions.SendMessageError
 import com.wire.kalium.network.serialization.XProtoBuf
@@ -9,7 +8,6 @@ import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -53,31 +51,15 @@ class MessageApiImp(
             queryParameter: String?,
             queryParameterValue: Any?,
             body: RequestBody
-        ): NetworkResponse<SendMessageResponse> {
-            return try {
-                val response = httpClient.post("$PATH_CONVERSATIONS/$conversationId$PATH_OTR_MESSAGE") {
-                    if (queryParameter != null) {
-                        parameter(queryParameter, queryParameterValue)
-                    }
-                    setBody(body)
+        ): NetworkResponse<SendMessageResponse> = wrapKaliumResponse<SendMessageResponse.MessageSent>({
+            if (it.status.value != 412) null
+            else NetworkResponse.Error(kException = SendMessageError.MissingDeviceError(errorBody = it.body()))
+        }) {
+            httpClient.post("$PATH_CONVERSATIONS/$conversationId$PATH_OTR_MESSAGE") {
+                if (queryParameter != null) {
+                    parameter(queryParameter, queryParameterValue)
                 }
-                return NetworkResponse.Success(httpResponse = response, value = response.body<SendMessageResponse.MessageSent>())
-            } catch (e: ResponseException) {
-                when (e.response.status.value) {
-                    // It's a 412 Error
-                    412 -> NetworkResponse.Error(
-                        kException = SendMessageError.MissingDeviceError(
-                            errorBody = e.response.body()
-                        )
-                    )
-                    else -> wrapKaliumResponse { e.response }
-                }
-            }
-            // TODO: is this even necessary since we catch 'Em all in wrapKaliumResponse
-            catch (e: Exception) {
-                NetworkResponse.Error(
-                    kException = KaliumException.GenericError(e)
-                )
+                setBody(body)
             }
         }
 
@@ -107,25 +89,17 @@ class MessageApiImp(
     override suspend fun qualifiedSendMessage(
         parameters: MessageApi.Parameters.QualifiedDefaultParameters,
         conversationId: ConversationId
-    ): NetworkResponse<QualifiedSendMessageResponse> {
-        return try {
-            val response = httpClient.post("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}$PATH_PROTEUS_MESSAGE") {
-                setBody(envelopeProtoMapper.encodeToProtobuf(parameters))
-                contentType(ContentType.Application.XProtoBuf)
-            }
-            NetworkResponse.Success(httpResponse = response, value = response.body<QualifiedSendMessageResponse.MessageSent>())
-        } catch (e: ResponseException) {
-            when (e.response.status.value) {
-                // It's a 412 Error
-                412 -> NetworkResponse.Error(
-                    kException = ProteusClientsChangedError(
-                        errorBody = e.response.body()
-                    )
-                )
-                else -> wrapKaliumResponse { e.response }
-            }
-        } catch (e: Exception) {
-            NetworkResponse.Error(kException = KaliumException.GenericError(e))
+    ): NetworkResponse<QualifiedSendMessageResponse> = wrapKaliumResponse<QualifiedSendMessageResponse.MessageSent>({
+        if (it.status.value != 412) null
+        else NetworkResponse.Error(
+            kException = ProteusClientsChangedError(
+                errorBody = it.body()
+            )
+        )
+    }) {
+        httpClient.post("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}$PATH_PROTEUS_MESSAGE") {
+            setBody(envelopeProtoMapper.encodeToProtobuf(parameters))
+            contentType(ContentType.Application.XProtoBuf)
         }
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationResponse.kt
@@ -1,35 +1,11 @@
 package com.wire.kalium.network.api.notification
 
 import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
-sealed class NotificationResponse {
-    abstract val time: String
-    abstract val hasMore: Boolean
-    abstract val notifications: List<EventResponse>
-
-    data class MissingSome(override val time: String, override val hasMore: Boolean, override val notifications: List<EventResponse>) :
-        NotificationResponse() {
-        internal constructor(notificationPage: NotificationPageResponse) : this(
-            notificationPage.time,
-            notificationPage.hasMore,
-            notificationPage.notifications
-        )
-    }
-
-    data class CompleteList(override val time: String, override val hasMore: Boolean, override val notifications: List<EventResponse>) :
-        NotificationResponse() {
-        internal constructor(notificationPage: NotificationPageResponse) : this(
-            notificationPage.time,
-            notificationPage.hasMore,
-            notificationPage.notifications
-        )
-    }
-}
-
-@Serializable
-internal data class NotificationPageResponse(
+data class NotificationResponse(
     @SerialName("time") val time: String,
     @SerialName("has_more") val hasMore: Boolean,
-    @SerialName("notifications") val notifications: List<EventResponse>
+    @SerialName("notifications") val notifications: List<EventResponse>,
+    @Transient val isMissingNotifications: Boolean = false
 )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkUtils.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkUtils.kt
@@ -3,18 +3,13 @@ package com.wire.kalium.network.utils
 import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.kaliumLogger
-import io.ktor.client.call.NoTransformationFoundException
 import io.ktor.client.call.body
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.RedirectResponseException
-import io.ktor.client.plugins.ResponseException
-import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
-import kotlinx.serialization.SerializationException
+import io.ktor.http.isSuccess
 
 internal fun HttpRequestBuilder.setWSSUrl(baseUrl: Url, vararg path: String) {
     url {
@@ -121,54 +116,62 @@ internal fun <T : Any> NetworkResponse<T>.onFailure(fn: (NetworkResponse.Error) 
 internal fun <T : Any> NetworkResponse<T>.onSuccess(fn: (NetworkResponse.Success<T>) -> Unit): NetworkResponse<T> =
     this.apply { if (this is NetworkResponse.Success) fn(this) }
 
-internal suspend inline fun <reified BodyType : Any> wrapKaliumResponse(performRequest: () -> HttpResponse): NetworkResponse<BodyType> =
-    try {
-        val result = performRequest()
-        NetworkResponse.Success(
-            value = result.body(),
-            httpResponse = result
-        )
-    } catch (e: ResponseException) { // ktor exception
-        when (e) {
-            is RedirectResponseException -> {
-                // 300 .. 399
-                NetworkResponse.Error(kException = KaliumException.RedirectError(e.response.body()))
-            }
-            is ClientRequestException -> {
-                // 400 .. 499
-                when (e.response.status) {
+/**
+ * Wraps exceptions thrown during the request or parsing of the response, like
+ * exceptions thrown due to inability to reach the server.
+ * This does **not** handle the response itself (i.e. HTTP status, body, etc.),
+ * but may be used to catch exceptions thrown during those steps.
+ * 
+ * @return [NetworkResponse.Success] if everything went smooth
+ * @return [NetworkResponse.Error] with a [KaliumException.GenericError] in case of an error
+ */
+private inline fun <reified ResponseType: Any> handlingNetworkException(
+    performRequest: () -> NetworkResponse<ResponseType>
+): NetworkResponse<ResponseType> = try {
+    performRequest()
+} catch (e: Exception) {
+    NetworkResponse.Error(KaliumException.GenericError(e))
+}
 
-                    // for 401 error the BE return response with content-type: text/html which kalium ktor client
-                    // has no idea how to parse -> app crash
-                    HttpStatusCode.Unauthorized -> {
-                        kaliumLogger.e("Unauthorized request", e)
-                        NetworkResponse.Error(KaliumException.Unauthorized(e.response.status.value))
-                    }
-
-                    else -> try {
-                            e.response.body() as ErrorResponse
-                        } catch (_: NoTransformationFoundException) {
-                            ErrorResponse(e.response.status.value, e.response.status.description, "")
-                        }.let { errorResponse ->
-                            NetworkResponse.Error(kException = KaliumException.InvalidRequestError(errorResponse))
-                        }
-                }
+/**
+ * Wraps a producer of [HttpResponse] and attempts to parse the server response based on the [BodyType].
+ * @return - Successful response (HTTP Status Codes from 200 to 299):
+ * a [NetworkResponse.Success] with the expected [BodyType] will be returned.
+ *
+ * - Unsuccessful response (any other HTTP Status Code):
+ * a [NetworkResponse.Error] with a [KaliumException]. Will try to read it the body as an [ErrorResponse].
+ * It's possible to intercept this and do the mapping to a [NetworkResponse] through [unsuccessfulResponseOverride].
+ *
+ * - Exceptions failure to reach server or parse response:
+ * a [NetworkResponse.Error] containing a [KaliumException.GenericError]
+ *
+ * @param unsuccessfulResponseOverride Allows to intercept any unsuccessful response
+ * and map it to a [NetworkResponse] as needed. Useful when handling custom ErrorBody
+ * @param performRequest the block that will result into the [HttpResponse]
+ * @see KaliumException
+ * @see ErrorResponse
+ */
+internal suspend inline fun <reified BodyType : Any> wrapKaliumResponse(
+    unsuccessfulResponseOverride: (HttpResponse) -> NetworkResponse<BodyType>? = { null },
+    performRequest: () -> HttpResponse
+): NetworkResponse<BodyType> = handlingNetworkException {
+    val result = performRequest()
+    val status = result.status
+    return if (status.isSuccess()) {
+        NetworkResponse.Success(result.body(), result)
+    } else {
+        unsuccessfulResponseOverride(result) ?: when (status.value) {
+            HttpStatusCode.Unauthorized.value -> {
+                kaliumLogger.e("Unauthorized request, $result")
+                NetworkResponse.Error(KaliumException.Unauthorized(status.value))
             }
-            is ServerResponseException -> {
-                // 500 .. 599
-                // TODO: do 500 errors have body
-                NetworkResponse.Error(kException = KaliumException.ServerError(e.response.body()))
-            }
+            in (300..399) -> NetworkResponse.Error(KaliumException.RedirectError(result.body()))
+            in (400..499) -> NetworkResponse.Error(KaliumException.InvalidRequestError(result.body()))
+            in (500..599) -> NetworkResponse.Error(KaliumException.ServerError(result.body()))
             else -> {
-                NetworkResponse.Error(kException = KaliumException.GenericError(e))
+                kaliumLogger.e("Server responded with unsupported status code: [$status]")
+                NetworkResponse.Error(KaliumException.ServerError(result.body()))
             }
         }
-    } catch (e: SerializationException) {
-        NetworkResponse.Error(
-            kException = KaliumException.GenericError(cause = e)
-        )
-    } catch (e: Exception) {
-        NetworkResponse.Error(
-            kException = KaliumException.GenericError(e)
-        )
     }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/notification/NotificationApiTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -93,7 +94,7 @@ class NotificationApiTest : ApiTest {
     }
 
     @Test
-    fun given404Response_whenGettingNotificationGettingAllNotifications_thenTheResponseIsParsedCorrectly() = runTest {
+    fun given404Response_whenGettingAllNotifications_thenTheResponseIsParsedCorrectly() = runTest {
         val httpClient = mockAuthenticatedHttpClient(
             NotificationEventsResponseJson.notificationsWithUnknownEventAtFirstPosition,
             statusCode = HttpStatusCode.NotFound
@@ -103,7 +104,21 @@ class NotificationApiTest : ApiTest {
         val result = notificationsApi.getAllNotifications(1, "")
 
         assertIs<NetworkResponse.Success<NotificationResponse>>(result)
-        assertIs<NotificationResponse.MissingSome>(result.value)
+        assertTrue { result.value.isMissingNotifications }
+    }
+
+    @Test
+    fun givenSuccessResponse_whenGettingAllNotifications_thenTheResponseIsParsedCorrectly() = runTest {
+        val httpClient = mockAuthenticatedHttpClient(
+            NotificationEventsResponseJson.notificationsWithUnknownEventAtFirstPosition,
+            statusCode = HttpStatusCode.OK
+        )
+        val notificationsApi = NotificationApiImpl(httpClient, TEST_BACKEND_CONFIG)
+
+        val result = notificationsApi.getAllNotifications(1, "")
+
+        assertIs<NetworkResponse.Success<NotificationResponse>>(result)
+        assertFalse { result.value.isMissingNotifications }
     }
 
     private companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

2.0.0 and up changes the default value of `expectSuccess` to `false` so it no longer throws an Exception when a non 200 response is returned.

### Solutions


Even though we could just flip this value back to `true`, I identified we had a chance to improve the current handling of failures in the network layer.

See the Kdoc, it talks by itself.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
