### PR TITLE
feat: Persist self user status (AR-1741, AR-1742, AR-1743)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapper.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.connection
 
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.publicuser.PublicUserMapper
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.network.api.user.connection.ConnectionDTO
@@ -17,7 +18,7 @@ interface ConnectionMapper {
 internal class ConnectionMapperImpl(
     private val idMapper: IdMapper,
     private val statusMapper: ConnectionStatusMapper,
-    private val userMapper: UserMapper
+    private val publicUserMapper: PublicUserMapper
 ) : ConnectionMapper {
     override fun fromApiToDao(state: ConnectionDTO): ConnectionEntity = ConnectionEntity(
         conversationId = state.conversationId,
@@ -37,7 +38,7 @@ internal class ConnectionMapperImpl(
         qualifiedToId = idMapper.fromDaoModel(state.qualifiedToId),
         status = statusMapper.fromDaoModel(state.status),
         toId = state.toId,
-        fromUser = otherUser?.let { userMapper.fromDaoModelToOtherUser(it) }
+        fromUser = otherUser?.let { publicUserMapper.fromDaoModelToPublicUser(it) }
     )
 
     override fun fromApiToModel(state: ConnectionDTO): Connection = Connection(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
@@ -41,7 +41,7 @@ class PublicUserMapperImpl(
         connectionStatus = connectionStateMapper.fromDaoConnectionStateToUser(connectionState = userEntity.connectionStatus),
         previewPicture = userEntity.previewAssetId,
         completePicture = userEntity.completeAssetId,
-        availabilityStatus = availabilityStatusMapper.fromDaoAvailabilityStatusToUser(userEntity.availabilityStatus)
+        availabilityStatus = availabilityStatusMapper.fromDaoAvailabilityStatusToModel(userEntity.availabilityStatus)
     )
 
     override fun fromUserDetailResponse(userDetailResponse: UserProfileDTO) = OtherUser(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
@@ -56,7 +56,8 @@ class PublicUserMapperImpl(private val idMapper: IdMapper) : PublicUserMapper {
         team = userDetailResponse.teamId,
         previewAssetId = userDetailResponse.assets.getPreviewAssetOrNull()?.key,
         completeAssetId = userDetailResponse.assets.getCompleteAssetOrNull()?.key,
-        connectionStatus = connectionState
+        connectionStatus = connectionState,
+        availabilityStatus = null
     )
 
     override fun fromUserDetailResponses(userDetailResponse: List<UserProfileDTO>) =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/model/OtherUser.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/model/OtherUser.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserAssetId
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 
 data class OtherUser(
@@ -16,7 +17,8 @@ data class OtherUser(
     val team: String?,
     val connectionStatus: ConnectionState = ConnectionState.NOT_CONNECTED,
     val previewPicture: UserAssetId?,
-    val completePicture: UserAssetId?
+    val completePicture: UserAssetId?,
+    val availabilityStatus: UserAvailabilityStatus?
 ) : User() {
 
     fun isUsingWireCloudBackEnd(): Boolean =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/model/OtherUser.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/model/OtherUser.kt
@@ -18,7 +18,7 @@ data class OtherUser(
     val connectionStatus: ConnectionState = ConnectionState.NOT_CONNECTED,
     val previewPicture: UserAssetId?,
     val completePicture: UserAssetId?,
-    val availabilityStatus: UserAvailabilityStatus?
+    val availabilityStatus: UserAvailabilityStatus
 ) : User() {
 
     fun isUsingWireCloudBackEnd(): Boolean =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/AvailabilityStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/AvailabilityStatusMapper.kt
@@ -3,12 +3,12 @@ package com.wire.kalium.logic.data.user
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 
 interface AvailabilityStatusMapper {
-    fun fromDaoAvailabilityStatusToUser(status: UserAvailabilityStatusEntity): UserAvailabilityStatus
-    fun fromUserAvailabilityStatusToDao(status: UserAvailabilityStatus): UserAvailabilityStatusEntity
+    fun fromDaoAvailabilityStatusToModel(status: UserAvailabilityStatusEntity): UserAvailabilityStatus
+    fun fromModelAvailabilityStatusToDao(status: UserAvailabilityStatus): UserAvailabilityStatusEntity
 }
 
 internal class AvailabilityStatusMapperImpl : AvailabilityStatusMapper {
-    override fun fromDaoAvailabilityStatusToUser(status: UserAvailabilityStatusEntity): UserAvailabilityStatus =
+    override fun fromDaoAvailabilityStatusToModel(status: UserAvailabilityStatusEntity): UserAvailabilityStatus =
         when (status) {
             UserAvailabilityStatusEntity.AVAILABLE -> UserAvailabilityStatus.AVAILABLE
             UserAvailabilityStatusEntity.BUSY -> UserAvailabilityStatus.BUSY
@@ -16,7 +16,7 @@ internal class AvailabilityStatusMapperImpl : AvailabilityStatusMapper {
             UserAvailabilityStatusEntity.NONE -> UserAvailabilityStatus.NONE
         }
 
-    override fun fromUserAvailabilityStatusToDao(status: UserAvailabilityStatus): UserAvailabilityStatusEntity =
+    override fun fromModelAvailabilityStatusToDao(status: UserAvailabilityStatus): UserAvailabilityStatusEntity =
         when (status) {
             UserAvailabilityStatus.AVAILABLE -> UserAvailabilityStatusEntity.AVAILABLE
             UserAvailabilityStatus.BUSY -> UserAvailabilityStatusEntity.BUSY

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/AvailabilityStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/AvailabilityStatusMapper.kt
@@ -1,0 +1,26 @@
+package com.wire.kalium.logic.data.user
+
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
+
+interface AvailabilityStatusMapper {
+    fun fromDaoAvailabilityStatusToUser(status: UserAvailabilityStatusEntity): UserAvailabilityStatus
+    fun fromUserAvailabilityStatusToDao(status: UserAvailabilityStatus): UserAvailabilityStatusEntity
+}
+
+internal class AvailabilityStatusMapperImpl : AvailabilityStatusMapper {
+    override fun fromDaoAvailabilityStatusToUser(status: UserAvailabilityStatusEntity): UserAvailabilityStatus =
+        when (status) {
+            UserAvailabilityStatusEntity.AVAILABLE -> UserAvailabilityStatus.AVAILABLE
+            UserAvailabilityStatusEntity.BUSY -> UserAvailabilityStatus.BUSY
+            UserAvailabilityStatusEntity.AWAY -> UserAvailabilityStatus.AWAY
+            UserAvailabilityStatusEntity.NONE -> UserAvailabilityStatus.NONE
+        }
+
+    override fun fromUserAvailabilityStatusToDao(status: UserAvailabilityStatus): UserAvailabilityStatusEntity =
+        when (status) {
+            UserAvailabilityStatus.AVAILABLE -> UserAvailabilityStatusEntity.AVAILABLE
+            UserAvailabilityStatus.BUSY -> UserAvailabilityStatusEntity.BUSY
+            UserAvailabilityStatus.AWAY -> UserAvailabilityStatusEntity.AWAY
+            UserAvailabilityStatus.NONE -> UserAvailabilityStatusEntity.NONE
+        }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/ConnectionStateMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/ConnectionStateMapper.kt
@@ -1,0 +1,36 @@
+package com.wire.kalium.logic.data.user
+
+import com.wire.kalium.persistence.dao.ConnectionEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
+
+interface ConnectionStateMapper {
+    fun fromDaoConnectionStateToUser(connectionState: ConnectionEntity.State): ConnectionState
+    fun fromUserConnectionStateToDao(connectionState: ConnectionState): ConnectionEntity.State
+}
+
+internal class ConnectionStateMapperImpl : ConnectionStateMapper {
+
+    override fun fromDaoConnectionStateToUser(connectionState: ConnectionEntity.State): ConnectionState =
+        when (connectionState) {
+            ConnectionEntity.State.NOT_CONNECTED -> ConnectionState.NOT_CONNECTED
+            ConnectionEntity.State.PENDING -> ConnectionState.PENDING
+            ConnectionEntity.State.SENT -> ConnectionState.SENT
+            ConnectionEntity.State.BLOCKED -> ConnectionState.BLOCKED
+            ConnectionEntity.State.IGNORED -> ConnectionState.IGNORED
+            ConnectionEntity.State.CANCELLED -> ConnectionState.CANCELLED
+            ConnectionEntity.State.MISSING_LEGALHOLD_CONSENT -> ConnectionState.MISSING_LEGALHOLD_CONSENT
+            ConnectionEntity.State.ACCEPTED -> ConnectionState.ACCEPTED
+        }
+
+    override fun fromUserConnectionStateToDao(connectionState: ConnectionState): ConnectionEntity.State =
+        when (connectionState) {
+            ConnectionState.NOT_CONNECTED -> ConnectionEntity.State.NOT_CONNECTED
+            ConnectionState.PENDING -> ConnectionEntity.State.PENDING
+            ConnectionState.SENT -> ConnectionEntity.State.SENT
+            ConnectionState.BLOCKED -> ConnectionEntity.State.BLOCKED
+            ConnectionState.IGNORED -> ConnectionEntity.State.IGNORED
+            ConnectionState.CANCELLED -> ConnectionEntity.State.CANCELLED
+            ConnectionState.MISSING_LEGALHOLD_CONSENT -> ConnectionEntity.State.MISSING_LEGALHOLD_CONSENT
+            ConnectionState.ACCEPTED -> ConnectionEntity.State.ACCEPTED
+        }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -88,7 +88,7 @@ internal class UserMapperImpl(
         connectionStateMapper.fromDaoConnectionStateToUser(connectionState = userEntity.connectionStatus),
         userEntity.previewAssetId,
         userEntity.completeAssetId,
-        availabilityStatusMapper.fromDaoAvailabilityStatusToUser(userEntity.availabilityStatus)
+        availabilityStatusMapper.fromDaoAvailabilityStatusToModel(userEntity.availabilityStatus)
     )
 
     override fun fromModelToUpdateApiModel(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -15,6 +15,7 @@ import com.wire.kalium.network.api.user.details.UserProfileDTO
 import com.wire.kalium.network.api.user.self.UserUpdateRequest
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.UserEntity
 import com.wire.kalium.persistence.dao.UserIDEntity as UserIdEntity
 
@@ -42,6 +43,8 @@ interface UserMapper {
 
     fun fromDaoConnectionStateToUser(connectionState: ConnectionEntity.State): ConnectionState
     fun fromUserConnectionStateToDao(connectionState: ConnectionState): ConnectionEntity.State
+    fun fromDaoAvailabilityStatusToUser(status: UserAvailabilityStatusEntity?): UserAvailabilityStatus?
+    fun fromUserAvailabilityStatusToDao(status: UserAvailabilityStatus?): UserAvailabilityStatusEntity?
 }
 
 internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.idMapper()) : UserMapper {
@@ -57,7 +60,8 @@ internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.id
             team = teamId,
             connectionStatus = ConnectionState.NOT_CONNECTED,
             previewPicture = assets.getPreviewAssetOrNull()?.key,
-            completePicture = assets.getCompleteAssetOrNull()?.key
+            completePicture = assets.getCompleteAssetOrNull()?.key,
+            availabilityStatus = null
         )
     }
 
@@ -71,7 +75,8 @@ internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.id
             accentId = userProfileDTO.accentId,
             team = userProfileDTO.teamId,
             previewAssetId = userProfileDTO.assets.getPreviewAssetOrNull()?.key,
-            completeAssetId = userProfileDTO.assets.getCompleteAssetOrNull()?.key
+            completeAssetId = userProfileDTO.assets.getCompleteAssetOrNull()?.key,
+            availabilityStatus = null
         )
     }
 
@@ -85,7 +90,8 @@ internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.id
         userEntity.team,
         fromDaoConnectionStateToUser(connectionState = userEntity.connectionStatus),
         userEntity.previewAssetId,
-        userEntity.completeAssetId
+        userEntity.completeAssetId,
+        fromDaoAvailabilityStatusToUser(userEntity.availabilityStatus)
     )
 
     override fun fromDaoModelToOtherUser(userEntity: UserEntity) = OtherUser(
@@ -98,7 +104,8 @@ internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.id
         userEntity.team,
         fromDaoConnectionStateToUser(connectionState = userEntity.connectionStatus),
         userEntity.previewAssetId,
-        userEntity.completeAssetId
+        userEntity.completeAssetId,
+        fromDaoAvailabilityStatusToUser(userEntity.availabilityStatus)
     )
 
     override fun fromModelToUpdateApiModel(
@@ -127,7 +134,8 @@ internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.id
             team = user.team,
             connectionStatus = fromUserConnectionStateToDao(connectionState = user.connectionStatus),
             previewAssetId = updateRequest.assets?.getPreviewAssetOrNull()?.key,
-            completeAssetId = updateRequest.assets?.getCompleteAssetOrNull()?.key
+            completeAssetId = updateRequest.assets?.getCompleteAssetOrNull()?.key,
+            availabilityStatus = null
         )
     }
 
@@ -141,7 +149,8 @@ internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.id
             accentId = accentId,
             team = teamId,
             previewAssetId = assets.getPreviewAssetOrNull()?.key,
-            completeAssetId = assets.getCompleteAssetOrNull()?.key
+            completeAssetId = assets.getCompleteAssetOrNull()?.key,
+            availabilityStatus = null
         )
     }
 
@@ -168,7 +177,8 @@ internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.id
             team = teamId,
             connectionStatus = ConnectionEntity.State.ACCEPTED,
             previewAssetId = null,
-            completeAssetId = null
+            completeAssetId = null,
+            availabilityStatus = null
         )
 
     override fun fromDaoConnectionStateToUser(connectionState: ConnectionEntity.State): ConnectionState =
@@ -193,5 +203,23 @@ internal class UserMapperImpl(private val idMapper: IdMapper = MapperProvider.id
             ConnectionState.CANCELLED -> ConnectionEntity.State.CANCELLED
             ConnectionState.MISSING_LEGALHOLD_CONSENT -> ConnectionEntity.State.MISSING_LEGALHOLD_CONSENT
             ConnectionState.ACCEPTED -> ConnectionEntity.State.ACCEPTED
+        }
+
+    override fun fromDaoAvailabilityStatusToUser(status: UserAvailabilityStatusEntity?): UserAvailabilityStatus? =
+        when (status) {
+            UserAvailabilityStatusEntity.AVAILABLE -> UserAvailabilityStatus.AVAILABLE
+            UserAvailabilityStatusEntity.BUSY -> UserAvailabilityStatus.BUSY
+            UserAvailabilityStatusEntity.AWAY -> UserAvailabilityStatus.AVAILABLE
+            UserAvailabilityStatusEntity.NONE -> UserAvailabilityStatus.NONE
+            null -> null
+        }
+
+    override fun fromUserAvailabilityStatusToDao(status: UserAvailabilityStatus?): UserAvailabilityStatusEntity? =
+        when (status) {
+            UserAvailabilityStatus.AVAILABLE -> UserAvailabilityStatusEntity.AVAILABLE
+            UserAvailabilityStatus.BUSY -> UserAvailabilityStatusEntity.BUSY
+            UserAvailabilityStatus.AWAY -> UserAvailabilityStatusEntity.AWAY
+            UserAvailabilityStatus.NONE -> UserAvailabilityStatusEntity.NONE
+            null -> null
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
@@ -23,6 +23,10 @@ data class Connection(
     val fromUser: OtherUser? = null
 )
 
+enum class UserAvailabilityStatus {
+    NONE, AVAILABLE, BUSY, AWAY
+}
+
 enum class ConnectionState {
     /** Default - No connection state */
     NOT_CONNECTED,
@@ -59,7 +63,8 @@ data class SelfUser(
     val team: String?,
     val connectionStatus: ConnectionState,
     val previewPicture: UserAssetId?,
-    val completePicture: UserAssetId?
+    val completePicture: UserAssetId?,
+    val availabilityStatus: UserAvailabilityStatus?
 ) : User()
 
 typealias UserAssetId = String

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
@@ -64,7 +64,7 @@ data class SelfUser(
     val connectionStatus: ConnectionState,
     val previewPicture: UserAssetId?,
     val completePicture: UserAssetId?,
-    val availabilityStatus: UserAvailabilityStatus?
+    val availabilityStatus: UserAvailabilityStatus
 ) : User()
 
 typealias UserAssetId = String

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.network.api.user.self.SelfApi
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.UserDAO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
@@ -45,6 +46,7 @@ interface UserRepository {
     suspend fun getAllContacts(): List<OtherUser>
     suspend fun getKnownUser(userId: UserId): Flow<OtherUser?>
     suspend fun fetchUserInfo(userId: UserId): Either<CoreFailure, OtherUser>
+    suspend fun updateSelfUserAvailabilityStatus(status: UserAvailabilityStatusEntity)
 }
 
 class UserDataSource(
@@ -140,6 +142,10 @@ class UserDataSource(
         wrapApiRequest { userDetailsApi.getUserInfo(idMapper.toApiModel(userId)) }.map { userProfile ->
             publicUserMapper.fromUserDetailResponse(userProfile)
         }
+
+    override suspend fun updateSelfUserAvailabilityStatus(status: UserAvailabilityStatusEntity) {
+        userDAO.updateUserAvailabilityStatus(_getSelfUserId(), status)
+    }
 
     companion object {
         const val SELF_USER_ID_KEY = "selfUserID"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -34,15 +34,20 @@ import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.session.SessionMapperImpl
 import com.wire.kalium.logic.data.team.TeamMapper
 import com.wire.kalium.logic.data.team.TeamMapperImpl
+import com.wire.kalium.logic.data.user.AvailabilityStatusMapper
+import com.wire.kalium.logic.data.user.AvailabilityStatusMapperImpl
+import com.wire.kalium.logic.data.user.ConnectionStateMapper
+import com.wire.kalium.logic.data.user.ConnectionStateMapperImpl
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.data.user.UserMapperImpl
-import com.wire.kalium.logic.data.user.UserTypeMapper
 import com.wire.kalium.logic.data.user.UserTypeMapperImpl
 
 internal object MapperProvider {
     fun idMapper(): IdMapper = IdMapperImpl()
     fun serverConfigMapper(): ServerConfigMapper = ServerConfigMapperImpl()
     fun sessionMapper(): SessionMapper = SessionMapperImpl(serverConfigMapper(), idMapper())
+    fun availabilityStatusMapper(): AvailabilityStatusMapper = AvailabilityStatusMapperImpl()
+    fun connectionStateMapper(): ConnectionStateMapper = ConnectionStateMapperImpl()
     fun userMapper(): UserMapper = UserMapperImpl(idMapper())
     fun teamMapper(): TeamMapper = TeamMapperImpl()
     fun messageMapper(): MessageMapper = MessageMapperImpl(idMapper())
@@ -59,5 +64,5 @@ internal object MapperProvider {
     fun conversationStatusMapper(): ConversationStatusMapper = ConversationStatusMapperImpl()
     fun callMapper(): CallMapper = CallMapper()
     fun connectionStatusMapper(): ConnectionStatusMapper = ConnectionStatusMapperImpl()
-    fun connectionMapper(): ConnectionMapper = ConnectionMapperImpl(idMapper(), connectionStatusMapper(), userMapper())
+    fun connectionMapper(): ConnectionMapper = ConnectionMapperImpl(idMapper(), connectionStatusMapper(), publicUserMapper())
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
@@ -1,0 +1,18 @@
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCase
+import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
+
+class UpdateSelfAvailabilityStatusUseCase(
+    private val userRepository: UserRepository,
+    private val syncManager: SyncManager
+) {
+    suspend fun invoke(status: UserAvailabilityStatusEntity) {
+        if (syncManager.isSlowSyncOngoing()) {
+            syncManager.waitUntilLive()
+        }
+        userRepository.updateSelfUserAvailabilityStatus(status)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapperTest.kt
@@ -71,9 +71,9 @@ class ConnectionMapperTest {
 
         val statusMapper = MapperProvider.connectionStatusMapper()
 
-        val userMapper = MapperProvider.userMapper()
+        val publicUserMapper = MapperProvider.publicUserMapper()
 
-        val mapper = ConnectionMapperImpl(idMapper, statusMapper, userMapper)
+        val mapper = ConnectionMapperImpl(idMapper, statusMapper, publicUserMapper)
 
         val stubConnectionResponse = ConnectionDTO(
             "someId",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -5,6 +5,9 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionMapperImpl
 import com.wire.kalium.logic.data.connection.ConnectionStatusMapperImpl
 import com.wire.kalium.logic.data.id.IdMapperImpl
+import com.wire.kalium.logic.data.publicuser.PublicUserMapperImpl
+import com.wire.kalium.logic.data.user.AvailabilityStatusMapperImpl
+import com.wire.kalium.logic.data.user.ConnectionStateMapperImpl
 import com.wire.kalium.logic.data.user.UserMapperImpl
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
@@ -51,7 +54,14 @@ class EventRepositoryTest {
 
     @Mock
     private val eventMapper: EventMapper =
-        EventMapper(IdMapperImpl(), ConnectionMapperImpl(IdMapperImpl(), ConnectionStatusMapperImpl(), UserMapperImpl()))
+        EventMapper(
+            IdMapperImpl(),
+            ConnectionMapperImpl(
+                IdMapperImpl(),
+                ConnectionStatusMapperImpl(),
+                PublicUserMapperImpl(IdMapperImpl(), AvailabilityStatusMapperImpl(), ConnectionStateMapperImpl())
+            )
+        )
 
     private lateinit var eventRepository: EventRepository
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -289,7 +289,8 @@ class SearchUserRepositoryTest {
                         accentId = i,
                         team = "team$i",
                         previewPicture = null,
-                        completePicture = null
+                        completePicture = null,
+                        availabilityStatus = null
                     )
                 )
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.publicuser
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkResponseError
 import com.wire.kalium.network.api.QualifiedID
@@ -290,7 +291,7 @@ class SearchUserRepositoryTest {
                         team = "team$i",
                         previewPicture = null,
                         completePicture = null,
-                        availabilityStatus = null
+                        availabilityStatus = UserAvailabilityStatus.NONE
                     )
                 )
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepositoryTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.feature.auth.AuthSession
@@ -18,6 +19,7 @@ import com.wire.kalium.network.api.model.getCompleteAssetOrNull
 import com.wire.kalium.network.api.model.getPreviewAssetOrNull
 import com.wire.kalium.network.api.user.register.RegisterApi
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -141,7 +143,7 @@ class RegisterAccountRepositoryTest {
                 connectionStatus = ConnectionState.ACCEPTED,
                 previewPicture = assets.getPreviewAssetOrNull()?.key,
                 completePicture = assets.getCompleteAssetOrNull()?.key,
-                availabilityStatus = null
+                availabilityStatus = UserAvailabilityStatus.NONE
             )
         }
         val authSession = with(SESSION) { AuthSession(UserId(userId.value, userId.domain), accessToken, refreshToken, tokenType, serverConfig) }
@@ -197,7 +199,7 @@ class RegisterAccountRepositoryTest {
                 connectionStatus = ConnectionState.ACCEPTED,
                 previewPicture = assets.getPreviewAssetOrNull()?.key,
                 completePicture = assets.getCompleteAssetOrNull()?.key,
-                availabilityStatus = null
+                availabilityStatus = UserAvailabilityStatus.NONE
             )
         }
         val authSession = with(SESSION) { AuthSession(UserId(userId.value, userId.domain), accessToken, refreshToken, tokenType, serverConfig) }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepositoryTest.kt
@@ -140,7 +140,8 @@ class RegisterAccountRepositoryTest {
                 team = teamId,
                 connectionStatus = ConnectionState.ACCEPTED,
                 previewPicture = assets.getPreviewAssetOrNull()?.key,
-                completePicture = assets.getCompleteAssetOrNull()?.key
+                completePicture = assets.getCompleteAssetOrNull()?.key,
+                availabilityStatus = null
             )
         }
         val authSession = with(SESSION) { AuthSession(UserId(userId.value, userId.domain), accessToken, refreshToken, tokenType, serverConfig) }
@@ -195,7 +196,8 @@ class RegisterAccountRepositoryTest {
                 team = teamId,
                 connectionStatus = ConnectionState.ACCEPTED,
                 previewPicture = assets.getPreviewAssetOrNull()?.key,
-                completePicture = assets.getCompleteAssetOrNull()?.key
+                completePicture = assets.getCompleteAssetOrNull()?.key,
+                availabilityStatus = null
             )
         }
         val authSession = with(SESSION) { AuthSession(UserId(userId.value, userId.domain), accessToken, refreshToken, tokenType, serverConfig) }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -13,6 +13,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.TeamDAO
 import com.wire.kalium.persistence.dao.TeamEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.UserEntity
 import io.mockative.ConfigurationApi
@@ -143,7 +144,7 @@ class TeamRepositoryTest {
             team = "teamId",
             previewAssetId = null,
             completeAssetId = null,
-            availabilityStatus = null
+            availabilityStatus = UserAvailabilityStatusEntity.NONE
         )
 
         given(userMapper)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -142,7 +142,8 @@ class TeamRepositoryTest {
             accentId = 1,
             team = "teamId",
             previewAssetId = null,
-            completeAssetId = null
+            completeAssetId = null,
+            availabilityStatus = null
         )
 
         given(userMapper)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/AvailabilityStatusMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/AvailabilityStatusMapperTest.kt
@@ -17,7 +17,7 @@ class AvailabilityStatusMapperTest {
     @Test
     fun givenDaoAvailabilityStatus_whenMappingFromDao_thenApiStatusReturn() {
         val expectedResult = UserAvailabilityStatus.AVAILABLE
-        val result = availabilityStatusMapper.fromDaoAvailabilityStatusToUser(UserAvailabilityStatusEntity.AVAILABLE)
+        val result = availabilityStatusMapper.fromDaoAvailabilityStatusToModel(UserAvailabilityStatusEntity.AVAILABLE)
 
         assertEquals(expectedResult, result)
     }
@@ -25,7 +25,7 @@ class AvailabilityStatusMapperTest {
     @Test
     fun givenApiAvailabilityStatus_whenMappingFromApi_thenDaoStatusReturn() {
         val expectedResult = UserAvailabilityStatus.BUSY
-        val result = availabilityStatusMapper.fromDaoAvailabilityStatusToUser(UserAvailabilityStatusEntity.BUSY)
+        val result = availabilityStatusMapper.fromDaoAvailabilityStatusToModel(UserAvailabilityStatusEntity.BUSY)
 
         assertEquals(expectedResult, result)
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/AvailabilityStatusMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/AvailabilityStatusMapperTest.kt
@@ -1,0 +1,32 @@
+package com.wire.kalium.logic.data.user
+
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AvailabilityStatusMapperTest {
+
+    private lateinit var availabilityStatusMapper: AvailabilityStatusMapper
+
+    @BeforeTest
+    fun setUp() {
+        availabilityStatusMapper = AvailabilityStatusMapperImpl()
+    }
+
+    @Test
+    fun givenDaoAvailabilityStatus_whenMappingFromDao_thenApiStatusReturn() {
+        val expectedResult = UserAvailabilityStatus.AVAILABLE
+        val result = availabilityStatusMapper.fromDaoAvailabilityStatusToUser(UserAvailabilityStatusEntity.AVAILABLE)
+
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun givenApiAvailabilityStatus_whenMappingFromApi_thenDaoStatusReturn() {
+        val expectedResult = UserAvailabilityStatus.BUSY
+        val result = availabilityStatusMapper.fromDaoAvailabilityStatusToUser(UserAvailabilityStatusEntity.BUSY)
+
+        assertEquals(expectedResult, result)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.framework.TestTeam
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.UserEntity
 import io.mockative.Mock
 import io.mockative.classOf
@@ -45,7 +46,7 @@ class UserMapperTest {
             connectionStatus = ConnectionEntity.State.ACCEPTED,
             previewAssetId = null,
             completeAssetId = null,
-            availabilityStatus = null
+            availabilityStatus = UserAvailabilityStatusEntity.NONE
         )
 
         val result = userMapper.fromTeamMemberToDaoModel(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
@@ -44,7 +44,8 @@ class UserMapperTest {
             team = "teamId",
             connectionStatus = ConnectionEntity.State.ACCEPTED,
             previewAssetId = null,
-            completeAssetId = null
+            completeAssetId = null,
+            availabilityStatus = null
         )
 
         val result = userMapper.fromTeamMemberToDaoModel(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserTypeMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserTypeMapperTest.kt
@@ -86,7 +86,8 @@ class UserTypeMapperTest {
             team = team,
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = "testPreviewPicture",
-            completePicture = "testCompletePicture"
+            completePicture = "testCompletePicture",
+            availabilityStatus = null
         )
     }
 
@@ -104,7 +105,8 @@ class UserTypeMapperTest {
             team = team,
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = "testPreviewPicture",
-            completePicture = "testCompletePicture"
+            completePicture = "testCompletePicture",
+            availabilityStatus = null,
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserTypeMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserTypeMapperTest.kt
@@ -87,7 +87,7 @@ class UserTypeMapperTest {
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = "testPreviewPicture",
             completePicture = "testCompletePicture",
-            availabilityStatus = null
+            availabilityStatus = UserAvailabilityStatus.NONE
         )
     }
 
@@ -106,7 +106,7 @@ class UserTypeMapperTest {
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = "testPreviewPicture",
             completePicture = "testCompletePicture",
-            availabilityStatus = null,
+            availabilityStatus = UserAvailabilityStatus.NONE,
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
@@ -150,7 +151,8 @@ class SendAssetMessageUseCaseTest {
             null,
             ConnectionState.ACCEPTED,
             "some_key",
-            "some_key"
+            "some_key",
+            UserAvailabilityStatus.NONE
         )
 
         val sendAssetUseCase =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
@@ -152,7 +152,8 @@ class SendImageUseCaseTest {
             null,
             ConnectionState.ACCEPTED,
             "some_key",
-            "some_key"
+            "some_key",
+            null
         )
 
         val sendImageUseCase =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
@@ -153,7 +154,7 @@ class SendImageUseCaseTest {
             ConnectionState.ACCEPTED,
             "some_key",
             "some_key",
-            null
+            UserAvailabilityStatus.NONE
         )
 
         val sendImageUseCase =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -102,7 +102,8 @@ class GetOrCreateOneToOneConversationUseCaseTest {
             accentId = 0,
             team = null,
             previewPicture = null,
-            completePicture = null
+            completePicture = null,
+            availabilityStatus = null
         )
         val CONVERSATION_DETAILS = ConversationDetails.OneOne(
             CONVERSATION,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -10,6 +10,7 @@ import com.wire.kalium.logic.data.conversation.UserType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.persistence.dao.ConversationEntity
@@ -103,7 +104,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
             team = null,
             previewPicture = null,
             completePicture = null,
-            availabilityStatus = null
+            availabilityStatus = UserAvailabilityStatus.NONE
         )
         val CONVERSATION_DETAILS = ConversationDetails.OneOne(
             CONVERSATION,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -14,6 +14,7 @@ import com.wire.kalium.logic.data.notification.LocalNotificationCommentType
 import com.wire.kalium.logic.data.notification.LocalNotificationMessage
 import com.wire.kalium.logic.data.notification.LocalNotificationMessageAuthor
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.framework.TestUser
 import io.mockative.Mock
@@ -382,7 +383,7 @@ class GetNotificationsUseCaseTest {
                 previewPicture = null,
                 completePicture = null,
                 team = null,
-                availabilityStatus = null
+                availabilityStatus = UserAvailabilityStatus.NONE
             )
 
         private fun otherUserName(id: QualifiedID) = "Other User Name ${id.value}"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -381,7 +381,8 @@ class GetNotificationsUseCaseTest {
                 accentId = 0,
                 previewPicture = null,
                 completePicture = null,
-                team = null
+                team = null,
+                availabilityStatus = null
             )
 
         private fun otherUserName(id: QualifiedID) = "Other User Name ${id.value}"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.configuration.ServerConfig
 import com.wire.kalium.logic.data.register.RegisterAccountRepository
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.functional.Either
@@ -228,7 +229,7 @@ class RegisterAccountUseCaseTest {
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = null,
             completePicture = null,
-            availabilityStatus = null
+            availabilityStatus = UserAvailabilityStatus.NONE
         )
         val TEST_AUTH_SESSION = AuthSession(TEST_SELF_USER.id, "access_token", "refresh_token", "token_type", TEST_SERVER_CONFIG)
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCaseTest.kt
@@ -227,7 +227,8 @@ class RegisterAccountUseCaseTest {
             team = null,
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = null,
-            completePicture = null
+            completePicture = null,
+            availabilityStatus = null
         )
         val TEST_AUTH_SESSION = AuthSession(TEST_SELF_USER.id, "access_token", "refresh_token", "token_type", TEST_SERVER_CONFIG)
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.feature.publicuser.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.SearchKnownUsersUseCaseImpl
 import io.ktor.client.plugins.convertLongTimeoutToLongWithInfiniteAsZero
@@ -57,7 +58,7 @@ class SearchKnownUserUseCaseTest {
                             connectionStatus = ConnectionState.ACCEPTED,
                             previewPicture = null,
                             completePicture = null,
-                            availabilityStatus = null
+                            availabilityStatus = UserAvailabilityStatus.NONE
                         )
                     )
                 )
@@ -101,7 +102,7 @@ class SearchKnownUserUseCaseTest {
                             connectionStatus = ConnectionState.ACCEPTED,
                             previewPicture = null,
                             completePicture = null,
-                            availabilityStatus = null
+                            availabilityStatus = UserAvailabilityStatus.NONE
                         )
                     )
                 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -56,7 +56,8 @@ class SearchKnownUserUseCaseTest {
                             team = null,
                             connectionStatus = ConnectionState.ACCEPTED,
                             previewPicture = null,
-                            completePicture = null
+                            completePicture = null,
+                            availabilityStatus = null
                         )
                     )
                 )
@@ -99,7 +100,8 @@ class SearchKnownUserUseCaseTest {
                             team = null,
                             connectionStatus = ConnectionState.ACCEPTED,
                             previewPicture = null,
-                            completePicture = null
+                            completePicture = null,
+                            availabilityStatus = null
                         )
                     )
                 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserDirectoryUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserDirectoryUseCaseTest.kt
@@ -89,7 +89,8 @@ class SearchUserDirectoryUseCaseTest {
                         team = null,
                         connectionStatus = ConnectionState.ACCEPTED,
                         previewPicture = null,
-                        completePicture = null
+                        completePicture = null,
+                        availabilityStatus = null
                     )
                 }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserDirectoryUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserDirectoryUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.feature.publicuser.Result
 import com.wire.kalium.logic.feature.publicuser.SearchUserDirectoryUseCase
 import com.wire.kalium.logic.feature.publicuser.SearchUserDirectoryUseCaseImpl
@@ -90,7 +91,7 @@ class SearchUserDirectoryUseCaseTest {
                         connectionStatus = ConnectionState.ACCEPTED,
                         previewPicture = null,
                         completePicture = null,
-                        availabilityStatus = null
+                        availabilityStatus = UserAvailabilityStatus.NONE
                     )
                 }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UploadUserAvatarUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UploadUserAvatarUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.asset.UploadedAssetId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.Either
@@ -99,6 +100,7 @@ class UploadUserAvatarUseCaseTest {
         null,
         ConnectionState.ACCEPTED,
         "some_key",
-        "some_key"
+        "some_key",
+        UserAvailabilityStatus.NONE
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 
@@ -21,7 +22,8 @@ object TestUser {
         team = "teamId",
         connectionStatus = ConnectionState.ACCEPTED,
         previewPicture = UserAssetId(),
-        completePicture = UserAssetId()
+        completePicture = UserAssetId(),
+        availabilityStatus = UserAvailabilityStatus.NONE
     )
 
     val OTHER = OtherUser(
@@ -34,6 +36,7 @@ object TestUser {
         team = "otherTeamId",
         connectionStatus = ConnectionState.ACCEPTED,
         previewPicture = UserAssetId(),
-        completePicture = UserAssetId()
+        completePicture = UserAssetId(),
+        availabilityStatus = UserAvailabilityStatus.NONE
     )
 }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -89,6 +89,7 @@ actual class UserDatabaseProvider(private val context: Context, userId: UserIDEn
                 qualified_idAdapter = QualifiedIDAdapter(),
                 accent_idAdapter = IntColumnAdapter,
                 connection_statusAdapter = EnumColumnAdapter(),
+                user_availability_statusAdapter = EnumColumnAdapter(),
             )
         )
     }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -1,5 +1,6 @@
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
 import com.wire.kalium.persistence.dao.ConnectionEntity;
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity;
 import kotlin.Int;
 
 CREATE TABLE User (
@@ -12,7 +13,8 @@ CREATE TABLE User (
     team TEXT,
     connection_status TEXT AS ConnectionEntity.State NOT NULL DEFAULT 'NOT_CONNECTED',
     preview_asset_id TEXT,
-    complete_asset_id TEXT
+    complete_asset_id TEXT,
+    user_availability_status TEXT AS UserAvailabilityStatusEntity
 );
 
 deleteAllUsers:
@@ -77,3 +79,6 @@ UPDATE User SET handle = ? WHERE qualified_id = ?;
 
 selectChanges:
 SELECT changes();
+
+updateUserAvailabilityStatus:
+UPDATE User SET user_availability_status = ? WHERE qualified_id = ?;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -14,7 +14,7 @@ CREATE TABLE User (
     connection_status TEXT AS ConnectionEntity.State NOT NULL DEFAULT 'NOT_CONNECTED',
     preview_asset_id TEXT,
     complete_asset_id TEXT,
-    user_availability_status TEXT AS UserAvailabilityStatusEntity
+    user_availability_status TEXT AS UserAvailabilityStatusEntity NOT NULL DEFAULT 'NONE'
 );
 
 deleteAllUsers:

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -12,6 +12,10 @@ data class QualifiedIDEntity(
 typealias UserIDEntity = QualifiedIDEntity
 typealias ConversationIDEntity = QualifiedIDEntity
 
+enum class UserAvailabilityStatusEntity {
+    NONE, AVAILABLE, BUSY, AWAY
+}
+
 data class UserEntity(
     val id: QualifiedIDEntity,
     val name: String?,
@@ -22,7 +26,10 @@ data class UserEntity(
     val team: String?,
     val connectionStatus: ConnectionEntity.State = ConnectionEntity.State.NOT_CONNECTED,
     val previewAssetId: UserAssetIdEntity?,
-    val completeAssetId: UserAssetIdEntity?
+    val completeAssetId: UserAssetIdEntity?,
+    // for now availabilityStatus is stored only locally and ignored for API models,
+    // later, when API start supporting it, it should be added into API model too
+    val availabilityStatus: UserAvailabilityStatusEntity?
 )
 
 internal typealias UserAssetIdEntity = String
@@ -72,8 +79,9 @@ interface UserDAO {
     suspend fun getUserByHandleAndConnectionState(
         handle: String,
         connectionState: ConnectionEntity.State
-    ) : List<UserEntity>
+    ): List<UserEntity>
 
     suspend fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity)
     suspend fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String)
+    suspend fun updateUserAvailabilityStatus(qualifiedID: QualifiedIDEntity, status: UserAvailabilityStatusEntity)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -29,7 +29,7 @@ data class UserEntity(
     val completeAssetId: UserAssetIdEntity?,
     // for now availabilityStatus is stored only locally and ignored for API models,
     // later, when API start supporting it, it should be added into API model too
-    val availabilityStatus: UserAvailabilityStatusEntity?
+    val availabilityStatus: UserAvailabilityStatusEntity
 )
 
 internal typealias UserAssetIdEntity = String

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -20,7 +20,8 @@ class UserMapper {
             team = user.team,
             connectionStatus = user.connection_status,
             previewAssetId = user.preview_asset_id,
-            completeAssetId = user.complete_asset_id
+            completeAssetId = user.complete_asset_id,
+            availabilityStatus = user.user_availability_status
         )
     }
 }
@@ -136,6 +137,10 @@ class UserDAOImpl(private val queries: UsersQueries) : UserDAO {
 
     override suspend fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String) {
         queries.updateUserhandle(handle, qualifiedID)
+    }
+
+    override suspend fun updateUserAvailabilityStatus(qualifiedID: QualifiedIDEntity, status: UserAvailabilityStatusEntity) {
+        queries.updateUserAvailabilityStatus(status, qualifiedID)
     }
 
     override suspend fun getAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): List<UserEntity> =

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -59,7 +59,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
             user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
-            ConnectionEntity.State.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity(), null
+            ConnectionEntity.State.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity(), UserAvailabilityStatusEntity.NONE
         )
         db.userDAO.updateSelfUser(updatedUser1)
         val result = db.userDAO.getUserByQualifiedID(user1.id).first()
@@ -71,7 +71,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
             user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
-            ConnectionEntity.State.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity(), null
+            ConnectionEntity.State.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity(), UserAvailabilityStatusEntity.NONE
         )
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
@@ -86,7 +86,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
             user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
-            ConnectionEntity.State.ACCEPTED, null, null, null
+            ConnectionEntity.State.ACCEPTED, null, null, UserAvailabilityStatusEntity.NONE
         )
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
@@ -161,7 +161,9 @@ class UserDAOTest : BaseDatabaseTest() {
                     accentId = 4,
                     team = "testTeam4",
                     ConnectionEntity.State.ACCEPTED,
-                    null, null, null
+                    null,
+                    null,
+                    UserAvailabilityStatusEntity.NONE
                 ),
                 UserEntity(
                     id = QualifiedIDEntity("5", "wire.com"),
@@ -172,7 +174,9 @@ class UserDAOTest : BaseDatabaseTest() {
                     accentId = 5,
                     team = "testTeam5",
                     ConnectionEntity.State.ACCEPTED,
-                    null, null, null
+                    null,
+                    null,
+                    UserAvailabilityStatusEntity.NONE
                 )
             )
             val mockUsers = commonEmailUsers + notCommonEmailUsers

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -59,7 +59,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
             user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
-            ConnectionEntity.State.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity()
+            ConnectionEntity.State.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity(), null
         )
         db.userDAO.updateSelfUser(updatedUser1)
         val result = db.userDAO.getUserByQualifiedID(user1.id).first()
@@ -71,7 +71,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
             user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
-            ConnectionEntity.State.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity()
+            ConnectionEntity.State.ACCEPTED, UserAssetIdEntity(), UserAssetIdEntity(), null
         )
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
@@ -86,7 +86,7 @@ class UserDAOTest : BaseDatabaseTest() {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
             user1.id, "John Doe", "johndoe", "email1", "phone1", 1, "team",
-            ConnectionEntity.State.ACCEPTED, null, null
+            ConnectionEntity.State.ACCEPTED, null, null, null
         )
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
@@ -161,7 +161,7 @@ class UserDAOTest : BaseDatabaseTest() {
                     accentId = 4,
                     team = "testTeam4",
                     ConnectionEntity.State.ACCEPTED,
-                    null, null
+                    null, null, null
                 ),
                 UserEntity(
                     id = QualifiedIDEntity("5", "wire.com"),
@@ -172,7 +172,7 @@ class UserDAOTest : BaseDatabaseTest() {
                     accentId = 5,
                     team = "testTeam5",
                     ConnectionEntity.State.ACCEPTED,
-                    null, null
+                    null, null, null
                 )
             )
             val mockUsers = commonEmailUsers + notCommonEmailUsers

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.persistence.utils.stubs
 
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.UserEntity
 
 fun newUserEntity(id: String = "test") =
@@ -14,7 +15,7 @@ fun newUserEntity(id: String = "test") =
         accentId = 1,
         team = "team",
         ConnectionEntity.State.ACCEPTED,
-        null, null
+        null, null, null
     )
 
 fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
@@ -27,7 +28,7 @@ fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
         accentId = 1,
         team = "team",
         ConnectionEntity.State.ACCEPTED,
-        null, null
+        null, null, null
     )
 
 fun newUserEntity(
@@ -41,6 +42,7 @@ fun newUserEntity(
     connectionStatus: ConnectionEntity.State = ConnectionEntity.State.ACCEPTED,
     previewAssetId: String = "previewAssetId",
     completeAssetId: String = "completeAssetId",
+    availabilityStatusEntity: UserAvailabilityStatusEntity? = null
 ): UserEntity {
     return UserEntity(
         id = QualifiedIDEntity(id, "wire.com"),
@@ -52,6 +54,7 @@ fun newUserEntity(
         team = team,
         connectionStatus = connectionStatus,
         previewAssetId = previewAssetId,
-        completeAssetId = completeAssetId
+        completeAssetId = completeAssetId,
+        availabilityStatus = availabilityStatusEntity
     )
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
@@ -31,6 +31,7 @@ fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
         null, null, null
     )
 
+@Suppress("LongParameterList")
 fun newUserEntity(
     id: String = "test",
     name: String = "testName",

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
@@ -15,7 +15,9 @@ fun newUserEntity(id: String = "test") =
         accentId = 1,
         team = "team",
         ConnectionEntity.State.ACCEPTED,
-        null, null, null
+        null,
+        null,
+        UserAvailabilityStatusEntity.NONE
     )
 
 fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
@@ -28,7 +30,9 @@ fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
         accentId = 1,
         team = "team",
         ConnectionEntity.State.ACCEPTED,
-        null, null, null
+        null,
+        null,
+        UserAvailabilityStatusEntity.NONE
     )
 
 @Suppress("LongParameterList")

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
@@ -43,7 +43,7 @@ fun newUserEntity(
     connectionStatus: ConnectionEntity.State = ConnectionEntity.State.ACCEPTED,
     previewAssetId: String = "previewAssetId",
     completeAssetId: String = "completeAssetId",
-    availabilityStatusEntity: UserAvailabilityStatusEntity? = null
+    availabilityStatusEntity: UserAvailabilityStatusEntity = UserAvailabilityStatusEntity.NONE
 ): UserEntity {
     return UserEntity(
         id = QualifiedIDEntity(id, "wire.com"),

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -66,7 +66,8 @@ actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
             User.Adapter(
                 qualified_idAdapter = QualifiedIDAdapter(),
                 accent_idAdapter = IntColumnAdapter,
-                connection_statusAdapter = EnumColumnAdapter()
+                connection_statusAdapter = EnumColumnAdapter(),
+                user_availability_statusAdapter = EnumColumnAdapter(),
             )
         )
         driver.execute(null, "PRAGMA foreign_keys=ON", 0)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -82,7 +82,8 @@ actual class UserDatabaseProvider(private val storePath: File) {
             User.Adapter(
                 qualified_idAdapter = QualifiedIDAdapter(),
                 accent_idAdapter = IntColumnAdapter,
-                connection_statusAdapter = EnumColumnAdapter()
+                connection_statusAdapter = EnumColumnAdapter(),
+                user_availability_statusAdapter = EnumColumnAdapter(),
             )
         )
     }


### PR DESCRIPTION
## Tasks [AR-1741](https://wearezeta.atlassian.net/browse/AR-1741),  [AR-1742](https://wearezeta.atlassian.net/browse/AR-1742),  [AR-1743](https://wearezeta.atlassian.net/browse/AR-1743)

# What's new in this PR?
- added `user_availability_status` filed into Users DB
- added `availabilityStatus` filed into Entity and Logic Users
- updated mappers for all these Users
- added `UpdateSelfAvailabilityStatusUseCase` for updating self Availability Status in the app