### PR TITLE
fix: params setup for pagination support in api

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.network.api.conversation
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.pagination.PaginationRequest
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.delete
@@ -10,7 +11,6 @@ import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
-import kotlinx.serialization.json.buildJsonObject
 
 class ConversationApiImpl internal constructor(private val authenticatedNetworkClient: AuthenticatedNetworkClient) : ConversationApi {
 
@@ -19,13 +19,7 @@ class ConversationApiImpl internal constructor(private val authenticatedNetworkC
     override suspend fun fetchConversationsIds(pagingState: String?): NetworkResponse<ConversationPagingResponse> =
         wrapKaliumResponse {
             httpClient.post("$PATH_CONVERSATIONS/$PATH_LIST_IDS") {
-                setBody(
-                    buildJsonObject {
-                        pagingState?.let {
-                            "paging_state" to it
-                        }
-                    }
-                )
+                setBody(PaginationRequest(pagingState = pagingState))
             }
         }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/pagination/PaginationRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/pagination/PaginationRequest.kt
@@ -1,0 +1,12 @@
+package com.wire.kalium.network.api.pagination
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PaginationRequest(
+    @SerialName("paging_state")
+    val pagingState: String?,
+    @SerialName("size")
+    val size: Int? = null // Set in case you want specific number of pages, otherwise, the backend will return default per endpoint
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
@@ -2,12 +2,12 @@ package com.wire.kalium.network.api.user.connection
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.pagination.PaginationRequest
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
-import kotlinx.serialization.json.buildJsonObject
 
 interface ConnectionApi {
 
@@ -23,13 +23,7 @@ class ConnectionApiImpl internal constructor(private val authenticatedNetworkCli
     override suspend fun fetchSelfUserConnections(pagingState: String?): NetworkResponse<ConnectionResponse> =
         wrapKaliumResponse {
             httpClient.post(PATH_CONNECTIONS) {
-                setBody(
-                    buildJsonObject {
-                        pagingState?.let {
-                            "paging_state" to it
-                        }
-                    }
-                )
+                setBody(PaginationRequest(pagingState = pagingState))
             }
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Border cases, right now we had some code and logic for calling paginated endpoints, but we were not setting this correctly on the request body, so we were stuck in a loop trying to get always more pages. 

This fixes the issue, creating a request class that can be used in paginated endpoints, right now: Conversations and Connections.

Thanks to @vitorhugods for the detailed eagle eye 🦅 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
