### PR TITLE
refactor: make CallManager dependency lazier

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserDataSource
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
+import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.call.CallsScope
 import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.feature.client.ClientScope
@@ -222,7 +223,7 @@ abstract class UserSessionScopeCommon(
     private val callMapper: CallMapper
         get() = CallMapper()
 
-    private val callManager by lazy {
+    private val callManager: Lazy<CallManager> = lazy {
         globalCallManager.getCallManagerForClient(
             userId = userId,
             callRepository = callRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/AnswerCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/AnswerCallUseCase.kt
@@ -7,11 +7,11 @@ interface AnswerCallUseCase {
 }
 
 internal class AnswerCallUseCaseImpl(
-    private val callManager: CallManager
+    private val callManager: Lazy<CallManager>
 ) : AnswerCallUseCase {
 
     override suspend fun invoke(conversationId: ConversationId) {
-        callManager.answerCall(
+        callManager.value.answerCall(
             conversationId = conversationId
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -13,7 +13,7 @@ import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.sync.SyncManager
 
 class CallsScope(
-    private val callManager: CallManager,
+    private val callManager: Lazy<CallManager>,
     private val callRepository: CallRepository,
     private val syncManager: SyncManager
 ) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
@@ -3,9 +3,9 @@ package com.wire.kalium.logic.feature.call.usecase
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
 
-class EndCallUseCase(private val callManager: CallManager) {
+class EndCallUseCase(private val callManager: Lazy<CallManager>) {
 
     suspend operator fun invoke(conversationId: ConversationId) {
-        callManager.endCall(conversationId)
+        callManager.value.endCall(conversationId)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCase.kt
@@ -2,9 +2,9 @@ package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.feature.call.CallManager
 
-class MuteCallUseCase(private val callManager: CallManager) {
+class MuteCallUseCase(private val callManager: Lazy<CallManager>) {
 
     suspend operator fun invoke() {
-        callManager.muteCall(true)
+        callManager.value.muteCall(true)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/RejectCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/RejectCallUseCase.kt
@@ -3,9 +3,9 @@ package com.wire.kalium.logic.feature.call.usecase
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
 
-class RejectCallUseCase(private val callManager: CallManager) {
+class RejectCallUseCase(private val callManager: Lazy<CallManager>) {
 
     suspend operator fun invoke(conversationId: ConversationId) {
-        callManager.rejectCall(conversationId)
+        callManager.value.rejectCall(conversationId)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
@@ -5,13 +5,13 @@ import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
 
-class StartCallUseCase(private val callManager: CallManager) {
+class StartCallUseCase(private val callManager: Lazy<CallManager>) {
 
     suspend operator fun invoke(
         conversationId: ConversationId,
         callType: CallType = CallType.AUDIO,
         conversationType: ConversationType = ConversationType.OneOnOne
     ) {
-        callManager.startCall(conversationId, callType, conversationType)
+        callManager.value.startCall(conversationId, callType, conversationType)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
@@ -2,9 +2,9 @@ package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.feature.call.CallManager
 
-class UnMuteCallUseCase(private val callManager: CallManager) {
+class UnMuteCallUseCase(private val callManager: Lazy<CallManager>) {
 
     suspend operator fun invoke() {
-        callManager.muteCall(false)
+        callManager.value.muteCall(false)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -28,6 +28,8 @@ import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.logic.wrapCryptoRequest
 import io.ktor.utils.io.core.toByteArray
 
+// Suppressed as it's an old issue
+@Suppress("LongParameterList")
 class ConversationEventReceiver(
     private val proteusClient: ProteusClient,
     private val messageRepository: MessageRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -35,7 +35,7 @@ class ConversationEventReceiver(
     private val mlsConversationRepository: MLSConversationRepository,
     private val userRepository: UserRepository,
     private val protoContentMapper: ProtoContentMapper,
-    private val callManagerImpl: CallManager,
+    private val callManagerImpl: Lazy<CallManager>,
     private val memberMapper: MemberMapper = MapperProvider.memberMapper(),
     private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : EventReceiver<Event.Conversation> {
@@ -187,7 +187,7 @@ class ConversationEventReceiver(
             }
             is MessageContent.Calling -> {
                 kaliumLogger.d("$TAG - MessageContent.Calling")
-                callManagerImpl.onCallingMessageReceived(
+                callManagerImpl.value.onCallingMessageReceived(
                     message = message,
                     content = message.content
                 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/AnswerCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/AnswerCallUseCaseTest.kt
@@ -23,7 +23,7 @@ class AnswerCallUseCaseTest {
     @BeforeTest
     fun setUp() {
         answerCallUseCase = AnswerCallUseCaseImpl(
-            callManager = callManager
+            callManager = lazy{ callManager }
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/EndCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/EndCallUseCaseTest.kt
@@ -23,7 +23,7 @@ class EndCallUseCaseTest {
 
     @BeforeTest
     fun setup() {
-        endCall = EndCallUseCase(callManager)
+        endCall = EndCallUseCase(lazy{ callManager })
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/RejectCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/RejectCallUseCaseTest.kt
@@ -24,7 +24,7 @@ class RejectCallUseCaseTest {
 
     @BeforeTest
     fun setup() {
-        rejectCallUseCase = RejectCallUseCase(callManager)
+        rejectCallUseCase = RejectCallUseCase(lazy{ callManager })
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/StartCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/StartCallUseCaseTest.kt
@@ -25,7 +25,7 @@ class StartCallUseCaseTest {
 
     @BeforeTest
     fun setup() {
-        startCall = StartCallUseCase(callManager)
+        startCall = StartCallUseCase(lazy{ callManager })
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We currently initiate the `CallManager` in a "lazy" way, but it is still initialized too soon.
Even before any calling message is processed or any call-related usecase is used, the `CallManager` and underlying AVS libs are initialized.

### Causes

- We pass the instance of `CallManager` to `ConversationEventReceiver`.
- So, whenever a sync is going on, independently of the kind of message received, a `CallManager` is already created.

### Solutions

Make it `Lazy<CallManager>`.
The `ConversationEventReceiver` will only call it when/if needed.
Same for other use cases.

If no call goes on, we don't need to initialize this guy.

This also helps with some circular dependencies, as `SyncManager`, `EventReceiver`, `CallManager` and `MessageSender` are cyclic. I'm still figuring out how to properly solve this.

### Testing

Compiler does it!

I've also run Reloaded manually with these changes, and everything runs smooth :)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
