### PR TITLE
feat(delete-message): Delete Failed Message (AR-2017)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -12,9 +12,9 @@ import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
 
@@ -22,39 +22,42 @@ class DeleteMessageUseCase(
     private val messageRepository: MessageRepository,
     private val userRepository: UserRepository,
     private val clientRepository: ClientRepository,
-    private val syncManager: SyncManager,
     private val messageSender: MessageSender,
     private val idMapper: IdMapper
 ) {
 
-    suspend operator fun invoke(conversationId: ConversationId, messageId: String, deleteForEveryone: Boolean): Either<CoreFailure, Unit> {
-        syncManager.startSyncIfIdle()
-        val selfUser = userRepository.observeSelfUser().first()
-
-        val generatedMessageUuid = uuid4().toString()
-        return clientRepository.currentClientId().flatMap { currentClientId ->
-            val message = Message.Regular(
-                id = generatedMessageUuid,
-                content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else MessageContent.DeleteForMe(
-                    messageId,
-                    conversationId = conversationId.value,
-                    qualifiedConversationId = idMapper.toProtoModel(conversationId)
-                ),
-                conversationId = if (deleteForEveryone) conversationId else selfUser.id,
-                date = Clock.System.now().toString(),
-                senderUserId = selfUser.id,
-                senderClientId = currentClientId,
-                status = Message.Status.PENDING,
-                editStatus = Message.EditStatus.NotEdited,
-            )
-            messageSender.sendMessage(message)
-        }.flatMap {
-            messageRepository.markMessageAsDeleted(messageId, conversationId)
-        }.onFailure {
-            kaliumLogger.withFeatureId(MESSAGES).w("delete message failure: $it")
-            if (it is CoreFailure.Unknown) {
-                it.rootCause?.printStackTrace()
+    suspend operator fun invoke(conversationId: ConversationId, messageId: String, deleteForEveryone: Boolean): Either<CoreFailure, Unit> =
+        messageRepository.getMessageById(conversationId, messageId).map {
+            when (it.status) {
+                Message.Status.FAILED -> messageRepository.deleteMessage(messageId, conversationId)
+                else -> {
+                    val selfUser = userRepository.observeSelfUser().first()
+                    val generatedMessageUuid = uuid4().toString()
+                    return clientRepository.currentClientId().flatMap { currentClientId ->
+                        val message = Message.Regular(
+                            id = generatedMessageUuid,
+                            content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else MessageContent.DeleteForMe(
+                                messageId,
+                                conversationId = conversationId.value,
+                                qualifiedConversationId = idMapper.toProtoModel(conversationId)
+                            ),
+                            conversationId = if (deleteForEveryone) conversationId else selfUser.id,
+                            date = Clock.System.now().toString(),
+                            senderUserId = selfUser.id,
+                            senderClientId = currentClientId,
+                            status = Message.Status.PENDING,
+                            editStatus = Message.EditStatus.NotEdited,
+                        )
+                        messageSender.sendMessage(message)
+                    }.flatMap {
+                        messageRepository.markMessageAsDeleted(messageId, conversationId)
+                    }.onFailure { failure ->
+                        kaliumLogger.withFeatureId(MESSAGES).w("delete message failure: $it")
+                        if (failure is CoreFailure.Unknown) {
+                            failure.rootCause?.printStackTrace()
+                        }
+                    }
+                }
             }
         }
-    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -109,7 +109,6 @@ class MessageScope(
             messageRepository,
             userRepository,
             clientRepository,
-            syncManager,
             messageSender,
             idMapper
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -97,9 +97,11 @@ class DeleteMessageUseCaseTest {
         // then
         verify(messageSender)
             .suspendFunction(messageSender::sendMessage)
-            .with(matching { message ->
-                message.conversationId == TEST_CONVERSATION_ID && message.content == deletedMessageContent
-            })
+            .with(
+                matching { message ->
+                    message.conversationId == TEST_CONVERSATION_ID && message.content == deletedMessageContent
+                }
+            )
             .wasInvoked(exactly = once)
         verify(messageRepository)
             .suspendFunction(messageRepository::markMessageAsDeleted)
@@ -180,21 +182,23 @@ class DeleteMessageUseCaseTest {
             .whenInvokedWith(anything(), anything())
             .thenReturn(Either.Right(TestMessage.TEXT_MESSAGE(Message.Status.SENT)))
 
-
         // when
         val result = deleteMessageUseCase(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID, deleteForEveryone).shouldSucceed()
         val deletedForMeContent = MessageContent.DeleteForMe(
-            TEST_MESSAGE_UUID, TEST_CONVERSATION_ID.value, idMapper.toProtoModel(
+            TEST_MESSAGE_UUID, TEST_CONVERSATION_ID.value,
+            idMapper.toProtoModel(
                 TEST_CONVERSATION_ID
             )
         )
 
-        //then
+        // then
         verify(messageSender)
             .suspendFunction(messageSender::sendMessage)
-            .with(matching { message ->
-                message.conversationId == TestUser.SELF.id && message.content == deletedForMeContent
-            })
+            .with(
+                matching { message ->
+                    message.conversationId == TestUser.SELF.id && message.content == deletedForMeContent
+                }
+            )
             .wasInvoked(exactly = once)
 
         verify(messageRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
@@ -19,6 +19,18 @@ object TestMessage {
         status = Message.Status.PENDING,
         editStatus = Message.EditStatus.NotEdited
     )
+
+    fun TEXT_MESSAGE(status: Message.Status) = Message.Regular(
+        id = TEST_MESSAGE_ID,
+        content = TEXT_CONTENT,
+        conversationId = ConversationId("conv", "id"),
+        date = "date",
+        senderUserId = TEST_SENDER_USER_ID,
+        senderClientId = TEST_SENDER_CLIENT_ID,
+        status = status,
+        editStatus = Message.EditStatus.NotEdited
+    )
+
     val MISSED_CALL_MESSAGE = Message.System(
         id = TEST_MESSAGE_ID,
         content = MessageContent.MissedCall,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Handle to delete failed messages in delete message usecase.

### Issues
When a message was failed and unsent, the delete wouldn't work because it was trying to delete a message that wasn't exist on the server side!

### Causes (Optional)
When the status was added it wasn't handled in the delete usecase.

### Solutions

Handle the failed messages in the usecase.

### Dependencies (Optional)
None!

Needs releases with:

- [ ] GitHub link to other pull request

### Testing
Try to delete failed message, it should be deleted! [either by delete for me, or delete for everyone!]

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Try to delete failed message, it should be deleted! [either by delete for me, or delete for everyone!]

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
