### PR TITLE
chore: logs to use the platform specific log writer 

### DIFF
--- a/logger/src/commonMain/kotlin/com/wire/kalium/logger/KaliumLogger.kt
+++ b/logger/src/commonMain/kotlin/com/wire/kalium/logger/KaliumLogger.kt
@@ -1,9 +1,9 @@
 package com.wire.kalium.logger
 
-import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import co.touchlab.kermit.StaticConfig
+import co.touchlab.kermit.platformLogWriter
 import co.touchlab.kermit.Logger as KermitLogger
 
 /**
@@ -56,14 +56,14 @@ class KaliumLogger(config: Config, logWriter: LogWriter? = null) {
         kermitLogger = if (logWriter == null) {
             KermitLogger(
                 config = StaticConfig(
-                    minSeverity = config.severityLevel, listOf(CommonWriter())
+                    minSeverity = config.severityLevel, listOf(platformLogWriter())
                 ),
                 tag = config.tag
             )
         } else {
             KermitLogger(
                 config = StaticConfig(
-                    minSeverity = config.severityLevel, listOf(logWriter, CommonWriter())
+                    minSeverity = config.severityLevel, listOf(logWriter, platformLogWriter())
                 ),
                 tag = config.tag
             )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, the logs are writing into a `CommonLogger` writer, that means writing the output to `System.out`.
With this change, we are now taking advantage of Kermit `platformLogWriter()`  that returns the platform specific logger, ie: Logcat for Android, and will send to the correct `LogLevel` by the platform.

### Attachments (Optional)

Before:
<img width="1497" alt="Screen Shot 2022-06-21 at 11 18 12" src="https://user-images.githubusercontent.com/5806454/175299581-b106e835-9116-444d-8e91-12803b8e95c4.png">

After:
<img width="1497" alt="Screen Shot 2022-06-21 at 11 49 34" src="https://user-images.githubusercontent.com/5806454/175299624-062a1259-04e2-4eca-87e1-1082f70e872a.png">

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
