### PR TITLE
fix: allCalls flow is not emitting data after being updated

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -27,7 +27,6 @@ import com.wire.kalium.logic.feature.call.scenario.OnParticipantListChanged
 import com.wire.kalium.logic.feature.call.scenario.OnSFTRequest
 import com.wire.kalium.logic.feature.call.scenario.OnSendOTR
 import com.wire.kalium.logic.feature.message.MessageSender
-import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.util.toInt
 import com.wire.kalium.logic.util.toTimeInMillis
 import kotlinx.coroutines.CoroutineScope
@@ -77,8 +76,8 @@ actual class CallManagerImpl(
                 onCallingReady()
             },
             //TODO(refactor): inject all of these CallbackHandlers in class constructor
-            sendHandler = OnSendOTR(deferredHandle, calling, selfUserId, selfClientId, messageSender, this),
-            sftRequestHandler = OnSFTRequest(deferredHandle, calling, callRepository, this),
+            sendHandler = OnSendOTR(deferredHandle, calling, selfUserId, selfClientId, messageSender, scope),
+            sftRequestHandler = OnSFTRequest(deferredHandle, calling, callRepository, scope),
             incomingCallHandler = OnIncomingCall(callRepository),
             missedCallHandler = OnMissedCall(callRepository),
             answeredCallHandler = OnAnsweredCall(callRepository),
