### PR TITLE
fix: multiple incoming call

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -218,7 +218,6 @@ actual class CallManagerImpl(
             inst = deferredHandle.await(),
             conversationId = federatedIdMapper.parseToFederatedId(conversationId)
         )
-        callingLogger.d("[$TAG][endCall] -> Called wcall_end()")
     }
 
     override suspend fun rejectCall(conversationId: ConversationId) = withCalling {
@@ -236,7 +235,6 @@ actual class CallManagerImpl(
             inst = deferredHandle.await(),
             conversationId = federatedIdMapper.parseToFederatedId(conversationId)
         )
-        callingLogger.d("[$TAG][rejectCall] -> Called wcall_reject()")
     }
 
     override suspend fun muteCall(shouldMute: Boolean) = withCalling {

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -13,6 +13,7 @@ import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.FederatedIdMapper
@@ -203,15 +204,39 @@ actual class CallManagerImpl(
     }
 
     override suspend fun endCall(conversationId: ConversationId) = withCalling {
-        callingLogger.d("$TAG -> ending Call for conversation = $conversationId..")
-        wcall_end(inst = deferredHandle.await(), conversationId = federatedIdMapper.parseToFederatedId(conversationId))
-        callingLogger.d("$TAG - wcall_end() called -> call for conversation = $conversationId ended")
+        callingLogger.d("[$TAG][endCall] -> ConversationId: [$conversationId]")
+        val conversationType = callRepository.getLastCallConversationTypeByConversationId(conversationId = conversationId)
+
+        callingLogger.d("[$TAG][endCall] -> ConversationType: [$conversationType]")
+        callRepository.updateCallStatusById(
+            conversationId = conversationId.toString(),
+            status = if (conversationType == Conversation.Type.GROUP) CallStatus.STILL_ONGOING else CallStatus.CLOSED
+        )
+
+        callingLogger.d("[$TAG][endCall] -> Calling wcall_end()")
+        wcall_end(
+            inst = deferredHandle.await(),
+            conversationId = federatedIdMapper.parseToFederatedId(conversationId)
+        )
+        callingLogger.d("[$TAG][endCall] -> Called wcall_end()")
     }
 
     override suspend fun rejectCall(conversationId: ConversationId) = withCalling {
-        callingLogger.d("$TAG -> rejecting call for conversation = $conversationId..")
-        wcall_reject(inst = deferredHandle.await(), conversationId = federatedIdMapper.parseToFederatedId(conversationId))
-        callingLogger.d("$TAG - wcall_reject() called -> call for conversation = $conversationId rejected")
+        callingLogger.d("[$TAG][rejectCall] -> ConversationId: [$conversationId]")
+        val conversationType = callRepository.getLastCallConversationTypeByConversationId(conversationId = conversationId)
+
+        callingLogger.d("[$TAG][rejectCall] -> ConversationType: [$conversationType]")
+        callRepository.updateCallStatusById(
+            conversationId = conversationId.toString(),
+            status = if (conversationType == Conversation.Type.GROUP) CallStatus.STILL_ONGOING else CallStatus.CLOSED
+        )
+
+        callingLogger.d("[$TAG][rejectCall] -> Calling wcall_reject()")
+        wcall_reject(
+            inst = deferredHandle.await(),
+            conversationId = federatedIdMapper.parseToFederatedId(conversationId)
+        )
+        callingLogger.d("[$TAG][rejectCall] -> Called wcall_reject()")
     }
 
     override suspend fun muteCall(shouldMute: Boolean) = withCalling {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMapper.kt
@@ -91,7 +91,7 @@ class CallMapper {
         else -> ConversationEntity.Type.ONE_ON_ONE
     }
 
-    private fun toConversationType(conversationType: ConversationEntity.Type): Conversation.Type = when (conversationType) {
+    fun toConversationType(conversationType: ConversationEntity.Type): Conversation.Type = when (conversationType) {
         ConversationEntity.Type.GROUP -> Conversation.Type.GROUP
         else -> Conversation.Type.ONE_ON_ONE
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.call
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.callingLogger
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -48,6 +49,7 @@ interface CallRepository {
     fun updateCallParticipants(conversationId: String, participants: List<Participant>)
     fun updateParticipantsActiveSpeaker(conversationId: String, activeSpeakers: CallActiveSpeakers)
     suspend fun getLastClosedCallCreatedByConversationId(conversationId: ConversationId): Flow<String?>
+    suspend fun getLastCallConversationTypeByConversationId(conversationId: ConversationId): Conversation.Type
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -207,6 +209,17 @@ internal class CallDataSource(
     override suspend fun updateCallStatusById(conversationId: String, status: CallStatus) {
         val callMetadataProfile = _callMetadataProfile.value
         val modifiedConversationId = conversationId.toConversationId()
+
+        // Update Call in Database
+        wrapStorageRequest {
+            callDAO.updateLastCallStatusByConversationId(
+                status = callMapper.toCallEntityStatus(callStatus = status),
+                conversationId = callMapper.fromConversationIdToQualifiedIDEntity(conversationId = modifiedConversationId)
+            )
+            callingLogger.i("[CallRepository][UpdateCallStatusById] -> ConversationId: [$conversationId] " +
+                    "| status: [$status]")
+        }
+
         callMetadataProfile.data[modifiedConversationId.toString()]?.let { call ->
             val updatedCallMetadata = callMetadataProfile.data.toMutableMap().apply {
                 val establishedTime =
@@ -215,16 +228,6 @@ internal class CallDataSource(
 
                 // Update Metadata
                 this[modifiedConversationId.toString()] = call.copy(establishedTime = establishedTime)
-
-                // Update Call in Database
-                wrapStorageRequest {
-                    callDAO.updateLastCallStatusByConversationId(
-                        status = callMapper.toCallEntityStatus(callStatus = status),
-                        conversationId = callMapper.fromConversationIdToQualifiedIDEntity(conversationId = modifiedConversationId)
-                    )
-                    callingLogger.i("[CallRepository][UpdateCallStatusById] -> ConversationId: [$conversationId] " +
-                            "| status: [$status]")
-                }
 
                 // Persist Missed Call Message if necessary
                 if ((status == CallStatus.CLOSED && establishedTime == null) || status == CallStatus.MISSED) {
@@ -318,6 +321,15 @@ internal class CallDataSource(
                 conversationId = conversationId
             )
         )
+
+    override suspend fun getLastCallConversationTypeByConversationId(conversationId: ConversationId): Conversation.Type =
+        callDAO.getLastCallConversationTypeByConversationId(
+            conversationId = callMapper.fromConversationIdToQualifiedIDEntity(
+                conversationId = conversationId
+            )
+        )?.let {
+            callMapper.toConversationType(conversationType = it)
+        } ?: Conversation.Type.ONE_ON_ONE
 
     private suspend fun persistMissedCallMessageIfNeeded(
         conversationId: ConversationId

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -768,13 +768,13 @@ class CallRepositoryTest {
     }
 
     @Test
-    fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateCallStatusIsCalled_thenDoNotUpdateTheStatus() = runTest {
+    fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateCallStatusIsCalled_thenUpdateTheStatus() = runTest {
         callRepository.updateCallStatusById(randomConversationIdString, CallStatus.INCOMING)
 
         verify(callDAO)
             .suspendFunction(callDAO::updateLastCallStatusByConversationId)
             .with(any(), any())
-            .wasInvoked(exactly = Times(0))
+            .wasInvoked(exactly = Times(1))
     }
 
     @Test

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
@@ -33,13 +33,13 @@ updateLastCallStatusByConversationId:
 UPDATE Call
 SET status = ?
 WHERE
-    conversation_id = ?
-    AND id IN (
+    id IN (
         SELECT id
         FROM Call
         WHERE
             status != 'CLOSED'
             AND status != 'MISSED'
+            AND conversation_id = ?
         ORDER BY created_at DESC
         LIMIT 1
     );

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAO.kt
@@ -32,4 +32,5 @@ interface CallDAO {
     suspend fun getCallerIdByConversationId(conversationId: QualifiedIDEntity): String
     suspend fun getCallStatusByConversationId(conversationId: QualifiedIDEntity): CallEntity.Status?
     suspend fun getLastClosedCallByConversationId(conversationId: QualifiedIDEntity): Flow<String?>
+    suspend fun getLastCallConversationTypeByConversationId(conversationId: QualifiedIDEntity): ConversationEntity.Type?
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
@@ -5,6 +5,7 @@ import com.squareup.sqldelight.runtime.coroutines.mapToList
 import com.squareup.sqldelight.runtime.coroutines.mapToOne
 import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.CallsQueries
+import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -92,4 +93,12 @@ internal class CallDAOImpl(private val callsQueries: CallsQueries) : CallDAO {
             .asFlow()
             .mapToOneOrNull()
             .map { it?.created_at }
+
+    override suspend fun getLastCallConversationTypeByConversationId(conversationId: QualifiedIDEntity): ConversationEntity.Type? =
+        callsQueries.selectLastCallByConversationId(conversationId)
+            .asFlow()
+            .mapToOneOrNull()
+            .map { call ->
+                call?.conversation_type
+            }.firstOrNull()
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2079](https://wearezeta.atlassian.net/browse/AR-2079) and [AR-2026](https://wearezeta.atlassian.net/browse/AR-2026)

### Issues

We were receiving multiple incoming calls when using the app, recurring calls or even ended calls kept on re-appearing after some time.

### Causes (Optional)

When rejecting/declining the incoming call, we would get the conversationID wrongly (combining `conversationId` and `id` would never match, as it was getting each from different calls).

### Solutions

Adjust the SQL query to get the correct call for conversation to update its status.