### PR TITLE
feat: search only by handle on search query starting with @ [AR-1558]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/SearchKnownUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/SearchKnownUsersUseCase.kt
@@ -2,17 +2,23 @@ package com.wire.kalium.logic.feature.publicuser
 
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
-import kotlinx.coroutines.flow.Flow
 
 interface SearchKnownUsersUseCase {
-    suspend operator fun invoke(searchQuery: String): Flow<UserSearchResult>
+    suspend operator fun invoke(searchQuery: String): UserSearchResult
 }
 
 internal class SearchKnownUsersUseCaseImpl(
     private val searchUserRepository: SearchUserRepository
 ) : SearchKnownUsersUseCase {
 
-    override suspend operator fun invoke(searchQuery: String): Flow<UserSearchResult> =
-        searchUserRepository.searchKnownUsers(searchQuery)
+    override suspend operator fun invoke(searchQuery: String): UserSearchResult {
+        return if (isUserLookingForHandle(searchQuery)) {
+            searchUserRepository.searchKnownUsersByHandle(searchQuery)
+        } else {
+            searchUserRepository.searchKnownUsersByNameOrHandleOrEmail(searchQuery)
+        }
+    }
+
+    private fun isUserLookingForHandle(searchQuery: String) = searchQuery.first() == '@'
 
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -33,8 +33,8 @@ class SearchKnownUserUseCaseTest {
     }
 
     @Test
-    fun whenSearchingWithQueryInHandleFormat_ThenSearchOnlyByHandle() = runTest {
-        //when
+    fun givenAnInputStartingWithAtSymbol_whenSearchingUsers_thenSearchOnlyByHandle() = runTest {
+        //given
         val handleSearchQuery = "@someHandle"
 
         given(searchUserRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -61,7 +61,7 @@ class SearchKnownUserUseCaseTest {
                     )
                 )
             )
-        //given
+        //when
         searchKnownUsersUseCase(handleSearchQuery)
         //then
         verify(searchUserRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -104,7 +104,7 @@ class SearchKnownUserUseCaseTest {
                     )
                 )
             )
-        //given
+        //when
         searchKnownUsersUseCase(searchQuery)
         //then
         verify(searchUserRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -76,8 +76,8 @@ class SearchKnownUserUseCaseTest {
     }
 
     @Test
-    fun whenSearchingQueryHasNotHandleFormat_ThenSearchByNameOrHandleOrEmail() = runTest {
-        //when
+    fun givenNormalInput_whenSearchingUsers_thenSearchByNameOrHandleOrEmail() = runTest {
+        //given
         val searchQuery = "someSearchQuery"
 
         given(searchUserRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -1,0 +1,121 @@
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.publicuser.SearchUserRepository
+import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.feature.publicuser.SearchKnownUsersUseCase
+import com.wire.kalium.logic.feature.publicuser.SearchKnownUsersUseCaseImpl
+import io.ktor.client.plugins.convertLongTimeoutToLongWithInfiniteAsZero
+import io.mockative.Mock
+import io.mockative.Times
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class SearchKnownUserUseCaseTest {
+
+    @Mock
+    private val searchUserRepository = mock(classOf<SearchUserRepository>())
+
+    private lateinit var searchKnownUsersUseCase: SearchKnownUsersUseCase
+
+    @BeforeTest
+    fun setUp() {
+        searchKnownUsersUseCase = SearchKnownUsersUseCaseImpl(searchUserRepository)
+    }
+
+    @Test
+    fun whenSearchingWithQueryInHandleFormat_ThenSearchOnlyByHandle() = runTest {
+        //when
+        val handleSearchQuery = "@someHandle"
+
+        given(searchUserRepository)
+            .suspendFunction(searchUserRepository::searchKnownUsersByHandle)
+            .whenInvokedWith(eq(handleSearchQuery))
+            .thenReturn(
+                UserSearchResult(
+                    listOf(
+                        OtherUser(
+                            id = QualifiedID(
+                                value = "someValue",
+                                domain = "someDomain",
+                            ),
+                            name = null,
+                            handle = null,
+                            email = null,
+                            phone = null,
+                            accentId = 0,
+                            team = null,
+                            connectionStatus = ConnectionState.ACCEPTED,
+                            previewPicture = null,
+                            completePicture = null
+                        )
+                    )
+                )
+            )
+        //given
+        searchKnownUsersUseCase(handleSearchQuery)
+        //then
+        verify(searchUserRepository)
+            .suspendFunction(searchUserRepository::searchKnownUsersByHandle)
+            .with(eq(handleSearchQuery))
+            .wasInvoked()
+
+        verify(searchUserRepository)
+            .suspendFunction(searchUserRepository::searchKnownUsersByNameOrHandleOrEmail)
+            .with(anything())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun whenSearchingQueryHasNotHandleFormat_ThenSearchByNameOrHandleOrEmail() = runTest {
+        //when
+        val searchQuery = "someSearchQuery"
+
+        given(searchUserRepository)
+            .suspendFunction(searchUserRepository::searchKnownUsersByNameOrHandleOrEmail)
+            .whenInvokedWith(eq(searchQuery))
+            .thenReturn(
+                UserSearchResult(
+                    listOf(
+                        OtherUser(
+                            id = QualifiedID(
+                                value = "someValue",
+                                domain = "someDomain",
+                            ),
+                            name = null,
+                            handle = null,
+                            email = null,
+                            phone = null,
+                            accentId = 0,
+                            team = null,
+                            connectionStatus = ConnectionState.ACCEPTED,
+                            previewPicture = null,
+                            completePicture = null
+                        )
+                    )
+                )
+            )
+        //given
+        searchKnownUsersUseCase(searchQuery)
+        //then
+        verify(searchUserRepository)
+            .suspendFunction(searchUserRepository::searchKnownUsersByHandle)
+            .with(anything())
+            .wasNotInvoked()
+
+        verify(searchUserRepository)
+            .suspendFunction(searchUserRepository::searchKnownUsersByNameOrHandleOrEmail)
+            .with(eq(searchQuery))
+            .wasInvoked()
+    }
+
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -54,5 +54,10 @@ OR  handle LIKE  ('%' || :searchQuery || '%')
 OR  email LIKE  ('%' || :searchQuery || '%'))
 AND connection_status = :connectionStatus;
 
+selectByHandleAndConnectionState:
+SELECT * FROM User
+WHERE handle LIKE ('%' || :searchQuery || '%')
+AND connection_status = :connectionStatus;
+
 updateUserhandle:
 UPDATE User SET handle = ? WHERE qualified_id = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -62,7 +62,12 @@ interface UserDAO {
     suspend fun getUserByNameOrHandleOrEmailAndConnectionState(
         searchQuery: String,
         connectionState: UserEntity.ConnectionState
-    ): Flow<List<UserEntity>>
+    ): List<UserEntity>
+
+    suspend fun getUserByHandleAndConnectionState(
+        handle: String,
+        connectionState: UserEntity.ConnectionState
+    ) : List<UserEntity>
 
     suspend fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity)
     suspend fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -82,12 +82,16 @@ class UserDAOImpl(private val queries: UsersQueries) : UserDAO {
     override suspend fun getUserByNameOrHandleOrEmailAndConnectionState(
         searchQuery: String,
         connectionState: UserEntity.ConnectionState
-    ): Flow<List<UserEntity>> {
-        return queries.selectByNameOrHandleOrEmailAndConnectionState(searchQuery, UserEntity.ConnectionState.ACCEPTED)
-            .asFlow()
-            .mapToList()
-            .map { entryList -> entryList.map(mapper::toModel) }
-    }
+    ) = queries.selectByNameOrHandleOrEmailAndConnectionState(searchQuery, connectionState)
+        .executeAsList()
+        .map(mapper::toModel)
+
+    override suspend fun getUserByHandleAndConnectionState(
+        handle: String,
+        connectionState: UserEntity.ConnectionState
+    ) = queries.selectByHandleAndConnectionState(handle, connectionState)
+        .executeAsList()
+        .map(mapper::toModel)
 
     override suspend fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity) {
         queries.deleteUser(qualifiedID)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -104,7 +104,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user2.email!!, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user2.email!!, UserEntity.ConnectionState.ACCEPTED)
         //then
         assertEquals(searchResult, listOf(user2))
     }
@@ -119,7 +119,7 @@ class UserDAOTest : BaseDatabaseTest() {
             db.userDAO.insertUsers(listOf(user1, user2, user3))
             //when
             val searchResult =
-                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user3.handle!!, UserEntity.ConnectionState.ACCEPTED).first()
+                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user3.handle!!, UserEntity.ConnectionState.ACCEPTED)
             //then
             assertEquals(searchResult, listOf(user3))
         }
@@ -134,7 +134,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUsers(listOf(user1, user2, user3))
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user1.name!!, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(user1.name!!, UserEntity.ConnectionState.ACCEPTED)
         //then
         assertEquals(searchResult, listOf(user1))
     }
