### PR TITLE
test: refactor DeleteMessageUseCaseTest with Arrangement pattern

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -37,7 +37,7 @@ class DeleteMessageUseCaseTest {
 
         val (arrangement, deleteMessageUseCase) = Arrangement()
             .withSendMessageSucceed()
-            .withSelfUserIs(TestUser.SELF)
+            .withSelfUser(TestUser.SELF)
             .withCurrentClientIdIs(SELF_CLIENT_ID)
             .withMessageRepositoryMarkMessageAsDeletedSucceed()
             .withMessageByStatus(Message.Status.SENT)
@@ -67,7 +67,7 @@ class DeleteMessageUseCaseTest {
         val deleteForEveryone = true
         val (arrangement, deleteMessageUseCase) = Arrangement()
             .withSendMessageSucceed()
-            .withSelfUserIs(TestUser.SELF)
+            .withSelfUser(TestUser.SELF)
             .withCurrentClientIdIs(SELF_CLIENT_ID)
             .withMessageRepositoryMarkMessageAsDeletedSucceed()
             .withMessageRepositoryDeleteMessageSucceed()
@@ -98,7 +98,7 @@ class DeleteMessageUseCaseTest {
         val deleteForEveryone = false
         val (arrangement, deleteMessageUseCase) = Arrangement()
             .withSendMessageSucceed()
-            .withSelfUserIs(TestUser.SELF)
+            .withSelfUser(TestUser.SELF)
             .withCurrentClientIdIs(SELF_CLIENT_ID)
             .withMessageRepositoryMarkMessageAsDeletedSucceed()
             .withMessageByStatus(Message.Status.SENT)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -62,7 +62,7 @@ class DeleteMessageUseCaseTest {
     }
 
     @Test
-    fun givenAFailedMessage_WhenDelete_TheMessageShouldBeDeleted() = runTest {
+    fun givenAFailedMessage_WhenItGetsDeletedForEveryone_TheMessageShouldBeDeleted() = runTest {
         // given
         val deleteForEveryone = true
         val (arrangement, deleteMessageUseCase) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -93,7 +93,7 @@ class DeleteMessageUseCaseTest {
     }
 
     @Test
-    fun givenASentMessage_WhenDeleteForEveryIsFalse_TheGeneratedMessageShouldBeCorrect() = runTest {
+    fun givenASentMessage_WhenDeleteForEveryoneIsFalse_TheGeneratedMessageShouldBeDeletedOnlyLocally() = runTest {
         // given
         val deleteForEveryone = false
         val (arrangement, deleteMessageUseCase) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -162,7 +162,7 @@ class DeleteMessageUseCaseTest {
                 .thenReturn(Either.Right(Unit))
         }
 
-        fun withSelfUserIs(selfUser: SelfUser) = apply {
+        fun withSelfUser(selfUser: SelfUser) = apply {
             given(userRepository)
                 .suspendFunction(userRepository::observeSelfUser)
                 .whenInvoked()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Updated deleteMessageUseCase with Arrangement Pattern

### Issues
To update and align current codebase with our agreements.

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
