### PR TITLE
refactor: change fold so it doesn't accept nullable lambdas

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSFTRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSFTRequest.kt
@@ -12,8 +12,7 @@ import com.wire.kalium.logic.feature.call.AvsSFTError
 import com.wire.kalium.logic.feature.call.CallManagerImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.nullableFold
 import kotlinx.coroutines.launch
 
 //TODO(testing): create unit test
@@ -30,7 +29,7 @@ class OnSFTRequest(
                 val responseData = callRepository.connectToSFT(
                     url = url,
                     data = dataString
-                ).fold({
+                ).nullableFold({
                     callingLogger.i("Could not connect to SFT server.")
                     null
                 }, {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Either.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Either.kt
@@ -56,7 +56,7 @@ sealed class Either<out L, out R> {
  * @see Left
  * @see Right
  */
-inline fun <L, R, T> Either<L, R>.fold(fnL: (L) -> T, fnR: (R) -> T): T = nullableFold(fnL, fnR)!!
+inline fun <L, R, T: Any> Either<L, R>.fold(fnL: (L) -> T, fnR: (R) -> T): T = nullableFold(fnL, fnR)!!
 
 
 /**


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`NullPointerException` during Runtime when returning null in `fold` nullables. The compiler doesn't complain about this:

```kotlin
val either: Either<Foo> = bar()

val result = either.fold({
    println("Left case")
    null
}, {
    println("Right case")
    it
})
```

### Causes

The definition of `fold` accepts lambdas that return null. It accepts nullable `T` types.

### Solutions

Explicitly declare `T: Any` instead of the implicit `T: Any?` when no supertype is specified.

### Testing

Compiler does it!

Can't write tests for this... as it doesn't compile anymore :) 
Type-safety FTW.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
