### PR TITLE
fix:  app crash when bluetooth is turned on(AR-1461)

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -34,7 +34,7 @@ object Versions {
     const val protobufLite = "3.19.4"
     const val pbandk = "0.13.0"
     const val turbine = "0.7.0"
-    const val avs = "8.1.3"
+    const val avs = "8.1.16"
     const val jna = "5.6.0@aar"
     const val mlsClient = "0.2.1"
     const val desugarJdk = "1.1.5"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If you have bluetooth enabled and you are on Android 12 or newer, the app may crash for you
-  on launch
-  or when you start or answer a call

### Causes (Optional)

Starting from Android and later a runtime permission is required to use bluetooth. And since AVS lib is accessing bluetooth feature at the time we initialize it, this crash the app

### Solutions

We already did an improvement on our side by making AVS initialize lazely when we start or answer a call.
On AVS side, Dusan moved the BT initialization after call is entered

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

On Android 12 or later, try to make calls with BT turned on


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
