### PR TITLE
chore: add observe ongoing calls usecase

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -9,6 +9,8 @@ import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveSpeakerUseCase
 import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.SetVideoPreviewUseCase
@@ -48,6 +50,12 @@ class CallsScope(
             syncManager = syncManager,
             conversationRepository = conversationRepository,
             userRepository = userRepository
+        )
+
+    val observeOngoingCalls: ObserveOngoingCallsUseCase
+        get() = ObserveOngoingCallsUseCaseImpl(
+            callRepository = callRepository,
+            syncManager = syncManager
         )
 
     val startCall: StartCallUseCase get() = StartCallUseCase(callManager)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingCallsUseCase.kt
@@ -1,0 +1,30 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.sync.SyncManager
+import kotlinx.coroutines.flow.Flow
+
+interface ObserveOngoingCallsUseCase {
+    suspend operator fun invoke(): Flow<List<Call>>
+}
+
+/**
+ *
+ * @param callRepository CallRepository for getting all the ongoing calls.
+ * @param syncManager SyncManager to sync the data before checking the calls.
+ *
+ * @return Flow<List<Call>> - Flow of Calls List that should be shown to the user.
+ * That Flow emits everytime when the list is changed
+ */
+internal class ObserveOngoingCallsUseCaseImpl(
+    private val callRepository: CallRepository,
+    private val syncManager: SyncManager
+) : ObserveOngoingCallsUseCase {
+
+    override suspend fun invoke(): Flow<List<Call>> {
+        syncManager.startSyncIfIdle()
+
+        return callRepository.ongoingCallsFlow()
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingCallsUseCaseTest.kt
@@ -1,0 +1,96 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallStatus
+import com.wire.kalium.logic.sync.SyncManager
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveOngoingCallsUseCaseTest {
+
+    @Mock
+    val syncManager: SyncManager = mock(classOf<SyncManager>())
+
+    @Mock
+    val callRepository: CallRepository = mock(classOf<CallRepository>())
+
+    private lateinit var observeOngoingCalls: ObserveOngoingCallsUseCase
+
+    @BeforeTest
+    fun setUp() {
+        observeOngoingCalls = ObserveOngoingCallsUseCaseImpl(
+            callRepository = callRepository,
+            syncManager = syncManager
+        )
+    }
+
+    @Test
+    fun givenAnEmptyCallList_whenInvokingObserveOngoingCallsUseCase_thenEmitsAnEmptyListOfCalls() = runTest {
+        given(callRepository)
+            .function(callRepository::ongoingCallsFlow)
+            .whenInvoked()
+            .thenReturn(flowOf(listOf()))
+
+        given(syncManager)
+            .function(syncManager::startSyncIfIdle)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        val result = observeOngoingCalls()
+
+        result.test {
+            assertEquals(listOf(), awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenAnOngoingCallList_whenInvokingObserveOngoingCallsUseCase_thenEmitsAnOngoingListOfCalls() = runTest {
+        given(callRepository)
+            .function(callRepository::ongoingCallsFlow)
+            .whenInvoked()
+            .thenReturn(flowOf(listOf(DUMMY_CALL)))
+
+        given(syncManager)
+            .function(syncManager::startSyncIfIdle)
+            .whenInvoked()
+            .thenReturn(Unit)
+
+        val result = observeOngoingCalls()
+
+        result.test {
+            assertEquals(listOf(DUMMY_CALL), awaitItem())
+            awaitComplete()
+        }
+    }
+
+    private companion object {
+        val DUMMY_CALL = Call(
+            conversationId = ConversationId(
+                value = "convId",
+                domain = "domainId"
+            ),
+            status = CallStatus.STILL_ONGOING,
+            isMuted = false,
+            isCameraOn = false,
+            callerId = "callerId",
+            conversationName = null,
+            conversationType = Conversation.Type.GROUP,
+            callerName = null,
+            callerTeamName = null
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to observe ongoing calls that is happening to be able to show on a particular conversation screen, we need a usecase to listen to the ongoing calls

### Solutions

Create ObserveOngoingCallsUseCase