### PR TITLE
chore: dont expose dao type to clients (proposal)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -8,17 +8,18 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.persistence.dao.ConversationEntity
 
 data class Conversation(
     val id: ConversationId,
     val name: String?,
-    val type: ConversationEntity.Type,
+    val type: Type,
     val teamId: TeamId?,
     val mutedStatus: MutedConversationStatus,
     val lastNotificationDate: String?,
     val lastModifiedDate: String?
-)
+) {
+    enum class Type { SELF, ONE_ON_ONE, GROUP }
+}
 
 sealed class ConversationDetails(open val conversation: Conversation) {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.data.conversation
 
-import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
@@ -60,7 +59,7 @@ internal class ConversationMapperImpl(
     override fun fromDaoModel(daoModel: PersistedConversation): Conversation = Conversation(
         idMapper.fromDaoModel(daoModel.id),
         daoModel.name,
-        daoModel.type.fromDaoModel(),
+        daoModel.type.fromDaoModelToType(),
         daoModel.teamId?.let { TeamId(it) },
         conversationStatusMapper.fromDaoModel(daoModel.mutedStatus),
         daoModel.lastNotificationDate,
@@ -166,5 +165,11 @@ internal class ConversationMapperImpl(
             ConversationResponse.Type.WAIT_FOR_CONNECTION,
             -> PersistedConversation.Type.ONE_ON_ONE
         }
+    }
+
+    private fun ConversationEntity.Type.fromDaoModelToType(): Conversation.Type = when (this) {
+        ConversationEntity.Type.SELF -> Conversation.Type.SELF
+        ConversationEntity.Type.ONE_ON_ONE -> Conversation.Type.ONE_ON_ONE
+        ConversationEntity.Type.GROUP -> Conversation.Type.GROUP
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -170,15 +170,15 @@ class ConversationDataSource(
 
     private suspend fun getDetailsFlowConversation(conversation: Conversation): Flow<ConversationDetails> =
         when (conversation.type) {
-            ConversationEntity.Type.SELF -> flowOf(ConversationDetails.Self(conversation))
-            ConversationEntity.Type.GROUP ->
+            Conversation.Type.SELF -> flowOf(ConversationDetails.Self(conversation))
+            Conversation.Type.GROUP ->
                 flowOf(
                     ConversationDetails.Group(
                         conversation,
                         LegalHoldStatus.DISABLED //TODO get actual legal hold status
                     )
                 )
-            ConversationEntity.Type.ONE_ON_ONE -> {
+            Conversation.Type.ONE_ON_ONE -> {
                 val selfUser = userRepository.getSelfUser().first()
 
                 getConversationMembers(conversation.id).map { members ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -79,7 +79,7 @@ class GetNotificationsUseCaseImpl(
                                 val author = getNotificationMessageAuthor(authors, it.senderUserId)
                                 messageMapper.fromMessageToLocalNotificationMessage(it, author)
                             }
-                            val isOneToOneConversation = conversationWithMessages.conversation.type == ConversationEntity.Type.ONE_ON_ONE
+                            val isOneToOneConversation = conversationWithMessages.conversation.type == Conversation.Type.ONE_ON_ONE
 
                             LocalNotificationConversation(
                                 id = conversationId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -241,7 +241,7 @@ class ConversationMapperTest {
                 domain = "testDomain",
             ),
             name = "testName",
-            type = ConversationEntity.Type.ONE_ON_ONE,
+            type = Conversation.Type.ONE_ON_ONE,
             teamId = TeamId("test"),
             mutedStatus = MutedConversationStatus.AllAllowed,
             lastNotificationDate = "testNotificationDate",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -83,7 +83,15 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         val USER_ID = UserId(value = "userId", domain = "domainId")
         val MEMBER = listOf(Member(USER_ID))
         val CONVERSATION_ID = ConversationId(value = "userId", domain = "domainId")
-        val CONVERSATION = Conversation(id = CONVERSATION_ID, name = null, type = ConversationEntity.Type.ONE_ON_ONE, teamId = null, MutedConversationStatus.AllAllowed, null, null)
+        val CONVERSATION = Conversation(
+            id = CONVERSATION_ID,
+            name = null,
+            type = Conversation.Type.ONE_ON_ONE,
+            teamId = null,
+            MutedConversationStatus.AllAllowed,
+            null,
+            null
+        )
         val OTHER_USER = OtherUser(
             id =
             USER_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -13,7 +13,6 @@ import com.wire.kalium.logic.data.notification.LocalNotificationMessage
 import com.wire.kalium.logic.data.notification.LocalNotificationMessageAuthor
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.persistence.dao.ConversationEntity
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.anything
@@ -228,7 +227,7 @@ class GetNotificationsUseCaseTest {
         private fun entityConversation(number: Int = 0, isOneOnOne: Boolean = true) = Conversation(
             conversationId(number),
             "conversation_${number}",
-            if (isOneOnOne) ConversationEntity.Type.ONE_ON_ONE else ConversationEntity.Type.GROUP,
+            if (isOneOnOne) Conversation.Type.ONE_ON_ONE else Conversation.Type.GROUP,
             null,
             MutedConversationStatus.AllAllowed,
             "2000-01-23T01:23:35.678+09:00",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -10,12 +10,44 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 object TestConversation {
     val ID = ConversationId("valueConvo", "domainConvo")
 
-    val ONE_ON_ONE = Conversation(ID.copy(value = "1O1 ID"), "ONE_ON_ONE Name", ConversationEntity.Type.ONE_ON_ONE, TestTeam.TEAM_ID, MutedConversationStatus.AllAllowed, null, null)
-    val SELF = Conversation(ID.copy(value = "SELF ID"), "SELF Name", ConversationEntity.Type.SELF, TestTeam.TEAM_ID, MutedConversationStatus.AllAllowed, null, null)
-    val GROUP = Conversation(ID.copy(value = "GROUP ID"), "GROUP Name", ConversationEntity.Type.GROUP, TestTeam.TEAM_ID, MutedConversationStatus.AllAllowed, null, null)
+    val ONE_ON_ONE = Conversation(
+        ID.copy(value = "1O1 ID"),
+        "ONE_ON_ONE Name",
+        Conversation.Type.ONE_ON_ONE,
+        TestTeam.TEAM_ID,
+        MutedConversationStatus.AllAllowed,
+        null,
+        null
+    )
+    val SELF = Conversation(
+        ID.copy(value = "SELF ID"),
+        "SELF Name",
+        Conversation.Type.SELF,
+        TestTeam.TEAM_ID,
+        MutedConversationStatus.AllAllowed,
+        null,
+        null
+    )
+    val GROUP = Conversation(
+        ID.copy(value = "GROUP ID"),
+        "GROUP Name",
+        Conversation.Type.GROUP,
+        TestTeam.TEAM_ID,
+        MutedConversationStatus.AllAllowed,
+        null,
+        null
+    )
 
     val NETWORK_ID = QualifiedID("valueConversation", "domainConversation")
 
     val ENTITY_ID = QualifiedIDEntity("valueConversation", "domainConversation")
-    val ENTITY = ConversationEntity(ENTITY_ID, "convo name", ConversationEntity.Type.SELF, "teamId", ConversationEntity.ProtocolInfo.Proteus, lastNotificationDate =  null, lastModifiedDate = "2022-03-30T15:36:00.000Z")
+    val ENTITY = ConversationEntity(
+        ENTITY_ID,
+        "convo name",
+        ConversationEntity.Type.SELF,
+        "teamId",
+        ConversationEntity.ProtocolInfo.Proteus,
+        lastNotificationDate = null,
+        lastModifiedDate = "2022-03-30T15:36:00.000Z"
+    )
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  
- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we are exposing the `ConversationEntity.Type` to clients, with this change we created an inner Type that lives on logic module therefore can be accessed by clients, or can be used for unit testing conversations on AR.

PS: Given the existing `ConversationDetails` type, it seems more difficult to just map it from the enum `ConversationEntity.Type` from DB. If you found a way to easily map it, let's talk :D

### Causes (Optional)

We are not exposing anymore a type from persistence module

### Solutions

Creates an equivalent enum on logic module side.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
