### PR TITLE
feat: unblock sync

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetAllCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetAllCallsUseCase.kt
@@ -10,7 +10,7 @@ class GetAllCallsUseCase(
     private val syncManager: SyncManager
 ) {
     suspend operator fun invoke(): Flow<List<Call>> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return callRepository.callsFlow()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -15,7 +15,7 @@ internal class GetIncomingCallsUseCaseImpl(
 ) : GetIncomingCallsUseCase {
 
     override suspend operator fun invoke(): Flow<List<Call>> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return callRepository.incomingCallsFlow()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetOngoingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetOngoingCallsUseCase.kt
@@ -10,7 +10,7 @@ class GetOngoingCallUseCase(
     private val syncManager: SyncManager
 ) {
     suspend operator fun invoke(): Flow<List<Call>> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return callRepository.ongoingCallsFlow()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
@@ -13,7 +13,7 @@ class CreateGroupConversationUseCase(
     private val syncManager: SyncManager
 ) {
     suspend operator fun invoke(name: String, members: List<Member>, options: ConversationOptions): Either<CoreFailure, Conversation> {
-        syncManager.waitForSyncToComplete()
+        syncManager.waitUntilLive()
         return conversationRepository.createGroupConversation(name, members, options)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationDetailsUseCase.kt
@@ -18,7 +18,7 @@ class GetConversationDetailsUseCase(
     }
 
     suspend operator fun invoke(conversationId: QualifiedID): Result {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return conversationRepository.getConversationDetails(conversationId).fold({
             Result.Failure(it)
         }, {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationsUseCase.kt
@@ -18,7 +18,7 @@ class GetConversationsUseCase(
     }
 
     suspend operator fun invoke(): Result {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return conversationRepository.getConversationList().fold({
             Result.Failure(it)
         }, {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
@@ -12,7 +12,7 @@ class ObserveConversationDetailsUseCase(
 ) {
 
     suspend operator fun invoke(conversationId: ConversationId): Flow<ConversationDetails> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return conversationRepository.getConversationDetailsById(conversationId)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCase.kt
@@ -14,7 +14,7 @@ class ObserveConversationListDetailsUseCase(
 ) {
 
     suspend operator fun invoke(): Flow<List<ConversationDetails>> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return conversationRepository.observeConversationList().map { conversations ->
             conversations.map { conversation ->
                 conversationRepository.getConversationDetailsById(conversation.id)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
@@ -21,7 +21,7 @@ class ObserveConversationMembersUseCase(
 ) {
 
     suspend operator fun invoke(conversationId: ConversationId): Flow<List<MemberDetails>> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         val selfDetailsFlow = userRepository.getSelfUser()
         val selfUser = selfDetailsFlow.first()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -27,7 +27,7 @@ class DeleteMessageUseCase(
 ) {
 
     suspend operator fun invoke(conversationId: ConversationId, messageId: String, deleteForEveryone: Boolean): Either<CoreFailure, Unit> {
-        syncManager.waitForSyncToComplete()
+        syncManager.waitUntilLive()
         val selfUser = userRepository.getSelfUser().first()
 
         val generatedMessageUuid = uuid4().toString()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -75,7 +75,7 @@ class MessageSenderImpl(
 ) : MessageSender {
 
     override suspend fun sendPendingMessage(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit> {
-        syncManager.waitForSyncToComplete()
+        syncManager.waitUntilLive()
         return messageRepository.getMessageById(conversationId, messageUuid).flatMap { message ->
             sendMessage(message)
         }.onFailure {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -25,7 +25,7 @@ class SendTextMessageUseCase(
 ) {
 
     suspend operator fun invoke(conversationId: ConversationId, text: String): Either<CoreFailure, Unit> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         val selfUser = userRepository.getSelfUser().first()
 
         val generatedMessageUuid = uuid4().toString()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/GetSelfTeamUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/GetSelfTeamUseCase.kt
@@ -16,7 +16,7 @@ class GetSelfTeamUseCase(
     private val syncManager: SyncManager
 ) {
     suspend operator fun invoke(): Flow<Team?> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return userRepository.getSelfUser()
             .flatMapLatest {
                 if (it.team != null) teamRepository.getTeam(it.team)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
@@ -10,7 +10,7 @@ class GetSelfUserUseCase(private val userRepository: UserRepository,
 ) {
 
     suspend operator fun invoke(): Flow<SelfUser> {
-        syncManager.waitForSyncToComplete()
+        syncManager.startSyncIfIdle()
         return userRepository.getSelfUser()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
@@ -10,7 +10,7 @@ class GetSelfUserUseCase(private val userRepository: UserRepository,
 ) {
 
     suspend operator fun invoke(): Flow<SelfUser> {
-        syncManager.awaitUntilSlowSyncCompletion()
+        syncManager.waitUntilSlowSyncCompletion()
         return userRepository.getSelfUser()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
@@ -10,7 +10,7 @@ class GetSelfUserUseCase(private val userRepository: UserRepository,
 ) {
 
     suspend operator fun invoke(): Flow<SelfUser> {
-        syncManager.startSyncIfIdle()
+        syncManager.awaitUntilSlowSyncCompletion()
         return userRepository.getSelfUser()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCase.kt
@@ -28,7 +28,7 @@ class SetUserHandleUseCase(
 ) {
     suspend operator fun invoke(_handle: String): SetUserHandleResult {
         if (syncManager.isSlowSyncOngoing()) {
-            syncManager.waitForSyncToComplete()
+            syncManager.waitUntilLive()
         }
         return validateUserHandle(_handle).let { handleState ->
             when (handleState) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCase.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.sync
 
+@Deprecated("Sync is triggered by other use cases as necessary and there is no need to call this UseCase directly anymore")
 class ListenToEventsUseCase(
     private val syncManager: SyncManager,
 ) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ListenToEventsUseCase.kt
@@ -6,7 +6,7 @@ class ListenToEventsUseCase(
 ) {
 
     suspend operator fun invoke() {
-        syncManager.waitForSyncToComplete()
+        syncManager.waitUntilLive()
     }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -32,7 +32,7 @@ interface SyncManager {
      * Suitable for operations where the user is required to be online
      * and without any pending events to be processed, for maximum sync.
      * @see startSyncIfIdle
-     * @see awaitUntilSlowSyncCompletion
+     * @see waitUntilSlowSyncCompletion
      */
     suspend fun waitUntilLive()
 
@@ -45,7 +45,7 @@ interface SyncManager {
      * @see startSyncIfIdle
      * @see waitUntilLive
      */
-    suspend fun awaitUntilSlowSyncCompletion()
+    suspend fun waitUntilSlowSyncCompletion()
 
     /**
      * Triggers sync, if not yet running.
@@ -53,7 +53,7 @@ interface SyncManager {
      *
      * Suitable for operations that the user can perform even while offline.
      * @see waitUntilLive
-     * @see awaitUntilSlowSyncCompletion
+     * @see waitUntilSlowSyncCompletion
      */
     fun startSyncIfIdle()
     suspend fun isSlowSyncOngoing(): Boolean
@@ -186,7 +186,7 @@ class SyncManagerImpl(
         syncRepository.syncState.first { it == SyncState.Live }
     }
 
-    override suspend fun awaitUntilSlowSyncCompletion() {
+    override suspend fun waitUntilSlowSyncCompletion() {
         startSyncIfIdle()
         syncRepository.syncState.first { it is SyncState.ProcessingPendingEvents || it is SyncState.Live }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -26,8 +26,11 @@ interface SyncManager {
 
     /**
      * Triggers sync, if not yet running.
-     * Even though Sync will run on a Job of its own, this function
-     * suspends the caller until all pending events are processed.
+     * Suspends the caller until all pending events are processed,
+     * Even though Sync will run on a Job of its own.
+     *
+     * Suitable for operations where the user is required to be online anyway
+     * and without any pending events to be processed.
      * @see startSyncIfIdle
      */
     suspend fun waitForSyncToComplete()
@@ -35,6 +38,8 @@ interface SyncManager {
     /**
      * Triggers sync, if not yet running.
      * Will run in a parallel job without waiting for completion.
+     *
+     * Suitable for operations that the user can perform even while offline.
      * @see waitForSyncToComplete
      */
     fun startSyncIfIdle()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCase.kt
@@ -1,5 +1,9 @@
 package com.wire.kalium.logic.sync
 
+@Deprecated(
+    "Sync is triggered by other use cases as necessary and there is no need to call this UseCase directly anymore. " +
+            "If necessary, use ObserveSyncStateUseCase to know when Pending Events are finished processing."
+)
 class SyncPendingEventsUseCase(
     private val syncManager: SyncManager
 ) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncPendingEventsUseCase.kt
@@ -12,6 +12,6 @@ class SyncPendingEventsUseCase(
      * Syncing only Pending Events, to find out what did we miss
      */
     suspend operator fun invoke() {
-        syncManager.waitForSyncToComplete()
+        syncManager.waitUntilLive()
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/GetAllCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/GetAllCallsUseCaseTest.kt
@@ -39,7 +39,7 @@ class GetAllCallsUseCaseTest {
         val calls2 = listOf(call2)
 
         val callsFlow = flowOf(calls1, calls2)
-        given(syncManager).coroutine { waitForSyncToComplete() }
+        given(syncManager).invocation { startSyncIfIdle() }
             .thenReturn(Unit)
         given(callRepository).invocation { callsFlow() }
             .then { callsFlow }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -8,6 +8,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.sync.SyncManager
 import io.mockative.Mock
 import io.mockative.anything
+import io.mockative.configure
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
@@ -26,7 +27,7 @@ class ObserveConversationDetailsUseCaseTest {
     private val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
 
     @Mock
-    private val syncManager: SyncManager = mock(SyncManager::class)
+    private val syncManager: SyncManager = configure(mock(SyncManager::class)) { stubsUnitByDefault = true }
 
     private lateinit var observeConversationsUseCase: ObserveConversationDetailsUseCase
 
@@ -38,10 +39,6 @@ class ObserveConversationDetailsUseCaseTest {
     @Test
     fun givenAConversationId_whenObservingConversationUseCase_thenTheConversationRepositoryShouldBeCalledWithTheCorrectID() = runTest {
         val conversationId = TestConversation.ID
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
 
         given(conversationRepository)
             .suspendFunction(conversationRepository::getConversationDetailsById)
@@ -60,11 +57,6 @@ class ObserveConversationDetailsUseCaseTest {
     fun givenAConversationID_whenObservingConversationUseCase_thenSyncManagerShouldBeCalled() = runTest {
         val conversationId = TestConversation.ID
 
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
-
         given(conversationRepository)
             .suspendFunction(conversationRepository::getConversationDetailsById)
             .whenInvokedWith(anything())
@@ -73,7 +65,7 @@ class ObserveConversationDetailsUseCaseTest {
         observeConversationsUseCase(conversationId)
 
         verify(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
+            .function(syncManager::startSyncIfIdle)
             .wasInvoked(exactly = once)
     }
 
@@ -84,11 +76,6 @@ class ObserveConversationDetailsUseCaseTest {
             ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED),
             ConversationDetails.Group(conversation.copy(name = "New Name"), LegalHoldStatus.DISABLED)
         )
-
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
 
         given(conversationRepository)
             .suspendFunction(conversationRepository::getConversationDetailsById)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.SyncManager
 import io.mockative.Mock
 import io.mockative.anything
+import io.mockative.configure
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
@@ -33,7 +34,7 @@ class ObserveConversationListDetailsUseCaseTest {
     private val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
 
     @Mock
-    private val syncManager: SyncManager = mock(SyncManager::class)
+    private val syncManager: SyncManager = configure(mock(SyncManager::class)) { stubsUnitByDefault = true }
 
     private lateinit var observeConversationsUseCase: ObserveConversationListDetailsUseCase
 
@@ -45,11 +46,6 @@ class ObserveConversationListDetailsUseCaseTest {
     @Test
     fun givenSomeConversations_whenObservingDetailsList_thenObserveConversationListShouldBeCalled() = runTest {
         val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
-
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
 
         given(conversationRepository)
             .suspendFunction(conversationRepository::observeConversationList)
@@ -73,11 +69,6 @@ class ObserveConversationListDetailsUseCaseTest {
     fun givenSomeConversations_whenObservingDetailsList_thenSyncManagerShouldBeCalled() = runTest {
         val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
 
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
-
         given(conversationRepository)
             .suspendFunction(conversationRepository::observeConversationList)
             .whenInvoked()
@@ -91,7 +82,7 @@ class ObserveConversationListDetailsUseCaseTest {
         observeConversationsUseCase().collect()
 
         verify(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
+            .function(syncManager::startSyncIfIdle)
             .wasInvoked(exactly = once)
 
     }
@@ -99,11 +90,6 @@ class ObserveConversationListDetailsUseCaseTest {
     @Test
     fun givenSomeConversations_whenObservingDetailsList_thenObserveConversationDetailsShouldBeCalledForEachID() = runTest {
         val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
-
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
 
         given(conversationRepository)
             .suspendFunction(conversationRepository::observeConversationList)
@@ -151,11 +137,6 @@ class ObserveConversationListDetailsUseCaseTest {
             secondOneOnOneDetails
         )
 
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
-
         given(conversationRepository)
             .suspendFunction(conversationRepository::observeConversationList)
             .whenInvoked()
@@ -191,11 +172,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val secondConversationsList = firstConversationsList + selfConversation
         val conversationListUpdates = Channel<List<Conversation>>(Channel.UNLIMITED)
         conversationListUpdates.send(firstConversationsList)
-
-        given(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
-            .whenInvoked()
-            .thenReturn(Unit)
 
         given(conversationRepository)
             .suspendFunction(conversationRepository::observeConversationList)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCaseTest.kt
@@ -77,7 +77,7 @@ class ObserveConversationMembersUseCaseTest {
         observeConversationMembers(conversationID)
 
         verify(syncManager)
-            .suspendFunction(syncManager::waitForSyncToComplete)
+            .function(syncManager::startSyncIfIdle)
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
@@ -105,7 +105,7 @@ class SetUserHandleUseCaseTest {
             .coroutine { updateLocalSelfUserHandle(handle) }
             .wasInvoked(exactly = once)
         verify(syncManager)
-            .coroutine { waitForSyncToComplete() }
+            .coroutine { waitUntilLive() }
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncManagerTest.kt
@@ -89,7 +89,7 @@ class SyncManagerTest {
 
             //When
             val waitJob = launch {
-                syncManager.awaitUntilSlowSyncCompletion()
+                syncManager.waitUntilSlowSyncCompletion()
             }
 
             //Then
@@ -112,7 +112,7 @@ class SyncManagerTest {
 
             //When
             val waitJob = launch {
-                syncManager.awaitUntilSlowSyncCompletion()
+                syncManager.waitUntilSlowSyncCompletion()
             }
 
             //Then


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sync is blocking in a lot of UseCases right now.

Things like getting list of conversations wait until all the events are processed to return results; sending of message waits for sync even BEFORE inserting into the DB, which freezes the send button while offline.

### Solutions

- Rename `performSyncIfWaitingOrFailed` to `startSyncIfIdle` and make it public so other UseCases can use it.
- Create a `waitUntilSlowSyncCompletion` so UseCases can at least hold until basic data is available. Useful for `GetSelfUser` for example.
- Rename `waitForSyncToComplete` to `waitUntilLive` as it better describes what it does (Sync doesn't "end", it stays alive, listening for new events until cancelled)
- Replace utilization of `waitForSyncToComplete` with one of three: `startSyncIfIdle`, `waitUntilSlowSyncCompletion`, or `waitUntilLive`;

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

On Reloaded, with this Kalium branch, just open the app and try to do basic operations. The app won't spend ages "loading" as it re-performs sync over and over again.

#### Attachments

Demo of how fast it shows conversations, as it doesn't wait for sync to complete:

![video_2022-05-28_06-06-42](https://user-images.githubusercontent.com/9389043/170809401-83b73308-d0ea-4cb2-8a06-33e13a710415.gif)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
