### PR TITLE
fix(calling): fix incoming call flow

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -36,7 +36,14 @@ interface CallRepository {
     fun incomingCallsFlow(): Flow<List<Call>>
     fun ongoingCallsFlow(): Flow<List<Call>>
     fun establishedCallsFlow(): Flow<List<Call>>
-    suspend fun createCall(conversationId: ConversationId, status: CallStatus, callerId: String, isMuted: Boolean, isCameraOn: Boolean)
+    suspend fun createCall(
+        conversationId: ConversationId,
+        status: CallStatus,
+        callerId: String,
+        isMuted: Boolean,
+        isCameraOn: Boolean
+    )
+
     suspend fun updateCallStatusById(conversationId: String, status: CallStatus)
     fun updateIsMutedById(conversationId: String, isMuted: Boolean)
     fun updateIsCameraOnById(conversationId: String, isCameraOn: Boolean)
@@ -77,7 +84,7 @@ internal class CallDataSource(
 
     override fun incomingCallsFlow(): Flow<List<Call>> = allCalls.map {
         it.calls.values.filter { call ->
-            call.status == CallStatus.INCOMING
+            call.status == CallStatus.INCOMING && call.participants.isEmpty()
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

IncomingCall flow returns the same value many times after accepting a call.
This causes some issues on the clients like displaying the same incoming call screen multiple times.

### Causes (Optional)

After accepting a call, the Participants callback will occur causing some changes on the `callsFlow`(since we are updating the participants list there). The old and the new values of the incoming call is not the same, so the new value will be emitted in the flow

### Solutions

Filter also by participants, incoming calls should not have an empty list of participants

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### How to Test

On the Android app, receive a 1:1 call and accept it
You should not see incoming call screen twice

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
