### PR TITLE
fix: disconnect websocket on live events flow cancellation [AR-1924]

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApiImpl.kt
@@ -11,23 +11,15 @@ import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.call.body
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.webSocket
-import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
-import io.ktor.http.HttpMethod
 import io.ktor.websocket.Frame
-import kotlinx.coroutines.channels.consume
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onCompletion
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 
 class NotificationApiImpl internal constructor(
@@ -53,7 +45,7 @@ class NotificationApiImpl internal constructor(
     ): NetworkResponse<NotificationResponse> =
         notificationsCall(querySize = querySize, queryClient = queryClient, querySince = querySince)
 
-    //TODO(refactor): rename this function. It gets the first page of notifications, not all of them.
+    // TODO(refactor): rename this function. It gets the first page of notifications, not all of them.
     override suspend fun getAllNotifications(querySize: Int, queryClient: String): NetworkResponse<NotificationResponse> =
         notificationsCall(querySize = querySize, queryClient = queryClient, querySince = null)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Take the following code for example:

```kt

val collectingJob = launch {
    notificationApi.listenToLiveEvents(clientId).collect {
        // Handle events
    }
}

// After a while, we cancel the collection, or the whole Scope it was launched in.
collectingjob.cancel()

```

When calling it, a WebSocket connection will be activated, events will be emitted, and after cancelling, **the connection won't be dropped**.

This sucks even more because the Backend won't send push notifications whilst the client has an active WebSocket connection.

### Causes

Ktor's function `webSocketSession()` returns a `WebSocketSession` that is its own `CoroutineScope`.

The scope of the flow collector isn't the same as the `WebSocketSession`. So this means that when cancelling the flow collection, the WebSocket will stay alive.

### Solutions

#### Simplest way

The simplest solution would be just adding `session.close()` inside the `onCompletion` that already exists, so it would be something like this:

```kt
.onCompletion {
    session.cancel()
    kaliumLogger.w("Websocket Closed", it)
    emit(WebSocketEvent.Close(it))
}
```

#### More complete solution

Instead I took a more sturdy approach and replaced `webSocketSession()` with Ktor's `webSocket()`, which does not create a different `CoroutineScope` at all and requires us to do all operations inside its curly braces.

### Testing

#### Test Coverage

- [ ] I have added automated test to this contribution

Unfortunately Ktor doesn't have a way to allow us to mock WebSocket servers in order to write tests.

#### How to Test

It's testable with running Reloaded with the changes in https://github.com/wireapp/kalium/pull/707, by setting the policy to `DISCONNECT_AFTER_PENDING_EVENTS`

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
