### PR TITLE
chore: copy libsodium artifact into native libs directory too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CRYPTOBOX_C_VERSION := "v1.1.3"
 LIBSODIUM_VERSION := "1.0.18-RELEASE"
 LIBCRYPTOBOX_ARTIFACT_FILE := libcryptobox.dylib
 LIBCRYPTOBOX_JNI_ARTIFACT_FILE := libcryptobox-jni.dylib
+LIBSODIUM_ARTIFACT_FILE := libsodium.dylib
 
 all: install-rust prepare-native cryptobox-c libsodium cryptobox4j copy-all-libs
 
@@ -45,7 +46,7 @@ libsodium:
 	cd libsodium && \
 	git checkout ${LIBSODIUM_VERSION} && \
 	./configure && \
-	make && make install
+	make
 
 cryptobox4j: cryptobox4j-clone cryptobox4j-compile
 
@@ -70,4 +71,5 @@ cryptobox4j-compile: cryptobox4j-clone
 copy-all-libs:
 	cd native && \
 	cp cryptobox4j/build/lib/${LIBCRYPTOBOX_JNI_ARTIFACT_FILE} libs/ && \
-	cp cryptobox-c/target/release/${LIBCRYPTOBOX_ARTIFACT_FILE} libs/
+	cp cryptobox-c/target/release/${LIBCRYPTOBOX_ARTIFACT_FILE} libs/ && \
+	cp libsodium/src/libsodium/.libs/${LIBSODIUM_ARTIFACT_FILE} libs/

--- a/README.md
+++ b/README.md
@@ -13,10 +13,16 @@
 
 #### Building on macOS 12
 
-Run `make`, then pass the libraries in `native/libs` and the location of `libsodium` to the VM options like so:
+Run
 
 ```
--Djava.library.path=/usr/local/lib/:/Users/tmpz/Code/Wire/kalium/native/libs
+make
+```
+
+then pass the location of the libraries in `native/libs` to the VM options like so:
+
+```
+-Djava.library.path=/Users/tmpz/Code/Wire/kalium/native/libs
 ```
 
 Note that the path needs to be adjusted for your machine.


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The make target for libsodium includes the command `make install` which can usually only executed by root successfully because it copies header files into /usr/lib/ directories.

Additionally the libsodium binary output will be copied into the user's system too but is missing in the `native/libs` directory.

### Solutions

Do not run `make install` but copy the artifact into `native/libs` on the `copy-all-libs` target
