### PR TITLE
feat(network): add conversation role to network layer [AR-1041]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MemberMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MemberMapper.kt
@@ -24,18 +24,18 @@ internal class MemberMapperImpl(private val idMapper: IdMapper) : MemberMapper {
         Member(idMapper.fromApiModel(conversationMember.qualifiedId))
 
     override fun fromApiModel(conversationMembersResponse: ConversationMembersResponse): MembersInfo {
-        val self = Member(idMapper.fromApiModel(conversationMembersResponse.self.userId))
+        val self = Member(idMapper.fromApiModel(conversationMembersResponse.self.id))
         val others = conversationMembersResponse.otherMembers.map { member ->
-            Member(idMapper.fromApiModel(member.userId))
+            Member(idMapper.fromApiModel(member.id))
         }
         return MembersInfo(self, others)
     }
 
     override fun fromApiModelToDaoModel(conversationMembersResponse: ConversationMembersResponse): List<PersistedMember> {
         val otherMembers = conversationMembersResponse.otherMembers.map { member ->
-            PersistedMember(idMapper.fromApiToDao(member.userId))
+            PersistedMember(idMapper.fromApiToDao(member.id))
         }
-        val selfMember = PersistedMember(idMapper.fromApiToDao(conversationMembersResponse.self.userId))
+        val selfMember = PersistedMember(idMapper.fromApiToDao(conversationMembersResponse.self.id))
         return otherMembers + selfMember
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MemberMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MemberMapper.kt
@@ -2,14 +2,14 @@ package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.network.api.UserId
-import com.wire.kalium.network.api.conversation.ConversationMember
+import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.user.client.SimpleClientResponse
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.Member as PersistedMember
 
 interface MemberMapper {
-    fun fromApiModel(conversationMember: ConversationMember): Member
+    fun fromApiModel(conversationMember:  ConversationMemberDTO.Other): Member
     fun fromApiModel(conversationMembersResponse: ConversationMembersResponse): MembersInfo
     fun fromMapOfClientsResponseToRecipients(qualifiedMap: Map<UserId, List<SimpleClientResponse>>): List<Recipient>
     fun fromApiModelToDaoModel(conversationMembersResponse: ConversationMembersResponse): List<PersistedMember>
@@ -20,8 +20,8 @@ interface MemberMapper {
 
 internal class MemberMapperImpl(private val idMapper: IdMapper) : MemberMapper {
 
-    override fun fromApiModel(conversationMember: ConversationMember): Member =
-        Member(idMapper.fromApiModel(conversationMember.qualifiedId))
+    override fun fromApiModel(conversationMember: ConversationMemberDTO.Other): Member =
+        Member(idMapper.fromApiModel(conversationMember.id))
 
     override fun fromApiModel(conversationMembersResponse: ConversationMembersResponse): MembersInfo {
         val self = Member(idMapper.fromApiModel(conversationMembersResponse.self.id))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -2,14 +2,12 @@ package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.TeamId
-import com.wire.kalium.logic.data.user.type.UserTypeMapper
 import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.conversation.ConvProtocol
+import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
-import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
-import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
 import com.wire.kalium.network.api.conversation.MutedStatus
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -153,10 +151,13 @@ class ConversationMapperTest {
         val ORIGINAL_CONVERSATION_ID = ConversationId("original", "oDomain")
         val SELF_USER_TEAM_ID = TeamId("teamID")
         val SELF_MEMBER_RESPONSE =
-            ConversationSelfMemberResponse(
-                UserId("selfId", "selfDomain"), "2022-04-11T20:24:57.237Z", MutedStatus.ALL_ALLOWED
+            ConversationMemberDTO.Self(
+                id = UserId("selfId", "selfDomain"),
+                conversationRole = "wire_member",
+                otrMutedRef = "2022-04-11T20:24:57.237Z",
+                otrMutedStatus = MutedStatus.ALL_ALLOWED
             )
-        val OTHER_MEMBERS = listOf(ConversationOtherMembersResponse(null, UserId("other1", "domain1")))
+        val OTHER_MEMBERS = listOf(ConversationMemberDTO.Other(service = null, id =  UserId("other1", "domain1"), conversationRole = "wire_admin"))
         val MEMBERS_RESPONSE = ConversationMembersResponse(SELF_MEMBER_RESPONSE, OTHER_MEMBERS)
         val CONVERSATION_RESPONSE = ConversationResponse(
             "creator",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -157,7 +157,8 @@ class ConversationMapperTest {
                 otrMutedRef = "2022-04-11T20:24:57.237Z",
                 otrMutedStatus = MutedStatus.ALL_ALLOWED
             )
-        val OTHER_MEMBERS = listOf(ConversationMemberDTO.Other(service = null, id =  UserId("other1", "domain1"), conversationRole = "wire_admin"))
+        val OTHER_MEMBERS =
+            listOf(ConversationMemberDTO.Other(service = null, id = UserId("other1", "domain1"), conversationRole = "wire_admin"))
         val MEMBERS_RESPONSE = ConversationMembersResponse(SELF_MEMBER_RESPONSE, OTHER_MEMBERS)
         val CONVERSATION_RESPONSE = ConversationResponse(
             "creator",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -12,11 +12,11 @@ import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.conversation.ConvProtocol
 import com.wire.kalium.network.api.conversation.ConversationApi
+import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationPagingResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationResponseDTO
-import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
 import com.wire.kalium.network.api.user.client.ClientApi
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
@@ -560,7 +560,7 @@ class ConversationRepositoryTest {
         val CONVERSATION_RESPONSE = ConversationResponse(
             "creator",
             ConversationMembersResponse(
-                ConversationSelfMemberResponse(MapperProvider.idMapper().toApiModel(TestUser.SELF.id)),
+                ConversationMemberDTO.Self(MapperProvider.idMapper().toApiModel(TestUser.SELF.id), "wire_member"),
                 emptyList()
             ),
             GROUP_NAME,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MemberMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MemberMapperTest.kt
@@ -3,10 +3,15 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
-import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
-import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
-import io.mockative.*
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -36,11 +41,11 @@ class MemberMapperTest {
         memberMapper.fromApiModel(membersResponse)
 
         verify(idMapper)
-            .invocation { idMapper.fromApiModel(SELF_MEMBER_RESPONSE.userId) }
+            .invocation { idMapper.fromApiModel(SELF_MEMBER_RESPONSE.id) }
             .wasInvoked(exactly = once)
 
         verify(idMapper)
-            .invocation { idMapper.fromApiModel(OTHER_MEMBER.userId) }
+            .invocation { idMapper.fromApiModel(OTHER_MEMBER.id) }
             .wasInvoked(exactly = once)
     }
 
@@ -92,8 +97,8 @@ class MemberMapperTest {
     }
 
     private companion object {
-        val SELF_MEMBER_RESPONSE = ConversationSelfMemberResponse(UserId("selfId", "selfDomain"))
-        val OTHER_MEMBER = ConversationOtherMembersResponse(null, UserId("other1", "domain1"))
+        val SELF_MEMBER_RESPONSE = ConversationMemberDTO.Self(UserId("selfId", "selfDomain"), "wire_admin")
+        val OTHER_MEMBER = ConversationMemberDTO.Other(id = UserId("other1", "domain1"), conversationRole = "wire_member", service = null)
         val MEMBERS_RESPONSE = ConversationMembersResponse(SELF_MEMBER_RESPONSE, listOf(OTHER_MEMBER))
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -7,9 +7,9 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.QualifiedID
 import com.wire.kalium.network.api.conversation.ConvProtocol
+import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
-import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 
@@ -61,7 +61,7 @@ object TestConversation {
     val CONVERSATION_RESPONSE = ConversationResponse(
         "creator",
         ConversationMembersResponse(
-            ConversationSelfMemberResponse(MapperProvider.idMapper().toApiModel(TestUser.SELF.id)),
+            ConversationMemberDTO.Self(MapperProvider.idMapper().toApiModel(TestUser.SELF.id), "wire_admin"),
             emptyList()
         ),
         ConversationRepositoryTest.GROUP_NAME,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationEvent.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationEvent.kt
@@ -5,15 +5,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ConversationMember(
-    @SerialName("conversation_role") val conversationRole: String?, // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed by Wire (i.e., no custom roles can have the same prefix)
-    @SerialName("qualified_id") val qualifiedId: UserId
-)
-
-@Serializable
 data class ConversationMembers(
     @SerialName("user_ids") val userIds: List<String>, // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed by Wire (i.e., no custom roles can have the same prefix)
-    @SerialName("users") val users: List<ConversationMember>
+    @SerialName("users") val users: List<ConversationMemberDTO.Other>
 )
 
 @Serializable

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -58,54 +58,51 @@ data class ConversationResponse(
 @Serializable
 data class ConversationMembersResponse(
     @SerialName("self")
-    val self: ConversationSelfMemberResponse,
+    val self: ConversationMemberDTO.Self,
 
     @SerialName("others")
-    val otherMembers: List<ConversationOtherMembersResponse>
+    val otherMembers: List<ConversationMemberDTO.Other>
 )
 
-@Serializable
-data class ConversationSelfMemberResponse(
-    @SerialName("qualified_id") override val userId: UserId,
-    @SerialName("otr_muted_ref") val otrMutedRef: String? = null,
-    @SerialName("otr_muted_status") @Serializable(with = MutedStatusSerializer::class) val otrMutedStatus: MutedStatus? = null
-    /*
+sealed class ConversationMemberDTO {
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles designed
     // by Wire (i.e., no custom roles can have the same prefix)
-    @SerialName("conversation_role") val conversationRole: String? = null,
+    // in swagger conversation_role is an optional field but according to Akshay:
+    // Hmm, the field is optional when sending it to the server. The server will always send the field.
+    //(The server assumes admin when the field is missing, I don't have the context behind this decision)
+    abstract val conversationRole: String
+    abstract val id: UserId
+    abstract val service: ServiceReferenceDTO?
 
-    @SerialName("service") val service: ServiceReferenceResponse? = null,
+    @Serializable
+    data class Self(
+        @SerialName(ID_SERIAL_NAME) override val id: UserId,
+        @SerialName(CONV_ROLE_SERIAL_NAME) override val conversationRole: String,
+        @SerialName(SERVICE_SERIAL_NAME) override val service: ServiceReferenceDTO? = null,
+        @SerialName("hidden") val hidden: Boolean? = null,
+        @SerialName("hidden_ref") val hiddenRef: String? = null,
+        @SerialName("otr_archived") val otrArchived: Boolean? = null,
+        @SerialName("otr_archived_ref") val otrArchivedRef: String? = null,
+        @SerialName("otr_muted_ref") val otrMutedRef: String? = null,
+        @SerialName("otr_muted_status") @Serializable(with = MutedStatusSerializer::class) val otrMutedStatus: MutedStatus? = null
+    ) : ConversationMemberDTO()
 
-    //@SerialName("status") val status
-    //@SerialName("status_ref") val status
-    //@SerialName("status_time") val status
+    @Serializable
+    data class Other(
+        @SerialName(ID_SERIAL_NAME) override val id: UserId,
+        @SerialName(CONV_ROLE_SERIAL_NAME) override val conversationRole: String,
+        @SerialName(SERVICE_SERIAL_NAME) override val service: ServiceReferenceDTO? = null
+    ) : ConversationMemberDTO()
 
-    @SerialName("otr_muted_ref") val otrMutedReference: String? = null,
-    @SerialName("otr_muted_status") val otrMutedStatus: Int? = null,
-
-    @SerialName("hidden") val hidden: Boolean? = null,
-    @SerialName("hidden_ref") val hiddenReference: String? = null,
-
-    @SerialName("otr_archived") val otrArchived: Boolean? = null,
-    @SerialName("otr_archived_ref") val otrArchivedReference: String? = null,
-    */
-) : ConversationMemberResponse
-
-@Serializable
-data class ConversationOtherMembersResponse(
-    @SerialName("service")
-    val service: ServiceReferenceResponse? = null,
-
-    @SerialName("qualified_id")
-    override val userId: UserId,
-) : ConversationMemberResponse
-
-interface ConversationMemberResponse {
-    val userId: UserId
+    private companion object {
+        const val ID_SERIAL_NAME = "qualified_id"
+        const val CONV_ROLE_SERIAL_NAME = "conversation_role"
+        const val SERVICE_SERIAL_NAME = "service"
+    }
 }
 
 @Serializable
-data class ServiceReferenceResponse(
+data class ServiceReferenceDTO(
     @SerialName("id")
     val id: String,
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
@@ -52,6 +52,7 @@ sealed class EventContentDTO {
             @SerialName("qualified_from") val qualifiedFrom: UserId,
             val time: String,
             @SerialName("data") val members: ConversationMembers,
+            @Deprecated("use qualifiedFrom", replaceWith = ReplaceWith("this.qualifiedFrom"))
             @SerialName("from") val from: String
         ) : Conversation()
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/ServiceReferenceDTOJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/ServiceReferenceDTOJson.kt
@@ -1,11 +1,11 @@
 package com.wire.kalium.api.tools.json
 
-import com.wire.kalium.network.api.conversation.ServiceReferenceResponse
+import com.wire.kalium.network.api.conversation.ServiceReferenceDTO
 
 
-object ServiceReferenceResponseJson {
+object ServiceReferenceDTOJson {
     val valid = ValidJsonProvider(
-        ServiceReferenceResponse("ID", "provider")
+        ServiceReferenceDTO("ID", "provider")
     ) {
         """
         |{

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
@@ -6,10 +6,12 @@ import com.wire.kalium.network.api.conversation.ConversationApi
 import com.wire.kalium.network.api.conversation.ConversationApiImpl
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ConversationApiTest : ApiTest {
 
     @Test

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -3,10 +3,9 @@ package com.wire.kalium.api.tools.json.api.conversation
 import com.wire.kalium.api.tools.json.ValidJsonProvider
 import com.wire.kalium.api.tools.json.model.QualifiedIDSamples
 import com.wire.kalium.network.api.conversation.ConvProtocol
+import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
-import com.wire.kalium.network.api.conversation.ConversationOtherMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
-import com.wire.kalium.network.api.conversation.ConversationSelfMemberResponse
 import com.wire.kalium.network.api.conversation.MutedStatus
 
 object ConversationResponseJson {
@@ -21,18 +20,19 @@ object ConversationResponseJson {
         |       "others": [
         |           {
         |               "qualified_id": {
-        |                   "domain": "${it.members.otherMembers[0].userId.domain}",
-        |                   "id": "${it.members.otherMembers[0].userId.value}"
+        |                   "domain": "${it.members.otherMembers[0].id.domain}",
+        |                   "id": "${it.members.otherMembers[0].id.value}"
         |               }
         |           }
         |       ],
         |       "self": {
         |           "qualified_id": {
-        |               "domain": "${it.members.self.userId.domain}",
-        |               "id": "${it.members.self.userId.value}"
+        |               "domain": "${it.members.self.id.domain}",
+        |               "id": "${it.members.self.id.value}"
         |           },
-        |           "otr_muted_ref": "2022-04-11T14:15:48.044Z",
-        |           "otr_muted_status": 0
+        |           "conversation_role" : "${it.members.self.conversationRole}"
+        |           "otr_muted_ref": "${it.members.self.otrMutedRef}",
+        |           "otr_muted_status": ${it.members.self.otrMutedStatus}
         |       }
         |   },
         |   "message_timer": ${it.messageTimer},
@@ -53,10 +53,13 @@ object ConversationResponseJson {
         ConversationResponse(
             "fdf23116-42a5-472c-8316-e10655f5d11e",
             ConversationMembersResponse(
-                ConversationSelfMemberResponse(
-                    QualifiedIDSamples.one
+                ConversationMemberDTO.Self(
+                    QualifiedIDSamples.one,
+                    "wire_admin",
+                    otrMutedRef = "2022-04-11T14:15:48.044Z",
+                    otrMutedStatus = MutedStatus.fromOrdinal(0)
                 ),
-                listOf(ConversationOtherMembersResponse(null, QualifiedIDSamples.two))
+                listOf(ConversationMemberDTO.Other( id = QualifiedIDSamples.two, conversationRole = "wire_member"))
             ),
             "group name",
             QualifiedIDSamples.one,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`conversation_role` is not parsed in the network layer

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

1. refactor the `ConversationMember` to one sealed class that contains information about both self and other members.
2. in swagger the field `conversation_role` is optional but according to Akshay: "Hmm, the field is optional when sending it to the server. The server will always send the field.(The server assumes admin when the field is missing, I don't have the context behind this decision)" therefore i opted to make it a required field in kalium.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
