### PR TITLE
fix: Wolfgang bug

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -28,7 +28,6 @@ import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.ConversationEntity.ProtocolInfo
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
-import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -167,9 +166,9 @@ class ConversationDataSource(
         conversationDAO.getConversationByQualifiedID(idMapper.toDaoModel(conversationID))
             .filterNotNull()
             .map(conversationMapper::fromDaoModel)
-            .flatMapLatest(::getDetailsFlowConversation)
+            .flatMapLatest(::getConversationDetailsFlow)
 
-    private suspend fun getDetailsFlowConversation(conversation: Conversation): Flow<ConversationDetails> =
+    private suspend fun getConversationDetailsFlow(conversation: Conversation): Flow<ConversationDetails> =
         when (conversation.type) {
             Conversation.Type.SELF -> flowOf(ConversationDetails.Self(conversation))
             Conversation.Type.GROUP ->
@@ -188,8 +187,15 @@ class ConversationDataSource(
                         members.firstOrNull { itemId -> itemId != selfUser.id }
                     }
                     .fold({
-                    // TODO: How to Handle failure when dealing with flows?
-                    throw IOException("Failure to fetch other user of 1:1 Conversation")
+                        when (it) {
+                            StorageFailure.DataNotFound -> {
+                                kaliumLogger.e("DataNotFound when fetching conversation members: $it")
+                            }
+                            is StorageFailure.Generic -> {
+                                kaliumLogger.e("Failure getting other 1:1 user for $conversation", it.rootCause)
+                            }
+                        }
+                        emptyFlow()
                 }, { otherUserIdOrNull ->
                         otherUserIdOrNull?.let {
                             userRepository.getKnownUser(it)


### PR DESCRIPTION
Crash when failing to get details of the other user in a 1:1 conversation caused by pending or ignored/blocked connection requests

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When fetching details of a conversation, the other user can be null or not found, leading to crashes.

### Causes

Pending or ignored connection requests received during sync can create conversations without the other member.

### Solutions

Ignore these conversations when fetching details.
This fixes the persistent issue at least, no need to clear data to get it working.

This is not a full fix.
We also need to stop processing these connection requests (or process them depending on the status), during sync.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
