### PR TITLE
fix: order of devices and conversation list [AR-2009] [AR-2070]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/SelfClientsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/SelfClientsUseCase.kt
@@ -12,7 +12,7 @@ interface SelfClientsUseCase {
 class SelfClientsUseCaseImpl(private val clientRepository: ClientRepository) : SelfClientsUseCase {
     override suspend fun invoke(): SelfClientsResult = clientRepository.selfListOfClients().fold(
         { SelfClientsResult.Failure.Generic(it) },
-        { SelfClientsResult.Success(it) }
+        { SelfClientsResult.Success(it.sortedByDescending { it.registrationTime }) }
     )
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationsAndConnectionsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationsAndConnectionsUseCase.kt
@@ -22,7 +22,10 @@ internal class ObserveConversationsAndConnectionsUseCaseImpl(
     override suspend fun invoke(): Flow<List<ConversationDetails>> {
         syncManager.startSyncIfIdle()
         return combine(observeConversationListDetailsUseCase(), observeConnectionListUseCase()) { conversations, connections ->
-            (conversations + connections).sortedByDescending { it.conversation.lastModifiedDate }
+            (conversations + connections).sortedWith(
+                compareByDescending<ConversationDetails> { it.conversation.lastModifiedDate }
+                    .thenBy(nullsLast()) { it.conversation.name?.lowercase() }
+            )
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/SelfClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/SelfClientsUseCaseTest.kt
@@ -20,12 +20,9 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 @OptIn(ConfigurationApi::class)
 class SelfClientsUseCaseTest {
-
 
     @Mock
     private val clientRepository = configure(mock(classOf<ClientRepository>())) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/SelfClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/SelfClientsUseCaseTest.kt
@@ -20,6 +20,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 @OptIn(ConfigurationApi::class)
 class SelfClientsUseCaseTest {
@@ -46,10 +48,24 @@ class SelfClientsUseCaseTest {
 
         val actual = selfClientsUseCase.invoke()
         assertIs<SelfClientsResult.Success>(actual)
-        assertEquals(expected, actual.clients)
     }
 
-
+    @Test
+    fun givenSelfListOfClientsSuccess_whenGettingListOfSelfClients_thenTheListIsSortedReverseChronologically() = runTest {
+        // given
+        val list = listOf(
+            CLIENT.copy(registrationTime = "2022.01.01"),
+            CLIENT.copy(registrationTime = "2022.01.02")
+        )
+        val sorted = listOf(list[1], list[0])
+        given(clientRepository)
+            .coroutine { clientRepository.selfListOfClients() }
+            .then { Either.Right(list) }
+        // when
+        val actual = (selfClientsUseCase.invoke() as SelfClientsResult.Success)
+        // then
+        assertEquals(sorted, actual.clients)
+    }
 
     @Test
     fun givenSelfListOfClientsFail_thenTheErrorPropagated() = runTest {
@@ -64,29 +80,20 @@ class SelfClientsUseCaseTest {
     }
 
     private companion object {
+        val CLIENT = Client(
+            id = PlainId(value = "client_id_1"),
+            type = ClientType.Permanent,
+            registrationTime = "2022.01.01",
+            location = null,
+            deviceType = DeviceType.Desktop,
+            label = null,
+            cookie = null,
+            capabilities = null,
+            model = "Mac ox"
+        )
         val CLIENTS_LIST = listOf(
-            Client(
-                id = PlainId(value = "client_id_1"),
-                type = ClientType.Permanent,
-                registrationTime = "31.08.1966",
-                location = null,
-                deviceType = DeviceType.Desktop,
-                label = null,
-                cookie = null,
-                capabilities = null,
-                model = "Mac ox"
-            ),
-            Client(
-                id = PlainId(value = "client_id_1"),
-                type = ClientType.Permanent,
-                registrationTime = "01.06.2022",
-                location = null,
-                deviceType = DeviceType.Phone,
-                label = null,
-                cookie = null,
-                capabilities = null,
-                model = "iphone 15"
-            ),
+            CLIENT.copy(id = PlainId(value = "client_id_1")),
+            CLIENT.copy(id = PlainId(value = "client_id_2"))
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationsAndConnectionsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationsAndConnectionsUseCaseTest.kt
@@ -1,8 +1,6 @@
 package com.wire.kalium.logic.feature.conversation
 
-import app.cash.turbine.test
 import com.wire.kalium.logic.feature.connection.ObserveConnectionListUseCase
-import com.wire.kalium.logic.framework.TestConnection
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversationDetails
 import com.wire.kalium.logic.framework.TestUser
@@ -54,7 +52,6 @@ class ObserveConversationsAndConnectionsUseCaseTest {
             .suspendFunction(observeConnectionListUseCase::invoke)
             .whenInvoked()
             .thenReturn(flowOf(listOf(TestConversationDetails.CONNECTION)))
-
 
         // when
         observeConversationsAndConnectionsUseCase().collect()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationsAndConnectionsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationsAndConnectionsUseCaseTest.kt
@@ -1,7 +1,11 @@
 package com.wire.kalium.logic.feature.conversation
 
+import app.cash.turbine.test
 import com.wire.kalium.logic.feature.connection.ObserveConnectionListUseCase
+import com.wire.kalium.logic.framework.TestConnection
+import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversationDetails
+import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.SyncManager
 import io.mockative.Mock
 import io.mockative.configure
@@ -10,10 +14,12 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class ObserveConversationsAndConnectionsUseCaseTest {
@@ -76,4 +82,43 @@ class ObserveConversationsAndConnectionsUseCaseTest {
             assertFailsWith<RuntimeException> { observeConversationsAndConnectionsUseCase().collect() }
         }
 
+    @Test
+    fun givenSomeConversationsAndConnections_whenObservingDetailsListAndConnections_thenListShouldBeSorted() = runTest {
+        // reverse chronologically, if both have the same time (or is unknown) then alphabetically, null names at the bottom
+        // given
+        val conversations = listOf(
+            TestConversation.CONVERSATION.copy(lastModifiedDate = "2022.01.02", name = "C"),
+            TestConversation.CONVERSATION.copy(lastModifiedDate = "2022.01.01", name = "Z"),
+            TestConversation.CONVERSATION.copy(lastModifiedDate = "2022.01.02", name = null),
+            TestConversation.CONVERSATION.copy(lastModifiedDate = "2022.01.02", name = "A")
+        ).map { TestConversationDetails.CONVERSATION_ONE_ONE.copy(conversation = it) }
+        val connections = listOf(
+            TestConversationDetails.CONNECTION.copy(lastModifiedDate = "2022.01.01", otherUser = TestUser.OTHER.copy(name = "Y")),
+            TestConversationDetails.CONNECTION.copy(lastModifiedDate = "2022.01.01", otherUser = TestUser.OTHER.copy(name = null)),
+            TestConversationDetails.CONNECTION.copy(lastModifiedDate = "2022.01.02", otherUser = TestUser.OTHER.copy(name = "B")),
+            TestConversationDetails.CONNECTION.copy(lastModifiedDate = "2022.01.02", otherUser = TestUser.OTHER.copy(name = "D"))
+        )
+        val sorted = listOf(
+            conversations[3],
+            connections[2],
+            conversations[0],
+            connections[3],
+            conversations[2],
+            connections[0],
+            conversations[1],
+            connections[1]
+        )
+        given(observeConversationListDetailsUseCase)
+            .suspendFunction(observeConversationListDetailsUseCase::invoke)
+            .whenInvoked()
+            .thenReturn(flowOf(conversations))
+        given(observeConnectionListUseCase)
+            .suspendFunction(observeConnectionListUseCase::invoke)
+            .whenInvoked()
+            .thenReturn(flowOf(connections))
+        // when
+        val result = observeConversationsAndConnectionsUseCase().first()
+        // then
+        assertEquals(result, sorted)
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Lists of devices after login and conversations after fresh install look like they are arranged randomly.

### Solutions

Sort list of devices by reverse chronological order and conversations by reverse chronological, and if that's enough or there is no "updated time" then by alphabetical order.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Install fresh version to see the conversation list order, have too many registered devices when logging in to see devices list order.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
