### PR TITLE
feat: remove asset remotely (AR-2034)

### DIFF
--- a/logger/src/commonMain/kotlin/com/wire/kalium/logger/KaliumLogger.kt
+++ b/logger/src/commonMain/kotlin/com/wire/kalium/logger/KaliumLogger.kt
@@ -136,7 +136,7 @@ class KaliumLogger(private val config: Config, vararg logWriters: LogWriter = ar
         )
 
         enum class ApplicationFlow {
-            SYNC, EVENT_RECEIVER, CONVERSATIONS, CONNECTIONS, MESSAGES, SEARCH, SESSION, REGISTER, CLIENTS, CALLING
+            SYNC, EVENT_RECEIVER, CONVERSATIONS, CONNECTIONS, MESSAGES, SEARCH, SESSION, REGISTER, CLIENTS, CALLING, ASSETS
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -85,6 +85,11 @@ interface AssetRepository {
      * @return [Either] a [CoreFailure] if anything went wrong, or Unit if operation was successful
      */
     suspend fun downloadUsersPictureAssets(assetIdList: List<UserAssetId?>): Either<CoreFailure, Unit>
+
+    /**
+     * Method used to delete asset locally (TODO) and externally
+     */
+    suspend fun deleteAsset(assetId: AssetId, assetToken: String?): Either<CoreFailure, Unit>
 }
 
 internal class AssetDataSource(
@@ -236,5 +241,11 @@ internal class AssetDataSource(
             downloadPublicAsset(idMapper.toQualifiedAssetId(userAssetId.value, userAssetId.domain))
         }
         return Either.Right(Unit)
+    }
+
+    override suspend fun deleteAsset(assetId: AssetId, assetToken: String?): Either<CoreFailure, Unit> {
+        return wrapApiRequest {
+            assetApi.deleteAsset(idMapper.toApiModel(assetId), assetToken)
+        }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -2,26 +2,32 @@ package com.wire.kalium.logic.feature.message
 
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.MESSAGES
+import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.ASSETS
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
 
+@Suppress("LongParameterList")
 class DeleteMessageUseCase(
     private val messageRepository: MessageRepository,
     private val userRepository: UserRepository,
     private val clientRepository: ClientRepository,
+    private val assetRepository: AssetRepository,
     private val syncManager: SyncManager,
     private val messageSender: MessageSender,
     private val idMapper: IdMapper
@@ -48,13 +54,31 @@ class DeleteMessageUseCase(
                 editStatus = Message.EditStatus.NotEdited,
             )
             messageSender.sendMessage(message)
-        }.flatMap {
-            messageRepository.markMessageAsDeleted(messageId, conversationId)
-        }.onFailure {
-            kaliumLogger.withFeatureId(MESSAGES).w("delete message failure: $it")
-            if (it is CoreFailure.Unknown) {
-                it.rootCause?.printStackTrace()
-            }
         }
+            .onSuccess {
+                messageRepository.getMessageById(conversationId, messageId)
+                    .onSuccess { message ->
+                        val assetToRemove = when (message.content) {
+                            is MessageContent.Asset -> (message.content as MessageContent.Asset).value.remoteData
+                            else -> null
+                        }
+                        if (assetToRemove != null) {
+                            assetRepository.deleteAsset(
+                                AssetId(assetToRemove.assetId, assetToRemove.assetDomain.orEmpty()),
+                                assetToRemove.assetToken
+                            )
+                                .onFailure {
+                                    kaliumLogger.withFeatureId(ASSETS).w("delete message asset failure: $it")
+                                }
+                        }
+                    }
+            }
+            .flatMap { messageRepository.markMessageAsDeleted(messageId, conversationId) }
+            .onFailure {
+                kaliumLogger.withFeatureId(MESSAGES).w("delete message failure: $it")
+                if (it is CoreFailure.Unknown) {
+                    it.rootCause?.printStackTrace()
+                }
+            }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -109,6 +109,7 @@ class MessageScope(
             messageRepository,
             userRepository,
             clientRepository,
+            assetRepository,
             syncManager,
             messageSender,
             idMapper

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Either.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Either.kt
@@ -56,7 +56,7 @@ sealed class Either<out L, out R> {
  * @see Left
  * @see Right
  */
-inline fun <L, R, T: Any> Either<L, R>.fold(fnL: (L) -> T, fnR: (R) -> T): T = nullableFold(fnL, fnR)!!
+inline fun <L, R, T : Any> Either<L, R>.fold(fnL: (L) -> T, fnR: (R) -> T): T = nullableFold(fnL, fnR)!!
 
 
 /**

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -195,7 +195,6 @@ class DeleteMessageUseCaseTest {
         @Mock
         val assetRepository: AssetRepository = mock(AssetRepository::class)
 
-
         val idMapper: IdMapper = IdMapperImpl()
 
         fun arrange() = this to DeleteMessageUseCase(
@@ -262,7 +261,6 @@ class DeleteMessageUseCaseTest {
                 .whenInvokedWith(anything(), anything())
                 .thenReturn(Either.Right(Unit))
         }
-
 
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -185,7 +185,6 @@ class DeleteMessageUseCaseTest {
 
     }
 
-
     @Test
     fun givenAMessage_whenDeleting_thenStartSyncIsInvoked() = runTest {
         // when

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/asset/AssetApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/asset/AssetApiImpl.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.AssetId
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -25,6 +26,8 @@ interface AssetApi {
         encryptedDataSource: Source,
         encryptedDataSize: Long
     ): NetworkResponse<AssetResponse>
+
+    suspend fun deleteAsset(assetId: AssetId, assetToken: String?): NetworkResponse<Unit>
 }
 
 class AssetApiImpl internal constructor(
@@ -72,6 +75,11 @@ class AssetApiImpl internal constructor(
                 contentType(ContentType.MultiPart.Mixed)
                 setBody(StreamAssetContent(metadata, encryptedDataSize, encryptedDataSource))
             }
+        }
+
+    override suspend fun deleteAsset(assetId: AssetId, assetToken: String?): NetworkResponse<Unit> =
+        wrapKaliumResponse {
+            httpClient.delete(buildAssetsPath(assetId))
         }
 
     private companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When message contains asset, then after deleting it delete also asset externally

### Issues

- after deleting message asset was still stored externally

### Solutions

Before marking message as removed 
- fetch message locally
- check if contains asset
- if yes remove asset remotely

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
