### PR TITLE
refactor: hold the sync state in a repository (AR-1438)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.cryptography.ProteusClientImpl
 import com.wire.kalium.logic.data.session.SessionDataSource
 import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.sync.InMemorySyncRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.UserSessionScopeProvider
 import com.wire.kalium.logic.di.UserSessionScopeProviderImpl
@@ -55,7 +56,7 @@ actual class CoreLogic(
             runBlocking { proteusClient.open() }
 
             val workScheduler = WorkScheduler(appContext, userId)
-            val syncManager = SyncManagerImpl(workScheduler)
+            val syncManager = SyncManagerImpl(workScheduler, InMemorySyncRepository())
 
             val userIDEntity = idMapper.toDaoModel(userId)
             val encryptedSettingsHolder =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SyncRepository.kt
@@ -1,0 +1,19 @@
+package com.wire.kalium.logic.data.sync
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.updateAndGet
+
+interface SyncRepository {
+    val syncState: StateFlow<SyncState>
+    fun updateSyncState(updateBlock: (currentState: SyncState) -> SyncState): SyncState
+}
+
+class InMemorySyncRepository : SyncRepository {
+    private val _syncState = MutableStateFlow(SyncState.WAITING)
+
+    override val syncState: StateFlow<SyncState> get() = _syncState
+
+    override fun updateSyncState(updateBlock: (currentState: SyncState) -> SyncState): SyncState =
+        _syncState.updateAndGet(updateBlock)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SyncRepository.kt
@@ -9,7 +9,7 @@ interface SyncRepository {
     fun updateSyncState(updateBlock: (currentState: SyncState) -> SyncState): SyncState
 }
 
-class InMemorySyncRepository : SyncRepository {
+internal class InMemorySyncRepository : SyncRepository {
     private val _syncState = MutableStateFlow(SyncState.WAITING)
 
     override val syncState: StateFlow<SyncState> get() = _syncState

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SyncState.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SyncState.kt
@@ -1,0 +1,7 @@
+package com.wire.kalium.logic.data.sync
+
+enum class SyncState {
+    WAITING,
+    SLOW_SYNC,
+    COMPLETED,
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SyncRepositoryTest.kt
@@ -1,0 +1,56 @@
+package com.wire.kalium.logic.data.sync
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SyncRepositoryTest {
+
+    private lateinit var syncRepository: SyncRepository
+
+    @BeforeTest
+    fun setup() {
+        syncRepository = InMemorySyncRepository()
+    }
+
+    @Test
+    fun givenNoChanges_whenGettingTheCurrentSyncState_thenTheResultShouldBeWaiting() {
+        //Given
+
+        //When
+        val result = syncRepository.syncState.value
+
+        //Then
+        assertEquals(SyncState.WAITING, result)
+    }
+
+    @Test
+    fun givenStateIsUpdated_whenGettingTheCurrentSyncState_thenTheResultIsTheUpdatedState() {
+        //Given
+        val updatedState = SyncState.COMPLETED
+        syncRepository.updateSyncState { updatedState }
+
+        //When
+        val result = syncRepository.syncState.value
+
+        //Then
+        assertEquals(updatedState, result)
+    }
+
+    @Test
+    fun givenAState_whenUpdatingTheCurrentSyncState_thenTheCurrentStateIsAvailableInTheLambda() {
+        //Given
+        val currentState = SyncState.COMPLETED
+        syncRepository.updateSyncState { currentState }
+
+        //When
+        var capturedState: SyncState? = null
+        val result = syncRepository.updateSyncState {
+            capturedState = it
+            SyncState.WAITING
+        }
+
+        //Then
+        assertEquals(currentState, capturedState)
+    }
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.cryptography.ProteusClientImpl
 import com.wire.kalium.logic.data.session.SessionDataSource
 import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.sync.InMemorySyncRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.UserSessionScopeProvider
 import com.wire.kalium.logic.di.UserSessionScopeProviderImpl
@@ -52,7 +53,7 @@ actual class CoreLogic(
             runBlocking { proteusClient.open() }
 
             val workScheduler = WorkScheduler(this, userId)
-            val syncManager = SyncManagerImpl(workScheduler)
+            val syncManager = SyncManagerImpl(workScheduler, InMemorySyncRepository())
             val encryptedSettingsHolder = EncryptedSettingsHolder(SettingOptions.UserSettings(idMapper.toDaoModel(userId)))
             val userPreferencesSettings = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
             val userDatabase = UserDatabaseProvider(File(rootStoragePath))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, the `SyncManager` is the one holding the SyncState, which makes it so far too many UseCases and other entities in the domain layer depend on it, even for read operations.

We can have circular dependencies:
* `Sync` may depend on `Calling` (for processing calling messages)
* `Calling` depends on `MessageSender` (for sending calling messages)
* `MessageSender` depends on `Sync` (to wait for sync to be completed before sending messages)

### Solutions

Move the logic of reading the `SyncState` to a repository, so we reduce the amount of circular dependencies.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution


----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
