### PR TITLE
refactor: rename access model and add access intof to conversation response

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -10,8 +10,8 @@ import com.wire.kalium.network.api.conversation.ConvTeamInfo
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.CreateConversationRequest
 import com.wire.kalium.network.api.conversation.ReceiptMode
-import com.wire.kalium.network.api.model.ConversationAccess
-import com.wire.kalium.network.api.model.ConversationAccessRole
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.ConversationEntity.GroupState
 import com.wire.kalium.persistence.dao.ConversationEntity.Protocol
@@ -22,8 +22,8 @@ interface ConversationMapper {
     fun fromApiModelToDaoModel(apiModel: ConversationResponse, mlsGroupState: GroupState?, selfUserTeamId: TeamId?): ConversationEntity
     fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol
     fun fromDaoModel(daoModel: ConversationEntity): Conversation
-    fun toApiModel(access: ConversationOptions.Access): ConversationAccess
-    fun toApiModel(accessRole: ConversationOptions.AccessRole): ConversationAccessRole
+    fun toApiModel(access: ConversationOptions.Access): ConversationAccessDTO
+    fun toApiModel(accessRole: ConversationOptions.AccessRole): ConversationAccessRoleDTO
     fun toApiModel(protocol: ConversationOptions.Protocol): ConvProtocol
     fun toApiModel(name: String?, members: List<UserId>, teamId: String?, options: ConversationOptions): CreateConversationRequest
     fun toConversationDetailsOneToOne(conversation: Conversation, otherUser: OtherUser, selfUser: SelfUser): ConversationDetails.OneOne
@@ -93,18 +93,18 @@ internal class ConversationMapperImpl(
         )
     }
 
