### PR TITLE
feat(calling): sort participants alphabetically

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -179,9 +179,10 @@ internal class CallDataSource(
         callProfile[conversationId]?.let { call ->
             callingLogger.i("updateCallParticipants() - conversationId: $conversationId with size of: ${participants.size}")
 
+            val sortedParticipants = participants.sortedBy { it.name }
             val updatedCalls = callProfile.calls.toMutableMap().apply {
                 this[conversationId] = call.copy(
-                    participants = participants,
+                    participants = sortedParticipants,
                     maxParticipants = max(call.maxParticipants, participants.size + 1)
                 )
             }
@@ -202,10 +203,11 @@ internal class CallDataSource(
                 participants = call.participants,
                 activeSpeakers = activeSpeakers
             )
+            val sortedParticipants = updatedParticipants.sortedBy { it.name }
 
             val updatedCalls = callProfile.calls.toMutableMap().apply {
                 this[conversationId] = call.copy(
-                    participants = updatedParticipants,
+                    participants = sortedParticipants,
                     maxParticipants = max(call.maxParticipants, updatedParticipants.size + 1)
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetAllCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetAllCallsUseCase.kt
@@ -9,7 +9,7 @@ class GetAllCallsUseCase(
     private val callRepository: CallRepository,
     private val syncManager: SyncManager
 ) {
-    suspend operator fun invoke(): Flow<List<Call>> {
+    operator fun invoke(): Flow<List<Call>> {
         syncManager.startSyncIfIdle()
         return callRepository.callsFlow()
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -296,23 +296,14 @@ class CallRepositoryTest {
     }
 
     @Test
-    fun givenNewCallParticipants_whenUpdatingParticipants_thenCallProfileIsUpdated() = runTest {
+    fun givenNewCallParticipants_whenUpdatingParticipants_thenCallProfileIsUpdatedWithAlphabeticallySortedParticipants() = runTest {
         callRepository.updateCallProfileFlow(
             CallProfile(
                 mapOf(establishedCall.conversationId.toString() to establishedCall)
             )
         )
 
-        val expectedParticipants = listOf(
-            Participant(
-                id = QualifiedID(
-                    value = "value1",
-                    domain = "domain1"
-                ),
-                clientId = "clientid",
-                isMuted = true
-            )
-        )
+        val expectedParticipants = listOf(participant1, participant2)
 
         val calls = callRepository.callsFlow()
 
@@ -321,7 +312,8 @@ class CallRepositoryTest {
             participants = expectedParticipants
         )
 
-        assertEquals(expectedParticipants, calls.first()[0].participants)
+        assertEquals(expectedParticipants.size, calls.first().first().participants.size)
+        assertEquals(participant2, calls.first().first().participants.first())
     }
 
     @Test
@@ -334,28 +326,18 @@ class CallRepositoryTest {
 
         val calls = callRepository.callsFlow()
 
-        val participants = listOf(
-            Participant(
-                id = QualifiedID(
-                    value = "value1",
-                    domain = "domain1"
-                ),
-                clientId = "clientid",
-                isMuted = false,
-                isSpeaking = false
-            )
-        )
+        val expectedParticipants = listOf(participant1, participant2)
 
         callRepository.updateCallParticipants(
             conversationId = establishedCall.conversationId.toString(),
-            participants = participants
+            participants = expectedParticipants
         )
 
         val expectedActiveSpeakers = CallActiveSpeakers(
             activeSpeakers = listOf(
                 CallActiveSpeaker(
                     userId = "value1@domain1",
-                    clientId = "clientid",
+                    clientId = "clientId1",
                     audioLevel = 1,
                     audioLevelNow = 1
                 )
@@ -367,7 +349,8 @@ class CallRepositoryTest {
             activeSpeakers = expectedActiveSpeakers
         )
 
-        assertEquals(true, calls.first()[0].participants.first().isSpeaking)
+        assertEquals(true, calls.first()[0].participants[1].isSpeaking)
+        assertEquals(participant2, calls.first()[0].participants.first())
     }
 
     private fun provideCall(id: ConversationId, status: CallStatus) = Call(
@@ -391,5 +374,23 @@ class CallRepositoryTest {
         private val conversationIdAnsweredCall = ConversationId("value2", "domain2")
         private val conversationIdIncomingCall = ConversationId("value3", "domain3")
         private val conversationIdEstablishedCall = ConversationId("value4", "domain4")
+        private val participant1 = Participant(
+            id = QualifiedID(
+                value = "value1",
+                domain = "domain1"
+            ),
+            name = "Wire user",
+            clientId = "clientId1",
+            isMuted = true
+        )
+        private val participant2 = Participant(
+            id = QualifiedID(
+                value = "value2",
+                domain = "domain2"
+            ),
+            name = "A user",
+            clientId = "clientId2",
+            isMuted = true
+        )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are passing non ordered participants list in a call

### Solutions

Order it alphabetically

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

On AR, start a group call to check if the titles are ordered.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
