### PR TITLE
fix: Notifications coming

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -158,7 +158,7 @@ class GetNotificationsUseCaseImpl(
         val newNotificationDate = if (eligibleMessages.isEmpty()) {
             messages.maxOf { it.date }
         } else {
-            timeParser.dateMinusMilliseconds(eligibleMessages.minOf { it.date }, 1L)
+            timeParser.dateMinusMilliseconds(eligibleMessages.minOf { it.date }, 100L)
         }
 
         conversation.lastNotificationDate.let {


### PR DESCRIPTION
### Issues

After changes for applying User Status into notifications, notifications stop coming.

### Causes (Optional)

Looks like SQLDelight doesn't see the difference between the times when the difference is only 1-10 milliseconds, while selecting from the DB.