@@ -87,7 +86,7 @@ actual class CallManagerImpl(
             metricsHandler = { conversationId: String, metricsJson: String, arg: Pointer? ->
                 callingLogger.i("$TAG -> metricsHandler")
             },
-            callConfigRequestHandler = OnConfigRequest(calling, callRepository, this),
+            callConfigRequestHandler = OnConfigRequest(calling, callRepository, scope),
             constantBitRateStateChangeHandler = { userId: String, clientId: String, isEnabled: Boolean, arg: Pointer? ->
                 callingLogger.i("$TAG -> constantBitRateStateChangeHandler")
             },

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.feature.call.scenario.OnParticipantListChanged
 import com.wire.kalium.logic.feature.call.scenario.OnSFTRequest
 import com.wire.kalium.logic.feature.call.scenario.OnSendOTR
 import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.util.toInt
 import com.wire.kalium.logic.util.toTimeInMillis
 import kotlinx.coroutines.CoroutineScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -9,7 +9,6 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.call.CallApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlin.math.max
@@ -18,7 +17,7 @@ interface CallRepository {
     suspend fun getCallConfigResponse(limit: Int?): Either<CoreFailure, String>
     suspend fun connectToSFT(url: String, data: String): Either<CoreFailure, ByteArray>
     fun updateCallProfileFlow(callProfile: CallProfile)
-    fun callsFlow(): StateFlow<List<Call>>
+    fun callsFlow(): Flow<List<Call>>
     fun incomingCallsFlow(): Flow<List<Call>>
     fun ongoingCallsFlow(): Flow<List<Call>>
     fun createCall(call: Call)
@@ -46,7 +45,9 @@ internal class CallDataSource(
         _callProfile.value = callProfile
     }
 
-    override fun callsFlow(): StateFlow<List<Call>> = MutableStateFlow(allCalls.value.calls.values.toList())
+    override fun callsFlow(): Flow<List<Call>> = _callProfile.map {
+                it.calls.values.toList()
+    }
 
     override fun incomingCallsFlow(): Flow<List<Call>> = allCalls.map {
         it.calls.values.filter { call ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -45,7 +45,7 @@ internal class CallDataSource(
         _callProfile.value = callProfile
     }
 
-    override fun callsFlow(): Flow<List<Call>> = _callProfile.map {
+    override fun callsFlow(): Flow<List<Call>> = allCalls.map {
                 it.calls.values.toList()
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetAllCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetAllCallsUseCase.kt
@@ -3,13 +3,13 @@ package com.wire.kalium.logic.feature.call.usecase
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.sync.SyncManager
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 class GetAllCallsUseCase(
     private val callRepository: CallRepository,
     private val syncManager: SyncManager
 ) {
-    suspend operator fun invoke(): StateFlow<List<Call>> {
+    suspend operator fun invoke(): Flow<List<Call>> {
         syncManager.waitForSlowSyncToComplete()
         return callRepository.callsFlow()
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -66,63 +66,63 @@ class CallRepositoryTest {
     }
 
     @Test
-    fun givenEmptyListOfCalls_whenGetAllCallsIsCalled_thenReturnAnEmptyListOfCalls() {
+    fun givenEmptyListOfCalls_whenGetAllCallsIsCalled_thenReturnAnEmptyListOfCalls() = runTest {
         val calls = callRepository.callsFlow()
 
-        assertEquals(0, calls.value.size)
+        assertEquals(0, calls.first().size)
     }
 
     @Test
-    fun givenAListOfCallProfiles_whenGetAllCallsIsCalled_thenReturnAListOfCalls() {
+    fun givenAListOfCallProfiles_whenGetAllCallsIsCalled_thenReturnAListOfCalls() = runTest {
         callRepository.updateCallProfileFlow(CallProfile(mapOfCallProfiles))
 
         val calls = callRepository.callsFlow()
 
-        assertEquals(mapOfCallProfiles.size, calls.value.size)
-        assertTrue(calls.value[0].instanceOf(Call::class))
+        assertEquals(mapOfCallProfiles.size, calls.first().size)
+        assertTrue(calls.first()[0].instanceOf(Call::class))
     }
 
     @Test
-    fun givenACallObject_whenCreateCallCalled_thenAddThatCallToTheFlow() {
+    fun givenACallObject_whenCreateCallCalled_thenAddThatCallToTheFlow() = runTest {
         callRepository.updateCallProfileFlow(CallProfile(mapOf(startedCall.conversationId.toString() to startedCall)))
 
         callRepository.createCall(answeredCall)
 
         val calls = callRepository.callsFlow()
-        assertEquals(2, calls.value.size)
-        assertEquals(calls.value[0], startedCall)
-        assertEquals(calls.value[1], answeredCall)
+        assertEquals(2, calls.first().size)
+        assertEquals(calls.first()[0], startedCall)
+        assertEquals(calls.first()[1], answeredCall)
     }
 
     @Test
-    fun givenACallObjectWithSameConversationIdAsAnotherOneInTheFlow_whenCreateCallCalled_thenReplaceTheCurrent() {
+    fun givenACallObjectWithSameConversationIdAsAnotherOneInTheFlow_whenCreateCallCalled_thenReplaceTheCurrent() = runTest {
         val incomingCall2 = provideCall(sharedConversationId, CallStatus.INCOMING)
         callRepository.updateCallProfileFlow(CallProfile(mapOfCallProfiles))
 
         callRepository.createCall(incomingCall2)
 
         val calls = callRepository.callsFlow()
-        assertEquals(mapOfCallProfiles.size, calls.value.size)
-        assertEquals(calls.value[0], incomingCall2)
+        assertEquals(mapOfCallProfiles.size, calls.first().size)
+        assertEquals(calls.first()[0], incomingCall2)
     }
 
     @Test
-    fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateCallStatusIsCalled_thenDoNotUpdateTheFlow() {
+    fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateCallStatusIsCalled_thenDoNotUpdateTheFlow() = runTest {
         callRepository.updateCallStatusById(randomConversationIdString, CallStatus.INCOMING)
 
         val calls = callRepository.callsFlow()
-        assertEquals(0, calls.value.size)
+        assertEquals(0, calls.first().size)
     }
 
     @Test
-    fun givenAConversationIdThatExistsInTheFlow_whenUpdateCallStatusIsCalled_thenUpdateCallStatusInTheFlow() {
+    fun givenAConversationIdThatExistsInTheFlow_whenUpdateCallStatusIsCalled_thenUpdateCallStatusInTheFlow() = runTest {
         callRepository.updateCallProfileFlow(CallProfile(mapOfCallProfiles))
 
         callRepository.updateCallStatusById(startedCall.conversationId.toString(), CallStatus.ESTABLISHED)
 
         val calls = callRepository.callsFlow()
-        assertEquals(mapOfCallProfiles.size, calls.value.size)
-        assertEquals(calls.value[0].status, CallStatus.ESTABLISHED)
+        assertEquals(mapOfCallProfiles.size, calls.first().size)
+        assertEquals(calls.first()[0].status, CallStatus.ESTABLISHED)
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/GetAllCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/GetAllCallsUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.feature.call
 
+import app.cash.turbine.test
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.usecase.GetAllCallsUseCase
@@ -8,8 +9,7 @@ import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -34,29 +34,35 @@ class GetAllCallsUseCaseTest {
     }
 
     @Test
-    fun givenAFlowOfCalls_whenUseCaseInvoked_thenReturnThatFlow() = runTest {
+    fun givenAFlowOfTwoCalls_whenUseCaseInvoked_thenAssertThatTheUseCaseIsEmittingTheRightCalls() = runTest {
+        val calls1 = listOf(call1, call2)
+        val calls2 = listOf(call2)
+
+        val callsFlow = flowOf(calls1, calls2)
         given(syncManager).coroutine { waitForSlowSyncToComplete() }
             .thenReturn(Unit)
         given(callRepository).invocation { callsFlow() }
-            .then { MutableStateFlow(calls) }
+            .then { callsFlow }
 
         val result = getAllCallsUseCase()
 
-        assertEquals(calls, result.first())
+        result.test {
+            assertEquals(calls1, awaitItem())
+            assertEquals(calls2, awaitItem())
+            awaitComplete()
+        }
     }
 
     companion object {
-        private val calls = listOf(
-            Call(
-                ConversationId("first", "domain"),
-                CallStatus.STARTED,
-                "caller-id"
-            ),
-            Call(
-                ConversationId("second", "domain"),
-                CallStatus.INCOMING,
-                "caller-id"
-            )
+        private val call1 = Call(
+            ConversationId("first", "domain"),
+            CallStatus.STARTED,
+            "caller-id"
+        )
+        private val call2 = Call(
+            ConversationId("second", "domain"),
+            CallStatus.INCOMING,
+            "caller-id"
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/GetAllCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/GetAllCallsUseCaseTest.kt
@@ -34,7 +34,7 @@ class GetAllCallsUseCaseTest {
     }
 
     @Test
-    fun givenAFlowOfTwoCalls_whenUseCaseInvoked_thenAssertThatTheUseCaseIsEmittingTheRightCalls() = runTest {
+    fun givenCallsFlowEmitsANewValue_whenUseCaseIsCollected_thenAssertThatTheUseCaseIsEmittingTheRightCalls() = runTest {
         val calls1 = listOf(call1, call2)
         val calls2 = listOf(call2)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`callsFlow()` is not being triggered when a call value of that flow is changed 

### Causes (Optional)

This is because we are creating a new MutableStateFlow for `callsFlow()`. Nothing will be fired because we are always passing the same value

### Solutions

I used the backup value of calls and map it to return the list of calls

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

with unit test
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
