### PR TITLE
fix(conference-call): passing a wrong json format to AVS

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.calling.callbacks.ClientsRequestHandler
 import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallClient
+import com.wire.kalium.logic.data.call.CallClientList
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.toConversationId
 import com.wire.kalium.logic.functional.map
@@ -13,8 +14,6 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 
 internal class OnClientsRequest(
     private val calling: Calling,
@@ -41,10 +40,12 @@ internal class OnClientsRequest(
                             )
                         }
                     }
+            }.map {
+                CallClientList(it)
             }.onSuccess { avsClients ->
                 callingLogger.d("OnClientsRequest() -> Sending recipients")
                 // TODO: use a json serializer and not recreate everytime it is used
-                val callClients = Json.encodeToString(avsClients)
+                val callClients = avsClients.toJsonString()
                 calling.wcall_set_clients_for_conv(
                     inst = inst,
                     convId = conversationId,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In clients handler, the json of clients  that we pass to AVS is encoded with an incorrect format 

Wrong passed JSON:
```
[ { userid: "value", clientid: "" } ]
```
Correct format:
```
{ clients: [ { userid: "value", clientid: "" } ] }
```

### Solutions

Fix that =)

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Nothing visible to test

#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
