### PR TITLE
chore: adjust call api url to v1 and not v0

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/call/CallApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/call/CallApiImpl.kt
@@ -15,7 +15,7 @@ class CallApiImpl internal constructor(private val authenticatedNetworkClient: A
 
     override suspend fun getCallConfig(limit: Int?): NetworkResponse<String> =
         wrapKaliumResponse {
-            httpClient.get("/$PATH_CALLS/$PATH_CONFIG") {
+            httpClient.get("$PATH_CALLS/$PATH_CONFIG") {
                 limit?.let { parameter(QUERY_KEY_LIMIT, it) }
             }
         }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/call/CallApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/call/CallApiTest.kt
@@ -19,7 +19,7 @@ class CallApiTest : ApiTest {
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertGet()
-                assertPathEqual("/$PATH_CALLS/$PATH_CONFIG")
+                assertPathEqual("$PATH_CALLS/$PATH_CONFIG")
             }
         )
 
@@ -36,7 +36,7 @@ class CallApiTest : ApiTest {
                 assertGet()
                 assertQueryExist(QUERY_KEY_LIMIT)
                 assertQueryParameter(QUERY_KEY_LIMIT, hasValue = "7")
-                assertPathEqual("/$PATH_CALLS/$PATH_CONFIG")
+                assertPathEqual("$PATH_CALLS/$PATH_CONFIG")
             }
         )
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[v0] Before: `https://prod-nginz-https.wire.com/calls/config/v2`
[v1] Now: `https://prod-nginz-https.wire.com/v1/calls/config/v2`

### Issues

Call API was calling config request from API v0 and not from v1.

### Causes (Optional)

Random issues in calling.

### Solutions

Remove initial backslash so it follows correctly to v1.