### PR TITLE
feat: respect muting options per conversation

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -95,6 +95,6 @@ class EventDataSource(
 
 
     private companion object {
-        const val NOTIFICATIONS_QUERY_SIZE = 500
+        const val NOTIFICATIONS_QUERY_SIZE = 100
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -92,9 +92,14 @@ class GetNotificationsUseCaseImpl(
                                             MutedConversationStatus.AllAllowed -> true
                                             MutedConversationStatus.OnlyMentionsAllowed -> {
                                                 when(val content = it.content) {
-                                                    is MessageContent.Text -> selfUser.name?.let { selfUsername ->
-                                                        content.value.contains(Regex(selfUsername))
-                                                    }.run { false }
+                                                    is MessageContent.Text ->  {
+                                                        val containsSelfUserName = selfUser.name?.let { selfUsername ->
+                                                            content.value.contains(selfUsername) } ?: false
+                                                        val containsSelfHandle = selfUser.handle?.let { selfHandle ->
+                                                            content.value.contains(selfHandle)
+                                                            } ?: false
+                                                        containsSelfUserName or containsSelfHandle
+                                                    }
                                                     else -> true
                                                 }
                                             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -6,13 +6,16 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.notification.LocalNotificationCommentType
 import com.wire.kalium.logic.data.notification.LocalNotificationMessage
 import com.wire.kalium.logic.data.notification.LocalNotificationMessageAuthor
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.framework.TestUser
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.anything
@@ -50,8 +53,13 @@ class GetNotificationsUseCaseTest {
 
     @Test
     fun givenEmptyConversationList_thenEmptyNotificationList() = runTest {
-        given(userRepository).coroutine { getSelfUserId() }.then { MY_ID }
-        given(conversationRepository).coroutine { getConversationsForNotifications() }.then { flowOf(listOf()) }
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+        given(conversationRepository)
+            .coroutine { getConversationsForNotifications() }
+            .then { flowOf(listOf()) }
 
         val notificationsListFlow = getNotificationsUseCase()
 
@@ -63,8 +71,16 @@ class GetNotificationsUseCaseTest {
 
     @Test
     fun givenConversationWithEmptyMessageList_thenEmptyNotificationList() = runTest {
-        given(userRepository).coroutine { getSelfUserId() }.then { MY_ID }
-        given(conversationRepository).coroutine { getConversationsForNotifications() }.then { flowOf(listOf(entityConversation())) }
+        given(userRepository)
+            .coroutine { getSelfUserId() }
+            .then { MY_ID }
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+        given(conversationRepository)
+            .coroutine { getConversationsForNotifications() }
+            .then { flowOf(listOf(entityConversation())) }
         given(messageRepository)
             .suspendFunction(messageRepository::getMessagesByConversationAfterDate)
             .whenInvokedWith(anything(), anything())
@@ -80,12 +96,27 @@ class GetNotificationsUseCaseTest {
 
     @Test
     fun givenConversationWithOnlyMyMessageList_thenEmptyNotificationList() = runTest {
-        given(userRepository).coroutine { getSelfUserId() }.then { MY_ID }
-        given(conversationRepository).coroutine { getConversationsForNotifications() }.then { flowOf(listOf(entityConversation())) }
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+        given(userRepository)
+            .coroutine { getSelfUserId() }
+            .then { MY_ID }
+        given(conversationRepository)
+            .coroutine { getConversationsForNotifications() }
+            .then { flowOf(listOf(entityConversation())) }
         given(messageRepository)
             .suspendFunction(messageRepository::getMessagesByConversationAfterDate)
             .whenInvokedWith(anything(), anything())
-            .then { conversationId, _ -> flowOf(listOf(entityMessage(conversationId))) }
+            .then { conversationId, _ ->
+                flowOf(
+                    listOf(
+                        entityTextMessage(conversationId),
+                        entityAssetMessage(conversationId, assetId = "test_asset")
+                    )
+                )
+            }
 
         val notificationsListFlow = getNotificationsUseCase()
 
@@ -97,8 +128,16 @@ class GetNotificationsUseCaseTest {
 
     @Test
     fun givenConversationWithMessageListIncludingMyMessages_thenNotificationListWithoutMyMessages() = runTest {
-        given(userRepository).coroutine { getSelfUserId() }.then { MY_ID }
-        given(conversationRepository).coroutine { getConversationsForNotifications() }.then { flowOf(listOf(entityConversation())) }
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+        given(userRepository)
+            .coroutine { getSelfUserId() }
+            .then { MY_ID }
+        given(conversationRepository)
+            .coroutine { getConversationsForNotifications() }
+            .then { flowOf(listOf(entityConversation())) }
         given(userRepository)
             .suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -109,8 +148,10 @@ class GetNotificationsUseCaseTest {
             .then { _, _ ->
                 flowOf(
                     listOf(
-                        entityMessage(conversationId()),
-                        entityMessage(conversationId(), otherUserId())
+                        entityTextMessage(conversationId()),
+                        entityAssetMessage(conversationId(), assetId = "test_asset"),
+                        entityTextMessage(conversationId(), otherUserId()),
+                        entityAssetMessage(conversationId(), otherUserId(), assetId = "test_asset")
                     )
                 )
             }
@@ -123,7 +164,10 @@ class GetNotificationsUseCaseTest {
             assertTrue(actual.size == 1)
             assertEquals(
                 actual[0].messages,
-                listOf(notificationMessage(authorName = otherUserName(otherUserId()), text = "test message message_id"))
+                listOf(
+                    notificationMessageText(authorName = otherUserName(otherUserId()), text = "test message message_id"),
+                    notificationMessageTextComment(authorName = otherUserName(otherUserId()))
+                )
             )
             awaitComplete()
         }
@@ -131,7 +175,13 @@ class GetNotificationsUseCaseTest {
 
     @Test
     fun givenFewConversationWithMessageLists_thenListOfFewNotifications() = runTest {
-        given(userRepository).coroutine { getSelfUserId() }.then { MY_ID }
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+        given(userRepository)
+            .coroutine { getSelfUserId() }
+            .then { MY_ID }
         given(conversationRepository)
             .coroutine { getConversationsForNotifications() }
             .then {
@@ -152,8 +202,9 @@ class GetNotificationsUseCaseTest {
             .then { conversationId, _ ->
                 flowOf(
                     listOf(
-                        entityMessage(conversationId, otherUserId(), "0"),
-                        entityMessage(conversationId, otherUserId(), "1")
+                        entityTextMessage(conversationId, otherUserId(), "0"),
+                        entityTextMessage(conversationId, otherUserId(), "1"),
+                        entityAssetMessage(conversationId, otherUserId(), messageId = "2", assetId = "test_asset")
                     )
                 )
             }
@@ -166,14 +217,16 @@ class GetNotificationsUseCaseTest {
             assertTrue(actual.size == 2)
             assertEquals(
                 actual[0].messages, listOf(
-                    notificationMessage(authorName = otherUserName(otherUserId()), text = "test message 0"),
-                    notificationMessage(authorName = otherUserName(otherUserId()), text = "test message 1")
+                    notificationMessageText(authorName = otherUserName(otherUserId()), text = "test message 0"),
+                    notificationMessageText(authorName = otherUserName(otherUserId()), text = "test message 1"),
+                    notificationMessageTextComment(authorName = otherUserName(otherUserId()))
                 )
             )
             assertEquals(
                 actual[1].messages, listOf(
-                    notificationMessage(authorName = otherUserName(otherUserId()), text = "test message 0"),
-                    notificationMessage(authorName = otherUserName(otherUserId()), text = "test message 1")
+                    notificationMessageText(authorName = otherUserName(otherUserId()), text = "test message 0"),
+                    notificationMessageText(authorName = otherUserName(otherUserId()), text = "test message 1"),
+                    notificationMessageTextComment(authorName = otherUserName(otherUserId()))
                 )
             )
             awaitComplete()
@@ -182,7 +235,13 @@ class GetNotificationsUseCaseTest {
 
     @Test
     fun givenFewConversationWithMessageListsButSameAuthor_thenAuthorInfoRequestedOnce() = runTest {
-        given(userRepository).coroutine { getSelfUserId() }.then { MY_ID }
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+        given(userRepository)
+            .coroutine { getSelfUserId() }
+            .then { MY_ID }
         given(conversationRepository)
             .coroutine { getConversationsForNotifications() }
             .then {
@@ -203,8 +262,9 @@ class GetNotificationsUseCaseTest {
             .then { conversationId, _ ->
                 flowOf(
                     listOf(
-                        entityMessage(conversationId, otherUserId(), "0"),
-                        entityMessage(conversationId, otherUserId(), "1")
+                        entityTextMessage(conversationId, otherUserId(), "0"),
+                        entityTextMessage(conversationId, otherUserId(), "1"),
+                        entityTextMessage(conversationId, otherUserId(), messageId = "2")
                     )
                 )
             }
@@ -220,7 +280,7 @@ class GetNotificationsUseCaseTest {
 
     companion object {
 
-        private val MY_ID = QualifiedID("my_id_value", "my_id_domain")
+        private val MY_ID = TestUser.USER_ID
 
         private fun conversationId(number: Int = 0) = QualifiedID("conversation_id_${number}_value", "conversation_id_${number}_domain")
 
@@ -236,7 +296,11 @@ class GetNotificationsUseCaseTest {
 
         private fun otherUserId(number: Int = 0) = QualifiedID("other_user_id_${number}_value", "other_user_id_${number}_domain")
 
-        private fun entityMessage(conversationId: QualifiedID, senderId: QualifiedID = MY_ID, messageId: String = "message_id") =
+        private fun entityTextMessage(
+            conversationId: QualifiedID,
+            senderId: QualifiedID = TestUser.USER_ID,
+            messageId: String = "message_id"
+        ) =
             Message(
                 messageId,
                 MessageContent.Text("test message $messageId"),
@@ -248,12 +312,66 @@ class GetNotificationsUseCaseTest {
                 Message.EditStatus.NotEdited
             )
 
-        private fun notificationMessage(authorName: String = "Author Name", time: String = "some_time", text: String = "test text") =
+        private fun entityAssetMessage(
+            conversationId: QualifiedID,
+            senderId: QualifiedID = TestUser.USER_ID,
+            messageId: String = "message_id",
+            assetId: String
+        ) =
+            Message(
+                messageId,
+                content = MessageContent.Asset(
+                    AssetContent(
+                        sizeInBytes = 1000,
+                        name = "some_asset.jpg",
+                        mimeType = "image/jpeg",
+                        metadata = AssetContent.AssetMetadata.Image(width = 100, height = 100),
+                        remoteData = AssetContent.RemoteData(
+                            otrKey = ByteArray(0),
+                            sha256 = ByteArray(16),
+                            assetId = assetId,
+                            assetToken = "==some-asset-token",
+                            assetDomain = "some-asset-domain.com",
+                            encryptionAlgorithm = AssetContent.RemoteData.EncryptionAlgorithm.AES_GCM
+                        ),
+                        downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
+                    )
+                ),
+                conversationId,
+                "some_time",
+                senderId,
+                ClientId("client_1"),
+                Message.Status.SENT,
+                Message.EditStatus.NotEdited
+            )
+
+        private fun notificationMessageText(
+            authorName: String = "Author Name",
+            time: String = "some_time",
+            text: String = "test text"
+        ) =
             LocalNotificationMessage.Text(
                 LocalNotificationMessageAuthor(authorName, null),
                 time,
                 text
             )
+
+        private fun notificationMessageTextComment(
+            authorName: String = "Author Name",
+            time: String = "some_time",
+        ) = notificationMessageText(authorName, time, "Something not a text")
+
+        private fun notificationMessageComment(
+            authorName: String = "Author Name",
+            time: String = "some_time",
+            commentType: LocalNotificationCommentType
+        ) =
+            LocalNotificationMessage.Comment(
+                LocalNotificationMessageAuthor(authorName, null),
+                time,
+                commentType
+            )
+
 
         private fun otherUser(id: QualifiedID) =
             OtherUser(

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -65,7 +65,7 @@ selectByGroupId:
 SELECT * FROM Conversation WHERE mls_group_id = ?;
 
 selectConversationsWithUnnotifiedMessages:
-SELECT * FROM Conversation WHERE muted_status = 'ALL_ALLOWED' AND (last_notified_message_date ISNULL OR DateTime(last_modified_date) > DateTime(last_notified_message_date));
+SELECT * FROM Conversation WHERE muted_status != 'ALL_MUTED' AND (last_notified_message_date ISNULL OR DateTime(last_modified_date) > DateTime(last_notified_message_date));
 
 updateConversationMutingStatus:
 UPDATE Conversation

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -9,7 +9,7 @@ CREATE TABLE Conversation (
     mls_group_id TEXT,
     mls_group_state TEXT AS ConversationEntity.GroupState NOT NULL,
     protocol TEXT AS ConversationEntity.Protocol NOT NULL,
-    muted_status TEXT AS ConversationEntity.MutedStatus DEFAULT "all_allowed" NOT NULL,
+    muted_status TEXT AS ConversationEntity.MutedStatus DEFAULT "ALL_ALLOWED" NOT NULL,
     muted_time INTEGER DEFAULT 0 NOT NULL,
     last_modified_date TEXT NOT NULL,
     last_notified_message_date TEXT
@@ -65,7 +65,7 @@ selectByGroupId:
 SELECT * FROM Conversation WHERE mls_group_id = ?;
 
 selectConversationsWithUnnotifiedMessages:
-SELECT * FROM Conversation WHERE last_notified_message_date ISNULL OR DateTime(last_modified_date) > DateTime(last_notified_message_date);
+SELECT * FROM Conversation WHERE muted_status = 'ALL_ALLOWED' AND (last_notified_message_date ISNULL OR DateTime(last_modified_date) > DateTime(last_notified_message_date));
 
 updateConversationMutingStatus:
 UPDATE Conversation

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -177,18 +177,29 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         // THEN
         // only conversation one should be selected for notifications
-        assertEquals(listOf(conversationEntity1), result)
+        assertEquals(listOf(conversationEntity1, conversationEntity3), result)
     }
 
     @Test
     fun givenMultipleConversations_whenGettingConversations_thenOrderIsCorrect() = runTest {
+        // GIVEN
         conversationDAO.insertConversation(conversationEntity1)
         conversationDAO.insertConversation(conversationEntity2)
+        conversationDAO.insertConversation(conversationEntity3)
+
+        // WHEN
+        // Updating the last notified date to later than last modified
+        conversationDAO
+            .updateConversationNotificationDate(
+                QualifiedIDEntity("2", "wire.com"),
+                "2022-03-30T15:37:10.000Z"
+            )
 
         val result = conversationDAO.getConversationsForNotifications().first()
-
+        // THEN
+        // The order of the conversations is not affected
         assertEquals(conversationEntity1, result.first())
-        assertEquals(conversationEntity2, result[1])
+        assertEquals(conversationEntity3, result[1])
 
     }
 
@@ -285,7 +296,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             ConversationEntity.Type.GROUP,
             null,
             ConversationEntity.ProtocolInfo.MLS("group3", ConversationEntity.GroupState.ESTABLISHED),
-            // This conversation was modifieid after the last time the user was notified about it
+            // This conversation was modified after the last time the user was notified about it
             lastNotificationDate = "2021-03-30T15:30:00.000Z",
             lastModifiedDate = "2021-03-30T15:36:00.000Z",
             // and it's status is set to be only notified if there is a mention for the user


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Mute options are not respected

### Solutions

Only get conversations where the mute status is not `ALL_MUTED`

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
