### PR TITLE
fix: protocontent mapper is not mapping GenericMessage.Content.Edited

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -11,7 +11,10 @@ import com.wire.kalium.protobuf.messages.EncryptionAlgorithm
 import com.wire.kalium.protobuf.messages.GenericMessage
 import com.wire.kalium.protobuf.messages.MessageDelete
 import com.wire.kalium.protobuf.messages.MessageHide
+import com.wire.kalium.protobuf.messages.MessageEdit
 import com.wire.kalium.protobuf.messages.Text
+import com.wire.kalium.protobuf.messages.Composite
+
 import pbandk.ByteArr
 
 interface ProtoContentMapper {
@@ -98,7 +101,22 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             is GenericMessage.Content.Confirmation -> MessageContent.Unknown
             is GenericMessage.Content.DataTransfer -> MessageContent.Unknown
             is GenericMessage.Content.Deleted -> MessageContent.DeleteMessage(protoContent.value.messageId)
-            is GenericMessage.Content.Edited -> MessageContent.Unknown
+            is GenericMessage.Content.Edited -> {
+                val replacingMessageId = protoContent.value.replacingMessageId
+                when (val editContent = protoContent.value.content) {
+                    is MessageEdit.Content.Text -> {
+                        MessageContent.TextEdited(replacingMessageId, editContent.value.content)
+                    }
+                    //TODO: for now we do not implement it
+                    is MessageEdit.Content.Composite -> {
+                        MessageContent.Unknown
+                    }
+                    else -> {
+                        kaliumLogger.w("Edit content is null. Message UUID = $genericMessage.")
+                        MessageContent.Unknown
+                    }
+                }
+            }
             is GenericMessage.Content.Ephemeral -> MessageContent.Unknown
             is GenericMessage.Content.External -> MessageContent.Unknown
             is GenericMessage.Content.Image -> MessageContent.Unknown // Deprecated in favor of GenericMessage.Content.Asset

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -111,8 +111,8 @@ class ProtoContentMapperImpl : ProtoContentMapper {
                     is MessageEdit.Content.Composite -> {
                         MessageContent.Unknown
                     }
-                    else -> {
-                        kaliumLogger.w("Edit content is null. Message UUID = $genericMessage.")
+                    null -> {
+                        kaliumLogger.w("Edit content is unexpected. Message UUID = $genericMessage.")
                         MessageContent.Unknown
                     }
                 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -132,6 +132,33 @@ class ProtoContentMapperTest {
         assertEquals(decoded, protoContent)
     }
 
+    @Test
+    fun givenEditedTextGenericMessage_whenMappingFromProtoData_thenTheReturnValueShouldHaveTheCorrectEditedMessageId() {
+        val replacedMessageId = "replacedMessageId"
+        val textContent = MessageEdit.Content.Text(Text("textContent"))
+        val genericMessage = GenericMessage(TEST_MESSAGE_UUID, GenericMessage.Content.Edited(MessageEdit(replacedMessageId, textContent)))
+        val protobufBlob = PlainMessageBlob(genericMessage.encodeToByteArray())
+
+        val result = protoContentMapper.decodeFromProtobuf(protobufBlob)
+
+        val content = result.messageContent
+        assertIs<MessageContent.TextEdited>(content)
+        assertEquals(replacedMessageId, content.editMessageId)
+    }
+
+    @Test
+    fun givenEditedTextGenericMessage_whenMappingFromProtoData_thenTheReturnValueShouldHaveTheCorrectUpdatedContent() {
+        val replacedMessageId = "replacedMessageId"
+        val textContent = MessageEdit.Content.Text(Text("textContent"))
+        val genericMessage = GenericMessage(TEST_MESSAGE_UUID, GenericMessage.Content.Edited(MessageEdit(replacedMessageId, textContent)))
+        val protobufBlob = PlainMessageBlob(genericMessage.encodeToByteArray())
+
+        val result = protoContentMapper.decodeFromProtobuf(protobufBlob)
+
+        val content = result.messageContent
+        assertIs<MessageContent.TextEdited>(content)
+        assertEquals(textContent.value.content, content.newContent)
+    }
 
     private companion object {
         const val TEST_MESSAGE_UUID = "testUuid"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -6,10 +6,13 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.messages.Asset
 import com.wire.kalium.protobuf.messages.GenericMessage
+import com.wire.kalium.protobuf.messages.MessageEdit
+import com.wire.kalium.protobuf.messages.Text
 import io.ktor.utils.io.core.toByteArray
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 class ProtoContentMapperTest {
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
