### PR TITLE
feat: request strong box keystore for EncryptedSharedPreferences

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
     const val ktxDateTime = "0.3.2"
     const val ktxSerialization = "1.3.2"
     const val multiplatformSettings = "0.8.1"
-    const val androidSecurity = "1.0.0"
+    const val androidSecurity = "1.1.0-alpha03"
     const val sqlDelight = "2.0.0-alpha01"
     const val pbandk = "0.14.1"
     const val turbine = "0.7.0"

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
@@ -2,20 +2,26 @@ package com.wire.kalium.persistence.kmm_settings
 
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import androidx.security.crypto.MasterKeys
 import com.russhwolf.settings.AndroidSettings
 import com.russhwolf.settings.Settings
 
 actual class EncryptedSettingsHolder(
-    applicationContext: Context,
-    options: SettingOptions,
-    masterKeyAlias: String = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+    private val applicationContext: Context,
+    options: SettingOptions
 ) {
+    private fun getOrCreateMasterKey(): MasterKey = MasterKey
+        .Builder(applicationContext)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .setRequestStrongBoxBacked(true)
+        .build()
+
     actual val encryptedSettings: Settings = AndroidSettings(
         EncryptedSharedPreferences.create(
-            options.fileName,
-            masterKeyAlias,
             applicationContext,
+            options.fileName,
+            getOrCreateMasterKey(),
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         ), false

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
@@ -3,7 +3,6 @@ package com.wire.kalium.persistence.kmm_settings
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
-import androidx.security.crypto.MasterKeys
 import com.russhwolf.settings.AndroidSettings
 import com.russhwolf.settings.Settings
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

encryption keys created by `KeyStore` are not using strongbox when available 

### Solutions

update android crypto library and use `.setRequestStrongBoxBacked(true)` when creating a encryption key

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
