### PR TITLE
chore: dont wait for sync on delete message (AR-1271)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -27,7 +27,7 @@ class DeleteMessageUseCase(
 ) {
 
     suspend operator fun invoke(conversationId: ConversationId, messageId: String, deleteForEveryone: Boolean): Either<CoreFailure, Unit> {
-        syncManager.waitUntilLive()
+        syncManager.startSyncIfIdle()
         val selfUser = userRepository.getSelfUser().first()
 
         val generatedMessageUuid = uuid4().toString()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When deleting messages, we can't display errors.

### Causes

`DeleteMessageUseCase` waits for sync to be complete / until live. If Sync fails - because of lack of internet connection for example - then the UseCase invocation will be hanging indeterminately.

### Solutions

Don't wait for sync. The decision to sync or not can be delegated to the `MessageSender`, which doesn't care about it for non-pending messages.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

### Notes

`MessageSender` doesn't wait for sync for deleting messages. Also, it blocks indefinitely while waiting for sync when sending pending messages. I'm thinking about adding a timeout for it inside `MessageSender`, and schedule the sending for the future it the timeout is hit.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
