### PR TITLE
fix: sync hanging when receiving calling messages on the background

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -58,9 +58,14 @@ actual class GlobalCallManager(
         }
     }
 
-    actual fun getFlowManager(): FlowManagerService = FlowManagerServiceImpl(appContext, Dispatchers.Default)
+    // Initialize it eagerly, so it's already initialized when `calling` is initialized
+    private val flowManager = FlowManagerServiceImpl(appContext, Dispatchers.Default)
 
-    actual fun getMediaManager(): MediaManagerService = MediaManagerServiceImpl(appContext)
+    actual fun getFlowManager(): FlowManagerService = flowManager
+
+    // Initialize it eagerly, so it's already initialized when `calling` is initialized
+    private val mediaManager = MediaManagerServiceImpl(appContext)
+    actual fun getMediaManager(): MediaManagerService = mediaManager
 }
 
 object LogHandlerImpl : LogHandler {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While on background, no messages are received after a call message.


### Causes

AVS requires Flow and Media managers to be initialized in order to process calling messages. And it never finishes initializing.

### Solutions

Start the managers eagerly.

### Testing

Manually tested 👍🏻

#### How to Test

1. Minimize an Android app and throw it away, killing it.
2. Call the account which is logged-in in the device
3. Send text messages to the same account
4. Open the app
5. You should see all messages and calls

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
