### PR TITLE
fix: users not in conversation SQL query 

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -97,20 +97,20 @@ updateUserAvailabilityStatus:
 UPDATE User SET user_availability_status = ? WHERE qualified_id = ?;
 
 getUsersNotInConversationByNameOrHandleOrEmail:
-SELECT * FROM User
-WHERE NOT EXISTS (SELECT user FROM Member WHERE conversation == :conversation_id)
+SELECT * FROM User AS user
+WHERE NOT EXISTS (SELECT user FROM Member AS member WHERE member.conversation == :converastion_id AND user.qualified_id == member.user)
 AND  (name LIKE ('%' || :searchQuery || '%')
 OR  handle LIKE  ('%' || :searchQuery || '%')
 OR  email LIKE  ('%' || :searchQuery || '%'))
 AND connection_status = "ACCEPTED";
 
 getUsersNotInConversationByHandle:
-SELECT * FROM User
-WHERE NOT EXISTS (SELECT user FROM Member WHERE conversation == :conversation_id)
+SELECT * FROM User AS user
+WHERE NOT EXISTS (SELECT user FROM Member AS member WHERE member.conversation == :converastion_id AND user.qualified_id == member.user)
 AND handle LIKE ('%' || :searchQuery || '%')
 AND connection_status = "ACCEPTED";
 
 getUsersNotPartOfTheConversation:
-SELECT * FROM User
- WHERE NOT EXISTS (SELECT user FROM Member WHERE conversation == ?)
+SELECT * FROM User AS user
+ WHERE NOT EXISTS (SELECT user FROM Member AS member WHERE member.conversation == :converastion_id AND user.qualified_id == member.user)
  AND connection_status = "ACCEPTED";

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
@@ -107,6 +107,102 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
         assertTrue { result == listOf(user1, user2) }
     }
 
+    @Test
+    fun givenAUserAndConversationMembers_whenGettingUsersByHandle_ThenReturnUserMatchingTheHandleAndNotInTheConversation() = runTest {
+        //given
+        val userThatIsPartOfConversation = newUserEntity(QualifiedIDEntity("3", "someDomain")).copy(handle = "handleMatch")
+
+        val allUsers = listOf(
+            user1.copy(handle = "handleMatch"),
+            user2.copy(handle = "handleMatch"),
+            userThatIsPartOfConversation
+        )
+
+        userDAO.upsertUsers(allUsers)
+
+        val conversationId = QualifiedIDEntity(value = "someValue", domain = "someDomain")
+
+        createTestConversation(
+            conversationId, listOf(
+                Member(
+                    user = QualifiedIDEntity(
+                        "3", "someDomain"
+                    ), role = Member.Role.Admin
+                )
+            )
+        )
+
+        //when
+        val result = userDAO.getUsersNotInConversationByHandle(conversationId, "handleMatch")
+
+        //then
+        assertTrue { result == (allUsers - userThatIsPartOfConversation) }
+    }
+
+    @Test
+    fun givenAUserAndConversationMembers_whenGettingUsersByEmail_ThenReturnUserMatchingTheEmailAndNotInTheConversation() = runTest {
+        //given
+        val userThatIsPartOfConversation = newUserEntity(QualifiedIDEntity("3", "someDomain")).copy(email = "emailMatch")
+
+        val allUsers = listOf(
+            user1.copy(email = "emailMatch"),
+            user2.copy(email = "emailMatch"),
+            userThatIsPartOfConversation
+        )
+
+        userDAO.upsertUsers(allUsers)
+
+        val conversationId = QualifiedIDEntity(value = "someValue", domain = "someDomain")
+
+        createTestConversation(
+            conversationId, listOf(
+                Member(
+                    user = QualifiedIDEntity(
+                        "3", "someDomain"
+                    ), role = Member.Role.Admin
+                )
+            )
+        )
+
+        //when
+        val result = userDAO.getUsersNotInConversationByNameOrHandleOrEmail(conversationId, "emailMatch")
+
+        //then
+        assertTrue { result == (allUsers - userThatIsPartOfConversation) }
+    }
+
+    @Test
+    fun givenAUserAndConversationMembers_whenGettingUsersByName_ThenReturnUserMatchingTheEmailAndNotInTheConversation() = runTest {
+        //given
+        val userThatIsPartOfConversation = newUserEntity(QualifiedIDEntity("3", "someDomain")).copy(name = "nameMatch")
+
+        val allUsers = listOf(
+            user1.copy(name = "nameMatch"),
+            user2.copy(name = "nameMatch"),
+            userThatIsPartOfConversation
+        )
+
+        userDAO.upsertUsers(allUsers)
+
+        val conversationId = QualifiedIDEntity(value = "someValue", domain = "someDomain")
+
+        createTestConversation(
+            conversationId, listOf(
+                Member(
+                    user = QualifiedIDEntity(
+                        "3", "someDomain"
+                    ), role = Member.Role.Admin
+                )
+            )
+        )
+
+        //when
+        val result = userDAO.getUsersNotInConversationByNameOrHandleOrEmail(conversationId, "nameMatch")
+
+        //then
+        assertTrue { result == (allUsers - userThatIsPartOfConversation) }
+    }
+
     private suspend fun createTestConversation(conversationIDEntity: QualifiedIDEntity, members: List<Member>) {
         conversationDAO.insertConversation(
             newConversationEntity(conversationIDEntity)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
@@ -45,7 +45,7 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
 
     @Test
     fun givenTheUserIsPartOfConversation_WHenGettingUsersNotPartOfConversation_ThenReturnUsersWithoutTheConversationMember() = runTest {
-        //given
+        // given
         val userThatIsPartOfConversation = newUserEntity(QualifiedIDEntity("3", "someDomain"))
 
         val allUsers = listOf(user1, user2, userThatIsPartOfConversation)
@@ -63,10 +63,10 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
             )
         )
 
-        //when
+        // when
         val result = userDAO.getUsersNotInConversation(conversationId)
 
-        //then
+        // then
         assertTrue { result == (allUsers - userThatIsPartOfConversation) }
     }
 
