### PR TITLE
fix: inserting the same config

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
@@ -95,22 +95,34 @@ internal class ServerConfigDataSource(
     override fun storeConfig(
         serverConfigResponse: ServerConfigResponse, domain: String?, apiVersion: Int, federation: Boolean
     ): Either<StorageFailure, ServerConfig> = wrapStorageRequest {
-        val newId = uuid4().toString()
         with(serverConfigResponse.endpoints) {
-            dao.insert(
-                id = newId,
-                apiBaseUrl = apiBaseUrl,
-                accountBaseUrl = accountsBaseUrl,
-                webSocketBaseUrl = webSocketBaseUrl,
-                blackListUrl = blackListUrl,
-                teamsUrl = teamsUrl,
-                websiteUrl = websiteUrl,
-                title = serverConfigResponse.title,
-                federation = federation,
-                domain = domain,
-                commonApiVersion = apiVersion
-            )
-            newId
+            // check if such config is already inserted
+            val storedConfigId = dao.configByUniqueFields(serverConfigResponse.title, apiBaseUrl, webSocketBaseUrl, domain)?.id
+            if (storedConfigId != null) {
+                // if already exists then just update it
+                dao.updateApiVersion(storedConfigId, apiVersion)
+                if (federation) dao.setFederationToTrue(storedConfigId)
+                storedConfigId
+            } else {
+                // otherwise insert new config
+                val newId = uuid4().toString()
+                dao.insert(
+                    ServerConfigurationDAO.InsertData(
+                        id = newId,
+                        apiBaseUrl = apiBaseUrl,
+                        accountBaseUrl = accountsBaseUrl,
+                        webSocketBaseUrl = webSocketBaseUrl,
+                        blackListUrl = blackListUrl,
+                        teamsUrl = teamsUrl,
+                        websiteUrl = websiteUrl,
+                        title = serverConfigResponse.title,
+                        federation = federation,
+                        domain = domain,
+                        commonApiVersion = apiVersion
+                    )
+                )
+                newId
+            }
         }
     }.flatMap { storedConfigId ->
         wrapStorageRequest { dao.configById(storedConfigId) }

--- a/persistence/src/commonMain/db_global/com/wire/kalium/persistence/ServerConfiguration.sq
+++ b/persistence/src/commonMain/db_global/com/wire/kalium/persistence/ServerConfiguration.sq
@@ -37,3 +37,7 @@ SELECT * FROM ServerConfiguration;
 
 getById:
 SELECT * FROM ServerConfiguration WHERE id = ?;
+
+/** this function should only be used when trying to insert new config, because config with this data may already exist with a different ID */
+getByUniqueFields:
+SELECT * FROM ServerConfiguration WHERE title = ? AND apiBaseUrl = ? AND webSocketBaseUrl = ? AND domain = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao_kalium_db/ServerConfigurationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao_kalium_db/ServerConfigurationDAO.kt
@@ -28,9 +28,7 @@ internal class ServerConfigMapper() {
 
 interface ServerConfigurationDAO {
     fun deleteById(id: String)
-    @Suppress("LongParameterList")
     fun insert(insertData: InsertData)
-
     fun allConfigFlow(): Flow<List<ServerConfigEntity>>
     fun allConfig(): List<ServerConfigEntity>
     fun configById(id: String): ServerConfigEntity?

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao_kalium_db/ServerConfigurationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao_kalium_db/ServerConfigurationDAOTest.kt
@@ -148,17 +148,19 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     private fun insertConfig(serverConfigEntity: ServerConfigEntity) {
         with(serverConfigEntity) {
             db.serverConfigurationDAO.insert(
-                id,
-                apiBaseUrl,
-                accountBaseUrl,
-                webSocketBaseUrl,
-                blackListUrl,
-                teamsUrl,
-                websiteUrl,
-                title,
-                federation,
-                domain,
-                commonApiVersion
+                ServerConfigurationDAO.InsertData(
+                    id,
+                    apiBaseUrl,
+                    accountBaseUrl,
+                    webSocketBaseUrl,
+                    blackListUrl,
+                    teamsUrl,
+                    websiteUrl,
+                    title,
+                    federation,
+                    domain,
+                    commonApiVersion
+                )
             )
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, when we try to store server config that's already stored, we receive `DataNotFound` error.

### Causes (Optional)

Insert query is in fact `INSERT OR IGNORE` and there are some `UNIQUE` fields, so when trying to insert the same config it's ignored, but new ID for this duplicated config is generated anyway and returned, so then to finally return this config, it tries to get it using newly generated ID and gets error because there is no such config stored.

### Solutions

First check if such config is already stored (comparing `title`, `apiBaseUrl`, `webSocketBaseUrl` and `domain`) and if so, then just update API versioning data (`commonApiVersion` and `federation`) because we may have more recent data for such config and pass this config's ID. If there is no such config stored yet, then generate new ID and insert it.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
