### PR TITLE
chore: add external blob to envelope mapper (AR-1760) [External Messages Part 2]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
@@ -9,16 +9,17 @@ import com.wire.kalium.protobuf.messages.GenericMessage
  *
  * It can be [ProtoContent] or [ExternalMessageInstructions].
  */
-sealed class ProtoContent {
+sealed interface ProtoContent {
+    val messageUid: String
 
     /**
      * Regular message, with readable content that can be simply used.
      * @see [ExternalMessageInstructions]
      */
     data class Readable(
-        val messageUid: String,
+        override val messageUid: String,
         val messageContent: MessageContent.FromProto
-    ) : ProtoContent()
+    ) : ProtoContent
 
     /**
      * The message doesn't contain an actual content,
@@ -33,9 +34,9 @@ sealed class ProtoContent {
      * @see [GenericMessage.Content.External]
      */
     class ExternalMessageInstructions(
-        val messageUid: String,
+        override val messageUid: String,
         val otrKey: ByteArray,
         val sha256: ByteArray?,
         val encryptionAlgorithm: MessageEncryptionAlgorithm?
-    ) : ProtoContent()
+    ) : ProtoContent
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.message
 
+import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.framework.TestConversation
@@ -11,6 +12,7 @@ import com.wire.kalium.protobuf.messages.Text
 import io.ktor.utils.io.core.toByteArray
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
@@ -163,6 +165,24 @@ class ProtoContentMapperTest {
         val content = result.messageContent
         assertIs<MessageContent.TextEdited>(content)
         assertEquals(textContent.value.content, content.newContent)
+    }
+
+    @Test
+    fun givenExternalMessageInstructions_whenEncodingToProtoAndBack_thenTheResultContentShouldEqualTheOriginal() {
+        val messageUid = TEST_MESSAGE_UUID
+        val otrKey = generateRandomAES256Key()
+        val sha256 = byteArrayOf(0x20, 0x42, 0x31)
+        val encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
+
+        val instructions = ProtoContent.ExternalMessageInstructions(messageUid, otrKey.data, sha256, encryptionAlgorithm)
+        val encoded = protoContentMapper.encodeToProtobuf(instructions)
+        val result = protoContentMapper.decodeFromProtobuf(encoded)
+
+        assertIs<ProtoContent.ExternalMessageInstructions>(result)
+        assertEquals(messageUid, result.messageUid)
+        assertContentEquals(otrKey.data, result.otrKey)
+        assertContentEquals(sha256, result.sha256)
+        assertEquals(encryptionAlgorithm, result.encryptionAlgorithm)
     }
 
     private companion object {

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/EnvelopeProtoMapperImpl.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/EnvelopeProtoMapperImpl.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.protobuf.otr.ClientMismatchStrategy
 import com.wire.kalium.protobuf.otr.QualifiedNewOtrMessage
 import com.wire.kalium.protobuf.otr.QualifiedUserEntry
 import com.wire.kalium.protobuf.otr.UserEntry
+import pbandk.ByteArr
 import pbandk.encodeToByteArray
 
 class EnvelopeProtoMapperImpl : EnvelopeProtoMapper {
@@ -28,6 +29,7 @@ class EnvelopeProtoMapperImpl : EnvelopeProtoMapper {
         return QualifiedNewOtrMessage(
             recipients = qualifiedEntries,
             sender = otrClientIdMapper.toOtrClientId(envelopeParameters.sender),
+            blob = envelopeParameters.data?.let { ByteArr(it) },
             //TODO(messaging): Handle different report types, etc.
             clientMismatchStrategy = QualifiedNewOtrMessage.ClientMismatchStrategy.ReportAll(ClientMismatchStrategy.ReportAll()),
             nativePush = envelopeParameters.nativePush,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApi.kt
@@ -68,13 +68,13 @@ interface MessageApi {
          * @param priority message priority
          * @param transient
          */
-        data class QualifiedDefaultParameters(
+        class QualifiedDefaultParameters(
             val sender: String,
             val recipients: QualifiedUserToClientToEncMsgMap,
             val nativePush: Boolean,
             val priority: MessagePriority,
             val transient: Boolean,
-            val `data`: String? = null,
+            val `data`: ByteArray? = null,
             val messageOption: QualifiedMessageOption
         ) : Parameters()
     }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/message/EnvelopeProtoMapperTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/message/EnvelopeProtoMapperTest.kt
@@ -1,0 +1,40 @@
+package com.wire.kalium.api.tools.json.api.message
+
+import com.wire.kalium.api.tools.IgnoreIOS
+import com.wire.kalium.network.api.message.MessageApi
+import com.wire.kalium.network.api.message.MessagePriority
+import com.wire.kalium.network.api.message.provideEnvelopeProtoMapper
+import com.wire.kalium.protobuf.decodeFromByteArray
+import com.wire.kalium.protobuf.otr.QualifiedNewOtrMessage
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+@IgnoreIOS
+class EnvelopeProtoMapperTest {
+
+    private val envelopeProtoMapper = provideEnvelopeProtoMapper()
+
+    @Test
+    fun givenEnvelopeWithData_whenMappingToProtobuf_thenBlobShouldMatch() {
+        val data = byteArrayOf(0x42, 0x13, 0x69)
+
+        val encoded = envelopeProtoMapper.encodeToProtobuf(
+            MessageApi.Parameters.QualifiedDefaultParameters(
+                sender = TEST_SENDER,
+                recipients = mapOf(),
+                nativePush = true,
+                priority = MessagePriority.HIGH,
+                transient = false,
+                data = data,
+                messageOption = MessageApi.QualifiedMessageOption.ReportAll
+            )
+        )
+        val newOtrMessage = QualifiedNewOtrMessage.decodeFromByteArray(encoded)
+
+        assertContentEquals(data, newOtrMessage.blob!!.array)
+    }
+
+    private companion object{
+        val TEST_SENDER = "9AFBD180"
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Following #632.

We don't take tje `data` parameter of the envelope into consideration when mapping to Protobuf.

### Solutions

Pass this `data` as the `blob` in the Protobuf model.

### Dependencies

Needs releases with:

- #632 

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
