### PR TITLE
fix: too frequent conversation list updates

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -19,6 +19,7 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.call.CallStatus
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.logic.util.TimeParser
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -107,6 +108,7 @@ internal class CallDataSource(
     ) {
         val conversation: ConversationDetails = conversationRepository
             .observeConversationDetailsById(conversationId)
+            .onlyRight()
             .first()
 
         // in OnIncomingCall we get callerId without a domain,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -251,11 +251,11 @@ class ConversationDataSource(
 
     private suspend fun getConversationDetailsFlow(conversation: Conversation): Flow<Either<StorageFailure, ConversationDetails>> =
         when (conversation.type) {
-        Conversation.Type.SELF -> flowOf(Either.Right(ConversationDetails.Self(conversation)))
-        // TODO(user-metadata): get actual legal hold status
-        Conversation.Type.GROUP -> flowOf(Either.Right(ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED)))
-        Conversation.Type.CONNECTION_PENDING, Conversation.Type.ONE_ON_ONE -> getOneToOneConversationDetailsFlow(conversation)
-    }
+            Conversation.Type.SELF -> flowOf(Either.Right(ConversationDetails.Self(conversation)))
+            // TODO(user-metadata): get actual legal hold status
+            Conversation.Type.GROUP -> flowOf(Either.Right(ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED)))
+            Conversation.Type.CONNECTION_PENDING, Conversation.Type.ONE_ON_ONE -> getOneToOneConversationDetailsFlow(conversation)
+        }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun getOneToOneConversationDetailsFlow(conversation: Conversation): Flow<Either<StorageFailure, ConversationDetails>> {
@@ -269,7 +269,7 @@ class ConversationDataSource(
                 },
                 { otherUserId ->
                     flowOf(otherUserId)
-                        .flatMapLatest { if(it != null) userRepository.getKnownUser(it) else flowOf(it) }
+                        .flatMapLatest { if (it != null) userRepository.getKnownUser(it) else flowOf(it) }
                         .wrapStorageRequest()
                         .map { it.map { conversationMapper.toConversationDetailsOneToOne(conversation, it, selfUser) } }
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -9,7 +9,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
-import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.di.MapperProvider
@@ -21,7 +20,6 @@ import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
-import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -38,7 +36,6 @@ import com.wire.kalium.persistence.dao.ConversationEntity.ProtocolInfo
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -86,6 +83,7 @@ interface ConversationRepository {
     suspend fun getConversationsByGroupState(
         groupState: Conversation.ProtocolInfo.MLS.GroupState
     ): Either<StorageFailure, List<Conversation>>
+
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit>
     suspend fun updateAllConversationsNotificationDate(date: String): Either<StorageFailure, Unit>
     suspend fun updateConversationModifiedDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit>
@@ -228,7 +226,7 @@ class ConversationDataSource(
             .flatMapLatest {
                 it.fold(
                     { flowOf(Either.Left(it)) },
-                    { getConversationDetailsFlow(conversationMapper.fromDaoModel(it)).map { Either.Right(it) } }
+                    { getConversationDetailsFlow(conversationMapper.fromDaoModel(it)) }
                 )
             }
 
@@ -251,24 +249,34 @@ class ConversationDataSource(
         }
     }
 
-    private suspend fun getConversationDetailsFlow(conversation: Conversation): Flow<ConversationDetails> = when (conversation.type) {
-        Conversation.Type.SELF -> flowOf(ConversationDetails.Self(conversation))
+    private suspend fun getConversationDetailsFlow(conversation: Conversation): Flow<Either<StorageFailure, ConversationDetails>> =
+        when (conversation.type) {
+        Conversation.Type.SELF -> flowOf(Either.Right(ConversationDetails.Self(conversation)))
         // TODO(user-metadata): get actual legal hold status
-        Conversation.Type.GROUP -> flowOf(ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED))
+        Conversation.Type.GROUP -> flowOf(Either.Right(ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED)))
         Conversation.Type.CONNECTION_PENDING, Conversation.Type.ONE_ON_ONE -> getOneToOneConversationDetailsFlow(conversation)
     }
 
-    private suspend fun getOneToOneConversationDetailsFlow(conversation: Conversation): Flow<ConversationDetails> {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun getOneToOneConversationDetailsFlow(conversation: Conversation): Flow<Either<StorageFailure, ConversationDetails>> {
         val selfUser = userRepository.observeSelfUser().first()
-        return getConversationMembers(conversation.id).map { members ->
-            members.firstOrNull { itemId -> itemId != selfUser.id }
-        }.fold(
-            { storageFailure -> logMemberDetailsError(conversation, storageFailure) },
-            { otherUserId -> otherUserId?.let { userRepository.getKnownUser(it) } ?: emptyFlow() }
-        ).filterNotNull().map { otherUser -> conversationMapper.toConversationDetailsOneToOne(conversation, otherUser, selfUser) }
+        return getConversationMembers(conversation.id)
+            .map { members -> members.firstOrNull { itemId -> itemId != selfUser.id } }
+            .fold(
+                { storageFailure ->
+                    logMemberDetailsError(conversation, storageFailure)
+                    flowOf(Either.Left(storageFailure))
+                },
+                { otherUserId ->
+                    flowOf(otherUserId)
+                        .flatMapLatest { if(it != null) userRepository.getKnownUser(it) else flowOf(it) }
+                        .wrapStorageRequest()
+                        .map { it.map { conversationMapper.toConversationDetailsOneToOne(conversation, it, selfUser) } }
+                }
+            )
     }
 
-    private fun logMemberDetailsError(conversation: Conversation, error: StorageFailure): Flow<OtherUser> {
+    private fun logMemberDetailsError(conversation: Conversation, error: StorageFailure) {
         when (error) {
             is StorageFailure.DataNotFound ->
                 kaliumLogger.withFeatureId(CONVERSATIONS).e("DataNotFound when fetching conversation members: $error")
@@ -276,15 +284,14 @@ class ConversationDataSource(
             is StorageFailure.Generic ->
                 kaliumLogger.withFeatureId(CONVERSATIONS).e("Failure getting other 1:1 user for $conversation", error.rootCause)
         }
-        return emptyFlow()
     }
 
     // Deprecated notice, so we can use newer versions of Kalium on Reloaded without breaking things.
     @Deprecated("This doesn't return conversation details", ReplaceWith("detailsById"))
     override suspend fun observeById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>> =
-            conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId)).filterNotNull()
-                .map(conversationMapper::fromDaoModel)
-                .wrapStorageRequest()
+        conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId)).filterNotNull()
+            .map(conversationMapper::fromDaoModel)
+            .wrapStorageRequest()
 
     override suspend fun detailsById(conversationId: ConversationId): Either<StorageFailure, Conversation> = wrapStorageRequest {
         conversationDAO.getConversationByQualifiedID(idMapper.toDaoModel(conversationId))?.let {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -62,7 +62,7 @@ internal class GetIncomingCallsUseCaseImpl(
                 .flatMapFromIterable { call ->
                     //getting ConversationDetails for each Call
                     conversationRepository.observeById(call.conversationId)
-                        .getOrElse(flowOf(null))
+                        .map { it.getOrElse(null) }
                 }
                 .map { conversations ->
                     val allowedConversations = conversations

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/ObserveConnectionListUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/ObserveConnectionListUseCase.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * Use Case that listen to any user connection changes
@@ -25,6 +26,6 @@ internal class ObserveConnectionListUseCaseImpl(
 
     override suspend operator fun invoke(): Flow<List<ConversationDetails>> {
         syncManager.startSyncIfIdle()
-        return connectionRepository.observeConnectionList()
+        return connectionRepository.observeConnectionList().distinctUntilChanged()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -25,8 +25,8 @@ class ConversationScope(
     val getConversations: GetConversationsUseCase
         get() = GetConversationsUseCase(conversationRepository, syncManager)
 
-    val getConversationDetails: GetConversationDetailsUseCase
-        get() = GetConversationDetailsUseCase(conversationRepository, syncManager)
+    val getConversationDetails: GetConversationUseCase
+        get() = GetConversationUseCase(conversationRepository, syncManager)
 
     val observeConversationListDetails: ObserveConversationListDetailsUseCase
         get() = ObserveConversationListDetailsUseCaseImpl(conversationRepository, syncManager, callRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationUseCase.kt
@@ -7,22 +7,20 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
-class GetConversationDetailsUseCase(
+class GetConversationUseCase(
     private val conversationRepository: ConversationRepository,
     private val syncManager: SyncManager
 ) {
     sealed class Result {
-        data class Success(val convFlow: Flow<Conversation>) : Result()
+        data class Success(val conversation: Conversation) : Result()
         data class Failure(val storageFailure: StorageFailure) : Result()
     }
 
-    suspend operator fun invoke(conversationId: QualifiedID): Result {
+    suspend operator fun invoke(conversationId: QualifiedID): Flow<Result> {
         syncManager.startSyncIfIdle()
-        return conversationRepository.observeById(conversationId).fold({
-            Result.Failure(it)
-        }, {
-            Result.Success(it)
-        })
+        return conversationRepository.observeById(conversationId)
+            .map { it.fold({ Result.Failure(it) }, { Result.Success(it) }) }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -3,8 +3,8 @@ package com.wire.kalium.logic.feature.conversation
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLS.GroupState
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
@@ -15,6 +15,7 @@ import com.wire.kalium.network.exceptions.isMlsStaleMessage
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 
 /**
@@ -43,6 +44,7 @@ class JoinExistingMLSConversationsUseCase(
             }
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun requestToJoinMLSGroupAndRetry(conversation: Conversation): Either<CoreFailure, Unit> =
         conversationRepository.requestToJoinMLSGroup(conversation)
             .flatMapLeft { failure ->
@@ -52,7 +54,7 @@ class JoinExistingMLSConversationsUseCase(
 
                         // Re-fetch current epoch and try again
                         return conversationRepository.fetchConversation(conversation.id).flatMap {
-                            conversationRepository.observeById(conversation.id).flatMap {
+                            conversationRepository.detailsById(conversation.id).flatMap { conversation ->
                                 requestToJoinMLSGroupAndRetry(conversation)
                             }
                         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
@@ -1,18 +1,29 @@
 package com.wire.kalium.logic.feature.conversation
 
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class ObserveConversationDetailsUseCase(
     private val conversationRepository: ConversationRepository,
     private val syncManager: SyncManager
 ) {
+    sealed class Result {
+        data class Success(val conversationDetails: ConversationDetails) : Result()
+        data class Failure(val storageFailure: StorageFailure) : Result()
+    }
 
-    suspend operator fun invoke(conversationId: ConversationId): Flow<ConversationDetails> {
+    suspend operator fun invoke(conversationId: ConversationId): Flow<Result> {
         syncManager.startSyncIfIdle()
         return conversationRepository.observeConversationDetailsById(conversationId)
+            .map { it.fold({ Result.Failure(it) }, { Result.Success(it) }) }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
@@ -1,13 +1,10 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.StorageFailure
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseImpl.kt
@@ -10,9 +10,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
 fun interface ObserveConversationListDetailsUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseImpl.kt
@@ -9,6 +9,7 @@ import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -52,6 +53,6 @@ internal class ObserveConversationListDetailsUseCaseImpl(
                     )
                 }
             }
-        }
+        }.distinctUntilChanged()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationsAndConnectionsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationsAndConnectionsUseCase.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.feature.connection.ObserveConnectionListUseCase
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 fun interface ObserveConversationsAndConnectionsUseCase {
     /**
@@ -23,6 +24,6 @@ internal class ObserveConversationsAndConnectionsUseCaseImpl(
         syncManager.startSyncIfIdle()
         return combine(observeConversationListDetailsUseCase(), observeConnectionListUseCase()) { conversations, connections ->
             (conversations + connections).sortedByDescending { it.conversation.lastModifiedDate }
-        }
+        }.distinctUntilChanged()
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -171,7 +171,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED)))
+            .thenReturn(flowOf(Either.Right(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED))))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -228,7 +228,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED)))
+            .thenReturn(flowOf(Either.Right(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED))))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -280,7 +280,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED)))
+            .thenReturn(flowOf(Either.Right(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED))))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -341,7 +341,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED)))
+            .thenReturn(flowOf(Either.Right(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED))))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -388,7 +388,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED)))
+            .thenReturn(flowOf(Either.Right(ConversationDetails.Group(groupConversation, LegalHoldStatus.ENABLED))))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -439,7 +439,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(oneOnOneConversationDetails))
+            .thenReturn(flowOf(Either.Right(oneOnOneConversationDetails)))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -497,7 +497,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(oneOnOneConversationDetails))
+            .thenReturn(flowOf(Either.Right(oneOnOneConversationDetails)))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -559,7 +559,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(oneOnOneConversationDetails))
+            .thenReturn(flowOf(Either.Right(oneOnOneConversationDetails)))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -625,7 +625,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(oneOnOneConversationDetails))
+            .thenReturn(flowOf(Either.Right(oneOnOneConversationDetails)))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
@@ -682,7 +682,7 @@ class CallRepositoryTest {
 
         given(conversationRepository).suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(oneOnOneConversationDetails))
+            .thenReturn(flowOf(Either.Right(oneOnOneConversationDetails)))
 
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -192,7 +192,7 @@ class ConversationRepositoryTest {
             .thenReturn(conversationEntityFlow)
 
         conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
-            assertIs<ConversationDetails.Group>(awaitItem())
+            assertIs<Either.Right<ConversationDetails.Group>>(awaitItem())
             awaitComplete()
         }
     }
@@ -209,7 +209,7 @@ class ConversationRepositoryTest {
             .thenReturn(conversationEntityFlow)
 
         conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
-            assertIs<ConversationDetails.Self>(awaitItem())
+            assertIs<Either.Right<ConversationDetails.Self>>(awaitItem())
             awaitComplete()
         }
     }
@@ -242,7 +242,7 @@ class ConversationRepositoryTest {
             .thenReturn(flowOf(TestUser.OTHER))
 
         conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
-            assertIs<ConversationDetails.OneOne>(awaitItem())
+            assertIs<Either.Right<ConversationDetails.OneOne>>(awaitItem())
             awaitComplete()
         }
     }
@@ -279,12 +279,12 @@ class ConversationRepositoryTest {
 
         conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
             val firstItem = awaitItem()
-            assertIs<ConversationDetails.OneOne>(firstItem)
-            assertEquals(otherUserDetailsSequence[0], firstItem.otherUser)
+            assertIs<Either.Right<ConversationDetails.OneOne>>(firstItem)
+            assertEquals(otherUserDetailsSequence[0], firstItem.value.otherUser)
 
             val secondItem = awaitItem()
-            assertIs<ConversationDetails.OneOne>(secondItem)
-            assertEquals(otherUserDetailsSequence[1], secondItem.otherUser)
+            assertIs<Either.Right<ConversationDetails.OneOne>>(secondItem)
+            assertEquals(otherUserDetailsSequence[1], secondItem.value.otherUser)
 
             awaitComplete()
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCaseTest.kt
@@ -48,7 +48,7 @@ class GetIncomingCallsUseCaseTest {
     fun givenNotEmptyCallList_whenInvokingGetIncomingCallsUseCase_thenNonEmptyNotificationList() = runTest {
         val (_, getIncomingCalls) = Arrangement()
             .withSelfUserStatus(UserAvailabilityStatus.AVAILABLE)
-            .withConversationDetails { id -> Either.Right(flowOf(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed))) }
+            .withConversationDetails { id -> flowOf(Either.Right(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed))) }
             .withIncomingCalls(
                 listOf<Call>(incomingCall(0), incomingCall(1))
             )
@@ -65,7 +65,7 @@ class GetIncomingCallsUseCaseTest {
     fun givenUserWithAwayStatus_whenIncomingCallComes_thenNoCallsPropagated() = runTest {
         val (_, getIncomingCalls) = Arrangement()
             .withSelfUserStatus(UserAvailabilityStatus.AWAY)
-            .withConversationDetails { id -> Either.Right(flowOf(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed))) }
+            .withConversationDetails { id -> flowOf(Either.Right(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed))) }
             .withIncomingCalls(
                 listOf<Call>(incomingCall(0), incomingCall(1))
             )
@@ -82,7 +82,7 @@ class GetIncomingCallsUseCaseTest {
     fun givenUserWithBusyStatus_whenIncomingCallComes_thenCallsPropagated() = runTest {
         val (_, getIncomingCalls) = Arrangement()
             .withSelfUserStatus(UserAvailabilityStatus.BUSY)
-            .withConversationDetails { id -> Either.Right(flowOf(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed))) }
+            .withConversationDetails { id -> flowOf(Either.Right(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed))) }
             .withIncomingCalls(
                 listOf<Call>(incomingCall(0), incomingCall(1))
             )
@@ -102,9 +102,9 @@ class GetIncomingCallsUseCaseTest {
             .withSelfUserStatus(UserAvailabilityStatus.AVAILABLE)
             .withConversationDetails { id ->
                 if (id == TestConversation.id(0))
-                    Either.Right(flowOf(conversationWithMuteStatus(id, MutedConversationStatus.AllMuted)))
+                    flowOf(Either.Right(conversationWithMuteStatus(id, MutedConversationStatus.AllMuted)))
                 else
-                    Either.Right(flowOf(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed)))
+                    flowOf(Either.Right(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed)))
             }
             .withIncomingCalls(
                 listOf<Call>(incomingCall(0), incomingCall(1))
@@ -123,7 +123,7 @@ class GetIncomingCallsUseCaseTest {
         val (_, getIncomingCalls) = Arrangement()
             .withSelfUserStatus(UserAvailabilityStatus.AVAILABLE)
             .withConversationDetails { id ->
-                Either.Right(flowOf(conversationWithMuteStatus(id, MutedConversationStatus.OnlyMentionsAllowed)))
+                flowOf(Either.Right(conversationWithMuteStatus(id, MutedConversationStatus.OnlyMentionsAllowed)))
             }
             .withIncomingCalls(
                 listOf<Call>(incomingCall(0), incomingCall(1))
@@ -144,9 +144,9 @@ class GetIncomingCallsUseCaseTest {
             .withSelfUserStatus(UserAvailabilityStatus.AVAILABLE)
             .withConversationDetails { id ->
                 if (id == TestConversation.id(0))
-                    Either.Left(StorageFailure.DataNotFound)
+                    flowOf(Either.Left(StorageFailure.DataNotFound))
                 else
-                    Either.Right(flowOf(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed)))
+                    flowOf(Either.Right(conversationWithMuteStatus(id, MutedConversationStatus.AllAllowed)))
             }
             .withIncomingCalls(
                 listOf<Call>(incomingCall(0), incomingCall(1))
@@ -203,7 +203,7 @@ class GetIncomingCallsUseCaseTest {
             return this
         }
 
-        fun withConversationDetails(detailsGetter: (ConversationId) -> Either<StorageFailure, Flow<Conversation>>): Arrangement {
+        fun withConversationDetails(detailsGetter: (ConversationId) -> Flow<Either<StorageFailure, Conversation>>): Arrangement {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::observeById)
                 .whenInvokedWith(any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -107,9 +107,9 @@ class JoinExistingMLSConversationsUseCaseTest {
 
         fun withGetConversationByIdSuccessful() = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::observeById)
+                .suspendFunction(conversationRepository::detailsById)
                 .whenInvokedWith(anything())
-                .then { Either.Right(flowOf(MLS_CONVERSATION1)) }
+                .then { Either.Right(MLS_CONVERSATION1) }
         }
 
         fun withRequestToJoinMLSGroupSuccessful() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -22,7 +22,6 @@ import io.mockative.once
 import io.mockative.twice
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -18,7 +18,6 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -1,10 +1,12 @@
 package com.wire.kalium.logic.feature.conversation
 
 import app.cash.turbine.test
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.SyncManager
 import io.mockative.Mock
 import io.mockative.anything
@@ -16,10 +18,12 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 class ObserveConversationDetailsUseCaseTest {
 
@@ -73,8 +77,8 @@ class ObserveConversationDetailsUseCaseTest {
     fun givenTheConversationIsUpdated_whenObservingConversationUseCase_thenThisUpdateIsPropagatedInTheFlow() = runTest {
         val conversation = TestConversation.GROUP()
         val conversationDetailsValues = listOf(
-            ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED),
-            ConversationDetails.Group(conversation.copy(name = "New Name"), LegalHoldStatus.DISABLED)
+            Either.Right(ConversationDetails.Group(conversation, LegalHoldStatus.DISABLED)),
+            Either.Right(ConversationDetails.Group(conversation.copy(name = "New Name"), LegalHoldStatus.DISABLED))
         )
 
         given(conversationRepository)
@@ -83,8 +87,32 @@ class ObserveConversationDetailsUseCaseTest {
             .then { conversationDetailsValues.asFlow() }
 
         observeConversationsUseCase(TestConversation.ID).test {
-            assertEquals(conversationDetailsValues[0], awaitItem())
-            assertEquals(conversationDetailsValues[1], awaitItem())
+            awaitItem().let { item ->
+                assertIs<ObserveConversationDetailsUseCase.Result.Success>(item)
+                assertEquals(conversationDetailsValues[0].value, item.conversationDetails)
+            }
+            awaitItem().let { item ->
+                assertIs<ObserveConversationDetailsUseCase.Result.Success>(item)
+                assertEquals(conversationDetailsValues[1].value, item.conversationDetails)
+            }
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenTheStorageFailure_whenObservingConversationUseCase_thenThisUpdateIsPropagatedInTheFlow() = runTest {
+        val failure = StorageFailure.DataNotFound
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationDetailsById)
+            .whenInvokedWith(anything())
+            .then { flowOf(Either.Left(failure)) }
+
+        observeConversationsUseCase(TestConversation.ID).test {
+            awaitItem().let { item ->
+                assertIs<ObserveConversationDetailsUseCase.Result.Failure>(item)
+                assertEquals(failure, item.storageFailure)
+            }
             awaitComplete()
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -333,7 +333,7 @@ class ObserveConversationListDetailsUseCaseTest {
             .suspendFunction(conversationRepository::observeConversationDetailsById)
             .whenInvokedWith(any())
             .then {
-                if(it == successConversation.id) flowOf(Either.Right(successConversationDetails))
+                if (it == successConversation.id) flowOf(Either.Right(successConversationDetails))
                 else flowOf(Either.Left(StorageFailure.DataNotFound))
             }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Conversation list updates were being done too frequently, especially when first launching the app and because of that the whole list was being rearranged every time.

### Causes (Optional)

When fixing one issue with 1-1 conversations with deleted user, we created this one, because until now empty item was emitted at the beginning for each conversation and because of that every actual update with proper data (for every conversation independently) was emitting the whole list again.

### Solutions

Don't emit empty item, instead handle storage failure and pass it through the flow, add `distinctUntilChanged` not to emit the same values multiple times.

Needs releases with:

- https://github.com/wireapp/wire-android-reloaded/pull/808

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Attachments (Optional)

#### With flickering:

https://user-images.githubusercontent.com/30429749/181587582-7bd49432-d2df-46ec-841a-d6a4c34463c7.mp4

&nbsp;
#### Without flickering:

https://user-images.githubusercontent.com/30429749/181587730-86a78809-ea17-48e3-bc70-e66769e0e1f3.mp4

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
