### PR TITLE
refactor: simplify, add docs and rename functions in `MessageSender`

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/SendCallingMessage.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/SendCallingMessage.kt
@@ -14,5 +14,5 @@ suspend fun CallManagerImpl.sendCallingMessage(conversationId: ConversationId, u
     val messageContent = MessageContent.Calling(data)
     val date = Clock.System.now().toString()
     val message = Message(UUID.randomUUID().toString(), messageContent, conversationId, date, userId, clientId, Message.Status.SENT)
-    return messageSender.trySendingOutgoingMessage(conversationId, message)
+    return messageSender.sendMessage(message)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
@@ -113,7 +113,7 @@ internal class SendAssetMessageUseCaseImpl(
             )
             messageRepository.persistMessage(message)
         }.flatMap {
-            messageSender.trySendingOutgoingMessageById(conversationId, generatedMessageUuid)
+            messageSender.sendPendingMessage(conversationId, generatedMessageUuid)
         }.onFailure {
             kaliumLogger.e("There was an error when trying to send the asset on the conversation")
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
@@ -118,7 +118,7 @@ internal class SendImageMessageUseCaseImpl(
             )
             messageRepository.persistMessage(message)
         }.flatMap {
-            messageSender.trySendingOutgoingMessageById(conversationId, generatedMessageUuid)
+            messageSender.sendPendingMessage(conversationId, generatedMessageUuid)
         }.onFailure {
             kaliumLogger.e("There was an error when trying to send the image message to the conversation")
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -41,7 +41,7 @@ class DeleteMessageUseCase(
                     senderClientId = currentClientId,
                     status = Message.Status.PENDING
                 )
-                messageSender.trySendingOutgoingMessage(conversationId, message)
+                messageSender.sendMessage(message)
             }.flatMap {
                 messageRepository.deleteMessage(messageId, conversationId)
             }.onFailure {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
@@ -16,23 +17,46 @@ import com.wire.kalium.logic.util.TimeParser
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 
+/**
+ * Responsible for orchestrating all the pieces necessary
+ * for sending a message to the wanted recipients.
+ * Will handle reading and updating message status, retries
+ * in case of connectivity issues, and encryption based on
+ * [ConversationOptions.Protocol].
+ *
+ * @see MessageSenderImpl
+ */
 interface MessageSender {
     /**
-     * Given a messageUuid with a conversationId to fetch from messagesDb and try
-     * to send the message with related recipients
+     * Given the [ConversationId] and UUID of a message that
+     * was previously persisted locally,
+     * attempts to send the message to suitable recipients.
+     *
+     * Will handle all the needed encryption and possible set-up
+     * steps and retries depending on the [ConversationOptions.Protocol].
+     *
+     * In case of connectivity failure, will schedule a retry in the future using a [MessageSendingScheduler].
      *
      * @param conversationId
      * @param messageUuid
      */
-    suspend fun trySendingOutgoingMessageById(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit>
+    suspend fun sendPendingMessage(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit>
 
     /**
-     * Given a message with a conversationId to send the message to related recipients
+     * Attempts to send the given [Message] to suitable recipients.
      *
-     * @param conversationId
-     * @param message
+     * Will handle all the needed encryption and possible set-up
+     * steps and retries depending on the [ConversationOptions.Protocol].
+     *
+     * Unlike [sendPendingMessage], will **not** handle connectivity failures
+     * and scheduling re-tries in the future.
+     * Suitable for fire-and-forget messages, like real-time calling signaling,
+     * or messages where retrying later is useless or would lead to unwanted behaviour.
+     *
+     * @param message that will be sent
+     * @see [sendPendingMessage]
      */
-    suspend fun trySendingOutgoingMessage(conversationId: ConversationId, message: Message): Either<CoreFailure, Unit>
+    suspend fun sendMessage(message: Message): Either<CoreFailure, Unit>
 }
 
 class MessageSenderImpl(
@@ -47,11 +71,11 @@ class MessageSenderImpl(
     private val timeParser: TimeParser
 ) : MessageSender {
 
-    override suspend fun trySendingOutgoingMessageById(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit> =
+    override suspend fun sendPendingMessage(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit> =
         suspending {
             syncManager.waitForSlowSyncToComplete()
             messageRepository.getMessageById(conversationId, messageUuid).flatMap { message ->
-                trySendingOutgoingMessage(conversationId, message)
+                sendMessage(message)
             }.onFailure {
                 kaliumLogger.i("Failed to send message. Failure = $it")
                 if (it is NetworkFailure.NoNetworkConnection) {
@@ -63,40 +87,42 @@ class MessageSenderImpl(
             }
         }
 
-    override suspend fun trySendingOutgoingMessage(conversationId: ConversationId, message: Message): Either<CoreFailure, Unit> =
+    override suspend fun sendMessage(message: Message): Either<CoreFailure, Unit> =
         suspending {
-            attemptToSend(conversationId, message)
+            attemptToSend(message)
                 .flatMap { messageRemoteTime ->
-                    messageRepository.updateMessageDate(conversationId, message.id, messageRemoteTime)
+                    messageRepository.updateMessageDate(message.conversationId, message.id, messageRemoteTime)
                         .flatMap {
-                            messageRepository.updateMessageStatus(MessageEntity.Status.SENT, conversationId, message.id)
+                            messageRepository.updateMessageStatus(MessageEntity.Status.SENT, message.conversationId, message.id)
                         }.flatMap {
                             // this should make sure that pending messages are ordered correctly after one of them is sent
                             messageRepository.updatePendingMessagesAddMillisToDate(
-                                conversationId,
+                                message.conversationId,
                                 timeParser.calculateMillisDifference(message.date, messageRemoteTime)
                             )
                         }
                 }
         }
 
-    private suspend fun attemptToSend(conversationId: ConversationId, message: Message): Either<CoreFailure, String> =
+    private suspend fun attemptToSend(message: Message): Either<CoreFailure, String> =
         suspending {
+            val conversationId = message.conversationId
             conversationRepository.getConversationProtocolInfo(conversationId).flatMap { protocolInfo ->
                 when (protocolInfo) {
                     is ConversationEntity.ProtocolInfo.MLS -> {
-                        attemptToSendWithMLS(conversationId, protocolInfo.groupId, message)
+                        attemptToSendWithMLS(protocolInfo.groupId, message)
                     }
                     is ConversationEntity.ProtocolInfo.Proteus -> {
                         // TODO: make this thread safe (per user)
-                        attemptToSendWithProteus(conversationId, message)
+                        attemptToSendWithProteus(message)
                     }
                 }
             }
         }
 
-    private suspend fun attemptToSendWithProteus(conversationId: ConversationId, message: Message): Either<CoreFailure, String> =
+    private suspend fun attemptToSendWithProteus(message: Message): Either<CoreFailure, String> =
         suspending {
+            val conversationId = message.conversationId
             conversationRepository.getConversationRecipients(conversationId)
                 .flatMap { recipients ->
                     sessionEstablisher.prepareRecipientsForNewOutgoingMessage(recipients).map { recipients }
@@ -108,14 +134,13 @@ class MessageSenderImpl(
         }
 
     private suspend fun attemptToSendWithMLS(
-        conversationId: ConversationId,
         groupId: String,
         message: Message
     ): Either<CoreFailure, String> =
         suspending {
             mlsMessageCreator.createOutgoingMLSMessage(groupId, message).flatMap { mlsMessage ->
                 // TODO handle mls-stale-message
-                messageRepository.sendMLSMessage(conversationId, mlsMessage).map {
+                messageRepository.sendMLSMessage(message.conversationId, mlsMessage).map {
                     message.date //TODO return actual server time from the response
                 }
             }
@@ -123,18 +148,18 @@ class MessageSenderImpl(
 
     /**
      * Attempts to send a Proteus envelope
-     * Will handle the failure and retry in case of [SendMessageFailure.ClientsHaveChanged]
+     * Will handle the failure and retry in case of [ProteusSendMessageFailure].
      */
     private suspend fun trySendingProteusEnvelope(
         conversationId: ConversationId,
         envelope: MessageEnvelope,
-        messageUuid: Message,
+        message: Message,
     ): Either<CoreFailure, String> = suspending {
         messageRepository.sendEnvelope(conversationId, envelope).coFold(
             {
                 when (it) {
                     is ProteusSendMessageFailure -> messageSendFailureHandler.handleClientsHaveChangedFailure(it).flatMap {
-                        attemptToSend(conversationId, messageUuid)
+                        attemptToSend(message)
                     }
                     else -> Either.Left(it)
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -42,7 +42,7 @@ class SendTextMessageUseCase(
                 )
                 messageRepository.persistMessage(message)
             }.flatMap {
-                messageSender.trySendingOutgoingMessageById(conversationId, generatedMessageUuid)
+                messageSender.sendPendingMessage(conversationId, generatedMessageUuid)
             }.onFailure {
                 kaliumLogger.e("There was an error trying to send the message $it")
                 if (it is CoreFailure.Unknown) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorker.kt
@@ -32,7 +32,7 @@ internal class PendingMessagesSenderWorker(
             .onSuccess { pendingMessages ->
                 pendingMessages.forEach { message ->
                     kaliumLogger.i("Attempting scheduled sending of message $message")
-                    messageSender.trySendingOutgoingMessageById(message.conversationId, message.id)
+                    messageSender.sendPendingMessage(message.conversationId, message.id)
                 }
             }.onFailure {
                 kaliumLogger.w("Failed to fetch and attempt retry of pending messages: $it")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCaseTest.kt
@@ -89,7 +89,7 @@ class SendAssetMessageUseCaseTest {
                 .with(any())
                 .wasInvoked(exactly = once)
             verify(arrangement.messageSender)
-                .suspendFunction(arrangement.messageSender::trySendingOutgoingMessageById)
+                .suspendFunction(arrangement.messageSender::sendPendingMessage)
                 .with(eq(conversationId), any())
                 .wasInvoked(exactly = once)
         }
@@ -149,7 +149,7 @@ class SendAssetMessageUseCaseTest {
                 .whenInvokedWith(any())
                 .thenReturn(Either.Right(Unit))
             given(messageSender)
-                .suspendFunction(messageSender::trySendingOutgoingMessageById)
+                .suspendFunction(messageSender::sendPendingMessage)
                 .whenInvokedWith(any(), any())
                 .thenReturn(Either.Right(Unit))
             return this

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
@@ -90,7 +90,7 @@ class SendImageUseCaseTest {
                 .with(any())
                 .wasInvoked(exactly = once)
             verify(arrangement.messageSender)
-                .suspendFunction(arrangement.messageSender::trySendingOutgoingMessageById)
+                .suspendFunction(arrangement.messageSender::sendPendingMessage)
                 .with(eq(conversationId), any())
                 .wasInvoked(exactly = once)
         }
@@ -150,7 +150,7 @@ class SendImageUseCaseTest {
                 .whenInvokedWith(any())
                 .thenReturn(Either.Right(Unit))
             given(messageSender)
-                .suspendFunction(messageSender::trySendingOutgoingMessageById)
+                .suspendFunction(messageSender::sendPendingMessage)
                 .whenInvokedWith(any(), any())
                 .thenReturn(Either.Right(Unit))
             return this

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -88,7 +88,7 @@ class MessageSenderTest {
         //given
         setupGivenSuccessResults()
         //when
-        val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+        val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
         //then
         assertIs<Either.Right<Unit>>(result)
     }
@@ -100,7 +100,7 @@ class MessageSenderTest {
             getConversationProtocol = false
         )
         //when
-        val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+        val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
         //then
         verify(messageRepository)
             .suspendFunction(messageRepository::updateMessageStatus)
@@ -117,7 +117,7 @@ class MessageSenderTest {
             getConversationsRecipient = false
         )
         //when
-        val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+        val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
         //then
         verify(messageRepository)
             .suspendFunction(messageRepository::updateMessageStatus)
@@ -135,7 +135,7 @@ class MessageSenderTest {
                 prepareRecipientsForNewOutGoingMessage = false
             )
             //when
-            val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+            val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
             //then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
@@ -153,7 +153,7 @@ class MessageSenderTest {
                 createOutgoingEnvelope = false
             )
             //when
-            val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+            val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
             //then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
@@ -171,7 +171,7 @@ class MessageSenderTest {
                 sendEnvelope = Either.Left(CoreFailure.Unknown(Throwable("some exception")))
             )
             //when
-            val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+            val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
             //then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
@@ -189,7 +189,7 @@ class MessageSenderTest {
                 updateMessageStatus = false
             )
             //when
-            val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+            val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
             //then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
@@ -207,7 +207,7 @@ class MessageSenderTest {
                 updateMessageDate = false
             )
             //when
-            val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+            val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
             //then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
@@ -225,7 +225,7 @@ class MessageSenderTest {
                 updateMessageDate = false
             )
             //when
-            val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+            val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
             //then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
@@ -241,7 +241,7 @@ class MessageSenderTest {
             sendEnvelope = Either.Left(NetworkFailure.NoNetworkConnection(null))
         )
 
-        messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+        messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
 
         verify(messageSendingScheduler)
             .suspendFunction(messageSendingScheduler::scheduleSendingOfPendingMessages)
@@ -255,7 +255,7 @@ class MessageSenderTest {
             sendEnvelope = failure
         )
 
-        val result = messageSender.trySendingOutgoingMessageById(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+        val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
 
         assertEquals(failure, result)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The names of the public functions inside `MessageSender` were a bit too close to each-other.

### Solutions

Tried to make their usage a bit more clear by changing the names and parameters needed in order to call them.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
