### PR TITLE
fix: unknown users in system messages [AR-1909] [AR-1872]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -26,7 +26,7 @@ interface UserMapper {
         userTypeEntity: UserTypeEntity?
     ): UserEntity
 
-    fun fromApiModelWithUserTypeEntityToDaoModel(userDTO: UserDTO): UserEntity
+    fun fromApiSelfModelToDaoModel(userDTO: UserDTO): UserEntity
     fun fromDaoModelToSelfUser(userEntity: UserEntity): SelfUser
 
     /**
@@ -156,7 +156,7 @@ internal class UserMapperImpl(
         )
     }
 
-    override fun fromApiModelWithUserTypeEntityToDaoModel(userDTO: UserDTO): UserEntity = with(userDTO) {
+    override fun fromApiSelfModelToDaoModel(userDTO: UserDTO): UserEntity = with(userDTO) {
         return UserEntity(
             id = idMapper.fromApiToDao(id),
             name = name,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -199,6 +199,10 @@ class ConversationEventReceiverImpl(
             onFailure { kaliumLogger.w("Failure fetching conversation details on MemberJoin Event: $event") }
             // Even if unable to fetch conversation details, at least attempt adding the member
             conversationRepository.persistMembers(event.members, event.conversationId)
+                .flatMap {
+                    // fetch all unknown users that haven't been persisted during slow sync, e.g. from another team
+                    userRepository.fetchUsersIfUnknownByIds(event.members.map { it.id }.toSet())
+                }
         }.onSuccess {
             val message = Message.System(
                 id = event.id,
@@ -217,6 +221,10 @@ class ConversationEventReceiverImpl(
             event.members.map { idMapper.toDaoModel(it.id) },
             idMapper.toDaoModel(event.conversationId)
         )
+        .flatMap {
+            // fetch all unknown users that haven't been persisted during slow sync, e.g. from another team
+            userRepository.fetchUsersIfUnknownByIds(event.members.map { it.id }.toSet())
+        }
         .onSuccess {
             val message = Message.System(
                 id = event.id,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -195,10 +195,6 @@ class ConversationEventReceiverImpl(
     private suspend fun handleMemberJoin(event: Event.Conversation.MemberJoin) =
         // Attempt to fetch conversation details if needed, as this might be an unknown conversation
         conversationRepository.fetchConversationIfUnknown(event.conversationId)
-            .flatMap {
-                // fetch required unknown users that haven't been persisted during slow sync, e.g. from another team
-                userRepository.fetchUsersIfUnknownByIds(event.members.map { it.id }.toSet())
-            }
             .run {
             onSuccess { kaliumLogger.v("Succeeded fetching conversation details on MemberJoin Event: $event") }
             onFailure { kaliumLogger.w("Failure fetching conversation details on MemberJoin Event: $event") }
@@ -224,6 +220,7 @@ class ConversationEventReceiverImpl(
         )
         .flatMap {
             // fetch required unknown users that haven't been persisted during slow sync, e.g. from another team
+            // and keep them to properly show this member-leave message
             userRepository.fetchUsersIfUnknownByIds(event.members.map { it.id }.toSet())
         }
         .onSuccess {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -221,7 +221,7 @@ class ConversationEventReceiverImpl(
         .flatMap {
             // fetch required unknown users that haven't been persisted during slow sync, e.g. from another team
             // and keep them to properly show this member-leave message
-            userRepository.fetchUsersIfUnknownByIds(event.members.map { it.id }.toSet())
+            userRepository.fetchUsersIfUnknownByIds(event.removedList.toSet())
         }
         .onSuccess {
             val message = Message.System(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -572,6 +572,10 @@ class ConversationRepositoryTest {
             .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
             .whenInvokedWith(any(), any())
             .thenDoNothing()
+        given(userRepository)
+            .suspendFunction(userRepository::fetchUsersIfUnknownByIds)
+            .whenInvokedWith(any())
+            .thenReturn(Either.Right(Unit))
 
         conversationRepository.addMembers(listOf(TestConversation.USER_1), conversationId)
             .shouldSucceed()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -92,7 +92,7 @@ class UserRepositoryTest {
     // TODO other UserRepository tests
 
 
-    private class Arrangement() {
+    private class Arrangement {
         @Mock
         val userDAO = configure(mock(classOf<UserDAO>())) { stubsUnitByDefault = true }
         @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -1,0 +1,139 @@
+package com.wire.kalium.logic.data.user
+
+import com.wire.kalium.logic.data.asset.AssetRepository
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.publicuser.PublicUserMapper
+import com.wire.kalium.logic.data.publicuser.SearchUserRepositoryTest
+import com.wire.kalium.logic.data.user.type.DomainUserTypeMapper
+import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.QualifiedID
+import com.wire.kalium.network.api.user.details.ListUserRequest
+import com.wire.kalium.network.api.user.details.UserDetailsApi
+import com.wire.kalium.network.api.user.details.UserProfileDTO
+import com.wire.kalium.network.api.user.details.qualifiedIds
+import com.wire.kalium.network.api.user.self.SelfApi
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.persistence.dao.MetadataDAO
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserDAO
+import com.wire.kalium.persistence.dao.UserEntity
+import com.wire.kalium.persistence.dao.UserIDEntity
+import io.ktor.http.HttpStatusCode
+import io.mockative.ConfigurationApi
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.configure
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@OptIn(ConfigurationApi::class)
+class UserRepositoryTest {
+
+    @Test
+    fun givenAllUsersAreKnown_whenFetchingUsersIfUnknown_thenShouldNotFetchFromApiAndSucceed() = runTest {
+        val requestedUserIds = setOf(
+            UserId(value = "id1", domain = "domain1"),
+            UserId(value = "id2", domain = "domain2")
+        )
+        val knownUserEntities = listOf(
+            TestUser.ENTITY.copy(id = UserIDEntity(value = "id1", domain = "domain1")),
+            TestUser.ENTITY.copy(id = UserIDEntity(value = "id2", domain = "domain2"))
+        )
+        val (arrangement, userRepository) = Arrangement()
+            .withSuccessfulGetUsersByQualifiedIdList(knownUserEntities)
+            .arrange()
+
+        given(arrangement.userDAO)
+            .suspendFunction(arrangement.userDAO::getUsersByQualifiedIDList)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(knownUserEntities))
+
+        userRepository.fetchUsersIfUnknownByIds(requestedUserIds).shouldSucceed()
+
+        verify(arrangement.userDetailsApi)
+            .suspendFunction(arrangement.userDetailsApi::getMultipleUsers)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenAUserIsNotKnown_whenFetchingUsersIfUnknown_thenShouldFetchFromAPIAndSucceed() = runTest {
+        val missingUserId = UserId(value = "id2", domain = "domain2")
+        val requestedUserIds = setOf(
+            UserId(value = "id1", domain = "domain1"),
+            missingUserId
+        )
+        val knownUserEntities = listOf(
+            TestUser.ENTITY.copy(id = UserIDEntity(value = "id1", domain = "domain1"))
+        )
+        val (arrangement, userRepository) = Arrangement()
+            .withSuccessfulGetUsersByQualifiedIdList(knownUserEntities)
+            .withSuccessfulGetMultipleUsersApiRequest(listOf(TestUser.USER_PROFILE_DTO))
+            .arrange()
+
+        userRepository.fetchUsersIfUnknownByIds(requestedUserIds).shouldSucceed()
+
+        verify(arrangement.userDetailsApi)
+            .suspendFunction(arrangement.userDetailsApi::getMultipleUsers)
+            .with(eq(ListUserRequest.qualifiedIds(listOf(QualifiedID(value = missingUserId.value, domain = missingUserId.domain)))))
+            .wasInvoked(exactly = once)
+    }
+
+    // TODO other UserRepository tests
+
+
+    private class Arrangement() {
+        @Mock
+        val userDAO = configure(mock(classOf<UserDAO>())) { stubsUnitByDefault = true }
+        @Mock
+        val metadataDAO = configure(mock(classOf<MetadataDAO>())) { stubsUnitByDefault = true }
+        @Mock
+        val selfApi = mock(classOf<SelfApi>())
+        @Mock
+        val userDetailsApi = mock(classOf<UserDetailsApi>())
+        @Mock
+        val assetRepository = mock(classOf<AssetRepository>())
+
+        val userRepository: UserRepository by lazy {
+            UserDataSource(userDAO, metadataDAO, selfApi, userDetailsApi, assetRepository)
+        }
+
+        init {
+            given(metadataDAO)
+                .suspendFunction(metadataDAO::valueByKey)
+                .whenInvokedWith(any())
+                .then { flowOf(TestUser.JSON_QUALIFIED_ID) }
+            given(userDAO).suspendFunction(userDAO::getUserByQualifiedID)
+                .whenInvokedWith(any())
+                .then { flowOf(TestUser.ENTITY) }
+        }
+
+        fun withSuccessfulGetUsersByQualifiedIdList(knownUserEntities: List<UserEntity>): Arrangement {
+            given(userDAO)
+                .suspendFunction(userDAO::getUsersByQualifiedIDList)
+                .whenInvokedWith(any())
+                .thenReturn(flowOf(knownUserEntities))
+            return this
+        }
+
+        fun withSuccessfulGetMultipleUsersApiRequest(result: List<UserProfileDTO>): Arrangement {
+            given(userDetailsApi)
+                .suspendFunction(userDetailsApi::getMultipleUsers)
+                .whenInvokedWith(any())
+                .thenReturn(NetworkResponse.Success(result, mapOf(), HttpStatusCode.OK.value))
+            return this
+        }
+
+        fun arrange() = this to userRepository
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -56,7 +56,7 @@ class UserRepositoryTest {
         given(arrangement.userDAO)
             .suspendFunction(arrangement.userDAO::getUsersByQualifiedIDList)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(knownUserEntities))
+            .thenReturn(knownUserEntities)
 
         userRepository.fetchUsersIfUnknownByIds(requestedUserIds).shouldSucceed()
 
@@ -122,7 +122,7 @@ class UserRepositoryTest {
             given(userDAO)
                 .suspendFunction(userDAO::getUsersByQualifiedIDList)
                 .whenInvokedWith(any())
-                .thenReturn(flowOf(knownUserEntities))
+                .thenReturn(knownUserEntities)
             return this
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -22,9 +22,9 @@ import com.wire.kalium.persistence.dao.UserTypeEntity
 
 object TestUser {
     val USER_ID = UserId("value", "domain")
-    val ENTITY_ID = QualifiedIDEntity("value", "domain")
-    val NETWORK_ID = com.wire.kalium.network.api.UserId(value = "value", domain = "domain")
-    const val JSON_QUALIFIED_ID = """{"value":"value" , "domain":"domain" }"""
+    val ENTITY_ID = QualifiedIDEntity("entityUserValue", "entityDomain")
+    val NETWORK_ID = com.wire.kalium.network.api.UserId(value = "networkValue", domain = "networkDomain")
+    const val JSON_QUALIFIED_ID = """{"value":"jsonValue" , "domain":"jsonDomain" }"""
 
     val SELF = SelfUser(
         USER_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -24,7 +24,7 @@ object TestUser {
     val USER_ID = UserId("value", "domain")
     val ENTITY_ID = QualifiedIDEntity("value", "domain")
     val NETWORK_ID = com.wire.kalium.network.api.UserId(value = "value", domain = "domain")
-    val JSON_QUALIFIED_ID = """{"value":"value" , "domain":"domain" }"""
+    const val JSON_QUALIFIED_ID = """{"value":"value" , "domain":"domain" }"""
 
     val SELF = SelfUser(
         USER_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -7,11 +7,24 @@ import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.network.api.model.AssetSizeDTO
+import com.wire.kalium.network.api.model.ServiceDTO
+import com.wire.kalium.network.api.model.UserAssetDTO
+import com.wire.kalium.network.api.model.UserAssetTypeDTO
+import com.wire.kalium.network.api.model.UserDTO
+import com.wire.kalium.network.api.user.LegalHoldStatusResponse
+import com.wire.kalium.network.api.user.details.UserProfileDTO
+import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
+import com.wire.kalium.persistence.dao.UserEntity
+import com.wire.kalium.persistence.dao.UserTypeEntity
 
 object TestUser {
     val USER_ID = UserId("value", "domain")
-    val ENTITY_ID = QualifiedIDEntity("entityUserValue", "entityDomain")
+    val ENTITY_ID = QualifiedIDEntity("value", "domain")
+    val NETWORK_ID = com.wire.kalium.network.api.UserId(value = "value", domain = "domain")
+    val JSON_QUALIFIED_ID = """{"value":"value" , "domain":"domain" }"""
 
     val SELF = SelfUser(
         USER_ID,
@@ -40,5 +53,39 @@ object TestUser {
         completePicture = UserAssetId("value2", "domain"),
         availabilityStatus = UserAvailabilityStatus.NONE,
         userType =  UserType.EXTERNAL
+    )
+
+    val ENTITY = UserEntity(
+        id = ENTITY_ID,
+        name = "username",
+        handle = "handle",
+        email = "email",
+        phone = "phone",
+        accentId = 0,
+        team = "teamId",
+        connectionStatus = ConnectionEntity.State.ACCEPTED,
+        previewAssetId = QualifiedIDEntity("value1", "domain"),
+        completeAssetId = QualifiedIDEntity("value2", "domain"),
+        availabilityStatus = UserAvailabilityStatusEntity.NONE,
+        userTypEntity = UserTypeEntity.EXTERNAL
+    )
+
+    val USER_PROFILE_DTO = UserProfileDTO(
+        id = NETWORK_ID,
+        name = "username",
+        handle = "handle",
+        email = "email",
+        accentId = 0,
+        legalHoldStatus = LegalHoldStatusResponse.DISABLED,
+        teamId = "teamId",
+        assets = listOf(
+            UserAssetDTO("value1", AssetSizeDTO.PREVIEW, UserAssetTypeDTO.IMAGE),
+            UserAssetDTO("value2", AssetSizeDTO.COMPLETE, UserAssetTypeDTO.IMAGE)
+        ),
+        deleted = false,
+        expiresAt = null,
+        nonQualifiedId = NETWORK_ID.value,
+        service = null
+
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiverTest.kt
@@ -181,6 +181,7 @@ class ConversationEventReceiverTest {
             .withRepositoryPersistingMessageDateReturning(Either.Right(Unit))
             .withFetchConversationIfUnknownSucceeding()
             .withPersistMembersSucceeding()
+            .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
             .arrange()
 
         eventReceiver.onEvent(event)
@@ -203,6 +204,7 @@ class ConversationEventReceiverTest {
             .withRepositoryPersistingMessageDateReturning(Either.Right(Unit))
             .withFetchConversationIfUnknownSucceeding()
             .withPersistMembersSucceeding()
+            .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
             .arrange()
 
         eventReceiver.onEvent(event)
@@ -364,6 +366,13 @@ class ConversationEventReceiverTest {
                 .suspendFunction(conversationRepository::persistMembers)
                 .whenInvokedWith(any(), any())
                 .thenReturn(Either.Right(Unit))
+        }
+
+        fun withFetchUsersIfUnknownByIdsReturning(result: Either<StorageFailure, Unit>) = apply {
+            given(userRepository)
+                .suspendFunction(userRepository::fetchUsersIfUnknownByIds)
+                .whenInvokedWith(any())
+                .thenReturn(result)
         }
 
         fun newMessageEvent(

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -73,7 +73,7 @@ selectAllUsersWithConnectionStatus:
 SELECT * FROM User WHERE connection_status = ?;
 
 selectByQualifiedId:
-SELECT * FROM User WHERE qualified_id = ?;
+SELECT * FROM User WHERE qualified_id IN ?;
 
 selectByNameOrHandleOrEmailAndConnectionState:
 SELECT * FROM User

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -98,6 +98,7 @@ interface UserDAO {
     suspend fun getAllUsers(): Flow<List<UserEntity>>
     suspend fun getAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): List<UserEntity>
     suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?>
+    suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): Flow<List<UserEntity>>
     suspend fun getUserByNameOrHandleOrEmailAndConnectionState(
         searchQuery: String,
         connectionState: ConnectionEntity.State

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -99,7 +99,7 @@ interface UserDAO {
     suspend fun getAllUsers(): Flow<List<UserEntity>>
     suspend fun getAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): List<UserEntity>
     suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?>
-    suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): Flow<List<UserEntity>>
+    suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): List<UserEntity>
     suspend fun getUserByNameOrHandleOrEmailAndConnectionState(
         searchQuery: String,
         connectionState: ConnectionEntity.State

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -121,10 +121,17 @@ class UserDAOImpl(
         .map { entryList -> entryList.map(mapper::toModel) }
 
     override suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?> {
-        return userQueries.selectByQualifiedId(qualifiedID)
+        return userQueries.selectByQualifiedId(listOf(qualifiedID))
             .asFlow()
             .mapToOneOrNull()
             .map { it?.let { mapper.toModel(it) } }
+    }
+
+    override suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): Flow<List<UserEntity>> {
+        return userQueries.selectByQualifiedId(qualifiedIDList)
+            .asFlow()
+            .mapToList()
+            .map { it.map { mapper.toModel(it) } }
     }
 
     override suspend fun getUserByNameOrHandleOrEmailAndConnectionState(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -126,11 +126,10 @@ class UserDAOImpl(
             .map { it?.let { mapper.toModel(it) } }
     }
 
-    override suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): Flow<List<UserEntity>> {
+    override suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): List<UserEntity> {
         return userQueries.selectByQualifiedId(qualifiedIDList)
-            .asFlow()
-            .mapToList()
-            .map { it.map { mapper.toModel(it) } }
+            .executeAsList()
+            .map { mapper.toModel(it) }
     }
 
     override suspend fun getUserByNameOrHandleOrEmailAndConnectionState(

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -461,7 +461,7 @@ class UserDAOTest : BaseDatabaseTest() {
         val users = listOf(user1, user2)
         val requestedIds = (users + user3).map { it.id }
         db.userDAO.upsertUsers(users)
-        val result = db.userDAO.getUsersByQualifiedIDList(requestedIds).first()
+        val result = db.userDAO.getUsersByQualifiedIDList(requestedIds)
         assertEquals(result, users)
         assertTrue(!result.contains(user3))
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -456,6 +456,16 @@ class UserDAOTest : BaseDatabaseTest() {
         assertNotNull(inserted2)
     }
 
+    @Test
+    fun givenListOfUsers_WhenGettingListOfUsers_ThenMatchingUsersAreReturned() = runTest {
+        val users = listOf(user1, user2)
+        val requestedIds = (users + user3).map { it.id }
+        db.userDAO.upsertUsers(users)
+        val result = db.userDAO.getUsersByQualifiedIDList(requestedIds).first()
+        assertEquals(result, users)
+        assertTrue(!result.contains(user3))
+    }
+
     private companion object {
         val USER_ENTITY_1 = newUserEntity(QualifiedIDEntity("1", "wire.com"))
         val USER_ENTITY_2 = newUserEntity(QualifiedIDEntity("2", "wire.com"))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some users aren't fetched by the app during the slow sync, because for instance they are from a different team, so they are displayed on system messages as "Deleted User".

### Solutions

Fetch unknown user data when handling system messages.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Add someone from other team to the group conversation and look at system messages from the perspective of other account, who isn't connected with that user.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
