### PR TITLE
feat: send external messages (AR-1760) [External Messages Part 3] 

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -54,6 +54,7 @@ interface MessageRepository {
         offset: Int,
         visibility: List<Message.Visibility> = Message.Visibility.values().toList()
     ): Flow<List<Message>>
+
     suspend fun getMessagesByConversationIdAndVisibilityAfterDate(
         conversationId: ConversationId,
         date: String,
@@ -193,7 +194,8 @@ class MessageDataSource(
                 //TODO(messaging): Handle other MessageOptions, native push, transient and priorities
                 MessageApi.Parameters.QualifiedDefaultParameters(
                     envelope.senderClientId.value,
-                    recipientMap, true, MessagePriority.HIGH, false, null, MessageApi.QualifiedMessageOption.ReportAll
+                    recipientMap, true, MessagePriority.HIGH, false, envelope.dataBlob?.data,
+                    MessageApi.QualifiedMessageOption.ReportAll
                 ),
                 idMapper.toApiModel(conversationId),
             )
@@ -203,6 +205,7 @@ class MessageDataSource(
                         && networkFailure.rootCause is ProteusClientsChangedError -> {
                     sendMessageFailureMapper.fromDTO(networkFailure.rootCause as ProteusClientsChangedError)
                 }
+
                 else -> networkFailure
             }
             Either.Left(failure)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContent.kt
@@ -9,16 +9,17 @@ import com.wire.kalium.protobuf.messages.GenericMessage
  *
  * It can be [ProtoContent] or [ExternalMessageInstructions].
  */
-sealed class ProtoContent {
+sealed interface ProtoContent {
+    val messageUid: String
 
     /**
      * Regular message, with readable content that can be simply used.
      * @see [ExternalMessageInstructions]
      */
     data class Readable(
-        val messageUid: String,
+        override val messageUid: String,
         val messageContent: MessageContent.FromProto
-    ) : ProtoContent()
+    ) : ProtoContent
 
     /**
      * The message doesn't contain an actual content,
@@ -33,9 +34,9 @@ sealed class ProtoContent {
      * @see [GenericMessage.Content.External]
      */
     class ExternalMessageInstructions(
-        val messageUid: String,
+        override val messageUid: String,
         val otrKey: ByteArray,
         val sha256: ByteArray?,
         val encryptionAlgorithm: MessageEncryptionAlgorithm?
-    ) : ProtoContent()
+    ) : ProtoContent
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
@@ -3,13 +3,19 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.cryptography.CryptoClientId
 import com.wire.kalium.cryptography.CryptoSessionId
 import com.wire.kalium.cryptography.ProteusClient
+import com.wire.kalium.cryptography.utils.PlainData
+import com.wire.kalium.cryptography.utils.calcSHA256
+import com.wire.kalium.cryptography.utils.encryptDataWithAES256
+import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.message.ClientPayload
 import com.wire.kalium.logic.data.message.EncryptedMessageBlob
 import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageEncryptionAlgorithm
 import com.wire.kalium.logic.data.message.MessageEnvelope
+import com.wire.kalium.logic.data.message.PlainMessageBlob
 import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.message.RecipientEntry
@@ -17,6 +23,7 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapCryptoRequest
 
 interface MessageEnvelopeCreator {
@@ -39,16 +46,20 @@ class MessageEnvelopeCreatorImpl(
         message: Message.Regular
     ): Either<CoreFailure, MessageEnvelope> {
         val senderClientId = message.senderClientId
-        val content = protoContentMapper.encodeToProtobuf(ProtoContent.Readable(message.id, message.content))
+        ProtoContent.Readable(message.id, message.content)
+
+        val actualMessageContent = ProtoContent.Readable(message.id, message.content)
+        val (encodedContent, externalDataBlob) = getContentAndExternalData(actualMessageContent, recipients)
 
         return recipients.foldToEitherWhileRight(mutableListOf<RecipientEntry>()) { recipient, recipientAccumulator ->
             recipient.clients.foldToEitherWhileRight(mutableListOf<ClientPayload>()) { client, clientAccumulator ->
                 val session = CryptoSessionId(idMapper.toCryptoQualifiedIDId(recipient.member.id), CryptoClientId(client.value))
 
-                wrapCryptoRequest { EncryptedMessageBlob(proteusClient.encrypt(content.data, session)) }
+                wrapCryptoRequest { EncryptedMessageBlob(proteusClient.encrypt(encodedContent.data, session)) }
                     .map { encryptedContent ->
                         clientAccumulator.also {
                             it.add(ClientPayload(client, encryptedContent))
+                            kaliumLogger.d("Encrypted message size: ${encryptedContent.data.size}")
                         }
                     }
             }.map { clientEntries ->
@@ -57,7 +68,59 @@ class MessageEnvelopeCreatorImpl(
                 }
             }
         }.map { recipientEntries ->
-            MessageEnvelope(senderClientId, recipientEntries)
+            MessageEnvelope(senderClientId, recipientEntries, externalDataBlob)
         }
+    }
+
+    private fun getContentAndExternalData(
+        actualMessageContent: ProtoContent.Readable,
+        recipients: List<Recipient>
+    ): Pair<PlainMessageBlob, EncryptedMessageBlob?> {
+        val encodedContent = protoContentMapper.encodeToProtobuf(actualMessageContent)
+
+        val encryptedMessageSizeEstimate = encodedContent.data.size + ENCRYPTED_MESSAGE_OVERHEAD
+        val totalClients = recipients.sumOf { recipient -> recipient.clients.size }
+
+        val totalEstimatedSize = encryptedMessageSizeEstimate + totalClients
+        kaliumLogger.v(
+            "Original message size: ${encodedContent.data.size}; " +
+                    "Estimated total message size = $totalEstimatedSize, " +
+                    "for $totalClients clients"
+        )
+
+        return if (totalEstimatedSize <= MAX_CONTENT_SIZE) {
+            kaliumLogger.v("External message is not needed")
+            encodedContent to null
+        } else {
+            kaliumLogger.v("Creating external message")
+            val otrKey = generateRandomAES256Key()
+            val encryptedExternalBlob = encryptDataWithAES256(PlainData(encodedContent.data), otrKey)
+            val contentHash = calcSHA256(encryptedExternalBlob.data)
+            val externalInstructions = protoContentMapper.encodeToProtobuf(
+                ProtoContent.ExternalMessageInstructions(
+                    actualMessageContent.messageUid,
+                    otrKey.data,
+                    contentHash,
+                    MessageEncryptionAlgorithm.AES_CBC
+                )
+            )
+            externalInstructions to EncryptedMessageBlob(encryptedExternalBlob.data)
+        }
+    }
+
+    internal companion object {
+        /**
+         * An encrypted Proteus message has extra information about the encryption itself.
+         * The content after encryption is around 190 bytes larger than the original
+         * when encrypting the first ever message to a client.
+         * Can be smaller (around 110 bytes) after the other client replies for the first time.
+         * In order to account the overhead added by each client and user, and to  add a safety margin
+         */
+        const val ENCRYPTED_MESSAGE_OVERHEAD = 256
+
+        /**
+         * Maximum size of the messages payload accepted by the servers without [ProtoContent.ExternalMessageInstructions].
+         */
+        const val MAX_CONTENT_SIZE = 256 * 1024
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -21,6 +21,7 @@ import io.mockative.anything
 import io.mockative.configure
 import io.mockative.eq
 import io.mockative.given
+import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
@@ -147,7 +148,7 @@ class MessageRepositoryTest {
     }
 
     @Test
-    fun givenAMessage_whenSendingReturnsSuccess_thenUpdateTheMessageDate() = runTest {
+    fun givenAMessage_whenSendingReturnsSuccess_thenSuccessShouldBePropagatedWithServerTime() = runTest {
         val messageEnvelope = MessageEnvelope(TEST_CLIENT_ID, listOf())
 
         given(idMapper)
@@ -169,6 +170,37 @@ class MessageRepositoryTest {
             .shouldSucceed {
                 assertSame(it, TEST_DATETIME)
             }
+    }
+
+    @Test
+    fun givenAMessageWithExternalBlob_whenSending_thenApiShouldBeCalledWithBlob() = runTest {
+        val dataBlob = EncryptedMessageBlob(byteArrayOf(0x42, 0x13, 0x69))
+        val messageEnvelope = MessageEnvelope(TEST_CLIENT_ID, listOf(), dataBlob)
+
+        given(idMapper)
+            .function(idMapper::toApiModel)
+            .whenInvokedWith(anything())
+            .then { TEST_NETWORK_QUALIFIED_ID_ENTITY }
+
+        given(messageApi)
+            .suspendFunction(messageApi::qualifiedSendMessage)
+            .whenInvokedWith(anything(), anything())
+            .then { _, _ ->
+                NetworkResponse.Success(
+                    QualifiedSendMessageResponse.MessageSent(TEST_DATETIME, mapOf(), mapOf(), mapOf()),
+                    emptyMap(),
+                    201
+                )
+            }
+        messageRepository.sendEnvelope(TEST_CONVERSATION_ID, messageEnvelope)
+            .shouldSucceed {
+                assertSame(it, TEST_DATETIME)
+            }
+
+        verify(messageApi)
+            .suspendFunction(messageApi::qualifiedSendMessage)
+            .with(matching { it.data!!.contentEquals(dataBlob.data) }, anything())
+            .wasInvoked(exactly = once)
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.message
 
+import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.framework.TestConversation
@@ -11,6 +12,7 @@ import com.wire.kalium.protobuf.messages.Text
 import io.ktor.utils.io.core.toByteArray
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
@@ -163,6 +165,24 @@ class ProtoContentMapperTest {
         val content = result.messageContent
         assertIs<MessageContent.TextEdited>(content)
         assertEquals(textContent.value.content, content.newContent)
+    }
+
+    @Test
+    fun givenExternalMessageInstructions_whenEncodingToProtoAndBack_thenTheResultContentShouldEqualTheOriginal() {
+        val messageUid = TEST_MESSAGE_UUID
+        val otrKey = generateRandomAES256Key()
+        val sha256 = byteArrayOf(0x20, 0x42, 0x31)
+        val encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
+
+        val instructions = ProtoContent.ExternalMessageInstructions(messageUid, otrKey.data, sha256, encryptionAlgorithm)
+        val encoded = protoContentMapper.encodeToProtobuf(instructions)
+        val result = protoContentMapper.decodeFromProtobuf(encoded)
+
+        assertIs<ProtoContent.ExternalMessageInstructions>(result)
+        assertEquals(messageUid, result.messageUid)
+        assertContentEquals(otrKey.data, result.otrKey)
+        assertContentEquals(sha256, result.sha256)
+        assertEquals(encryptionAlgorithm, result.encryptionAlgorithm)
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreatorTest.kt
@@ -10,6 +10,7 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.message.PlainMessageBlob
+import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestMessage
@@ -19,6 +20,7 @@ import io.mockative.Mock
 import io.mockative.anything
 import io.mockative.eq
 import io.mockative.given
+import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
@@ -26,8 +28,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -70,6 +74,78 @@ class MessageEnvelopeCreatorTest {
                     .suspendFunction(proteusClient::encrypt)
                     .with(eq(plainData), eq(CryptoSessionId(CryptoUserID(recipient.member.id.value, recipient.member.id.domain), CryptoClientId(client.value))))
                     .wasInvoked(exactly = once)
+            }
+        }
+    }
+
+    @Test
+    fun givenMessageContentIsTooBig_whenCreatingAnEnvelope_thenShouldCreateExternalMessageInstructions() = runTest {
+        // Given
+        // A big byte array as the readable content
+        val plainData = ByteArray(SUPER_BIG_CONTENT_SIZE) { it.toByte() }
+
+        val recipients = TEST_RECIPIENTS
+        val externalInstructionsArray = byteArrayOf(0x42, 0x13)
+        val encryptedData = byteArrayOf(0x66)
+        // Should only attempt to E2EE the external instructions, not the content itself
+        given(proteusClient)
+            .suspendFunction(proteusClient::encrypt)
+            .whenInvokedWith(matching { it.contentEquals(externalInstructionsArray) }, anything())
+            .thenReturn(encryptedData)
+
+        given(protoContentMapper)
+            .function(protoContentMapper::encodeToProtobuf)
+            .whenInvokedWith(matching { it is ProtoContent.Readable })
+            .thenReturn(PlainMessageBlob(plainData))
+
+        given(protoContentMapper)
+            .function(protoContentMapper::encodeToProtobuf)
+            .whenInvokedWith(matching { it is ProtoContent.ExternalMessageInstructions })
+            .thenReturn(PlainMessageBlob(externalInstructionsArray))
+
+        // When
+        val envelope = messageEnvelopeCreator.createOutgoingEnvelope(recipients, TestMessage.TEXT_MESSAGE)
+
+        // Then
+        envelope.shouldSucceed {
+            assertTrue { it.dataBlob!!.data.size >= SUPER_BIG_CONTENT_SIZE }
+
+            it.recipients.forEach { recipientEntry ->
+                recipientEntry.clientPayloads.forEach { clientPayload ->
+                    assertEquals(encryptedData, clientPayload.payload.data)
+                }
+            }
+        }
+    }
+    @Test
+    fun givenMessageContentIsSmall_whenCreatingAnEnvelope_thenShouldNotCreateExternalMessageInstructions() = runTest {
+        // Given
+        val plainData = ByteArray(1) { it.toByte() }
+
+        val recipients = TEST_RECIPIENTS
+        val encryptedData = byteArrayOf(0x66)
+        // Should only attempt to E2EE the content itself
+        given(proteusClient)
+            .suspendFunction(proteusClient::encrypt)
+            .whenInvokedWith(matching { it.contentEquals(plainData) }, anything())
+            .thenReturn(encryptedData)
+
+        given(protoContentMapper)
+            .function(protoContentMapper::encodeToProtobuf)
+            .whenInvokedWith(matching { it is ProtoContent.Readable })
+            .thenReturn(PlainMessageBlob(plainData))
+
+        // When
+        val envelope = messageEnvelopeCreator.createOutgoingEnvelope(recipients, TestMessage.TEXT_MESSAGE)
+
+        // Then
+        envelope.shouldSucceed {
+            assertNull(it.dataBlob)
+
+            it.recipients.forEach { recipientEntry ->
+                recipientEntry.clientPayloads.forEach { clientPayload ->
+                    assertEquals(encryptedData, clientPayload.payload.data)
+                }
             }
         }
     }
@@ -154,6 +230,10 @@ class MessageEnvelopeCreatorTest {
     }
 
     private companion object {
+        /**
+         * A content size so big it would alone go over the 256KB limit in the backend
+         */
+        val SUPER_BIG_CONTENT_SIZE = 300 * 1024
         val TEST_CONTACT_CLIENT_1 = ClientId("clientId1")
         val TEST_CONTACT_CLIENT_2 = ClientId("clientId2")
         val TEST_MEMBER_1 = Member(UserId("value1", "domain1"))

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/EnvelopeProtoMapperImpl.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/api/message/EnvelopeProtoMapperImpl.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.protobuf.otr.ClientMismatchStrategy
 import com.wire.kalium.protobuf.otr.QualifiedNewOtrMessage
 import com.wire.kalium.protobuf.otr.QualifiedUserEntry
 import com.wire.kalium.protobuf.otr.UserEntry
+import pbandk.ByteArr
 import pbandk.encodeToByteArray
 
 class EnvelopeProtoMapperImpl : EnvelopeProtoMapper {
@@ -28,6 +29,7 @@ class EnvelopeProtoMapperImpl : EnvelopeProtoMapper {
         return QualifiedNewOtrMessage(
             recipients = qualifiedEntries,
             sender = otrClientIdMapper.toOtrClientId(envelopeParameters.sender),
+            blob = envelopeParameters.data?.let { ByteArr(it) },
             //TODO(messaging): Handle different report types, etc.
             clientMismatchStrategy = QualifiedNewOtrMessage.ClientMismatchStrategy.ReportAll(ClientMismatchStrategy.ReportAll()),
             nativePush = envelopeParameters.nativePush,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApi.kt
@@ -68,13 +68,13 @@ interface MessageApi {
          * @param priority message priority
          * @param transient
          */
-        data class QualifiedDefaultParameters(
+        class QualifiedDefaultParameters(
             val sender: String,
             val recipients: QualifiedUserToClientToEncMsgMap,
             val nativePush: Boolean,
             val priority: MessagePriority,
             val transient: Boolean,
-            val `data`: String? = null,
+            val `data`: ByteArray? = null,
             val messageOption: QualifiedMessageOption
         ) : Parameters()
     }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/message/EnvelopeProtoMapperTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/message/EnvelopeProtoMapperTest.kt
@@ -1,0 +1,40 @@
+package com.wire.kalium.api.tools.json.api.message
+
+import com.wire.kalium.api.tools.IgnoreIOS
+import com.wire.kalium.network.api.message.MessageApi
+import com.wire.kalium.network.api.message.MessagePriority
+import com.wire.kalium.network.api.message.provideEnvelopeProtoMapper
+import com.wire.kalium.protobuf.decodeFromByteArray
+import com.wire.kalium.protobuf.otr.QualifiedNewOtrMessage
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+@IgnoreIOS
+class EnvelopeProtoMapperTest {
+
+    private val envelopeProtoMapper = provideEnvelopeProtoMapper()
+
+    @Test
+    fun givenEnvelopeWithData_whenMappingToProtobuf_thenBlobShouldMatch() {
+        val data = byteArrayOf(0x42, 0x13, 0x69)
+
+        val encoded = envelopeProtoMapper.encodeToProtobuf(
+            MessageApi.Parameters.QualifiedDefaultParameters(
+                sender = TEST_SENDER,
+                recipients = mapOf(),
+                nativePush = true,
+                priority = MessagePriority.HIGH,
+                transient = false,
+                data = data,
+                messageOption = MessageApi.QualifiedMessageOption.ReportAll
+            )
+        )
+        val newOtrMessage = QualifiedNewOtrMessage.decodeFromByteArray(encoded)
+
+        assertContentEquals(data, newOtrMessage.blob!!.array)
+    }
+
+    private companion object{
+        val TEST_SENDER = "9AFBD180"
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Following #632 and #633.
We don't send [external messages](https://github.com/wireapp/generic-message-proto#external).

### Solutions

Now that we are able to serialize external instructions and envelopes with blobs, this PR aims to roughly estimate the size of messages (with some safety margin) and actually encrypt external messages when the Proteus envelope is too big.

### Dependencies

Needs releases with:

- #632 
- #633 

### Testing

Manually tested on Reloaded, by hard-coding a big content in Kalium and triggering this.
Messages are successfully received as `External Messages` on other Reloaded clients, Web and Android.

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Send a text wall message on a group of ~120 people, with ~600 or so clients.
Or hard-code as I did.
Tests were added anyway.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
