### PR TITLE
chore: add file size and name to restrictive asset

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -17,7 +17,12 @@ sealed class MessageContent {
     data class Asset(val value: AssetContent) : Regular()
     data class DeleteMessage(val messageId: String) : Regular()
     data class TextEdited(val editMessageId: String, val newContent: String) : Regular()
-    data class RestrictedAsset(val mimeType: String) : Regular()
+    data class RestrictedAsset(
+        val mimeType: String,
+        val sizeInBytes: Long,
+        val name: String? = null,
+    ) : Regular()
+
     data class DeleteForMe(
         val messageId: String,
         val conversationId: String,
@@ -39,7 +44,7 @@ sealed class MessageContent {
         data class Removed(override val members: List<UserId>) : MemberChange(members)
     }
 
-    object MissedCall: System()
+    object MissedCall : System()
 
     // we can add other types to be processed, but signaling ones shouldn't be persisted
     object Ignored : Signaling() // messages that aren't processed in any way

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -160,7 +160,9 @@ class MessageMapperImpl(
         is MessageContent.Calling -> MessageEntityContent.Unknown()
         is MessageContent.DeleteMessage -> MessageEntityContent.Unknown()
         is MessageContent.TextEdited -> MessageEntityContent.Unknown()
-        is MessageContent.RestrictedAsset -> MessageEntityContent.RestrictedAsset(this.mimeType)
+        is MessageContent.RestrictedAsset -> MessageEntityContent.RestrictedAsset(
+            this.mimeType, this.sizeInBytes, this.name
+        )
         is MessageContent.DeleteForMe -> MessageEntityContent.Unknown()
         MessageContent.Empty -> MessageEntityContent.Unknown()
     }
@@ -186,7 +188,9 @@ class MessageMapperImpl(
             MapperProvider.assetMapper().fromAssetEntityToAssetContent(this)
         )
 
-        is MessageEntityContent.RestrictedAsset -> MessageContent.RestrictedAsset(this.mimeType)
+        is MessageEntityContent.RestrictedAsset -> MessageContent.RestrictedAsset(
+            this.mimeType, this.assetSizeInBytes, this.assetName
+        )
         is MessageEntityContent.Unknown -> MessageContent.Unknown(this.typeName, this.encodedData, hidden)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -304,7 +304,11 @@ class ConversationEventReceiverImpl(
                                 }
 
                         } else {
-                            val newMessage = message.copy(content = MessageContent.RestrictedAsset(content.value.mimeType))
+                            val newMessage = message.copy(
+                                content = MessageContent.RestrictedAsset(
+                                    content.value.mimeType, content.value.sizeInBytes, content.value.name
+                                )
+                            )
                             persistMessage(newMessage)
 
                         }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -39,6 +39,8 @@ CREATE TABLE MessageRestrictedAssetContent (
       conversation_id TEXT AS QualifiedIDEntity NOT NULL,
 
       asset_mime_type TEXT NOT NULL,
+      asset_size INTEGER NOT NULL,
+      asset_name TEXT,
 
       FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE,
       PRIMARY KEY (message_id, conversation_id)
@@ -151,8 +153,8 @@ message_id = excluded.message_id,
 text_body = excluded.text_body;
 
 insertMessageRestrictedAssetContent:
-INSERT INTO MessageRestrictedAssetContent(message_id, conversation_id, asset_mime_type)
-VALUES(?, ?, ?)
+INSERT INTO MessageRestrictedAssetContent(message_id, conversation_id, asset_mime_type,asset_size,asset_name)
+VALUES(?, ?, ?,?,?)
 ON CONFLICT(message_id, conversation_id) DO UPDATE SET
 message_id = excluded.message_id,
 asset_mime_type = excluded.asset_mime_type;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -53,8 +53,9 @@ class MessageMapper {
 
     fun toModel(content: SQLDelightMessageTextContent) = MessageEntityContent.Text(content.text_body ?: "")
 
-    fun toModel(content: MessageRestrictedAssetContent) = MessageEntityContent.RestrictedAsset(content.asset_mime_type)
-
+    fun toModel(content: MessageRestrictedAssetContent) = MessageEntityContent.RestrictedAsset(
+        content.asset_mime_type, content.asset_size, content.asset_name
+    )
 
     fun toModel(content: SQLDelightMessageAssetContent) = MessageEntityContent.Asset(
         assetSizeInBytes = content.asset_size,
@@ -133,7 +134,9 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
                 is MessageEntityContent.RestrictedAsset -> queries.insertMessageRestrictedAssetContent(
                     message_id = message.id,
                     conversation_id = message.conversationId,
-                    asset_mime_type = content.mimeType
+                    asset_mime_type = content.mimeType,
+                    asset_size = content.assetSizeInBytes,
+                    asset_name = content.assetName
                 )
                 is MessageEntityContent.Asset -> queries.insertMessageAssetContent(
                     message_id = message.id,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -126,7 +126,11 @@ sealed class MessageEntityContent {
         val memberChangeType: MessageEntity.MemberChangeType
     ) : System()
 
-    data class RestrictedAsset(val mimeType: String) : Regular()
+    data class RestrictedAsset(
+        val mimeType: String,
+        val assetSizeInBytes: Long,
+        val assetName: String? = null,
+    ) : Regular()
 
     object MissedCall : System()
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

to show the restrictive file message with the the name and size


### Solutions
add file size and name to the restrictive asset table in the DB 

### Dependencies (Optional)


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
