### PR TITLE
feat(accept-conn): calling api to update connection status - part 1 (AR-1503)

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import kotlinx.serialization.json.buildJsonObject
 
@@ -12,6 +13,7 @@ interface ConnectionApi {
 
     suspend fun fetchSelfUserConnections(pagingState: String?): NetworkResponse<ConnectionResponse>
     suspend fun createConnection(userId: UserId): NetworkResponse<Connection>
+    suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionState): NetworkResponse<Connection>
 }
 
 class ConnectionApiImpl internal constructor(private val authenticatedNetworkClient: AuthenticatedNetworkClient) : ConnectionApi {
@@ -34,6 +36,13 @@ class ConnectionApiImpl internal constructor(private val authenticatedNetworkCli
     override suspend fun createConnection(userId: UserId): NetworkResponse<Connection> =
         wrapKaliumResponse {
             httpClient.post("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}")
+        }
+
+    override suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionState): NetworkResponse<Connection> =
+        wrapKaliumResponse {
+            httpClient.put("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}") {
+                setBody(connectionStatus)
+            }
         }
 
     private companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionApiTest.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.user.connection.ConnectionApi
 import com.wire.kalium.network.api.user.connection.ConnectionApiImpl
+import com.wire.kalium.network.api.user.connection.ConnectionState
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
@@ -69,6 +70,31 @@ class ConnectionApiTest : ApiTest {
 
     }
 
+    @Test
+    fun givenAConnectionRequestUpdate_whenInvokingWithAnUserAndAConnectionStatus_thenShouldReturnsACorrectConnectionResponse() =
+        runTest {
+            // given
+            val userId = UserId("user_id", "domain_id")
+            val httpClient = mockAuthenticatedNetworkClient(
+                CREATE_CONNECTION_RESPONSE.rawJson,
+                statusCode = HttpStatusCode.OK,
+                assertion = {
+                    assertJson()
+                    assertPut()
+                    assertPathEqual("$PATH_CONNECTIONS_ENDPOINT/${userId.domain}/${userId.value}")
+                    assertBodyContent(GET_CONNECTION_STATUS_REQUEST.rawJson)
+                }
+            )
+            val connectionApi = ConnectionApiImpl(httpClient)
+
+            // when
+            val response = connectionApi.updateConnection(userId, ConnectionState.ACCEPTED)
+
+            // then
+            assertTrue(response.isSuccessful())
+        }
+
+
     private companion object {
         const val PATH_CONNECTIONS = "/list-connections"
         const val PATH_CONNECTIONS_ENDPOINT = "/connections"
@@ -77,5 +103,6 @@ class ConnectionApiTest : ApiTest {
         val CREATE_CONNECTION_RESPONSE = ConnectionResponsesJson.CreateConnectionResponse.jsonProvider
         val GET_CONNECTIONS_NO_PAGING_REQUEST = ConnectionRequestsJson.validEmptyBody
         val GET_CONNECTIONS_WITH_PAGING_REQUEST = ConnectionRequestsJson.validPagingState
+        val GET_CONNECTION_STATUS_REQUEST = ConnectionRequestsJson.validConnectionStatusUpdate
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionRequestsJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionRequestsJson.kt
@@ -18,4 +18,12 @@ object ConnectionRequestsJson {
             }
         """.trimIndent()
     }
+
+    val validConnectionStatusUpdate = ValidJsonProvider(String) {
+        """
+            {
+                "status": "accepted"                            
+            }
+        """.trimIndent()
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

https://wearezeta.atlassian.net/browse/AR-1503

### Issues

Creates the API call for accepting a connection request (in fact, updating a connection status).

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
