### PR TITLE
fix: remove self user from public self user search

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
@@ -52,10 +52,12 @@ internal interface SearchUserRepository {
 
 data class SearchUsersOptions(
     val conversationExcluded: ConversationMemberExcludedOptions,
+    val selfUserIncluded: Boolean
 ) {
     companion object {
         val Default = SearchUsersOptions(
             conversationExcluded = ConversationMemberExcludedOptions.None,
+            selfUserIncluded = false
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
@@ -133,12 +133,13 @@ internal class SearchUserRepositoryImpl(
                 userDetailsApi.getMultipleUsers(ListUserRequest.qualifiedIds(it.documents.map { it.qualifiedID }))
             }.map { userDetailsResponses ->
                 val selfUser = getSelfUser()
+
                 UserSearchResult(userDetailsResponses.map { userProfileDTO ->
                     publicUserMapper.fromUserDetailResponseWithUsertype(
                         userDetailResponse = userProfileDTO,
                         userType = userTypeMapper.fromOtherUserTeamAndDomain(
                             otherUserDomain = userProfileDTO.id.domain,
-                            selfUserTeamId = getSelfUser().teamId?.value,
+                            selfUserTeamId = selfUser.teamId?.value,
                             otherUserTeamId = userProfileDTO.teamId,
                             selfUserDomain = selfUser.id.domain
                         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapper.kt
@@ -81,7 +81,7 @@ internal class UserSearchApiWrapperImpl(
                     val isConversationMember = conversationMembersId?.contains(domainId) ?: false
                     val isSelfUser = selfUser.id == domainId
 
-                    // neglate it because that is exactly what we do not want to have in filter results
+                    // negate it because that is exactly what we do not want to have in filter results
                     !(isConversationMember || isSelfUser)
                 }
             } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapper.kt
@@ -2,6 +2,9 @@ package com.wire.kalium.logic.data.publicuser
 
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserDataSource
+import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
@@ -10,7 +13,15 @@ import com.wire.kalium.network.api.contact.search.UserSearchApi
 import com.wire.kalium.network.api.contact.search.UserSearchRequest
 import com.wire.kalium.network.api.contact.search.UserSearchResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
+import com.wire.kalium.persistence.dao.MetadataDAO
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserDAO
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 internal interface UserSearchApiWrapper {
     /*
@@ -28,6 +39,9 @@ internal interface UserSearchApiWrapper {
 internal class UserSearchApiWrapperImpl(
     private val userSearchApi: UserSearchApi,
     private val conversationDAO: ConversationDAO,
+    private val userDAO: UserDAO,
+    private val metadataDAO: MetadataDAO,
+    private val userMapper: UserMapper = MapperProvider.userMapper(),
     private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : UserSearchApiWrapper {
 
@@ -36,9 +50,8 @@ internal class UserSearchApiWrapperImpl(
         domain: String,
         maxResultSize: Int?,
         searchUsersOptions: SearchUsersOptions
-    ): Either<NetworkFailure, UserSearchResponse> {
-
-        val searchResponse = wrapApiRequest {
+    ): Either<NetworkFailure, UserSearchResponse> =
+        wrapApiRequest {
             userSearchApi.search(
                 UserSearchRequest(
                     searchQuery = searchQuery,
@@ -46,26 +59,57 @@ internal class UserSearchApiWrapperImpl(
                     maxResultSize = maxResultSize
                 )
             )
+        }.map { userSearchResponse ->
+            filter(userSearchResponse, searchUsersOptions)
         }
 
-        return if (searchUsersOptions.conversationExcluded is ConversationMemberExcludedOptions.ConversationExcluded) {
-            val conversationMembersId = conversationDAO.getAllMembers(
-                qualifiedID = idMapper.toDaoModel(qualifiedID = searchUsersOptions.conversationExcluded.conversationId)
-            ).firstOrNull()?.map { idMapper.fromDaoModel(it.user) }
+    private suspend fun filter(
+        userSearchResponse: UserSearchResponse,
+        searchUsersOptions: SearchUsersOptions
+    ): UserSearchResponse {
+        val selfUser = getSelfUser()
 
-            searchResponse.map {
-                val filteredContactResponse = it.documents.filter { contactDTO ->
-                    !(conversationMembersId?.contains(idMapper.fromApiModel(contactDTO.qualifiedID)) ?: false)
+        val filteredContactResponse =
+            if (searchUsersOptions.conversationExcluded is ConversationMemberExcludedOptions.ConversationExcluded) {
+                val conversationMembersId = conversationDAO.getAllMembers(
+                    qualifiedID = idMapper.toDaoModel(qualifiedID = searchUsersOptions.conversationExcluded.conversationId)
+                ).firstOrNull()?.map { idMapper.fromDaoModel(it.user) }
+
+                userSearchResponse.documents.filter { contactDTO ->
+                    val domainId = idMapper.fromApiModel(contactDTO.qualifiedID)
+
+                    val isNotMemberOfConversation = !(conversationMembersId?.contains(domainId) ?: false)
+                    val isNotSelfUser = selfUser.id != domainId
+
+                    isNotMemberOfConversation || isNotSelfUser
                 }
+            } else {
+                userSearchResponse.documents.filter { contactDTO ->
+                    val domainId = idMapper.fromApiModel(contactDTO.qualifiedID)
 
-                it.copy(
-                    documents = filteredContactResponse,
-                    found = filteredContactResponse.size,
-                    returned = filteredContactResponse.size
-                )
+                    selfUser.id != domainId
+                }
             }
-        } else {
-            searchResponse
-        }
+
+        return userSearchResponse.copy(
+            documents = filteredContactResponse,
+            found = filteredContactResponse.size,
+            returned = filteredContactResponse.size
+        )
+    }
+
+    // TODO: code duplication here for getting self user, the same is done inside
+    // UserRepository and SearchUserReopsitory what would be best ?
+    // creating SelfUserDao managing the UserEntity corresponding to SelfUser ?
+    private suspend fun getSelfUser(): SelfUser {
+        return metadataDAO.valueByKey(UserDataSource.SELF_USER_ID_KEY)
+            .filterNotNull()
+            .flatMapMerge { encodedValue ->
+                val selfUserID: QualifiedIDEntity = Json.decodeFromString(encodedValue)
+
+                userDAO.getUserByQualifiedID(selfUserID)
+                    .filterNotNull()
+                    .map(userMapper::fromDaoModelToSelfUser)
+            }.firstOrNull() ?: throw IllegalStateException()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapper.kt
@@ -78,10 +78,11 @@ internal class UserSearchApiWrapperImpl(
                 userSearchResponse.documents.filter { contactDTO ->
                     val domainId = idMapper.fromApiModel(contactDTO.qualifiedID)
 
-                    val isNotMemberOfConversation = !(conversationMembersId?.contains(domainId) ?: false)
-                    val isNotSelfUser = selfUser.id != domainId
+                    val isConversationMember = conversationMembersId?.contains(domainId) ?: false
+                    val isSelfUser = selfUser.id == domainId
 
-                    isNotMemberOfConversation || isNotSelfUser
+                    // neglate it because that is exactly what we do not want to have in filter results
+                    !(isConversationMember || isSelfUser)
                 }
             } else {
                 userSearchResponse.documents.filter { contactDTO ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -198,6 +198,8 @@ abstract class UserSessionScopeCommon(
     private val userSearchApiWrapper: UserSearchApiWrapper = UserSearchApiWrapperImpl(
         authenticatedDataSourceSet.authenticatedNetworkContainer.userSearchApi,
         userDatabaseProvider.conversationDAO,
+        userDatabaseProvider.userDAO,
+        userDatabaseProvider.metadataDAO
     )
 
     private val publicUserRepository: SearchUserRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchUsersUseCase.kt
@@ -4,7 +4,6 @@ import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.id.parseIntoQualifiedID
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.network.exceptions.KaliumException
 import io.ktor.http.HttpStatusCode

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchUsersUseCase.kt
@@ -18,9 +18,8 @@ interface SearchUsersUseCase {
 }
 
 internal class SearchUsersUseCaseImpl(
-    private val userRepository: UserRepository,
     private val searchUserRepository: SearchUserRepository,
-    private val connectionRepository: ConnectionRepository,
+    private val connectionRepository: ConnectionRepository
 ) : SearchUsersUseCase {
 
     override suspend operator fun invoke(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchUsersUseCase.kt
@@ -52,6 +52,3 @@ internal class SearchUsersUseCaseImpl(
         })
     }
 }
-
-
-

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -35,7 +35,7 @@ class UserScope internal constructor(
     val syncSelfUser: SyncSelfUserUseCase get() = SyncSelfUserUseCase(userRepository)
     val syncContacts: SyncContactsUseCase get() = SyncContactsUseCaseImpl(userRepository)
     val uploadUserAvatar: UploadUserAvatarUseCase get() = UploadUserAvatarUseCaseImpl(userRepository, assetRepository)
-    val searchUsers: SearchUsersUseCase get() = SearchUsersUseCaseImpl(userRepository, searchUserRepository, connectionRepository)
+    val searchUsers: SearchUsersUseCase get() = SearchUsersUseCaseImpl(searchUserRepository, connectionRepository)
     val searchKnownUsers: SearchKnownUsersUseCase get() = SearchKnownUsersUseCaseImpl(searchUserRepository, userRepository)
     val getPublicAsset: GetAvatarAssetUseCase get() = GetAvatarAssetUseCaseImpl(assetRepository)
     val searchUserDirectory: SearchUserDirectoryUseCase get() = SearchUserDirectoryUseCaseImpl(searchUserRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -372,8 +372,9 @@ class SearchUserRepositoryTest {
                 searchQuery = "someQuery",
                 searchUsersOptions = SearchUsersOptions(
                     conversationExcluded = ConversationMemberExcludedOptions.ConversationExcluded(
-                        ConversationId("someValue", "someDomain")
-                    )
+                        ConversationId("someValue", "someDomain"),
+                    ),
+                    selfUserIncluded = true
                 )
             )
 
@@ -407,7 +408,8 @@ class SearchUserRepositoryTest {
             searchUsersOptions = SearchUsersOptions(
                 conversationExcluded = ConversationMemberExcludedOptions.ConversationExcluded(
                     ConversationId("someValue", "someDomain")
-                )
+                ),
+                selfUserIncluded = true
             )
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
@@ -126,7 +126,7 @@ class UserSearchApiWrapperTest {
         val (_, userSearchApiWrapper) = Arrangement().withSuccessConversationExcludedFullSearch(
             conversationMembers,
             searchResultUsers,
-
+            selfUser
             ).arrange()
 
         val result = userSearchApiWrapper.search(
@@ -160,6 +160,7 @@ class UserSearchApiWrapperTest {
         )
 
         val expectedResult = listOf(
+            Arrangement.generateContactDTO(UserId("value1", "someDomain")),
             Arrangement.generateContactDTO(UserId("value2", "someDomain")),
             Arrangement.generateContactDTO(UserId("value3", "someDomain"))
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
@@ -479,7 +479,7 @@ class UserSearchApiWrapperTest {
                 previewAssetId = null,
                 completeAssetId = null,
                 availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
-                userTypEntity = UserTypeEntity.EXTERNAL
+                userType = UserTypeEntity.EXTERNAL
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -33,16 +33,16 @@ class SearchKnownUserUseCaseTest {
 
     @Test
     fun givenAnInputStartingWithAtSymbol_whenSearchingUsers_thenSearchOnlyByHandle() = runTest {
-        //given
+        // given
         val handleSearchQuery = "@someHandle"
 
         val (arrangement, searchKnownUsersUseCase) = Arrangement()
             .withSuccessFullSelfUserRetrieve()
             .withSearchByHandle(handleSearchQuery).arrange()
 
-        //when
+        // when
         searchKnownUsersUseCase(handleSearchQuery)
-        //then
+        // then
         verify(arrangement.searchUserRepository)
             .suspendFunction(arrangement.searchUserRepository::searchKnownUsersByHandle)
             .with(eq(handleSearchQuery), anything())
@@ -56,16 +56,16 @@ class SearchKnownUserUseCaseTest {
 
     @Test
     fun givenNormalInput_whenSearchingUsers_thenSearchByNameOrHandleOrEmail() = runTest {
-        //given
+        // given
         val searchQuery = "someSearchQuery"
 
         val (arrangement, searchKnownUsersUseCase) = Arrangement()
             .withSuccessFullSelfUserRetrieve()
             .withSearchKnownUsersByNameOrHandleOrEmail(searchQuery)
             .arrange()
-        //when
+        // when
         searchKnownUsersUseCase(searchQuery)
-        //then
+        // then
         with(arrangement) {
             verify(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchKnownUsersByHandle)
@@ -81,16 +81,16 @@ class SearchKnownUserUseCaseTest {
 
     @Test
     fun givenFederatedInput_whenSearchingUsers_thenSearchByNameOrHandleOrEmail() = runTest {
-        //given
+        // given
         val searchQuery = "someSearchQuery@wire.com"
 
         val (arrangement, searchKnownUsersUseCase) = Arrangement()
             .withSuccessFullSelfUserRetrieve()
             .withSearchKnownUsersByNameOrHandleOrEmail()
             .arrange()
-        //when
+        // when
         searchKnownUsersUseCase(searchQuery)
-        //then
+        // then
         with(arrangement) {
             verify(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchKnownUsersByHandle)
@@ -106,7 +106,7 @@ class SearchKnownUserUseCaseTest {
 
     @Test
     fun test() = runTest {
-        //given
+        // given
         val searchQuery = "someSearchQuery"
 
         val selfUserId = QualifiedID(
@@ -133,16 +133,16 @@ class SearchKnownUserUseCaseTest {
             .withSuccessFullSelfUserRetrieve(selfUserId)
             .withSearchKnownUsersByNameOrHandleOrEmail(searchQuery, otherUserContainingSelfUserId)
             .arrange()
-        //when
+        // when
         val result = searchKnownUsersUseCase(searchQuery)
-        //then
+        // then
         assertIs<Result.Success>(result)
         assertFalse(result.userSearchResult.result.contains(otherUserContainingSelfUserId))
     }
 
     @Test
     fun givenSearchingForHandleWithConversationExcluded_whenSearchingUsers_ThenPropagateTheSearchOption() = runTest {
-        //given
+        // given
         val searchQuery = "@someHandle"
 
         val searchUsersOptions = SearchUsersOptions(
@@ -163,13 +163,13 @@ class SearchKnownUserUseCaseTest {
             )
             .arrange()
 
-        //when
+        // when
         val result = searchKnownUsersUseCase(
             searchQuery = searchQuery,
             searchUsersOptions = searchUsersOptions
         )
 
-        //then
+        // then
         assertIs<Result.Success>(result)
         verify(arrangement.searchUserRepository)
             .suspendFunction(arrangement.searchUserRepository::searchKnownUsersByHandle)
@@ -179,7 +179,7 @@ class SearchKnownUserUseCaseTest {
 
     @Test
     fun givenSearchingForNameOrHandleOrEmailWithConversationExcluded_whenSearchingUsers_ThenPropagateTheSearchOption() = runTest {
-        //given
+        // given
         val searchQuery = "someSearchQuery"
 
         val searchUsersOptions = SearchUsersOptions(
@@ -199,13 +199,13 @@ class SearchKnownUserUseCaseTest {
             )
             .arrange()
 
-        //when
+        // when
         val result = searchKnownUsersUseCase(
             searchQuery = searchQuery,
             searchUsersOptions = searchUsersOptions
         )
 
-        //then
+        // then
         assertIs<Result.Success>(result)
         verify(arrangement.searchUserRepository)
             .suspendFunction(arrangement.searchUserRepository::searchKnownUsersByNameOrHandleOrEmail)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -148,7 +148,8 @@ class SearchKnownUserUseCaseTest {
         val searchUsersOptions = SearchUsersOptions(
             ConversationMemberExcludedOptions.ConversationExcluded(
                 ConversationId("someValue", "someDomain")
-            )
+            ),
+            selfUserIncluded = false
         )
 
         val (arrangement, searchKnownUsersUseCase) = Arrangement()
@@ -184,7 +185,7 @@ class SearchKnownUserUseCaseTest {
         val searchUsersOptions = SearchUsersOptions(
             ConversationMemberExcludedOptions.ConversationExcluded(
                 ConversationId("someValue", "someDomain")
-            )
+            ), selfUserIncluded = false
         )
 
         val (arrangement, searchKnownUsersUseCase) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -325,4 +325,3 @@ class SearchKnownUserUseCaseTest {
         }
     }
 }
-

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
@@ -4,11 +4,8 @@ import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
-<<<<<<< HEAD
-=======
 import com.wire.kalium.logic.data.publicuser.ConversationMemberExcludedOptions
 import com.wire.kalium.logic.data.user.UserId
->>>>>>> develop
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.publicuser.SearchUsersOptions
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
@@ -16,10 +13,6 @@ import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
-<<<<<<< HEAD
-import com.wire.kalium.logic.data.user.UserId
-=======
->>>>>>> develop
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.publicuser.search.Result
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersUseCase
@@ -34,10 +27,7 @@ import io.mockative.classOf
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
-<<<<<<< HEAD
-=======
 import io.mockative.verify
->>>>>>> develop
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -163,7 +153,8 @@ class SearchUserUseCaseTest {
                     "someValue",
                     "someDomain"
                 )
-            )
+            ),
+            selfUserIncluded = false
         )
 
         given(searchUserRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
@@ -3,19 +3,17 @@ package com.wire.kalium.logic.feature.user
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
-import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.publicuser.search.Result
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersUseCaseImpl
-import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.api.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
@@ -25,7 +23,6 @@ import io.mockative.classOf
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -54,23 +51,23 @@ class SearchUserUseCaseTest {
 
     @Test
     fun givenValidParams_whenSearchingPublicUser_thenCorrectlyPropagateSuccessResult() = runTest {
-        //given
+        // given
         val expected = Either.Right(VALID_SEARCH_PUBLIC_RESULT)
 
         given(searchUserRepository)
             .suspendFunction(searchUserRepository::searchUserDirectory)
             .whenInvokedWith(anything(), anything(), anything(), anything())
             .thenReturn(expected)
-        //when
+        // when
         val actual = searchUsersUseCase(TEST_QUERY)
-        //then
+        // then
         assertIs<Result.Success>(actual)
         assertEquals(expected.value, actual.userSearchResult)
     }
 
     @Test
     fun givenPendingConnectionRequests_whenSearchingPublicUser_thenCorrectlyPropagateUserWithConnectionStatus() = runTest {
-        //given
+        // given
         val expected = Either.Right(VALID_SEARCH_PUBLIC_RESULT)
 
         given(connectionRepository)
@@ -82,9 +79,9 @@ class SearchUserUseCaseTest {
             .suspendFunction(searchUserRepository::searchUserDirectory)
             .whenInvokedWith(anything(), anything(), anything(), anything())
             .thenReturn(expected)
-        //when
+        // when
         val actual = searchUsersUseCase(TEST_QUERY)
-        //then
+        // then
         assertIs<Result.Success>(actual)
         assertEquals(
             actual.userSearchResult.result.first { it.id == PENDING_CONNECTION.qualifiedToId }.connectionStatus,
@@ -94,33 +91,33 @@ class SearchUserUseCaseTest {
 
     @Test
     fun givenValidParams_federated_whenSearchingPublicUser_thenCorrectlyPropagateSuccessResult() = runTest {
-        //given
+        // given
         val expected = Either.Right(VALID_SEARCH_PUBLIC_RESULT)
 
         given(searchUserRepository)
             .suspendFunction(searchUserRepository::searchUserDirectory)
             .whenInvokedWith(eq("testQuery"), eq("wire.com"), anything(), anything())
             .thenReturn(expected)
-        //when
+        // when
         val actual = searchUsersUseCase(TEST_QUERY_FEDERATED)
-        //then
+        // then
         assertIs<Result.Success>(actual)
         assertEquals(expected.value, actual.userSearchResult)
     }
 
     @Test
     fun givenFailure_whenSearchingPublicUser_thenCorrectlyPropagateFailureResult() = runTest {
-        //given
+        // given
         val expected = TEST_CORE_FAILURE
 
         given(searchUserRepository)
             .suspendFunction(searchUserRepository::searchUserDirectory)
             .whenInvokedWith(eq("testQuery"), eq(""), anything(), anything())
             .thenReturn(expected)
-        //when
+        // when
         val actual = searchUsersUseCase(TEST_QUERY)
 
-        //then
+        // then
         assertIs<Result.Failure.InvalidQuery>(actual)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
@@ -38,21 +38,13 @@ class SearchUserUseCaseTest {
     private val searchUserRepository = mock(classOf<SearchUserRepository>())
 
     @Mock
-    private val userRepository = mock(classOf<UserRepository>())
-
-    @Mock
     private val connectionRepository = mock(classOf<ConnectionRepository>())
 
     private lateinit var searchUsersUseCase: SearchUsersUseCase
 
     @BeforeTest
     fun setUp() {
-        searchUsersUseCase = SearchUsersUseCaseImpl(userRepository, searchUserRepository, connectionRepository)
-
-        given(userRepository)
-            .suspendFunction(userRepository::observeSelfUser)
-            .whenInvoked()
-            .thenReturn(flowOf(TestUser.SELF))
+        searchUsersUseCase = SearchUsersUseCaseImpl(searchUserRepository, connectionRepository)
 
         given(connectionRepository)
             .suspendFunction(connectionRepository::getConnectionRequests)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

public search result was including the self user

### Solutions

filter out the self user from the public user search api results

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
