### PR TITLE
fix: incoming call screen sometimes not appearing for group calls

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -84,7 +84,7 @@ internal class CallDataSource(
 
     override fun incomingCallsFlow(): Flow<List<Call>> = allCalls.map {
         it.calls.values.filter { call ->
-            call.status == CallStatus.INCOMING && call.participants.isEmpty()
+            call.status == CallStatus.INCOMING
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -51,7 +51,9 @@ internal class GetIncomingCallsUseCaseImpl(
             .flatMapLatest {
                 //if user is AWAY we don't show any IncomingCalls
                 if (it.availabilityStatus == UserAvailabilityStatus.AWAY) flowOf(listOf())
-                else callRepository.incomingCallsFlow()
+                else callRepository.incomingCallsFlow().distinctUntilChanged {
+                        old, new -> old.firstOrNull()?.conversationId == new.firstOrNull()?.conversationId
+                }
             }
 
     private fun Flow<List<Call>>.onlyCallsInNotMutedConversations(): Flow<List<Call>> =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On Android app, the incoming call screen is not appearing when we have an incoming call

### Causes (Optional)

It's a regression of this PR : [fix(calling): fix incoming call flow](https://github.com/wireapp/kalium/pull/645)

### Solutions

Using `distinctUntilChanged` to ensure that we are not emitting  the same incoming call many times
We need to check by id only because for group calls we can have already a list of participants that is not empty

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### How to Test

Receive 1:1  and group calls

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
