### PR TITLE
feat: add use case to observe sync state

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -67,6 +67,7 @@ import com.wire.kalium.logic.feature.user.UserScope
 import com.wire.kalium.logic.sync.ConversationEventReceiver
 import com.wire.kalium.logic.sync.ConversationEventReceiverImpl
 import com.wire.kalium.logic.sync.ListenToEventsUseCase
+import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.sync.SyncManagerImpl
 import com.wire.kalium.logic.sync.SyncPendingEventsUseCase
@@ -284,6 +285,8 @@ abstract class UserSessionScopeCommon(
         get() = ListenToEventsUseCase(syncManager)
     val syncPendingEvents: SyncPendingEventsUseCase
         get() = SyncPendingEventsUseCase(syncManager)
+    val observeSyncState: ObserveSyncStateUseCase
+        get() = ObserveSyncStateUseCase(syncRepository)
     val client: ClientScope
         get() = ClientScope(
             clientRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
@@ -1,0 +1,11 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logic.data.sync.SyncRepository
+import com.wire.kalium.logic.data.sync.SyncState
+import kotlinx.coroutines.flow.Flow
+
+class ObserveSyncStateUseCase(
+    private val syncRepository: SyncRepository
+) {
+    operator fun invoke(): Flow<SyncState> = syncRepository.syncState
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.wire.kalium.logic.sync
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.sync.InMemorySyncRepository
+import com.wire.kalium.logic.data.sync.SyncRepository
+import com.wire.kalium.logic.data.sync.SyncState
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObserveSyncStateUseCaseTest {
+
+    private lateinit var syncRepository: SyncRepository
+    private lateinit var observeSyncState: ObserveSyncStateUseCase
+
+    @BeforeTest
+    fun setup() {
+        syncRepository = InMemorySyncRepository()
+        observeSyncState = ObserveSyncStateUseCase(syncRepository)
+    }
+
+    @Test
+    fun givenSyncStateInitialStateAndNoUpdates_whenObservingSyncState_thenTheFlowEmitsOnlyInitialState() = runTest {
+        val initialState = SyncState.ProcessingPendingEvents
+        syncRepository.updateSyncState { initialState }
+
+        observeSyncState().test {
+            assertEquals(initialState, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenSyncStateInitialStateAndUpdatesAfterCollecting_whenObservingSyncState_thenTheFlowEmitsAllValues() = runTest {
+        val initialState = SyncState.ProcessingPendingEvents
+        syncRepository.updateSyncState { initialState }
+
+        observeSyncState().test {
+            assertEquals(initialState, awaitItem())
+
+            val secondState = SyncState.Live
+            syncRepository.updateSyncState { secondState }
+            assertEquals(secondState, awaitItem())
+
+            val thirdState = SyncState.Failed(CoreFailure.Unknown(null))
+            syncRepository.updateSyncState { thirdState }
+            assertEquals(thirdState, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Consumer apps have no way to display sync/online/offline status to users.

### Causes

The only functionalities regarding Sync currently exposed are through `SyncManager` and some other `SyncPendingEventsUseCase` and `ListenToEventsUseCase`.

### Solutions

Create a `ObserveSyncStateUseCase`.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
