### PR TITLE
feat: add CurrentSessionFlowUseCase

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionFlowUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionFlowUseCase.kt
@@ -1,0 +1,21 @@
+package com.wire.kalium.logic.feature.session
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.functional.fold
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class CurrentSessionFlowUseCase(private val sessionRepository: SessionRepository) {
+    operator fun invoke(): Flow<CurrentSessionResult> =
+        sessionRepository.currentSessionFlow().map {
+            it.fold({
+                when (it) {
+                    StorageFailure.DataNotFound -> CurrentSessionResult.Failure.SessionNotFound
+                    is StorageFailure.Generic -> CurrentSessionResult.Failure.Generic(it)
+                }
+            }, { authSession ->
+                CurrentSessionResult.Success(authSession)
+            })
+        }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionUseCase.kt
@@ -16,7 +16,7 @@ sealed class CurrentSessionResult {
 }
 
 class CurrentSessionUseCase(private val sessionRepository: SessionRepository) {
-    suspend operator fun invoke(): CurrentSessionResult =
+    operator fun invoke(): CurrentSessionResult =
         sessionRepository.currentSession().fold({
             when (it) {
                 StorageFailure.DataNotFound -> CurrentSessionResult.Failure.SessionNotFound

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/SessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/SessionScope.kt
@@ -8,5 +8,6 @@ class SessionScope(
     val allSessions get() = GetSessionsUseCase(sessionRepository)
     val saveSession get() = SaveSessionUseCase(sessionRepository)
     val currentSession get() = CurrentSessionUseCase(sessionRepository)
+    val currentSessionFlow get() = CurrentSessionFlowUseCase(sessionRepository)
     val updateCurrentSession get() = UpdateCurrentSessionUseCase(sessionRepository)
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionFlowUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionFlowUseCaseTest.kt
@@ -1,0 +1,77 @@
+package com.wire.kalium.logic.feature.session
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.ServerConfig
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.AuthSession
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.stubs.newServerConfig
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CurrentSessionFlowUseCaseTest {
+    @Mock
+    val sessionRepository: SessionRepository = mock(classOf<SessionRepository>())
+
+    lateinit var currentSessionFlowUseCase: CurrentSessionFlowUseCase
+
+    @BeforeTest
+    fun setup() {
+        currentSessionFlowUseCase = CurrentSessionFlowUseCase(sessionRepository)
+    }
+
+    @Test
+    fun givenAUserID_whenCurrentSessionFlowEmitsSuccess_thenTheSuccessIsPropagated() = runTest {
+        val expected: AuthSession = randomAuthSession()
+
+        given(sessionRepository).invocation { currentSessionFlow() }.then { flow { emit(Either.Right(expected)) } }
+
+        currentSessionFlowUseCase().test {
+            awaitItem().run {
+                assertIs<CurrentSessionResult.Success>(this)
+                assertEquals(expected, this.authSession)
+            }
+            awaitComplete()
+        }
+
+        verify(sessionRepository).invocation { currentSessionFlow() }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAUserID_whenCurrentSessionFlowEmitsFailWithNoSessionFound_thenTheErrorIsPropagated() = runTest {
+        val expected: StorageFailure = StorageFailure.DataNotFound
+
+        given(sessionRepository).invocation { currentSessionFlow() }.then { flow { emit(Either.Left(expected)) } }
+
+        currentSessionFlowUseCase().test {
+            assertIs<CurrentSessionResult.Failure.SessionNotFound>(awaitItem())
+            awaitComplete()
+        }
+
+        verify(sessionRepository).invocation { currentSessionFlow() }.wasInvoked(exactly = once)
+    }
+
+
+    private companion object {
+        val randomString get() = Random.nextBytes(64).decodeToString()
+        val TEST_SERVER_CONFIG: ServerConfig = newServerConfig(1)
+
+        fun randomAuthSession(): AuthSession =
+            AuthSession(UserId("user_id", "domain.de"), randomString, randomString, randomString, TEST_SERVER_CONFIG)
+    }
+}

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -96,6 +96,7 @@ kotlin {
                 implementation(kotlin("test"))
                 // coroutines
                 implementation(Dependencies.Coroutines.test)
+                implementation(Dependencies.Test.turbine)
                 // MultiplatformSettings
                 implementation(Dependencies.MultiplatformSettings.test)
             }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/SessionStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/SessionStorageTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.persistence.client
 
+import app.cash.turbine.test
 import com.russhwolf.settings.MockSettings
 import com.russhwolf.settings.Settings
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -88,6 +89,9 @@ class SessionDAOTest {
     @Test
     fun givenAUserId_WhenCallingUpdateCurrentSession_ThenItWillBeStoredLocally() = runTest {
         assertNull(sessionStorage.currentSession())
+        sessionStorage.currentSessionFlow().test {
+            assertNull(awaitItem())
+        }
         val session1 =
             PersistenceSession(
                 QualifiedIDEntity("user_id_1", "user_domain_1"),
@@ -112,6 +116,9 @@ class SessionDAOTest {
         sessionStorage.setCurrentSession(QualifiedIDEntity("user_id_1", "user_domain_1"))
 
         assertEquals(session1, sessionStorage.currentSession())
+        sessionStorage.currentSessionFlow().test {
+            assertEquals(session1, awaitItem())
+        }
     }
 
     private companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we only have a use case that returns a single value of the current session, and we have no way to observe changes to the current session. This caused the need to implement a check every interval of the current session, but it's not a proper way of doing that.

### Solutions

Implemented `currentSessionFlow()` using `MutableSharedFlow` to observe current session changes which can be used by invoking `CurrentSessionFlowUseCase`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
