### PR TITLE
feat: join existing MLS conversations on login AR-2060

### DIFF
--- a/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -59,6 +59,8 @@ fun currentUserSession(): UserSessionScope {
 }
 
 suspend fun selectConversation(userSession: UserSessionScope): Conversation {
+    userSession.syncManager.waitUntilSlowSyncCompletion()
+
     val conversations = userSession.conversations.getConversations().let {
         when (it) {
             is GetConversationsUseCase.Result.Success -> it.convFlow.first()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapper.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.data.connection
 
 import com.wire.kalium.logic.data.conversation.ConversationDetails
-import com.wire.kalium.logic.data.conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.publicuser.PublicUserMapper
 import com.wire.kalium.logic.data.user.Connection

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -37,12 +37,12 @@ data class Conversation(
     enum class Type { SELF, ONE_ON_ONE, GROUP, CONNECTION_PENDING }
     enum class AccessRole { TEAM_MEMBER, NON_TEAM_MEMBER, GUEST, SERVICE }
     enum class Access { PRIVATE, INVITE, LINK, CODE }
-}
 
-sealed class ProtocolInfo {
-    object Proteus : ProtocolInfo()
-    data class MLS(val groupId: String, val groupState: GroupState, val epoch: ULong) : ProtocolInfo() {
-        enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
+    sealed class ProtocolInfo {
+        object Proteus : ProtocolInfo()
+        data class MLS(val groupId: String, val groupState: GroupState, val epoch: ULong) : ProtocolInfo() {
+            enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
+        }
     }
 }
 
@@ -70,7 +70,7 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         val userType: UserType,
         val lastModifiedDate: String,
         val connection: com.wire.kalium.logic.data.user.Connection,
-        val protocolInfo: ProtocolInfo,
+        val protocolInfo: Conversation.ProtocolInfo,
         val access: List<Conversation.Access>,
         val accessRole: List<Conversation.AccessRole>
     ) : ConversationDetails(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -41,8 +41,8 @@ data class Conversation(
 
 sealed class ProtocolInfo {
     object Proteus : ProtocolInfo()
-    data class MLS(val groupId: String, val groupState: GroupState) : ProtocolInfo() {
-        enum class GroupState { PENDING, PENDING_WELCOME_MESSAGE, ESTABLISHED }
+    data class MLS(val groupId: String, val groupState: GroupState, val epoch: ULong) : ProtocolInfo() {
+        enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -24,6 +24,7 @@ interface ConversationMapper {
     fun fromDaoModel(daoModel: ConversationEntity): Conversation
     fun toDAOAccess(accessList: Set<ConversationAccessDTO>): List<ConversationEntity.Access>
     fun toDAOAccessRole(accessRoleList: Set<ConversationAccessRoleDTO>): List<ConversationEntity.AccessRole>
+    fun toDAOGroupState(groupState: com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState): GroupState
     fun toApiModel(access: Conversation.Access): ConversationAccessDTO
     fun toApiModel(accessRole: Conversation.AccessRole): ConversationAccessRoleDTO
     fun toApiModel(protocol: ConversationOptions.Protocol): ConvProtocol
@@ -91,6 +92,14 @@ internal class ConversationMapperImpl(
         }
     }
 
+    override fun toDAOGroupState(groupState: com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState): GroupState =
+        when (groupState) {
+            com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED -> GroupState.ESTABLISHED
+            com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN -> GroupState.PENDING_JOIN
+            com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState.PENDING_WELCOME_MESSAGE -> GroupState.PENDING_WELCOME_MESSAGE
+            com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState.PENDING_CREATION -> GroupState.PENDING_CREATION
+        }
+
     override fun toApiModel(name: String?, members: List<UserId>, teamId: String?, options: ConversationOptions) =
         CreateConversationRequest(qualifiedUsers = if (options.protocol == ConversationOptions.Protocol.PROTEUS) members.map {
             idMapper.toApiModel(it)
@@ -142,7 +151,7 @@ internal class ConversationMapperImpl(
 
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {
         return when (protocol) {
-            ConvProtocol.MLS -> ProtocolInfo.MLS(groupId ?: "", mlsGroupState ?: GroupState.PENDING)
+            ConvProtocol.MLS -> ProtocolInfo.MLS(groupId ?: "", mlsGroupState ?: GroupState.PENDING_JOIN, epoch ?: 0UL)
             ConvProtocol.PROTEUS -> ProtocolInfo.Proteus
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -24,7 +24,7 @@ interface ConversationMapper {
     fun fromDaoModel(daoModel: ConversationEntity): Conversation
     fun toDAOAccess(accessList: Set<ConversationAccessDTO>): List<ConversationEntity.Access>
     fun toDAOAccessRole(accessRoleList: Set<ConversationAccessRoleDTO>): List<ConversationEntity.AccessRole>
-    fun toDAOGroupState(groupState: com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState): GroupState
+    fun toDAOGroupState(groupState: Conversation.ProtocolInfo.MLS.GroupState): GroupState
     fun toApiModel(access: Conversation.Access): ConversationAccessDTO
     fun toApiModel(accessRole: Conversation.AccessRole): ConversationAccessRoleDTO
     fun toApiModel(protocol: ConversationOptions.Protocol): ConvProtocol
@@ -92,16 +92,17 @@ internal class ConversationMapperImpl(
         }
     }
 
-    override fun toDAOGroupState(groupState: com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState): GroupState =
+    override fun toDAOGroupState(groupState: Conversation.ProtocolInfo.MLS.GroupState): GroupState =
         when (groupState) {
-            com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED -> GroupState.ESTABLISHED
-            com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN -> GroupState.PENDING_JOIN
-            com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState.PENDING_WELCOME_MESSAGE -> GroupState.PENDING_WELCOME_MESSAGE
-            com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState.PENDING_CREATION -> GroupState.PENDING_CREATION
+            Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED -> GroupState.ESTABLISHED
+            Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN -> GroupState.PENDING_JOIN
+            Conversation.ProtocolInfo.MLS.GroupState.PENDING_WELCOME_MESSAGE -> GroupState.PENDING_WELCOME_MESSAGE
+            Conversation.ProtocolInfo.MLS.GroupState.PENDING_CREATION -> GroupState.PENDING_CREATION
         }
 
     override fun toApiModel(name: String?, members: List<UserId>, teamId: String?, options: ConversationOptions) =
-        CreateConversationRequest(qualifiedUsers = if (options.protocol == ConversationOptions.Protocol.PROTEUS) members.map {
+        CreateConversationRequest(
+            qualifiedUsers = if (options.protocol == ConversationOptions.Protocol.PROTEUS) members.map {
             idMapper.toApiModel(it)
         } else emptyList(),
             name = name,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -83,7 +83,7 @@ interface ConversationRepository {
 
     suspend fun getConversationsForNotifications(): Flow<List<Conversation>>
     suspend fun getConversationsByGroupState(
-        groupState: com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState
+        groupState: Conversation.ProtocolInfo.MLS.GroupState
     ): Either<StorageFailure, List<Conversation>>
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit>
     suspend fun updateAllConversationsNotificationDate(date: String): Either<StorageFailure, Unit>
@@ -124,7 +124,7 @@ class ConversationDataSource(
     }
 
     override suspend fun requestToJoinMLSGroup(conversation: Conversation): Either<CoreFailure, Unit> {
-        return if (conversation.protocol is com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS) {
+        return if (conversation.protocol is Conversation.ProtocolInfo.MLS) {
             mlsConversationRepository.requestToJoinGroup(
                 conversation.protocol.groupId,
                 conversation.protocol.epoch
@@ -374,12 +374,11 @@ class ConversationDataSource(
         conversationDAO.getConversationsForNotifications().filterNotNull().map { it.map(conversationMapper::fromDaoModel) }
 
     override suspend fun getConversationsByGroupState(
-        groupState: com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState
+        groupState: Conversation.ProtocolInfo.MLS.GroupState
     ): Either<StorageFailure, List<Conversation>> =
         wrapStorageRequest {
-            conversationDAO.getConversationsByGroupState(
-                conversationMapper.toDAOGroupState(groupState)
-            ).map(conversationMapper::fromDaoModel)
+            conversationDAO.getConversationsByGroupState(conversationMapper.toDAOGroupState(groupState))
+                .map(conversationMapper::fromDaoModel)
         }
 
     override suspend fun updateConversationNotificationDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -95,7 +95,7 @@ class MLSConversationDataSource(
     }
 
     override suspend fun addMemberToMLSGroup(groupID: String, userIdList: List<UserId>): Either<CoreFailure, Unit> =
-        //TODO: check for federated and non-federated members
+        // TODO: check for federated and non-federated members
         keyPackageRepository.claimKeyPackages(userIdList).flatMap { keyPackages ->
             mlsClientProvider.getMLSClient().flatMap { client ->
                 val clientKeyPackageList = keyPackages

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -29,6 +30,7 @@ interface MLSConversationRepository {
     suspend fun hasEstablishedMLSGroup(groupID: String): Either<CoreFailure, Boolean>
     suspend fun messageFromMLSMessage(messageEvent: Event.Conversation.NewMLSMessage): Either<CoreFailure, ByteArray?>
     suspend fun addMemberToMLSGroup(groupID: String, userIdList: List<UserId>): Either<CoreFailure, Unit>
+    suspend fun requestToJoinGroup(groupID: String, epoch: ULong): Either<CoreFailure, Unit>
 }
 
 class MLSConversationDataSource(
@@ -80,6 +82,17 @@ class MLSConversationDataSource(
         getConversationMembers(groupID).flatMap { members ->
             establishMLSGroup(groupID, members)
         }
+
+    override suspend fun requestToJoinGroup(groupID: String, epoch: ULong): Either<CoreFailure, Unit> {
+        kaliumLogger.d("Requesting to re-join MLS group $groupID with epoch $epoch")
+        return mlsClientProvider.getMLSClient().flatMap { mlsClient ->
+            wrapApiRequest {
+                mlsMessageApi.sendMessage(MLSMessageApi.Message(mlsClient.joinConversation(groupID, epoch)))
+            }.onSuccess {
+                conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE, groupID)
+            }
+        }
+    }
 
     override suspend fun addMemberToMLSGroup(groupID: String, userIdList: List<UserId>): Either<CoreFailure, Unit> =
         //TODO: check for federated and non-federated members

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
@@ -13,7 +13,8 @@ class ProtocolInfoMapperImpl : ProtocolInfoMapper {
             is ConversationEntity.ProtocolInfo.Proteus -> ProtocolInfo.Proteus
             is ConversationEntity.ProtocolInfo.MLS -> ProtocolInfo.MLS(
                 protocolInfo.groupId,
-                ProtocolInfo.MLS.GroupState.valueOf(protocolInfo.groupState.name)
+                ProtocolInfo.MLS.GroupState.valueOf(protocolInfo.groupState.name),
+                protocolInfo.epoch
             )
         }
 
@@ -22,7 +23,8 @@ class ProtocolInfoMapperImpl : ProtocolInfoMapper {
             is ProtocolInfo.Proteus -> ConversationEntity.ProtocolInfo.Proteus
             is ProtocolInfo.MLS -> ConversationEntity.ProtocolInfo.MLS(
                 protocolInfo.groupId,
-                ConversationEntity.GroupState.valueOf(protocolInfo.groupState.name)
+                ConversationEntity.GroupState.valueOf(protocolInfo.groupState.name),
+                protocolInfo.epoch
             )
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
@@ -3,25 +3,25 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.persistence.dao.ConversationEntity
 
 interface ProtocolInfoMapper {
-    fun fromEntity(protocolInfo: ConversationEntity.ProtocolInfo): ProtocolInfo
-    fun toEntity(protocolInfo: ProtocolInfo): ConversationEntity.ProtocolInfo
+    fun fromEntity(protocolInfo: ConversationEntity.ProtocolInfo): Conversation.ProtocolInfo
+    fun toEntity(protocolInfo: Conversation.ProtocolInfo): ConversationEntity.ProtocolInfo
 }
 
 class ProtocolInfoMapperImpl : ProtocolInfoMapper {
     override fun fromEntity(protocolInfo: ConversationEntity.ProtocolInfo) =
         when (protocolInfo) {
-            is ConversationEntity.ProtocolInfo.Proteus -> ProtocolInfo.Proteus
-            is ConversationEntity.ProtocolInfo.MLS -> ProtocolInfo.MLS(
+            is ConversationEntity.ProtocolInfo.Proteus -> Conversation.ProtocolInfo.Proteus
+            is ConversationEntity.ProtocolInfo.MLS -> Conversation.ProtocolInfo.MLS(
                 protocolInfo.groupId,
-                ProtocolInfo.MLS.GroupState.valueOf(protocolInfo.groupState.name),
+                Conversation.ProtocolInfo.MLS.GroupState.valueOf(protocolInfo.groupState.name),
                 protocolInfo.epoch
             )
         }
 
-    override fun toEntity(protocolInfo: ProtocolInfo) =
+    override fun toEntity(protocolInfo: Conversation.ProtocolInfo) =
         when (protocolInfo) {
-            is ProtocolInfo.Proteus -> ConversationEntity.ProtocolInfo.Proteus
-            is ProtocolInfo.MLS -> ConversationEntity.ProtocolInfo.MLS(
+            is Conversation.ProtocolInfo.Proteus -> ConversationEntity.ProtocolInfo.Proteus
+            is Conversation.ProtocolInfo.MLS -> ConversationEntity.ProtocolInfo.MLS(
                 protocolInfo.groupId,
                 ConversationEntity.GroupState.valueOf(protocolInfo.groupState.name),
                 protocolInfo.epoch

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
@@ -28,5 +28,3 @@ class ProtocolInfoMapperImpl : ProtocolInfoMapper {
             )
         }
 }
-
-

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
@@ -2,8 +2,7 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.conversation.Member
-import com.wire.kalium.logic.data.conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.flatMap

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -64,5 +64,8 @@ class ConversationScope(
     val markConnectionRequestAsNotified: MarkConnectionRequestAsNotifiedUseCase
         get() = MarkConnectionRequestAsNotifiedUseCaseImpl(connectionRepository)
 
+    val joinExistingMLSConversations: JoinExistingMLSConversationsUseCase
+        get() = JoinExistingMLSConversationsUseCase(conversationRepository)
+
     val updateConversationAccess: UpdateConversationAccessRoleUseCase get() = UpdateConversationAccessRoleUseCase(conversationRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -19,8 +19,7 @@ import com.wire.kalium.network.exceptions.isMlsStaleMessage
  */
 class JoinExistingMLSConversationsUseCase(
     val conversationRepository: ConversationRepository
-    ) {
-
+) {
     suspend operator fun invoke(): Either<CoreFailure, Unit> =
         conversationRepository.getConversationsByGroupState(GroupState.PENDING_JOIN).flatMap { pendingConversations ->
             kaliumLogger.d("Requesting to re-join ${pendingConversations.size} existing MLS conversation(s)")
@@ -50,5 +49,4 @@ class JoinExistingMLSConversationsUseCase(
                     }
                 }
             }
-
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -7,8 +7,8 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLS.GroupState
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
-import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isMlsStaleMessage
@@ -52,20 +52,19 @@ class JoinExistingMLSConversationsUseCase(
 
     private suspend fun requestToJoinMLSGroupAndRetry(conversation: Conversation): Either<CoreFailure, Unit> =
         conversationRepository.requestToJoinMLSGroup(conversation)
-            .onFailure { failure ->
+            .flatMapLeft { failure ->
                 if (failure is NetworkFailure.ServerMiscommunication && failure.kaliumException is KaliumException.InvalidRequestError) {
                     if (failure.kaliumException.isMlsStaleMessage()) {
                         kaliumLogger.w("Epoch out of date for conversation ${conversation.id}, re-fetching and re-trying")
 
                         // Re-fetch current epoch and try again
-                        conversationRepository.fetchConversation(conversation.id).flatMap {
+                        return conversationRepository.fetchConversation(conversation.id).flatMap {
                             conversationRepository.observeById(conversation.id).flatMap {
                                 requestToJoinMLSGroupAndRetry(conversation)
                             }
                         }
-                    } else {
-                        Either.Left(failure)
                     }
                 }
+                Either.Left(failure)
             }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -41,7 +41,7 @@ class JoinExistingMLSConversationsUseCase(
                         // Re-fetch current epoch and try again
                         conversationRepository.fetchConversation(conversation.id).flatMap {
                             conversationRepository.observeById(conversation.id).flatMap {
-                                conversationRepository.requestToJoinMLSGroup(conversation)
+                                requestToJoinMLSGroupAndRetry(conversation)
                             }
                         }
                     } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -4,7 +4,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLS.GroupState
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -1,0 +1,54 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.ProtocolInfo.MLS.GroupState
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.foldToEitherWhileRight
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isMlsStaleMessage
+
+/**
+ * Send an external add proposal to join all MLS conversations which the user is member
+ * of but has not yet joined the corresponding MLS group.
+ */
+class JoinExistingMLSConversationsUseCase(
+    val conversationRepository: ConversationRepository
+    ) {
+
+    suspend operator fun invoke(): Either<CoreFailure, Unit> =
+        conversationRepository.getConversationsByGroupState(GroupState.PENDING_JOIN).flatMap { pendingConversations ->
+            kaliumLogger.d("Requesting to re-join ${pendingConversations.size} existing MLS conversation(s)")
+
+            return pendingConversations.map { conversation ->
+                requestToJoinMLSGroupAndRetry(conversation)
+            }.foldToEitherWhileRight(Unit) { _, _ ->
+                Either.Right(Unit)
+            }
+        }
+
+    private suspend fun requestToJoinMLSGroupAndRetry(conversation: Conversation): Either<CoreFailure, Unit> =
+        conversationRepository.requestToJoinMLSGroup(conversation)
+            .onFailure { failure ->
+                if (failure is NetworkFailure.ServerMiscommunication && failure.kaliumException is KaliumException.InvalidRequestError) {
+                    if (failure.kaliumException.isMlsStaleMessage()) {
+                        kaliumLogger.w("Epoch out of date for conversation ${conversation.id}, re-fetching and re-trying")
+
+                        // Re-fetch current epoch and try again
+                        conversationRepository.fetchConversation(conversation.id).flatMap {
+                            conversationRepository.observeById(conversation.id).flatMap {
+                                conversationRepository.requestToJoinMLSGroup(conversation)
+                            }
+                        }
+                    } else {
+                        Either.Left(failure)
+                    }
+                }
+            }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Either.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Either.kt
@@ -108,6 +108,16 @@ inline fun <T, L, R> Either<L, R>.flatMap(fn: (R) -> Either<L, T>): Either<L, T>
     }
 
 /**
+ * Left-biased flatMap() FP convention which means that Left is assumed to be the default case
+ * to operate on. If it is Right, operations like map, flatMap, ... return the Right value unchanged.
+ */
+inline fun <L, R> Either<L, R>.flatMapLeft(fn: (L) -> Either<L, R>): Either<L, R> =
+    when (this) {
+        is Left -> fn(value)
+        is Right -> Right(value)
+    }
+
+/**
  * Left-biased onFailure() FP convention dictates that when this class is Left, it'll perform
  * the onFailure functionality passed as a parameter, but, overall will still return an [Either]
  * object, so you chain calls.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
@@ -25,6 +25,7 @@ class SlowSyncWorker(
                 .flatMap { userSessionScope.connection.syncConnections() }
                 .flatMap { userSessionScope.team.syncSelfTeamUseCase() }
                 .flatMap { userSessionScope.users.syncContacts() }
+                .flatMap { userSessionScope.conversations.joinExistingMLSConversations() }
                 .onSuccess { userSessionScope.syncManager.onSlowSyncComplete() }
                 .onFailure { userSessionScope.syncManager.onSlowSyncFailure(it) }
         } catch (e: Exception) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -171,6 +171,7 @@ class ConversationMapperTest {
             "name",
             ORIGINAL_CONVERSATION_ID,
             null,
+            0UL,
             ConversationResponse.Type.GROUP,
             null,
             null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -115,7 +115,7 @@ class ConversationRepositoryTest {
             "time",
             CONVERSATION_RESPONSE.copy(groupId = groupId, protocol = ConvProtocol.MLS)
         )
-        val protocolInfo = ConversationEntity.ProtocolInfo.MLS(groupId, ConversationEntity.GroupState.ESTABLISHED)
+        val protocolInfo = ConversationEntity.ProtocolInfo.MLS(groupId, ConversationEntity.GroupState.ESTABLISHED, 0UL)
 
         given(userRepository)
             .suspendFunction(userRepository::observeSelfUser)
@@ -751,6 +751,7 @@ class ConversationRepositoryTest {
             GROUP_NAME,
             TestConversation.NETWORK_ID,
             null,
+            0UL,
             ConversationResponse.Type.GROUP,
             0,
             null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -29,8 +29,6 @@ import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -155,7 +153,7 @@ class MLSConversationRepositoryTest {
             .wasInvoked(once)
     }
 
-    class Arrangement() {
+    class Arrangement {
         @Mock
         val keyPackageRepository = mock(classOf<KeyPackageRepository>())
 
@@ -267,8 +265,8 @@ class MLSConversationRepositoryTest {
         )
 
         internal companion object {
-            val EPOCH = 5UL
-            val GROUP_ID = "groupId"
+            const val EPOCH = 5UL
+            const val GROUP_ID = "groupId"
             val MEMBERS = listOf(Member(TestUser.ENTITY_ID, Member.Role.Member))
             val KEY_PACKAGE = KeyPackageDTO(
                 "client1",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -33,228 +33,229 @@ import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 
-// TODO: enable the tests once the issue with creating MLS conversations is solved
-@Ignore
 @OptIn(ExperimentalCoroutinesApi::class)
 class MLSConversationRepositoryTest {
-
-    @Mock
-    private val keyPackageRepository = mock(classOf<KeyPackageRepository>())
-
-    @Mock
-    private val mlsClientProvider = mock(classOf<MLSClientProvider>())
-
-    @Mock
-    private val conversationDAO = mock(classOf<ConversationDAO>())
-
-    @Mock
-    private val mlsMessageApi = mock(classOf<MLSMessageApi>())
-
-    private lateinit var mlsConversationRepository: MLSConversationRepository
-
-    @BeforeTest
-    fun setup() {
-        mlsConversationRepository = MLSConversationDataSource(
-            keyPackageRepository,
-            mlsClientProvider,
-            mlsMessageApi,
-            conversationDAO
-        )
-    }
-
     @Test
     fun givenConversation_whenCallingEstablishMLSGroup_thenGroupIsCreatedAndWelcomeMessageIsSent() = runTest {
-        given(conversationDAO)
-            .suspendFunction(conversationDAO::getConversationByGroupID)
-            .whenInvokedWith(anything())
-            .then { flowOf(TestConversation.ENTITY) }
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withGetConversationByGroupIdSuccessful()
+            .withGetAllMembersSuccessful()
+            .withClaimKeyPackagesSuccessful()
+            .withGetMLSClientSuccessful()
+            .withCreateMLSConversationSuccessful()
+            .withSendWelcomeMessageSuccessful()
+            .withSendMLSMessageSuccessful()
+            .withUpdateConversationGroupStateSuccessful()
+            .arrange()
 
-        given(conversationDAO)
-            .suspendFunction(conversationDAO::getAllMembers)
-            .whenInvokedWith(anything())
-            .then { flowOf(MEMBERS) }
-
-        given(keyPackageRepository)
-            .suspendFunction(keyPackageRepository::claimKeyPackages)
-            .whenInvokedWith(anything())
-            .then { Either.Right(listOf(KEY_PACKAGE)) }
-
-        given(mlsClientProvider)
-            .suspendFunction(mlsClientProvider::getMLSClient)
-            .whenInvokedWith(anything())
-            .then { Either.Right(MLS_CLIENT) }
-
-        given(MLS_CLIENT)
-            .function(MLS_CLIENT::createConversation)
-            .whenInvokedWith(anything(), anything())
-            .thenReturn(Pair(HANDSHAKE, WELCOME))
-
-        given(mlsMessageApi)
-            .suspendFunction(mlsMessageApi::sendWelcomeMessage)
-            .whenInvokedWith(anything())
-            .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
-
-        given(mlsMessageApi)
-            .suspendFunction(mlsMessageApi::sendMessage)
-            .whenInvokedWith(anything())
-            .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
-
-        given(conversationDAO)
-            .suspendFunction(conversationDAO::updateConversationGroupState)
-            .whenInvokedWith(anything(), anything())
-            .thenDoNothing()
-
-        val result = mlsConversationRepository.establishMLSGroup(GROUP_ID)
-
+        val result = mlsConversationRepository.establishMLSGroup(Arrangement.GROUP_ID)
         result.shouldSucceed()
 
-        verify(MLS_CLIENT)
-            .function(MLS_CLIENT::createConversation)
-            .with(eq(GROUP_ID), anything())
+        verify(Arrangement.MLS_CLIENT)
+            .function(Arrangement.MLS_CLIENT::createConversation)
+            .with(eq(Arrangement.GROUP_ID), anything())
             .wasInvoked(once)
 
-        verify(mlsMessageApi).coroutine { sendWelcomeMessage(MLSMessageApi.WelcomeMessage(WELCOME)) }
+        verify(arrangement.mlsMessageApi).coroutine { sendWelcomeMessage(MLSMessageApi.WelcomeMessage(Arrangement.WELCOME)) }
             .wasInvoked(once)
 
-        verify(mlsMessageApi).coroutine { sendMessage(MLSMessageApi.Message(HANDSHAKE)) }
+        verify(arrangement.mlsMessageApi).coroutine { sendMessage(MLSMessageApi.Message(Arrangement.HANDSHAKE)) }
             .wasInvoked(once)
     }
 
     @Test
     fun givenExistingConversation_whenCallingEstablishMLSGroupFromWelcome_ThenGroupIsCreatedAndGroupStateIsUpdated() = runTest {
-        given(mlsClientProvider)
-            .suspendFunction(mlsClientProvider::getMLSClient)
-            .whenInvokedWith(anything())
-            .then { Either.Right(MLS_CLIENT) }
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withGetMLSClientSuccessful()
+            .withProcessWelcomeMessageSuccessful()
+            .withGetConversationByGroupIdSuccessful()
+            .withUpdateConversationGroupStateSuccessful()
+            .arrange()
 
-        given(MLS_CLIENT)
-            .function(MLS_CLIENT::processWelcomeMessage)
-            .whenInvokedWith(anything())
-            .thenReturn(GROUP_ID)
+        mlsConversationRepository.establishMLSGroupFromWelcome(Arrangement.WELCOME_EVENT).shouldSucceed()
 
-        given(conversationDAO)
-            .suspendFunction(conversationDAO::getConversationByGroupID)
-            .whenInvokedWith(anything())
-            .then { flowOf(TestConversation.ENTITY) }
-
-        given(conversationDAO)
-            .suspendFunction(conversationDAO::updateConversationGroupState)
-            .whenInvokedWith(anything(), anything())
-            .thenDoNothing()
-
-        mlsConversationRepository.establishMLSGroupFromWelcome(WELCOME_EVENT).shouldSucceed()
-
-        verify(MLS_CLIENT)
-            .function(MLS_CLIENT::processWelcomeMessage)
+        verify(Arrangement.MLS_CLIENT)
+            .function(Arrangement.MLS_CLIENT::processWelcomeMessage)
             .with(anyInstanceOf(ByteArray::class))
             .wasInvoked(once)
 
-        verify(conversationDAO)
-            .suspendFunction(conversationDAO::updateConversationGroupState)
-            .with(eq(ConversationEntity.GroupState.ESTABLISHED), eq(GROUP_ID))
+        verify(arrangement.conversationDAO)
+            .suspendFunction(arrangement.conversationDAO::updateConversationGroupState)
+            .with(eq(ConversationEntity.GroupState.ESTABLISHED), eq(Arrangement.GROUP_ID))
             .wasInvoked(once)
     }
 
     @Test
     fun givenNonExistingConversation_whenCallingEstablishMLSGroupFromWelcome_ThenGroupIsCreatedButConversationIsNotInserted() = runTest {
-        given(mlsClientProvider)
-            .suspendFunction(mlsClientProvider::getMLSClient)
-            .whenInvokedWith(anything())
-            .then { Either.Right(MLS_CLIENT) }
+        val (_, mlsConversationRepository) = Arrangement()
+            .withGetMLSClientSuccessful()
+            .withProcessWelcomeMessageSuccessful()
+            .withGetConversationByGroupIdFailing()
+            .arrange()
 
-        given(MLS_CLIENT)
-            .function(MLS_CLIENT::processWelcomeMessage)
-            .whenInvokedWith(anything())
-            .thenReturn(GROUP_ID)
+        mlsConversationRepository.establishMLSGroupFromWelcome(Arrangement.WELCOME_EVENT).shouldSucceed()
 
-        given(conversationDAO)
-            .suspendFunction(conversationDAO::getConversationByGroupID)
-            .whenInvokedWith(anything())
-            .then { flowOf(null) }
-
-        mlsConversationRepository.establishMLSGroupFromWelcome(WELCOME_EVENT).shouldSucceed()
-
-        verify(MLS_CLIENT)
-            .function(MLS_CLIENT::processWelcomeMessage)
+        verify(Arrangement.MLS_CLIENT)
+            .function(Arrangement.MLS_CLIENT::processWelcomeMessage)
             .with(anyInstanceOf(ByteArray::class))
             .wasInvoked(once)
     }
 
     @Test
     fun givenAnMLSConversationAndAPISucceeds_whenAddingMembersToConversation_thenShouldSucceed() = runTest {
-        given(keyPackageRepository)
-            .suspendFunction(keyPackageRepository::claimKeyPackages)
-            .whenInvokedWith(anything())
-            .then { Either.Right(listOf(KEY_PACKAGE)) }
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withClaimKeyPackagesSuccessful()
+            .withGetMLSClientSuccessful()
+            .withAddMLSMemberSuccessful()
+            .withSendWelcomeMessageSuccessful()
+            .withSendMLSMessageSuccessful()
+            .withInsertMemberSuccessful()
+            .arrange()
 
-        given(mlsClientProvider)
-            .suspendFunction(mlsClientProvider::getMLSClient)
-            .whenInvokedWith(anything())
-            .then { Either.Right(MLS_CLIENT) }
-
-        given(MLS_CLIENT)
-            .function(MLS_CLIENT::addMember)
-            .whenInvokedWith(anything(), anything())
-            .thenReturn(Pair(HANDSHAKE, WELCOME))
-
-        given(mlsMessageApi)
-            .suspendFunction(mlsMessageApi::sendWelcomeMessage)
-            .whenInvokedWith(anything())
-            .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
-
-        given(mlsMessageApi)
-            .suspendFunction(mlsMessageApi::sendMessage)
-            .whenInvokedWith(anything())
-            .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
-
-
-        given(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, String>())
-            .whenInvokedWith(anything(), anything())
-            .thenDoNothing()
-
-
-        val result = mlsConversationRepository.addMemberToMLSGroup(GROUP_ID, listOf(TestConversation.USER_ID1))
-
+        val result = mlsConversationRepository.addMemberToMLSGroup(Arrangement.GROUP_ID, listOf(TestConversation.USER_ID1))
         result.shouldSucceed()
 
-        verify(MLS_CLIENT)
-            .function(MLS_CLIENT::addMember)
-            .with(eq(GROUP_ID), anything())
+        verify(Arrangement.MLS_CLIENT)
+            .function(Arrangement.MLS_CLIENT::addMember)
+            .with(eq(Arrangement.GROUP_ID), anything())
             .wasInvoked(once)
 
-        verify(mlsMessageApi).coroutine { sendWelcomeMessage(MLSMessageApi.WelcomeMessage(WELCOME)) }
+        verify(arrangement.mlsMessageApi).coroutine { sendWelcomeMessage(MLSMessageApi.WelcomeMessage(Arrangement.WELCOME)) }
             .wasInvoked(once)
 
-        verify(mlsMessageApi).coroutine { sendMessage(MLSMessageApi.Message(HANDSHAKE)) }
+        verify(arrangement.mlsMessageApi).coroutine { sendMessage(MLSMessageApi.Message(Arrangement.HANDSHAKE)) }
             .wasInvoked(once)
 
-        verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, String>())
+        verify(arrangement.conversationDAO)
+            .suspendFunction(arrangement.conversationDAO::insertMembers, fun2<List<Member>, String>())
             .with(anything(), anything())
             .wasInvoked(exactly = once)
     }
 
+    class Arrangement() {
+        @Mock
+        val keyPackageRepository = mock(classOf<KeyPackageRepository>())
 
-    private companion object {
-        val GROUP_ID = "groupId"
-        val MEMBERS = listOf(Member(TestUser.ENTITY_ID, TODO()))
-        val KEY_PACKAGE = KeyPackageDTO(
-            "client1",
-            "wire.com",
-            "keyPackage",
-            "keyPackageRef",
-            "user1"
+        @Mock
+        val mlsClientProvider = mock(classOf<MLSClientProvider>())
+
+        @Mock
+        val conversationDAO = mock(classOf<ConversationDAO>())
+
+        @Mock
+        val mlsMessageApi = mock(classOf<MLSMessageApi>())
+
+        fun withGetConversationByGroupIdSuccessful() = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::getConversationByGroupID)
+                .whenInvokedWith(anything())
+                .then { flowOf(TestConversation.ENTITY) }
+        }
+
+        fun withGetConversationByGroupIdFailing() = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::getConversationByGroupID)
+                .whenInvokedWith(anything())
+                .then { flowOf(null) }
+        }
+
+        fun withGetAllMembersSuccessful() = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::getAllMembers)
+                .whenInvokedWith(anything())
+                .then { flowOf(MEMBERS) }
+        }
+
+        fun withInsertMemberSuccessful() = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, String>())
+                .whenInvokedWith(anything(), anything())
+                .thenDoNothing()
+        }
+
+        fun withClaimKeyPackagesSuccessful() = apply {
+            given(keyPackageRepository)
+                .suspendFunction(keyPackageRepository::claimKeyPackages)
+                .whenInvokedWith(anything())
+                .then { Either.Right(listOf(KEY_PACKAGE)) }
+        }
+
+        fun withGetMLSClientSuccessful() = apply {
+            given(mlsClientProvider)
+                .suspendFunction(mlsClientProvider::getMLSClient)
+                .whenInvokedWith(anything())
+                .then { Either.Right(MLS_CLIENT) }
+        }
+
+        fun withCreateMLSConversationSuccessful() = apply {
+            given(MLS_CLIENT)
+                .function(MLS_CLIENT::createConversation)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(Pair(HANDSHAKE, WELCOME))
+        }
+
+        fun withAddMLSMemberSuccessful() = apply {
+            given(MLS_CLIENT)
+                .function(MLS_CLIENT::addMember)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(Pair(HANDSHAKE, WELCOME))
+        }
+
+        fun withProcessWelcomeMessageSuccessful() = apply {
+            given(MLS_CLIENT)
+                .function(MLS_CLIENT::processWelcomeMessage)
+                .whenInvokedWith(anything())
+                .thenReturn(GROUP_ID)
+        }
+
+        fun withSendWelcomeMessageSuccessful() = apply {
+            given(mlsMessageApi)
+                .suspendFunction(mlsMessageApi::sendWelcomeMessage)
+                .whenInvokedWith(anything())
+                .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
+        }
+
+        fun withSendMLSMessageSuccessful() = apply {
+            given(mlsMessageApi)
+                .suspendFunction(mlsMessageApi::sendMessage)
+                .whenInvokedWith(anything())
+                .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
+        }
+
+        fun withUpdateConversationGroupStateSuccessful() = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::updateConversationGroupState)
+                .whenInvokedWith(anything(), anything())
+                .thenDoNothing()
+        }
+
+        fun arrange() = this to MLSConversationDataSource(
+            keyPackageRepository,
+            mlsClientProvider,
+            mlsMessageApi,
+            conversationDAO
         )
-        val MLS_CLIENT = mock(classOf<MLSClient>())
-        val WELCOME = "welcome".encodeToByteArray()
-        val HANDSHAKE = "handshake".encodeToByteArray()
-        val WELCOME_EVENT = Event.Conversation.MLSWelcome(
-            "eventId",
-            TestConversation.ID,
-            TestUser.USER_ID,
-            WELCOME.encodeBase64(),
-            timestampIso = "2022-03-30T15:36:00.000Z"
-        )
+
+        internal companion object {
+            val GROUP_ID = "groupId"
+            val MEMBERS = listOf(Member(TestUser.ENTITY_ID, Member.Role.Member))
+            val KEY_PACKAGE = KeyPackageDTO(
+                "client1",
+                "wire.com",
+                "keyPackage",
+                "keyPackageRef",
+                "user1"
+            )
+            val MLS_CLIENT = mock(classOf<MLSClient>())
+            val WELCOME = "welcome".encodeToByteArray()
+            val HANDSHAKE = "handshake".encodeToByteArray()
+            val WELCOME_EVENT = Event.Conversation.MLSWelcome(
+                "eventId",
+                TestConversation.ID,
+                TestUser.USER_ID,
+                WELCOME.encodeBase64(),
+                timestampIso = "2022-03-30T15:36:00.000Z"
+            )
+        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
@@ -26,20 +26,23 @@ class ProtocolInfoMapperTest {
     @Test
     fun givenEntityMLSProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
         val mappedValue = protocolInfoMapper.fromEntity(CONV_ENTITY_MLS_PROTOCOL_INFO)
-        assertIs<ProtocolInfo>(mappedValue)
+        assertIs<Conversation.ProtocolInfo>(mappedValue)
         assertEquals(mappedValue, CONVERSATION_MLS_PROTOCOL_INFO)
     }
 
     @Test
     fun givenEntityProteusProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
         val mappedValue = protocolInfoMapper.fromEntity(CONV_ENTITY_MLS_PROTOCOL_INFO)
-        assertIs<ProtocolInfo>(mappedValue)
+        assertIs<Conversation.ProtocolInfo>(mappedValue)
         assertEquals(mappedValue, CONVERSATION_MLS_PROTOCOL_INFO)
     }
 
     companion object {
-        val CONVERSATION_MLS_PROTOCOL_INFO = ProtocolInfo.MLS("GROUP_ID", groupState = ProtocolInfo.MLS.GroupState.ESTABLISHED, 5UL)
-        val CONVERSATION_PROTEUS_PROTOCOL_INFO = ProtocolInfo.Proteus
+        val CONVERSATION_MLS_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
+            "GROUP_ID",
+            Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED,
+            5UL)
+        val CONVERSATION_PROTEUS_PROTOCOL_INFO = Conversation.ProtocolInfo.Proteus
 
         val CONV_ENTITY_MLS_PROTOCOL_INFO =
             ConversationEntity.ProtocolInfo.MLS("GROUP_ID", groupState = ConversationEntity.GroupState.ESTABLISHED, 5UL)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
@@ -38,11 +38,11 @@ class ProtocolInfoMapperTest {
     }
 
     companion object {
-        val CONVERSATION_MLS_PROTOCOL_INFO = ProtocolInfo.MLS("GROUP_ID", groupState = ProtocolInfo.MLS.GroupState.ESTABLISHED)
+        val CONVERSATION_MLS_PROTOCOL_INFO = ProtocolInfo.MLS("GROUP_ID", groupState = ProtocolInfo.MLS.GroupState.ESTABLISHED, 5UL)
         val CONVERSATION_PROTEUS_PROTOCOL_INFO = ProtocolInfo.Proteus
 
         val CONV_ENTITY_MLS_PROTOCOL_INFO =
-            ConversationEntity.ProtocolInfo.MLS("GROUP_ID", groupState = ConversationEntity.GroupState.ESTABLISHED)
+            ConversationEntity.ProtocolInfo.MLS("GROUP_ID", groupState = ConversationEntity.GroupState.ESTABLISHED, 5UL)
         val CONV_ENTITY_PROTEUS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo.Proteus
 
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
@@ -135,7 +135,7 @@ class AddMemberToConversationUseCaseTest {
         companion object {
             const val mlsGroupId = "mlsGroupId"
             val proteusProtocolInfo = ProtocolInfo.Proteus
-            val mlsProtocolInfo = ProtocolInfo.MLS(mlsGroupId, groupState = ProtocolInfo.MLS.GroupState.ESTABLISHED)
+            val mlsProtocolInfo = ProtocolInfo.MLS(mlsGroupId, groupState = ProtocolInfo.MLS.GroupState.ESTABLISHED, 0UL)
 
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
-import com.wire.kalium.logic.data.conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.OtherUser

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -1,0 +1,144 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.twice
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class JoinExistingMLSConversationsUseCaseTest {
+
+    @Test
+    fun givenExistingConversations_whenInvokingUseCase_ThenRequestToJoinConversationIsCalledForAllConversations() =
+        runTest {
+            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+                .withGetConversationsByGroupStateSuccessful()
+                .withRequestToJoinMLSGroupSuccessful()
+                .arrange()
+
+            joinExistingMLSConversationsUseCase().shouldSucceed()
+
+            verify(arrangement.conversationRepository)
+                .suspendFunction(arrangement.conversationRepository::requestToJoinMLSGroup)
+                .with(eq(Arrangement.MLS_CONVERSATION1))
+
+            verify(arrangement.conversationRepository)
+                .suspendFunction(arrangement.conversationRepository::requestToJoinMLSGroup)
+                .with(eq(Arrangement.MLS_CONVERSATION2))
+        }
+
+    @Test
+    fun givenOutOfDateEpochFailure_whenInvokingUseCase_ThenRetryWithNewEpoch() = runTest {
+        val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+            .withGetConversationsByGroupStateSuccessful()
+            .withRequestToJoinMLSGroupSuccessful()
+            .withRequestToJoinMLSGroupFailing(Arrangement.MLS_STALE_MESSAGE_FAILURE, times = 1)
+            .withFetchConversationSuccessful()
+            .withGetConversationByIdSuccessful()
+            .arrange()
+
+        joinExistingMLSConversationsUseCase().shouldSucceed()
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::fetchConversation)
+            .with(eq(Arrangement.MLS_CONVERSATION1.id))
+            .wasInvoked(once)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::requestToJoinMLSGroup)
+            .with(eq(Arrangement.MLS_CONVERSATION1))
+            .wasInvoked(twice)
+
+    }
+
+    private class Arrangement {
+        @Mock
+        val conversationRepository = mock(classOf<ConversationRepository>())
+
+        fun arrange() = this to JoinExistingMLSConversationsUseCase(conversationRepository)
+
+        fun withGetConversationsByGroupStateSuccessful() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::getConversationsByGroupState)
+                .whenInvokedWith(anything())
+                .then { Either.Right(listOf(MLS_CONVERSATION1, MLS_CONVERSATION2)) }
+        }
+
+        fun withFetchConversationSuccessful() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::fetchConversation)
+                .whenInvokedWith(anything())
+                .then { Either.Right(Unit) }
+        }
+
+        fun withGetConversationByIdSuccessful() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::observeById)
+                .whenInvokedWith(anything())
+                .then { Either.Right(flowOf(MLS_CONVERSATION1)) }
+        }
+
+        fun withRequestToJoinMLSGroupSuccessful() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::requestToJoinMLSGroup)
+                .whenInvokedWith(anything())
+                .then { Either.Right(Unit) }
+        }
+
+        fun withRequestToJoinMLSGroupFailing(failure: CoreFailure, times: Int = Int.MAX_VALUE) = apply {
+            var invocationCounter = 0
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::requestToJoinMLSGroup)
+                .whenInvokedWith(matching { invocationCounter += 1; invocationCounter <= times })
+                .then { Either.Left(failure) }
+        }
+
+        companion object {
+            val MLS_STALE_MESSAGE_FAILURE = NetworkFailure.ServerMiscommunication(
+                KaliumException.InvalidRequestError(
+                    ErrorResponse(
+                        403,
+                        "The conversation epoch in a message is too old",
+                        "mls-stale-message"
+                    )
+                )
+            )
+
+            val MLS_CONVERSATION1 = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    "group1",
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 1UL
+                )
+            ).copy(id = ConversationId("id1", "domain"))
+
+            val MLS_CONVERSATION2 = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    "group1",
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 1UL
+                )
+            ).copy(id = ConversationId("id2", "domain"))
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -53,7 +53,7 @@ class JoinExistingMLSConversationsUseCaseTest {
     @Test
     fun givenOutOfDateEpochFailure_whenInvokingUseCase_ThenRetryWithNewEpoch() = runTest {
         val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
-            .withGetConversationsByGroupStateSuccessful()
+            .withGetConversationsByGroupStateSuccessful(conversations = listOf(Arrangement.MLS_CONVERSATION1))
             .withRequestToJoinMLSGroupSuccessful()
             .withRequestToJoinMLSGroupFailing(Arrangement.MLS_STALE_MESSAGE_FAILURE, times = 1)
             .withFetchConversationSuccessful()
@@ -90,12 +90,13 @@ class JoinExistingMLSConversationsUseCaseTest {
 
         fun arrange() = this to JoinExistingMLSConversationsUseCase(conversationRepository)
 
-        fun withGetConversationsByGroupStateSuccessful() = apply {
-            given(conversationRepository)
-                .suspendFunction(conversationRepository::getConversationsByGroupState)
-                .whenInvokedWith(anything())
-                .then { Either.Right(listOf(MLS_CONVERSATION1, MLS_CONVERSATION2)) }
-        }
+        fun withGetConversationsByGroupStateSuccessful(conversations: List<Conversation> = listOf(MLS_CONVERSATION1, MLS_CONVERSATION2)) =
+            apply {
+                given(conversationRepository)
+                    .suspendFunction(conversationRepository::getConversationsByGroupState)
+                    .whenInvokedWith(anything())
+                    .then { Either.Right(conversations) }
+            }
 
         fun withFetchConversationSuccessful() = apply {
             given(conversationRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -47,7 +47,7 @@ class JoinExistingMLSConversationsUseCaseTest {
             verify(arrangement.conversationRepository)
                 .suspendFunction(arrangement.conversationRepository::requestToJoinMLSGroup)
                 .with(eq(Arrangement.MLS_CONVERSATION2))
-                .wasInvoked(once
+                .wasInvoked(once)
         }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
-import com.wire.kalium.logic.data.conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -7,7 +7,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
-import com.wire.kalium.logic.data.conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.AssetContent

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -4,7 +4,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepositoryTest
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
-import com.wire.kalium.logic.data.conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -140,4 +140,17 @@ object TestConversation {
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST)
     )
+
+    val MLS_CONVERSATION = Conversation(
+        ConversationId("conv_id", "domain"),
+        "MLS Name",
+        Conversation.Type.ONE_ON_ONE,
+        TestTeam.TEAM_ID,
+        ProtocolInfo.MLS("group_id", ProtocolInfo.MLS.GroupState.PENDING_JOIN, 0UL),
+        MutedConversationStatus.AllAllowed,
+        null,
+        null,
+        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST)
+    )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -93,6 +93,7 @@ object TestConversation {
         ConversationRepositoryTest.GROUP_NAME,
         NETWORK_ID,
         null,
+        0UL,
         ConversationResponse.Type.GROUP,
         0,
         null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.logic.framework
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
-import com.wire.kalium.logic.data.conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.type.UserType
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationResponse.kt
@@ -25,6 +25,9 @@ data class ConversationResponse(
     @SerialName("group_id")
     val groupId: String?,
 
+    @SerialName("epoch")
+    val epoch: ULong?,
+
     @Serializable(with = ConversationTypeSerializer::class)
     val type: Type,
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -57,8 +57,6 @@ data class ProteusClientsChangedError(
     val errorBody: QualifiedSendMessageResponse.MissingDevicesResponse
 ) : KaliumException.FeatureError()
 
-
-
 fun KaliumException.InvalidRequestError.isInvalidCredentials(): Boolean {
     return errorResponse.label == INVALID_CREDENTIALS
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -14,6 +14,7 @@ import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_EMAIL
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_HANDLE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.KEY_EXISTS
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MISSING_AUTH
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_STALE_MESSAGE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.NO_TEAM
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.OPERATION_DENIED
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.TOO_MANY_CLIENTS
@@ -55,6 +56,8 @@ sealed class SendMessageError : KaliumException.FeatureError() {
 data class ProteusClientsChangedError(
     val errorBody: QualifiedSendMessageResponse.MissingDevicesResponse
 ) : KaliumException.FeatureError()
+
+
 
 fun KaliumException.InvalidRequestError.isInvalidCredentials(): Boolean {
     return errorResponse.label == INVALID_CREDENTIALS
@@ -118,4 +121,8 @@ fun KaliumException.InvalidRequestError.isNoTeam(): Boolean {
 
 fun KaliumException.InvalidRequestError.isOperationDenied(): Boolean {
     return errorResponse.label == OPERATION_DENIED
+}
+
+fun KaliumException.InvalidRequestError.isMlsStaleMessage(): Boolean {
+    return errorResponse.label == MLS_STALE_MESSAGE
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -16,6 +16,12 @@ internal object NetworkErrorLabel {
     const val HANDLE_EXISTS = "handle-exists"
     const val NO_TEAM = "no-team"
     const val OPERATION_DENIED = "operation-denied"
+    const val MLS_STALE_MESSAGE = "mls-stale-message"
+    const val MLS_SELF_REMOVAL_NOT_ALLOWED = "mls-self-removal-not-allowed"
+    const val MLS_COMMIT_MISSING_REFERENCES = "mls-commit-missing-references"
+    const val MLS_CLIENT_MISMATCH = "mls-client-mismatch"
+    const val MLS_UNSUPPORTED_PROPOSAL = "mls-unsupported-proposal"
+    const val MLS_KEY_PACKAGE_REF_NOT_FOUND = "mls-key-package-ref-not-found"
 
     object KaliumCustom {
         const val MISSING_REFRESH_TOKEN = "missing-refresh_token"

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationResponseJson.kt
@@ -62,6 +62,7 @@ object ConversationResponseJson {
             "group name",
             QualifiedIDSamples.one,
             "groupID",
+            0UL,
             ConversationResponse.Type.GROUP,
             null,
             "teamID",

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -9,6 +9,7 @@ CREATE TABLE Conversation (
     team_id TEXT,
     mls_group_id TEXT,
     mls_group_state TEXT AS ConversationEntity.GroupState NOT NULL,
+    mls_epoch INTEGER DEFAULT 0 NOT NULL,
     protocol TEXT AS ConversationEntity.Protocol NOT NULL,
     muted_status TEXT AS ConversationEntity.MutedStatus DEFAULT "ALL_ALLOWED" NOT NULL,
     muted_time INTEGER DEFAULT 0 NOT NULL,
@@ -25,13 +26,14 @@ deleteConversation:
 DELETE FROM Conversation WHERE qualified_id = ?;
 
 insertConversation:
-INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, protocol, muted_status, muted_time, last_modified_date, last_notified_message_date, access_list, access_role_list)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, last_modified_date, last_notified_message_date, access_list, access_role_list)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
 type = excluded.type,
 team_id = excluded.team_id,
 mls_group_id = excluded.mls_group_id,
+mls_epoch = excluded.mls_epoch,
 protocol = excluded.protocol,
 muted_status = excluded.muted_status,
 muted_time = excluded.muted_time,
@@ -68,6 +70,9 @@ SELECT * FROM Conversation WHERE qualified_id = ?;
 
 selectByGroupId:
 SELECT * FROM Conversation WHERE mls_group_id = ?;
+
+selectByGroupState:
+SELECT * FROM Conversation WHERE mls_group_state = ? AND protocol = ?;
 
 getConversationIdByGroupId:
 SELECT qualified_id FROM Conversation WHERE mls_group_id = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -21,7 +21,7 @@ data class ConversationEntity(
 
     enum class Type { SELF, ONE_ON_ONE, GROUP, CONNECTION_PENDING }
 
-    enum class GroupState { PENDING, PENDING_WELCOME_MESSAGE, ESTABLISHED }
+    enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
 
     enum class Protocol { PROTEUS, MLS }
 
@@ -29,7 +29,7 @@ data class ConversationEntity(
 
     sealed class ProtocolInfo {
         object Proteus : ProtocolInfo()
-        data class MLS(val groupId: String, val groupState: GroupState) : ProtocolInfo()
+        data class MLS(val groupId: String, val groupState: GroupState, val epoch: ULong) : ProtocolInfo()
     }
 }
 
@@ -60,6 +60,7 @@ interface ConversationDAO {
     suspend fun getAllConversationWithOtherUser(userId: UserIDEntity): List<ConversationEntity>
     suspend fun getConversationByGroupID(groupID: String): Flow<ConversationEntity?>
     suspend fun getConversationIdByGroupID(groupID: String): QualifiedIDEntity?
+    suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationEntity>
     suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity)
     suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity)
     suspend fun insertMembers(memberList: List<Member>, conversationID: QualifiedIDEntity)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -166,7 +166,6 @@ class ConversationDAOImpl(
             .executeAsList()
             .map(conversationMapper::toModel)
 
-
     override suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity) {
         conversationQueries.deleteConversation(qualifiedID)
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -44,6 +44,8 @@ class MemberMapper {
     }
 }
 
+private const val MLS_DEFAULT_EPOCH = 0L
+
 class ConversationDAOImpl(
     private val conversationQueries: ConversationsQueries,
     private val userQueries: UsersQueries,
@@ -82,7 +84,7 @@ class ConversationDAOImpl(
                 if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.groupState
                 else ConversationEntity.GroupState.ESTABLISHED,
                 if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.epoch.toLong()
-                else 0,
+                else MLS_DEFAULT_EPOCH,
                 if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) ConversationEntity.Protocol.MLS
                 else ConversationEntity.Protocol.PROTEUS,
                 mutedStatus,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -23,9 +23,9 @@ private class ConversationMapper {
             protocolInfo = when (protocol) {
                 ConversationEntity.Protocol.MLS -> ConversationEntity.ProtocolInfo.MLS(
                     mls_group_id ?: "",
-                    mls_group_state
+                    mls_group_state,
+                    mls_epoch.toULong()
                 )
-
                 ConversationEntity.Protocol.PROTEUS -> ConversationEntity.ProtocolInfo.Proteus
             },
             mutedStatus = muted_status,
@@ -79,12 +79,12 @@ class ConversationDAOImpl(
                 teamId,
                 if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.groupId
                 else null,
-
                 if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.groupState
                 else ConversationEntity.GroupState.ESTABLISHED,
+                if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.epoch.toLong()
+                else 0,
                 if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) ConversationEntity.Protocol.MLS
                 else ConversationEntity.Protocol.PROTEUS,
-
                 mutedStatus,
                 mutedTime,
                 lastModifiedDate,
@@ -160,6 +160,12 @@ class ConversationDAOImpl(
 
     override suspend fun getConversationIdByGroupID(groupID: String) =
         conversationQueries.getConversationIdByGroupId(groupID).executeAsOne()
+
+    override suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationEntity> =
+        conversationQueries.selectByGroupState(groupState, ConversationEntity.Protocol.MLS)
+            .executeAsList()
+            .map(conversationMapper::toModel)
+
 
     override suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity) {
         conversationQueries.deleteConversation(qualifiedID)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -325,7 +325,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             "conversation2",
             ConversationEntity.Type.ONE_ON_ONE,
             null,
-            ConversationEntity.ProtocolInfo.MLS("group2", ConversationEntity.GroupState.ESTABLISHED),
+            ConversationEntity.ProtocolInfo.MLS("group2", ConversationEntity.GroupState.ESTABLISHED, 0UL),
             lastNotificationDate = null,
             lastModifiedDate = "2021-03-30T15:36:00.000Z",
             mutedStatus = ConversationEntity.MutedStatus.ALL_MUTED,
@@ -338,7 +338,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             "conversation3",
             ConversationEntity.Type.GROUP,
             null,
-            ConversationEntity.ProtocolInfo.MLS("group3", ConversationEntity.GroupState.ESTABLISHED),
+            ConversationEntity.ProtocolInfo.MLS("group3", ConversationEntity.GroupState.ESTABLISHED, 0UL),
             // This conversation was modified after the last time the user was notified about it
             lastNotificationDate = "2021-03-30T15:30:00.000Z",
             lastModifiedDate = "2021-03-30T15:36:00.000Z",

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -255,8 +255,6 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         conversationDAO.insertConversation(conversationEntity1)
         conversationDAO.insertConversation(conversationEntity2)
-
-
         conversationDAO.insertMember(member1, conversationEntity1.id)
         conversationDAO.insertMember(member2, conversationEntity1.id)
         conversationDAO.getAllMembers(conversationEntity1.id).first().also { actual ->

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -75,6 +75,15 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenExistingMLSConversation_ThenConversationCanBeRetrievedByGroupState() = runTest {
+        conversationDAO.insertConversation(conversationEntity2)
+        conversationDAO.insertConversation(conversationEntity3)
+        val result =
+            conversationDAO.getConversationsByGroupState(ConversationEntity.GroupState.ESTABLISHED)
+        assertEquals(listOf(conversationEntity2), result)
+    }
+
+    @Test
     fun givenExistingConversation_ThenConversationGroupStateCanBeUpdated() = runTest {
         conversationDAO.insertConversation(conversationEntity2)
         conversationDAO.updateConversationGroupState(
@@ -338,7 +347,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             "conversation3",
             ConversationEntity.Type.GROUP,
             null,
-            ConversationEntity.ProtocolInfo.MLS("group3", ConversationEntity.GroupState.ESTABLISHED, 0UL),
+            ConversationEntity.ProtocolInfo.MLS("group3", ConversationEntity.GroupState.PENDING_JOIN, 0UL),
             // This conversation was modified after the last time the user was notified about it
             lastNotificationDate = "2021-03-30T15:30:00.000Z",
             lastModifiedDate = "2021-03-30T15:36:00.000Z",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Implements: [Use case: join existing conversation from a new device (MLS)](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/576454924/Use+case+join+existing+conversation+from+a+new+device+MLS)

During the slow sync we send a request to join all existing MLS conversations.

#### Todo:
- [x] Unit tests
- [x] Execute join requests in parallel

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

1. Login to an account which has previously been added to MLS conversations
2. Check the logs that we are sending request to join these conversations3. 
### Notes (Optional)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
