### PR TITLE
chore: install rust via rustup instead of brew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ all: install-rust prepare-native cryptobox-c libsodium cryptobox4j copy-all-libs
 
 .PHONY: install-rust
 install-rust:
-	brew install rust
+	@curl https://sh.rustup.rs -sSf | sh -s -- -y
+	@source "${HOME}/.cargo/env"
 
 .PHONY: clean-native
 clean-native:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Brew-installed rust behaves weird and brew is a dependency not mentioned anywhere.

### Solutions

Use the rustup toolchain installer which is the usual way how to install rust on other systems

### Dependencies (Optional)

Only `curl` but AFAIK curl comes with xcode command line binaries.