@@ -179,7 +179,7 @@ class UserDAOTest : BaseDatabaseTest() {
             db.userDAO.insertUsers(mockUsers)
             //when
             val searchResult =
-                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED)
             //then
             assertEquals(searchResult, commonEmailUsers)
         }
@@ -194,7 +194,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val nonExistingEmailQuery = "doesnotexist@wire.com"
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(nonExistingEmailQuery, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(nonExistingEmailQuery, UserEntity.ConnectionState.ACCEPTED)
         //then
         assertTrue { searchResult.isEmpty() }
     }
@@ -208,7 +208,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUsers(mockUsers)
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonEmailPrefix, UserEntity.ConnectionState.ACCEPTED)
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.email!!, commonEmailPrefix)
@@ -224,7 +224,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUsers(mockUsers)
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonHandlePrefix, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonHandlePrefix, UserEntity.ConnectionState.ACCEPTED)
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.handle!!, commonHandlePrefix)
@@ -240,7 +240,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUsers(mockUsers)
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonNamePrefix, UserEntity.ConnectionState.ACCEPTED)
         //then
         searchResult.forEach { userEntity ->
             assertContains(userEntity.name!!, commonNamePrefix)
@@ -261,7 +261,7 @@ class UserDAOTest : BaseDatabaseTest() {
             db.userDAO.insertUsers(mockUsers)
             //when
             val searchResult =
-                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+                db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED)
             //then
             assertEquals(mockUsers, searchResult)
         }
