### PR TITLE
fix: ignore or hide some message types [AR-1827]

### DIFF
--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -93,7 +93,7 @@ class CallManagerTest {
         val CLIENT_ID = ClientId(value = "clientId")
         val USER_ID = UserId(value = "userId", domain = "domainId")
         val CALL_CONTENT = MessageContent.Calling(value = "content")
-        val CALL_MESSAGE = Message.Client(
+        val CALL_MESSAGE = Message.Regular(
             id = "id",
             content = CALL_CONTENT,
             conversationId = ConversationId(value = "value", domain = "domain"),

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -127,7 +127,7 @@ actual class CallManagerImpl(
         return calling.action(handle)
     }
 
-    override suspend fun onCallingMessageReceived(message: Message.Client, content: MessageContent.Calling) =
+    override suspend fun onCallingMessageReceived(message: Message.Regular, content: MessageContent.Calling) =
         withCalling {
             callingLogger.i("$TAG - onCallingMessageReceived called")
             val msg = content.value.toByteArray()

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
@@ -64,7 +64,7 @@ class OnHttpRequest(
     ): Either<CoreFailure, Unit> {
         val messageContent = MessageContent.Calling(data)
         val date = Clock.System.now().toString()
-        val message = Message.Client(
+        val message = Message.Regular(
             id = uuid4().toString(),
             content = messageContent,
             conversationId = conversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -15,9 +15,9 @@ sealed class Message(
     open val visibility: Visibility
 ) {
 
-    data class Client(
+    data class Regular(
         override val id: String,
-        override val content: MessageContent.Client,
+        override val content: MessageContent.Regular,
         override val conversationId: ConversationId,
         override val date: String,
         override val senderUserId: UserId,
@@ -27,9 +27,9 @@ sealed class Message(
         val editStatus : EditStatus
     ) : Message(id, content, conversationId, date, senderUserId, status, visibility)
 
-    data class Server(
+    data class System(
         override val id: String,
-        override val content: MessageContent.Server,
+        override val content: MessageContent.System,
         override val conversationId: ConversationId,
         override val date: String,
         override val senderUserId: UserId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -5,31 +5,36 @@ import com.wire.kalium.protobuf.messages.QualifiedConversationId
 
 sealed class MessageContent {
 
-    sealed class Client : MessageContent()
-    sealed class Server : MessageContent()
+    sealed class System : MessageContent()
+    sealed class FromProto : MessageContent()
+    sealed class Regular : FromProto()
+    sealed class Signaling : FromProto()
 
     // client message content types
-    data class Text(val value: String) : Client()
-    data class Calling(val value: String) : Client()
-    data class Asset(val value: AssetContent) : Client()
-    data class DeleteMessage(val messageId: String) : Client()
-    data class TextEdited(val editMessageId :String, val newContent : String) : Client()
+    data class Text(val value: String) : Regular()
+    data class Calling(val value: String) : Regular()
+    data class Asset(val value: AssetContent) : Regular()
+    data class DeleteMessage(val messageId: String) : Regular()
+    data class TextEdited(val editMessageId :String, val newContent : String) : Regular()
     data class DeleteForMe(
         val messageId: String,
         val conversationId: String,
         val qualifiedConversationId: QualifiedConversationId?
-    ) : Client()
+    ) : Regular()
 
     data class Unknown( // messages that aren't yet handled properly but stored in db in case
         val typeName: String? = null,
-        val encodedData: ByteArray? = null
-    ) : Client()
-    object Ignored : Client() // messages that aren't processed in any way
-    object Empty : Client()
+        val encodedData: ByteArray? = null,
+        val hidden: Boolean = false
+    ) : Regular()
+    object Empty : Regular()
 
     // server message content types
-    sealed class MemberChange(open val members: List<Member>) : Server() {
+    sealed class MemberChange(open val members: List<Member>) : System() {
         data class Added(override val members: List<Member>) : MemberChange(members)
         data class Removed(override val members: List<Member>) : MemberChange(members)
     }
+
+    // we can add other types to be processed, but signaling ones shouldn't be persisted
+    object Ignored : Signaling() // messages that aren't processed in any way
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -20,7 +20,10 @@ sealed class MessageContent {
         val qualifiedConversationId: QualifiedConversationId?
     ) : Client()
 
-    data class Unknown(val encodedData: ByteArray? = null) : Client() // messages that aren't yet handled properly but stored in db in case
+    data class Unknown( // messages that aren't yet handled properly but stored in db in case
+        val typeName: String? = null,
+        val encodedData: ByteArray? = null
+    ) : Client()
     object Ignored : Client() // messages that aren't processed in any way
     object Empty : Client()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -20,7 +20,8 @@ sealed class MessageContent {
         val qualifiedConversationId: QualifiedConversationId?
     ) : Client()
 
-    data class Unknown(val encodedData: ByteArray? = null) : Client()
+    data class Unknown(val encodedData: ByteArray? = null) : Client() // messages that aren't yet handled properly but stored in db in case
+    object Ignored : Client() // messages that aren't processed in any way
     object Empty : Client()
 
     // server message content types

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -32,11 +32,7 @@ class MessageMapperImpl(
             Message.Status.READ -> MessageEntity.Status.READ
             Message.Status.FAILED -> MessageEntity.Status.FAILED
         }
-        val visibility = when (message.visibility) {
-            Message.Visibility.VISIBLE -> MessageEntity.Visibility.VISIBLE
-            Message.Visibility.HIDDEN -> MessageEntity.Visibility.HIDDEN
-            Message.Visibility.DELETED -> MessageEntity.Visibility.DELETED
-        }
+        val visibility = message.visibility.toEntityVisibility()
         return when (message) {
             is Message.Client -> MessageEntity.Client(
                 id = message.id,
@@ -178,4 +174,10 @@ class MessageMapperImpl(
             }
         }
     }
+}
+
+fun Message.Visibility.toEntityVisibility(): MessageEntity.Visibility = when (this) {
+    Message.Visibility.VISIBLE -> MessageEntity.Visibility.VISIBLE
+    Message.Visibility.HIDDEN -> MessageEntity.Visibility.HIDDEN
+    Message.Visibility.DELETED -> MessageEntity.Visibility.DELETED
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -141,7 +141,7 @@ class MessageMapperImpl(
                 assetNormalizedLoudness = if (metadata is Audio) metadata.normalizedLoudness else null
             )
         }
-        is MessageContent.Unknown -> MessageEntityContent.Unknown(this.encodedData)
+        is MessageContent.Unknown -> MessageEntityContent.Unknown(this.typeName, this.encodedData)
         else -> MessageEntityContent.Unknown()
     }
 
@@ -162,7 +162,7 @@ class MessageMapperImpl(
         is MessageEntityContent.Asset -> MessageContent.Asset(
             MapperProvider.assetMapper().fromAssetEntityToAssetContent(this)
         )
-        is MessageEntityContent.Unknown -> MessageContent.Unknown(this.encodedData)
+        is MessageEntityContent.Unknown -> MessageContent.Unknown(this.typeName, this.encodedData)
     }
 
     private fun MessageEntityContent.Server.toMessageContent(): MessageContent.Server = when (this) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -31,7 +31,6 @@ import kotlinx.datetime.Clock
 
 @Suppress("TooManyFunctions")
 interface MessageRepository {
-    suspend fun getMessagesForConversation(conversationId: ConversationId, limit: Int, offset: Int): Flow<List<Message>>
     suspend fun persistMessage(message: Message): Either<CoreFailure, Unit>
     suspend fun deleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun markMessageAsDeleted(messageUuid: String, conversationId: ConversationId): Either<StorageFailure, Unit>
@@ -51,7 +50,17 @@ interface MessageRepository {
     suspend fun updateMessageDate(conversationId: ConversationId, messageUuid: String, date: String): Either<CoreFailure, Unit>
     suspend fun updatePendingMessagesAddMillisToDate(conversationId: ConversationId, millis: Long): Either<CoreFailure, Unit>
     suspend fun getMessageById(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Message>
-    suspend fun getMessagesByConversationAfterDate(conversationId: ConversationId, date: String): Flow<List<Message>>
+    suspend fun getMessagesByConversationIdAndVisibility(
+        conversationId: ConversationId,
+        limit: Int,
+        offset: Int,
+        visibility: List<Message.Visibility> = Message.Visibility.values().toList()
+    ): Flow<List<Message>>
+    suspend fun getMessagesByConversationIdAndVisibilityAfterDate(
+        conversationId: ConversationId,
+        date: String,
+        visibility: List<Message.Visibility> = Message.Visibility.values().toList()
+    ): Flow<List<Message>>
 
     /**
      * Send a Proteus [MessageEnvelope] to the given [conversationId].
@@ -90,11 +99,18 @@ class MessageDataSource(
     private val sendMessageFailureMapper: SendMessageFailureMapper = MapperProvider.sendMessageFailureMapper()
 ) : MessageRepository {
 
-    override suspend fun getMessagesForConversation(conversationId: ConversationId, limit: Int, offset: Int): Flow<List<Message>> {
-        return messageDAO.getMessagesByConversation(idMapper.toDaoModel(conversationId), limit, offset).map { messagelist ->
-            messagelist.map(messageMapper::fromEntityToMessage)
-        }
-    }
+    override suspend fun getMessagesByConversationIdAndVisibility(
+        conversationId: ConversationId,
+        limit: Int,
+        offset: Int,
+        visibility: List<Message.Visibility>
+    ): Flow<List<Message>> =
+        messageDAO.getMessagesByConversationAndVisibility(
+            idMapper.toDaoModel(conversationId),
+            limit,
+            offset,
+            visibility.map { it.toEntityVisibility() }
+        ).map { messagelist -> messagelist.map(messageMapper::fromEntityToMessage) }
 
     override suspend fun persistMessage(message: Message): Either<CoreFailure, Unit> = wrapStorageRequest {
         messageDAO.insertMessage(messageMapper.fromMessageToEntity(message))
@@ -130,11 +146,15 @@ class MessageDataSource(
             Either.Left(it)
         }
 
-    override suspend fun getMessagesByConversationAfterDate(conversationId: ConversationId, date: String): Flow<List<Message>> {
-        return messageDAO.getMessagesByConversationAfterDate(idMapper.toDaoModel(conversationId), date).map { messageList ->
-            messageList.map(messageMapper::fromEntityToMessage)
-        }
-    }
+    override suspend fun getMessagesByConversationIdAndVisibilityAfterDate(
+        conversationId: ConversationId,
+        date: String,
+        visibility: List<Message.Visibility>
+    ): Flow<List<Message>> = messageDAO.getMessagesByConversationAndVisibilityAfterDate(
+        idMapper.toDaoModel(conversationId),
+        date,
+        visibility.map { it.toEntityVisibility() }
+    ).map { messageList -> messageList.map(messageMapper::fromEntityToMessage) }
 
     override suspend fun updateMessageStatus(messageStatus: MessageEntity.Status, conversationId: ConversationId, messageUuid: String) =
         wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
@@ -1,3 +1,7 @@
 package com.wire.kalium.logic.data.message
 
-data class ProtoContent(val messageUid: String, val messageContent: MessageContent.Client)
+data class ProtoContent(
+    val messageUid: String,
+    val messageContent: MessageContent.Client,
+    val visibility: Message.Visibility = Message.Visibility.VISIBLE
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
@@ -2,6 +2,5 @@ package com.wire.kalium.logic.data.message
 
 data class ProtoContent(
     val messageUid: String,
-    val messageContent: MessageContent.Client,
-    val visibility: Message.Visibility = Message.Visibility.VISIBLE
+    val messageContent: MessageContent.FromProto
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -81,6 +81,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
         return PlainMessageBlob(message.encodeToByteArray())
     }
 
+    @Suppress("ComplexMethod", "LongMethod")
     override fun decodeFromProtobuf(encodedContent: PlainMessageBlob): ProtoContent {
         val genericMessage = GenericMessage.decodeFromByteArray(encodedContent.data)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -16,10 +16,12 @@ import com.wire.kalium.protobuf.messages.Text
 import com.wire.kalium.protobuf.messages.Composite
 
 import pbandk.ByteArr
+import pbandk.Message as ProtoMessage
 
 interface ProtoContentMapper {
     fun encodeToProtobuf(protoContent: ProtoContent): PlainMessageBlob
     fun decodeFromProtobuf(encodedContent: PlainMessageBlob): ProtoContent
+    fun contentTypeName(encodedContent: PlainMessageBlob): String?
 }
 
 class ProtoContentMapperImpl : ProtoContentMapper {
@@ -150,5 +152,10 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             else -> Message.Visibility.HIDDEN
         }
         return ProtoContent(genericMessage.messageId, content, visibility)
+    }
+
+    override fun contentTypeName(encodedContent: PlainMessageBlob): String? {
+        val genericMessage = GenericMessage.decodeFromByteArray(encodedContent.data)
+        return genericMessage.content?.value?.let { it as? ProtoMessage }?.descriptor?.name
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -119,8 +119,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             }
             is GenericMessage.Content.Ephemeral -> MessageContent.Ignored
             is GenericMessage.Content.External -> MessageContent.Unknown(encodedContent.data)
-            is GenericMessage.Content.Image ->
-                MessageContent.Unknown(encodedContent.data) // Deprecated in favor of GenericMessage.Content.Asset
+            is GenericMessage.Content.Image -> MessageContent.Ignored // Deprecated in favor of GenericMessage.Content.Asset
             is GenericMessage.Content.Hidden -> {
                 val hiddenMessage = genericMessage.hidden
                 if (hiddenMessage != null) {
@@ -146,7 +145,6 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             is GenericMessage.Content.Composite,
             is GenericMessage.Content.Edited,
             is GenericMessage.Content.External,
-            is GenericMessage.Content.Image,
             is GenericMessage.Content.Location -> Message.Visibility.VISIBLE
             is GenericMessage.Content.Deleted -> Message.Visibility.DELETED
             else -> Message.Visibility.HIDDEN

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -94,8 +94,8 @@ class ProtoContentMapperImpl : ProtoContentMapper {
                 MessageContent.Asset(MapperProvider.assetMapper().fromProtoAssetMessageToAssetContent(protoContent.value))
             }
             is GenericMessage.Content.Availability -> MessageContent.Ignored
-            is GenericMessage.Content.ButtonAction -> MessageContent.Unknown(typeName, encodedContent.data)
-            is GenericMessage.Content.ButtonActionConfirmation -> MessageContent.Unknown(typeName, encodedContent.data)
+            is GenericMessage.Content.ButtonAction -> MessageContent.Unknown(typeName, encodedContent.data, true)
+            is GenericMessage.Content.ButtonActionConfirmation -> MessageContent.Unknown(typeName, encodedContent.data, true)
             is GenericMessage.Content.Calling -> MessageContent.Calling(value = protoContent.value.content)
             is GenericMessage.Content.Cleared -> MessageContent.Ignored
             is GenericMessage.Content.ClientAction -> MessageContent.Ignored
@@ -137,20 +137,9 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             is GenericMessage.Content.Reaction -> MessageContent.Ignored
             else -> {
                 kaliumLogger.w("Null content when parsing protobuf. Message UUID = $genericMessage.")
-                MessageContent.Unknown(typeName, encodedContent.data)
+                MessageContent.Ignored
             }
         }
-        val visibility = when (genericMessage.content) {
-            is GenericMessage.Content.Text,
-            is GenericMessage.Content.Asset,
-            is GenericMessage.Content.Calling,
-            is GenericMessage.Content.Composite,
-            is GenericMessage.Content.Edited,
-            is GenericMessage.Content.External,
-            is GenericMessage.Content.Location -> Message.Visibility.VISIBLE
-            is GenericMessage.Content.Deleted -> Message.Visibility.DELETED
-            else -> Message.Visibility.HIDDEN
-        }
-        return ProtoContent(genericMessage.messageId, content, visibility)
+        return ProtoContent(genericMessage.messageId, content)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -133,7 +133,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             is GenericMessage.Content.Knock -> MessageContent.Ignored
             is GenericMessage.Content.LastRead -> MessageContent.Ignored
             is GenericMessage.Content.Location -> MessageContent.Unknown(encodedContent.data)
-            is GenericMessage.Content.Reaction -> MessageContent.Unknown(encodedContent.data)
+            is GenericMessage.Content.Reaction -> MessageContent.Ignored
             else -> {
                 kaliumLogger.w("Null content when parsing protobuf. Message UUID = $genericMessage.")
                 MessageContent.Unknown(encodedContent.data)
@@ -143,6 +143,7 @@ class ProtoContentMapperImpl : ProtoContentMapper {
             is GenericMessage.Content.Text,
             is GenericMessage.Content.Asset,
             is GenericMessage.Content.Calling,
+            is GenericMessage.Content.Composite,
             is GenericMessage.Content.Edited,
             is GenericMessage.Content.External,
             is GenericMessage.Content.Image,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
@@ -104,7 +104,7 @@ internal class SendAssetMessageUseCaseImpl(
         // Create a unique message ID
         val generatedMessageUuid = uuid4().toString()
 
-        val message = Message.Client(
+        val message = Message.Regular(
             id = generatedMessageUuid,
             content = MessageContent.Asset(
                 provideAssetMessageContent(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendImageMessageUseCase.kt
@@ -101,7 +101,7 @@ internal class SendImageMessageUseCaseImpl(
         val generatedMessageUuid = uuid4().toString()
 
         return clientRepository.currentClientId().flatMap { currentClientId ->
-            val message = Message.Client(
+            val message = Message.Regular(
                 id = generatedMessageUuid,
                 content = MessageContent.Asset(
                     provideAssetMessageContent(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -8,7 +8,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 
 interface CallManager {
-    suspend fun onCallingMessageReceived(message: Message.Client, content: MessageContent.Calling)
+    suspend fun onCallingMessageReceived(message: Message.Regular, content: MessageContent.Calling)
     suspend fun startCall(
         conversationId: ConversationId,
         callType: CallType,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -32,7 +32,7 @@ class DeleteMessageUseCase(
 
         val generatedMessageUuid = uuid4().toString()
         return clientRepository.currentClientId().flatMap { currentClientId ->
-            val message = Message.Client(
+            val message = Message.Regular(
                 id = generatedMessageUuid,
                 content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else MessageContent.DeleteForMe(
                     messageId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -126,24 +126,28 @@ class GetNotificationsUseCaseImpl(
         selfUser: SelfUser,
         conversationMutedStatus: MutedConversationStatus
     ): Boolean =
-        when(conversationMutedStatus) {
-            MutedConversationStatus.AllAllowed -> true
-            MutedConversationStatus.OnlyMentionsAllowed -> {
-                when(val content = message.content) {
-                    is MessageContent.Text ->  {
-                        val containsSelfUserName = selfUser.name?.let { selfUsername ->
-                            content.value.contains("@$selfUsername")
-                        } ?: false
-                        val containsSelfHandle = selfUser.handle?.let { selfHandle ->
-                            content.value.contains("@$selfHandle")
-                        } ?: false
+        when {
+            message is Message.Server -> false
+            message.visibility != Message.Visibility.VISIBLE -> false
+            else -> when (conversationMutedStatus) {
+                MutedConversationStatus.AllAllowed -> true
+                MutedConversationStatus.OnlyMentionsAllowed -> {
+                    when (val content = message.content) {
+                        is MessageContent.Text -> {
+                            val containsSelfUserName = selfUser.name?.let { selfUsername ->
+                                content.value.contains("@$selfUsername")
+                            } ?: false
+                            val containsSelfHandle = selfUser.handle?.let { selfHandle ->
+                                content.value.contains("@$selfHandle")
+                            } ?: false
 
-                        containsSelfUserName or containsSelfHandle
+                            containsSelfUserName or containsSelfHandle
+                        }
+                        else -> false
                     }
-                    else -> false
                 }
+                else -> false
             }
-            else -> false
         }
 
     private data class ConversationWithMessages(val messages: List<Message>, val conversation: Conversation)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -47,9 +47,18 @@ class GetNotificationsUseCaseImpl(
                     // Fetching the Messages for the Conversation that are newer than `lastNotificationDate`
                     val messagesListFlow = if (conversation.lastNotificationDate == null) {
                         // that is a new conversation, lets just fetch last 100 messages for it
-                        messageRepository.getMessagesForConversation(conversation.id, 100, 0)
+                        messageRepository.getMessagesByConversationIdAndVisibility(
+                            conversation.id,
+                            100,
+                            0,
+                            listOf(Message.Visibility.VISIBLE)
+                        )
                     } else {
-                        messageRepository.getMessagesByConversationAfterDate(conversation.id, conversation.lastNotificationDate)
+                        messageRepository.getMessagesByConversationIdAndVisibilityAfterDate(
+                            conversation.id,
+                            conversation.lastNotificationDate,
+                            listOf(Message.Visibility.VISIBLE)
+                        )
                     }
 
                     messagesListFlow

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -122,7 +122,7 @@ class GetNotificationsUseCaseImpl(
         publicUserMapper.fromPublicUserToLocalNotificationMessageAuthor(authors.firstOrNull { it?.id == senderUserId })
 
     private fun shouldMessageBeVisibleAsNotification(message: Message) =
-        message !is Message.Server && message.visibility == Message.Visibility.VISIBLE
+        message !is Message.System && message.visibility == Message.Visibility.VISIBLE
 
     private fun shouldIncludeMessageForNotifications(
         message: Message,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
@@ -3,11 +3,15 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.persistence.dao.message.MessageEntity
 import kotlinx.coroutines.flow.Flow
 
 class GetRecentMessagesUseCase(private val messageRepository: MessageRepository) {
 
-    suspend operator fun invoke(conversationId: ConversationId, limit: Int = 100, offset: Int = 0): Flow<List<Message>> {
-        return messageRepository.getMessagesForConversation(conversationId, limit, offset)
-    }
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        limit: Int = 100,
+        offset: Int = 0,
+        visibility: List<Message.Visibility> = Message.Visibility.values().toList()
+    ): Flow<List<Message>> = messageRepository.getMessagesByConversationIdAndVisibility(conversationId, limit, offset, visibility)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
@@ -14,7 +14,7 @@ interface MLSMessageCreator {
 
     suspend fun createOutgoingMLSMessage(
         groupId: String,
-        message: Message.Client
+        message: Message.Regular
     ): Either<CoreFailure, MLSMessageApi.Message>
 
 }
@@ -24,7 +24,7 @@ class MLSMessageCreatorImpl(
     private val protoContentMapper: ProtoContentMapper,
 ): MLSMessageCreator {
 
-    override suspend fun createOutgoingMLSMessage(groupId: String, message: Message.Client): Either<CoreFailure, MLSMessageApi.Message> {
+    override suspend fun createOutgoingMLSMessage(groupId: String, message: Message.Regular): Either<CoreFailure, MLSMessageApi.Message> {
         return mlsClientProvider.getMLSClient().flatMap { client ->
             kaliumLogger.i("Creating outgoing MLS message (groupID = $groupId)")
             val content = protoContentMapper.encodeToProtobuf(ProtoContent(message.id, message.content))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
@@ -23,7 +23,7 @@ interface MessageEnvelopeCreator {
 
     suspend fun createOutgoingEnvelope(
         recipients: List<Recipient>,
-        message: Message.Client
+        message: Message.Regular
     ): Either<CoreFailure, MessageEnvelope>
 
 }
@@ -36,7 +36,7 @@ class MessageEnvelopeCreatorImpl(
 
     override suspend fun createOutgoingEnvelope(
         recipients: List<Recipient>,
-        message: Message.Client
+        message: Message.Regular
     ): Either<CoreFailure, MessageEnvelope> {
         val senderClientId = message.senderClientId
         val content = protoContentMapper.encodeToProtobuf(ProtoContent(message.id, message.content))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -31,7 +31,7 @@ class SendTextMessageUseCase(
         val generatedMessageUuid = uuid4().toString()
 
         return clientRepository.currentClientId().flatMap { currentClientId ->
-            val message = Message.Client(
+            val message = Message.Regular(
                 id = generatedMessageUuid,
                 content = MessageContent.Text(text),
                 conversationId = conversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -76,6 +76,7 @@ class ConversationEventReceiverImpl(
                     senderClientId = event.senderClientId,
                     status = Message.Status.SENT,
                     editStatus = Message.EditStatus.NotEdited,
+                    visibility = protoContent.visibility
                 )
 
                 processMessage(message)
@@ -167,6 +168,7 @@ class ConversationEventReceiverImpl(
                     senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
                     status = Message.Status.SENT,
                     editStatus = Message.EditStatus.NotEdited,
+                    visibility = protoContent.visibility
                 )
                 processMessage(message)
             }
@@ -235,6 +237,9 @@ class ConversationEventReceiverImpl(
                     messageRepository.persistMessage(message)
                 }
                 MessageContent.Empty -> TODO()
+                MessageContent.Ignored -> {
+                    kaliumLogger.i(message = "Ignored Message received: $message")
+                }
             }
             is Message.Server -> when (message.content) {
                 is MessageContent.MemberChange ->  {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -15,6 +15,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.PlainMessageBlob
+import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
@@ -28,6 +29,7 @@ import com.wire.kalium.logic.sync.handler.MessageTextEditHandler
 import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.logic.wrapCryptoRequest
 import io.ktor.utils.io.core.toByteArray
+import kotlin.math.sign
 
 interface ConversationEventReceiver : EventReceiver<Event.Conversation>
 
@@ -57,6 +59,46 @@ class ConversationEventReceiverImpl(
         }
     }
 
+    private suspend fun handleProtoContent(
+        conversationId: ConversationId,
+        timestampIso: String,
+        senderUserId: UserId,
+        senderClientId: ClientId,
+        protoContent: ProtoContent
+    ) {
+        when (protoContent.messageContent) {
+            is MessageContent.Regular -> {
+                val visibility = when (protoContent.messageContent) {
+                    is MessageContent.DeleteMessage -> Message.Visibility.HIDDEN
+                    is MessageContent.TextEdited -> Message.Visibility.HIDDEN
+                    is MessageContent.DeleteForMe -> Message.Visibility.HIDDEN
+                    MessageContent.Empty -> Message.Visibility.HIDDEN
+                    is MessageContent.Unknown ->
+                        if(protoContent.messageContent.hidden) Message.Visibility.HIDDEN
+                        else Message.Visibility.VISIBLE
+                    is MessageContent.Text -> Message.Visibility.VISIBLE
+                    is MessageContent.Calling -> Message.Visibility.VISIBLE
+                    is MessageContent.Asset -> Message.Visibility.VISIBLE
+                }
+                val message = Message.Regular(
+                    id = protoContent.messageUid,
+                    content = protoContent.messageContent,
+                    conversationId = conversationId,
+                    date = timestampIso,
+                    senderUserId = senderUserId,
+                    senderClientId = senderClientId,
+                    status = Message.Status.SENT,
+                    editStatus = Message.EditStatus.NotEdited,
+                    visibility = visibility
+                )
+                processMessage(message)
+            }
+            is MessageContent.Signaling -> {
+                processSignaling(protoContent.messageContent)
+            }
+        }
+    }
+
     private suspend fun handleNewMessage(event: Event.Conversation.NewMessage) {
         val decodedContentBytes = Base64.decodeFromBase64(event.content.toByteArray())
         val cryptoSessionId =
@@ -66,24 +108,17 @@ class ConversationEventReceiverImpl(
                 // TODO(important): Insert a failed message into the database to notify user that encryption is kaputt
                 kaliumLogger.e("$TAG - failure on proteus message: ${it.proteusException.stackTraceToString()}")
             }.onSuccess { plainMessageBlob ->
-                val protoContent = protoContentMapper.decodeFromProtobuf(plainMessageBlob)
-                val message = Message.Client(
-                    id = protoContent.messageUid,
-                    content = protoContent.messageContent,
+                handleProtoContent(
                     conversationId = event.conversationId,
-                    date = event.timestampIso,
+                    timestampIso = event.timestampIso,
                     senderUserId = event.senderUserId,
                     senderClientId = event.senderClientId,
-                    status = Message.Status.SENT,
-                    editStatus = Message.EditStatus.NotEdited,
-                    visibility = protoContent.visibility
+                    protoContent = protoContentMapper.decodeFromProtobuf(plainMessageBlob)
                 )
-
-                processMessage(message)
             }
     }
 
-    private fun updateAssetMessage(persistedMessage: Message.Client, newMessageRemoteData: AssetContent.RemoteData): Message? =
+    private fun updateAssetMessage(persistedMessage: Message.Regular, newMessageRemoteData: AssetContent.RemoteData): Message? =
         // The message was previously received with just metadata info, so let's update it with the raw data info
         if (persistedMessage.content is MessageContent.Asset) {
             persistedMessage.copy(
@@ -116,13 +151,14 @@ class ConversationEventReceiverImpl(
             idMapper.toDaoModel(event.conversationId)
         )
         .onSuccess {
-            val message = Message.Server(
+            val message = Message.System(
                 id = event.id,
                 content = MessageContent.MemberChange.Added(members = event.members),
                 conversationId = event.conversationId,
                 date = event.timestampIso,
                 senderUserId = event.addedBy,
-                status = Message.Status.SENT
+                status = Message.Status.SENT,
+                visibility = Message.Visibility.VISIBLE
             )
             processMessage(message)
         }
@@ -134,13 +170,14 @@ class ConversationEventReceiverImpl(
             idMapper.toDaoModel(event.conversationId)
         )
         .onSuccess {
-            val message = Message.Server(
+            val message = Message.System(
                 id = event.id,
                 content = MessageContent.MemberChange.Removed(members = event.members),
                 conversationId = event.conversationId,
                 date = event.timestampIso,
                 senderUserId = event.removedBy,
-                status = Message.Status.SENT
+                status = Message.Status.SENT,
+                visibility = Message.Visibility.VISIBLE
             )
             processMessage(message)
         }
@@ -158,20 +195,23 @@ class ConversationEventReceiverImpl(
                 kaliumLogger.e("$TAG - failure on MLS message: $it")
             }.onSuccess { mlsMessage ->
                 val plainMessageBlob = mlsMessage?.let { PlainMessageBlob(it) } ?: return@onSuccess
-                val protoContent = protoContentMapper.decodeFromProtobuf(plainMessageBlob)
-                val message = Message.Client(
-                    id = protoContent.messageUid,
-                    content = protoContent.messageContent,
+
+                handleProtoContent(
                     conversationId = event.conversationId,
-                    date = event.timestampIso,
+                    timestampIso = event.timestampIso,
                     senderUserId = event.senderUserId,
                     senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
-                    status = Message.Status.SENT,
-                    editStatus = Message.EditStatus.NotEdited,
-                    visibility = protoContent.visibility
+                    protoContent = protoContentMapper.decodeFromProtobuf(plainMessageBlob)
                 )
-                processMessage(message)
             }
+
+    private fun processSignaling(signaling: MessageContent.Signaling) {
+        when (signaling) {
+            MessageContent.Ignored -> {
+                kaliumLogger.i(message = "Ignored Signaling Message received: $signaling")
+            }
+        }
+    }
 
     @Suppress("ComplexMethod", "LongMethod")
     private suspend fun processMessage(message: Message) {
@@ -179,7 +219,7 @@ class ConversationEventReceiverImpl(
 
         val isMyMessage = userRepository.getSelfUserId() == message.senderUserId
         when (message) {
-            is Message.Client -> when (message.content) {
+            is Message.Regular -> when (message.content) {
                 is MessageContent.Text -> messageRepository.persistMessage(message)
                 is MessageContent.Asset -> {
                     messageRepository.getMessageById(message.conversationId, message.id)
@@ -190,7 +230,7 @@ class ConversationEventReceiverImpl(
                         .onSuccess { persistedMessage ->
                             // Check the second asset message is from the same original sender
                             if (isSenderVerified(persistedMessage.id, persistedMessage.conversationId, message.senderUserId)
-                                && persistedMessage is Message.Client && persistedMessage.content is MessageContent.Asset
+                                && persistedMessage is Message.Regular && persistedMessage.content is MessageContent.Asset
                             ) {
                                 // The asset message received contains the asset decryption keys,
                                 // so update the preview message persisted previously
@@ -231,18 +271,15 @@ class ConversationEventReceiverImpl(
                         content = message.content
                     )
                 }
-                is MessageContent.TextEdited -> editTextHandler.handle(message,message.content)
+                is MessageContent.TextEdited -> editTextHandler.handle(message, message.content)
                 is MessageContent.Unknown -> {
                     kaliumLogger.i(message = "Unknown Message received: $message")
                     messageRepository.persistMessage(message)
                 }
                 MessageContent.Empty -> TODO()
-                MessageContent.Ignored -> {
-                    kaliumLogger.i(message = "Ignored Message received: $message")
-                }
             }
-            is Message.Server -> when (message.content) {
-                is MessageContent.MemberChange ->  {
+            is Message.System -> when (message.content) {
+                is MessageContent.MemberChange -> {
                     kaliumLogger.i(message = "System MemberChange Message received: $message")
                     messageRepository.persistMessage(message)
                 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -175,7 +175,7 @@ class MessageRepositoryTest {
         val TEST_QUALIFIED_ID_ENTITY = PersistenceQualifiedId("value", "domain")
         val TEST_NETWORK_QUALIFIED_ID_ENTITY = NetworkQualifiedId("value", "domain")
         val TEST_MESSAGE_ENTITY =
-            MessageEntity.Client(
+            MessageEntity.Regular(
                 id = "uid",
                 content = MessageEntityContent.Text("content"),
                 conversationId = TEST_QUALIFIED_ID_ENTITY,
@@ -190,7 +190,7 @@ class MessageRepositoryTest {
         val TEST_USER_ID = UserId("userId", "domain")
         val TEST_CONTENT = MessageContent.Text("Ciao!")
         val TEST_DATETIME = "2022-04-21T20:56:22.393Z"
-        val TEST_MESSAGE = Message.Client(
+        val TEST_MESSAGE = Message.Regular(
             id = "uid",
             content = TEST_CONTENT,
             conversationId = TEST_CONVERSATION_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -73,20 +73,20 @@ class MessageRepositoryTest {
             .then { mappedId }
 
         given(messageDAO)
-            .suspendFunction(messageDAO::getMessagesByConversation)
-            .whenInvokedWith(anything(), anything(), anything())
-            .then { _, _, _ -> flowOf(listOf()) }
+            .suspendFunction(messageDAO::getMessagesByConversationAndVisibility)
+            .whenInvokedWith(anything(), anything(), anything(), anything())
+            .then { _, _, _, _ -> flowOf(listOf()) }
 
         given(messageMapper)
             .function(messageMapper::fromEntityToMessage)
             .whenInvokedWith(anything())
             .then { TEST_MESSAGE }
 
-        messageRepository.getMessagesForConversation(TEST_CONVERSATION_ID, 0, 0).collect()
+        messageRepository.getMessagesByConversationIdAndVisibility(TEST_CONVERSATION_ID, 0, 0).collect()
 
         verify(messageDAO)
-            .suspendFunction(messageDAO::getMessagesByConversation)
-            .with(eq(mappedId), anything(), anything())
+            .suspendFunction(messageDAO::getMessagesByConversationAndVisibility)
+            .with(eq(mappedId), anything(), anything(), anything())
             .wasInvoked(exactly = once)
     }
 
@@ -100,16 +100,16 @@ class MessageRepositoryTest {
             .then { mappedMessage }
 
         given(messageDAO)
-            .suspendFunction(messageDAO::getMessagesByConversation)
-            .whenInvokedWith(anything(), anything(), anything())
-            .then { _, _, _ -> flowOf(listOf(entity)) }
+            .suspendFunction(messageDAO::getMessagesByConversationAndVisibility)
+            .whenInvokedWith(anything(), anything(), anything(), anything())
+            .then { _, _, _, _ -> flowOf(listOf(entity)) }
 
         given(idMapper)
             .function(idMapper::toDaoModel)
             .whenInvokedWith(anything())
             .then { TEST_QUALIFIED_ID_ENTITY }
 
-        val messageList = messageRepository.getMessagesForConversation(TEST_CONVERSATION_ID, 0, 0)
+        val messageList = messageRepository.getMessagesByConversationIdAndVisibility(TEST_CONVERSATION_ID, 0, 0)
             .first()
         assertEquals(listOf(mappedMessage), messageList)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -28,7 +28,7 @@ class ProtoContentMapperTest {
     @Test
     fun givenTextContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
         val messageContent = MessageContent.Text("Hello")
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.VISIBLE)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -77,7 +77,7 @@ class ProtoContentMapperTest {
                 downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
             )
         )
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.VISIBLE)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -88,7 +88,7 @@ class ProtoContentMapperTest {
     @Test
     fun givenCallingContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
         val callingContent = MessageContent.Calling("Calling")
-        val protoContent = ProtoContent(TEST_CALLING_UUID, callingContent, Message.Visibility.VISIBLE)
+        val protoContent = ProtoContent(TEST_CALLING_UUID, callingContent)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -99,7 +99,7 @@ class ProtoContentMapperTest {
     @Test
     fun givenDeleteMessageContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
         val messageContent = MessageContent.DeleteMessage(TEST_MESSAGE_UUID)
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.DELETED)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -114,7 +114,7 @@ class ProtoContentMapperTest {
                 TEST_CONVERSATION_ID
             )
         )
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.HIDDEN)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -127,7 +127,7 @@ class ProtoContentMapperTest {
         val messageContent = MessageContent.DeleteForMe(
             TEST_MESSAGE_UUID, TEST_CONVERSATION_UUID, null
         )
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.HIDDEN)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -28,7 +28,7 @@ class ProtoContentMapperTest {
     @Test
     fun givenTextContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
         val messageContent = MessageContent.Text("Hello")
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.VISIBLE)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -77,7 +77,7 @@ class ProtoContentMapperTest {
                 downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
             )
         )
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.VISIBLE)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -88,7 +88,7 @@ class ProtoContentMapperTest {
     @Test
     fun givenCallingContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
         val callingContent = MessageContent.Calling("Calling")
-        val protoContent = ProtoContent(TEST_CALLING_UUID, callingContent)
+        val protoContent = ProtoContent(TEST_CALLING_UUID, callingContent, Message.Visibility.VISIBLE)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -99,7 +99,7 @@ class ProtoContentMapperTest {
     @Test
     fun givenDeleteMessageContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
         val messageContent = MessageContent.DeleteMessage(TEST_MESSAGE_UUID)
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.DELETED)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -114,7 +114,7 @@ class ProtoContentMapperTest {
                 TEST_CONVERSATION_ID
             )
         )
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.HIDDEN)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)
@@ -127,7 +127,7 @@ class ProtoContentMapperTest {
         val messageContent = MessageContent.DeleteForMe(
             TEST_MESSAGE_UUID, TEST_CONVERSATION_UUID, null
         )
-        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent)
+        val protoContent = ProtoContent(TEST_MESSAGE_UUID, messageContent, Message.Visibility.HIDDEN)
 
         val encoded = protoContentMapper.encodeToProtobuf(protoContent)
         val decoded = protoContentMapper.decodeFromProtobuf(encoded)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
@@ -101,7 +101,7 @@ class GetMessageAssetUseCaseTest {
         val someAssetToken = "==some-asset-token"
 
         private val mockedMessage by lazy {
-            Message.Client(
+            Message.Regular(
                 id = msgId,
                 content = MessageContent.Asset(
                     AssetContent(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -83,9 +83,9 @@ class GetNotificationsUseCaseTest {
             .coroutine { getConversationsForNotifications() }
             .then { flowOf(listOf(entityConversation())) }
         given(messageRepository)
-            .suspendFunction(messageRepository::getMessagesByConversationAfterDate)
-            .whenInvokedWith(anything(), anything())
-            .then { _, _ -> flowOf(listOf()) }
+            .suspendFunction(messageRepository::getMessagesByConversationIdAndVisibilityAfterDate)
+            .whenInvokedWith(anything(), anything(), anything())
+            .then { _, _, _ -> flowOf(listOf()) }
 
         val notificationsListFlow = getNotificationsUseCase()
 
@@ -108,9 +108,9 @@ class GetNotificationsUseCaseTest {
             .coroutine { getConversationsForNotifications() }
             .then { flowOf(listOf(entityConversation())) }
         given(messageRepository)
-            .suspendFunction(messageRepository::getMessagesByConversationAfterDate)
-            .whenInvokedWith(anything(), anything())
-            .then { conversationId, _ ->
+            .suspendFunction(messageRepository::getMessagesByConversationIdAndVisibilityAfterDate)
+            .whenInvokedWith(anything(), anything(), anything())
+            .then { conversationId, _, _ ->
                 flowOf(
                     listOf(
                         entityTextMessage(conversationId),
@@ -144,9 +144,9 @@ class GetNotificationsUseCaseTest {
             .whenInvokedWith(any())
             .then { id -> flowOf(otherUser(id)) }
         given(messageRepository)
-            .suspendFunction(messageRepository::getMessagesByConversationAfterDate)
-            .whenInvokedWith(eq(conversationId()), anything())
-            .then { _, _ ->
+            .suspendFunction(messageRepository::getMessagesByConversationIdAndVisibilityAfterDate)
+            .whenInvokedWith(anything(), anything(), anything())
+            .then { _, _, _ ->
                 flowOf(
                     listOf(
                         entityTextMessage(conversationId()),
@@ -198,9 +198,9 @@ class GetNotificationsUseCaseTest {
             .whenInvokedWith(any())
             .then { id -> flowOf(otherUser(id)) }
         given(messageRepository)
-            .suspendFunction(messageRepository::getMessagesByConversationAfterDate)
-            .whenInvokedWith(anything(), anything())
-            .then { conversationId, _ ->
+            .suspendFunction(messageRepository::getMessagesByConversationIdAndVisibilityAfterDate)
+            .whenInvokedWith(anything(), anything(), anything())
+            .then { conversationId, _, _ ->
                 flowOf(
                     listOf(
                         entityTextMessage(conversationId, otherUserId(), "0"),
@@ -258,9 +258,9 @@ class GetNotificationsUseCaseTest {
             .whenInvokedWith(any())
             .then { id -> flowOf(otherUser(id)) }
         given(messageRepository)
-            .suspendFunction(messageRepository::getMessagesByConversationAfterDate)
-            .whenInvokedWith(anything(), anything())
-            .then { conversationId, _ ->
+            .suspendFunction(messageRepository::getMessagesByConversationIdAndVisibilityAfterDate)
+            .whenInvokedWith(anything(), anything(), anything())
+            .then { conversationId, _, _ ->
                 flowOf(
                     listOf(
                         entityTextMessage(conversationId, otherUserId(), "0"),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -22,7 +22,6 @@ import io.mockative.Mock
 import io.mockative.any
 import io.mockative.anything
 import io.mockative.classOf
-import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
@@ -349,7 +348,7 @@ class GetNotificationsUseCaseTest {
             messageId: String = "message_id",
             visibility: Message.Visibility = Message.Visibility.VISIBLE
         ) =
-            Message.Client(
+            Message.Regular(
                 id = messageId,
                 content = MessageContent.Text("test message $messageId"),
                 conversationId = conversationId,
@@ -367,7 +366,7 @@ class GetNotificationsUseCaseTest {
             messageId: String = "message_id",
             assetId: String
         ) =
-            Message.Client(
+            Message.Regular(
                 id = messageId,
                 content = MessageContent.Asset(
                     AssetContent(
@@ -399,7 +398,7 @@ class GetNotificationsUseCaseTest {
             senderId: QualifiedID = TestUser.USER_ID,
             messageId: String = "message_id"
         ) =
-            Message.Server(
+            Message.System(
                 id = messageId,
                 content = MessageContent.MemberChange.Removed(listOf(Member(senderId))),
                 conversationId = conversationId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
@@ -9,7 +9,7 @@ object TestMessage {
     val TEST_SENDER_USER_ID = TestUser.USER_ID
     val TEST_SENDER_CLIENT_ID = TestClient.CLIENT_ID
     val TEXT_CONTENT = MessageContent.Text("Ciao!")
-    val TEXT_MESSAGE = Message.Client(
+    val TEXT_MESSAGE = Message.Regular(
         id = TEST_MESSAGE_ID,
         content = TEXT_CONTENT,
         conversationId = ConversationId("conv", "id"),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/MessageTextEditHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/MessageTextEditHandlerTest.kt
@@ -28,7 +28,7 @@ class MessageTextEditHandlerTest {
     @Test
     fun givenACorrectMessageAndMessageContent_whenHandeling_ThenDataGetsUpdatedCorrectly() = runTest {
         //given
-        val mockMessage = Message.Client(
+        val mockMessage = Message.Regular(
             id = "someId",
             content = MessageContent.Text("some new content"),
             conversationId = ConversationId("someValue", "someDomain"),

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -14,7 +14,7 @@ actual class CallManagerImpl : CallManager {
         kaliumLogger.w("CallManager initialized for JVM but not supported yet.")
     }
 
-    override suspend fun onCallingMessageReceived(message: Message.Client, content: MessageContent.Calling) {
+    override suspend fun onCallingMessageReceived(message: Message.Regular, content: MessageContent.Calling) {
         kaliumLogger.w("onCallingMessageReceived for JVM but not supported yet.")
     }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -73,6 +73,7 @@ CREATE TABLE MessageUnknownContent (
       message_id TEXT NOT NULL,
       conversation_id TEXT AS QualifiedIDEntity NOT NULL,
 
+      unknown_type_name TEXT,
       unknown_encoded_data BLOB,
 
       FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE,
@@ -154,10 +155,11 @@ member_change_list = excluded.member_change_list,
 member_change_type = excluded.member_change_type;
 
 insertMessageUnknownContent:
-INSERT INTO MessageUnknownContent(message_id, conversation_id, unknown_encoded_data)
-VALUES(?, ?, ?)
+INSERT INTO MessageUnknownContent(message_id, conversation_id, unknown_type_name, unknown_encoded_data)
+VALUES(?, ?, ?, ?)
 ON CONFLICT(message_id, conversation_id) DO UPDATE SET
 message_id = excluded.message_id,
+unknown_type_name = excluded.unknown_type_name,
 unknown_encoded_data = excluded.unknown_encoded_data;
 
 updateMessageStatus:

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -196,11 +196,11 @@ SELECT * FROM Message ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;
 selectById:
 SELECT * FROM Message WHERE id = ? AND conversation_id = ?;
 
-selectByConversationId:
-SELECT * FROM Message WHERE conversation_id = ? ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;
+selectByConversationIdAndVisibility:
+SELECT * FROM Message WHERE conversation_id = ? AND visibility IN ? ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;
 
-selectMessagesByConversationIdAfterDate:
-SELECT * FROM Message WHERE conversation_id = ? AND Datetime(date) > Datetime(?) ORDER BY Datetime(date) DESC;
+selectMessagesByConversationIdAndVisibilityAfterDate:
+SELECT * FROM Message WHERE conversation_id = ? AND visibility IN ? AND Datetime(date) > Datetime(?) ORDER BY Datetime(date) DESC;
 
 selectMessagesFromUserByStatus:
 SELECT * FROM Message WHERE sender_user_id = ? AND status = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -18,8 +18,17 @@ interface MessageDAO {
     suspend fun updateMessagesAddMillisToDate(millis: Long, conversationId: QualifiedIDEntity, status: MessageEntity.Status)
     suspend fun getMessagesFromAllConversations(limit: Int, offset: Int): Flow<List<MessageEntity>>
     suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?>
-    suspend fun getMessagesByConversation(conversationId: QualifiedIDEntity, limit: Int, offset: Int): Flow<List<MessageEntity>>
-    suspend fun getMessagesByConversationAfterDate(conversationId: QualifiedIDEntity, date: String): Flow<List<MessageEntity>>
+    suspend fun getMessagesByConversationAndVisibility(
+        conversationId: QualifiedIDEntity,
+        limit: Int,
+        offset: Int,
+        visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.values().toList()
+    ): Flow<List<MessageEntity>>
+    suspend fun getMessagesByConversationAndVisibilityAfterDate(
+        conversationId: QualifiedIDEntity,
+        date: String,
+        visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.values().toList()
+    ): Flow<List<MessageEntity>>
     suspend fun getAllPendingMessagesFromUser(userId: UserIDEntity): List<MessageEntity>
     suspend fun updateTextMessageContent(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -183,14 +183,23 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             .mapToOneOrNull()
             .flatMapLatest { it?.toMessageEntityFlow() ?: flowOf(null) }
 
-    override suspend fun getMessagesByConversation(conversationId: QualifiedIDEntity, limit: Int, offset: Int): Flow<List<MessageEntity>> =
-        queries.selectByConversationId(conversationId, limit.toLong(), offset.toLong())
+    override suspend fun getMessagesByConversationAndVisibility(
+        conversationId: QualifiedIDEntity,
+        limit: Int,
+        offset: Int,
+        visibility: List<MessageEntity.Visibility>
+    ): Flow<List<MessageEntity>> =
+        queries.selectByConversationIdAndVisibility(conversationId, visibility, limit.toLong(), offset.toLong())
             .asFlow()
             .mapToList()
             .toMessageEntityListFlow()
 
-    override suspend fun getMessagesByConversationAfterDate(conversationId: QualifiedIDEntity, date: String): Flow<List<MessageEntity>> =
-        queries.selectMessagesByConversationIdAfterDate(conversationId, date)
+    override suspend fun getMessagesByConversationAndVisibilityAfterDate(
+        conversationId: QualifiedIDEntity,
+        date: String,
+        visibility: List<MessageEntity.Visibility>
+    ): Flow<List<MessageEntity>>  =
+        queries.selectMessagesByConversationIdAndVisibilityAfterDate(conversationId, visibility, date)
             .asFlow()
             .mapToList()
             .toMessageEntityListFlow()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -71,7 +71,10 @@ class MessageMapper {
         memberChangeType = content.member_change_type
     )
 
-    fun toModel(content: SQLDelightMessageUnknownContent) = MessageEntityContent.Unknown(encodedData = content.unknown_encoded_data)
+    fun toModel(content: SQLDelightMessageUnknownContent) = MessageEntityContent.Unknown(
+        typeName = content.unknown_type_name,
+        encodedData = content.unknown_encoded_data
+    )
 
     private fun mapEditStatus(lastEditTimestamp: String?) =
         lastEditTimestamp?.let { MessageEntity.EditStatus.Edited(it) }
@@ -139,7 +142,8 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
                 is MessageEntityContent.Unknown -> queries.insertMessageUnknownContent(
                     message_id = message.id,
                     conversation_id = message.conversationId,
-                    unknown_encoded_data = content.encodedData
+                    unknown_encoded_data = content.encodedData,
+                    unknown_type_name = content.typeName
                 )
                 is MessageEntityContent.MemberChange -> queries.insertMemberChangeMessage(
                     message_id = message.id,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.persistence.MessageUnknownContent as SQLDelightMessageUnk
 
 class MessageMapper {
     fun toModel(msg: SQLDelightMessage, content: MessageEntityContent): MessageEntity = when (content) {
-        is MessageEntityContent.Client -> MessageEntity.Client(
+        is MessageEntityContent.Regular -> MessageEntity.Regular(
             content = content,
             id = msg.id,
             conversationId = msg.conversation_id,
@@ -36,7 +36,7 @@ class MessageMapper {
             editStatus = mapEditStatus(msg.last_edit_timestamp),
             visibility = msg.visibility
         )
-        is MessageEntityContent.Server -> MessageEntity.Server(
+        is MessageEntityContent.System -> MessageEntity.System(
             content = content,
             id = msg.id,
             conversationId = msg.conversation_id,
@@ -110,7 +110,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
                 conversation_id = message.conversationId,
                 date = message.date,
                 sender_user_id = message.senderUserId,
-                sender_client_id = if (message is MessageEntity.Client) message.senderClientId else null,
+                sender_client_id = if (message is MessageEntity.Regular) message.senderClientId else null,
                 visibility = message.visibility,
                 status = message.status,
                 content_type = contentTypeOf(message.content)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -13,21 +13,21 @@ sealed class MessageEntity(
     open val visibility: Visibility
 ) {
 
-    data class Client(
+    data class Regular(
         override val id: String,
         override val conversationId: QualifiedIDEntity,
         override val date: String,
         override val senderUserId: QualifiedIDEntity,
         override val status: Status,
         override val visibility: Visibility = Visibility.VISIBLE,
-        override val content: MessageEntityContent.Client,
+        override val content: MessageEntityContent.Regular,
         val senderClientId: String,
         val editStatus: EditStatus
     ) : MessageEntity(id, content, conversationId, date, senderUserId, status, visibility)
 
-    data class Server(
+    data class System(
         override val id: String,
-        override val content: MessageEntityContent.Server,
+        override val content: MessageEntityContent.System,
         override val conversationId: QualifiedIDEntity,
         override val date: String,
         override val senderUserId: QualifiedIDEntity,
@@ -90,10 +90,10 @@ sealed class MessageEntity(
 
 sealed class MessageEntityContent {
 
-    sealed class Client : MessageEntityContent()
-    sealed class Server : MessageEntityContent()
+    sealed class Regular : MessageEntityContent()
+    sealed class System : MessageEntityContent()
 
-    data class Text(val messageBody: String) : Client()
+    data class Text(val messageBody: String) : Regular()
 
     data class Asset(
         val assetSizeInBytes: Long,
@@ -114,15 +114,15 @@ sealed class MessageEntityContent {
         val assetHeight: Int? = null,
         val assetDurationMs: Long? = null,
         val assetNormalizedLoudness: ByteArray? = null,
-    ) : Client()
+    ) : Regular()
 
     data class Unknown(
         val typeName: String? = null,
         val encodedData: ByteArray? = null
-    ) : Client()
+    ) : Regular()
 
     data class MemberChange(
         val memberUserIdList: List<QualifiedIDEntity>,
         val memberChangeType: MessageEntity.MemberChangeType
-    ) : Server()
+    ) : System()
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -116,7 +116,10 @@ sealed class MessageEntityContent {
         val assetNormalizedLoudness: ByteArray? = null,
     ) : Client()
 
-    data class Unknown(val encodedData: ByteArray? = null) : Client()
+    data class Unknown(
+        val typeName: String? = null,
+        val encodedData: ByteArray? = null
+    ) : Client()
 
     data class MemberChange(
         val memberUserIdList: List<QualifiedIDEntity>,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MessageDAOTest.kt
@@ -221,18 +221,23 @@ class MessageDAOTest : BaseDatabaseTest() {
         val conversationInQuestion = conversationEntity1
         val otherConversation = conversationEntity2
 
+        val visibilityInQuestion = MessageEntity.Visibility.VISIBLE
+        val otherVisibility = MessageEntity.Visibility.HIDDEN
+
         val expectedMessages = listOf(
             newMessageEntity(
                 "1",
                 conversationId = conversationInQuestion.id,
                 senderUserId = userEntity1.id,
-                status = MessageEntity.Status.PENDING
+                status = MessageEntity.Status.PENDING,
+                visibility = visibilityInQuestion
             ),
             newMessageEntity(
                 "2",
                 conversationId = conversationInQuestion.id,
                 senderUserId = userEntity1.id,
-                status = MessageEntity.Status.PENDING
+                status = MessageEntity.Status.PENDING,
+                visibility = visibilityInQuestion
             )
         )
 
@@ -242,19 +247,30 @@ class MessageDAOTest : BaseDatabaseTest() {
                 // different conversation
                 conversationId = otherConversation.id,
                 senderUserId = userEntity1.id,
-                status = MessageEntity.Status.READ
+                status = MessageEntity.Status.READ,
+                visibility = visibilityInQuestion
             ),
             newMessageEntity(
                 "4",
                 // different conversation
                 conversationId = otherConversation.id,
                 senderUserId = userEntity1.id,
-                status = MessageEntity.Status.PENDING
+                status = MessageEntity.Status.PENDING,
+                visibility = visibilityInQuestion
+            ),
+            newMessageEntity(
+                "5",
+                // different conversation
+                conversationId = conversationInQuestion.id,
+                senderUserId = userEntity1.id,
+                status = MessageEntity.Status.PENDING,
+                visibility = otherVisibility
             )
         )
 
         messageDAO.insertMessages(allMessages)
-        val result = messageDAO.getMessagesByConversation(conversationInQuestion.id, 10, 0)
+        val result =
+            messageDAO.getMessagesByConversationAndVisibility(conversationInQuestion.id, 10, 0, listOf(visibilityInQuestion))
         assertContentEquals(expectedMessages, result.first())
     }
 
@@ -288,7 +304,7 @@ class MessageDAOTest : BaseDatabaseTest() {
         )
 
         messageDAO.insertMessages(allMessages)
-        val result = messageDAO.getMessagesByConversationAfterDate(conversationInQuestion.id, dateInQuestion)
+        val result = messageDAO.getMessagesByConversationAndVisibilityAfterDate(conversationInQuestion.id, dateInQuestion)
         assertContentEquals(expectedMessages, result.first())
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
@@ -7,7 +7,7 @@ import com.wire.kalium.persistence.dao.message.MessageEntityContent
 @Suppress("LongParameterList")
 fun newMessageEntity(
     id: String = "testMessage",
-    content: MessageEntityContent.Client = MessageEntityContent.Text("Test Text"),
+    content: MessageEntityContent.Regular = MessageEntityContent.Text("Test Text"),
     conversationId: QualifiedIDEntity = QualifiedIDEntity("convId", "convDomain"),
     senderUserId: QualifiedIDEntity = QualifiedIDEntity("senderId", "senderDomain"),
     senderClientId: String = "senderClientId",
@@ -15,7 +15,7 @@ fun newMessageEntity(
     editStatus : MessageEntity.EditStatus = MessageEntity.EditStatus.NotEdited,
     date: String = "2022-03-30T15:36:00.000Z",
     visibility: MessageEntity.Visibility = MessageEntity.Visibility.VISIBLE
-) = MessageEntity.Client(
+) = MessageEntity.Regular(
     id = id,
     content = content,
     conversationId = conversationId,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
@@ -13,7 +13,8 @@ fun newMessageEntity(
     senderClientId: String = "senderClientId",
     status: MessageEntity.Status = MessageEntity.Status.PENDING,
     editStatus : MessageEntity.EditStatus = MessageEntity.EditStatus.NotEdited,
-    date: String = "2022-03-30T15:36:00.000Z"
+    date: String = "2022-03-30T15:36:00.000Z",
+    visibility: MessageEntity.Visibility = MessageEntity.Visibility.VISIBLE
 ) = MessageEntity.Client(
     id = id,
     content = content,
@@ -23,5 +24,5 @@ fun newMessageEntity(
     senderClientId = senderClientId,
     status = status,
     editStatus = editStatus,
-    visibility = MessageEntity.Visibility.VISIBLE
+    visibility = visibility
 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently all message types, even ones not yet handled by app, are stored in DB as "Unknown" and visible with "content is not available".

### Solutions

Add Visibility.HIDDEN to messages that shouldn't be visible but only persisted, ignore some types that are actually more like actions than messages and shouldn't be stored.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
