### PR TITLE
chore: make logout observable (AR-1924)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutReason.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutReason.kt
@@ -1,0 +1,18 @@
+package com.wire.kalium.logic.data.logout
+
+/**
+ * Describes a reason that led to a logout.
+ */
+enum class LogoutReason {
+    /**
+     * User initiated the logout manually.
+     */
+    USER_INTENTION,
+
+    /**
+     * The session has expired. The server rejects
+     * the credentials and there's no way around a re-authentication.
+     * It's appropriate to warn the user and ask for a new login.
+     */
+    EXPIRED_SESSION;
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
@@ -9,8 +9,23 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
 
 internal interface LogoutRepository {
+
+    /**
+     * Listen to a logout event.
+     * The event caries a [LogoutReason].
+     */
     suspend fun observeLogout(): Flow<LogoutReason>
+
+    /**
+     * Propagates the logout event and [reason],
+     * listenable through [observeLogout]
+     */
     suspend fun onLogout(reason: LogoutReason)
+
+    /**
+     * Informs the backend about the logout,
+     * invalidating the current credentials.
+     */
     suspend fun logout(): Either<CoreFailure, Unit>
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
@@ -1,18 +1,30 @@
 package com.wire.kalium.logic.data.logout
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.user.logout.LogoutApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
 
-interface LogoutRepository {
+internal interface LogoutRepository {
+    suspend fun observeLogout(): Flow<LogoutReason>
+    suspend fun onLogout(reason: LogoutReason)
     suspend fun logout(): Either<CoreFailure, Unit>
 }
 
 internal class LogoutDataSource(
     private val logoutApi: LogoutApi,
 ) : LogoutRepository {
-    override suspend fun logout(): Either<NetworkFailure, Unit> =
+
+    private val logoutEventsChannel = Channel<LogoutReason>()
+
+    override suspend fun observeLogout(): Flow<LogoutReason> = logoutEventsChannel.consumeAsFlow()
+
+    override suspend fun onLogout(reason: LogoutReason) = logoutEventsChannel.send(reason)
+
+    override suspend fun logout(): Either<CoreFailure, Unit> =
         wrapApiRequest { logoutApi.logout() }
+
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.logout.LogoutRepository
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.di.UserSessionScopeProvider
@@ -13,7 +14,8 @@ import com.wire.kalium.logic.functional.isLeft
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 
-class LogoutUseCase @Suppress("LongParameterList") constructor(
+// TODO(testing): This class is a pain to test because of AuthenticatedDataSourceSet
+class LogoutUseCase @Suppress("LongParameterList") internal constructor(
     private val logoutRepository: LogoutRepository,
     private val sessionRepository: SessionRepository,
     private val userId: QualifiedID,
@@ -23,10 +25,11 @@ class LogoutUseCase @Suppress("LongParameterList") constructor(
     private val deregisterTokenUseCase: DeregisterTokenUseCase,
     private val userSessionScopeProvider: UserSessionScopeProvider = UserSessionScopeProviderImpl
 ) {
-    suspend operator fun invoke() {
-        //TODO(important): deregister push notification token
+
+    suspend operator fun invoke(reason: LogoutReason = LogoutReason.USER_INTENTION) {
         deregisterTokenUseCase()
         logoutRepository.logout()
+        logoutRepository.onLogout(reason)
         clearCrypto()
         clearUserStorage()
         clearUserSessionAndUpdateCurrent()
@@ -35,10 +38,6 @@ class LogoutUseCase @Suppress("LongParameterList") constructor(
 
     private fun clearInMemoryUserSession() {
         userSessionScopeProvider.delete(userId)
-    }
-
-    private suspend fun deregisterNativePushToken() {
-        deregisterTokenUseCase()
     }
 
     private fun clearUserSessionAndUpdateCurrent() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -26,6 +26,9 @@ class LogoutUseCase @Suppress("LongParameterList") internal constructor(
     private val userSessionScopeProvider: UserSessionScopeProvider = UserSessionScopeProviderImpl
 ) {
 
+    // TODO(refactor): Maybe we can simplify by taking some of the responsibility away from here.
+    //                 Perhaps [UserSessionScope] (or another specialised class) can observe
+    //                 the [LogoutRepository.observeLogout] and invalidating everything in [CoreLogic] level.
     suspend operator fun invoke(reason: LogoutReason = LogoutReason.USER_INTENTION) {
         deregisterTokenUseCase()
         logoutRepository.logout()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
@@ -1,0 +1,59 @@
+package com.wire.kalium.logic.data.logout
+
+import app.cash.turbine.test
+import com.wire.kalium.network.api.user.logout.LogoutApi
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LogoutRepositoryTest {
+
+    @Test
+    fun givenLogoutFlowIsBeingObserved_whenInvokingOnLogout_thenFlowShouldEmit() = runTest {
+        // Given
+        val reason = LogoutReason.USER_INTENTION
+
+        val (_, logoutRepository) = Arrangement().arrange()
+
+        logoutRepository.observeLogout().test {
+
+            // When
+            logoutRepository.onLogout(reason)
+
+            // Then
+            assertEquals(reason, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenOnLogoutWasNotInvoked_whenObservingLogoutFlow_thenNoEventsShouldBePresent() = runTest {
+        // Given - NOOP
+
+        val (_, logoutRepository) = Arrangement().arrange()
+
+        // When
+        logoutRepository.observeLogout().test {
+
+            // Then
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class Arrangement {
+
+        @Mock
+        private val logoutApi = mock(classOf<LogoutApi>())
+
+        private val logoutDataSource = LogoutDataSource(logoutApi)
+
+        fun arrange() = this to logoutDataSource
+
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

One of the criterias to stop sync automatically is when the user logs out.
Currently there are no ways to receive this event.

### Solutions

- Add a `observeLogout(): Flow<LogoutReason>` function to `LogoutRepository`.
- Add a `onLogout(reason: LogoutReason)` to `LogoutRepository`.

The idea is that `onLogout` should be called by entities (like the UseCases) with a reason. This event can be observed and handled by the SyncManager later.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
