### PR TITLE
fix(keypackages-api): mls keypackages count api call

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -14,6 +14,7 @@ import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.keypackage.KeyPackageApi
+import com.wire.kalium.network.api.keypackage.KeyPackageCountDTO
 import com.wire.kalium.network.api.keypackage.KeyPackageDTO
 import io.ktor.util.encodeBase64
 
@@ -23,7 +24,7 @@ interface KeyPackageRepository {
 
     suspend fun uploadNewKeyPackages(clientId: ClientId, amount: Int = 100): Either<CoreFailure, Unit>
 
-    suspend fun getAvailableKeyPackageCount(clientId: ClientId): Either<NetworkFailure, Int>
+    suspend fun getAvailableKeyPackageCount(clientId: ClientId): Either<NetworkFailure, KeyPackageCountDTO>
 
 }
 
@@ -56,7 +57,7 @@ class KeyPackageDataSource(
             }
         }
 
-    override suspend fun getAvailableKeyPackageCount(clientId: ClientId): Either<NetworkFailure, Int> =
+    override suspend fun getAvailableKeyPackageCount(clientId: ClientId): Either<NetworkFailure, KeyPackageCountDTO> =
         wrapApiRequest {
             keyPackageApi.getAvailableKeyPackageCount(clientId.value)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.keypackage.ClaimedKeyPackageList
 import com.wire.kalium.network.api.keypackage.KeyPackage
 import com.wire.kalium.network.api.keypackage.KeyPackageApi
+import com.wire.kalium.network.api.keypackage.KeyPackageCountDTO
 import com.wire.kalium.network.api.keypackage.KeyPackageDTO
 import com.wire.kalium.network.api.keypackage.KeyPackageRef
 import com.wire.kalium.network.utils.NetworkResponse
@@ -67,12 +68,12 @@ class KeyPackageRepositoryTest {
     @Test
     fun givenExistingClient_whenGettingAvailableKeyPackageCount_thenResultShouldBePropagated() = runTest {
         given(keyPackageApi).suspendFunction(keyPackageApi::getAvailableKeyPackageCount).whenInvokedWith(eq(SELF_CLIENT_ID.value))
-            .thenReturn(NetworkResponse.Success(KEY_PACKAGE_COUNT, mapOf(), 200))
+            .thenReturn(NetworkResponse.Success(KEY_PACKAGE_COUNT_DTO, mapOf(), 200))
 
         val keyPackageCount = keyPackageRepository.getAvailableKeyPackageCount(SELF_CLIENT_ID)
 
-        assertIs<Either.Right<Int>>(keyPackageCount)
-        assertEquals(KEY_PACKAGE_COUNT, keyPackageCount.value)
+        assertIs<Either.Right<KeyPackageCountDTO>>(keyPackageCount)
+        assertEquals(KEY_PACKAGE_COUNT_DTO.count, keyPackageCount.value.count)
     }
 
     @Test
@@ -92,6 +93,7 @@ class KeyPackageRepositoryTest {
 
     private companion object {
         const val KEY_PACKAGE_COUNT = 100
+        val KEY_PACKAGE_COUNT_DTO = KeyPackageCountDTO(KEY_PACKAGE_COUNT)
         val SELF_CLIENT_ID: ClientId = PlainId("client_self")
         val OTHER_CLIENT_ID: ClientId = PlainId("client_other")
         val USER_ID = UserId("user_id", "wire.com")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/keypackage/KeyPackageApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/keypackage/KeyPackageApi.kt
@@ -42,7 +42,7 @@ interface KeyPackageApi {
      *
      * @return unclaimed key package count
      */
-    suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<Int>
+    suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO>
 }
 
 typealias KeyPackage = String

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/keypackage/KeyPackageApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/keypackage/KeyPackageApiImpl.kt
@@ -28,7 +28,7 @@ class KeyPackageApiImpl internal constructor(private val authenticatedNetworkCli
             }
         }
 
-    override suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<Int> =
+    override suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO> =
         wrapKaliumResponse { httpClient.get("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId/$PATH_COUNT") }
 
     private companion object {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/keypackage/KeyPackageDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/keypackage/KeyPackageDTO.kt
@@ -27,4 +27,9 @@ data class KeyPackageDTO(
     val keyPackageRef: KeyPackageRef,
     @SerialName("user")
     val userId: String
-    )
+)
+
+@Serializable
+data class KeyPackageCountDTO(
+    @SerialName("count") val count: Int
+)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/keypackage/KeyPackageApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/keypackage/KeyPackageApiTest.kt
@@ -16,7 +16,7 @@ class KeyPackageApiTest: ApiTest {
     @Test
     fun givenAValidClientId_whenCallingGetAvailableKeyPackageCountEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
-            KEY_PACKAGE_COUNT.toString(),
+            KeyPackageJson.keyPackageCountJson(KEY_PACKAGE_COUNT).rawJson,
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertGet()
@@ -27,7 +27,7 @@ class KeyPackageApiTest: ApiTest {
 
         val response = keyPackageApi.getAvailableKeyPackageCount(VALID_CLIENT_ID)
         assertTrue(response.isSuccessful())
-        assertEquals(response.value, KEY_PACKAGE_COUNT)
+        assertEquals(response.value.count, KEY_PACKAGE_COUNT)
     }
 
     @Test

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/keypackage/KeyPackageJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/keypackage/KeyPackageJson.kt
@@ -2,19 +2,23 @@ package com.wire.kalium.api.tools.json.api.keypackage
 
 import com.wire.kalium.api.tools.json.ValidJsonProvider
 import com.wire.kalium.network.api.keypackage.ClaimedKeyPackageList
+import com.wire.kalium.network.api.keypackage.KeyPackageCountDTO
 import com.wire.kalium.network.api.keypackage.KeyPackageDTO
-import com.wire.kalium.network.api.prekey.PreKeyDTO
 
 object KeyPackageJson {
 
     val valid = ValidJsonProvider(
-        ClaimedKeyPackageList(listOf(
-            KeyPackageDTO("defkrr8e7grgsoufhg8",
-            "wire.com",
-            "keyPackage",
-            "keyPackageRef",
-            "fdf23116-42a5-472c-8316-e10655f5d11e")
-        ))
+        ClaimedKeyPackageList(
+            listOf(
+                KeyPackageDTO(
+                    "defkrr8e7grgsoufhg8",
+                    "wire.com",
+                    "keyPackage",
+                    "keyPackageRef",
+                    "fdf23116-42a5-472c-8316-e10655f5d11e"
+                )
+            )
+        )
     ) {
         """
         |{
@@ -29,5 +33,12 @@ object KeyPackageJson {
         |  ]
         |}
         """.trimMargin()
+    }
+
+    fun keyPackageCountJson(count: Int) = ValidJsonProvider(
+        KeyPackageCountDTO(count)
+
+    ) {
+        """{"count":${it.count}}""".trimMargin()
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Fix the KeyPackagesAPI call

### Issues

The return dto was not correct, added a new one.

### Causes (Optional)
Considered as Integer! but was a json model and the value in it.

### Solutions

Added a proper DTO.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test


### Notes (Optional)


### Attachments (Optional)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
