### PR TITLE
fix: map the team name when getting the other user details

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -305,7 +305,7 @@ abstract class UserSessionScopeCommon(
             messageSendingScheduler,
             timeParser
         )
-    val users: UserScope get() = UserScope(userRepository, publicUserRepository, syncManager, assetRepository)
+    val users: UserScope get() = UserScope(userRepository, publicUserRepository, syncManager, assetRepository, teamRepository)
     val logout: LogoutUseCase
         get() = LogoutUseCase(
             logoutRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCase.kt
@@ -1,8 +1,12 @@
 package com.wire.kalium.logic.feature.user
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.team.Team
+import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.firstOrNull
 
@@ -19,22 +23,49 @@ fun interface GetUserInfoUseCase {
     suspend operator fun invoke(userId: UserId): GetUserInfoResult
 }
 
-internal class GetUserInfoUseCaseImpl(private val userRepository: UserRepository) : GetUserInfoUseCase {
+internal class GetUserInfoUseCaseImpl(
+    private val userRepository: UserRepository,
+    private val teamRepository: TeamRepository
+) : GetUserInfoUseCase {
 
     override suspend fun invoke(userId: UserId): GetUserInfoResult {
-        val otherUser = userRepository.getKnownUser(userId).firstOrNull()
-        if (otherUser != null) return GetUserInfoResult.Success(otherUser)
-        return userRepository.fetchUserInfo(userId)
-            .fold({
-                GetUserInfoResult.Failure
-            }, {
-                GetUserInfoResult.Success(it)
-            })
+        return getOtherUser(userId).fold(
+            { GetUserInfoResult.Failure },
+            { otherUser ->
+                getOtherUserTeam(otherUser).fold(
+                    { GetUserInfoResult.Failure },
+                    { team -> GetUserInfoResult.Success(otherUser, team) })
+            }
+        )
+    }
+
+    private suspend fun getOtherUser(userId: UserId): Either<CoreFailure, OtherUser> {
+        val localOtherUser = userRepository.getKnownUser(userId).firstOrNull()
+
+        return if (localOtherUser != null) {
+            Either.Right(localOtherUser)
+        } else {
+            userRepository.fetchUserInfo(userId)
+        }
+    }
+
+    private suspend fun getOtherUserTeam(otherUser: OtherUser): Either<CoreFailure, Team?> {
+        return if (otherUser.team != null) {
+            val localTeam = teamRepository.getTeam(otherUser.team).firstOrNull()
+
+            if (localTeam == null) {
+                teamRepository.fetchTeamById(otherUser.team)
+            } else {
+                Either.Right(localTeam)
+            }
+        } else {
+            Either.Right(null)
+        }
     }
 
 }
 
 sealed class GetUserInfoResult {
-    class Success(val otherUser: OtherUser) : GetUserInfoResult()
+    class Success(val otherUser: OtherUser, val team: Team?) : GetUserInfoResult()
     object Failure : GetUserInfoResult()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCase.kt
@@ -8,6 +8,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.wrapStorageRequest
 import kotlinx.coroutines.flow.firstOrNull
 
 /**
@@ -40,12 +41,14 @@ internal class GetUserInfoUseCaseImpl(
     }
 
     private suspend fun getOtherUser(userId: UserId): Either<CoreFailure, OtherUser> {
-        val localOtherUser = userRepository.getKnownUser(userId).firstOrNull()
+        return wrapStorageRequest {
+            val localOtherUser = userRepository.getKnownUser(userId).firstOrNull()
 
-        return if (localOtherUser != null) {
-            Either.Right(localOtherUser)
-        } else {
-            userRepository.fetchUserInfo(userId)
+            return if (localOtherUser != null) {
+                Either.Right(localOtherUser)
+            } else {
+                userRepository.fetchUserInfo(userId)
+            }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
+import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCaseImpl
@@ -21,7 +22,8 @@ class UserScope(
     private val userRepository: UserRepository,
     private val searchUserRepository: SearchUserRepository,
     private val syncManager: SyncManager,
-    private val assetRepository: AssetRepository
+    private val assetRepository: AssetRepository,
+    private val teamRepository: TeamRepository
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
     val getSelfUser: GetSelfUserUseCase get() = GetSelfUserUseCase(userRepository, syncManager)
@@ -34,5 +36,5 @@ class UserScope(
     val setUserHandle: SetUserHandleUseCase get() = SetUserHandleUseCase(userRepository, validateUserHandleUseCase, syncManager)
     val getAllKnownUsers: GetAllContactsUseCase get() = GetAllContactsUseCaseImpl(userRepository)
     val getKnownUser: GetKnownUserUseCase get() = GetKnownUserUseCaseImpl(userRepository)
-    val getUserInfo: GetUserInfoUseCase get() = GetUserInfoUseCaseImpl(userRepository)
+    val getUserInfo: GetUserInfoUseCase get() = GetUserInfoUseCaseImpl(userRepository,teamRepository)
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -66,7 +66,12 @@ class TeamRepositoryTest {
 
     @Test
     fun givenSelfUserExists_whenFetchingTeamInfo_thenTeamInfoShouldBeSuccessful() = runTest {
-        val team = TestTeam.dto(
+        val teamDto = TestTeam.dto(
+            id = "teamId",
+            name = "teamName"
+        )
+
+        val team = Team(
             id = "teamId",
             name = "teamName"
         )
@@ -74,7 +79,7 @@ class TeamRepositoryTest {
         given(teamsApi)
             .suspendFunction(teamsApi::getTeamInfo)
             .whenInvokedWith(oneOf("teamId"))
-            .then { NetworkResponse.Success(value = team, headers = mapOf(), httpCode = 200) }
+            .then { NetworkResponse.Success(value = teamDto, headers = mapOf(), httpCode = 200) }
 
         val teamEntity = TeamEntity(
             id = "teamId", name = "teamName"
@@ -82,8 +87,15 @@ class TeamRepositoryTest {
 
         given(teamMapper)
             .function(teamMapper::fromDtoToEntity)
-            .whenInvokedWith(oneOf(team))
+            .whenInvokedWith(oneOf(teamDto))
             .then { teamEntity }
+
+        given(teamMapper)
+            .function(teamMapper::fromDaoModelToTeam)
+            .whenInvokedWith(oneOf(teamEntity))
+            .then { team }
+
+        teamMapper.fromDaoModelToTeam(teamEntity)
 
         val result = teamRepository.fetchTeamById(teamId = "teamId")
 
@@ -95,7 +107,9 @@ class TeamRepositoryTest {
 
 
         // Verifies that when fetching team by id, it succeeded
-        result.shouldSucceed()
+        result.shouldSucceed{ returnTeam ->
+            assertEquals(team,returnTeam)
+        }
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
@@ -19,8 +19,8 @@ class GetUserInfoUseCaseTest {
     fun givenAUserId_whenInvokingGetUserInfoDetails_thenShouldReturnsASuccessResult() = runTest {
         // given
         val (arrangement, useCase) = arrangement
-            .withSuccessFullUserRetrive(localUserPresent = false)
-            .withSuccessTeamRetrive(localTeamPresent = true)
+            .withSuccessfulUserRetrieve(localUserPresent = false)
+            .withSuccessfulTeamRetrieve(localTeamPresent = true)
             .arrange()
 
         // when
@@ -46,8 +46,8 @@ class GetUserInfoUseCaseTest {
     fun givenAUserId_whenInvokingGetUserInfoDetailsAndExistsLocally_thenShouldReturnsImmediatelySuccessResult() = runTest {
         // given
         val (arrangement, useCase) = arrangement
-            .withSuccessFullUserRetrive(localUserPresent = true)
-            .withSuccessTeamRetrive(localTeamPresent = true)
+            .withSuccessfulUserRetrieve(localUserPresent = true)
+            .withSuccessfulTeamRetrieve(localTeamPresent = true)
             .arrange()
 
         // when
@@ -73,8 +73,8 @@ class GetUserInfoUseCaseTest {
     fun givenAUserId_whenInvokingGetUserInfoDetailsWithErrors_thenShouldReturnsAFailure() = runTest {
         // given
         val (arrangement, useCase) = arrangement
-            .withFailingUserRetrive()
-            .withSuccessTeamRetrive()
+            .withFailingUserRetrieve()
+            .withSuccessfulTeamRetrieve()
             .arrange()
 
         // when
@@ -100,7 +100,7 @@ class GetUserInfoUseCaseTest {
     fun givenAUserWithNoTeam_WhenGettingDetails_thenShouldReturnSuccessResultAndDoNotRetrieveTeam() = runTest {
         // given
         val (arrangement, useCase) = arrangement
-            .withSuccessFullUserRetrive(hasTeam = false)
+            .withSuccessfulUserRetrieve(hasTeam = false)
             .arrange()
 
         // when
@@ -126,8 +126,8 @@ class GetUserInfoUseCaseTest {
     fun givenAUserWithTeamNotExistingLocally_WhenGettingDetails_thenShouldReturnSuccessResultAndGetRemoteUserTeam() = runTest {
         // given
         val (arrangement, useCase) = arrangement
-            .withSuccessFullUserRetrive()
-            .withSuccessTeamRetrive(localTeamPresent = false)
+            .withSuccessfulUserRetrieve()
+            .withSuccessfulTeamRetrieve(localTeamPresent = false)
             .arrange()
 
         // when
@@ -159,7 +159,7 @@ class GetUserInfoUseCaseTest {
         runTest {
             // given
             val (arrangement, useCase) = arrangement
-                .withFailingUserRetrive()
+                .withFailingUserRetrieve()
                 .withFailingTeamRetrieve()
                 .arrange()
             // when
@@ -196,7 +196,7 @@ class GetUserInfoUseCaseTest {
         // given
 
         val (arrangement, useCase) = arrangement
-            .withSuccessFullUserRetrive(localUserPresent = true)
+            .withSuccessfulUserRetrieve(localUserPresent = true)
             .withFailingTeamRetrieve()
             .arrange()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.framework.TestUser.OTHER
@@ -22,11 +23,15 @@ class GetUserInfoUseCaseTest {
     @Mock
     private val userRepository: UserRepository = mock(UserRepository::class)
 
+    @Mock
+    private val teamRepository: TeamRepository = mock(TeamRepository::class)
+
+
     lateinit var getUserInfoUseCase: GetUserInfoUseCase
 
     @BeforeTest
     fun setUp() {
-        getUserInfoUseCase = GetUserInfoUseCaseImpl(userRepository)
+        getUserInfoUseCase = GetUserInfoUseCaseImpl(userRepository,teamRepository)
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
@@ -1,284 +1,232 @@
 package com.wire.kalium.logic.feature.user
 
-import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.team.Team
-import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.framework.TestUser.OTHER
-import com.wire.kalium.logic.functional.Either
-import io.mockative.Mock
 import io.mockative.any
 import io.mockative.eq
-import io.mockative.given
-import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class GetUserInfoUseCaseTest {
 
-    @Mock
-    private val userRepository: UserRepository = mock(UserRepository::class)
-
-    @Mock
-    private val teamRepository: TeamRepository = mock(TeamRepository::class)
-
-    lateinit var getUserInfoUseCase: GetUserInfoUseCase
-
-    @BeforeTest
-    fun setUp() {
-        getUserInfoUseCase = GetUserInfoUseCaseImpl(userRepository, teamRepository)
-    }
+    private val arrangement = GetUserInfoUseCaseTestArrangement()
 
     @Test
     fun givenAUserId_whenInvokingGetUserInfoDetails_thenShouldReturnsASuccessResult() = runTest {
         // given
-        given(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(flowOf(null))
+        val (arrangement, useCase) = arrangement
+            .withSuccessFullUserRetrive(localUserPresent = false)
+            .withSuccessTeamRetrive(localTeamPresent = true)
+            .arrange()
 
-        given(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .whenInvokedWith(any())
-            .thenReturn(flowOf(team))
-
-        given(userRepository)
-            .suspendFunction(userRepository::fetchUserInfo)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(Either.Right(OTHER))
         // when
-        val result = getUserInfoUseCase(userId)
+        val result = useCase(userId)
 
         // then
         assertEquals(OTHER, (result as GetUserInfoResult.Success).otherUser)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .with(eq(userId))
-            .wasInvoked(once)
+        with(arrangement) {
+            verify(userRepository)
+                .suspendFunction(userRepository::getKnownUser)
+                .with(eq(userId))
+                .wasInvoked(once)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::fetchUserInfo)
-            .with(eq(userId))
-            .wasInvoked(once)
+            verify(userRepository)
+                .suspendFunction(userRepository::fetchUserInfo)
+                .with(eq(userId))
+                .wasInvoked(once)
+        }
     }
-
 
     @Test
     fun givenAUserId_whenInvokingGetUserInfoDetailsAndExistsLocally_thenShouldReturnsImmediatelySuccessResult() = runTest {
         // given
-        given(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(flowOf(OTHER))
+        val (arrangement, useCase) = arrangement
+            .withSuccessFullUserRetrive(localUserPresent = true)
+            .withSuccessTeamRetrive(localTeamPresent = true)
+            .arrange()
 
-        given(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .whenInvokedWith(any())
-            .thenReturn(flowOf(team))
         // when
-        val result = getUserInfoUseCase(userId)
+        val result = useCase(userId)
 
         // then
         assertEquals(OTHER, (result as GetUserInfoResult.Success).otherUser)
-        verify(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .with(eq(userId))
-            .wasInvoked(once)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::fetchUserInfo)
-            .with(eq(userId))
-            .wasNotInvoked()
+        with(arrangement) {
+            verify(userRepository)
+                .suspendFunction(userRepository::getKnownUser)
+                .with(eq(userId))
+                .wasInvoked(once)
+
+            verify(userRepository)
+                .suspendFunction(userRepository::fetchUserInfo)
+                .with(eq(userId))
+                .wasNotInvoked()
+        }
     }
-
 
     @Test
     fun givenAUserId_whenInvokingGetUserInfoDetailsWithErrors_thenShouldReturnsAFailure() = runTest {
         // given
-        given(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(flowOf(null))
-
-        given(userRepository)
-            .suspendFunction(userRepository::fetchUserInfo)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
+        val (arrangement, useCase) = arrangement
+            .withFailingUserRetrive()
+            .withSuccessTeamRetrive()
+            .arrange()
 
         // when
-        val result = getUserInfoUseCase(userId)
+        val result = useCase(userId)
 
         // then
         assertEquals(GetUserInfoResult.Failure, result)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .with(eq(userId))
-            .wasInvoked(once)
+        with(arrangement) {
+            verify(userRepository)
+                .suspendFunction(userRepository::getKnownUser)
+                .with(eq(userId))
+                .wasInvoked(once)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::fetchUserInfo)
-            .with(eq(userId))
-            .wasInvoked(once)
+            verify(userRepository)
+                .suspendFunction(userRepository::fetchUserInfo)
+                .with(eq(userId))
+                .wasInvoked(once)
+        }
     }
-
 
     @Test
     fun givenAUserWithNoTeam_WhenGettingDetails_thenShouldReturnSuccessResultAndDoNotRetrieveTeam() = runTest {
         // given
-        given(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(flowOf(OTHER.copy(team = null)))
+        val (arrangement, useCase) = arrangement
+            .withSuccessFullUserRetrive(hasTeam = false)
+            .arrange()
 
-        given(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .whenInvokedWith(any())
-            .thenReturn(flowOf(team))
         // when
-        val result = getUserInfoUseCase(userId)
+        val result = useCase(userId)
 
         // then
         assertEquals(OTHER.copy(team = null), (result as GetUserInfoResult.Success).otherUser)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .with(eq(userId))
-            .wasInvoked(once)
+        with(arrangement) {
+            verify(userRepository)
+                .suspendFunction(userRepository::getKnownUser)
+                .with(eq(userId))
+                .wasInvoked(once)
 
-        verify(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .with(any())
-            .wasNotInvoked()
+            verify(teamRepository)
+                .suspendFunction(teamRepository::getTeam)
+                .with(any())
+                .wasNotInvoked()
+        }
     }
 
     @Test
     fun givenAUserWithTeamNotExistingLocally_WhenGettingDetails_thenShouldReturnSuccessResultAndGetRemoteUserTeam() = runTest {
         // given
-        given(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(flowOf(OTHER))
+        val (arrangement, useCase) = arrangement
+            .withSuccessFullUserRetrive()
+            .withSuccessTeamRetrive(localTeamPresent = false)
+            .arrange()
 
-        given(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .whenInvokedWith(any())
-            .thenReturn(flowOf(null))
-
-        given(teamRepository)
-            .suspendFunction(teamRepository::fetchTeamById)
-            .whenInvokedWith(any())
-            .thenReturn(Either.Right(team))
         // when
-        val result = getUserInfoUseCase(userId)
+        val result = useCase(userId)
 
         // then
         assertEquals(OTHER, (result as GetUserInfoResult.Success).otherUser)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .with(eq(userId))
-            .wasInvoked(once)
+        with(arrangement) {
+            verify(userRepository)
+                .suspendFunction(userRepository::getKnownUser)
+                .with(eq(userId))
+                .wasInvoked(once)
 
-        verify(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .with(any())
-            .wasInvoked(once)
+            verify(teamRepository)
+                .suspendFunction(teamRepository::getTeam)
+                .with(any())
+                .wasInvoked(once)
 
-        verify(teamRepository)
-            .suspendFunction(teamRepository::fetchTeamById)
-            .with(any())
-            .wasInvoked(once)
+            verify(teamRepository)
+                .suspendFunction(teamRepository::fetchTeamById)
+                .with(any())
+                .wasInvoked(once)
+        }
     }
 
     @Test
-    fun givenAUserWithTeamNotExistingLocallyAndFetchingUserInfoFails_WhenGettingDetails_ThenPropagateTheFailureAndDoNotGetTheTeamDetails() = runTest {
-        // given
-        given(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(flowOf(null))
+    fun givenAUserWithTeamNotExistingLocallyAndFetchingUserInfoFails_WhenGettingDetails_ThenPropagateTheFailureAndDoNotGetTheTeamDetails() =
+        runTest {
+            // given
+            val (arrangement, useCase) = arrangement
+                .withFailingUserRetrive()
+                .withFailingTeamRetrieve()
+                .arrange()
+            // when
+            val result = useCase(userId)
 
-        given(userRepository)
-            .suspendFunction(userRepository::fetchUserInfo)
-            .whenInvokedWith(any())
-            .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
+            // then
+            assertIs<GetUserInfoResult.Failure>(result)
 
-        // when
-        val result = getUserInfoUseCase(userId)
+            with(arrangement) {
+                verify(userRepository)
+                    .suspendFunction(userRepository::getKnownUser)
+                    .with(eq(userId))
+                    .wasInvoked(once)
 
-        // then
-        assertIs<GetUserInfoResult.Failure>(result)
+                verify(userRepository)
+                    .suspendFunction(userRepository::fetchUserInfo)
+                    .with(any())
+                    .wasInvoked(once)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .with(eq(userId))
-            .wasInvoked(once)
+                verify(teamRepository)
+                    .suspendFunction(teamRepository::getTeam)
+                    .with(any())
+                    .wasNotInvoked()
 
-        verify(userRepository)
-            .suspendFunction(userRepository::fetchUserInfo)
-            .with(any())
-            .wasInvoked(once)
-
-        verify(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .with(any())
-            .wasNotInvoked()
-
-        verify(teamRepository)
-            .suspendFunction(teamRepository::fetchTeamById)
-            .with(any())
-            .wasInvoked()
-    }
+                verify(teamRepository)
+                    .suspendFunction(teamRepository::fetchTeamById)
+                    .with(any())
+                    .wasInvoked()
+            }
+        }
 
     @Test
     fun givenAUserWithTeamNotExistingLocallyAndFetchingTeamFails_WhenGettingDetails_ThenPropagateTheFailure() = runTest {
         // given
-        given(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .whenInvokedWith(eq(userId))
-            .thenReturn(flowOf(OTHER))
 
-        given(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .whenInvokedWith(any())
-            .thenReturn(flowOf(null))
+        val (arrangement, useCase) = arrangement
+            .withSuccessFullUserRetrive(localUserPresent = true)
+            .withFailingTeamRetrieve()
+            .arrange()
 
-        given(teamRepository)
-            .suspendFunction(teamRepository::fetchTeamById)
-            .whenInvokedWith(any())
-            .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
         // when
-        val result = getUserInfoUseCase(userId)
+        val result = useCase(userId)
 
         // then
         assertIs<GetUserInfoResult.Failure>(result)
 
-        verify(userRepository)
-            .suspendFunction(userRepository::getKnownUser)
-            .with(eq(userId))
-            .wasInvoked(once)
+        with(arrangement) {
+            verify(userRepository)
+                .suspendFunction(userRepository::getKnownUser)
+                .with(eq(userId))
+                .wasInvoked(once)
 
-        verify(teamRepository)
-            .suspendFunction(teamRepository::getTeam)
-            .with(any())
-            .wasInvoked(once)
+            verify(teamRepository)
+                .suspendFunction(teamRepository::getTeam)
+                .with(any())
+                .wasInvoked(once)
 
-        verify(teamRepository)
-            .suspendFunction(teamRepository::fetchTeamById)
-            .with(any())
-            .wasInvoked(once)
+            verify(teamRepository)
+                .suspendFunction(teamRepository::fetchTeamById)
+                .with(any())
+                .wasInvoked(once)
+        }
     }
 
-
+    private companion object {
+        val userId = UserId("some_user", "some_domain")
+    }
 
 }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
@@ -160,7 +160,7 @@ class GetUserInfoUseCaseTest {
     }
 
     @Test
-    fun givenAUserWithTeamNotExistiningLocally_WhenGettingDetails_thenShouldReturnSuccessResultAndGetRemoteUserTeam() = runTest {
+    fun givenAUserWithTeamNotExistingLocally_WhenGettingDetails_thenShouldReturnSuccessResultAndGetRemoteUserTeam() = runTest {
         // given
         given(userRepository)
             .suspendFunction(userRepository::getKnownUser)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
@@ -58,6 +58,7 @@ class GetUserInfoUseCaseTest {
 
         // then
         assertEquals(OTHER, (result as GetUserInfoResult.Success).otherUser)
+
         verify(userRepository)
             .suspendFunction(userRepository::getKnownUser)
             .with(eq(userId))
@@ -278,11 +279,8 @@ class GetUserInfoUseCaseTest {
     }
 
 
-    private companion object {
-        val userId = UserId("some_user", "some_domain")
-
-        val team = Team("teamId", "teamName")
-    }
 
 }
+
+
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTest.kt
@@ -44,11 +44,15 @@ class GetUserInfoUseCaseTest {
             .whenInvokedWith(eq(userId))
             .thenReturn(flowOf(null))
 
+        given(teamRepository)
+            .suspendFunction(teamRepository::getTeam)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(team))
+
         given(userRepository)
             .suspendFunction(userRepository::fetchUserInfo)
             .whenInvokedWith(eq(userId))
             .thenReturn(Either.Right(OTHER))
-
         // when
         val result = getUserInfoUseCase(userId)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
@@ -17,17 +17,10 @@ import kotlin.test.BeforeTest
 class GetUserInfoUseCaseTestArrangement {
 
     @Mock
-    private val userRepository: UserRepository = mock(UserRepository::class)
+    val userRepository: UserRepository = mock(UserRepository::class)
 
     @Mock
-    private val teamRepository: TeamRepository = mock(TeamRepository::class)
-
-    private lateinit var getUserInfoUseCase: GetUserInfoUseCase
-
-    @BeforeTest
-    fun setUp() {
-        getUserInfoUseCase = GetUserInfoUseCaseImpl(userRepository, teamRepository)
-    }
+    val teamRepository: TeamRepository = mock(TeamRepository::class)
 
     fun withSuccessFullUserRetrive(
         localUserPresent: Boolean = true,
@@ -53,11 +46,11 @@ class GetUserInfoUseCaseTestArrangement {
         return this
     }
 
-    fun withFailingUserRetrive() {
+    fun withFailingUserRetrive(): GetUserInfoUseCaseTestArrangement {
         given(userRepository)
             .suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(TestUser.OTHER))
+            .thenReturn(flowOf(null))
 
         given(userRepository)
             .suspendFunction(userRepository::fetchUserInfo)
@@ -83,10 +76,10 @@ class GetUserInfoUseCaseTestArrangement {
             )
 
         if (!localTeamPresent) {
-            given(userRepository)
-                .suspendFunction(userRepository::fetchUserInfo)
+            given(teamRepository)
+                .suspendFunction(teamRepository::fetchTeamById)
                 .whenInvokedWith(any())
-                .thenReturn(Either.Right(TestUser.OTHER))
+                .thenReturn(Either.Right(team))
         }
 
         return this
@@ -97,7 +90,7 @@ class GetUserInfoUseCaseTestArrangement {
             .suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
             .thenReturn(
-                flowOf(team)
+                flowOf(null)
             )
 
         given(teamRepository)
@@ -111,7 +104,7 @@ class GetUserInfoUseCaseTestArrangement {
     }
 
     fun arrange(): Pair<GetUserInfoUseCaseTestArrangement, GetUserInfoUseCase> {
-        return this to getUserInfoUseCase
+        return this to GetUserInfoUseCaseImpl(userRepository, teamRepository)
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
@@ -1,0 +1,75 @@
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.team.Team
+import com.wire.kalium.logic.data.team.TeamRepository
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.flow.flowOf
+import kotlin.test.BeforeTest
+
+class GetUserInfoUseCaseTestArrangement {
+
+    @Mock
+    private val userRepository: UserRepository = mock(UserRepository::class)
+
+    @Mock
+    private val teamRepository: TeamRepository = mock(TeamRepository::class)
+
+    lateinit var getUserInfoUseCase: GetUserInfoUseCase
+
+    @BeforeTest
+    fun setUp() {
+        getUserInfoUseCase = GetUserInfoUseCaseImpl(userRepository, teamRepository)
+    }
+
+    fun withSuccessFullUserRetrive(
+        localUserPresent: Boolean = true,
+        hasTeam: Boolean = true
+    ): GetUserInfoUseCaseTestArrangement {
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(any())
+            .thenReturn(
+                flowOf(
+                    if (!localUserPresent) null
+                    else if (hasTeam) TestUser.OTHER else TestUser.OTHER.copy(team = null)
+                )
+            )
+
+        if (localUserPresent) {
+            given(userRepository)
+                .suspendFunction(userRepository::fetchUserInfo)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(TestUser.OTHER))
+        }
+
+        return this
+    }
+
+    fun withFailingUserRetrive() {
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(eq(userId))
+            .thenReturn(flowOf(TestUser.OTHER))
+
+        given(userRepository)
+            .suspendFunction(userRepository::fetchUserInfo)
+            .whenInvokedWith(any())
+            .thenReturn(
+                Either.Left(CoreFailure.Unknown(RuntimeException("some error")))
+            )
+    }
+
+    private companion object {
+        val userId = UserId("some_user", "some_domain")
+
+        val team = Team("teamId", "teamName")
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
@@ -22,7 +22,7 @@ class GetUserInfoUseCaseTestArrangement {
     @Mock
     val teamRepository: TeamRepository = mock(TeamRepository::class)
 
-    fun withSuccessFullUserRetrive(
+    fun withSuccessfulUserRetrieve(
         localUserPresent: Boolean = true,
         hasTeam: Boolean = true
     ): GetUserInfoUseCaseTestArrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
@@ -62,7 +62,7 @@ class GetUserInfoUseCaseTestArrangement {
         return this
     }
 
-    fun withSuccessTeamRetrive(
+    fun withSuccessfulTeamRetrieve(
         localTeamPresent: Boolean = true,
     ): GetUserInfoUseCaseTestArrangement {
         given(teamRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
@@ -46,7 +46,7 @@ class GetUserInfoUseCaseTestArrangement {
         return this
     }
 
-    fun withFailingUserRetrive(): GetUserInfoUseCaseTestArrangement {
+    fun withFailingUserRetrieve(): GetUserInfoUseCaseTestArrangement {
         given(userRepository)
             .suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- we were not mapping the team name when getting the user details 

### Solutions

- map the team name by getting it locally if exists if not get it form remote.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
