### PR TITLE
feat: add api version and base url to unauthenticated requests

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -61,6 +61,7 @@ data class ServerConfig(
 interface ServerConfigMapper {
     fun toDTO(serverConfig: ServerConfig): ServerConfigDTO
     fun toEntity(serverConfig: ServerConfig): ServerConfigEntity
+    fun toDTO(serverConfigEntity: ServerConfigEntity): ServerConfigDTO
     fun fromEntity(serverConfigEntity: ServerConfigEntity): ServerConfig
 }
 
@@ -93,6 +94,19 @@ class ServerConfigMapperImpl : ServerConfigMapper {
                 federation,
                 commonApiVersion.version,
                 domain
+            )
+        }
+    override fun toDTO(serverConfigEntity: ServerConfigEntity): ServerConfigDTO =
+        with(serverConfigEntity) {
+            ServerConfigDTO(
+                Url(apiBaseUrl),
+                Url(accountBaseUrl),
+                Url(webSocketBaseUrl),
+                Url(blackListUrl),
+                Url(teamsUrl),
+                Url(websiteUrl),
+                title,
+                commonApiVersion
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthServerConfigManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthServerConfigManagerImpl.kt
@@ -1,0 +1,13 @@
+package com.wire.kalium.logic.feature.auth
+
+import com.wire.kalium.logic.configuration.server.ServerConfigRepository
+import com.wire.kalium.network.AuthServerConfigManager
+import com.wire.kalium.network.tools.ServerConfigDTO
+
+internal class AuthServerConfigManagerImpl internal constructor(
+    private val serverConfigRepository: ServerConfigRepository
+) : AuthServerConfigManager {
+    override fun getCurrentAuthServer(): ServerConfigDTO {
+        TODO("Not yet implemented")
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.logic.feature.user.EnableLoggingUseCase
 import com.wire.kalium.logic.feature.user.EnableLoggingUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsLoggingEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsLoggingEnabledUseCaseImpl
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.network.UnauthenticatedNetworkContainer
 import com.wire.kalium.persistence.client.TokenStorage
 import com.wire.kalium.persistence.client.TokenStorageImpl
@@ -47,6 +48,7 @@ class AuthenticationScope(
 ) {
 
     private val unauthenticatedNetworkContainer: UnauthenticatedNetworkContainer by lazy {
+        kaliumLogger.d("AuthenticationScope is creating UnauthenticatedNetworkContainer")
         UnauthenticatedNetworkContainer()
     }
     private val serverConfigMapper: ServerConfigMapper get() = ServerConfigMapperImpl()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -14,6 +14,7 @@ import com.wire.kalium.network.api.configuration.ServerConfigApi
 import com.wire.kalium.network.api.versioning.VersionApi
 import com.wire.kalium.network.api.versioning.VersionInfoDTO
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.persistence.dao_kalium_db.CurrentAuthenticationServerDAO
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAO
 import io.mockative.ConfigurationApi
 import io.mockative.Mock
@@ -52,11 +53,15 @@ class ServerConfigRepositoryTest {
     @Mock
     private val serverConfigUtil = mock(classOf<ServerConfigUtil>())
 
+    @Mock
+    private val currentAuthenticationServerDAO: CurrentAuthenticationServerDAO = mock(classOf<CurrentAuthenticationServerDAO>())
+
     private lateinit var serverConfigRepository: ServerConfigRepository
 
     @BeforeTest
     fun setup() {
-        serverConfigRepository = ServerConfigDataSource(serverConfigApi, serverConfigDAO, versionApi, serverConfigUtil)
+        serverConfigRepository =
+            ServerConfigDataSource(serverConfigApi, serverConfigDAO, versionApi, serverConfigUtil, currentAuthenticationServerDAO)
     }
 
     @Test

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/AuthServerConfigManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/AuthServerConfigManager.kt
@@ -1,0 +1,7 @@
+package com.wire.kalium.network
+
+import com.wire.kalium.network.tools.ServerConfigDTO
+
+interface AuthServerConfigManager {
+    fun getCurrentAuthServer(): ServerConfigDTO
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
@@ -47,9 +47,9 @@ internal class AuthenticatedNetworkClient(engine: HttpClientEngine, sessionManag
  * needed configurations to talk with a Wire backend, like
  * Serialization, and Content Negotiation.
  */
-internal class UnauthenticatedNetworkClient(engine: HttpClientEngine) {
-    // TODO: Make it so it has a base URL
-    val httpClient: HttpClient = provideBaseHttpClient(engine, HttpClientOptions.NoDefaultHost)
+internal class UnauthenticatedNetworkClient(engine: HttpClientEngine, authServerConfigManager: AuthServerConfigManager) {
+    val httpClient: HttpClient =
+        provideBaseHttpClient(engine, HttpClientOptions.UnauthenticatedWireClient(authServerConfigManager.getCurrentAuthServer()))
 }
 
 /**
@@ -89,7 +89,9 @@ internal class AuthenticatedWebSocketClient(
 }
 
 internal sealed class HttpClientOptions {
+    @Deprecated("use either UnauthenticatedWireClient or ExternalClient")
     object NoDefaultHost : HttpClientOptions()
+    data class UnauthenticatedWireClient(val serverConfigDTO: ServerConfigDTO) : HttpClientOptions()
     data class DefaultHost(val serverConfigDTO: ServerConfigDTO) : HttpClientOptions()
 }
 
@@ -117,19 +119,11 @@ internal fun provideBaseHttpClient(
         when (options) {
             HttpClientOptions.NoDefaultHost -> {/* do nothing */
             }
-
             is HttpClientOptions.DefaultHost -> {
-                with(options.serverConfigDTO) {
-                    // enforce https as url protocol
-                    url.protocol = URLProtocol.HTTPS
-                    // add the default host
-                    url.host = apiBaseUrl.host
-
-                    // for api version 0 no api version should be added to the request
-                    url.encodedPath =
-                        if (shouldAddApiVersion(apiVersion)) apiBaseUrl.encodedPath + "v${apiVersion}/"
-                        else apiBaseUrl.encodedPath
-                }
+                setWireBaseUrl(options.serverConfigDTO)
+            }
+            is HttpClientOptions.UnauthenticatedWireClient -> {
+                setWireBaseUrl(options.serverConfigDTO)
             }
         }
     }
@@ -150,3 +144,17 @@ internal fun provideBaseHttpClient(
 
 internal fun shouldAddApiVersion(apiVersion: Int): Boolean = apiVersion >= MINIMUM_API_VERSION_TO_ADD
 private const val MINIMUM_API_VERSION_TO_ADD = 1
+
+
+private fun DefaultRequest.DefaultRequestBuilder.setWireBaseUrl(serverConfigDTO: ServerConfigDTO) {
+    with(serverConfigDTO) {
+        // enforce https as url protocol
+        url.protocol = URLProtocol.HTTPS
+        // add the default host
+        url.host = apiBaseUrl.host
+        // for api version 0 no api version should be added to the request
+        url.encodedPath =
+            if (shouldAddApiVersion(apiVersion)) apiBaseUrl.encodedPath + "v${apiVersion}/"
+            else apiBaseUrl.encodedPath
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/UnauthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/UnauthenticatedNetworkContainer.kt
@@ -13,10 +13,11 @@ import com.wire.kalium.network.api.versioning.VersionApiImpl
 import io.ktor.client.engine.HttpClientEngine
 
 class UnauthenticatedNetworkContainer constructor(
+    private val authServerConfigManager: Lazy<AuthServerConfigManager>,
     engine: HttpClientEngine = defaultHttpEngine()
 ) {
     internal val unauthenticatedNetworkClient by lazy {
-        UnauthenticatedNetworkClient(engine)
+        UnauthenticatedNetworkClient(engine, authServerConfigManager.value)
     }
 
     val loginApi: LoginApi get() = LoginApiImpl(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/LoginApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/login/LoginApiImpl.kt
@@ -10,14 +10,12 @@ import com.wire.kalium.network.utils.CustomErrors
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.flatMap
 import com.wire.kalium.network.utils.mapSuccess
-import com.wire.kalium.network.utils.setUrl
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.http.Url
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -47,8 +45,8 @@ class LoginApiImpl internal constructor(
         param: LoginApi.LoginParam, persist: Boolean, apiBaseUrl: String
     ): NetworkResponse<SessionDTO> =
         wrapKaliumResponse<AccessTokenDTO> {
-            httpClient.post {
-                setUrl(Url(apiBaseUrl), PATH_LOGIN)
+            httpClient.post(PATH_LOGIN) {
+                //setUrl(Url(apiBaseUrl), )
                 parameter(QUERY_PERSIST, persist)
                 setBody(param.toRequestBody())
             }
@@ -62,8 +60,8 @@ class LoginApiImpl internal constructor(
             // this is a hack to get the user QualifiedUserId on login
             // TODO(optimization): remove this one when login endpoint return a QualifiedUserId
             wrapKaliumResponse<UserDTO> {
-                httpClient.get {
-                    setUrl(Url(apiBaseUrl), PATH_SELF)
+                httpClient.get(PATH_SELF) {
+                    //setUrl(Url(apiBaseUrl), )
                     bearerAuth(tokensPairResponse.value.first.value)
                 }
             }.mapSuccess {

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -7,6 +7,8 @@ import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.wire.kalium.persistence.DBUtil
 import com.wire.kalium.persistence.GlobalDatabase
 import com.wire.kalium.persistence.ServerConfiguration
+import com.wire.kalium.persistence.dao_kalium_db.CurrentAuthenticationServerDAO
+import com.wire.kalium.persistence.dao_kalium_db.CurrentAuthenticationServerDAOImpl
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAO
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
@@ -45,11 +47,14 @@ actual class GlobalDatabaseProvider(private val context: Context, kaliumPreferen
     actual val serverConfigurationDAO: ServerConfigurationDAO
         get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries)
 
+
+    actual val currentAuthenticationServerDAO: CurrentAuthenticationServerDAO
+        get() = CurrentAuthenticationServerDAOImpl(database.currentAuthenticationServerQueries)
+
+
     actual fun nuke(): Boolean = DBUtil.deleteDB(driver, context, dbName)
 
     companion object {
         private const val DATABASE_SECRET_KEY = "global-db-secret"
     }
-
-
 }

--- a/persistence/src/commonMain/db_global/com/wire/kalium/persistence/CurrentAuthenticationServer.sq
+++ b/persistence/src/commonMain/db_global/com/wire/kalium/persistence/CurrentAuthenticationServer.sq
@@ -1,0 +1,12 @@
+CREATE TABLE CurrentAuthenticationServer (
+    id INTEGER PRIMARY KEY NOT NULL,
+    serverConfigId TEXT NOT NULL,
+    FOREIGN KEY (serverConfigId) REFERENCES ServerConfiguration(id)
+);
+
+
+update:
+INSERT OR REPLACE INTO CurrentAuthenticationServer(id, serverConfigId) VALUES(1, ?);
+
+select:
+SELECT serverConfigId FROM CurrentAuthenticationServer WHERE id = 1;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao_kalium_db/CurrentAuthenticationServerDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao_kalium_db/CurrentAuthenticationServerDAO.kt
@@ -1,0 +1,22 @@
+package com.wire.kalium.persistence.dao_kalium_db
+
+import com.squareup.sqldelight.runtime.coroutines.asFlow
+import com.squareup.sqldelight.runtime.coroutines.mapToOne
+import com.wire.kalium.persistence.CurrentAuthenticationServerQueries
+import kotlinx.coroutines.flow.Flow
+
+interface CurrentAuthenticationServerDAO {
+    fun update(serverConfigId: String)
+    fun select(): String?
+    fun selectFlow(): Flow<String>
+}
+
+internal class CurrentAuthenticationServerDAOImpl(
+    private val queries: CurrentAuthenticationServerQueries
+): CurrentAuthenticationServerDAO {
+    override fun update(serverConfigId: String) = queries.update(serverConfigId)
+
+    override fun select(): String? = queries.select().executeAsOneOrNull()
+
+    override fun selectFlow(): Flow<String> = queries.select().asFlow().mapToOne()
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao_kalium_db/CurrentAuthenticationServerDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao_kalium_db/CurrentAuthenticationServerDAO.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface CurrentAuthenticationServerDAO {
     fun update(serverConfigId: String)
-    fun select(): String?
-    fun selectFlow(): Flow<String>
+    fun currentConfigId(): String?
+    fun currentConfigIdFlow(): Flow<String>
 }
 
 internal class CurrentAuthenticationServerDAOImpl(
@@ -16,7 +16,7 @@ internal class CurrentAuthenticationServerDAOImpl(
 ): CurrentAuthenticationServerDAO {
     override fun update(serverConfigId: String) = queries.update(serverConfigId)
 
-    override fun select(): String? = queries.select().executeAsOneOrNull()
+    override fun currentConfigId(): String? = queries.select().executeAsOneOrNull()
 
-    override fun selectFlow(): Flow<String> = queries.select().asFlow().mapToOne()
+    override fun currentConfigIdFlow(): Flow<String> = queries.select().asFlow().mapToOne()
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -1,9 +1,11 @@
 package com.wire.kalium.persistence.db
 
+import com.wire.kalium.persistence.dao_kalium_db.CurrentAuthenticationServerDAO
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAO
 
 expect class GlobalDatabaseProvider {
     val serverConfigurationDAO: ServerConfigurationDAO
+    val currentAuthenticationServerDAO: CurrentAuthenticationServerDAO
 
     fun nuke(): Boolean
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao_kalium_db/CurrentAuthenticationServerDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao_kalium_db/CurrentAuthenticationServerDAOTest.kt
@@ -33,7 +33,7 @@ class CurrentAuthenticationServerDAOTest: GlobalDBBaseTest() {
         insertConfig(serverConfigEntity)
         db.currentAuthenticationServerDAO.update(expected)
 
-        db.currentAuthenticationServerDAO.select().also { actual ->
+        db.currentAuthenticationServerDAO.currentConfigId().also { actual ->
             assertEquals(expected, actual)
         }
     }
@@ -47,12 +47,12 @@ class CurrentAuthenticationServerDAOTest: GlobalDBBaseTest() {
         insertConfig(serverConfigEntity2)
 
         db.currentAuthenticationServerDAO.update(serverConfigEntity1.id)
-        db.currentAuthenticationServerDAO.select().also { actual ->
+        db.currentAuthenticationServerDAO.currentConfigId().also { actual ->
             assertEquals(serverConfigEntity1.id, actual)
         }
 
         db.currentAuthenticationServerDAO.update(serverConfigEntity2.id)
-        db.currentAuthenticationServerDAO.select().also { actual ->
+        db.currentAuthenticationServerDAO.currentConfigId().also { actual ->
             assertEquals(serverConfigEntity2.id, actual)
         }
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao_kalium_db/CurrentAuthenticationServerDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao_kalium_db/CurrentAuthenticationServerDAOTest.kt
@@ -1,0 +1,77 @@
+package com.wire.kalium.persistence.dao_kalium_db
+
+import com.wire.kalium.persistence.GlobalDBBaseTest
+import com.wire.kalium.persistence.db.GlobalDatabaseProvider
+import com.wire.kalium.persistence.model.ServerConfigEntity
+import com.wire.kalium.persistence.utils.stubs.newServerConfig
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CurrentAuthenticationServerDAOTest: GlobalDBBaseTest() {
+
+    lateinit var db: GlobalDatabaseProvider
+
+    @BeforeTest
+    fun setup() {
+        db = createDatabase()
+    }
+
+    @AfterTest
+    fun nuke() {
+        deleteDatabase()
+    }
+
+    @Test
+    fun givenValidServerConfig_thenItCanBeSetAsTheCurrentAuthenticationServer() = runTest {
+        val serverConfigEntity = newServerConfig(1)
+        val expected = serverConfigEntity.id
+        insertConfig(serverConfigEntity)
+        db.currentAuthenticationServerDAO.update(expected)
+
+        db.currentAuthenticationServerDAO.select().also { actual ->
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun givenMultipleServerConfig_whenUpdatingCurrentAuthServer_thenItCanBeUpdated() = runTest {
+        val serverConfigEntity1 = newServerConfig(1)
+        val serverConfigEntity2 = newServerConfig(2)
+
+        insertConfig(serverConfigEntity1)
+        insertConfig(serverConfigEntity2)
+
+        db.currentAuthenticationServerDAO.update(serverConfigEntity1.id)
+        db.currentAuthenticationServerDAO.select().also { actual ->
+            assertEquals(serverConfigEntity1.id, actual)
+        }
+
+        db.currentAuthenticationServerDAO.update(serverConfigEntity2.id)
+        db.currentAuthenticationServerDAO.select().also { actual ->
+            assertEquals(serverConfigEntity2.id, actual)
+        }
+    }
+
+    private fun insertConfig(serverConfigEntity: ServerConfigEntity) {
+        with(serverConfigEntity) {
+            db.serverConfigurationDAO.insert(
+                id,
+                apiBaseUrl,
+                accountBaseUrl,
+                webSocketBaseUrl,
+                blackListUrl,
+                teamsUrl,
+                websiteUrl,
+                title,
+                federation,
+                domain,
+                commonApiVersion
+            )
+        }
+    }
+}

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.adapter.primitive.IntColumnAdapter
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import com.wire.kalium.persistence.GlobalDatabase
 import com.wire.kalium.persistence.ServerConfiguration
+import com.wire.kalium.persistence.dao_kalium_db.CurrentAuthenticationServerDAO
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAO
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
@@ -25,6 +26,9 @@ actual class GlobalDatabaseProvider(passphrase: String) {
 
     actual val serverConfigurationDAO: ServerConfigurationDAO
         get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries)
+
+    actual val currentAuthenticationServerDAO: CurrentAuthenticationServerDAO
+        get() = TODO("Not yet implemented")
 
     actual fun nuke(): Boolean {
         TODO("Not yet implemented")

--- a/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.persistence.db
 
+import com.wire.kalium.persistence.dao_kalium_db.CurrentAuthenticationServerDAO
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAO
 
 actual class GlobalDatabaseProvider {
@@ -9,5 +10,8 @@ actual class GlobalDatabaseProvider {
     actual fun nuke(): Boolean {
         TODO("Not yet implemented")
     }
+
+    actual val currentAuthenticationServerDAO: CurrentAuthenticationServerDAO
+        get() = TODO("Not yet implemented")
 
 }

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -5,6 +5,8 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.wire.kalium.persistence.GlobalDatabase
 import com.wire.kalium.persistence.ServerConfiguration
+import com.wire.kalium.persistence.dao_kalium_db.CurrentAuthenticationServerDAO
+import com.wire.kalium.persistence.dao_kalium_db.CurrentAuthenticationServerDAOImpl
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAO
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
@@ -43,6 +45,8 @@ actual class GlobalDatabaseProvider(private val storePath: File) {
     actual val serverConfigurationDAO: ServerConfigurationDAO
         get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries)
 
+    actual val currentAuthenticationServerDAO: CurrentAuthenticationServerDAO
+        get() = CurrentAuthenticationServerDAOImpl(database.currentAuthenticationServerQueries)
     actual fun nuke(): Boolean {
         return storePath.resolve(dbName).delete()
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. unauthenticated network requests (login, register ... ect) doesn't yet have versions.
2. it's annoying to carry around the auth server object for each unauthenticated API request.

### Solutions

1. add current Auth server DB table to store the ID of the auth server
2. add `AuthServerManager` interface in network to get the server configurations.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

this PR will fail test since it require some changes to the code, but i wanted to get some feed back about the change before i proceed with it

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
