### PR TITLE
feat: CLI file logging

### DIFF
--- a/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -5,8 +5,12 @@ import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.output.TermUi.echo
 import com.github.ajalt.clikt.output.TermUi.prompt
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.prompt
+import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.file
+import com.wire.kalium.logger.FileLogger
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logic.CoreLogger
 import com.wire.kalium.logic.CoreLogic
@@ -36,6 +40,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.io.File
 
 private val coreLogic = CoreLogic("Kalium CLI", "${CLIApplication.HOME_DIRECTORY}/.kalium/accounts", kaliumConfigs = KaliumConfigs())
 
@@ -255,8 +260,17 @@ class RefillKeyPackagesCommand : CliktCommand(name = "refill-key-packages") {
 
 class CLIApplication : CliktCommand(allowMultipleSubcommands = true) {
 
+    private val logLevel by option(help = "log level").enum<KaliumLogLevel>().default(KaliumLogLevel.WARN)
+    private val logFile by option(help = "output file for logs").file(canBeDir = false)
+
+    private val fileLogger: FileLogger by lazy { FileLogger(logFile ?: File("kalium.log")) }
+
     override fun run() = runBlocking {
-        CoreLogger.setLoggingLevel(KaliumLogLevel.DEBUG)
+        if (logFile != null) {
+            CoreLogger.setLoggingLevel(logLevel, listOf(fileLogger))
+        } else {
+            CoreLogger.setLoggingLevel(logLevel)
+        }
     }
 
     companion object {

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/CryptographyLogger.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/CryptographyLogger.kt
@@ -12,7 +12,8 @@ object CryptographyLogger {
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "Crypto"
-            ), logWriterList = logWriterList
+            ),
+            logWriterList = logWriterList
         )
     }
 }

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/CryptographyLogger.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/CryptographyLogger.kt
@@ -7,12 +7,12 @@ import com.wire.kalium.logger.KaliumLogger
 internal var kaliumLogger = KaliumLogger.disabled()
 
 object CryptographyLogger {
-    fun setLoggingLevel(level: KaliumLogLevel, logWriter: LogWriter? = null) {
+    fun setLoggingLevel(level: KaliumLogLevel, logWriterList: List<LogWriter>? = null) {
         kaliumLogger = KaliumLogger(
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "Crypto"
-            ), logWriter = logWriter
+            ), logWriterList = logWriterList
         )
     }
 }

