### PR TITLE
feat(delete-message): add visibility to all message layer [AR-1125] [AR-1126]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -3,7 +3,6 @@ package com.wire.kalium.logic.data.message
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.persistence.dao.message.MessageEntity
 
 data class Message(
     val id: String,
@@ -12,9 +11,14 @@ data class Message(
     val date: String,
     val senderUserId: UserId,
     val senderClientId: ClientId,
-    val status: Status
+    val status: Status,
+    val visibility: Visibility = Visibility.VISIBLE
 ) {
     enum class Status {
         PENDING, SENT, READ, FAILED
+    }
+
+    enum class Visibility {
+        VISIBLE, DELETED, HIDDEN
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -1,12 +1,10 @@
 package com.wire.kalium.logic.data.message
 
-import com.wire.kalium.logic.data.id.ConversationId
-
 sealed class MessageContent {
     data class Text(val value: String) : MessageContent()
     data class Calling(val value: String) : MessageContent()
     data class Asset(val value: AssetContent) : MessageContent()
     data class DeleteMessage(val messageId: String) : MessageContent()
-    data class DeleteForMe(val messageId: String, val conversationId: ConversationId) : MessageContent()
+    data class DeleteForMe(val messageId: String) : MessageContent()
     object Unknown : MessageContent()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -28,8 +28,6 @@ class MessageMapperImpl(private val idMapper: IdMapper) : MessageMapper {
         }
         val messageContent = when (message.content) {
             is MessageContent.Text -> TextMessageContent(messageBody = message.content.value)
-            is MessageContent.DeleteMessage -> TextMessageContent(messageBody = message.content.messageId)
-            is MessageContent.DeleteForMe -> TextMessageContent(messageBody = message.content.messageId)
             is MessageContent.Asset -> {
                 with(message.content.value) {
                     AssetMessageContent(
@@ -87,6 +85,11 @@ class MessageMapperImpl(private val idMapper: IdMapper) : MessageMapper {
             MessageEntity.Status.READ -> Message.Status.READ
             MessageEntity.Status.FAILED -> Message.Status.FAILED
         }
+        val visibility = when (message.visibility) {
+            MessageEntity.Visibility.VISIBLE -> Message.Visibility.VISIBLE
+            MessageEntity.Visibility.HIDDEN -> Message.Visibility.HIDDEN
+            MessageEntity.Visibility.DELETED -> Message.Visibility.DELETED
+        }
         return Message(
             message.id,
             content,
@@ -94,7 +97,8 @@ class MessageMapperImpl(private val idMapper: IdMapper) : MessageMapper {
             message.date,
             idMapper.fromDaoModel(message.senderUserId),
             ClientId(message.senderClientId),
-            status
+            status,
+            visibility
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -28,7 +28,7 @@ interface MessageRepository {
     suspend fun deleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun deleteMessage(messageUuid: String): Either<CoreFailure, Unit>
     suspend fun softDeleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
-    suspend fun hideMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
+    suspend fun hideMessage(messageUuid: String): Either<CoreFailure, Unit>
     suspend fun updateMessageStatus(
         messageStatus: MessageEntity.Status,
         conversationId: ConversationId,
@@ -89,17 +89,15 @@ class MessageDataSource(
     override suspend fun softDeleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit> {
         messageDAO.updateMessageVisibility(
             visibility = MessageEntity.Visibility.DELETED,
-            conversationId = idMapper.toDaoModel(conversationId),
             id = messageUuid
         )
         //TODO: Handle failures
         return Either.Right(Unit)
     }
 
-    override suspend fun hideMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit> {
+    override suspend fun hideMessage(messageUuid: String): Either<CoreFailure, Unit> {
         messageDAO.updateMessageVisibility(
             visibility = MessageEntity.Visibility.HIDDEN,
-            conversationId = idMapper.toDaoModel(conversationId),
             id = messageUuid
         )
         //TODO: Handle failures

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -73,15 +73,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
                 GenericMessage.Content.Deleted(MessageDelete(messageId = messageContent.messageId))
             }
             is MessageContent.DeleteForMe -> {
-                val qualifiedConversationId =
-                    QualifiedConversationId(id = messageContent.conversationId.value, domain = messageContent.conversationId.domain)
-                GenericMessage.Content.Hidden(
-                    MessageHide(
-                        conversationId = messageContent.conversationId.value,
-                        messageId = messageContent.messageId,
-                        qualifiedConversationId = qualifiedConversationId
-                    )
-                )
+                GenericMessage.Content.Hidden(MessageHide(messageId = messageContent.messageId))
             }
             else -> {
                 throw IllegalArgumentException("Unexpected message content type: $messageContent")
@@ -111,7 +103,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             is GenericMessage.Content.Composite -> MessageContent.Unknown
             is GenericMessage.Content.Confirmation -> MessageContent.Unknown
             is GenericMessage.Content.DataTransfer -> MessageContent.Unknown
-            is GenericMessage.Content.Deleted -> MessageContent.DeleteMessage(genericMessage.messageId)
+            is GenericMessage.Content.Deleted -> MessageContent.DeleteMessage(protoContent.value.messageId)
             is GenericMessage.Content.Edited -> MessageContent.Unknown
             is GenericMessage.Content.Ephemeral -> MessageContent.Unknown
             is GenericMessage.Content.External -> MessageContent.Unknown
@@ -119,13 +111,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             is GenericMessage.Content.Hidden -> {
                 val hiddenMessage = genericMessage.hidden
                 if (hiddenMessage != null) {
-                    MessageContent.DeleteForMe(
-                        hiddenMessage.messageId,
-                        ConversationId(
-                            hiddenMessage.qualifiedConversationId!!.id,
-                            hiddenMessage.qualifiedConversationId!!.domain
-                        )
-                    )
+                    MessageContent.DeleteForMe(hiddenMessage.messageId)
                 } else {
                     kaliumLogger.w("Hidden message is null. Message UUID = $genericMessage.")
                     MessageContent.Unknown

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -3,8 +3,8 @@ package com.wire.kalium.logic.feature.message
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
@@ -34,10 +34,7 @@ class DeleteMessageUseCase(
             clientRepository.currentClientId().flatMap { currentClientId ->
                 val message = Message(
                     id = generatedMessageUuid,
-                    content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else MessageContent.DeleteForMe(
-                        messageId,
-                        conversationId
-                    ),
+                    content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else MessageContent.DeleteForMe(messageId),
                     conversationId = if (deleteForEveryone) conversationId else conversationRepository.getSelfConversationId(),
                     date = Clock.System.now().toString(),
                     senderUserId = selfUser.id,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -171,11 +171,11 @@ class ConversationEventReceiver(
             }
             is MessageContent.DeleteMessage ->
                 if (isSenderVerified(message.content.messageId, message.conversationId, message.senderUserId))
-                    messageRepository.softDeleteMessage(messageUuid = message.content.messageId, message.conversationId)
+                    messageRepository.softDeleteMessage(messageUuid = message.content.messageId, conversationId = message.conversationId)
                 else kaliumLogger.i(message = "Delete message sender is not verified: $message")
             is MessageContent.DeleteForMe ->
-                if (isSenderVerified(message.content.messageId, message.conversationId, message.senderUserId))
-                    messageRepository.hideMessage(messageUuid = message.content.messageId, message.content.conversationId)
+                if (message.conversationId == conversationRepository.getSelfConversationId())
+                    messageRepository.hideMessage(messageUuid = message.content.messageId)
                 else kaliumLogger.i(message = "Delete message sender is not verified: $message")
             is MessageContent.Calling -> {
                 kaliumLogger.d("$TAG - MessageContent.Calling")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -49,12 +49,7 @@ class ProtoContentMapperTest {
 
     @Test
     fun givenHideMessageContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
-        val messageContent = MessageContent.DeleteForMe(
-            TEST_MESSAGE_UUID, conversationId = ConversationId(
-                TEST_MESSAGE_UUID,
-                TEST_MESSAGE_UUID
-            )
-        )
+        val messageContent = MessageContent.DeleteForMe(TEST_MESSAGE_UUID)
         val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -47,7 +47,7 @@ DELETE FROM Message WHERE  id = ?;
 updateMessageVisibility:
 UPDATE Message
 SET visibility = ?, text_body = ?
-WHERE id = ? AND conversation_id = ?;
+WHERE id = ?;
 
 insertMessage:
 INSERT INTO Message(id, text_body, asset_mime_type, asset_size, asset_name, asset_image_width, asset_image_height, asset_otr_key, asset_sha256, asset_id, asset_token, asset_domain, asset_encryption_algorithm, content_type, conversation_id, date, sender_user_id, sender_client_id, visibility, status)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -52,7 +52,7 @@ data class MessageEntity(
 interface MessageDAO {
     suspend fun deleteMessage(id: String, conversationsId: QualifiedIDEntity)
     suspend fun deleteMessage(id: String)
-    suspend fun updateMessageVisibility(visibility: MessageEntity.Visibility, id: String, conversationId: QualifiedIDEntity)
+    suspend fun updateMessageVisibility(visibility: MessageEntity.Visibility, id: String)
     suspend fun deleteAllMessages()
     suspend fun insertMessage(message: MessageEntity)
     suspend fun insertMessages(messages: List<MessageEntity>)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -55,8 +55,8 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
 
     override suspend fun deleteMessage(id: String) = queries.deleteMessageById(id)
 
-    override suspend fun updateMessageVisibility(visibility: MessageEntity.Visibility, id: String, conversationId: QualifiedIDEntity) =
-        queries.updateMessageVisibility(visibility, "", id, conversationId)
+    override suspend fun updateMessageVisibility(visibility: MessageEntity.Visibility, id: String) =
+        queries.updateMessageVisibility(visibility, "", id)
 
     override suspend fun deleteAllMessages() = queries.deleteAllMessages()
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -43,7 +43,8 @@ class MessageMapper {
             date = msg.date,
             senderUserId = msg.sender_user_id,
             senderClientId = msg.sender_client_id,
-            status = msg.status
+            status = msg.status,
+            visibility = msg.visibility
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
[AR-1125]
[AR-1126]

### Causes (Optional)

Need the visibility field to handle deleted messages in the UI


### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

[AR-1125]:https://wearezeta.atlassian.net/browse/AR-1125
[AR-1126]:https://wearezeta.atlassian.net/browse/AR-1126