### PR TITLE
feat: add use case for refilling key packages

### DIFF
--- a/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase.RegisterClientParam
 import com.wire.kalium.logic.feature.client.SelfClientsResult
 import com.wire.kalium.logic.feature.conversation.GetConversationsUseCase
+import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesResult
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsResult
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
@@ -156,8 +157,8 @@ class LoginCommand : CliktCommand(name = "login") {
     private val environment: String? by option(help = "Choose backend environment: can be production or staging")
 
     private val serverConfig: ServerConfig.Links by lazy {
-        if (environment == "production") {
-            ServerConfig.PRODUCTION
+        if (environment == "staging") {
+            ServerConfig.STAGING
         } else {
             ServerConfig.DEFAULT
         }
@@ -241,6 +242,17 @@ class AddMemberToGroupCommand : CliktCommand(name = "add-member") {
     }
 }
 
+class RefillKeyPackagesCommand : CliktCommand(name = "refill-key-packages") {
+    override fun run() = runBlocking {
+        val userSession = currentUserSession()
+
+        when (val result = userSession.client.refillKeyPackages()) {
+            is RefillKeyPackagesResult.Success -> echo("key packages were refilled")
+            is RefillKeyPackagesResult.Failure -> throw PrintMessage("refill key packages failed: ${result.failure}")
+        }
+    }
+}
+
 class CLIApplication : CliktCommand(allowMultipleSubcommands = true) {
 
     override fun run() = runBlocking {
@@ -254,5 +266,10 @@ class CLIApplication : CliktCommand(allowMultipleSubcommands = true) {
 }
 
 fun main(args: Array<String>) = CLIApplication().subcommands(
-    LoginCommand(), CreateGroupCommand(), ListenGroupCommand(), DeleteClientCommand(), AddMemberToGroupCommand()
+    LoginCommand(),
+    CreateGroupCommand(),
+    ListenGroupCommand(),
+    DeleteClientCommand(),
+    AddMemberToGroupCommand(),
+    RefillKeyPackagesCommand()
 ).main(args)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -7,6 +7,8 @@ import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCase
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCaseImpl
+import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCase
+import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCaseImpl
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCase
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCaseImpl
 import com.wire.kalium.logic.feature.session.RegisterTokenUseCase
@@ -34,4 +36,5 @@ class ClientScope(
     val deregisterNativePushToken: DeregisterTokenUseCase get() = DeregisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
     val mlsKeyPackageCountUseCase: MLSKeyPackageCountUseCase
         get() = MLSKeyPackageCountUseCaseImpl(keyPackageRepository, clientRepository)
+    val refillKeyPackages: RefillKeyPackagesUseCase get() = RefillKeyPackagesUseCaseImpl(keyPackageRepository, clientRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
@@ -5,6 +5,8 @@ import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 
 interface MLSKeyPackageCountUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
@@ -31,9 +31,9 @@ class RefillKeyPackagesUseCaseImpl(
 
         clientRepository.currentClientId().flatMap { selfClientId ->
             keyPackageRepository.getAvailableKeyPackageCount(selfClientId)
-                .flatMap { count ->
-                    if (needsRefill(count.count)) {
-                        keyPackageRepository.uploadNewKeyPackages(selfClientId, amount = KEY_PACKAGE_LIMIT - count.count).flatMap {
+                .flatMap {
+                    if (needsRefill(it.count)) {
+                        keyPackageRepository.uploadNewKeyPackages(selfClientId, amount = KEY_PACKAGE_LIMIT - it.count).flatMap {
                             Either.Right(Unit)
                         }
                     } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
@@ -1,0 +1,47 @@
+package com.wire.kalium.logic.feature.keypackage
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
+
+sealed class RefillKeyPackagesResult {
+
+    object Success : RefillKeyPackagesResult()
+    class Failure(val failure: CoreFailure) : RefillKeyPackagesResult()
+
+}
+
+interface RefillKeyPackagesUseCase {
+
+    suspend operator fun invoke(): RefillKeyPackagesResult
+
+}
+
+internal const val KEY_PACKAGE_LIMIT = 100
+
+class RefillKeyPackagesUseCaseImpl(
+    private val keyPackageRepository: KeyPackageRepository,
+    private val clientRepository: ClientRepository
+) : RefillKeyPackagesUseCase {
+    override suspend operator fun invoke(): RefillKeyPackagesResult =
+
+        clientRepository.currentClientId().flatMap { selfClientId ->
+            keyPackageRepository.getAvailableKeyPackageCount(selfClientId)
+                .flatMap { count ->
+                    if (count.count < (KEY_PACKAGE_LIMIT * 0.5)) {
+                        keyPackageRepository.uploadNewKeyPackages(selfClientId, amount = KEY_PACKAGE_LIMIT - count.count).flatMap {
+                            Either.Right(Unit)
+                        }
+                    } else {
+                        Either.Right(Unit)
+                    }
+                }
+        }.fold({ failure ->
+            RefillKeyPackagesResult.Failure(failure)
+        }, {
+            RefillKeyPackagesResult.Success
+        })
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCaseTest.kt
@@ -1,0 +1,86 @@
+package com.wire.kalium.logic.feature.keypackage
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.network.api.keypackage.KeyPackageCountDTO
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class RefillKeyPackageUseCaseTest {
+
+    @Mock
+    private val keyPackageRepository = mock(classOf<KeyPackageRepository>())
+
+    @Mock
+    private val clientRepository: ClientRepository = mock(classOf())
+
+    private lateinit var refillKeyPackageUseCase: RefillKeyPackagesUseCase
+
+    @BeforeTest
+    fun setup() {
+        refillKeyPackageUseCase = RefillKeyPackagesUseCaseImpl(
+            keyPackageRepository, clientRepository
+        )
+    }
+
+    @Test
+    fun givenKeyPackageCountIs50PercentBelowLimit_ThenRequestToRefillKeyPackageIsPerformed() = runTest {
+        val keyPackageCount = (KEY_PACKAGE_LIMIT * 0.5 - 1).toInt()
+
+        given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked().then { Either.Right(TestClient.CLIENT_ID) }
+        given(keyPackageRepository).suspendFunction(keyPackageRepository::getAvailableKeyPackageCount).whenInvokedWith(anything())
+            .then { Either.Right(KeyPackageCountDTO(keyPackageCount)) }
+        given(keyPackageRepository).suspendFunction(keyPackageRepository::uploadNewKeyPackages).whenInvokedWith(eq(TestClient.CLIENT_ID), anything())
+            .thenReturn(Either.Right(Unit))
+
+        val actual = refillKeyPackageUseCase()
+
+        verify(keyPackageRepository).coroutine {
+            uploadNewKeyPackages(TestClient.CLIENT_ID, KEY_PACKAGE_LIMIT - keyPackageCount)
+        }.wasInvoked(once)
+
+        assertIs<RefillKeyPackagesResult.Success>(actual)
+    }
+
+    @Test
+    fun givenKeyPackageCount50PercentAboveLimit_ThenNoRequestToRefillKeyPackagesIsPerformed() = runTest {
+        val keyPackageCount = (KEY_PACKAGE_LIMIT * 0.5).toInt()
+
+        given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked().then { Either.Right(TestClient.CLIENT_ID) }
+        given(keyPackageRepository).suspendFunction(keyPackageRepository::getAvailableKeyPackageCount).whenInvokedWith(anything())
+            .then { Either.Right(KeyPackageCountDTO(keyPackageCount)) }
+
+        val actual = refillKeyPackageUseCase()
+
+        assertIs<RefillKeyPackagesResult.Success>(actual)
+    }
+
+    @Test
+    fun givenErrorIsEncountered_ThenFailureIsPropagated() = runTest {
+        val networkFailure = NetworkFailure.NoNetworkConnection(null)
+
+        given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked().then { Either.Right(TestClient.CLIENT_ID) }
+        given(keyPackageRepository).suspendFunction(keyPackageRepository::getAvailableKeyPackageCount).whenInvokedWith(anything())
+            .then { Either.Left(networkFailure) }
+
+        val actual = refillKeyPackageUseCase()
+
+        assertIs<RefillKeyPackagesResult.Failure>(actual)
+        assertEquals(actual.failure, networkFailure)
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Add a use case for refilling the key packages if are 50% below the desired count.
- Add CLI command for refilling key packages

https://wearezeta.atlassian.net/browse/CL-10

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Change the amount key packages we initially upload to something like 10.

run:
`> cli login refill-key-packages`

And you should observe that we initially upload 10 key packages followed by 90 when we check if we need to refill them.

### Notes

As discussed the refilling could be triggered in a sync step. This will be done in separate PR.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
