### PR TITLE
feat: start sync automagically (AR-1924)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
@@ -33,7 +33,7 @@ internal class LogoutDataSource(
     private val logoutApi: LogoutApi,
 ) : LogoutRepository {
 
-    private val logoutEventsChannel = Channel<LogoutReason>()
+    private val logoutEventsChannel = Channel<LogoutReason>(capacity = Channel.CONFLATED)
 
     override suspend fun observeLogout(): Flow<LogoutReason> = logoutEventsChannel.consumeAsFlow()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SyncRepository.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.updateAndGet
 
 internal interface SyncRepository {
-    val syncStateState: StateFlow<SyncState>
+    val syncState: StateFlow<SyncState>
     val connectionPolicyState: StateFlow<ConnectionPolicy>
     fun updateSyncState(updateBlock: (currentState: SyncState) -> SyncState): SyncState
     fun setConnectionPolicy(connectionPolicy: ConnectionPolicy)
@@ -16,7 +16,7 @@ internal interface SyncRepository {
 
 internal class InMemorySyncRepository : SyncRepository {
     private val _syncState = MutableStateFlow<SyncState>(SyncState.Waiting)
-    override val syncStateState get() = _syncState.asStateFlow()
+    override val syncState get() = _syncState.asStateFlow()
 
     private val _connectionPolicy = MutableStateFlow(ConnectionPolicy.KEEP_ALIVE)
     override val connectionPolicyState get() = _connectionPolicy.asStateFlow()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -90,6 +90,8 @@ import com.wire.kalium.logic.sync.FeatureConfigEventReceiver
 import com.wire.kalium.logic.sync.FeatureConfigEventReceiverImpl
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import com.wire.kalium.logic.sync.SetConnectionPolicyUseCase
+import com.wire.kalium.logic.sync.SyncCriteriaProvider
+import com.wire.kalium.logic.sync.SyncCriteriaProviderImpl
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.sync.SyncManagerImpl
 import com.wire.kalium.logic.sync.UserEventReceiver
@@ -283,12 +285,16 @@ abstract class UserSessionScopeCommon(
             conversationEventReceiver, userEventReceiver, featureConfigEventReceiver
         )
 
+    private val syncCriteriaProvider: SyncCriteriaProvider
+        get() = SyncCriteriaProviderImpl(clientRepository, logoutRepository)
+
     val syncManager: SyncManager by lazy {
         SyncManagerImpl(
             authenticatedDataSourceSet.userSessionWorkScheduler,
             syncRepository,
             eventProcessor,
-            eventGatherer
+            eventGatherer,
+            syncCriteriaProvider
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManager.kt
@@ -44,7 +44,7 @@ internal class KeyPackageManagerImpl(
 
     init {
         refillKeyPackageJob = refillKeyPackagesScope.launch {
-            syncRepository.syncStateState.collect { syncState ->
+            syncRepository.syncState.collect { syncState ->
                 ensureActive()
                 if (syncState == SyncState.Live) {
                     refillKeyPackagesIfNeeded()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
@@ -7,5 +7,5 @@ import kotlinx.coroutines.flow.Flow
 class ObserveSyncStateUseCase internal constructor(
     private val syncRepository: SyncRepository
 ) {
-    operator fun invoke(): Flow<SyncState> = syncRepository.syncStateState
+    operator fun invoke(): Flow<SyncState> = syncRepository.syncState
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SlowSyncWorker.kt
@@ -19,7 +19,8 @@ class SlowSyncWorker(
         kaliumLogger.withFeatureId(SYNC).d("Sync: Starting SlowSync")
 
         val result = try {
-            // todo : to move the feature configs call outside the sync
+            // TODO: to move the feature configs call outside the sync
+            // TODO(optimization): Handle cancellation
             userSessionScope.syncFeatureConfigsUseCase()
             userSessionScope.users.syncSelfUser()
                 .flatMap { userSessionScope.conversations.syncConversations() }
@@ -42,7 +43,6 @@ class SlowSyncWorker(
                 }
                 Result.Failure
             }
-
             is Either.Right -> {
                 kaliumLogger.withFeatureId(SYNC).i("SLOW SYNC SUCCESS $result")
                 Result.Success

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -32,7 +32,7 @@ interface SyncManager {
     @Deprecated(
         message = "SyncManager won't serve as a Sync Utils anymore",
         ReplaceWith(
-            expression = "SyncRepository.syncState.first { it is SyncState.Live }",
+            expression = "syncRepository.syncState.first { it is SyncState.Live }",
             imports = arrayOf(
                 "com.wire.kalium.logic.data.sync.SyncRepository",
                 "com.wire.kalium.logic.data.sync.SyncState"
@@ -52,7 +52,7 @@ interface SyncManager {
     @Deprecated(
         message = "SyncManager won't serve as a Sync Utils anymore",
         ReplaceWith(
-            expression = "SyncRepository.syncState.first { it in setOf(SyncState.GatheringPendingEvents, SyncState.Live) }",
+            expression = "syncRepository.syncState.first { it in setOf(SyncState.GatheringPendingEvents, SyncState.Live) }",
             imports = arrayOf(
                 "com.wire.kalium.logic.data.sync.SyncRepository",
                 "com.wire.kalium.logic.data.sync.SyncState"
@@ -74,7 +74,10 @@ interface SyncManager {
      * @see waitUntilLive
      * @see waitUntilSlowSyncCompletion
      */
-    @Deprecated("Sync can't be forced to start. It will be started automatically once conditions are met")
+    @Deprecated(
+        "Sync can't be forced to start. It will be started automatically once conditions are met",
+        ReplaceWith("")
+    )
     fun startSyncIfIdle()
     suspend fun isSlowSyncOngoing(): Boolean
     suspend fun isSlowSyncCompleted(): Boolean
@@ -182,28 +185,31 @@ internal class SyncManagerImpl(
     @Deprecated(
         "SyncManager won't serve as a Sync Utils anymore",
         replaceWith = ReplaceWith(
-            "SyncRepository.syncState.first { it is SyncState.Live }",
+            "syncRepository.syncState.first { it is SyncState.Live }",
             "com.wire.kalium.logic.data.sync.SyncRepository",
             "com.wire.kalium.logic.data.sync.SyncState"
         )
     )
     override suspend fun waitUntilLive() {
-        syncRepository.syncStateState.first { it == SyncState.Live }
+        syncRepository.syncState.first { it == SyncState.Live }
     }
 
     @Deprecated(
         "SyncManager won't serve as a Sync Utils anymore",
         replaceWith = ReplaceWith(
-            "SyncRepository.syncState.first { it in setOf(SyncState.GatheringPendingEvents, SyncState.Live) }",
+            "syncRepository.syncState.first { it in setOf(SyncState.GatheringPendingEvents, SyncState.Live) }",
             "com.wire.kalium.logic.data.sync.SyncRepository",
             "com.wire.kalium.logic.data.sync.SyncState"
         )
     )
     override suspend fun waitUntilSlowSyncCompletion() {
-        syncRepository.syncStateState.first { it in setOf(SyncState.GatheringPendingEvents, SyncState.Live) }
+        syncRepository.syncState.first { it in setOf(SyncState.GatheringPendingEvents, SyncState.Live) }
     }
 
-    @Deprecated("Sync can't be forced to start. It will be started automatically once conditions are met")
+    @Deprecated(
+        "Sync can't be forced to start. It will be started automatically once conditions are met",
+        ReplaceWith("")
+    )
     override fun startSyncIfIdle() {
         /** NO-OP **/
     }
@@ -215,12 +221,13 @@ internal class SyncManagerImpl(
                     userSessionWorkScheduler.enqueueSlowSyncIfNeeded()
                     SyncState.SlowSync
                 }
+
                 else -> it
             }
         }
     }
 
-    override suspend fun isSlowSyncOngoing(): Boolean = syncRepository.syncStateState.first() == SyncState.SlowSync
+    override suspend fun isSlowSyncOngoing(): Boolean = syncRepository.syncState.first() == SyncState.SlowSync
     override suspend fun isSlowSyncCompleted(): Boolean =
-        syncRepository.syncStateState.first() in setOf(SyncState.GatheringPendingEvents, SyncState.Live)
+        syncRepository.syncState.first() in setOf(SyncState.GatheringPendingEvents, SyncState.Live)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -29,16 +29,6 @@ interface SyncManager {
      * @see startSyncIfIdle
      * @see waitUntilSlowSyncCompletion
      */
-    @Deprecated(
-        message = "SyncManager won't serve as a Sync Utils anymore",
-        ReplaceWith(
-            expression = "syncRepository.syncState.first { it is SyncState.Live }",
-            imports = arrayOf(
-                "com.wire.kalium.logic.data.sync.SyncRepository",
-                "com.wire.kalium.logic.data.sync.SyncState"
-            ),
-        )
-    )
     suspend fun waitUntilLive()
 
     /**
@@ -182,14 +172,6 @@ internal class SyncManagerImpl(
 
     override fun onSlowSyncFailure(cause: CoreFailure) = syncRepository.updateSyncState { SyncState.Failed(cause) }
 
-    @Deprecated(
-        "SyncManager won't serve as a Sync Utils anymore",
-        replaceWith = ReplaceWith(
-            "syncRepository.syncState.first { it is SyncState.Live }",
-            "com.wire.kalium.logic.data.sync.SyncRepository",
-            "com.wire.kalium.logic.data.sync.SyncState"
-        )
-    )
     override suspend fun waitUntilLive() {
         syncRepository.syncState.first { it == SyncState.Live }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SyncRepositoryTest.kt
@@ -20,7 +20,7 @@ class SyncRepositoryTest {
         //Given
 
         //When
-        val result = syncRepository.syncStateState.first()
+        val result = syncRepository.syncState.first()
 
         //Then
         assertEquals(SyncState.Waiting, result)
@@ -33,7 +33,7 @@ class SyncRepositoryTest {
         syncRepository.updateSyncState { updatedState }
 
         //When
-        val result = syncRepository.syncStateState.first()
+        val result = syncRepository.syncState.first()
 
         //Then
         assertEquals(updatedState, result)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncManagerTest.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.sync
 
 import app.cash.turbine.test
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.sync.InMemorySyncRepository
 import com.wire.kalium.logic.data.sync.SyncRepository
 import com.wire.kalium.logic.data.sync.SyncState
@@ -15,50 +16,210 @@ import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
-import io.mockative.twice
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 @OptIn(ConfigurationApi::class, ExperimentalCoroutinesApi::class)
-@Ignore // Ignored until SyncManager is re-worked to use SyncCriteriaProvider
 class SyncManagerTest {
 
-    @Mock
-    private val workScheduler: UserSessionWorkScheduler = configure(mock(UserSessionWorkScheduler::class)) {
-        stubsUnitByDefault = true
+    @Test
+    fun givenSyncManagerWasCreated_whenSyncCriteriaAreMet_thenShouldStartSlowSync() = runTest(TestKaliumDispatcher.default) {
+        // Given
+        val syncCriteriaChannel = Channel<SyncCriteriaResolution>(Channel.UNLIMITED)
+
+        val (arrangement, _) = Arrangement()
+            .withCriteriaProviderReturning(syncCriteriaChannel.consumeAsFlow())
+            .arrange()
+
+        // When
+        syncCriteriaChannel.send(SyncCriteriaResolution.Ready)
+        advanceUntilIdle()
+
+        // Then
+        verify(arrangement.workScheduler)
+            .function(arrangement.workScheduler::enqueueSlowSyncIfNeeded)
+            .wasInvoked(exactly = once)
     }
 
-    @Mock
-    private val eventProcessor: EventProcessor =
-        configure(mock(EventProcessor::class)) { stubsUnitByDefault = true }
+    @Test
+    fun givenSyncManagerWasCreated_whenSyncCriteriaAreNotYetMet_thenShouldNotStartSlowSync() = runTest {
+        // Given
+        val syncCriteriaChannel = Channel<SyncCriteriaResolution>(Channel.UNLIMITED)
 
-    @Mock
-    private val eventGatherer: EventGatherer = mock(EventGatherer::class)
+        val (arrangement, _) = Arrangement()
+            .withCriteriaProviderReturning(syncCriteriaChannel.consumeAsFlow())
+            .arrange()
 
-    @Mock
-    private val syncCriteriaProvider: SyncCriteriaProvider = mock(SyncCriteriaProvider::class)
+        // When
+        syncCriteriaChannel.send(SyncCriteriaResolution.MissingRequirement("Test cause"))
 
-    private lateinit var syncRepository: SyncRepository
-    private lateinit var syncManager: SyncManager
+        // Then
+        verify(arrangement.workScheduler)
+            .function(arrangement.workScheduler::enqueueSlowSyncIfNeeded)
+            .wasNotInvoked()
+    }
 
-    @BeforeTest
-    fun setup() {
-        syncRepository = InMemorySyncRepository()
-        syncManager = SyncManagerImpl(
+    @Test
+    fun givenSyncCriteriaAreMet_whenCallingOnSlowSyncCompleted_thenShouldStartGatheringEvents() = runTest(TestKaliumDispatcher.default) {
+        // Given
+        val (arrangement, syncManager) = Arrangement()
+            .withSyncCriteriaMet()
+            .withEventGathererReturning(emptyFlow())
+            .arrange()
+
+        arrangement.syncRepository.syncState.test {
+            // starts with Waiting
+            assertIs<SyncState.Waiting>(awaitItem())
+
+            // When
+            syncManager.onSlowSyncComplete()
+            advanceUntilIdle()
+
+            // Then
+            assertIs<SyncState.GatheringPendingEvents>(awaitItem())
+
+            // A failure happens when live events close the flow
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Then
+        verify(arrangement.eventGatherer)
+            .suspendFunction(arrangement.eventGatherer::gatherEvents)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSyncCriteriaAreMet_whenSlowSyncIsNotYetCompleted_thenShouldNotGatherEvents() = runTest(TestKaliumDispatcher.default) {
+        // Given
+        val (arrangement, _) = Arrangement()
+            .withSyncCriteriaMet()
+            .withEventGathererReturning(emptyFlow())
+            .arrange()
+
+        arrangement.syncRepository.syncState.test {
+            // Then
+            assertIs<SyncState.Waiting>(awaitItem())
+
+            expectNoEvents()
+
+            // A failure happens when live events close the flow
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Then
+        verify(arrangement.eventGatherer)
+            .suspendFunction(arrangement.eventGatherer::gatherEvents)
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenSlowSyncCompletedAndAnEventIsReceived_whenSyncing_thenTheEventProcessorIsCalled() = runTest(TestKaliumDispatcher.default) {
+        // Given
+        val event = TestEvent.memberJoin()
+        val (arrangement, syncManager) = Arrangement()
+            .withSyncCriteriaMet()
+            .withEventGathererReturning(flowOf(event))
+            .arrange()
+
+        // When
+        syncManager.onSlowSyncComplete()
+        advanceUntilIdle()
+
+        // Then
+        verify(arrangement.eventProcessor)
+            .suspendFunction(arrangement.eventProcessor::processEvent)
+            .with(eq(event))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenGathererFails_whenSyncing_thenTheStatusIsUpdatedToFailed() = runTest(TestKaliumDispatcher.default) {
+        // Given
+        val coreFailureCause = NetworkFailure.NoNetworkConnection(null)
+        val (arrangement, syncManager) = Arrangement()
+            .withSyncCriteriaMet()
+            .withEventGathererThrowing(KaliumSyncException("Oopsie", coreFailureCause))
+            .arrange()
+
+        // When
+        syncManager.onSlowSyncComplete()
+        advanceUntilIdle()
+
+        assertEquals(SyncState.Failed(coreFailureCause), arrangement.syncRepository.syncState.first())
+    }
+
+    @Test
+    fun givenGathererFlowThrows_whenSyncing_thenTheStatusIsUpdatedToFailed() = runTest(TestKaliumDispatcher.default) {
+        // Given
+        val coreFailureCause = NetworkFailure.NoNetworkConnection(null)
+        val (arrangement, syncManager) = Arrangement()
+            .withSyncCriteriaMet()
+            .withEventGathererReturning(flow { throw throw KaliumSyncException("Oopsie", coreFailureCause) })
+            .arrange()
+
+        // When
+        syncManager.onSlowSyncComplete()
+        advanceUntilIdle()
+
+        assertEquals(SyncState.Failed(coreFailureCause), arrangement.syncRepository.syncState.first())
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val workScheduler: UserSessionWorkScheduler = configure(mock(UserSessionWorkScheduler::class)) {
+            stubsUnitByDefault = true
+        }
+
+        @Mock
+        val eventProcessor: EventProcessor = configure(mock(EventProcessor::class)) { stubsUnitByDefault = true }
+
+        @Mock
+        val eventGatherer: EventGatherer = mock(EventGatherer::class)
+
+        @Mock
+        val syncCriteriaProvider: SyncCriteriaProvider = mock(SyncCriteriaProvider::class)
+
+        val syncRepository: SyncRepository = InMemorySyncRepository()
+
+        fun withCriteriaProviderReturning(criteriaFlow: Flow<SyncCriteriaResolution>) = apply {
+            given(syncCriteriaProvider)
+                .suspendFunction(syncCriteriaProvider::syncCriteriaFlow)
+                .whenInvoked()
+                .thenReturn(criteriaFlow)
+        }
+
+        fun withSyncCriteriaMet() = apply {
+            withCriteriaProviderReturning(flowOf(SyncCriteriaResolution.Ready))
+        }
+
+        fun withEventGathererReturning(eventFlow: Flow<Event>) = apply {
+            given(eventGatherer)
+                .suspendFunction(eventGatherer::gatherEvents)
+                .whenInvoked()
+                .thenReturn(eventFlow)
+        }
+
+        fun withEventGathererThrowing(throwable: Throwable) = apply {
+            given(eventGatherer)
+                .suspendFunction(eventGatherer::gatherEvents)
+                .whenInvoked()
+                .thenThrow(throwable)
+        }
+
+        private val syncManager = SyncManagerImpl(
             workScheduler,
             syncRepository,
             eventProcessor,
@@ -66,295 +227,7 @@ class SyncManagerTest {
             syncCriteriaProvider,
             TestKaliumDispatcher
         )
-    }
 
-    @Test
-    fun givenSyncStatusWaiting_whenWaitingForSyncToComplete_thenShouldSuspendUntilCompletion() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        syncRepository.updateSyncState { SyncState.Waiting }
-
-        //When
-        val waitJob = launch {
-            syncManager.waitUntilLive()
-        }
-
-        //Then
-        // Is suspending
-        assertTrue(waitJob.isActive)
-
-        // Sync completes
-        syncRepository.updateSyncState { SyncState.Live }
-        waitJob.join()
-
-        // Stops suspending
-        assertFalse(waitJob.isActive)
-    }
-
-    @Test
-    fun givenSyncStatusWaiting_whenWaitingForSlowSyncToComplete_thenShouldSuspendUntilSlowSyncCompletion() =
-        runTest(TestKaliumDispatcher.default) {
-            //Given
-            syncRepository.updateSyncState { SyncState.Waiting }
-
-            //When
-            val waitJob = launch {
-                syncManager.waitUntilSlowSyncCompletion()
-            }
-
-            //Then
-            // Is suspending
-            assertTrue(waitJob.isActive)
-
-            // Sync completes
-            syncRepository.updateSyncState { SyncState.GatheringPendingEvents }
-            waitJob.join()
-
-            // Stops suspending
-            assertFalse(waitJob.isActive)
-        }
-
-    @Test
-    fun givenSyncStatusSlowSync_whenWaitingForSlowSyncToComplete_thenShouldSuspendUntilSlowSyncCompletion() =
-        runTest(TestKaliumDispatcher.default) {
-            //Given
-            syncRepository.updateSyncState { SyncState.SlowSync }
-
-            //When
-            val waitJob = launch {
-                syncManager.waitUntilSlowSyncCompletion()
-            }
-
-            //Then
-            // Is suspending
-            assertTrue(waitJob.isActive)
-
-            // Sync completes
-            syncRepository.updateSyncState { SyncState.GatheringPendingEvents }
-            waitJob.join()
-
-            // Stops suspending
-            assertFalse(waitJob.isActive)
-        }
-
-    @Test
-    fun givenSyncStatusIsFailed_whenWaitingForSyncToComplete_thenShouldSuspendUntilCompletion() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        syncRepository.updateSyncState { SyncState.Failed(NetworkFailure.NoNetworkConnection(null)) }
-
-        //When
-        val waitJob = launch {
-            syncManager.waitUntilLive()
-        }
-
-        //Then
-        // Is suspending
-        assertTrue(waitJob.isActive)
-
-        // Sync completes
-        syncRepository.updateSyncState { SyncState.Live }
-        waitJob.join()
-
-        // Stops suspending
-        assertFalse(waitJob.isActive)
-    }
-
-
-    @Test
-    fun givenSyncStatusIsLive_whenWaitingForSyncToComplete_thenShouldNotSuspend() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        syncRepository.updateSyncState { SyncState.Live }
-
-        //When
-        val waitJob = launch {
-            syncManager.waitUntilLive()
-        }
-
-        //Then
-        waitJob.join()
-        // Is not suspending
-        assertFalse(waitJob.isActive)
-    }
-
-    @Test
-    fun givenSyncIsFailed_whenWaitingForSyncToComplete_thenShouldStartSyncCallingTheScheduler() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        syncRepository.updateSyncState { SyncState.Failed(NetworkFailure.NoNetworkConnection(null)) }
-
-        //When
-        val waitJob = launch {
-            syncManager.waitUntilLive()
-        }
-        // Do stuff until there's no other job waiting
-        advanceUntilIdle()
-
-        // Sync completes
-        syncRepository.updateSyncState { SyncState.Live }
-        waitJob.join()
-
-        //Then
-        verify(workScheduler)
-            .function(workScheduler::enqueueSlowSyncIfNeeded)
-            .wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenSyncStatusIsLive_whenStartingSync_thenShouldNotCallTheSlowSyncScheduler() = runTest(TestKaliumDispatcher.default) {
-        syncRepository.updateSyncState { SyncState.Live }
-
-        syncManager.startSyncIfIdle()
-
-        verify(workScheduler)
-            .function(workScheduler::enqueueSlowSyncIfNeeded)
-            .wasNotInvoked()
-    }
-
-    @Test
-    fun givenSyncStatusIsGatheringPendingEvents_whenStartingSync_thenShouldNotCallTheSlowSyncScheduler() =
-        runTest(TestKaliumDispatcher.default) {
-            syncRepository.updateSyncState { SyncState.GatheringPendingEvents }
-
-            syncManager.startSyncIfIdle()
-
-            verify(workScheduler)
-                .function(workScheduler::enqueueSlowSyncIfNeeded)
-                .wasNotInvoked()
-        }
-
-    @Test
-    fun givenSyncStatusIsSlowSync_whenStartingSync_thenShouldNotCallTheSlowSyncScheduler() = runTest(TestKaliumDispatcher.default) {
-        syncRepository.updateSyncState { SyncState.SlowSync }
-
-        syncManager.startSyncIfIdle()
-
-        verify(workScheduler)
-            .function(workScheduler::enqueueSlowSyncIfNeeded)
-            .wasNotInvoked()
-    }
-
-    @Test
-    fun givenSyncIsFailed_whenStartingSync_thenShouldCallTheSlowSyncScheduler() = runTest(TestKaliumDispatcher.default) {
-        syncRepository.updateSyncState { SyncState.Failed(NetworkFailure.NoNetworkConnection(null)) }
-
-        syncManager.startSyncIfIdle()
-
-        verify(workScheduler)
-            .function(workScheduler::enqueueSlowSyncIfNeeded)
-            .wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenSyncIsWaiting_whenStartingSync_thenShouldCallTheSlowSyncScheduler() = runTest(TestKaliumDispatcher.default) {
-        syncRepository.updateSyncState { SyncState.Waiting }
-
-        syncManager.startSyncIfIdle()
-
-        verify(workScheduler)
-            .function(workScheduler::enqueueSlowSyncIfNeeded)
-            .wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenSlowSyncCompleted_whenCallingOnSlowSyncCompleted_thenShouldStartGatheringEvents() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        syncRepository.updateSyncState { SyncState.SlowSync }
-
-        given(eventGatherer)
-            .suspendFunction(eventGatherer::gatherEvents)
-            .whenInvoked()
-            .thenReturn(emptyFlow())
-
-        syncRepository.syncStateState.test {
-            assertIs<SyncState.SlowSync>(awaitItem())
-
-            //When
-            syncManager.onSlowSyncComplete()
-            advanceUntilIdle()
-
-            //Then
-            assertIs<SyncState.GatheringPendingEvents>(awaitItem())
-
-            // A failure happens when live events close the flow
-            cancelAndIgnoreRemainingEvents()
-        }
-
-        //Then
-        verify(eventGatherer)
-            .suspendFunction(eventGatherer::gatherEvents)
-            .wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenSlowSyncCompletedAndAnEventIsReceived_whenSyncing_thenTheEventProcessorIsCalled() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        val event = TestEvent.memberJoin()
-
-        given(eventGatherer)
-            .suspendFunction(eventGatherer::gatherEvents)
-            .whenInvoked()
-            .thenReturn(flowOf(event))
-
-        //When
-        syncManager.onSlowSyncComplete()
-        advanceUntilIdle()
-
-        //Then
-        verify(eventProcessor)
-            .suspendFunction(eventProcessor::processEvent)
-            .with(eq(event))
-            .wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenGathererFails_whenSyncing_thenTheStatusIsUpdatedToFailed() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        val coreFailureCause = NetworkFailure.NoNetworkConnection(null)
-        given(eventGatherer)
-            .suspendFunction(eventGatherer::gatherEvents)
-            .whenInvoked()
-            .thenThrow(KaliumSyncException("Oopsie", coreFailureCause))
-
-        //When
-        syncManager.onSlowSyncComplete()
-        advanceUntilIdle()
-
-        assertEquals(SyncState.Failed(coreFailureCause), syncRepository.syncStateState.first())
-    }
-
-    @Test
-    fun givenGathererFlowThrows_whenSyncing_thenTheStatusIsUpdatedToFailed() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        val coreFailureCause = NetworkFailure.NoNetworkConnection(null)
-        given(eventGatherer)
-            .suspendFunction(eventGatherer::gatherEvents)
-            .whenInvoked()
-            .thenReturn(flow { throw KaliumSyncException("Oopsie", coreFailureCause) })
-
-        //When
-        syncManager.onSlowSyncComplete()
-        advanceUntilIdle()
-
-        assertEquals(SyncState.Failed(coreFailureCause), syncRepository.syncStateState.first())
-    }
-
-    @Test
-    fun givenGathererFails_whenSyncingForTheSecondTime_thenShouldGatherAgain() = runTest(TestKaliumDispatcher.default) {
-        //Given
-        val coreFailureCause = NetworkFailure.NoNetworkConnection(null)
-        given(eventGatherer)
-            .suspendFunction(eventGatherer::gatherEvents)
-            .whenInvoked()
-            .thenThrow(KaliumSyncException("Oopsie", coreFailureCause))
-
-        //When
-        syncManager.onSlowSyncComplete()
-        // Fails
-        advanceUntilIdle()
-        // Try Again
-        syncManager.onSlowSyncComplete()
-        advanceUntilIdle()
-
-        verify(eventGatherer)
-            .suspendFunction(eventGatherer::gatherEvents)
-            .wasInvoked(exactly = twice)
+        fun arrange() = this to syncManager
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncManagerTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -33,6 +34,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 @OptIn(ConfigurationApi::class, ExperimentalCoroutinesApi::class)
+@Ignore // Ignored until SyncManager is re-worked to use SyncCriteriaProvider
 class SyncManagerTest {
 
     @Mock
@@ -47,6 +49,9 @@ class SyncManagerTest {
     @Mock
     private val eventGatherer: EventGatherer = mock(EventGatherer::class)
 
+    @Mock
+    private val syncCriteriaProvider: SyncCriteriaProvider = mock(SyncCriteriaProvider::class)
+
     private lateinit var syncRepository: SyncRepository
     private lateinit var syncManager: SyncManager
 
@@ -58,6 +63,7 @@ class SyncManagerTest {
             syncRepository,
             eventProcessor,
             eventGatherer,
+            syncCriteriaProvider,
             TestKaliumDispatcher
         )
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to call `SyncManager` everywhere in the code.

### Solutions

- Start using the newly added mechanisms, like `SyncCriteriaProvider` to start Sync automatically.
- Disable `startSyncIfIdle` and deprecate similar functions in `SyncManager` so they can be removed in a future PR.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

Also, tested manually on Reloaded using these changes.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
