### PR TITLE
fix: conversation order after inserting the same conv twice

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -22,8 +22,8 @@ deleteConversation:
 DELETE FROM Conversation WHERE qualified_id = ?;
 
 insertConversation:
-INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, protocol, muted_status, muted_time, last_modified_date)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, protocol, muted_status, muted_time, last_modified_date, last_notified_message_date)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
 type = excluded.type,
@@ -32,7 +32,8 @@ mls_group_id = excluded.mls_group_id,
 protocol = excluded.protocol,
 muted_status = excluded.muted_status,
 muted_time = excluded.muted_time,
-last_modified_date = excluded.last_modified_date;
+last_modified_date = last_modified_date,
+last_notified_message_date = last_notified_message_date;
 
 updateConversation:
 UPDATE Conversation

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -75,7 +75,8 @@ class ConversationDAOImpl(
             if (conversationEntity.protocolInfo is ConversationEntity.ProtocolInfo.MLS) ConversationEntity.Protocol.MLS else ConversationEntity.Protocol.PROTEUS,
             conversationEntity.mutedStatus,
             conversationEntity.mutedTime,
-            conversationEntity.lastModifiedDate
+            conversationEntity.lastModifiedDate,
+            conversationEntity.lastNotificationDate
         )
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -224,6 +224,20 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
 
+    @Test
+    fun givenConversation_whenInsertingStoredConversation_thenLastChangesTimeIsNotChanged() = runTest {
+        val conv1Stored = conversationEntity1.copy(lastNotificationDate = "2022-04-30T15:36:00.000Z", lastModifiedDate = "2022-03-30T15:36:00.000Z", name = "old name")
+        val conv1AfterSync = conversationEntity1.copy(lastNotificationDate = "2023-04-30T15:36:00.000Z", lastModifiedDate = "2023-03-30T15:36:00.000Z", name = "new name")
+
+        val expected = conv1AfterSync.copy(lastModifiedDate = "2022-03-30T15:36:00.000Z", lastNotificationDate = "2022-04-30T15:36:00.000Z")
+        conversationDAO.insertConversation(conv1Stored)
+        conversationDAO.insertConversation(conv1AfterSync)
+
+        val actual = conversationDAO.getConversationByQualifiedID(conv1AfterSync.id).first()
+        assertEquals(expected, actual)
+    }
+
+
     private companion object {
         val user1 = newUserEntity(id = "1")
         val user2 = newUserEntity(id = "2")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

sync breaking conversations order and changes the `last_notified_message_date` to null

### Causes (Optional)

the insert quarry update all the conversation properties.
 
### Solutions

change the insert to not update some values

```
insertConversation:
INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, protocol, muted_status, muted_time, last_modified_date, last_notified_message_date)
VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
ON CONFLICT(qualified_id) DO UPDATE SET
name = excluded.name,
type = excluded.type,
team_id = excluded.team_id,
mls_group_id = excluded.mls_group_id,
protocol = excluded.protocol,
muted_status = excluded.muted_status,
muted_time = excluded.muted_time,
last_modified_date = last_modified_date,
last_notified_message_date = last_notified_message_date;
```

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test
run ConversationDAOTest

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
