### PR TITLE
fix: email not passed to UserEntity

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -87,8 +87,8 @@ internal class UserMapperImpl(
             id = idMapper.fromApiToDao(userProfileDTO.id),
             name = userProfileDTO.name,
             handle = userProfileDTO.handle,
-            email = null,
-            phone = null,
+            email = userProfileDTO.email,
+            phone = null, // TODO phone number not available in `UserProfileDTO`
             accentId = userProfileDTO.accentId,
             team = userProfileDTO.teamId,
             previewAssetId = userProfileDTO.assets.getPreviewAssetOrNull()?.let {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
@@ -1,31 +1,40 @@
 package com.wire.kalium.logic.data.user
 
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.id.PersistenceQualifiedId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.framework.TestTeam
+import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.UserEntity
 import com.wire.kalium.persistence.dao.UserTypeEntity
 import io.mockative.Mock
+import io.mockative.any
 import io.mockative.classOf
+import io.mockative.given
 import io.mockative.mock
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class UserMapperTest {
 
-    private lateinit var userMapper: UserMapper
-
-    @Mock
-    private val idMapper = mock(classOf<IdMapper>())
-
-    @BeforeTest
-    fun setUp() {
-        userMapper = UserMapperImpl(idMapper = idMapper)
+    @Test
+    fun givenUserProfileDTOAndUserTypeEntity_whenMappingFromApiResponse_thenDaoModelIsReturned() = runTest {
+        // Given
+        val givenResponse = TestUser.USER_PROFILE_DTO
+        val givenUserTypeEntity = UserTypeEntity.EXTERNAL
+        val expectedResult = TestUser.ENTITY.copy(
+            phone = null, // UserProfileDTO doesn't contain the phone
+            connectionStatus = ConnectionEntity.State.NOT_CONNECTED // UserProfileDTO doesn't contain the connection status
+        )
+        val (_, userMapper) = Arrangement().arrange()
+        // When
+        val result = userMapper.fromApiModelWithUserTypeEntityToDaoModel(givenResponse, givenUserTypeEntity)
+        // Then
+        assertEquals(expectedResult, result)
     }
 
     @Test
@@ -51,6 +60,7 @@ class UserMapperTest {
             availabilityStatus = UserAvailabilityStatusEntity.NONE,
             userTypEntity = UserTypeEntity.INTERNAL,
         )
+        val (_, userMapper) = Arrangement().arrange()
 
         val result = userMapper.fromTeamMemberToDaoModel(
             teamId = TeamId("teamId"),
@@ -59,5 +69,26 @@ class UserMapperTest {
         )
 
         assertEquals(expectedResult, result)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        private val idMapper = mock(classOf<IdMapper>())
+
+        private val userMapper = UserMapperImpl(idMapper = idMapper)
+
+        init {
+            given(idMapper)
+                .function(idMapper::fromApiToDao)
+                .whenInvokedWith(any())
+                .then { TestUser.ENTITY_ID }
+            given(idMapper)
+                .function(idMapper::toQualifiedAssetIdEntity)
+                .whenInvokedWith(any(), any())
+                .then { value, _ -> PersistenceQualifiedId(value, TestUser.ENTITY_ID.domain) }
+        }
+
+        fun arrange() = this to userMapper
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -63,8 +63,8 @@ object TestUser {
         accentId = 0,
         team = "teamId",
         connectionStatus = ConnectionEntity.State.ACCEPTED,
-        previewAssetId = QualifiedIDEntity("value1", "domain"),
-        completeAssetId = QualifiedIDEntity("value2", "domain"),
+        previewAssetId = QualifiedIDEntity("value1", ENTITY_ID.domain),
+        completeAssetId = QualifiedIDEntity("value2", ENTITY_ID.domain),
         availabilityStatus = UserAvailabilityStatusEntity.NONE,
         userTypEntity = UserTypeEntity.EXTERNAL
     )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

User's email was not passed to the `UserEntity` in `UserMapper`, instead it was always null.

### Solutions

Pass on the email to the `UserEntity`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
