### PR TITLE
feat: add use case to observe member details by id list [AR-1809]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -26,6 +26,9 @@ class ConversationScope(
     val observeConversationMembers: ObserveConversationMembersUseCase
         get() = ObserveConversationMembersUseCase(conversationRepository, userRepository, syncManager, UserTypeMapperImpl())
 
+    val observeMemberDetailsByIds: ObserveMemberDetailsByIdsUseCase
+        get() = ObserveMemberDetailsByIdsUseCase(userRepository, syncManager, UserTypeMapperImpl())
+
     val observeConversationDetails: ObserveConversationDetailsUseCase
         get() = ObserveConversationDetailsUseCase(conversationRepository, syncManager)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveMemberDetailsByIdsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveMemberDetailsByIdsUseCase.kt
@@ -1,0 +1,44 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.data.user.UserTypeMapper
+import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
+class ObserveMemberDetailsByIdsUseCase(
+    private val userRepository: UserRepository,
+    private val syncManager: SyncManager,
+    private val userTypeMapper: UserTypeMapper,
+) {
+
+    suspend operator fun invoke(userIdList: List<UserId>): Flow<List<MemberDetails>> {
+        syncManager.startSyncIfIdle()
+        val selfDetailsFlow = userRepository.getSelfUser()
+        val selfUser = selfDetailsFlow.first()
+
+        return flowOf(userIdList).map { members ->
+            members.map {
+                if (it == selfUser.id) {
+                    selfDetailsFlow.map(MemberDetails::Self)
+                } else {
+                    userRepository.getKnownUser(it).filterNotNull().map { otherUser ->
+                        MemberDetails.Other(
+                            otherUser = otherUser,
+                            userType = userTypeMapper.fromOtherUserAndSelfUser(otherUser, selfUser)
+                        )
+                    }
+                }
+            }
+        }.flatMapLatest { detailsFlows ->
+            combine(detailsFlows) { it.toList() }
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveMemberDetailsByIdsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveMemberDetailsByIdsUseCaseTest.kt
@@ -1,0 +1,121 @@
+package com.wire.kalium.logic.feature.conversation
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.conversation.UserType
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.data.user.UserTypeMapper
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.sync.SyncManager
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.configure
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class ObserveMemberDetailsByIdsUseCaseTest {
+
+    @Mock
+    private val userRepository = mock(UserRepository::class)
+
+    @Mock
+    private val userTypeMapper = mock(UserTypeMapper::class)
+
+    @Mock
+    private val syncManager = configure(mock(SyncManager::class)) {
+        stubsUnitByDefault = true
+    }
+
+    private lateinit var observeMemberDetailsByIds: ObserveMemberDetailsByIdsUseCase
+
+    @BeforeTest
+    fun setup() {
+        observeMemberDetailsByIds = ObserveMemberDetailsByIdsUseCase(
+            userRepository,
+            syncManager,
+            userTypeMapper
+        )
+    }
+
+    @Test
+    fun givenAUserIdList_whenObservingMembers_thenTheSyncManagerIsCalled() = runTest {
+        val userIds = listOf(TestUser.SELF.id)
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        observeMemberDetailsByIds(userIds)
+
+        verify(syncManager)
+            .function(syncManager::startSyncIfIdle)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSelfUserUpdates_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow() = runTest {
+        val firstSelfUser = TestUser.SELF
+        val secondSelfUser = firstSelfUser.copy(name = "Updated name")
+        val selfUserUpdates = listOf(firstSelfUser, secondSelfUser)
+        val userIds = listOf(firstSelfUser.id)
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(selfUserUpdates.asFlow())
+
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(anything())
+            .thenReturn(flowOf())
+
+        observeMemberDetailsByIds(userIds).test {
+            assertContentEquals(listOf(MemberDetails.Self(firstSelfUser)), awaitItem())
+            assertContentEquals(listOf(MemberDetails.Self(secondSelfUser)), awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenOtherUserUpdates_whenObservingMembers_thenTheUpdateIsPropagatedInTheFlow() = runTest {
+        val firstOtherUser = TestUser.OTHER
+        val secondOtherUser = firstOtherUser.copy(name = "Updated name")
+        val otherUserUpdates = listOf(firstOtherUser, secondOtherUser)
+        val userIds = listOf(firstOtherUser.id)
+
+        given(userRepository)
+            .suspendFunction(userRepository::getSelfUser)
+            .whenInvoked()
+            .thenReturn(flowOf(TestUser.SELF))
+
+        given(userRepository)
+            .suspendFunction(userRepository::getKnownUser)
+            .whenInvokedWith(anything())
+            .thenReturn(otherUserUpdates.asFlow())
+
+        given(userTypeMapper)
+            .function(userTypeMapper::fromOtherUserAndSelfUser)
+            .whenInvokedWith(anything(),anything())
+            .thenReturn(UserType.GUEST)
+
+        observeMemberDetailsByIds(userIds).test {
+            assertContentEquals(listOf(MemberDetails.Other(firstOtherUser, UserType.GUEST)), awaitItem())
+            assertContentEquals(listOf(MemberDetails.Other(secondOtherUser, UserType.GUEST)), awaitItem())
+            awaitComplete()
+        }
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we observe conversation members that are currently in the conversation so when trying to display a message from a user that's already removed from group, we get `NoSuchElementException`.

### Solutions

Implement new use case that allows us to observe member details by passing list of user ids that we want to observe.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
