### PR TITLE
feat(conversation)!: add member to group conversation usecase (AR-1849)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Note that the path needs to be adjusted for your machine.
 ##### Troubleshooting
 
 ###### Unknown host CPU architecture: arm64
+`This solution won't work! an alternative solution is to use OpenJDK, but that won't work either, so PLEASE DON'T WASTE MORE TIME on it till there is a permanent and working solution for M1 machines! Otherwise, please use x86-based machines to build and run the CLI app!`
 
-If you get `Unknown host CPU architecture: arm64` on Apple Silicon (M1 Mac), [follow this stack overflow answer](https://stackoverflow.com/questions/69541831/unknown-host-cpu-architecture-arm64-android-ndk-siliconm1-apple-macbook-pro).
+If you get `Unknown host CPU architecture: arm64` on Apple Silicon (M1 Mac)
+, [follow this stack overflow answer](https://stackoverflow.com/questions/69541831/unknown-host-cpu-architecture-arm64-android-ndk-siliconm1-apple-macbook-pro)
+.
 
 Change `/Users/<your-user>/Library/Android/sdk/ndk/<your-ndk-version-number>` to
 

--- a/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -3,6 +3,8 @@ package com.wire.kalium.cli
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.output.TermUi.echo
+import com.github.ajalt.clikt.output.TermUi.prompt
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.prompt
 import com.wire.kalium.logger.KaliumLogLevel
@@ -10,9 +12,12 @@ import com.wire.kalium.logic.CoreLogger
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.client.DeleteClientParam
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
@@ -42,15 +47,47 @@ fun restoreSession(): AuthSession? {
     }
 }
 
+fun currentUserSession(): UserSessionScope {
+    val authSession = restoreSession() ?: throw PrintMessage("no active session")
+    return coreLogic.getSessionScope(authSession.tokens.userId)
+}
+
+suspend fun selectConversation(userSession: UserSessionScope): Conversation {
+    val conversations = userSession.conversations.getConversations().let {
+        when (it) {
+            is GetConversationsUseCase.Result.Success -> it.convFlow.first()
+            is GetConversationsUseCase.Result.Failure -> throw PrintMessage("Failed to retrieve conversation: ${it.storageFailure}")
+            else -> throw PrintMessage("Failed to retrieve conversation: Unknown reason")
+        }
+    }
+
+    conversations.forEachIndexed { index, conversation ->
+        echo("$index) ${conversation.id.value}  Name: ${conversation.name}")
+    }
+
+    val selectedConversationIndex =
+        prompt("Enter conversation index", promptSuffix = ": ")?.toInt() ?: throw PrintMessage("Index must be an integer")
+    return conversations[selectedConversationIndex]
+}
+
+suspend fun selectConnection(userSession: UserSessionScope): OtherUser {
+    val connections = userSession.users.getAllKnownUsers()
+    connections.forEachIndexed { index, connection ->
+        echo("$index) ${connection.id.value}  Name: ${connection.name}")
+    }
+    val selectedConnectionIndex =
+        prompt("Enter connection index", promptSuffix = ": ")?.toInt() ?: throw PrintMessage("Index must be an integer")
+    return connections[selectedConnectionIndex]
+}
+
 class DeleteClientCommand : CliktCommand(name = "delete-client") {
 
     private val password: String by option(help = "Account password").prompt("password", promptSuffix = ": ", hideInput = true)
 
     override fun run() = runBlocking {
-        val authSession = restoreSession() ?: throw PrintMessage("no active session")
-        val userSession = coreLogic.getSessionScope(authSession.tokens.userId)
+        val userSession = currentUserSession()
 
-        val selfClientsResult = userSession.client.selfClients()
+        val selfClientsResult = currentUserSession().client.selfClients()
 
         if (selfClientsResult !is SelfClientsResult.Success) {
             throw PrintMessage("failed to retrieve self clients")
@@ -77,8 +114,7 @@ class CreateGroupCommand : CliktCommand(name = "create-group") {
     private val name: String by option(help = "Name of the group").prompt()
 
     override fun run() = runBlocking {
-        val authSession = restoreSession() ?: throw PrintMessage("no active session")
-        val userSession = coreLogic.getSessionScope(authSession.tokens.userId)
+        val userSession = currentUserSession()
 
         val users = userSession.users.getAllKnownUsers()
 
@@ -91,9 +127,7 @@ class CreateGroupCommand : CliktCommand(name = "create-group") {
         val members = userIndices.map { Member(users[it].id) }
 
         val result = userSession.conversations.createGroupConversation(
-            name,
-            members,
-            ConversationOptions(protocol = ConversationOptions.Protocol.MLS)
+            name, members, ConversationOptions(protocol = ConversationOptions.Protocol.MLS)
         )
         when (result) {
             is Either.Right -> echo("group created successfully")
@@ -159,23 +193,8 @@ class LoginCommand : CliktCommand(name = "login") {
 class ListenGroupCommand : CliktCommand(name = "listen-group") {
 
     override fun run() = runBlocking {
-        val authSession = restoreSession() ?: throw PrintMessage("no active session")
-        val userSession = coreLogic.getSessionScope(authSession.tokens.userId)
-        val conversations = userSession.conversations.getConversations().let {
-            when (it) {
-                is GetConversationsUseCase.Result.Success -> it.convFlow.first()
-                is GetConversationsUseCase.Result.Failure -> throw PrintMessage("Failed to retrieve conversation: ${it.storageFailure}")
-                else -> throw PrintMessage("Failed to retrieve conversation: Unknown reason")
-            }
-        }
-
-        conversations.forEachIndexed { index, conversation ->
-            echo("$index) ${conversation.id.value}  Name: ${conversation.name}")
-        }
-
-        val conversationIndex =
-            prompt("Enter conversation index", promptSuffix = ": ")?.toInt() ?: throw PrintMessage("Index must be an integer")
-        val conversationID = conversations[conversationIndex].id
+        val userSession = currentUserSession()
+        val conversationID = selectConversation(userSession).id
 
         GlobalScope.launch(Dispatchers.Default) {
             userSession.listenToEvents()
@@ -186,7 +205,8 @@ class ListenGroupCommand : CliktCommand(name = "listen-group") {
                 for (message in it) {
                     when (val content = message.content) {
                         is MessageContent.Text -> echo("> ${content.value}")
-                        is MessageContent.Unknown -> { /* do nothing */ }
+                        is MessageContent.Unknown -> { /* do nothing */
+                        }
                     }
                 }
             }
@@ -201,6 +221,18 @@ class ListenGroupCommand : CliktCommand(name = "listen-group") {
 
 }
 
+class AddMemberToGroupCommand : CliktCommand(name = "add-member") {
+    override fun run() = runBlocking {
+
+        val userSession = currentUserSession()
+
+        val selectedConversation = selectConversation(userSession)
+        val selectedConnection = selectConnection(userSession)
+
+        userSession.conversations.addMemberToConversationUseCase(selectedConversation.id, listOf(Member(id = selectedConnection.id)))
+    }
+}
+
 class CLIApplication : CliktCommand(allowMultipleSubcommands = true) {
 
     override fun run() = runBlocking {
@@ -213,6 +245,6 @@ class CLIApplication : CliktCommand(allowMultipleSubcommands = true) {
 
 }
 
-fun main(args: Array<String>) = CLIApplication()
-    .subcommands(LoginCommand(), CreateGroupCommand(), ListenGroupCommand(), DeleteClientCommand())
-    .main(args)
+fun main(args: Array<String>) = CLIApplication().subcommands(
+    LoginCommand(), CreateGroupCommand(), ListenGroupCommand(), DeleteClientCommand(), AddMemberToGroupCommand()
+).main(args)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -14,6 +14,7 @@ data class Conversation(
     val name: String?,
     val type: Type,
     val teamId: TeamId?,
+    val protocolInfo: ProtocolInfo,
     val mutedStatus: MutedConversationStatus,
     val lastNotificationDate: String?,
     val lastModifiedDate: String?
@@ -44,12 +45,14 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         val userType: UserType,
         val lastModifiedDate: String?,
         val connection: com.wire.kalium.logic.data.user.Connection,
+        val protocolInfo: ProtocolInfo
     ) : ConversationDetails(
         Conversation(
             id = conversationId,
             name = otherUser?.name,
             type = Conversation.Type.CONNECTION_PENDING,
             teamId = otherUser?.team?.let { TeamId(it) },
+            protocolInfo,
             mutedStatus = MutedConversationStatus.AllAllowed,
             lastNotificationDate = null,
             lastModifiedDate = lastModifiedDate,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -33,6 +33,7 @@ internal class ConversationMapperImpl(
     private val idMapper: IdMapper,
     private val conversationStatusMapper: ConversationStatusMapper,
     private val userTypeMapper: UserTypeMapper,
+    private val protocolInfoMapper: ProtocolInfoMapper
 ) : ConversationMapper {
 
     override fun fromApiModelToDaoModel(
@@ -59,6 +60,7 @@ internal class ConversationMapperImpl(
         name = daoModel.name,
         type = daoModel.type.fromDaoModelToType(),
         teamId = daoModel.teamId?.let { TeamId(it) },
+        protocolInfo = protocolInfoMapper.fromEntity(daoModel.protocolInfo),
         mutedStatus = conversationStatusMapper.fromDaoModel(daoModel.mutedStatus),
         lastNotificationDate = daoModel.lastNotificationDate,
         lastModifiedDate = daoModel.lastModifiedDate

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
+import com.wire.kalium.network.api.conversation.AddParticipantRequest
+import com.wire.kalium.network.api.conversation.AddParticipantResponse
 import com.wire.kalium.network.api.conversation.ConversationApi
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.user.client.ClientApi
@@ -49,10 +51,12 @@ interface ConversationRepository {
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun fetchConversationIfUnknown(conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun getConversationDetails(conversationId: ConversationId): Either<StorageFailure, Flow<Conversation>>
+    suspend fun getConversationDetailsById(conversationId: ConversationId): Either<StorageFailure, Conversation>
     suspend fun getConversationRecipients(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
     suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, ProtocolInfo>
     suspend fun observeConversationMembers(conversationID: ConversationId): Flow<List<Member>>
     suspend fun persistMembers(members: List<Member>, conversationID: ConversationId): Either<CoreFailure, Unit>
+    suspend fun addMembers(members: List<Member>, conversationID: ConversationId): Either<NetworkFailure, AddParticipantResponse>
     suspend fun deleteMember(userID: QualifiedIDEntity, conversationID: QualifiedIDEntity): Either<CoreFailure, Unit>
     suspend fun deleteMembers(userIDList: List<QualifiedIDEntity>, conversationID: QualifiedIDEntity): Either<CoreFailure, Unit>
     suspend fun getOneToOneConversationDetailsByUserId(otherUserId: UserId): Either<CoreFailure, ConversationDetails.OneOne>
@@ -248,6 +252,13 @@ class ConversationDataSource(
                 .map(conversationMapper::fromDaoModel)
         }
 
+    override suspend fun getConversationDetailsById(conversationId: ConversationId): Either<StorageFailure, Conversation> =
+        wrapStorageRequest {
+            conversationDAO.getConversationByQualifiedID(idMapper.toDaoModel(conversationId))?.let {
+                conversationMapper.fromDaoModel(it)
+            }
+        }
+
     override suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, ProtocolInfo> =
         wrapStorageRequest {
             conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId)).first()?.protocolInfo
@@ -270,6 +281,20 @@ class ConversationDataSource(
             conversationDAO.insertMembers(
                 members.map(memberMapper::toDaoModel),
                 idMapper.toDaoModel(conversationID)
+            )
+        }
+
+    override suspend fun addMembers(
+        members: List<Member>,
+        conversationID: ConversationId
+    ): Either<NetworkFailure, AddParticipantResponse> =
+        wrapApiRequest {
+            val users = members.map {
+                idMapper.toApiModel(it.id)
+            }
+            val addParticipantRequest = AddParticipantRequest(users, DEFAULT_MEMBER_ROLE)
+            conversationApi.addParticipant(
+                addParticipantRequest, idMapper.toApiModel(conversationID)
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -27,7 +27,7 @@ interface MLSConversationRepository {
     suspend fun establishMLSGroupFromWelcome(welcomeEvent: Event.Conversation.MLSWelcome): Either<CoreFailure, Unit>
     suspend fun hasEstablishedMLSGroup(groupID: String): Either<CoreFailure, Boolean>
     suspend fun messageFromMLSMessage(messageEvent: Event.Conversation.NewMLSMessage): Either<CoreFailure, ByteArray?>
-
+    suspend fun addMemberToMLSGroup(groupID: String, members: List<UserId>): Either<CoreFailure, Unit>
 }
 
 class MLSConversationDataSource(
@@ -78,6 +78,40 @@ class MLSConversationDataSource(
     override suspend fun establishMLSGroup(groupID: String): Either<CoreFailure, Unit> =
         getConversationMembers(groupID).flatMap { members ->
             establishMLSGroup(groupID, members)
+        }
+
+    override suspend fun addMemberToMLSGroup(groupID: String, members: List<UserId>): Either<CoreFailure, Unit> =
+        //check for federated and non-federated members
+        keyPackageRepository.claimKeyPackages(members).flatMap { keyPackages ->
+            mlsClientProvider.getMLSClient().flatMap { client ->
+                val clientKeyPackageList = keyPackages
+                    .map {
+                        Pair(
+                            CryptoQualifiedClientId(it.clientID, CryptoQualifiedID(it.userId, it.domain)),
+                            it.keyPackage.decodeBase64Bytes()
+                        )
+                    }
+                client.addMember(groupID, clientKeyPackageList)?.let { (handshake, welcome) ->
+                    wrapApiRequest {
+                        mlsMessageApi.sendMessage(MLSMessageApi.Message(handshake))
+                    }.flatMap {
+                        wrapApiRequest {
+                            mlsMessageApi.sendWelcomeMessage(MLSMessageApi.WelcomeMessage(welcome))
+                        }
+                    }.flatMap {
+                        wrapStorageRequest {
+                            val list = members.map {
+                                com.wire.kalium.persistence.dao.Member(idMapper.toDaoModel(it))
+                            }
+                            conversationDAO.insertMembers(list, groupID)
+                        }
+                    }.flatMap {
+                        Either.Right(Unit)
+                    }
+                } ?: run {
+                    Either.Right(Unit)
+                }
+            }
         }
 
     private suspend fun establishMLSGroup(groupID: String, members: List<UserId>): Either<CoreFailure, Unit> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
@@ -1,0 +1,30 @@
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.persistence.dao.ConversationEntity
+
+interface ProtocolInfoMapper {
+    fun fromEntity(protocolInfo: ConversationEntity.ProtocolInfo): ProtocolInfo
+    fun toEntity(protocolInfo: ProtocolInfo): ConversationEntity.ProtocolInfo
+}
+
+class ProtocolInfoMapperImpl : ProtocolInfoMapper {
+    override fun fromEntity(protocolInfo: ConversationEntity.ProtocolInfo) =
+        when (protocolInfo) {
+            is ConversationEntity.ProtocolInfo.Proteus -> ProtocolInfo.Proteus
+            is ConversationEntity.ProtocolInfo.MLS -> ProtocolInfo.MLS(
+                protocolInfo.groupId,
+                GroupState.valueOf(protocolInfo.groupState.name)
+            )
+        }
+
+    override fun toEntity(protocolInfo: ProtocolInfo) =
+        when (protocolInfo) {
+            is ProtocolInfo.Proteus -> ConversationEntity.ProtocolInfo.Proteus
+            is ProtocolInfo.MLS -> ConversationEntity.ProtocolInfo.MLS(
+                protocolInfo.groupId,
+                ConversationEntity.GroupState.valueOf(protocolInfo.groupState.name)
+            )
+        }
+}
+
+

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMapper.kt
@@ -2,6 +2,8 @@ package com.wire.kalium.logic.data.id
 
 import com.wire.kalium.cryptography.CryptoQualifiedID
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.user.client.SimpleClientResponse
 import com.wire.kalium.protobuf.messages.QualifiedConversationId
 
@@ -21,6 +23,8 @@ interface IdMapper {
     fun toProtoModel(conversationId: ConversationId): QualifiedConversationId
     fun toQualifiedAssetId(value: String, domain: String = ""): QualifiedID
     fun toQualifiedAssetIdEntity(value: String, domain: String = ""): PersistenceQualifiedId
+    fun toMember(userId: UserId): Member
+    fun toUserId(member: Member): UserId
 }
 
 internal class IdMapperImpl : IdMapper {
@@ -55,4 +59,6 @@ internal class IdMapperImpl : IdMapper {
     override fun toQualifiedAssetId(value: String, domain: String) = QualifiedID(value, domain)
 
     override fun toQualifiedAssetIdEntity(value: String, domain: String) = PersistenceQualifiedId(value, domain)
+    override fun toMember(userId: UserId): Member = Member(id = userId)
+    override fun toUserId(member: Member): UserId = member.id
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -19,6 +19,7 @@ import com.wire.kalium.logic.data.conversation.ConversationStatusMapper
 import com.wire.kalium.logic.data.conversation.ConversationStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.MemberMapper
 import com.wire.kalium.logic.data.conversation.MemberMapperImpl
+import com.wire.kalium.logic.data.conversation.ProtocolInfoMapperImpl
 import com.wire.kalium.logic.data.event.EventMapper
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -21,6 +21,8 @@ import com.wire.kalium.logic.data.conversation.MLSConversationDataSource
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.EventDataSource
 import com.wire.kalium.logic.data.event.EventRepository
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.keypackage.KeyPackageDataSource
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
@@ -96,6 +98,8 @@ abstract class UserSessionScopeCommon(
 
     private val encryptedSettingsHolder: EncryptedSettingsHolder = authenticatedDataSourceSet.encryptedSettingsHolder
     private val userPreferencesSettings = authenticatedDataSourceSet.kaliumPreferencesSettings
+    private val idMapper: IdMapper
+        get() = IdMapperImpl()
     private val eventInfoStorage: EventInfoStorage
         get() = EventInfoStorageImpl(userPreferencesSettings)
 
@@ -314,7 +318,9 @@ abstract class UserSessionScopeCommon(
             conversationRepository,
             connectionRepository,
             userRepository,
-            syncManager
+            syncManager,
+            mlsConversationRepository,
+            idMapper
         )
     val messages: MessageScope
         get() = MessageScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.feature.conversation
 
-import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.Member
@@ -13,7 +12,7 @@ import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.ConversationEntity.ProtocolInfo.Proteus
 
 interface AddMemberToConversationUseCase {
-    suspend operator fun invoke(conversationId: ConversationId, clientId: ClientId, members: List<Member>)
+    suspend operator fun invoke(conversationId: ConversationId, members: List<Member>)
 }
 
 class AddMemberToConversationUseCaseImpl(
@@ -21,7 +20,7 @@ class AddMemberToConversationUseCaseImpl(
     private val mlsConversationRepository: MLSConversationRepository,
     private val idMapper: IdMapper
 ) : AddMemberToConversationUseCase {
-    override suspend fun invoke(conversationId: ConversationId, clientId: ClientId, members: List<Member>) {
+    override suspend fun invoke(conversationId: ConversationId, members: List<Member>) {
 
         val userIdsMembers = members.map {
             idMapper.toUserId(it)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
@@ -1,0 +1,47 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.network.api.conversation.AddParticipantResponse
+import com.wire.kalium.persistence.dao.ConversationEntity
+import com.wire.kalium.persistence.dao.ConversationEntity.ProtocolInfo.Proteus
+
+interface AddMemberToConversationUseCase {
+    suspend operator fun invoke(conversationId: ConversationId, clientId: ClientId, members: List<Member>)
+}
+
+class AddMemberToConversationUseCaseImpl(
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val idMapper: IdMapper
+) : AddMemberToConversationUseCase {
+    override suspend fun invoke(conversationId: ConversationId, clientId: ClientId, members: List<Member>) {
+
+        val userIdsMembers = members.map {
+            idMapper.toUserId(it)
+        }
+        conversationRepository.getConversationProtocolInfo(conversationId).flatMap { protocolInfo ->
+            when (protocolInfo) {
+                is Proteus -> conversationRepository.addMembers(members, conversationId).map {
+                    when (it) {
+                        is AddParticipantResponse.ConversationUnchanged -> {}
+                        is AddParticipantResponse.UserAdded -> {
+                            //persist the user in the db
+                            conversationRepository.persistMembers(members, conversationId)
+                        }
+                    }
+                }
+
+                is ConversationEntity.ProtocolInfo.MLS -> {
+                    mlsConversationRepository.addMemberToMLSGroup("", userIdsMembers)
+                }
+            }
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -2,6 +2,8 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.user.UserTypeMapperImpl
 import com.wire.kalium.logic.feature.connection.ObserveConnectionListUseCase
@@ -12,7 +14,9 @@ class ConversationScope(
     private val conversationRepository: ConversationRepository,
     private val connectionRepository: ConnectionRepository,
     private val userRepository: UserRepository,
-    private val syncManager: SyncManager
+    private val syncManager: SyncManager,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val idMapper: IdMapper
 ) {
     val getConversations: GetConversationsUseCase
         get() = GetConversationsUseCase(conversationRepository, syncManager)
@@ -37,6 +41,9 @@ class ConversationScope(
 
     val createGroupConversation: CreateGroupConversationUseCase
         get() = CreateGroupConversationUseCase(conversationRepository, syncManager)
+
+    val addMemberToConversationUseCase: AddMemberToConversationUseCase
+        get() = AddMemberToConversationUseCaseImpl(conversationRepository, mlsConversationRepository, idMapper)
 
     val getOrCreateOneToOneConversationUseCase: GetOrCreateOneToOneConversationUseCase
         get() = GetOrCreateOneToOneConversationUseCase(conversationRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -30,6 +30,7 @@ import io.mockative.anything
 import io.mockative.classOf
 import io.mockative.configure
 import io.mockative.eq
+import io.mockative.fun2
 import io.mockative.given
 import io.mockative.matching
 import io.mockative.mock
@@ -296,7 +297,7 @@ class ConversationRepositoryTest {
             .thenDoNothing()
 
         given(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers)
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
             .whenInvokedWith(anything(), anything())
             .thenDoNothing()
 
@@ -315,7 +316,7 @@ class ConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers)
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
             .with(anything(), anything())
             .wasInvoked(once)
     }
@@ -340,7 +341,7 @@ class ConversationRepositoryTest {
             .thenDoNothing()
 
         given(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers)
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
             .whenInvokedWith(anything(), anything())
             .thenDoNothing()
 
@@ -359,7 +360,7 @@ class ConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers)
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
             .with(anything(), anything())
             .wasInvoked(once)
     }
@@ -387,8 +388,8 @@ class ConversationRepositoryTest {
             .thenDoNothing()
 
         given(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers)
-            .whenInvokedWith(anything(), anything())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .whenInvokedWith(any(), any())
             .thenDoNothing()
 
         given(mlsConversationRepository)
@@ -410,7 +411,7 @@ class ConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers)
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
             .with(anything(), anything())
             .wasInvoked(once)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
@@ -1,0 +1,49 @@
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.persistence.dao.ConversationEntity
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ProtocolInfoMapperTest {
+    private val protocolInfoMapper = ProtocolInfoMapperImpl()
+
+    @Test
+    fun givenConversationMLSProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
+        val mappedValue = protocolInfoMapper.toEntity(CONVERSATION_MLS_PROTOCOL_INFO)
+        assertIs<ConversationEntity.ProtocolInfo>(mappedValue)
+        assertEquals(mappedValue, CONV_ENTITY_MLS_PROTOCOL_INFO)
+    }
+
+    @Test
+    fun givenConversationProteusProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
+        val mappedValue = protocolInfoMapper.toEntity(CONVERSATION_PROTEUS_PROTOCOL_INFO)
+        assertIs<ConversationEntity.ProtocolInfo>(mappedValue)
+        assertEquals(mappedValue, CONV_ENTITY_PROTEUS_PROTOCOL_INFO)
+    }
+
+    @Test
+    fun givenEntityMLSProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
+        val mappedValue = protocolInfoMapper.fromEntity(CONV_ENTITY_MLS_PROTOCOL_INFO)
+        assertIs<ProtocolInfo>(mappedValue)
+        assertEquals(mappedValue, CONVERSATION_MLS_PROTOCOL_INFO)
+    }
+
+    @Test
+    fun givenEntityProteusProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
+        val mappedValue = protocolInfoMapper.fromEntity(CONV_ENTITY_MLS_PROTOCOL_INFO)
+        assertIs<ProtocolInfo>(mappedValue)
+        assertEquals(mappedValue, CONVERSATION_MLS_PROTOCOL_INFO)
+    }
+
+    companion object {
+        val CONVERSATION_MLS_PROTOCOL_INFO = ProtocolInfo.MLS("GROUP_ID", groupState = GroupState.ESTABLISHED)
+        val CONVERSATION_PROTEUS_PROTOCOL_INFO = ProtocolInfo.Proteus
+
+        val CONV_ENTITY_MLS_PROTOCOL_INFO =
+            ConversationEntity.ProtocolInfo.MLS("GROUP_ID", groupState = ConversationEntity.GroupState.ESTABLISHED)
+        val CONV_ENTITY_PROTEUS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo.Proteus
+
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/IdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/IdMapperTest.kt
@@ -1,5 +1,7 @@
 package com.wire.kalium.logic.data.id
 
+import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.user.client.DeviceTypeDTO
 import com.wire.kalium.network.api.user.client.SimpleClientResponse
 import com.wire.kalium.protobuf.messages.QualifiedConversationId
@@ -77,6 +79,26 @@ class IdMapperTest {
 
         assertEquals(qualifiedIDEntity.value, value)
         assertEquals(qualifiedIDEntity.domain, domain)
+    }
+
+    @Test
+    fun givenUserID_whenMappingToMember_thenTheIDShouldBeMappedCorrectly() {
+        val userId = UserId("TestValue", "TestDomain")
+
+        val member = idMapper.toMember(userId)
+
+        assertEquals(userId.value, member.id.value)
+        assertEquals(userId.domain, member.id.domain)
+    }
+
+    @Test
+    fun givenMember_whenMappingToUserId_thenTheIDShouldBeMappedCorrectly() {
+        val member = Member(UserId("TestValue", "TestDomain"))
+
+        val userId = idMapper.toUserId(member)
+
+        assertEquals(member.id.value, userId.value)
+        assertEquals(member.id.domain, userId.domain)
     }
 
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlin.test.Test
+
+class AddMemberToConversationUseCaseTest {
+
+    @Test
+    fun givenMemberAndConversation_WhenAddMemberIsSuccessful_ThenMemberIsAddedToDB() {
+    }
+
+    @Test
+    fun givenMemberAndConversation_WhenAddMemberIsFailed_ThenMemberNotAddedToDB() {
+    }
+
+    private class Arrangement {
+        @Mock
+        private val conversationRepository = mock(classOf<ConversationRepository>())
+
+        @Mock
+        private val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
+
+        @Mock
+        val idMapper = mock(classOf<IdMapper>())
+
+        private val addMemberUseCase = AddMemberToConversationUseCaseImpl(
+            conversationRepository,
+            mlsConversationRepository,
+            idMapper
+        )
+
+        fun withCreateGroupConversationReturning(conversation: Conversation) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::createGroupConversation)
+                .whenInvokedWith(any(), any(), any())
+                .thenReturn(Either.Right(conversation))
+        }
+
+        fun arrange() = this to addMemberUseCase
+    }
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
@@ -1,15 +1,23 @@
 package com.wire.kalium.logic.feature.conversation
 
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.GroupState
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.id.IdMapperImpl
+import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.network.api.conversation.AddParticipantResponse
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
 class AddMemberToConversationUseCaseTest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCaseTest.kt
@@ -33,7 +33,7 @@ class CreateGroupConversationUseCaseTest {
 
         val (arrangement, createGroupConversation) = Arrangement()
             .withUpdateConversationModifiedDateSucceeding()
-            .withCreateGroupConversationReturning(TestConversation.GROUP)
+            .withCreateGroupConversationReturning(TestConversation.GROUP())
             .arrange()
 
         createGroupConversation(name, members, conversationOptions)
@@ -52,7 +52,7 @@ class CreateGroupConversationUseCaseTest {
 
         val (arrangement, createGroupConversation) = Arrangement()
             .withUpdateConversationModifiedDateSucceeding()
-            .withCreateGroupConversationReturning(TestConversation.GROUP)
+            .withCreateGroupConversationReturning(TestConversation.GROUP())
             .arrange()
 
         createGroupConversation(name, members, conversationOptions)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.UserType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.publicuser.model.OtherUser
@@ -14,14 +15,11 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.persistence.dao.ConversationEntity
 import io.mockative.Mock
-import io.mockative.Times
 import io.mockative.anything
 import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
-import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -101,6 +99,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
             name = null,
             type = Conversation.Type.ONE_ON_ONE,
             teamId = null,
+            ProtocolInfo.Proteus,
             MutedConversationStatus.AllAllowed,
             null,
             null

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -71,7 +71,7 @@ class ObserveConversationDetailsUseCaseTest {
 
     @Test
     fun givenTheConversationIsUpdated_whenObservingConversationUseCase_thenThisUpdateIsPropagatedInTheFlow() = runTest {
-        val conversation = TestConversation.GROUP
+        val conversation = TestConversation.GROUP()
         val conversationDetailsValues = listOf(
             ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED),
             ConversationDetails.Group(conversation.copy(name = "New Name"), LegalHoldStatus.DISABLED)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -45,7 +45,7 @@ class ObserveConversationListDetailsUseCaseTest {
 
     @Test
     fun givenSomeConversations_whenObservingDetailsList_thenObserveConversationListShouldBeCalled() = runTest {
-        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
+        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP())
 
         given(conversationRepository)
             .suspendFunction(conversationRepository::observeConversationList)
@@ -67,7 +67,7 @@ class ObserveConversationListDetailsUseCaseTest {
 
     @Test
     fun givenSomeConversations_whenObservingDetailsList_thenSyncManagerShouldBeCalled() = runTest {
-        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
+        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP())
 
         given(conversationRepository)
             .suspendFunction(conversationRepository::observeConversationList)
@@ -89,7 +89,7 @@ class ObserveConversationListDetailsUseCaseTest {
 
     @Test
     fun givenSomeConversations_whenObservingDetailsList_thenObserveConversationDetailsShouldBeCalledForEachID() = runTest {
-        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP)
+        val conversations = listOf(TestConversation.SELF, TestConversation.GROUP())
 
         given(conversationRepository)
             .suspendFunction(conversationRepository::observeConversationList)
@@ -114,7 +114,7 @@ class ObserveConversationListDetailsUseCaseTest {
     @Test
     fun givenSomeConversationsDetailsAreUpdated_whenObservingDetailsList_thenTheUpdateIsPropagatedThroughTheFlow() = runTest {
         val oneOnOneConversation = TestConversation.ONE_ON_ONE
-        val groupConversation = TestConversation.GROUP
+        val groupConversation = TestConversation.GROUP()
         val conversations = listOf(groupConversation, oneOnOneConversation)
 
         val groupConversationUpdates = listOf(ConversationDetails.Group(groupConversation, LegalHoldStatus.DISABLED))
@@ -162,7 +162,7 @@ class ObserveConversationListDetailsUseCaseTest {
 
     @Test
     fun givenAConversationIsAddedToTheList_whenObservingDetailsList_thenTheUpdateIsPropagatedThroughTheFlow() = runTest {
-        val groupConversation = TestConversation.GROUP
+        val groupConversation = TestConversation.GROUP()
         val groupConversationDetails = ConversationDetails.Group(groupConversation, LegalHoldStatus.DISABLED)
 
         val selfConversation = TestConversation.SELF

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.AssetContent
@@ -436,6 +437,7 @@ class GetNotificationsUseCaseTest {
             "conversation_${number}",
             if (isOneOnOne) Conversation.Type.ONE_ON_ONE else Conversation.Type.GROUP,
             null,
+            ProtocolInfo.Proteus,
             mutedStatus,
             TIME_EARLIER,
             TIME_EARLIER

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -2,7 +2,9 @@ package com.wire.kalium.logic.framework
 
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepositoryTest
+import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.QualifiedID
@@ -23,6 +25,7 @@ object TestConversation {
         "ONE_ON_ONE Name",
         Conversation.Type.ONE_ON_ONE,
         TestTeam.TEAM_ID,
+        ProtocolInfo.Proteus,
         MutedConversationStatus.AllAllowed,
         null,
         null
@@ -32,15 +35,18 @@ object TestConversation {
         "SELF Name",
         Conversation.Type.SELF,
         TestTeam.TEAM_ID,
+        ProtocolInfo.Proteus,
         MutedConversationStatus.AllAllowed,
         null,
         null
     )
-    val GROUP = Conversation(
+
+    fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
         ID.copy(value = "GROUP ID"),
         "GROUP Name",
         Conversation.Type.GROUP,
         TestTeam.TEAM_ID,
+        protocolInfo,
         MutedConversationStatus.AllAllowed,
         null,
         null
@@ -51,12 +57,18 @@ object TestConversation {
         "ONE_ON_ONE Name",
         Conversation.Type.ONE_ON_ONE,
         TestTeam.TEAM_ID,
+        ProtocolInfo.Proteus,
         MutedConversationStatus.AllAllowed,
         null,
         null
     )
 
+
     val NETWORK_ID = QualifiedID("valueConversation", "domainConversation")
+    val MEMBER_TEST1 = Member(com.wire.kalium.logic.data.user.UserId("member1", "domainMember"))
+    val MEMBER_TEST2 = Member(com.wire.kalium.logic.data.user.UserId("member2", "domainMember"))
+    val NETWORK_USER_ID1 = com.wire.kalium.network.api.UserId(value = "member1", domain = "domainMember")
+    val NETWORK_USER_ID2 = com.wire.kalium.network.api.UserId(value = "member2", domain = "domainMember")
 
     val CONVERSATION_RESPONSE = ConversationResponse(
         "creator",

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -64,6 +64,9 @@ SELECT * FROM Conversation WHERE qualified_id = ?;
 selectByGroupId:
 SELECT * FROM Conversation WHERE mls_group_id = ?;
 
+getConversationIdByGroupId:
+SELECT qualified_id FROM Conversation WHERE mls_group_id = ?;
+
 selectConversationsWithUnnotifiedMessages:
 SELECT * FROM Conversation WHERE muted_status != 'ALL_MUTED' AND (last_notified_message_date ISNULL OR DateTime(last_modified_date) > DateTime(last_notified_message_date));
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -46,9 +46,11 @@ interface ConversationDAO {
     suspend fun getConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity?
     suspend fun getAllConversationWithOtherUser(userId: UserIDEntity): List<ConversationEntity>
     suspend fun getConversationByGroupID(groupID: String): Flow<ConversationEntity?>
+    suspend fun getConversationIdByGroupID(groupID: String): QualifiedIDEntity?
     suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity)
     suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity)
     suspend fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity)
+    suspend fun insertMembers(memberList: List<Member>, groupId: String)
     suspend fun deleteMemberByQualifiedID(userID: QualifiedIDEntity, conversationID: QualifiedIDEntity)
     suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, conversationID: QualifiedIDEntity)
     suspend fun getAllMembers(qualifiedID: QualifiedIDEntity): Flow<List<Member>>

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -67,6 +67,14 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenExistingMLSConversation_ThenConversationIdCanBeRetrievedByGroupID() = runTest {
+        conversationDAO.insertConversation(conversationEntity2)
+        val result =
+            conversationDAO.getConversationIdByGroupID((conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId)
+        assertEquals(conversationEntity2.id, result)
+    }
+
+    @Test
     fun givenExistingConversation_ThenConversationGroupStateCanBeUpdated() = runTest {
         conversationDAO.insertConversation(conversationEntity2)
         conversationDAO.updateConversationGroupState(
@@ -111,6 +119,17 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.insertMembers(listOf(member1, member2), conversationEntity1.id)
 
         assertEquals(setOf(member1, member2), conversationDAO.getAllMembers(conversationEntity1.id).first().toSet())
+    }
+
+    @Test
+    fun givenExistingMLSConversation_whenAddingMembersByGroupId_ThenAllMembersCanBeRetrieved() = runTest {
+        conversationDAO.insertConversation(conversationEntity2)
+        conversationDAO.insertMembers(
+            listOf(member1, member2),
+            (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId
+        )
+
+        assertEquals(setOf(member1, member2), conversationDAO.getAllMembers(conversationEntity2.id).first().toSet())
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Added the usecase for adding members to a group conversation.
This usecase supports both MLS and Proteus conversations.


Needs releases with:
- Needs to be released with AR changes
- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

[AR-1849]: https://wearezeta.atlassian.net/browse/AR-1849