### PR TITLE
chore: map external messages to protobuf (AR-1760) [External Messages Part 1]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
@@ -9,16 +9,17 @@ import com.wire.kalium.protobuf.messages.GenericMessage
  *
  * It can be [ProtoContent] or [ExternalMessageInstructions].
  */
-sealed class ProtoContent {
+sealed interface ProtoContent {
+    val messageUid: String
 
     /**
      * Regular message, with readable content that can be simply used.
      * @see [ExternalMessageInstructions]
      */
     data class Readable(
-        val messageUid: String,
+        override val messageUid: String,
         val messageContent: MessageContent.FromProto
-    ) : ProtoContent()
+    ) : ProtoContent
 
     /**
      * The message doesn't contain an actual content,
@@ -33,9 +34,9 @@ sealed class ProtoContent {
      * @see [GenericMessage.Content.External]
      */
     class ExternalMessageInstructions(
-        val messageUid: String,
+        override val messageUid: String,
         val otrKey: ByteArray,
         val sha256: ByteArray?,
         val encryptionAlgorithm: MessageEncryptionAlgorithm?
-    ) : ProtoContent()
+    ) : ProtoContent
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.message
 
+import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.framework.TestConversation
@@ -11,6 +12,7 @@ import com.wire.kalium.protobuf.messages.Text
 import io.ktor.utils.io.core.toByteArray
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
@@ -163,6 +165,24 @@ class ProtoContentMapperTest {
         val content = result.messageContent
         assertIs<MessageContent.TextEdited>(content)
         assertEquals(textContent.value.content, content.newContent)
+    }
+
+    @Test
+    fun givenExternalMessageInstructions_whenEncodingToProtoAndBack_thenTheResultContentShouldEqualTheOriginal() {
+        val messageUid = TEST_MESSAGE_UUID
+        val otrKey = generateRandomAES256Key()
+        val sha256 = byteArrayOf(0x20, 0x42, 0x31)
+        val encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
+
+        val instructions = ProtoContent.ExternalMessageInstructions(messageUid, otrKey.data, sha256, encryptionAlgorithm)
+        val encoded = protoContentMapper.encodeToProtobuf(instructions)
+        val result = protoContentMapper.decodeFromProtobuf(encoded)
+
+        assertIs<ProtoContent.ExternalMessageInstructions>(result)
+        assertEquals(messageUid, result.messageUid)
+        assertContentEquals(otrKey.data, result.otrKey)
+        assertContentEquals(sha256, result.sha256)
+        assertEquals(encryptionAlgorithm, result.encryptionAlgorithm)
     }
 
     private companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

As seen in [OTR-Proto](https://github.com/wireapp/generic-message-proto#external):

> [External] message content is used if original message results in large payload, that would not be accepted by backend. Regular messages are encrypted multiple times (per recipient) and in case of multiple participants even quite small message can generate huge payload. In that case we want to encrypt original message with symmetric encryption and only send a key to all participants.

### Solutions

In this PR, I'm addressing one part of the step: making the `ProtoContentMapper` accept `ExternalMessageInstructions` and return the encoded ByteArray.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
