### PR TITLE
feat: don't wait for sync when getting connection requests

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/ObserveConnectionListUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/ObserveConnectionListUseCase.kt
@@ -23,7 +23,7 @@ internal class ObserveConnectionListUseCaseImpl(
 ) : ObserveConnectionListUseCase {
 
     override suspend operator fun invoke(): Flow<List<Connection>> {
-        syncManager.waitUntilLive()
+        syncManager.startSyncIfIdle()
         return connectionRepository.observeConnectionList()
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Can't see cached connection requests and conversations when calling `ObserveConnectionListUseCase`.

### Causes

`ObserveConnectionListUseCaseImpl` waits until app is live to start returning results, even if we already have them locally.

### Solutions

Just trigger sync instead of waiting for the app to become online.

### Testing

#### How to Test

- Build reloaded with this change on Kalium.
- Open main/conversations screen

![SpeedIAmSpeedGIF](https://user-images.githubusercontent.com/9389043/175040036-6931efc6-3cf0-49db-b75d-4f8bd0059ae5.gif)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
