### PR TITLE
fix: edge cases old big accounts

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -33,14 +33,12 @@ import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.ConversationEntity.ProtocolInfo
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 
 interface ConversationRepository {
     suspend fun getSelfConversationId(): ConversationId

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
@@ -16,12 +16,10 @@ class ConversationApiImpl internal constructor(private val authenticatedNetworkC
 
     private val httpClient get() = authenticatedNetworkClient.httpClient
 
-    @Suppress("MagicNumber")
     override suspend fun fetchConversationsIds(pagingState: String?): NetworkResponse<ConversationPagingResponse> =
         wrapKaliumResponse {
             httpClient.post("$PATH_CONVERSATIONS/$PATH_LIST_IDS") {
-                // fixme: adjust "size" value later on when server can handle the load
-                setBody(PaginationRequest(pagingState = pagingState, size = 200))
+                setBody(PaginationRequest(pagingState = pagingState, size = MAX_CONVERSATION_DETAILS_COUNT))
             }
         }
 
@@ -108,5 +106,7 @@ class ConversationApiImpl internal constructor(private val authenticatedNetworkC
         const val QUERY_KEY_START = "start"
         const val QUERY_KEY_SIZE = "size"
         const val QUERY_KEY_IDS = "qualified_ids"
+
+        const val MAX_CONVERSATION_DETAILS_COUNT = 200 // fixme: adjust "size" value later on when server can handle the load
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
@@ -16,10 +16,11 @@ class ConversationApiImpl internal constructor(private val authenticatedNetworkC
 
     private val httpClient get() = authenticatedNetworkClient.httpClient
 
+    @Suppress("MagicNumber")
     override suspend fun fetchConversationsIds(pagingState: String?): NetworkResponse<ConversationPagingResponse> =
         wrapKaliumResponse {
             httpClient.post("$PATH_CONVERSATIONS/$PATH_LIST_IDS") {
-                setBody(PaginationRequest(pagingState = pagingState))
+                setBody(PaginationRequest(pagingState = pagingState, 200))
             }
         }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
@@ -20,7 +20,8 @@ class ConversationApiImpl internal constructor(private val authenticatedNetworkC
     override suspend fun fetchConversationsIds(pagingState: String?): NetworkResponse<ConversationPagingResponse> =
         wrapKaliumResponse {
             httpClient.post("$PATH_CONVERSATIONS/$PATH_LIST_IDS") {
-                setBody(PaginationRequest(pagingState = pagingState, 200))
+                // fixme: adjust "size" value later on when server can handle the load
+                setBody(PaginationRequest(pagingState = pagingState, size = 200))
             }
         }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -27,7 +27,7 @@ data class ConversationResponse(
     val type: Type,
 
     @SerialName("message_timer")
-    val messageTimer: Int?,
+    val messageTimer: Long?,
 
     @SerialName("team")
     val teamId: TeamId?,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/CreateConversationRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/CreateConversationRequest.kt
@@ -27,7 +27,7 @@ data class CreateConversationRequest(
     @SerialName("team")
     val convTeamInfo: ConvTeamInfo?,
     @SerialName("message_timer")
-    val messageTimer: Int?, // Per-conversation message time
+    val messageTimer: Long?, // Per-conversation message time
     // Receipt mode, controls if read receipts are enabled for the conversation.
     // Any positive value is interpreted as enabled.
     @SerialName("receipt_mode")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After testing with big old accounts, we found out that:
- The server can't handle the load of 1000 ids to fetch conversations ids (413 error)
- `messageTimer` field for older messages, doesn't fit in a `Int` 🙃 

### Solutions

The requests to fetch conversations details, are now made in batch, taking in advantage the pagination from lists-ids endpoint. Now instead of collecting all-ids, we fetch it and persisted right away.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
