### PR TITLE
fix: parse SFT connection data string to json

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/call/CallApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/call/CallApiImpl.kt
@@ -1,16 +1,13 @@
 package com.wire.kalium.network.api.call
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.parameter
-import io.ktor.client.request.header
 import io.ktor.client.request.setBody
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
 
 class CallApiImpl internal constructor(private val authenticatedNetworkClient: AuthenticatedNetworkClient) : CallApi {
 
@@ -26,8 +23,10 @@ class CallApiImpl internal constructor(private val authenticatedNetworkClient: A
     override suspend fun connectToSFT(url: String, data: String): NetworkResponse<ByteArray> =
         wrapKaliumResponse {
             httpClient.post(urlString = url) {
-                header(HttpHeaders.Accept, ContentType.Application.Json)
-                setBody(data)
+                // We are parsing the data string to json due to Ktor serialization escaping the string
+                // and thus backend not recognizing and returning a 400 - Bad Request
+                val json = KtxSerializer.json.parseToJsonElement(data)
+                setBody(json)
             }
         }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/call/CallApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/call/CallApiTest.kt
@@ -44,6 +44,33 @@ class CallApiTest : ApiTest {
         callApi.getCallConfig(limit = 7)
     }
 
+    @Test
+    fun givenCallApi_whenConnectingToSFT_theREquestShouldBeConfiguredCorrectly() = runTest {
+        val sftConnectionURL = "sft.connection.url1"
+        val sftConnectionData = """
+            |{
+            |   "sft":"connection"
+            |}
+        """.trimIndent()
+
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = GET_CALL_SFT.rawJson,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertJson()
+                assertPost()
+                assertPathEqual(sftConnectionURL)
+                assertBodyContent(sftConnectionData)
+            }
+        )
+
+        val callApi: CallApi = CallApiImpl(networkClient)
+        callApi.connectToSFT(
+            url = sftConnectionURL,
+            data = sftConnectionData
+        )
+    }
+
     private companion object {
 
         const val PATH_CALLS = "calls"
@@ -59,5 +86,6 @@ class CallApiTest : ApiTest {
             """.trimIndent()
         }
         val GET_CALL_CONFIG = AnyResponseProvider(data = "", jsonProvider)
+        val GET_CALL_SFT = AnyResponseProvider(data = "", jsonProvider)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Due to Ktor serialization on the data string we were sending to connect to a SFT server, the characters were being escaped: `{\"foo\":\"bar\"}`.

### Solutions

Properly parse the data string to a json so Ktor doesn't serialize/escape its content and thus successfully connecting to the SFT server.