--- a/logger/src/commonMain/kotlin/com/wire/kalium/logger/KaliumLogger.kt
+++ b/logger/src/commonMain/kotlin/com/wire/kalium/logger/KaliumLogger.kt
@@ -48,12 +48,12 @@ enum class KaliumLogLevel {
  * in the android case we use it to write the logs on file
  *
  */
-class KaliumLogger(config: Config, logWriter: LogWriter? = null) {
+class KaliumLogger(config: Config, logWriterList: List<LogWriter>? = null) {
 
     private val kermitLogger: KermitLogger
 
     init {
-        kermitLogger = if (logWriter == null) {
+        kermitLogger = if (logWriterList == null) {
             KermitLogger(
                 config = StaticConfig(
                     minSeverity = config.severityLevel, listOf(platformLogWriter())
@@ -63,7 +63,7 @@ class KaliumLogger(config: Config, logWriter: LogWriter? = null) {
         } else {
             KermitLogger(
                 config = StaticConfig(
-                    minSeverity = config.severityLevel, listOf(logWriter, platformLogWriter())
+                    minSeverity = config.severityLevel, logWriterList
                 ),
                 tag = config.tag
             )

--- a/logger/src/jvmMain/kotlin/com/wire/kalium/logger/FileLogger.kt
+++ b/logger/src/jvmMain/kotlin/com/wire/kalium/logger/FileLogger.kt
@@ -10,15 +10,17 @@ import kotlin.time.DurationUnit
 
 private var LOG_FILE_FLUSH_PERIOD = 5.seconds.toLong(DurationUnit.MILLISECONDS)
 
-class FileLogger(outputfile: File): LogWriter() {
+class FileLogger(outputfile: File) : LogWriter() {
 
     private val writer = outputfile.bufferedWriter()
 
     init {
         // Attempt to close & flush the output file before the process terminates
-        Runtime.getRuntime().addShutdownHook(Thread() {
-            writer.close()
-        })
+        Runtime.getRuntime().addShutdownHook(
+            Thread() {
+                writer.close()
+            }
+        )
 
         // Flush the output file every 5 seconds for the case when there a low log output
         Timer().scheduleAtFixedRate(delay = LOG_FILE_FLUSH_PERIOD, period = LOG_FILE_FLUSH_PERIOD) {

--- a/logger/src/jvmMain/kotlin/com/wire/kalium/logger/FileLogger.kt
+++ b/logger/src/jvmMain/kotlin/com/wire/kalium/logger/FileLogger.kt
@@ -1,0 +1,41 @@
+package com.wire.kalium.logger
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import java.io.File
+import java.util.Timer
+import kotlin.concurrent.scheduleAtFixedRate
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+
+private var LOG_FILE_FLUSH_PERIOD = 5.seconds.toLong(DurationUnit.MILLISECONDS)
+
+class FileLogger(outputfile: File): LogWriter() {
+
+    private val writer = outputfile.bufferedWriter()
+
+    init {
+        // Attempt to close & flush the output file before the process terminates
+        Runtime.getRuntime().addShutdownHook(Thread() {
+            writer.close()
+        })
+
+        // Flush the output file every 5 seconds for the case when there a low log output
+        Timer().scheduleAtFixedRate(delay = LOG_FILE_FLUSH_PERIOD, period = LOG_FILE_FLUSH_PERIOD) {
+            writer.flush()
+        }
+    }
+
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        val str = "$severity: ($tag) $message"
+        writer.write(str)
+        writer.newLine()
+
+        throwable?.let {
+            val thString = it.stackTraceToString()
+            writer.write(thString)
+            writer.newLine()
+        }
+    }
+
+}

--- a/logger/src/jvmMain/kotlin/com/wire/kalium/logger/FileLogger.kt
+++ b/logger/src/jvmMain/kotlin/com/wire/kalium/logger/FileLogger.kt
@@ -17,7 +17,7 @@ class FileLogger(outputfile: File) : LogWriter() {
     init {
         // Attempt to close & flush the output file before the process terminates
         Runtime.getRuntime().addShutdownHook(
-            Thread() {
+            Thread {
                 writer.close()
             }
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
@@ -16,14 +16,16 @@ object CoreLogger {
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "CoreLogic"
-            ), logWriterList = logWriterList
+            ),
+            logWriterList = logWriterList
         )
 
         callingLogger = KaliumLogger(
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "Calling"
-            ), logWriterList = logWriterList
+            ),
+            logWriterList = logWriterList
         )
 
         NetworkLogger.setLoggingLevel(level = level, logWriterList = logWriterList)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
@@ -5,27 +5,29 @@ import com.wire.kalium.cryptography.CryptographyLogger
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.NetworkLogger
+import com.wire.kalium.persistence.PersistenceLogger
 
 internal var kaliumLogger = KaliumLogger.disabled()
 internal var callingLogger = KaliumLogger.disabled()
 
 object CoreLogger {
-    fun setLoggingLevel(level: KaliumLogLevel, logWriter: LogWriter? = null) {
+    fun setLoggingLevel(level: KaliumLogLevel, logWriterList: List<LogWriter>? = null) {
         kaliumLogger = KaliumLogger(
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "CoreLogic"
-            ), logWriter = logWriter
+            ), logWriterList = logWriterList
         )
 
         callingLogger = KaliumLogger(
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "Calling"
-            ), logWriter = logWriter
+            ), logWriterList = logWriterList
         )
 
-        NetworkLogger.setLoggingLevel(level = level, logWriter = logWriter)
-        CryptographyLogger.setLoggingLevel(level = level, logWriter = logWriter)
+        NetworkLogger.setLoggingLevel(level = level, logWriterList = logWriterList)
+        CryptographyLogger.setLoggingLevel(level = level, logWriterList = logWriterList)
+        PersistenceLogger.setLoggingLevel(level = level, logWriterList = logWriterList)
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
@@ -15,7 +15,6 @@ import io.ktor.client.plugins.compression.ContentEncoding
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.plugins.logging.SIMPLE
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.serialization.kotlinx.json.json
 
@@ -95,7 +94,7 @@ internal class AuthenticatedWebSocketClient(
         }
 }
 
-internal class KaliumHttpLogger(): Logger {
+internal class KaliumHttpLogger : Logger {
     override fun log(message: String) {
         kaliumLogger.d(message)
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
@@ -95,6 +95,13 @@ internal class AuthenticatedWebSocketClient(
         }
 }
 
+internal class KaliumHttpLogger(): Logger {
+    override fun log(message: String) {
+        kaliumLogger.d(message)
+    }
+
+}
+
 @Suppress("MagicNumber")
 internal fun provideBaseHttpClient(
     engine: HttpClientEngine,
@@ -104,7 +111,7 @@ internal fun provideBaseHttpClient(
 
     if (NetworkLogger.isRequestLoggingEnabled) {
         install(Logging) {
-            logger = Logger.SIMPLE
+            logger = KaliumHttpLogger()
             level = LogLevel.ALL
         }
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkLogger.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkLogger.kt
@@ -12,7 +12,8 @@ object NetworkLogger {
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "Network"
-            ), logWriterList = logWriterList
+            ),
+            logWriterList = logWriterList
         )
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkLogger.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkLogger.kt
@@ -7,12 +7,12 @@ import com.wire.kalium.logger.KaliumLogger
 internal var kaliumLogger = KaliumLogger.disabled()
 
 object NetworkLogger {
-    fun setLoggingLevel(level: KaliumLogLevel, logWriter: LogWriter? = null) {
+    fun setLoggingLevel(level: KaliumLogLevel, logWriterList: List<LogWriter>? = null) {
         kaliumLogger = KaliumLogger(
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "Network"
-            ), logWriter = logWriter
+            ), logWriterList = logWriterList
         )
     }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/PersistenceLogger.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/PersistenceLogger.kt
@@ -7,12 +7,12 @@ import com.wire.kalium.logger.KaliumLogger
 internal var kaliumLogger = KaliumLogger.disabled()
 
 object PersistenceLogger {
-    fun setLoggingLevel(level: KaliumLogLevel, logWriter: LogWriter?) {
+    fun setLoggingLevel(level: KaliumLogLevel, logWriterList: List<LogWriter>?) {
         kaliumLogger = KaliumLogger(
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "Persistence"
-            ), logWriter = logWriter
+            ), logWriterList = logWriterList
         )
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/PersistenceLogger.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/PersistenceLogger.kt
@@ -12,7 +12,8 @@ object PersistenceLogger {
             config = KaliumLogger.Config(
                 severity = level,
                 tag = "Persistence"
-            ), logWriterList = logWriterList
+            ),
+            logWriterList = logWriterList
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Add the `--log-file <file>`option to the CLI for redirecting logs to a a file
- Add the `--log-level <level>` option to the CLI for setting the log level

### Issues

The CLI app becomes unusable if you have DEBUG logs on and you execute commands which require any kind of interaction with the user, because the  prompts for user input interrupted by the logs.

### Solutions

Add option to redirect all logs to a file and keep the console free for user interaction.

### Notes

- The KaliumLogger didn't allow not including logging to the console so I had to make breaking change.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