@@ -280,7 +280,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUsers(mockUsers)
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED)
         //then
         searchResult.forEach { userEntity ->
             assertEquals(UserEntity.ConnectionState.ACCEPTED, userEntity.connectionStatus)
@@ -302,7 +302,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUsers(mockUsers)
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED)
         //then
         assertTrue(searchResult.size == 2)
         searchResult.forEach { userEntity ->
@@ -327,7 +327,30 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUsers(mockUsers)
         //when
         val searchResult =
-            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED).first()
+            db.userDAO.getUserByNameOrHandleOrEmailAndConnectionState(commonPrefix, UserEntity.ConnectionState.ACCEPTED)
+        //then
+        assertEquals(expectedResult, searchResult)
+    }
+
+    @Test
+    fun givenTheListOfUser_whenQueriedByHandle_ThenResultContainsOnlyTheUserHavingTheHandleAndAreConnected() = runTest {
+        val expectedResult = listOf(
+            USER_ENTITY_1.copy(handle = "@someHandle"),
+            USER_ENTITY_4.copy(handle = "@someHandle1")
+        )
+
+        val mockUsers = listOf(
+            USER_ENTITY_1.copy(handle = "@someHandle"),
+            USER_ENTITY_2.copy(connectionStatus = UserEntity.ConnectionState.NOT_CONNECTED),
+            USER_ENTITY_3.copy(connectionStatus = UserEntity.ConnectionState.NOT_CONNECTED),
+            USER_ENTITY_4.copy(handle = "@someHandle1")
+        )
+
+        db.userDAO.insertUsers(mockUsers)
+
+        //when
+        val searchResult = db.userDAO.getUserByHandleAndConnectionState("some", UserEntity.ConnectionState.ACCEPTED)
+
         //then
         assertEquals(expectedResult, searchResult)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently while searching for the known users with a query starting with '@' we don't get results, even when searching valid handles.

### Solutions

- Add a new query to `Users.sq` to search based on user handle only.
- Add a check on the `SearchKnownUserUseCase`, which verifies if we should search only by handle or keep the normal search.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
