### PR TITLE
feat: add update group role use case [AR-1603]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -67,5 +67,9 @@ class ConversationScope(
     val joinExistingMLSConversations: JoinExistingMLSConversationsUseCase
         get() = JoinExistingMLSConversationsUseCase(conversationRepository)
 
-    val updateConversationAccess: UpdateConversationAccessRoleUseCase get() = UpdateConversationAccessRoleUseCase(conversationRepository)
+    val updateConversationAccess: UpdateConversationAccessRoleUseCase
+        get() = UpdateConversationAccessRoleUseCase(conversationRepository)
+
+    val updateConversationMemberRole: UpdateConversationMemberRoleUseCase
+        get() = UpdateConversationMemberRoleUseCaseImpl(conversationRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMemberRoleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMemberRoleUseCase.kt
@@ -21,7 +21,7 @@ interface UpdateConversationMemberRoleUseCase {
 
 internal class UpdateConversationMemberRoleUseCaseImpl(
     private val conversationRepository: ConversationRepository
-): UpdateConversationMemberRoleUseCase {
+) : UpdateConversationMemberRoleUseCase {
 
     override suspend fun invoke(conversationId: ConversationId, userId: UserId, role: Member.Role): UpdateConversationMemberRoleResult =
         conversationRepository.updateConversationMemberRole(conversationId, userId, role)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMemberRoleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMemberRoleUseCase.kt
@@ -1,0 +1,41 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.kaliumLogger
+
+interface UpdateConversationMemberRoleUseCase {
+    /**
+     * Use case that allows a conversation member to change its role to:
+     * [Member.Role.Admin] or [Member.Role.Member]
+     *
+     * @param conversationId the id of the conversation where status wants to be changed
+     * @param mutedConversationStatus new status to set the given conversation
+     * @return an [ConversationUpdateStatusResult] containing Success or Failure cases
+     */
+    suspend operator fun invoke(conversationId: ConversationId, userId: UserId, role: Member.Role): UpdateConversationMemberRoleResult
+}
+
+internal class UpdateConversationMemberRoleUseCaseImpl(
+    private val conversationRepository: ConversationRepository
+): UpdateConversationMemberRoleUseCase {
+
+    override suspend fun invoke(conversationId: ConversationId, userId: UserId, role: Member.Role): UpdateConversationMemberRoleResult =
+        conversationRepository.updateConversationMemberRole(conversationId, userId, role)
+            .fold({
+                kaliumLogger.e(
+                    "Something went wrong when updating the role of user:$userId in conversation:$conversationId to $role"
+                )
+                UpdateConversationMemberRoleResult.Failure
+            }, {
+                UpdateConversationMemberRoleResult.Success
+            })
+}
+
+sealed class UpdateConversationMemberRoleResult {
+    object Success : UpdateConversationMemberRoleResult()
+    object Failure : UpdateConversationMemberRoleResult()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -20,6 +20,7 @@ import com.wire.kalium.network.api.conversation.ConversationPagingResponse
 import com.wire.kalium.network.api.conversation.ConversationResponse
 import com.wire.kalium.network.api.conversation.ConversationResponseDTO
 import com.wire.kalium.network.api.conversation.model.ConversationAccessInfoDTO
+import com.wire.kalium.network.api.conversation.model.ConversationMemberRoleDTO
 import com.wire.kalium.network.api.conversation.model.UpdateConversationAccessResponse
 import com.wire.kalium.network.api.model.ConversationAccessDTO
 import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
@@ -29,7 +30,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.ConversationIDEntity
-import com.wire.kalium.persistence.dao.Member
+import com.wire.kalium.persistence.dao.Member as MemberEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import io.ktor.http.HttpStatusCode
 import io.mockative.Mock
@@ -234,7 +235,7 @@ class ConversationRepositoryTest {
         given(conversationDAO)
             .suspendFunction(conversationDAO::getAllMembers)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(listOf(Member(TestUser.ENTITY_ID, Member.Role.Member))))
+            .thenReturn(flowOf(listOf(MemberEntity(TestUser.ENTITY_ID, MemberEntity.Role.Member))))
 
         given(userRepository)
             .suspendFunction(userRepository::getKnownUser)
@@ -270,7 +271,7 @@ class ConversationRepositoryTest {
         given(conversationDAO)
             .suspendFunction(conversationDAO::getAllMembers)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(listOf(Member(TestUser.ENTITY_ID, Member.Role.Member))))
+            .thenReturn(flowOf(listOf(MemberEntity(TestUser.ENTITY_ID, MemberEntity.Role.Member))))
 
         given(userRepository)
             .suspendFunction(userRepository::getKnownUser)
@@ -308,7 +309,7 @@ class ConversationRepositoryTest {
             .thenDoNothing()
 
         given(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .whenInvokedWith(anything(), anything())
             .thenDoNothing()
 
@@ -326,7 +327,7 @@ class ConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .with(anything(), anything())
             .wasInvoked(once)
     }
@@ -351,7 +352,7 @@ class ConversationRepositoryTest {
             .thenDoNothing()
 
         given(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .whenInvokedWith(anything(), anything())
             .thenDoNothing()
 
@@ -369,7 +370,7 @@ class ConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .with(anything(), anything())
             .wasInvoked(once)
     }
@@ -399,7 +400,7 @@ class ConversationRepositoryTest {
             .thenDoNothing()
 
         given(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .whenInvokedWith(any(), any())
             .thenDoNothing()
 
@@ -422,7 +423,7 @@ class ConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .with(anything(), anything())
             .wasInvoked(once)
 
@@ -575,7 +576,7 @@ class ConversationRepositoryTest {
                 )
             )
         given(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .whenInvokedWith(any(), any())
             .thenDoNothing()
         given(userRepository)
@@ -587,7 +588,7 @@ class ConversationRepositoryTest {
             .shouldSucceed()
 
         verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .with(anything(), anything())
             .wasInvoked(exactly = once)
     }
@@ -610,7 +611,7 @@ class ConversationRepositoryTest {
             .shouldSucceed()
 
         verify(conversationDAO)
-            .suspendFunction(conversationDAO::insertMembers, fun2<List<Member>, QualifiedIDEntity>())
+            .suspendFunction(conversationDAO::insertMembers, fun2<List<MemberEntity>, QualifiedIDEntity>())
             .with(any(), any())
             .wasNotInvoked()
     }
@@ -690,6 +691,41 @@ class ConversationRepositoryTest {
         }
     }
 
+    @Test
+    fun givenUpdateConversationMemberRoleSuccess_whenUpdatingConversationMemberRole_thenTheNewRoleIsUpdatedLocally() = runTest {
+        val (arrange, conversationRepository) = Arrangement()
+            .withApiUpdateConversationMemberRoleReturns(NetworkResponse.Success(Unit, mapOf(), 200))
+            .withDaoUpdateConversationMemberRoleSuccess()
+            .arrange()
+        val conversationId = ConversationId("conv_id", "conv_domain")
+        val userId: UserId = UserId("user_id", "user_domain")
+        val newRole = Member.Role.Admin
+
+        conversationRepository.updateConversationMemberRole(conversationId, userId, newRole).shouldSucceed()
+
+        with(arrange) {
+            verify(conversationApi)
+                .coroutine {
+                    conversationApi.updateConversationMemberRole(
+                        MapperProvider.idMapper().toApiModel(conversationId),
+                        MapperProvider.idMapper().toApiModel(userId),
+                        ConversationMemberRoleDTO(MapperProvider.conversationRoleMapper().toApi(newRole))
+                    )
+                }
+                .wasInvoked(exactly = once)
+
+            verify(conversationDAO)
+                .coroutine {
+                    conversationDAO.updateConversationMemberRole(
+                        MapperProvider.idMapper().toDaoModel(conversationId),
+                        MapperProvider.idMapper().toDaoModel(userId),
+                        MapperProvider.conversationRoleMapper().toDAO(newRole)
+                    )
+                }
+                .wasInvoked(exactly = once)
+        }
+    }
+
     private class Arrangement {
         @Mock
         val userRepository: UserRepository = mock(UserRepository::class)
@@ -728,6 +764,20 @@ class ConversationRepositoryTest {
                 .suspendFunction(conversationDAO::updateAccess)
                 .whenInvokedWith(any(), any(), any())
                 .thenThrow(exception)
+        }
+
+        fun withApiUpdateConversationMemberRoleReturns(response: NetworkResponse<Unit>) = apply {
+            given(conversationApi)
+                .suspendFunction(conversationApi::updateConversationMemberRole)
+                .whenInvokedWith(any(), any(), any())
+                .thenReturn(response)
+        }
+
+        fun withDaoUpdateConversationMemberRoleSuccess() = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::updateConversationMemberRole)
+                .whenInvokedWith(any(), any(), any())
+                .thenReturn(Unit)
         }
 
         fun arrange() = this to conversationRepository

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMemberRoleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMemberRoleUseCaseTest.kt
@@ -1,0 +1,73 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class UpdateConversationMemberRoleUseCaseTest {
+
+    @Mock
+    private val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
+
+    private lateinit var updateConversationMemberRoleUseCase: UpdateConversationMemberRoleUseCase
+
+    @BeforeTest
+    fun setup() {
+        updateConversationMemberRoleUseCase = UpdateConversationMemberRoleUseCaseImpl(conversationRepository)
+    }
+
+    @Test
+    fun givenAConversationIdAndUserId_whenInvokingRoleChangeSucceeds_thenShouldDelegateTheCallAndReturnASuccessResult() = runTest {
+        val conversationId = TestConversation.ID
+        val userId = TestUser.USER_ID
+        val newRole = Member.Role.Admin
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::updateConversationMemberRole)
+            .whenInvokedWith(any(), any(), eq(newRole))
+            .thenReturn(Either.Right(Unit))
+
+        val result = updateConversationMemberRoleUseCase(conversationId, userId, newRole)
+        assertIs<UpdateConversationMemberRoleResult.Success>(result)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::updateConversationMemberRole)
+            .with(any(), any(), eq(newRole))
+            .wasInvoked(exactly = once)
+
+    }
+
+    @Test
+    fun givenAConversationIdAndUserId_whenInvokingRoleChangeFails_thenShouldDelegateTheCallAndReturnAFailureResult() = runTest {
+        val conversationId = TestConversation.ID
+        val userId = TestUser.USER_ID
+        val newRole = Member.Role.Admin
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::updateConversationMemberRole)
+            .whenInvokedWith(any(), any(), eq(newRole))
+            .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
+
+        val result = updateConversationMemberRoleUseCase(conversationId, userId, newRole)
+        assertIs<UpdateConversationMemberRoleResult.Failure>(result)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::updateConversationMemberRole)
+            .with(any(), any(), eq(newRole))
+            .wasInvoked(exactly = once)
+
+    }
+
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApi.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.network.api.conversation
 import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.conversation.model.ConversationAccessInfoDTO
+import com.wire.kalium.network.api.conversation.model.ConversationMemberRoleDTO
 import com.wire.kalium.network.api.conversation.model.UpdateConversationAccessResponse
 import com.wire.kalium.network.utils.NetworkResponse
 
@@ -40,4 +41,10 @@ interface ConversationApi {
         conversationId: ConversationId,
         conversationAccessInfoDTO: ConversationAccessInfoDTO
     ): NetworkResponse<UpdateConversationAccessResponse>
+
+    suspend fun updateConversationMemberRole(
+        conversationId: ConversationId,
+        userId: UserId,
+        conversationMemberRoleDTO: ConversationMemberRoleDTO
+    ): NetworkResponse<Unit>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
@@ -126,7 +126,7 @@ class ConversationApiImpl internal constructor(private val authenticatedNetworkC
         conversationId: ConversationId,
         userId: UserId,
         conversationMemberRoleDTO: ConversationMemberRoleDTO
-        ): NetworkResponse<Unit> = wrapKaliumResponse {
+    ): NetworkResponse<Unit> = wrapKaliumResponse {
         httpClient.put(
             "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_MEMBERS/${userId.domain}/${userId.value}"
         ) {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationApiImpl.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.conversation.model.ConversationAccessInfoDTO
+import com.wire.kalium.network.api.conversation.model.ConversationMemberRoleDTO
 import com.wire.kalium.network.api.conversation.model.UpdateConversationAccessResponse
 import com.wire.kalium.network.api.notification.EventContentDTO
 import com.wire.kalium.network.api.pagination.PaginationRequest
@@ -119,6 +120,18 @@ class ConversationApiImpl internal constructor(private val authenticatedNetworkC
         }
     } catch (e: IOException) {
         NetworkResponse.Error(KaliumException.GenericError(e))
+    }
+
+    override suspend fun updateConversationMemberRole(
+        conversationId: ConversationId,
+        userId: UserId,
+        conversationMemberRoleDTO: ConversationMemberRoleDTO
+        ): NetworkResponse<Unit> = wrapKaliumResponse {
+        httpClient.put(
+            "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_MEMBERS/${userId.domain}/${userId.value}"
+        ) {
+            setBody(conversationMemberRoleDTO)
+        }
     }
 
     private companion object {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/model/ConversationMemberRoleDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/model/ConversationMemberRoleDTO.kt
@@ -1,0 +1,12 @@
+package com.wire.kalium.network.api.conversation.model
+
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
+import com.wire.kalium.network.api.notification.EventContentDTO
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConversationMemberRoleDTO(
+    @SerialName("conversation_role") val conversationRole: String
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/model/ConversationMemberRoleDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/model/ConversationMemberRoleDTO.kt
@@ -1,8 +1,5 @@
 package com.wire.kalium.network.api.conversation.model
 
-import com.wire.kalium.network.api.model.ConversationAccessDTO
-import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
-import com.wire.kalium.network.api.notification.EventContentDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
@@ -168,7 +168,7 @@ class ConversationApiTest : ApiTest {
 
     @Test
     fun whenUpdatingMemberRole_thenTheRequestShouldBeConfiguredCorrectly() = runTest {
-        val conversationId =  ConversationId("conversationId", "conversationDomain")
+        val conversationId = ConversationId("conversationId", "conversationDomain")
         val userId = UserId("userId", "userDomain")
         val memberRole = ConversationMemberRoleDTO("conversation_role")
         val networkClient = mockAuthenticatedNetworkClient(

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/conversation/ConversationApiTest.kt
@@ -3,9 +3,11 @@ package com.wire.kalium.api.tools.json.api.conversation
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.tools.json.api.notification.EventContentDTOJson
 import com.wire.kalium.network.api.ConversationId
+import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.conversation.ConversationApi
 import com.wire.kalium.network.api.conversation.ConversationApiImpl
 import com.wire.kalium.network.api.conversation.model.ConversationAccessInfoDTO
+import com.wire.kalium.network.api.conversation.model.ConversationMemberRoleDTO
 import com.wire.kalium.network.api.conversation.model.UpdateConversationAccessResponse
 import com.wire.kalium.network.api.model.ConversationAccessDTO
 import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
@@ -162,6 +164,23 @@ class ConversationApiTest : ApiTest {
             assertIs<NetworkResponse.Success<UpdateConversationAccessResponse.AccessUpdated>>(it)
             assertEquals(ConversationAccessRoleDTO.DEFAULT_VALUE_WHEN_NULL, it.value.event.data.accessRole)
         }
+    }
+
+    @Test
+    fun whenUpdatingMemberRole_thenTheRequestShouldBeConfiguredCorrectly() = runTest {
+        val conversationId =  ConversationId("conversationId", "conversationDomain")
+        val userId = UserId("userId", "userDomain")
+        val memberRole = ConversationMemberRoleDTO("conversation_role")
+        val networkClient = mockAuthenticatedNetworkClient(
+            "", statusCode = HttpStatusCode.NoContent,
+            assertion = {
+                assertPut()
+                assertPathEqual("/conversations/conversationDomain/conversationId/members/userDomain/userId")
+            }
+        )
+
+        val conversationApi = ConversationApiImpl(networkClient)
+        conversationApi.updateConversationMemberRole(conversationId, userId, memberRole)
     }
 
     private companion object {

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -22,3 +22,8 @@ SELECT * FROM Member WHERE conversation LIKE ('%' || :searchQuery || '%');
 
 selectAllConversationsByMember:
 SELECT * FROM Member WHERE user = ?;
+
+updateMemberRole:
+UPDATE Member
+SET role = ?
+WHERE user = ? AND conversation = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -87,4 +87,6 @@ interface ConversationDAO {
         accessList: List<ConversationEntity.Access>,
         accessRoleList: List<ConversationEntity.AccessRole>
     )
+
+    suspend fun updateConversationMemberRole(conversationId: QualifiedIDEntity, userId: UserIDEntity, role: Member.Role)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -250,4 +250,7 @@ class ConversationDAOImpl(
     ) {
         conversationQueries.updateAccess(accessList, accessRoleList, conversationID)
     }
+
+    override suspend fun updateConversationMemberRole(conversationId: QualifiedIDEntity, userId: UserIDEntity, role: Member.Role) =
+        memberQueries.updateMemberRole(role, userId, conversationId)
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -309,6 +309,23 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
     }
 
+    @Test
+    fun givenMember_whenUpdatingMemberRole_thenItsUpdated() = runTest {
+        // given
+        val conversation = conversationEntity1
+        val member = member1.copy(role = Member.Role.Member)
+        val newRole = Member.Role.Admin
+        val expected = member.copy(role = newRole)
+        conversationDAO.insertConversation(conversation)
+        conversationDAO.insertMember(member, conversation.id)
+        // when
+        conversationDAO.updateConversationMemberRole(conversation.id, member.user, newRole)
+        // then
+        conversationDAO.getAllMembers(conversation.id).first().also { actual ->
+            assertEquals(expected, actual[0])
+        }
+    }
+
     private companion object {
         val user1 = newUserEntity(id = "1")
         val user2 = newUserEntity(id = "2")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to be able to change the member's role in the group as an admin.

### Solutions

Implemented the use case, relevant functions in the API and DAO repositories and new DB query.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
