### PR TITLE
fix: logout use case stuck at updating the logout status channel

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -32,7 +32,7 @@ class LogoutUseCase @Suppress("LongParameterList") internal constructor(
     suspend operator fun invoke(reason: LogoutReason = LogoutReason.USER_INTENTION) {
         deregisterTokenUseCase()
         logoutRepository.logout()
-        logoutRepository.onLogout(reason)
+//         logoutRepository.onLogout(reason)
         clearCrypto()
         clearUserStorage()
         clearUserSessionAndUpdateCurrent()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -32,7 +32,6 @@ class LogoutUseCase @Suppress("LongParameterList") internal constructor(
     suspend operator fun invoke(reason: LogoutReason = LogoutReason.USER_INTENTION) {
         deregisterTokenUseCase()
         logoutRepository.logout()
-//         logoutRepository.onLogout(reason)
         clearCrypto()
         clearUserStorage()
         clearUserSessionAndUpdateCurrent()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

logout use case stuck at updating the logout status channel

### Cause

the channel is not observed anywhere 

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
