### PR TITLE
chore: consistent wire links

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -3,7 +3,9 @@ package com.wire.kalium.logic.configuration.server
 import com.wire.kalium.network.tools.ApiVersionDTO
 import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.persistence.model.ServerConfigEntity
+import io.ktor.http.URLBuilder
 import io.ktor.http.Url
+import io.ktor.http.appendPathSegments
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -29,7 +31,23 @@ data class ServerConfig(
         @SerialName("teamsUrl") val teams: String,
         @SerialName("websiteUrl") val website: String,
         @SerialName("title") val title: String
-    )
+    ) {
+        val forgotPassword: String
+            get() = URLBuilder(Url(accounts)).apply {
+                appendPathSegments(FORGOT_PASSWORD_PATH)
+            }.buildString()
+
+        val pricing: String
+            get() = URLBuilder(urlString = website).apply {
+                appendPathSegments(PRICING_PATH)
+            }.buildString()
+
+        val tos: String
+            get() = URLBuilder(urlString = website).apply {
+                appendPathSegments(TOS_PATH)
+            }.buildString()
+    }
+
     @Serializable
     data class MetaData(
         @SerialName("federation") val federation: Boolean,
@@ -60,6 +78,10 @@ data class ServerConfig(
             title = "staging"
         )
         val DEFAULT = PRODUCTION
+
+        private const val FORGOT_PASSWORD_PATH = "forgot"
+        private const val PRICING_PATH = "pricing"
+        private const val TOS_PATH = "legal"
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.persistence.model.ServerConfigEntity
 import io.ktor.http.URLBuilder
 import io.ktor.http.Url
-import io.ktor.http.appendPathSegments
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -33,18 +32,27 @@ data class ServerConfig(
         @SerialName("title") val title: String
     ) {
         val forgotPassword: String
-            get() = URLBuilder(Url(accounts)).apply {
-                appendPathSegments(FORGOT_PASSWORD_PATH)
+            get() = URLBuilder().apply {
+                val url = Url(accounts)
+                host = url.host
+                protocol = url.protocol
+                pathSegments = url.pathSegments + FORGOT_PASSWORD_PATH
             }.buildString()
 
         val pricing: String
-            get() = URLBuilder(urlString = website).apply {
-                appendPathSegments(PRICING_PATH)
+            get() = URLBuilder().apply {
+                val url = Url(website)
+                host = url.host
+                protocol = url.protocol
+                pathSegments = url.pathSegments + PRICING_PATH
             }.buildString()
 
         val tos: String
-            get() = URLBuilder(urlString = website).apply {
-                appendPathSegments(TOS_PATH)
+            get() = URLBuilder().apply {
+                val url = Url(website)
+                host = url.host
+                protocol = url.protocol
+                pathSegments = url.pathSegments + TOS_PATH
             }.buildString()
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigTest.kt
@@ -1,0 +1,40 @@
+package com.wire.kalium.logic.configuration.server
+
+import com.wire.kalium.logic.util.stubs.newServerConfig
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ServerConfigTest {
+
+    private lateinit var serverConfig: ServerConfig.Links
+
+    @BeforeTest
+    fun setup() {
+        serverConfig = newServerConfig(1).links
+    }
+
+    @Test
+    fun whenCreatingForgotPasswordUrl_thenItsCorrect() {
+        val expected =  serverConfig.accounts + "/forgot"
+        serverConfig.forgotPassword.also { actual ->
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun whenTOSUrl_thenItsCorrect() {
+        val expected =  serverConfig.website + "/pricing"
+        serverConfig.pricing.also { actual ->
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun whenPricingUrl_thenItsCorrect() {
+        val expected =  serverConfig.website + "/legal"
+        serverConfig.tos.also { actual ->
+            assertEquals(expected, actual)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigTest.kt
@@ -16,7 +16,7 @@ class ServerConfigTest {
 
     @Test
     fun whenCreatingForgotPasswordUrl_thenItsCorrect() {
-        val expected =  serverConfig.accounts + "/forgot"
+        val expected =  serverConfig.accounts + "forgot"
         serverConfig.forgotPassword.also { actual ->
             assertEquals(expected, actual)
         }
@@ -24,7 +24,7 @@ class ServerConfigTest {
 
     @Test
     fun whenTOSUrl_thenItsCorrect() {
-        val expected =  serverConfig.website + "/pricing"
+        val expected =  serverConfig.website + "pricing"
         serverConfig.pricing.also { actual ->
             assertEquals(expected, actual)
         }
@@ -32,7 +32,7 @@ class ServerConfigTest {
 
     @Test
     fun whenPricingUrl_thenItsCorrect() {
-        val expected =  serverConfig.website + "/legal"
+        val expected =  serverConfig.website + "legal"
         serverConfig.tos.also { actual ->
             assertEquals(expected, actual)
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when introducing changes to `ServerConfig` data class it can break some links in the app e.g. pricing, TOS and passwordRest

### Solutions

move the creation of those urls to kalium so it's more consistent and add unit tests

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
