### PR TITLE
feat: (AR-1553) Splitting search query for federated search

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -18,6 +18,7 @@ data class QualifiedID(
 }
 
 const val VALUE_DOMAIN_SEPARATOR = "@"
+val FEDERATION_REGEX = Regex("[^@.]+@[^@.]+\\.[^@]+")
 
 typealias ConversationId = QualifiedID
 
@@ -38,4 +39,12 @@ fun String.parseIntoQualifiedID(): QualifiedID {
     val components = split("@")
     if (components.size < 2) throw IllegalStateException("The string trying to parse is not a valid one")
     return QualifiedID(value = components.first(), domain = components.last())
+}
+
+fun String.parseSearchQueryToQualifiedID(): QualifiedID {
+    val isFederationSearch = matches(FEDERATION_REGEX)
+
+    return if (isFederationSearch) parseIntoQualifiedID() else
+        QualifiedID(this, "")
+
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/FederationRegexTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/FederationRegexTest.kt
@@ -1,0 +1,84 @@
+package com.wire.kalium.logic.data.id
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FederationRegexTest {
+    @Test
+    fun givenUser_correctFederatedId_matchesRegex() {
+        val userId = "damian@wire.com"
+
+        assertTrue(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_doubleDotFederation_matchesRegex() {
+        val userId = "damian@wire.com.pl"
+
+        assertTrue(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_tripleDotFederation_matchesRegex() {
+        val userId = "damian@wire.com.pl.anything"
+
+        assertTrue(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_containsNumericCharacters_matchesRegex() {
+        val userId = "damian1@wire1.com1.pl1.anything1"
+
+        assertTrue(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_containsSpecialCharacters_matchesRegex() {
+        val userId = "damian1!#$%^&*()@wire1!#$%^&*().com1!#$%^&*().pl!#$%^&*()1.anything1!#$%^&*()"
+
+        assertTrue(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_containsDoubleAtCharacter_notMatchesRegex() {
+        val userId = "dam@ian@wire.com.pl.anything"
+
+        assertFalse(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_missingAtCharacter_notMatchesRegex() {
+        val userId = "damianwire.com.pl.anything"
+
+        assertFalse(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_missingDotCharacter_notMatchesRegex() {
+        val userId = "damian@wire"
+
+        assertFalse(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_dotBeforeAtCharacter_notMatchesRegex() {
+        val userId = "wire.com@damian"
+
+        assertFalse(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_startsWithAtCharacter_notMatchesRegex() {
+        val userId = "@damian.wire.com"
+
+        assertFalse(userId.matches(FEDERATION_REGEX))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_endsWithAtCharacter_notMatchesRegex() {
+        val userId = "damian.wire.com@"
+
+        assertFalse(userId.matches(FEDERATION_REGEX))
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/ParseSearchQueryToQualifiedIDTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/ParseSearchQueryToQualifiedIDTest.kt
@@ -1,0 +1,57 @@
+package com.wire.kalium.logic.data.id
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ParseSearchQueryToQualifiedIDTest {
+    @Test
+    fun givenUser_correctFederatedId_splitToValueAndDomain() {
+        val searchQuery = "damian@wire.com"
+
+        assertEquals(searchQuery.parseSearchQueryToQualifiedID(), QualifiedID("damian", "wire.com"))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_doubleDotFederation_splitToValueAndDomain() {
+        val searchQuery = "damian@wire.com.pl"
+
+        assertEquals(searchQuery.parseSearchQueryToQualifiedID(), QualifiedID("damian", "wire.com.pl"))
+    }
+
+
+    @Test
+    fun givenUser_correctFederatedId_containsDoubleAtCharacter_everythingIsValue_domainIsEmpty() {
+        val searchQuery = "dam@ian@wire.com.pl.anything"
+
+        assertEquals(searchQuery.parseSearchQueryToQualifiedID(), QualifiedID("dam@ian@wire.com.pl.anything", ""))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_missingAtCharacter_everythingIsValue_domainIsEmpty() {
+        val searchQuery = "damianwire.com.pl.anything"
+
+        assertEquals(searchQuery.parseSearchQueryToQualifiedID(), QualifiedID("damianwire.com.pl.anything", ""))
+    }
+
+
+    @Test
+    fun givenUser_correctFederatedId_dotBeforeAtCharacter_everythingIsValue_domainIsEmpty() {
+        val searchQuery = "wire.com@damian"
+
+        assertEquals(searchQuery.parseSearchQueryToQualifiedID(), QualifiedID("wire.com@damian", ""))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_startsWithAtCharacter_everythingIsValue_domainIsEmpty() {
+        val searchQuery = "@damian.wire.com"
+
+        assertEquals(searchQuery.parseSearchQueryToQualifiedID(), QualifiedID("@damian.wire.com", ""))
+    }
+
+    @Test
+    fun givenUser_correctFederatedId_endsWithAtCharacter_everythingIsValue_domainIsEmpty() {
+        val searchQuery = "damian.wire.com@"
+
+        assertEquals(searchQuery.parseSearchQueryToQualifiedID(), QualifiedID("damian.wire.com@", ""))
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This is logic needed in the android reload repo https://github.com/wireapp/wire-android-reloaded/pull/649

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
https://wearezeta.atlassian.net/browse/AR-1553
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
