### PR TITLE
ci: enable `EnforceSerializableFields` on all modules

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -636,4 +636,4 @@ style:
 WireRuleSet:
     EnforceSerializableFields:
         active: true
-        excludes: [ '**/*test/**', '**/persistence/**', '**/logic/**' ]
+        excludes: [ '**/*test/**']

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallClient.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallClient.kt
@@ -12,7 +12,8 @@ data class CallClient(
 
 @Serializable
 data class CallClientList(
-    val clients: List<CallClient>
+    @SerialName("clients") val clients: List<CallClient>
 ) {
+    //TODO(optimization): Use a shared Json instance instead of creating one every time.
     fun toJsonString(): String = Json { isLenient = true }.encodeToString(serializer(), this)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMapper.kt
@@ -48,10 +48,10 @@ class CallMapper {
         fun fromCallMemberToParticipant(member: CallMember): Participant = with(member) {
             Participant(
                 id = QualifiedID(
-                    value = userid.removeDomain(),
-                    domain = userid.getDomain()
+                    value = userId.removeDomain(),
+                    domain = userId.getDomain()
                 ),
-                clientId = clientid,
+                clientId = clientId,
                 muted = muted == 1
             )
         }
@@ -59,10 +59,10 @@ class CallMapper {
         fun fromCallMemberToCallClient(member: CallMember): CallClient = with(member) {
             CallClient(
                 userId = QualifiedID(
-                    value = userid.removeDomain(),
-                    domain = userid.getDomain()
+                    value = userId.removeDomain(),
+                    domain = userId.getDomain()
                 ).toString(),
-                clientId = clientid
+                clientId = clientId
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallParticipants.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallParticipants.kt
@@ -1,18 +1,19 @@
 package com.wire.kalium.logic.data.call
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class CallParticipants(
-    val convid: String,
-    val members: List<CallMember>
+    @SerialName("convid") val convId: String,
+    @SerialName("members") val members: List<CallMember>
 )
 
 @Serializable
 data class CallMember(
-    val userid: String,
-    val clientid: String,
-    val aestab: Int,
-    val vrecv: Int,
-    val muted: Int
+    @SerialName("userid") val userId: String,
+    @SerialName("clientid") val clientId: String,
+    @SerialName("aestab") val aestab: Int,
+    @SerialName("vrecv") val vrecv: Int,
+    @SerialName("muted") val muted: Int
 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallMapperTest.kt
@@ -140,8 +140,8 @@ class CallMapperTest {
 
     private companion object {
         private val DUMMY_CALL_MEMBER = CallMember(
-            userid = "dummyId@dummyDomain",
-            clientid = "dummyClientId",
+            userId = "dummyId@dummyDomain",
+            clientId = "dummyClientId",
             aestab = 0,
             vrecv = 0,
             muted = 0

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/SessionStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/SessionStorage.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
@@ -108,7 +109,7 @@ class SessionStorageImpl(
             .also { sessionsUpdatedFlow.tryEmit(Unit) }
 
     override fun allSessions(): Map<UserIDEntity, AuthSessionEntity>? =
-        kaliumPreferences.getSerializable(SESSIONS_KEY, SessionsMap.serializer())?.s?.ifEmpty { null }
+        kaliumPreferences.getSerializable(SESSIONS_KEY, SessionsMap.serializer())?.sessions?.ifEmpty { null }
 
     override fun userSession(userId: UserIDEntity): AuthSessionEntity? =
         allSessions()?.let { sessionMap ->
@@ -134,4 +135,4 @@ class SessionStorageImpl(
 // At runtime an object of 'SessionsMap' contains just 'Map<String, PersistenceSession>'
 @Serializable
 @JvmInline
-private value class SessionsMap(val s: Map<UserIDEntity, AuthSessionEntity>)
+private value class SessionsMap(@SerialName("s") val sessions: Map<UserIDEntity, AuthSessionEntity>)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/TokenStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/TokenStorage.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.persistence.client
 
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 interface TokenStorage {
@@ -18,7 +19,10 @@ interface TokenStorage {
 }
 
 @Serializable
-data class NotificationTokenEntity(val token: String, val transport: String)
+data class NotificationTokenEntity(
+    @SerialName("token") val token: String,
+    @SerialName("transport") val transport: String
+)
 
 
 class TokenStorageImpl(private val kaliumPreferences: KaliumPreferences) : TokenStorage {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -1,12 +1,13 @@
 package com.wire.kalium.persistence.dao
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class QualifiedIDEntity(
-    val value: String,
-    val domain: String
+    @SerialName("value") val value: String,
+    @SerialName("domain") val domain: String
 )
 
 typealias UserIDEntity = QualifiedIDEntity

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/kmm_settings/KaliumPreferencesTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/kmm_settings/KaliumPreferencesTest.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.persistence.kmm_settings
 
 import com.russhwolf.settings.MockSettings
 import com.russhwolf.settings.Settings
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 import kotlin.test.BeforeTest
@@ -48,7 +49,7 @@ class KaliumPreferencesTest {
         kaliumPreferences.putSerializable(KEY1, testValue, TestValueClass.serializer())
 
         assertEquals(kaliumPreferences.getSerializable(KEY1, TestValueClass.serializer()), testValue)
-        assertEquals(kaliumPreferences.getSerializable(KEY1, TestValueClass.serializer())?.s, TEST_LIST)
+        assertEquals(kaliumPreferences.getSerializable(KEY1, TestValueClass.serializer())?.values, TEST_LIST)
     }
 
 
@@ -60,4 +61,6 @@ class KaliumPreferencesTest {
 
 @Serializable
 @JvmInline
-private value class TestValueClass(val s: List<String>)
+private value class TestValueClass(
+    @SerialName("s") val values: List<String>
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are not checking `EnforceSerializableFields` on all modules. Which can lead to breaking changes in the future being missed.

### Solutions

Enable them everywhere in Kalium.

### Testing

#### How to Test

`./gradlew detekt`

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