@@ -109,7 +109,7 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
 
     @Test
     fun givenAUserAndConversationMembers_whenGettingUsersByHandle_ThenReturnUserMatchingTheHandleAndNotInTheConversation() = runTest {
-        //given
+        // given
         val userThatIsPartOfConversation = newUserEntity(QualifiedIDEntity("3", "someDomain")).copy(handle = "handleMatch")
 
         val allUsers = listOf(
@@ -132,16 +132,16 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
             )
         )
 
-        //when
+        // when
         val result = userDAO.getUsersNotInConversationByHandle(conversationId, "handleMatch")
 
-        //then
+        // then
         assertTrue { result == (allUsers - userThatIsPartOfConversation) }
     }
 
     @Test
     fun givenAUserAndConversationMembers_whenGettingUsersByEmail_ThenReturnUserMatchingTheEmailAndNotInTheConversation() = runTest {
-        //given
+        // given
         val userThatIsPartOfConversation = newUserEntity(QualifiedIDEntity("3", "someDomain")).copy(email = "emailMatch")
 
         val allUsers = listOf(
@@ -164,16 +164,16 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
             )
         )
 
-        //when
+        // when
         val result = userDAO.getUsersNotInConversationByNameOrHandleOrEmail(conversationId, "emailMatch")
 
-        //then
+        // then
         assertTrue { result == (allUsers - userThatIsPartOfConversation) }
     }
 
     @Test
     fun givenAUserAndConversationMembers_whenGettingUsersByName_ThenReturnUserMatchingTheEmailAndNotInTheConversation() = runTest {
-        //given
+        // given
         val userThatIsPartOfConversation = newUserEntity(QualifiedIDEntity("3", "someDomain")).copy(name = "nameMatch")
 
         val allUsers = listOf(
@@ -196,10 +196,10 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
             )
         )
 
-        //when
+        // when
         val result = userDAO.getUsersNotInConversationByNameOrHandleOrEmail(conversationId, "nameMatch")
 
-        //then
+        // then
         assertTrue { result == (allUsers - userThatIsPartOfConversation) }
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
@@ -45,9 +45,11 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
 
     @Test
     fun givenTheUserIsPartOfConversation_WHenGettingUsersNotPartOfConversation_ThenReturnUsersWithoutTheConversationMember() = runTest {
+        //given
         val userThatIsPartOfConversation = newUserEntity(QualifiedIDEntity("3", "someDomain"))
 
-        userDAO.upsertUsers(listOf(user1, user2, userThatIsPartOfConversation))
+        val allUsers = listOf(user1, user2, userThatIsPartOfConversation)
+        userDAO.upsertUsers(allUsers)
 
         val conversationId = QualifiedIDEntity(value = "someValue", domain = "someDomain")
 
@@ -61,9 +63,11 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
             )
         )
 
+        //when
         val result = userDAO.getUsersNotInConversation(conversationId)
 
-        assertTrue { !result.contains(userThatIsPartOfConversation) }
+        //then
+        assertTrue { result == (allUsers - userThatIsPartOfConversation) }
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- the Query was uncorrect the previous one was. :

```
getUsersNotPartOfTheConversation:
SELECT * FROM User AS user
 WHERE NOT EXISTS (SELECT user FROM Member AS member WHERE member.conversation == :converastion_id)
 AND connection_status = "ACCEPTED";
```

which in fact always returned a empty list because if the converastion_id is valid every user from User returns true for WHERE NOT EXISTS as there must be a member having this conversadtion_id  which in turn was neglated and returned a empty list 
### Solutions

add additional check on the user id of the member 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

Added regression tests

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
