### PR TITLE
chore: update pbandk to 0.14.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,12 +29,6 @@ object Versions {
     const val multiplatformSettings = "0.8.1"
     const val androidSecurity = "1.0.0"
     const val sqlDelight = "2.0.0-alpha01"
-
-    @Deprecated("A new implementation is available. Use the protobuf project instead.")
-    const val wireJvmMessageProto = "1.36.0"
-
-    @Deprecated("A new implementation is available. Use the protobuf project instead.")
-    const val protobufLite = "3.19.4"
     const val pbandk = "0.13.0"
     const val turbine = "0.7.0"
     const val avs = "8.1.16"
@@ -180,11 +174,6 @@ object Dependencies {
     }
 
     object Protobuf {
-        @Deprecated("A new implementation is available. Use the protobuf project instead.")
-        const val wireJvmMessageProto = "com.wire:generic-message-proto:${Versions.wireJvmMessageProto}"
-
-        @Deprecated("A new implementation is available. Use the protobuf project instead.")
-        const val protobufLite = "com.google.protobuf:protobuf-javalite:${Versions.protobufLite}"
         const val pbandkRuntime = "pro.streem.pbandk:pbandk-runtime:${Versions.pbandk}"
     }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val multiplatformSettings = "0.8.1"
     const val androidSecurity = "1.0.0"
     const val sqlDelight = "2.0.0-alpha01"
-    const val pbandk = "0.13.0"
+    const val pbandk = "0.14.1"
     const val turbine = "0.7.0"
     const val avs = "8.1.16"
     const val jna = "5.6.0@aar"

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                implementation(project(":protobuf"))
                 api(project(":logger"))
 
                 // coroutines
@@ -78,7 +79,6 @@ kotlin {
             addCommonKotlinJvmSourceDir()
             dependencies {
                 implementation(Dependencies.Ktor.okHttp)
-                implementation(Dependencies.Protobuf.wireJvmMessageProto)
             }
         }
         val jvmTest by getting
@@ -86,11 +86,6 @@ kotlin {
             addCommonKotlinJvmSourceDir()
             dependencies {
                 implementation(Dependencies.Ktor.okHttp)
-                implementation(Dependencies.Protobuf.wireJvmMessageProto) {
-                    // Don't use the runtime Protobuf included in wire. We can use Protobuf Lite instead
-                    exclude(module = "protobuf-java")
-                }
-                implementation(Dependencies.Protobuf.protobufLite)
             }
         }
         val androidTest by getting

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/OtrClientEntryMapper.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/OtrClientEntryMapper.kt
@@ -1,15 +1,13 @@
 package com.wire.kalium.network.api.message
 
-import com.google.protobuf.ByteString
-import com.wire.messages.Otr
-import java.nio.charset.Charset
+import com.wire.kalium.protobuf.otr.ClientEntry
+import pbandk.ByteArr
 
 class OtrClientEntryMapper {
 
     private val clientIdMapper = OtrClientIdMapper()
-
-    fun toOtrClientEntry(clientPayload: Map.Entry<String, ByteArray>): Otr.ClientEntry = Otr.ClientEntry.newBuilder()
-        .setClient(clientIdMapper.toOtrClientId(clientPayload.key))
-        .setText(ByteString.copyFrom(clientPayload.value))
-        .build()
+    fun toOtrClientEntry(clientPayload: Map.Entry<String, ByteArray>): ClientEntry = ClientEntry(
+        client = clientIdMapper.toOtrClientId(clientPayload.key),
+        text = ByteArr(clientPayload.value),
+    )
 }

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/OtrClientIdMapper.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/OtrClientIdMapper.kt
@@ -1,15 +1,13 @@
 package com.wire.kalium.network.api.message
 
-import com.wire.messages.Otr
+import com.wire.kalium.protobuf.otr.ClientId
 import java.math.BigInteger
 
 class OtrClientIdMapper {
 
-    fun toOtrClientId(clientId: String): Otr.ClientId = Otr.ClientId.newBuilder()
-        .setClient(BigInteger(clientId, CLIENT_ID_RADIX).toLong())
-        .build()
+    fun toOtrClientId(clientId: String): ClientId = ClientId(BigInteger(clientId, CLIENT_ID_RADIX).toLong())
 
-    fun fromOtrClientId(otrClientId: Otr.ClientId): String = otrClientId.client.toBigInteger().toString(CLIENT_ID_RADIX)
+    fun fromOtrClientId(otrClientId: ClientId): String = otrClientId.client.toBigInteger().toString(CLIENT_ID_RADIX)
 
     companion object {
         private const val CLIENT_ID_RADIX = 16

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/OtrUserIdMapper.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/OtrUserIdMapper.kt
@@ -1,25 +1,23 @@
 package com.wire.kalium.network.api.message
 
-import com.google.protobuf.ByteString
-import com.wire.messages.Otr
+import com.wire.kalium.protobuf.otr.UserId
+import pbandk.ByteArr
 import java.nio.ByteBuffer
 import java.util.UUID
 
 class OtrUserIdMapper {
 
-    fun toOtrUserId(userId: String): Otr.UserId {
+    fun toOtrUserId(userId: String): UserId {
         val bytes = ByteArray(USER_UID_BYTE_COUNT)
         val byteBuffer = ByteBuffer.wrap(bytes).asLongBuffer()
         val uuid = UUID.fromString(userId)
         byteBuffer.put(uuid.mostSignificantBits)
         byteBuffer.put(uuid.leastSignificantBits)
-        return Otr.UserId.newBuilder()
-            .setUuid(ByteString.copyFrom(bytes))
-            .build()
+        return UserId(uuid = (ByteArr(bytes)))
     }
 
-    fun fromOtrUserId(otrUserId: Otr.UserId): String {
-        val bytes = otrUserId.uuid.toByteArray()
+    fun fromOtrUserId(otrUserId: UserId): String {
+        val bytes = otrUserId.uuid.array
         val byteBuffer = ByteBuffer.wrap(bytes)
         return UUID(byteBuffer.long, byteBuffer.long).toString()
     }

--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -58,7 +58,7 @@ kotlin {
         val commonMain by getting {
             kotlin.srcDir(codegenProject.file("generated"))
             dependencies {
-                api("pro.streem.pbandk:pbandk-runtime:${Versions.pbandk}")
+                api(Dependencies.Protobuf.pbandkRuntime)
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

PBandK was updated to `0.14.1`, and there are some new features we can take advantage of, like proper `required` support for proto v2.

This means that required fields are no longer generated as Kotlin optionals (?).

### Solutions

Update to `0.14.1` and fix breaking changes.
Only 1 was detected.

### Dependencies

Needs releases with:

- #611 

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
