### PR TITLE
chore: make client ID observable (AR-1924)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProviderImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProviderImpl.kt
@@ -21,7 +21,7 @@ actual class MLSClientProviderImpl actual constructor(
     private val kaliumPreferences: KaliumPreferences
 ) : MLSClientProvider {
 
-    override fun getMLSClient(clientId: ClientId?): Either<CoreFailure, MLSClient> {
+    override suspend fun getMLSClient(clientId: ClientId?): Either<CoreFailure, MLSClient> {
         val location = "$rootKeyStorePath/${userId.domain}/${userId.value}"
         val cryptoUserId = CryptoUserID(value = userId.value, domain = userId.domain)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -2,24 +2,29 @@ package com.wire.kalium.logic.data.client
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.mapLeft
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.user.pushToken.PushTokenBody
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
 import com.wire.kalium.persistence.dao.client.ClientDAO
 import io.ktor.util.encodeBase64
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import com.wire.kalium.persistence.dao.client.Client as ClientEntity
 
 interface ClientRepository {
     suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client>
     suspend fun registerMLSClient(clientId: ClientId, publicKey: ByteArray): Either<CoreFailure, Unit>
-    fun persistClientId(clientId: ClientId): Either<CoreFailure, Unit>
-    fun currentClientId(): Either<CoreFailure, ClientId>
+    suspend fun persistClientId(clientId: ClientId): Either<CoreFailure, Unit>
+    suspend fun currentClientId(): Either<CoreFailure, ClientId>
+    suspend fun observeCurrentClientId(): Flow<ClientId?>
     suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit>
     suspend fun selfListOfClients(): Either<NetworkFailure, List<Client>>
     suspend fun clientInfo(clientId: ClientId /* = com.wire.kalium.logic.data.id.PlainId */): Either<NetworkFailure, Client>
@@ -38,14 +43,23 @@ class ClientDataSource(
         return clientRemoteRepository.registerClient(param)
     }
 
-    override fun persistClientId(clientId: ClientId): Either<CoreFailure, Unit> =
-        wrapStorageRequest { clientRegistrationStorage.registeredClientId = clientId.value }
+    override suspend fun persistClientId(clientId: ClientId): Either<CoreFailure, Unit> =
+        wrapStorageRequest { clientRegistrationStorage.setRegisteredClientId(clientId.value) }
 
-    override fun currentClientId(): Either<CoreFailure, ClientId> {
-        return clientRegistrationStorage.registeredClientId?.let { clientId ->
-            Either.Right(ClientId(clientId))
-        } ?: Either.Left(CoreFailure.MissingClientRegistration)
+    override suspend fun currentClientId(): Either<CoreFailure, ClientId> = wrapStorageRequest {
+        clientRegistrationStorage.getRegisteredClientId()?.let { ClientId(it) }
+    }.mapLeft {
+        if (it is StorageFailure.DataNotFound) {
+            CoreFailure.MissingClientRegistration
+        } else {
+            it
+        }
     }
+
+    override suspend fun observeCurrentClientId(): Flow<ClientId?> =
+        clientRegistrationStorage.observeRegisteredClientId().map { rawClientId ->
+            rawClientId?.let { ClientId(it) }
+        }
 
     override suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit> {
         return clientRemoteRepository.deleteClient(param)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProvider.kt
@@ -9,7 +9,7 @@ import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 
 interface MLSClientProvider {
 
-    fun getMLSClient(clientId: ClientId? = null): Either<CoreFailure, MLSClient>
+    suspend fun getMLSClient(clientId: ClientId? = null): Either<CoreFailure, MLSClient>
 
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -203,7 +203,7 @@ abstract class UserSessionScopeCommon(
         )
 
     private val clientRegistrationStorage: ClientRegistrationStorage
-        get() = ClientRegistrationStorageImpl(userPreferencesSettings)
+        get() = ClientRegistrationStorageImpl(userDatabaseProvider.metadataDAO)
 
     private val clientRepository: ClientRepository
         get() = ClientDataSource(clientRemoteRepository, clientRegistrationStorage, userDatabaseProvider.clientDAO)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -53,7 +53,7 @@ class LogoutUseCase @Suppress("LongParameterList") constructor(
         authenticatedDataSourceSet.kaliumPreferencesSettings.nuke()
     }
 
-    private fun clearCrypto() {
+    private suspend fun clearCrypto() {
         authenticatedDataSourceSet.proteusClient.clearLocalFiles()
 
         clientRepository.currentClientId().let { clientID ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -117,7 +117,7 @@ class ClientRepositoryTest {
         clientRepository.persistClientId(clientId)
 
         verify(clientRegistrationStorage)
-            .setter(clientRegistrationStorage::registeredClientId)
+            .suspendFunction(clientRegistrationStorage::setRegisteredClientId)
             .with(eq(clientRepository))
     }
 
@@ -125,7 +125,7 @@ class ClientRepositoryTest {
     fun givenAClientIdIsStored_whenGettingRegisteredClientId_thenTheStoredValueShouldBeReturned() = runTest {
         val clientId = CLIENT_ID
         given(clientRegistrationStorage)
-            .getter(clientRegistrationStorage::registeredClientId)
+            .suspendFunction(clientRegistrationStorage::getRegisteredClientId)
             .whenInvoked()
             .then { clientId.value }
 
@@ -139,7 +139,7 @@ class ClientRepositoryTest {
     @Test
     fun givenNoClientIdIsStored_whenGettingRegisteredClientId_thenShouldFailWithMissingRegistration() = runTest {
         given(clientRegistrationStorage)
-            .getter(clientRegistrationStorage::registeredClientId)
+            .suspendFunction(clientRegistrationStorage::getRegisteredClientId)
             .whenInvoked()
             .then { null }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -1,9 +1,11 @@
 package com.wire.kalium.logic.data.client
 
+import app.cash.turbine.test
 import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.framework.TestClient
@@ -27,6 +29,7 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -44,11 +47,6 @@ class ClientRepositoryTest {
 
     @Mock
     private val clientRegistrationStorage = configure(mock(classOf<ClientRegistrationStorage>())) {
-        stubsUnitByDefault = true
-    }
-
-    @Mock
-    private val tokenStorage = configure(mock(classOf<TokenStorage>())) {
         stubsUnitByDefault = true
     }
 
@@ -305,6 +303,27 @@ class ClientRepositoryTest {
         verify(clientRemoteRepository).suspendFunction(clientRemoteRepository::registerToken)
             .with(any())
             .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenClientStorageUpdatesTheClientId_whenObservingClientId_thenUpdatesShouldBePropagated() = runTest {
+        // Given
+        val values = listOf("first", "second")
+
+        given(clientRegistrationStorage)
+            .suspendFunction(clientRegistrationStorage::observeRegisteredClientId)
+            .whenInvoked()
+            .thenReturn(values.asFlow())
+
+        // When
+        clientRepository.observeCurrentClientId().test {
+
+            // Then
+            values.forEach {
+                assertEquals(ClientId(it), awaitItem())
+            }
+            cancelAndConsumeRemainingEvents()
+        }
     }
 
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -80,7 +80,7 @@ class MLSConversationRepositoryTest {
             .then { Either.Right(listOf(KEY_PACKAGE)) }
 
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(anything())
             .then { Either.Right(MLS_CLIENT) }
 
@@ -123,7 +123,7 @@ class MLSConversationRepositoryTest {
     @Test
     fun givenExistingConversation_whenCallingEstablishMLSGroupFromWelcome_ThenGroupIsCreatedAndGroupStateIsUpdated() = runTest {
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(anything())
             .then { Either.Right(MLS_CLIENT) }
 
@@ -158,7 +158,7 @@ class MLSConversationRepositoryTest {
     @Test
     fun givenNonExistingConversation_whenCallingEstablishMLSGroupFromWelcome_ThenGroupIsCreatedButConversationIsNotInserted() = runTest {
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(anything())
             .then { Either.Right(MLS_CLIENT) }
 
@@ -188,7 +188,7 @@ class MLSConversationRepositoryTest {
             .then { Either.Right(listOf(KEY_PACKAGE)) }
 
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(anything())
             .then { Either.Right(MLS_CLIENT) }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -92,7 +92,7 @@ class EventRepositoryTest {
 
         val clientId = TestClient.CLIENT_ID
         given(clientRepository)
-            .function(clientRepository::currentClientId)
+            .suspendFunction(clientRepository::currentClientId)
             .whenInvoked()
             .thenReturn(Either.Right(clientId))
 
@@ -121,7 +121,7 @@ class EventRepositoryTest {
 
         val clientId = TestClient.CLIENT_ID
         given(clientRepository)
-            .function(clientRepository::currentClientId)
+            .suspendFunction(clientRepository::currentClientId)
             .whenInvoked()
             .thenReturn(Either.Right(clientId))
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -51,7 +51,7 @@ class KeyPackageRepositoryTest {
 
     @Test
     fun givenExistingClient_whenUploadingKeyPackages_thenKeyPackagesShouldBeGeneratedAndPassedToApi() = runTest {
-        given(mlsClientProvider).function(mlsClientProvider::getMLSClient).whenInvokedWith(eq(SELF_CLIENT_ID))
+        given(mlsClientProvider).suspendFunction(mlsClientProvider::getMLSClient).whenInvokedWith(eq(SELF_CLIENT_ID))
             .then { Either.Right(MLS_CLIENT) }
 
         given(MLS_CLIENT).function(MLS_CLIENT::generateKeyPackages).whenInvokedWith(eq(1)).then { KEY_PACKAGES }
@@ -82,7 +82,7 @@ class KeyPackageRepositoryTest {
             .whenInvokedWith(eq(KeyPackageApi.Param.SkipOwnClient(MapperProvider.idMapper().toApiModel(USER_ID), SELF_CLIENT_ID.value)))
             .thenReturn(NetworkResponse.Success(CLAIMED_KEY_PACKAGES, mapOf(), 200))
 
-        given(clientRepository).function(clientRepository::currentClientId).whenInvoked().then { Either.Right(SELF_CLIENT_ID) }
+        given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked().then { Either.Right(SELF_CLIENT_ID) }
 
         val result = keyPackageRepository.claimKeyPackages(listOf(USER_ID))
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCaseTest.kt
@@ -169,7 +169,7 @@ class SendAssetMessageUseCaseTest {
                 .whenInvoked()
                 .thenReturn(flowOf(fakeSelfUser()))
             given(clientRepository)
-                .function(clientRepository::currentClientId)
+                .suspendFunction(clientRepository::currentClientId)
                 .whenInvoked()
                 .thenReturn(Either.Right(someClientId))
             given(messageRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/SendImageUseCaseTest.kt
@@ -171,7 +171,7 @@ class SendImageUseCaseTest {
                 .whenInvoked()
                 .thenReturn(flowOf(fakeSelfUser()))
             given(clientRepository)
-                .function(clientRepository::currentClientId)
+                .suspendFunction(clientRepository::currentClientId)
                 .whenInvoked()
                 .thenReturn(Either.Right(someClientId))
             given(messageRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
@@ -34,7 +34,8 @@ class NeedsToRegisterClientUseCaseTest {
     @Test
     fun givenClientIdIsRegistered_thenReturnFalse() = runTest {
         given(clientRepository)
-            .invocation { clientRepository.currentClientId() }
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
             .then { Either.Right(CLIENT_ID) }
 
         val actual = needsToRegisterClientUseCase.invoke()
@@ -44,7 +45,8 @@ class NeedsToRegisterClientUseCaseTest {
     @Test
     fun givenClientIdIsNotRegistered_thenReturnTrue() = runTest {
         given(clientRepository)
-            .invocation { clientRepository.currentClientId() }
+            .suspendFunction(clientRepository::currentClientId)
+            .whenInvoked()
             .then { Either.Left(CoreFailure.MissingClientRegistration) }
 
         val actual = needsToRegisterClientUseCase.invoke()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -177,7 +177,7 @@ class RegisterClientUseCaseTest {
         registerClient(RegisterClientUseCase.RegisterClientParam(TEST_PASSWORD, TEST_CAPABILITIES))
 
         verify(clientRepository)
-            .function(clientRepository::persistClientId)
+            .suspendFunction(clientRepository::persistClientId)
             .with(anything())
             .wasNotInvoked()
     }
@@ -191,7 +191,7 @@ class RegisterClientUseCaseTest {
             .then { Either.Right(registeredClient) }
 
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(eq(CLIENT.id))
             .then { Either.Right(MLS_CLIENT) }
 
@@ -208,7 +208,7 @@ class RegisterClientUseCaseTest {
         registerClient(RegisterClientUseCase.RegisterClientParam(TEST_PASSWORD, TEST_CAPABILITIES))
 
         verify(clientRepository)
-            .function(clientRepository::persistClientId)
+            .suspendFunction(clientRepository::persistClientId)
             .with(anything())
             .wasNotInvoked()
     }
@@ -222,7 +222,7 @@ class RegisterClientUseCaseTest {
             .then { Either.Right(registeredClient) }
 
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(eq(CLIENT.id))
             .then { Either.Right(MLS_CLIENT) }
 
@@ -244,7 +244,7 @@ class RegisterClientUseCaseTest {
         registerClient(RegisterClientUseCase.RegisterClientParam(TEST_PASSWORD, TEST_CAPABILITIES))
 
         verify(clientRepository)
-            .function(clientRepository::persistClientId)
+            .suspendFunction(clientRepository::persistClientId)
             .with(anything())
             .wasNotInvoked()
     }
@@ -258,7 +258,7 @@ class RegisterClientUseCaseTest {
             .then { Either.Right(registeredClient) }
 
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(eq(CLIENT.id))
             .then { Either.Right(MLS_CLIENT) }
 
@@ -278,14 +278,14 @@ class RegisterClientUseCaseTest {
             .thenReturn(Either.Right(Unit))
 
         given(clientRepository)
-            .function(clientRepository::persistClientId)
+            .suspendFunction(clientRepository::persistClientId)
             .whenInvokedWith(anything())
             .then { Either.Right(Unit) }
 
         registerClient(RegisterClientUseCase.RegisterClientParam(TEST_PASSWORD, TEST_CAPABILITIES))
 
         verify(clientRepository)
-            .function(clientRepository::persistClientId)
+            .suspendFunction(clientRepository::persistClientId)
             .with(eq(registeredClient.id))
             .wasInvoked(once)
     }
@@ -298,7 +298,7 @@ class RegisterClientUseCaseTest {
             .then { Either.Right(CLIENT) }
 
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(eq(CLIENT.id))
             .then { Either.Right(MLS_CLIENT) }
 
@@ -319,7 +319,7 @@ class RegisterClientUseCaseTest {
 
         val persistFailure = TEST_FAILURE
         given(clientRepository)
-            .function(clientRepository::persistClientId)
+            .suspendFunction(clientRepository::persistClientId)
             .whenInvokedWith(anything())
             .then { Either.Left(persistFailure) }
 
@@ -338,7 +338,7 @@ class RegisterClientUseCaseTest {
             .then { Either.Right(CLIENT) }
 
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(eq(CLIENT.id))
             .then { Either.Right(MLS_CLIENT) }
 
@@ -358,7 +358,7 @@ class RegisterClientUseCaseTest {
             .thenReturn(Either.Right(Unit))
 
         given(clientRepository)
-            .function(clientRepository::persistClientId)
+            .suspendFunction(clientRepository::persistClientId)
             .whenInvokedWith(anything())
             .then { Either.Right(Unit) }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCaseTest.kt
@@ -42,7 +42,7 @@ class MLSKeyPackageCountUseCaseTest {
     fun givenClientIdIsNotRegistered_ThenReturnGenericError() = runTest {
 
         val clientFetchError = CoreFailure.MissingClientRegistration
-        given(clientRepository).function(clientRepository::currentClientId).whenInvoked()
+        given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked()
             .then { Either.Left(clientFetchError) }
 
         val actual = keyPackageCountUseCase()
@@ -58,7 +58,7 @@ class MLSKeyPackageCountUseCaseTest {
         given(keyPackageRepository).suspendFunction(keyPackageRepository::getAvailableKeyPackageCount).whenInvokedWith(anything())
             .then { Either.Right(KEY_PACKAGE_COUNT_DTO) }
 
-        given(clientRepository).function(clientRepository::currentClientId).whenInvoked().then { Either.Right(TestClient.CLIENT_ID) }
+        given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked().then { Either.Right(TestClient.CLIENT_ID) }
 
         val actual = keyPackageCountUseCase()
 
@@ -76,7 +76,7 @@ class MLSKeyPackageCountUseCaseTest {
         given(keyPackageRepository).suspendFunction(keyPackageRepository::getAvailableKeyPackageCount).whenInvokedWith(anything())
             .then { Either.Left(networkFailure) }
 
-        given(clientRepository).function(clientRepository::currentClientId).whenInvoked().then { Either.Right(TestClient.CLIENT_ID) }
+        given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked().then { Either.Right(TestClient.CLIENT_ID) }
 
         val actual = keyPackageCountUseCase()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -76,7 +76,7 @@ class DeleteMessageUseCaseTest {
             .whenInvoked()
             .thenReturn(flowOf(TestUser.SELF))
         given(clientRepository)
-            .function(clientRepository::currentClientId)
+            .suspendFunction(clientRepository::currentClientId)
             .whenInvoked()
             .then { Either.Right(SELF_CLIENT_ID) }
         given(messageRepository)
@@ -114,7 +114,7 @@ class DeleteMessageUseCaseTest {
             .whenInvoked()
             .thenReturn(flowOf(TestUser.SELF))
         given(clientRepository)
-            .function(clientRepository::currentClientId)
+            .suspendFunction(clientRepository::currentClientId)
             .whenInvoked()
             .then { Either.Right(SELF_CLIENT_ID) }
         given(messageRepository)
@@ -158,7 +158,7 @@ class DeleteMessageUseCaseTest {
             .whenInvoked()
             .thenReturn(flowOf(TestUser.SELF))
         given(clientRepository)
-            .function(clientRepository::currentClientId)
+            .suspendFunction(clientRepository::currentClientId)
             .whenInvoked()
             .then { Either.Right(SELF_CLIENT_ID) }
         given(messageRepository)
@@ -188,7 +188,7 @@ class DeleteMessageUseCaseTest {
             .whenInvoked()
             .thenReturn(flowOf(TestUser.SELF))
         given(clientRepository)
-            .function(clientRepository::currentClientId)
+            .suspendFunction(clientRepository::currentClientId)
             .whenInvoked()
             .then { Either.Right(SELF_CLIENT_ID) }
         given(messageRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreatorTest.kt
@@ -40,7 +40,7 @@ class MLSMessageCreatorTest {
     fun givenMessage_whenCreatingMLSMessage_thenMLSClientShouldBeUsedToEncryptProtobufContent() = runTest {
         val encryptedData = byteArrayOf()
         given(mlsClientProvider)
-            .function(mlsClientProvider::getMLSClient)
+            .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(anything())
             .then { Either.Right(MLS_CLIENT)}
 

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProvider.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProvider.kt
@@ -21,7 +21,7 @@ actual class MLSClientProviderImpl actual constructor(
     private val kaliumPreferences: KaliumPreferences
 ): MLSClientProvider {
 
-    override fun getMLSClient(clientId: ClientId?): Either<CoreFailure, MLSClient> {
+    override suspend fun getMLSClient(clientId: ClientId?): Either<CoreFailure, MLSClient> {
         val cryptoUserId = CryptoUserID(userId.value, userId.domain)
 
         // Make sure all intermediate directories exists

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Metadata.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Metadata.sq
@@ -10,3 +10,6 @@ ON CONFLICT(key) DO UPDATE SET stringValue = excluded.stringValue;
 
 selectValueByKey:
 SELECT stringValue FROM Metadata WHERE key = ?;
+
+deleteValue:
+DELETE FROM Metadata WHERE key = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
@@ -1,14 +1,26 @@
 package com.wire.kalium.persistence.client
 
-import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
+import com.wire.kalium.persistence.dao.MetadataDAO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 
 interface ClientRegistrationStorage {
-    var registeredClientId: String?
+    suspend fun getRegisteredClientId(): String?
+    suspend fun setRegisteredClientId(registeredClientId: String)
+    suspend fun observeRegisteredClientId(): Flow<String?>
 }
 
-class ClientRegistrationStorageImpl(private val kaliumPreferences: KaliumPreferences): ClientRegistrationStorage {
+class ClientRegistrationStorageImpl(private val metadataDAO: MetadataDAO) : ClientRegistrationStorage {
 
-    override var registeredClientId: String?
+
+    override suspend fun getRegisteredClientId(): String? = observeRegisteredClientId().first()
+
+    override suspend fun setRegisteredClientId(registeredClientId: String) =
+        metadataDAO.insertValue(registeredClientId, REGISTERED_CLIENT_ID_KEY)
+
+    override suspend fun observeRegisteredClientId(): Flow<String?> = metadataDAO.valueByKey(REGISTERED_CLIENT_ID_KEY)
+
+    var registeredClientId: String?
         get() = kaliumPreferences.getString(REGISTERED_CLIENT_ID_KEY)
         set(value) = kaliumPreferences.putString(REGISTERED_CLIENT_ID_KEY, value)
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.first
 
 interface ClientRegistrationStorage {
     suspend fun getRegisteredClientId(): String?
-    suspend fun setRegisteredClientId(registeredClientId: String)
+    suspend fun setRegisteredClientId(registeredClientId: String?)
     suspend fun observeRegisteredClientId(): Flow<String?>
 }
 
@@ -15,14 +15,13 @@ class ClientRegistrationStorageImpl(private val metadataDAO: MetadataDAO) : Clie
 
     override suspend fun getRegisteredClientId(): String? = observeRegisteredClientId().first()
 
-    override suspend fun setRegisteredClientId(registeredClientId: String) =
+    override suspend fun setRegisteredClientId(registeredClientId: String?) = registeredClientId?.let {
         metadataDAO.insertValue(registeredClientId, REGISTERED_CLIENT_ID_KEY)
+    } ?: run {
+        metadataDAO.deleteValue(REGISTERED_CLIENT_ID_KEY)
+    }
 
     override suspend fun observeRegisteredClientId(): Flow<String?> = metadataDAO.valueByKey(REGISTERED_CLIENT_ID_KEY)
-
-    var registeredClientId: String?
-        get() = kaliumPreferences.getString(REGISTERED_CLIENT_ID_KEY)
-        set(value) = kaliumPreferences.putString(REGISTERED_CLIENT_ID_KEY, value)
 
     private companion object {
         const val REGISTERED_CLIENT_ID_KEY = "registered_client_id"

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAO.kt
@@ -4,5 +4,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface MetadataDAO {
     suspend fun insertValue(value: String, key: String)
+    suspend fun deleteValue(key: String)
     suspend fun valueByKey(key: String): Flow<String?>
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
@@ -12,6 +12,10 @@ class MetadataDAOImpl(private val metadataQueries: MetadataQueries): MetadataDAO
         metadataQueries.insertValue(key, value)
     }
 
+    override suspend fun deleteValue(key: String) {
+        metadataQueries.deleteValue(key)
+    }
+
     override suspend fun valueByKey(key: String): Flow<String?> {
         return metadataQueries.selectValueByKey(key).asFlow().mapToOneOrNull()
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageTest.kt
@@ -2,58 +2,57 @@ package com.wire.kalium.persistence.client
 
 import com.russhwolf.settings.MockSettings
 import com.russhwolf.settings.Settings
+import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
+import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class ClientRegistrationStorageTest {
-
-    private val mockSettings: Settings = MockSettings()
-    private val kaliumPreferences = KaliumPreferencesSettings(mockSettings)
+class ClientRegistrationStorageTest: BaseDatabaseTest() {
 
     private lateinit var clientRegistrationStorage: ClientRegistrationStorageImpl
 
     @BeforeTest
     fun setup(){
-        mockSettings.clear()
-        clientRegistrationStorage = ClientRegistrationStorageImpl(kaliumPreferences)
+        val database = createDatabase()
+        clientRegistrationStorage = ClientRegistrationStorageImpl(database.metadataDAO)
     }
 
     @Test
-    fun givenNoClientIdWasSaved_whenGettingTheLastClientId_thenResultShouldBeNull(){
-        assertNull(clientRegistrationStorage.registeredClientId)
+    fun givenNoClientIdWasSaved_whenGettingTheLastClientId_thenResultShouldBeNull() = runTest {
+        assertNull(clientRegistrationStorage.getRegisteredClientId())
     }
 
     @Test
-    fun givenAnClientIdWasSaved_whenGettingTheLastClientId_thenTheSavedIdShouldBeReturned(){
+    fun givenAnClientIdWasSaved_whenGettingTheLastClientId_thenTheSavedIdShouldBeReturned() = runTest {
         val testId = "😎ClientId"
-        clientRegistrationStorage.registeredClientId = testId
+        clientRegistrationStorage.setRegisteredClientId(testId)
 
-        val result = clientRegistrationStorage.registeredClientId
+        val result = clientRegistrationStorage.getRegisteredClientId()
 
         assertEquals(testId, result)
     }
 
     @Test
-    fun givenTheLastIdWasUpdatedMultipleTimes_whenGettingTheLastClientId_thenTheLatestIdShouldBeReturned(){
+    fun givenTheLastIdWasUpdatedMultipleTimes_whenGettingTheLastClientId_thenTheLatestIdShouldBeReturned() = runTest {
         val latestId = "sold"
-        clientRegistrationStorage.registeredClientId = "give it once"
-        clientRegistrationStorage.registeredClientId = "give it twice"
-        clientRegistrationStorage.registeredClientId = latestId
+        clientRegistrationStorage.setRegisteredClientId("give it once")
+        clientRegistrationStorage.setRegisteredClientId("give it twice")
+        clientRegistrationStorage.setRegisteredClientId(latestId)
 
-        val result = clientRegistrationStorage.registeredClientId
+        val result = clientRegistrationStorage.getRegisteredClientId()
 
         assertEquals(latestId, result)
     }
 
     @Test
-    fun givenTheLastIdExisted_andWasUpdatedToNull_whenGettingTheLastClientId_thenNullShouldBeReturned(){
-        clientRegistrationStorage.registeredClientId = "give it once"
-        clientRegistrationStorage.registeredClientId = null
+    fun givenTheLastIdExisted_andWasUpdatedToNull_whenGettingTheLastClientId_thenNullShouldBeReturned() = runTest {
+        clientRegistrationStorage.setRegisteredClientId("give it once")
+        clientRegistrationStorage.setRegisteredClientId(null)
 
-        val result = clientRegistrationStorage.registeredClientId
+        val result = clientRegistrationStorage.getRegisteredClientId()
 
         assertNull(result)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to make Sync more reactive and automagic 🪄, we need to observe the registered client ID.

### Solutions

In this PR. Add a way to observe the client ID.

I tried using the [Coroutines extensions from Multiplatform-Settings](https://github.com/russhwolf/multiplatform-settings#coroutine-apis), but it's only supported for `AndroidSettings`, `AppleSettings`, and `JvmPreferencesSettings`. So it can't be done for all our platforms.

Re-worked the `ClientRegistrationStorage` to use `MetadataDAO`.

Added the needed `suspend` modifier and fixed everywhere it was needed.


### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
