### PR TITLE
fix: added guard against hard casting error

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
@@ -107,6 +107,14 @@ class AssetMapperImpl : AssetMapper {
         }
 
     override fun fromProtoAssetMessageToAssetContent(protoAssetMessage: Asset): AssetContent {
+        val defaultRemoteData = AssetContent.RemoteData(
+            otrKey = ByteArray(0),
+            sha256 = ByteArray(0),
+            assetId = "",
+            assetDomain = null,
+            assetToken = null,
+            encryptionAlgorithm = null
+        )
         with(protoAssetMessage) {
             return AssetContent(
                 sizeInBytes = original?.size ?: 0,
@@ -118,28 +126,26 @@ class AssetMapperImpl : AssetMapper {
                     else -> null
                 },
                 remoteData = status?.run {
-                    with((this as Asset.Status.Uploaded).value) {
-                        AssetContent.RemoteData(
-                            otrKey = otrKey.array,
-                            sha256 = sha256.array,
-                            assetId = assetId ?: "",
-                            assetDomain = assetDomain,
-                            assetToken = assetToken,
-                            encryptionAlgorithm = when (encryption) {
-                                EncryptionAlgorithm.AES_CBC -> AES_CBC
-                                EncryptionAlgorithm.AES_GCM -> AES_GCM
-                                else -> null
+                    when (this) {
+                        is Asset.Status.Uploaded -> {
+                            with(value) {
+                                AssetContent.RemoteData(
+                                    otrKey = otrKey.array,
+                                    sha256 = sha256.array,
+                                    assetId = assetId ?: "",
+                                    assetDomain = assetDomain,
+                                    assetToken = assetToken,
+                                    encryptionAlgorithm = when (encryption) {
+                                        EncryptionAlgorithm.AES_CBC -> AES_CBC
+                                        EncryptionAlgorithm.AES_GCM -> AES_GCM
+                                        else -> null
+                                    }
+                                )
                             }
-                        )
+                        }
+                        is Asset.Status.NotUploaded -> defaultRemoteData
                     }
-                } ?: AssetContent.RemoteData(
-                    otrKey = ByteArray(0),
-                    sha256 = ByteArray(0),
-                    assetId = "",
-                    assetDomain = null,
-                    assetToken = null,
-                    encryptionAlgorithm = null
-                ),
+                } ?: defaultRemoteData,
                 downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
@@ -106,6 +106,7 @@ class AssetMapperImpl : AssetMapper {
             }
         }
 
+    @Suppress("ComplexMethod")
     override fun fromProtoAssetMessageToAssetContent(protoAssetMessage: Asset): AssetContent {
         val defaultRemoteData = AssetContent.RemoteData(
             otrKey = ByteArray(0),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -3,6 +3,10 @@ package com.wire.kalium.logic.data.message
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.protobuf.encodeToByteArray
+import com.wire.kalium.protobuf.messages.Asset
+import com.wire.kalium.protobuf.messages.GenericMessage
+import io.ktor.utils.io.core.toByteArray
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,6 +25,55 @@ class ProtoContentMapperTest {
     @Test
     fun givenTextContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
         val messageContent = MessageContent.Text("Hello")
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
+
+        val encoded = protoContentMapper.encodeToProtobuf(protoContent)
+        val decoded = protoContentMapper.decodeFromProtobuf(encoded)
+
+        assertEquals(decoded, protoContent)
+    }
+
+    @Test
+    fun givenProtoAssetContentWithStatusNotUploaded_whenMappingBackFromProtoData_thenTheDecodingGoesCorrectly() {
+        val assetName = "Mocked-Asset.bin"
+        val mockedAsset = assetName.toByteArray()
+        val protobuf = GenericMessage(
+            TEST_MESSAGE_UUID, GenericMessage.Content.Asset(
+                Asset(
+                    original = Asset.Original(
+                        mimeType = "file/binary",
+                        size = mockedAsset.size.toLong(),
+                        name = assetName,
+                    ),
+                    status = Asset.Status.NotUploaded(Asset.NotUploaded.CANCELLED),
+                )
+            )
+        )
+        val encoded = PlainMessageBlob(protobuf.encodeToByteArray())
+        protoContentMapper.decodeFromProtobuf(encoded)
+    }
+
+    @Test
+    fun givenProtoAssetContent_whenMappingBack_thenTheContentsShouldMatchTheOriginal() {
+        val assetName = "Mocked-Asset.bin"
+        val mockedAsset = assetName.toByteArray()
+        val defaultRemoteData = AssetContent.RemoteData(
+            otrKey = ByteArray(0),
+            sha256 = ByteArray(0),
+            assetId = "",
+            assetDomain = null,
+            assetToken = null,
+            encryptionAlgorithm = AssetContent.RemoteData.EncryptionAlgorithm.AES_CBC
+        )
+        val messageContent = MessageContent.Asset(
+            AssetContent(
+                sizeInBytes = mockedAsset.size.toLong(),
+                name = assetName,
+                mimeType = "file/binary",
+                remoteData = defaultRemoteData,
+                downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
+            )
+        )
         val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After logging with my production account on a fresh device, I got some weird crashes when trying to apply a hard cast on the `status` field of an Asset message. So I added this

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
