### PR TITLE
chore: enable logging by default

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsLoggingEnabledUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsLoggingEnabledUseCase.kt
@@ -1,9 +1,7 @@
 package com.wire.kalium.logic.feature.user
 
-import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.logic.kaliumLogger
 
 interface IsLoggingEnabledUseCase {
     operator fun invoke(): Boolean
@@ -16,19 +14,8 @@ class IsLoggingEnabledUseCaseImpl(
 
     override operator fun invoke(): Boolean =
         userConfigRepository.isLoggingEnabled().fold({
-            when (it) {
-                StorageFailure.DataNotFound -> {
-                    kaliumLogger.e("Data not found")
-                    false
-                }
-                is StorageFailure.Generic -> {
-                    kaliumLogger.e("Storage Error : ${it.rootCause}")
-                    false
-                }
-            }
+            false
         }, {
             it
         })
-
 }
-

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/UserConfigStorage.kt
@@ -34,14 +34,14 @@ class UserConfigStorageImpl(private val kaliumPreferences: KaliumPreferences) : 
     }
 
     override fun isLoggingEnables(): Boolean =
-        kaliumPreferences.getBoolean(ENABLE_LOGGING)
+        kaliumPreferences.getBoolean(ENABLE_LOGGING, true)
 
     override fun persistFileSharingStatus(enabled: Boolean) {
         kaliumPreferences.putBoolean(FILE_SHARING, enabled)
     }
 
     override fun isFileSharingEnabled(): Boolean =
-        kaliumPreferences.getBoolean(FILE_SHARING)
+        kaliumPreferences.getBoolean(FILE_SHARING, true)
 
     private companion object {
         const val ENABLE_LOGGING = "enable_logging"

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmm_settings/KaliumPreferences.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmm_settings/KaliumPreferences.kt
@@ -21,6 +21,7 @@ interface KaliumPreferences {
 
     fun putBoolean(key: String, value: Boolean)
     fun getBoolean(key: String, defaultValue: Boolean = false): Boolean
+    fun getBoolean(key: String): Boolean?
 
 }
 
@@ -35,6 +36,9 @@ class KaliumPreferencesSettings(
 
     override fun getBoolean(key: String, defaultValue: Boolean): Boolean =
         encryptedSettings.getBoolean(key, defaultValue)
+
+    override fun getBoolean(key: String): Boolean? =
+        encryptedSettings.getBooleanOrNull(key)
 
     override fun remove(key: String) = encryptedSettings.remove(key)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

as of now we are trying to catch the logs to understand the app behaviour , so we enabled the logs by default 

### Solutions

give the is logging enabled true default value from the user config storage 


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
