### PR TITLE
feat(accept-conn): calling repo to update connection status - part 2 (AR-1504)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -3,8 +3,10 @@ package com.wire.kalium.logic.data.connection
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.failure.InvalidMappingFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.map
@@ -15,19 +17,20 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.user.connection.Connection
 import com.wire.kalium.network.api.user.connection.ConnectionApi
-import com.wire.kalium.network.api.user.connection.ConnectionState
+import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
 import com.wire.kalium.persistence.dao.ConversationDAO
-import com.wire.kalium.persistence.dao.UserEntity
 
 interface ConnectionRepository {
     suspend fun fetchSelfUserConnections(): Either<CoreFailure, Unit>
     suspend fun sendUserConnection(userId: UserId): Either<CoreFailure, Unit>
+    suspend fun updateConnectionStatus(userId: UserId, connectionState: ConnectionState): Either<CoreFailure, Unit>
 }
 
 internal class ConnectionDataSource(
     private val conversationDAO: ConversationDAO,
     private val connectionApi: ConnectionApi,
-    private val idMapper: IdMapper = MapperProvider.idMapper()
+    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val connectionStatusMapper: ConnectionStatusMapper = MapperProvider.connectionStatusMapper()
 ) : ConnectionRepository {
 
     override suspend fun fetchSelfUserConnections(): Either<CoreFailure, Unit> {
@@ -55,19 +58,23 @@ internal class ConnectionDataSource(
         return wrapApiRequest {
             connectionApi.createConnection(idMapper.toApiModel(userId))
         }.map { connection ->
-            val connectionSent = connection.copy(status = ConnectionState.SENT)
+            val connectionSent = connection.copy(status = ConnectionStateDTO.SENT)
             updateUserConnectionStatus(listOf(connectionSent))
         }
     }
 
-    private fun connectionStateToDao(state: ConnectionState): UserEntity.ConnectionState = when (state) {
-        ConnectionState.PENDING -> UserEntity.ConnectionState.PENDING
-        ConnectionState.SENT -> UserEntity.ConnectionState.SENT
-        ConnectionState.BLOCKED -> UserEntity.ConnectionState.BLOCKED
-        ConnectionState.IGNORED -> UserEntity.ConnectionState.IGNORED
-        ConnectionState.CANCELLED -> UserEntity.ConnectionState.CANCELLED
-        ConnectionState.MISSING_LEGALHOLD_CONSENT -> UserEntity.ConnectionState.MISSING_LEGALHOLD_CONSENT
-        ConnectionState.ACCEPTED -> UserEntity.ConnectionState.ACCEPTED
+    override suspend fun updateConnectionStatus(userId: UserId, connectionState: ConnectionState): Either<CoreFailure, Unit> {
+        val connectionStatus = connectionStatusMapper.connectionStateToApi(connectionState)
+        return if (connectionStatus == null)
+            Either.Left(InvalidMappingFailure)
+        else {
+            wrapApiRequest {
+                connectionApi.updateConnection(idMapper.toApiModel(userId), connectionStatus)
+            }.map { connection ->
+                val connectionSent = connection.copy(status = connectionStatus)
+                updateUserConnectionStatus(listOf(connectionSent))
+            }
+        }
     }
 
     private suspend fun updateUserConnectionStatus(
@@ -77,7 +84,7 @@ internal class ConnectionDataSource(
             connections.forEach { connection ->
                 conversationDAO.updateOrInsertOneOnOneMemberWithConnectionStatus(
                     userId = idMapper.fromApiToDao(connection.qualifiedToId),
-                    status = connectionStateToDao(state = connection.status),
+                    status = connectionStatusMapper.connectionStateToDao(state = connection.status),
                     conversationID = idMapper.fromApiToDao(connection.qualifiedConversationId)
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -17,7 +17,7 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.user.connection.Connection
 import com.wire.kalium.network.api.user.connection.ConnectionApi
-import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
+import com.wire.kalium.network.api.user.connection.ConnectionStatusDTO
 import com.wire.kalium.persistence.dao.ConversationDAO
 
 interface ConnectionRepository {
@@ -58,7 +58,7 @@ internal class ConnectionDataSource(
         return wrapApiRequest {
             connectionApi.createConnection(idMapper.toApiModel(userId))
         }.map { connection ->
-            val connectionSent = connection.copy(status = ConnectionStateDTO.SENT)
+            val connectionSent = connection.copy(status = ConnectionStatusDTO.SENT)
             updateUserConnectionStatus(listOf(connectionSent))
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -17,7 +17,7 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.user.connection.Connection
 import com.wire.kalium.network.api.user.connection.ConnectionApi
-import com.wire.kalium.network.api.user.connection.ConnectionStatusDTO
+import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
 import com.wire.kalium.persistence.dao.ConversationDAO
 
 interface ConnectionRepository {
@@ -58,7 +58,7 @@ internal class ConnectionDataSource(
         return wrapApiRequest {
             connectionApi.createConnection(idMapper.toApiModel(userId))
         }.map { connection ->
-            val connectionSent = connection.copy(status = ConnectionStatusDTO.SENT)
+            val connectionSent = connection.copy(status = ConnectionStateDTO.SENT)
             updateUserConnectionStatus(listOf(connectionSent))
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapper.kt
@@ -1,0 +1,34 @@
+package com.wire.kalium.logic.data.connection
+
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
+import com.wire.kalium.persistence.dao.UserEntity
+
+interface ConnectionStatusMapper {
+    fun connectionStateToDao(state: ConnectionStateDTO): UserEntity.ConnectionState
+    fun connectionStateToApi(state: ConnectionState): ConnectionStateDTO?
+}
+
+internal class ConnectionStatusMapperImpl : ConnectionStatusMapper {
+    override fun connectionStateToDao(state: ConnectionStateDTO): UserEntity.ConnectionState = when (state) {
+        ConnectionStateDTO.PENDING -> UserEntity.ConnectionState.PENDING
+        ConnectionStateDTO.SENT -> UserEntity.ConnectionState.SENT
+        ConnectionStateDTO.BLOCKED -> UserEntity.ConnectionState.BLOCKED
+        ConnectionStateDTO.IGNORED -> UserEntity.ConnectionState.IGNORED
+        ConnectionStateDTO.CANCELLED -> UserEntity.ConnectionState.CANCELLED
+        ConnectionStateDTO.MISSING_LEGALHOLD_CONSENT -> UserEntity.ConnectionState.MISSING_LEGALHOLD_CONSENT
+        ConnectionStateDTO.ACCEPTED -> UserEntity.ConnectionState.ACCEPTED
+    }
+
+    override fun connectionStateToApi(state: ConnectionState): ConnectionStateDTO? = when (state) {
+        ConnectionState.PENDING -> ConnectionStateDTO.PENDING
+        ConnectionState.SENT -> ConnectionStateDTO.SENT
+        ConnectionState.BLOCKED -> ConnectionStateDTO.BLOCKED
+        ConnectionState.IGNORED -> ConnectionStateDTO.IGNORED
+        ConnectionState.CANCELLED -> ConnectionStateDTO.CANCELLED
+        ConnectionState.MISSING_LEGALHOLD_CONSENT -> ConnectionStateDTO.MISSING_LEGALHOLD_CONSENT
+        ConnectionState.ACCEPTED -> ConnectionStateDTO.ACCEPTED
+        ConnectionState.NOT_CONNECTED -> null
+    }
+}
+

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapper.kt
@@ -1,33 +1,33 @@
 package com.wire.kalium.logic.data.connection
 
 import com.wire.kalium.logic.data.user.ConnectionState
-import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
+import com.wire.kalium.network.api.user.connection.ConnectionStatusDTO
 import com.wire.kalium.persistence.dao.UserEntity
 
 interface ConnectionStatusMapper {
-    fun connectionStateToDao(state: ConnectionStateDTO): UserEntity.ConnectionState
-    fun connectionStateToApi(state: ConnectionState): ConnectionStateDTO?
+    fun connectionStateToDao(state: ConnectionStatusDTO): UserEntity.ConnectionState
+    fun connectionStateToApi(state: ConnectionState): ConnectionStatusDTO?
 }
 
 internal class ConnectionStatusMapperImpl : ConnectionStatusMapper {
-    override fun connectionStateToDao(state: ConnectionStateDTO): UserEntity.ConnectionState = when (state) {
-        ConnectionStateDTO.PENDING -> UserEntity.ConnectionState.PENDING
-        ConnectionStateDTO.SENT -> UserEntity.ConnectionState.SENT
-        ConnectionStateDTO.BLOCKED -> UserEntity.ConnectionState.BLOCKED
-        ConnectionStateDTO.IGNORED -> UserEntity.ConnectionState.IGNORED
-        ConnectionStateDTO.CANCELLED -> UserEntity.ConnectionState.CANCELLED
-        ConnectionStateDTO.MISSING_LEGALHOLD_CONSENT -> UserEntity.ConnectionState.MISSING_LEGALHOLD_CONSENT
-        ConnectionStateDTO.ACCEPTED -> UserEntity.ConnectionState.ACCEPTED
+    override fun connectionStateToDao(state: ConnectionStatusDTO): UserEntity.ConnectionState = when (state) {
+        ConnectionStatusDTO.PENDING -> UserEntity.ConnectionState.PENDING
+        ConnectionStatusDTO.SENT -> UserEntity.ConnectionState.SENT
+        ConnectionStatusDTO.BLOCKED -> UserEntity.ConnectionState.BLOCKED
+        ConnectionStatusDTO.IGNORED -> UserEntity.ConnectionState.IGNORED
+        ConnectionStatusDTO.CANCELLED -> UserEntity.ConnectionState.CANCELLED
+        ConnectionStatusDTO.MISSING_LEGALHOLD_CONSENT -> UserEntity.ConnectionState.MISSING_LEGALHOLD_CONSENT
+        ConnectionStatusDTO.ACCEPTED -> UserEntity.ConnectionState.ACCEPTED
     }
 
-    override fun connectionStateToApi(state: ConnectionState): ConnectionStateDTO? = when (state) {
-        ConnectionState.PENDING -> ConnectionStateDTO.PENDING
-        ConnectionState.SENT -> ConnectionStateDTO.SENT
-        ConnectionState.BLOCKED -> ConnectionStateDTO.BLOCKED
-        ConnectionState.IGNORED -> ConnectionStateDTO.IGNORED
-        ConnectionState.CANCELLED -> ConnectionStateDTO.CANCELLED
-        ConnectionState.MISSING_LEGALHOLD_CONSENT -> ConnectionStateDTO.MISSING_LEGALHOLD_CONSENT
-        ConnectionState.ACCEPTED -> ConnectionStateDTO.ACCEPTED
+    override fun connectionStateToApi(state: ConnectionState): ConnectionStatusDTO? = when (state) {
+        ConnectionState.PENDING -> ConnectionStatusDTO.PENDING
+        ConnectionState.SENT -> ConnectionStatusDTO.SENT
+        ConnectionState.BLOCKED -> ConnectionStatusDTO.BLOCKED
+        ConnectionState.IGNORED -> ConnectionStatusDTO.IGNORED
+        ConnectionState.CANCELLED -> ConnectionStatusDTO.CANCELLED
+        ConnectionState.MISSING_LEGALHOLD_CONSENT -> ConnectionStatusDTO.MISSING_LEGALHOLD_CONSENT
+        ConnectionState.ACCEPTED -> ConnectionStatusDTO.ACCEPTED
         ConnectionState.NOT_CONNECTED -> null
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapper.kt
@@ -1,33 +1,33 @@
 package com.wire.kalium.logic.data.connection
 
 import com.wire.kalium.logic.data.user.ConnectionState
-import com.wire.kalium.network.api.user.connection.ConnectionStatusDTO
+import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
 import com.wire.kalium.persistence.dao.UserEntity
 
 interface ConnectionStatusMapper {
-    fun connectionStateToDao(state: ConnectionStatusDTO): UserEntity.ConnectionState
-    fun connectionStateToApi(state: ConnectionState): ConnectionStatusDTO?
+    fun connectionStateToDao(state: ConnectionStateDTO): UserEntity.ConnectionState
+    fun connectionStateToApi(state: ConnectionState): ConnectionStateDTO?
 }
 
 internal class ConnectionStatusMapperImpl : ConnectionStatusMapper {
-    override fun connectionStateToDao(state: ConnectionStatusDTO): UserEntity.ConnectionState = when (state) {
-        ConnectionStatusDTO.PENDING -> UserEntity.ConnectionState.PENDING
-        ConnectionStatusDTO.SENT -> UserEntity.ConnectionState.SENT
-        ConnectionStatusDTO.BLOCKED -> UserEntity.ConnectionState.BLOCKED
-        ConnectionStatusDTO.IGNORED -> UserEntity.ConnectionState.IGNORED
-        ConnectionStatusDTO.CANCELLED -> UserEntity.ConnectionState.CANCELLED
-        ConnectionStatusDTO.MISSING_LEGALHOLD_CONSENT -> UserEntity.ConnectionState.MISSING_LEGALHOLD_CONSENT
-        ConnectionStatusDTO.ACCEPTED -> UserEntity.ConnectionState.ACCEPTED
+    override fun connectionStateToDao(state: ConnectionStateDTO): UserEntity.ConnectionState = when (state) {
+        ConnectionStateDTO.PENDING -> UserEntity.ConnectionState.PENDING
+        ConnectionStateDTO.SENT -> UserEntity.ConnectionState.SENT
+        ConnectionStateDTO.BLOCKED -> UserEntity.ConnectionState.BLOCKED
+        ConnectionStateDTO.IGNORED -> UserEntity.ConnectionState.IGNORED
+        ConnectionStateDTO.CANCELLED -> UserEntity.ConnectionState.CANCELLED
+        ConnectionStateDTO.MISSING_LEGALHOLD_CONSENT -> UserEntity.ConnectionState.MISSING_LEGALHOLD_CONSENT
+        ConnectionStateDTO.ACCEPTED -> UserEntity.ConnectionState.ACCEPTED
     }
 
-    override fun connectionStateToApi(state: ConnectionState): ConnectionStatusDTO? = when (state) {
-        ConnectionState.PENDING -> ConnectionStatusDTO.PENDING
-        ConnectionState.SENT -> ConnectionStatusDTO.SENT
-        ConnectionState.BLOCKED -> ConnectionStatusDTO.BLOCKED
-        ConnectionState.IGNORED -> ConnectionStatusDTO.IGNORED
-        ConnectionState.CANCELLED -> ConnectionStatusDTO.CANCELLED
-        ConnectionState.MISSING_LEGALHOLD_CONSENT -> ConnectionStatusDTO.MISSING_LEGALHOLD_CONSENT
-        ConnectionState.ACCEPTED -> ConnectionStatusDTO.ACCEPTED
+    override fun connectionStateToApi(state: ConnectionState): ConnectionStateDTO? = when (state) {
+        ConnectionState.PENDING -> ConnectionStateDTO.PENDING
+        ConnectionState.SENT -> ConnectionStateDTO.SENT
+        ConnectionState.BLOCKED -> ConnectionStateDTO.BLOCKED
+        ConnectionState.IGNORED -> ConnectionStateDTO.IGNORED
+        ConnectionState.CANCELLED -> ConnectionStateDTO.CANCELLED
+        ConnectionState.MISSING_LEGALHOLD_CONSENT -> ConnectionStateDTO.MISSING_LEGALHOLD_CONSENT
+        ConnectionState.ACCEPTED -> ConnectionStateDTO.ACCEPTED
         ConnectionState.NOT_CONNECTED -> null
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -6,6 +6,8 @@ import com.wire.kalium.logic.configuration.ServerConfigMapperImpl
 import com.wire.kalium.logic.data.asset.AssetMapper
 import com.wire.kalium.logic.data.asset.AssetMapperImpl
 import com.wire.kalium.logic.data.client.ClientMapper
+import com.wire.kalium.logic.data.connection.ConnectionStatusMapper
+import com.wire.kalium.logic.data.connection.ConnectionStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.ConversationMapper
 import com.wire.kalium.logic.data.conversation.ConversationMapperImpl
 import com.wire.kalium.logic.data.conversation.ConversationStatusMapper
@@ -50,4 +52,5 @@ internal object MapperProvider {
     fun locationMapper(): LocationMapper = LocationMapper()
     fun clientMapper(clientConfig: ClientConfig): ClientMapper = ClientMapper(preyKeyMapper(), locationMapper(), clientConfig)
     fun conversationStatusMapper(): ConversationStatusMapper = ConversationStatusMapperImpl()
+    fun connectionStatusMapper(): ConnectionStatusMapper = ConnectionStatusMapperImpl()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/InvalidMappingFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/failure/InvalidMappingFailure.kt
@@ -1,0 +1,5 @@
+package com.wire.kalium.logic.failure
+
+import com.wire.kalium.logic.CoreFailure
+
+object InvalidMappingFailure : CoreFailure.FeatureFailure()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -8,7 +8,7 @@ import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.user.connection.Connection
 import com.wire.kalium.network.api.user.connection.ConnectionApi
 import com.wire.kalium.network.api.user.connection.ConnectionResponse
-import com.wire.kalium.network.api.user.connection.ConnectionStatusDTO
+import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
@@ -168,7 +168,7 @@ class ConnectionRepositoryTest {
         val userId = NetworkUserId("user_id", "domain_id")
         given(connectionApi)
             .suspendFunction(connectionApi::updateConnection)
-            .whenInvokedWith(eq(userId), eq(ConnectionStatusDTO.ACCEPTED))
+            .whenInvokedWith(eq(userId), eq(ConnectionStateDTO.ACCEPTED))
             .then { _, _ -> NetworkResponse.Success(connection1, mapOf(), 200) }
         given(conversationDAO)
             .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
@@ -181,7 +181,7 @@ class ConnectionRepositoryTest {
         // then
         verify(connectionApi)
             .suspendFunction(connectionApi::updateConnection)
-            .with(eq(userId), eq(ConnectionStatusDTO.ACCEPTED))
+            .with(eq(userId), eq(ConnectionStateDTO.ACCEPTED))
             .wasInvoked(once)
         verify(conversationDAO)
             .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
@@ -208,7 +208,7 @@ class ConnectionRepositoryTest {
         result.shouldFail()
         verify(connectionApi)
             .suspendFunction(connectionApi::updateConnection)
-            .with(eq(userId), eq(ConnectionStatusDTO.ACCEPTED))
+            .with(eq(userId), eq(ConnectionStateDTO.ACCEPTED))
             .wasNotInvoked()
         verify(conversationDAO)
             .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
@@ -235,7 +235,7 @@ class ConnectionRepositoryTest {
         result.shouldFail()
         verify(connectionApi)
             .suspendFunction(connectionApi::updateConnection)
-            .with(eq(userId), eq(ConnectionStatusDTO.ACCEPTED))
+            .with(eq(userId), eq(ConnectionStateDTO.ACCEPTED))
             .wasInvoked(once)
         verify(conversationDAO)
             .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
@@ -250,7 +250,7 @@ class ConnectionRepositoryTest {
             lastUpdate = "lastUpdate",
             qualifiedConversationId = ConversationId("conversationId1", "domain"),
             qualifiedToId = NetworkUserId("connectionId1", "domain"),
-            status = ConnectionStatusDTO.ACCEPTED,
+            status = ConnectionStateDTO.ACCEPTED,
             toId = "connectionId1"
         )
         val connection2 = Connection(
@@ -259,7 +259,7 @@ class ConnectionRepositoryTest {
             lastUpdate = "lastUpdate",
             qualifiedConversationId = ConversationId("conversationId2", "domain"),
             qualifiedToId = NetworkUserId("connectionId2", "domain"),
-            status = ConnectionStatusDTO.ACCEPTED,
+            status = ConnectionStateDTO.ACCEPTED,
             toId = "connectionId2"
         )
         val connectionsResponse = ConnectionResponse(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -8,7 +8,7 @@ import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.user.connection.Connection
 import com.wire.kalium.network.api.user.connection.ConnectionApi
 import com.wire.kalium.network.api.user.connection.ConnectionResponse
-import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
+import com.wire.kalium.network.api.user.connection.ConnectionStatusDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
@@ -168,7 +168,7 @@ class ConnectionRepositoryTest {
         val userId = NetworkUserId("user_id", "domain_id")
         given(connectionApi)
             .suspendFunction(connectionApi::updateConnection)
-            .whenInvokedWith(eq(userId), eq(ConnectionStateDTO.ACCEPTED))
+            .whenInvokedWith(eq(userId), eq(ConnectionStatusDTO.ACCEPTED))
             .then { _, _ -> NetworkResponse.Success(connection1, mapOf(), 200) }
         given(conversationDAO)
             .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
@@ -181,7 +181,7 @@ class ConnectionRepositoryTest {
         // then
         verify(connectionApi)
             .suspendFunction(connectionApi::updateConnection)
-            .with(eq(userId), eq(ConnectionStateDTO.ACCEPTED))
+            .with(eq(userId), eq(ConnectionStatusDTO.ACCEPTED))
             .wasInvoked(once)
         verify(conversationDAO)
             .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
@@ -208,7 +208,7 @@ class ConnectionRepositoryTest {
         result.shouldFail()
         verify(connectionApi)
             .suspendFunction(connectionApi::updateConnection)
-            .with(eq(userId), eq(ConnectionStateDTO.ACCEPTED))
+            .with(eq(userId), eq(ConnectionStatusDTO.ACCEPTED))
             .wasNotInvoked()
         verify(conversationDAO)
             .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
@@ -235,7 +235,7 @@ class ConnectionRepositoryTest {
         result.shouldFail()
         verify(connectionApi)
             .suspendFunction(connectionApi::updateConnection)
-            .with(eq(userId), eq(ConnectionStateDTO.ACCEPTED))
+            .with(eq(userId), eq(ConnectionStatusDTO.ACCEPTED))
             .wasInvoked(once)
         verify(conversationDAO)
             .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
@@ -250,7 +250,7 @@ class ConnectionRepositoryTest {
             lastUpdate = "lastUpdate",
             qualifiedConversationId = ConversationId("conversationId1", "domain"),
             qualifiedToId = NetworkUserId("connectionId1", "domain"),
-            status = ConnectionStateDTO.ACCEPTED,
+            status = ConnectionStatusDTO.ACCEPTED,
             toId = "connectionId1"
         )
         val connection2 = Connection(
@@ -259,7 +259,7 @@ class ConnectionRepositoryTest {
             lastUpdate = "lastUpdate",
             qualifiedConversationId = ConversationId("conversationId2", "domain"),
             qualifiedToId = NetworkUserId("connectionId2", "domain"),
-            status = ConnectionStateDTO.ACCEPTED,
+            status = ConnectionStatusDTO.ACCEPTED,
             toId = "connectionId2"
         )
         val connectionsResponse = ConnectionResponse(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapperTest.kt
@@ -1,0 +1,37 @@
+package com.wire.kalium.logic.data.connection
+
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
+import com.wire.kalium.persistence.dao.UserEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ConnectionStatusMapperTest {
+
+    private val mapper = ConnectionStatusMapperImpl()
+
+    @Test
+    fun givenAModelConnectionState_whenMappingToDaoModel_thenTheFieldsShouldBeMappedCorrectly() {
+        val accepted = ConnectionStateDTO.ACCEPTED
+        val daoState = mapper.connectionStateToDao(accepted)
+
+        assertEquals(UserEntity.ConnectionState.ACCEPTED, daoState)
+    }
+
+    @Test
+    fun givenAModelConnectionState_whenMappingToApiModel_thenTheFieldsShouldBeMappedCorrectly() {
+        val accepted = ConnectionState.ACCEPTED
+        val apiState = mapper.connectionStateToApi(accepted)
+
+        assertEquals(ConnectionStateDTO.ACCEPTED, apiState)
+    }
+
+    @Test
+    fun givenAModelConnectionState_whenMappingToApiModelToAnInvalid_thenTheFieldsShouldReturnsNull() {
+        val accepted = ConnectionState.NOT_CONNECTED
+        val apiState = mapper.connectionStateToApi(accepted)
+
+        assertNull(apiState)
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
@@ -13,7 +13,7 @@ interface ConnectionApi {
 
     suspend fun fetchSelfUserConnections(pagingState: String?): NetworkResponse<ConnectionResponse>
     suspend fun createConnection(userId: UserId): NetworkResponse<Connection>
-    suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionState): NetworkResponse<Connection>
+    suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStateDTO): NetworkResponse<Connection>
 }
 
 class ConnectionApiImpl internal constructor(private val authenticatedNetworkClient: AuthenticatedNetworkClient) : ConnectionApi {
@@ -38,7 +38,7 @@ class ConnectionApiImpl internal constructor(private val authenticatedNetworkCli
             httpClient.post("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}")
         }
 
-    override suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionState): NetworkResponse<Connection> =
+    override suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStateDTO): NetworkResponse<Connection> =
         wrapKaliumResponse {
             httpClient.put("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}") {
                 setBody(connectionStatus)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
@@ -13,7 +13,7 @@ interface ConnectionApi {
 
     suspend fun fetchSelfUserConnections(pagingState: String?): NetworkResponse<ConnectionResponse>
     suspend fun createConnection(userId: UserId): NetworkResponse<Connection>
-    suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStatusDTO): NetworkResponse<Connection>
+    suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStateDTO): NetworkResponse<Connection>
 }
 
 class ConnectionApiImpl internal constructor(private val authenticatedNetworkClient: AuthenticatedNetworkClient) : ConnectionApi {
@@ -38,7 +38,7 @@ class ConnectionApiImpl internal constructor(private val authenticatedNetworkCli
             httpClient.post("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}")
         }
 
-    override suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStatusDTO): NetworkResponse<Connection> =
+    override suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStateDTO): NetworkResponse<Connection> =
         wrapKaliumResponse {
             httpClient.put("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}") {
                 setBody(connectionStatus)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
@@ -13,7 +13,7 @@ interface ConnectionApi {
 
     suspend fun fetchSelfUserConnections(pagingState: String?): NetworkResponse<ConnectionResponse>
     suspend fun createConnection(userId: UserId): NetworkResponse<Connection>
-    suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStateDTO): NetworkResponse<Connection>
+    suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStatusDTO): NetworkResponse<Connection>
 }
 
 class ConnectionApiImpl internal constructor(private val authenticatedNetworkClient: AuthenticatedNetworkClient) : ConnectionApi {
@@ -38,7 +38,7 @@ class ConnectionApiImpl internal constructor(private val authenticatedNetworkCli
             httpClient.post("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}")
         }
 
-    override suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStateDTO): NetworkResponse<Connection> =
+    override suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStatusDTO): NetworkResponse<Connection> =
         wrapKaliumResponse {
             httpClient.put("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}") {
                 setBody(connectionStatus)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
@@ -19,12 +19,12 @@ data class Connection(
     @SerialName("last_update") val lastUpdate: String,
     @SerialName("qualified_conversation") val qualifiedConversationId: ConversationId,
     @SerialName("qualified_to") val qualifiedToId: UserId,
-    @SerialName("status") val status: ConnectionState,
+    @SerialName("status") val status: ConnectionStateDTO,
     @SerialName("to") val toId: String
 )
 
 @Serializable
-enum class ConnectionState {
+enum class ConnectionStateDTO {
     /** The other user has sent a connection request to this one */
     @SerialName("pending")
     PENDING,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
@@ -19,12 +19,12 @@ data class Connection(
     @SerialName("last_update") val lastUpdate: String,
     @SerialName("qualified_conversation") val qualifiedConversationId: ConversationId,
     @SerialName("qualified_to") val qualifiedToId: UserId,
-    @SerialName("status") val status: ConnectionStatusDTO,
+    @SerialName("status") val status: ConnectionStateDTO,
     @SerialName("to") val toId: String
 )
 
 @Serializable
-enum class ConnectionStatusDTO {
+enum class ConnectionStateDTO {
     /** The other user has sent a connection request to this one */
     @SerialName("pending")
     PENDING,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionResponse.kt
@@ -19,12 +19,12 @@ data class Connection(
     @SerialName("last_update") val lastUpdate: String,
     @SerialName("qualified_conversation") val qualifiedConversationId: ConversationId,
     @SerialName("qualified_to") val qualifiedToId: UserId,
-    @SerialName("status") val status: ConnectionStateDTO,
+    @SerialName("status") val status: ConnectionStatusDTO,
     @SerialName("to") val toId: String
 )
 
 @Serializable
-enum class ConnectionStateDTO {
+enum class ConnectionStatusDTO {
     /** The other user has sent a connection request to this one */
     @SerialName("pending")
     PENDING,

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionApiTest.kt
@@ -4,7 +4,7 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.user.connection.ConnectionApi
 import com.wire.kalium.network.api.user.connection.ConnectionApiImpl
-import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
+import com.wire.kalium.network.api.user.connection.ConnectionStatusDTO
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
@@ -88,7 +88,7 @@ class ConnectionApiTest : ApiTest {
             val connectionApi = ConnectionApiImpl(httpClient)
 
             // when
-            val response = connectionApi.updateConnection(userId, ConnectionStateDTO.ACCEPTED)
+            val response = connectionApi.updateConnection(userId, ConnectionStatusDTO.ACCEPTED)
 
             // then
             assertTrue(response.isSuccessful())

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionApiTest.kt
@@ -4,7 +4,7 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.user.connection.ConnectionApi
 import com.wire.kalium.network.api.user.connection.ConnectionApiImpl
-import com.wire.kalium.network.api.user.connection.ConnectionStatusDTO
+import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
@@ -88,7 +88,7 @@ class ConnectionApiTest : ApiTest {
             val connectionApi = ConnectionApiImpl(httpClient)
 
             // when
-            val response = connectionApi.updateConnection(userId, ConnectionStatusDTO.ACCEPTED)
+            val response = connectionApi.updateConnection(userId, ConnectionStateDTO.ACCEPTED)
 
             // then
             assertTrue(response.isSuccessful())

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/connection/ConnectionApiTest.kt
@@ -4,7 +4,7 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.user.connection.ConnectionApi
 import com.wire.kalium.network.api.user.connection.ConnectionApiImpl
-import com.wire.kalium.network.api.user.connection.ConnectionState
+import com.wire.kalium.network.api.user.connection.ConnectionStateDTO
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
@@ -88,7 +88,7 @@ class ConnectionApiTest : ApiTest {
             val connectionApi = ConnectionApiImpl(httpClient)
 
             // when
-            val response = connectionApi.updateConnection(userId, ConnectionState.ACCEPTED)
+            val response = connectionApi.updateConnection(userId, ConnectionStateDTO.ACCEPTED)
 
             // then
             assertTrue(response.isSuccessful())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Creates the repository to update remotely and locally the status of a connection request.
- Also extracted the mapper to an external class and provided using a constructor injection to standardize to project

Prev PR (API) : #521 

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