-    override fun toApiModel(access: ConversationOptions.Access): ConversationAccess = when (access) {
-        ConversationOptions.Access.PRIVATE -> ConversationAccess.PRIVATE
-        ConversationOptions.Access.CODE -> ConversationAccess.CODE
-        ConversationOptions.Access.INVITE -> ConversationAccess.INVITE
-        ConversationOptions.Access.LINK -> ConversationAccess.LINK
+    override fun toApiModel(access: ConversationOptions.Access): ConversationAccessDTO = when (access) {
+        ConversationOptions.Access.PRIVATE -> ConversationAccessDTO.PRIVATE
+        ConversationOptions.Access.CODE -> ConversationAccessDTO.CODE
+        ConversationOptions.Access.INVITE -> ConversationAccessDTO.INVITE
+        ConversationOptions.Access.LINK -> ConversationAccessDTO.LINK
     }
 
-    override fun toApiModel(accessRole: ConversationOptions.AccessRole): ConversationAccessRole = when (accessRole) {
-        ConversationOptions.AccessRole.TEAM_MEMBER -> ConversationAccessRole.TEAM_MEMBER
-        ConversationOptions.AccessRole.NON_TEAM_MEMBER -> ConversationAccessRole.NON_TEAM_MEMBER
-        ConversationOptions.AccessRole.GUEST -> ConversationAccessRole.GUEST
-        ConversationOptions.AccessRole.SERVICE -> ConversationAccessRole.SERVICE
+    override fun toApiModel(accessRole: ConversationOptions.AccessRole): ConversationAccessRoleDTO = when (accessRole) {
+        ConversationOptions.AccessRole.TEAM_MEMBER -> ConversationAccessRoleDTO.TEAM_MEMBER
+        ConversationOptions.AccessRole.NON_TEAM_MEMBER -> ConversationAccessRoleDTO.NON_TEAM_MEMBER
+        ConversationOptions.AccessRole.GUEST -> ConversationAccessRoleDTO.GUEST
+        ConversationOptions.AccessRole.SERVICE -> ConversationAccessRoleDTO.SERVICE
     }
 
     override fun toApiModel(protocol: ConversationOptions.Protocol): ConvProtocol = when (protocol) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -9,6 +9,8 @@ import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.MutedStatus
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import io.mockative.Mock
@@ -173,7 +175,13 @@ class ConversationMapperTest {
             null,
             null,
             ConvProtocol.PROTEUS,
-            lastEventTime = "2022-03-30T15:36:00.000Z"
+            lastEventTime = "2022-03-30T15:36:00.000Z",
+            access = setOf(ConversationAccessDTO.INVITE, ConversationAccessDTO.CODE),
+            accessRole = setOf(
+                ConversationAccessRoleDTO.GUEST,
+                ConversationAccessRoleDTO.TEAM_MEMBER,
+                ConversationAccessRoleDTO.NON_TEAM_MEMBER
+            )
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -313,7 +313,6 @@ class ConversationRepositoryTest {
             ConversationOptions(protocol = ConversationOptions.Protocol.PROTEUS)
         )
 
-
         result.shouldSucceed { }
 
         verify(conversationDAO)
@@ -356,7 +355,6 @@ class ConversationRepositoryTest {
             listOf(TestUser.USER_ID),
             ConversationOptions(protocol = ConversationOptions.Protocol.PROTEUS)
         )
-
 
         result.shouldSucceed { }
 
@@ -663,5 +661,4 @@ class ConversationRepositoryTest {
             lastNotificationDate = null,
         )
     }
-
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -18,6 +18,8 @@ import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationPagingResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationResponseDTO
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import com.wire.kalium.network.api.user.client.ClientApi
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
@@ -430,7 +432,7 @@ class ConversationRepositoryTest {
     @Test
     fun givenUserHasKnownContactAndConversation_WhenGettingConversationDetailsByExistingConversation_ReturnTheCorrectConversation() =
         runTest {
-            //given
+            // given
             given(conversationDAO)
                 .suspendFunction(conversationDAO::getAllConversationWithOtherUser)
                 .whenInvokedWith(anything())
@@ -445,9 +447,9 @@ class ConversationRepositoryTest {
                 .whenInvokedWith(any())
                 .thenReturn(flowOf(TestUser.OTHER))
 
-            //when
+            // when
             val result = conversationRepository.getOneToOneConversationDetailsByUserId(OTHER_USER_ID)
-            //then
+            // then
             assertIs<Either.Right<ConversationDetails.OneOne>>(result)
         }
 
@@ -631,7 +633,13 @@ class ConversationRepositoryTest {
             0,
             null,
             ConvProtocol.PROTEUS,
-            lastEventTime = "2022-03-30T15:36:00.000Z"
+            lastEventTime = "2022-03-30T15:36:00.000Z",
+            access = setOf(ConversationAccessDTO.INVITE, ConversationAccessDTO.CODE),
+            accessRole = setOf(
+                ConversationAccessRoleDTO.GUEST,
+                ConversationAccessRoleDTO.TEAM_MEMBER,
+                ConversationAccessRoleDTO.NON_TEAM_MEMBER
+            )
         )
 
         val CONVERSATION_RESPONSE_DTO = ConversationResponseDTO(
@@ -652,7 +660,7 @@ class ConversationRepositoryTest {
             teamId = null,
             protocolInfo = ConversationEntity.ProtocolInfo.Proteus,
             lastModifiedDate = "2022-03-30T15:36:00.000Z",
-            lastNotificationDate = null
+            lastNotificationDate = null,
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -14,6 +14,8 @@ import com.wire.kalium.network.api.conversation.ConvProtocol
 import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 
@@ -89,7 +91,13 @@ object TestConversation {
         0,
         null,
         ConvProtocol.PROTEUS,
-        lastEventTime = "2022-03-30T15:36:00.000Z"
+        lastEventTime = "2022-03-30T15:36:00.000Z",
+        access = setOf(ConversationAccessDTO.INVITE, ConversationAccessDTO.CODE),
+        accessRole = setOf(
+            ConversationAccessRoleDTO.GUEST,
+            ConversationAccessRoleDTO.TEAM_MEMBER,
+            ConversationAccessRoleDTO.NON_TEAM_MEMBER
+        )
     )
 
     val ADD_MEMBER_TO_CONVERSATION_SUCCESSFUL_RESPONSE =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -67,7 +67,6 @@ object TestConversation {
         null
     )
 
-
     val NETWORK_ID = QualifiedID("valueConversation", "domainConversation")
     val USER_1 = UserId("member1", "domainMember")
     val MEMBER_TEST1 = Member(USER_1, Member.Role.Admin)
@@ -76,7 +75,6 @@ object TestConversation {
     val NETWORK_USER_ID1 = com.wire.kalium.network.api.UserId(value = "member1", domain = "domainMember")
     val NETWORK_USER_ID2 = com.wire.kalium.network.api.UserId(value = "member2", domain = "domainMember")
     val USER_ID1 = UserId(value = "member1", domain = "domainMember")
-
 
     val CONVERSATION_RESPONSE = ConversationResponse(
         "creator",

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -3,6 +3,8 @@ package com.wire.kalium.network.api.conversation
 import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.TeamId
 import com.wire.kalium.network.api.UserId
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -36,7 +38,10 @@ data class ConversationResponse(
     val protocol: ConvProtocol,
 
     @SerialName("last_event_time")
-    val lastEventTime: String
+    val lastEventTime: String,
+
+    @SerialName("access") val access: Set<ConversationAccessDTO>,
+    @SerialName("access_role_v2") val accessRole: Set<ConversationAccessRoleDTO>?,
 ) {
 
     val isOneOnOneConversation: Boolean

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -74,7 +74,7 @@ sealed class ConversationMemberDTO {
     // by Wire (i.e., no custom roles can have the same prefix)
     // in swagger conversation_role is an optional field but according to Akshay:
     // Hmm, the field is optional when sending it to the server. The server will always send the field.
-    //(The server assumes admin when the field is missing, I don't have the context behind this decision)
+    // (The server assumes admin when the field is missing, I don't have the context behind this decision)
     abstract val conversationRole: String
     abstract val id: UserId
     abstract val service: ServiceReferenceDTO?

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/CreateConversationRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/CreateConversationRequest.kt
@@ -2,8 +2,8 @@ package com.wire.kalium.network.api.conversation
 
 import com.wire.kalium.network.api.TeamId
 import com.wire.kalium.network.api.UserId
-import com.wire.kalium.network.api.model.ConversationAccess
-import com.wire.kalium.network.api.model.ConversationAccessRole
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -21,9 +21,9 @@ data class CreateConversationRequest(
     @SerialName("name")
     val name: String?,
     @SerialName("access")
-    val access: List<ConversationAccess>?,
+    val access: List<ConversationAccessDTO>?,
     @SerialName("access_role_v2")
-    val accessRole: List<ConversationAccessRole>?,
+    val accessRole: List<ConversationAccessRoleDTO>?,
     @SerialName("team")
     val convTeamInfo: ConvTeamInfo?,
     @SerialName("message_timer")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/model/ConversationAccessData.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/model/ConversationAccessData.kt
@@ -1,15 +1,15 @@
 package com.wire.kalium.network.api.conversation.model
 
-import com.wire.kalium.network.api.model.ConversationAccess
-import com.wire.kalium.network.api.model.ConversationAccessRole
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import com.wire.kalium.network.api.notification.EventContentDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ConversationAccessData(
-    @SerialName("access") val access: Set<ConversationAccess>,
-    @SerialName("access_role_v2") val accessRole: Set<ConversationAccessRole>?
+    @SerialName("access") val access: Set<ConversationAccessDTO>,
+    @SerialName("access_role_v2") val accessRole: Set<ConversationAccessRoleDTO>?
 )
 
 sealed class UpdateConversationAccessResponse {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/ConversationAccessDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/ConversationAccessDTO.kt
@@ -4,15 +4,15 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class ConversationAccessRole {
-    @SerialName("team_member")
-    TEAM_MEMBER,
-    @SerialName("non_team_member")
-    NON_TEAM_MEMBER,
-    @SerialName("guest")
-    GUEST,
-    @SerialName("service")
-    SERVICE;
+enum class ConversationAccessDTO {
+    @SerialName("private")
+    PRIVATE,
+    @SerialName("code")
+    CODE,
+    @SerialName("invite")
+    INVITE,
+    @SerialName("link")
+    LINK;
 
     override fun toString(): String {
         return this.name.lowercase()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/ConversationAccessRoleDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/model/ConversationAccessRoleDTO.kt
@@ -4,15 +4,15 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class ConversationAccess {
-    @SerialName("private")
-    PRIVATE,
-    @SerialName("code")
-    CODE,
-    @SerialName("invite")
-    INVITE,
-    @SerialName("link")
-    LINK;
+enum class ConversationAccessRoleDTO {
+    @SerialName("team_member")
+    TEAM_MEMBER,
+    @SerialName("non_team_member")
+    NON_TEAM_MEMBER,
+    @SerialName("guest")
+    GUEST,
+    @SerialName("service")
+    SERVICE;
 
     override fun toString(): String {
         return this.name.lowercase()

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
@@ -7,7 +7,7 @@ import com.wire.kalium.network.api.conversation.ConversationApi
 import com.wire.kalium.network.api.conversation.ConversationApiImpl
 import com.wire.kalium.network.api.conversation.model.ConversationAccessData
 import com.wire.kalium.network.api.conversation.model.UpdateConversationAccessResponse
-import com.wire.kalium.network.api.model.ConversationAccess
+import com.wire.kalium.network.api.model.ConversationAccessDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
@@ -102,7 +102,7 @@ class ConversationApiTest : ApiTest {
     @Test
     fun whenUpdatingAccessRole_thenTheRequestShouldBeConfiguredCorrectly() = runTest {
         val accessRoles = ConversationAccessData(
-            setOf(ConversationAccess.PRIVATE, ConversationAccess.INVITE), null
+            setOf(ConversationAccessDTO.PRIVATE, ConversationAccessDTO.INVITE), null
         )
         val networkClient = mockAuthenticatedNetworkClient(
             "", statusCode = HttpStatusCode.NoContent,
@@ -119,7 +119,7 @@ class ConversationApiTest : ApiTest {
     @Test
     fun givenAccessUnchangedResponse_whenUpdatingAccessRole_thenAccessUnchangedIsPropagated() = runTest {
         val accessRoles = ConversationAccessData(
-            setOf(ConversationAccess.PRIVATE, ConversationAccess.INVITE), null
+            setOf(ConversationAccessDTO.PRIVATE, ConversationAccessDTO.INVITE), null
         )
         val networkClient = mockAuthenticatedNetworkClient(
             "", statusCode = HttpStatusCode.NoContent
@@ -134,7 +134,7 @@ class ConversationApiTest : ApiTest {
     @Test
     fun givenSuccessAccessUpdateResponse_whenUpdatingAccessRole_thenAccessUpdateEventIsPropagated() = runTest {
         val accessRoles = ConversationAccessData(
-            setOf(ConversationAccess.PRIVATE, ConversationAccess.INVITE), null
+            setOf(ConversationAccessDTO.PRIVATE, ConversationAccessDTO.INVITE), null
         )
         val networkClient = mockAuthenticatedNetworkClient(
             EventContentDTOJson.valid.rawJson, statusCode = HttpStatusCode.OK

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -9,8 +9,10 @@ import com.wire.kalium.network.api.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.MutedStatus
 import com.wire.kalium.network.api.conversation.ServiceReferenceDTO
-import com.wire.kalium.network.tools.KtxSerializer.json
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -37,6 +39,8 @@ object ConversationResponseJson {
             put("type", it.type.ordinal)
             put("protocol", it.protocol.toString())
             put("last_event_time", it.lastEventTime)
+            putAccessSet(it.access)
+            it.accessRole?.let { putAccessRoleSet(it) }
             it.messageTimer?.let { put("message_timer", it) }
             it.name?.let { put("name", it) }
             it.teamId?.let { put("team", it) }
@@ -62,9 +66,23 @@ object ConversationResponseJson {
             null,
             "teamID",
             ConvProtocol.PROTEUS,
-            lastEventTime = "2022-03-30T15:36:00.000Z"
+            lastEventTime = "2022-03-30T15:36:00.000Z",
+            access = setOf(ConversationAccessDTO.INVITE, ConversationAccessDTO.CODE),
+            accessRole = setOf(
+                ConversationAccessRoleDTO.GUEST,
+                ConversationAccessRoleDTO.TEAM_MEMBER,
+                ConversationAccessRoleDTO.NON_TEAM_MEMBER
+            )
         ), conversationResponseSerializer
     )
+}
+
+fun JsonObjectBuilder.putAccessRoleSet(accessRole: Set<ConversationAccessRoleDTO>) = putJsonArray("access_role_v2") {
+    accessRole.forEach { add(it.toString()) }
+}
+
+fun JsonObjectBuilder.putAccessSet(access: Set<ConversationAccessDTO>) = putJsonArray("access") {
+    access.forEach { add(it.toString()) }
 }
 
 fun JsonObjectBuilder.putQualifiedId(id: QualifiedID) = putJsonObject("qualified_id") {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/CreateConversationRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/CreateConversationRequestJson.kt
@@ -6,8 +6,8 @@ import com.wire.kalium.network.api.conversation.ConvProtocol
 import com.wire.kalium.network.api.conversation.ConvTeamInfo
 import com.wire.kalium.network.api.conversation.CreateConversationRequest
 import com.wire.kalium.network.api.conversation.ReceiptMode
-import com.wire.kalium.network.api.model.ConversationAccess
-import com.wire.kalium.network.api.model.ConversationAccessRole
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 
 object CreateConversationRequestJson {
 
@@ -15,8 +15,8 @@ object CreateConversationRequestJson {
         CreateConversationRequest(
             listOf(QualifiedIDSamples.one),
             name = "NameOfThisGroupConversation",
-            listOf(ConversationAccess.PRIVATE),
-            listOf(ConversationAccessRole.TEAM_MEMBER),
+            listOf(ConversationAccessDTO.PRIVATE),
+            listOf(ConversationAccessRoleDTO.TEAM_MEMBER),
             ConvTeamInfo(false, "teamID"),
             0,
             ReceiptMode.DISABLED,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

missing access and access role info in the ConversationResponse.kt

### Causes (Optional)

just forgot to add it in the previous PR

### Solutions

1. rename `ConversationAccess` to `ConversationAccessDTO`
2. rename `ConversationAccessRole` to `ConversationAccessRoleDTO`
3. add access and accessRole to `ConversationResponse`


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
