### PR TITLE
chore: make cryptobox4j version configurable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 JAVA_HOME := $(shell /usr/libexec/java_home)
 CRYPTOBOX_C_VERSION := "v1.1.3"
+CRYPTOBOX4J_VERSION := "1.1.1"
 LIBSODIUM_VERSION := "1.0.18-RELEASE"
 LIBCRYPTOBOX_ARTIFACT_FILE := libcryptobox.dylib
 LIBCRYPTOBOX_JNI_ARTIFACT_FILE := libcryptobox-jni.dylib
@@ -37,7 +38,9 @@ cryptobox4j-clone:
 	@echo "Cloning and building cryptobox4j"
 	cd native && \
 	rm -rf cryptobox4j  && \
-	git clone https://github.com/wireapp/cryptobox4j.git
+	git clone https://github.com/wireapp/cryptobox4j.git && \
+	cd cryptobox4j && \
+	git checkout ${CRYPTOBOX4J_VERSION}
 
 libsodium:
 	@echo "Getting libsodium"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Kalium CLI currently did not run with the latest cryptobox4j version but with an older version (1.1.1).

### Solutions

Make cryptobox4j version adjustable in Makefile and set it to 1.1.1

### Dependencies

Version needs to be updated in a commit if a newer version of cryptobox4j will be needed in the future

#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
