### PR TITLE
feat: put new conversations on top (AR-1673)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
@@ -1,12 +1,15 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.datetime.Clock
 
 class CreateGroupConversationUseCase(
     private val conversationRepository: ConversationRepository,
@@ -14,6 +17,8 @@ class CreateGroupConversationUseCase(
 ) {
     suspend operator fun invoke(name: String, members: List<Member>, options: ConversationOptions): Either<CoreFailure, Conversation> {
         syncManager.waitUntilLive()
-        return conversationRepository.createGroupConversation(name, members, options)
+        return conversationRepository.createGroupConversation(name, members, options).flatMap { conversation ->
+            conversationRepository.updateConversationModifiedDate(conversation.id, Clock.System.now().toString()).map { conversation }
+        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCaseTest.kt
@@ -1,0 +1,97 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationOptions
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.logic.test_util.wasInTheLastSecond
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.configure
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.toInstant
+import kotlin.test.Test
+
+class CreateGroupConversationUseCaseTest {
+
+
+    @Test
+    fun givenNameMembersAndOptions_whenCreatingGroupConversation_thenRepositoryCreateGroupShouldBeCalled() = runTest {
+        val name = "Conv Name"
+        val members = listOf(Member(TestUser.USER_ID), Member(TestUser.OTHER.id))
+        val conversationOptions = ConversationOptions(protocol = ConversationOptions.Protocol.MLS)
+
+        val (arrangement, createGroupConversation) = Arrangement()
+            .withUpdateConversationModifiedDateSucceeding()
+            .withCreateGroupConversationReturning(TestConversation.GROUP)
+            .arrange()
+
+        createGroupConversation(name, members, conversationOptions)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::createGroupConversation)
+            .with(eq(name), eq(members), eq(conversationOptions))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenNameMembersAndOptions_whenCreatingGroupConversation_thenConversationModifiedDateIsUpdated() = runTest {
+        val name = "Conv Name"
+        val members = listOf(Member(TestUser.USER_ID), Member(TestUser.OTHER.id))
+        val conversationOptions = ConversationOptions(protocol = ConversationOptions.Protocol.MLS)
+
+        val (arrangement, createGroupConversation) = Arrangement()
+            .withUpdateConversationModifiedDateSucceeding()
+            .withCreateGroupConversationReturning(TestConversation.GROUP)
+            .arrange()
+
+        createGroupConversation(name, members, conversationOptions)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateConversationModifiedDate)
+            .with(any(), matching { it.toInstant().wasInTheLastSecond })
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val conversationRepository = mock(ConversationRepository::class)
+
+        @Mock
+        val syncManager = configure(mock(SyncManager::class)) {
+            stubsUnitByDefault = true
+        }
+
+        private val createGroupConversation = CreateGroupConversationUseCase(
+            conversationRepository, syncManager
+        )
+
+        fun withCreateGroupConversationReturning(conversation: Conversation) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::createGroupConversation)
+                .whenInvokedWith(any(), any(), any())
+                .thenReturn(Either.Right(conversation))
+        }
+
+        fun withUpdateConversationModifiedDateSucceeding() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::updateConversationModifiedDate)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun arrange() = this to createGroupConversation
+    }
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -1,9 +1,15 @@
 package com.wire.kalium.logic.framework
 
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepositoryTest
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.QualifiedID
+import com.wire.kalium.network.api.conversation.ConvProtocol
+import com.wire.kalium.network.api.conversation.ConversationMembersResponse
+import com.wire.kalium.network.api.conversation.ConversationResponse
+import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 
@@ -51,6 +57,22 @@ object TestConversation {
     )
 
     val NETWORK_ID = QualifiedID("valueConversation", "domainConversation")
+
+    val CONVERSATION_RESPONSE = ConversationResponse(
+        "creator",
+        ConversationMembersResponse(
+            ConversationSelfMemberResponse(MapperProvider.idMapper().toApiModel(TestUser.SELF.id)),
+            emptyList()
+        ),
+        ConversationRepositoryTest.GROUP_NAME,
+        NETWORK_ID,
+        null,
+        ConversationResponse.Type.GROUP,
+        0,
+        null,
+        ConvProtocol.PROTEUS,
+        lastEventTime = "2022-03-30T15:36:00.000Z"
+    )
 
     val ENTITY_ID = QualifiedIDEntity("valueConversation", "domainConversation")
     val ENTITY = ConversationEntity(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiverTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.handler.MessageTextEditHandler
+import com.wire.kalium.logic.test_util.wasInTheLastSecond
 import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.messages.GenericMessage
@@ -157,11 +158,7 @@ class ConversationEventReceiverTest {
 
         verify(arrangement.conversationRepository)
             .suspendFunction(arrangement.conversationRepository::updateConversationModifiedDate)
-            .with(eq(event.conversationId), matching {
-                val instant = it.toInstant()
-                val difference = Clock.System.now() - instant
-                difference < 1.seconds
-            })
+            .with(eq(event.conversationId), matching { it.toInstant().wasInTheLastSecond })
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiverTest.kt
@@ -28,7 +28,6 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.handler.MessageTextEditHandler
 import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.protobuf.encodeToByteArray
-import com.wire.kalium.protobuf.messages.External
 import com.wire.kalium.protobuf.messages.GenericMessage
 import com.wire.kalium.protobuf.messages.Text
 import io.ktor.utils.io.core.toByteArray
@@ -43,7 +42,10 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.toInstant
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
 
 class ConversationEventReceiverTest {
 
@@ -115,6 +117,54 @@ class ConversationEventReceiverTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenNewConversationEvent_whenHandlingIt_thenInsertConversationFromEventShouldBeCalled() = runTest {
+        val event = Event.Conversation.NewConversation(
+            id = "eventId",
+            conversationId = TestConversation.ID,
+            timestampIso = "timestamp",
+            conversation = TestConversation.CONVERSATION_RESPONSE
+        )
+
+        val (arrangement, eventReceiver) = Arrangement()
+            .withUpdateConversationModifiedDateReturning(Either.Right(Unit))
+            .withInsertConversationFromEventReturning(Either.Right(Unit))
+            .arrange()
+
+        eventReceiver.onEvent(event)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::insertConversationFromEvent)
+            .with(eq(event))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenNewConversationEvent_whenHandlingIt_thenConversationLastModifiedShouldBeUpdated() = runTest {
+        val event = Event.Conversation.NewConversation(
+            id = "eventId",
+            conversationId = TestConversation.ID,
+            timestampIso = "timestamp",
+            conversation = TestConversation.CONVERSATION_RESPONSE
+        )
+
+        val (arrangement, eventReceiver) = Arrangement()
+            .withUpdateConversationModifiedDateReturning(Either.Right(Unit))
+            .withInsertConversationFromEventReturning(Either.Right(Unit))
+            .arrange()
+
+        eventReceiver.onEvent(event)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateConversationModifiedDate)
+            .with(eq(event.conversationId), matching {
+                val instant = it.toInstant()
+                val difference = Clock.System.now() - instant
+                difference < 1.seconds
+            })
+            .wasInvoked(exactly = once)
+    }
+
     private class Arrangement {
         @Mock
         val proteusClient = mock(classOf<ProteusClient>())
@@ -123,7 +173,7 @@ class ConversationEventReceiverTest {
         val messageRepository = mock(classOf<MessageRepository>())
 
         @Mock
-        private val conversationRepository = mock(classOf<ConversationRepository>())
+        val conversationRepository = mock(classOf<ConversationRepository>())
 
         @Mock
         private val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
@@ -187,6 +237,13 @@ class ConversationEventReceiverTest {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::updateConversationModifiedDate)
                 .whenInvokedWith(any(), any())
+                .thenReturn(result)
+        }
+
+        fun withInsertConversationFromEventReturning(result: Either<StorageFailure, Unit>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::insertConversationFromEvent)
+                .whenInvokedWith(any())
                 .thenReturn(result)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TimeUtils.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TimeUtils.kt
@@ -1,0 +1,11 @@
+package com.wire.kalium.logic.test_util
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.seconds
+
+val Instant.wasInTheLastSecond: Boolean
+    get() {
+        val difference = Clock.System.now() - this
+        return difference < 1.seconds
+    }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After being added to conversations or after creating conversations, they are staying on the very bottom of the list.

### Causes

The field `lastModifiedDate` that comes from the server is a LIE. The server doesn't store this information and this field shouldn't be used.

### Solutions

Update the field ourselves so we can sort the conversations.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

#### When creating group
* Create a group conversation

#### When a new group is added with you as a member
* As User A, create a group and add account B
* As User B, the new group should appear on the top of the conversation list

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
