### PR TITLE
ci: abort current jobs when updating PR or develop branch

### DIFF
--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [ opened, synchronize ] # Don't rerun on `edited` to save time
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
 jobs:
   gradle-run-tests:
     runs-on: macos-latest

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [ opened, synchronize ] # Don't rerun on `edited` to save time
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
 jobs:
   gradle-run-tests:
     runs-on: macos-latest

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -7,6 +7,10 @@ on:
     branches: # Runs on develop to have the coverage diff on every PR
         - 'develop'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   gradle-run-tests:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Tests currently take a ton of time to run, and when multiple pushes are sent in a row, this creates a big queue of jobs to run on Github Actions.

For example, if someone sends three pushes in a short interval, which is a possible scenario (a couple of review suggestions + merge from develop, for example), all tests will run 3 times.

Android and iOS tests run on Mac machines, which are very limited for us. Which can cause looooong waits until all jobs are through.

We can manually abort all jobs, but this is error-prone.

### Solutions

Automatically abort jobs running in a PR when a new push is made.

For now, only long-lasting jobs are affected (JVM/JS, Android and iOS tests), so code-style (which runs on Linux anyway) can be seen.

#### Implementation details

Add a concurrency group to long-lasting jobs.
The concurrency group looks like: `[gitHubWorkFlow]-[prNumber]`.
Where `gitHubWorkFlow` is the name of the job. This avoids job A cancelling job B when job A is manually retried.

For the JVM/JS tests, that also run on `develop`, they look like `[gitHubWorkFlow]-[branchName]`, so the job will be aborted if there's a new push. This job's only purpose is to add coverage to Codecov. So it doesn't add much keeping an already-outdated reference.

### Testing

Manually testing in this PR by triggering an empty commit.

### Attachments

As you can see, the three jobs were automatically cancelled once I pushed a new empty commit to this PR:
<img width="495" alt="image" src="https://user-images.githubusercontent.com/9389043/181632935-c6d4b455-0b26-45e8-85c5-b9b423e1c9c6.png">


----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
