### PR TITLE
fix: stuck processing calling messages in the background (AR-2133)

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -31,7 +31,7 @@ object Versions {
     const val sqlDelight = "2.0.0-alpha01"
     const val pbandk = "0.14.1"
     const val turbine = "0.7.0"
-    const val avs = "8.1.18"
+    const val avs = "8.2.4"
     const val jna = "5.6.0@aar"
     const val mlsClient = "0.2.2"
     const val desugarJdk = "1.1.5"

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -3,6 +3,10 @@ package com.wire.kalium.logic.feature.call
 import com.sun.jna.Pointer
 import com.wire.kalium.calling.CallTypeCalling
 import com.wire.kalium.calling.Calling
+import com.wire.kalium.calling.callbacks.ConstantBitRateStateChangeHandler
+import com.wire.kalium.calling.callbacks.MetricsHandler
+import com.wire.kalium.calling.callbacks.ReadyHandler
+import com.wire.kalium.calling.callbacks.VideoReceiveStateHandler
 import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.calling.types.Uint32_t
 import com.wire.kalium.logic.callingLogger
@@ -95,8 +99,8 @@ actual class CallManagerImpl(
         val handle = calling.wcall_create(
             userId = selfUserId,
             clientId = selfClientId,
-            readyHandler = { version: Int, arg: Pointer? ->
-                callingLogger.i("$TAG -> readyHandler")
+            readyHandler = ReadyHandler { version: Int, arg: Pointer? ->
+                callingLogger.i("$TAG -> readyHandler; version=$version; arg=$arg")
                 onCallingReady()
                 waitInitializationJob.complete()
                 Unit
@@ -116,14 +120,16 @@ actual class CallManagerImpl(
             answeredCallHandler = OnAnsweredCall(callRepository, scope).keepingStrongReference(),
             establishedCallHandler = OnEstablishedCall(callRepository, scope).keepingStrongReference(),
             closeCallHandler = OnCloseCall(callRepository, scope).keepingStrongReference(),
-            metricsHandler = { conversationId: String, metricsJson: String, arg: Pointer? ->
+            metricsHandler = MetricsHandler { conversationId: String, metricsJson: String, arg: Pointer? ->
                 callingLogger.i("$TAG -> metricsHandler")
             }.keepingStrongReference(),
             callConfigRequestHandler = OnConfigRequest(calling, callRepository, scope).keepingStrongReference(),
-            constantBitRateStateChangeHandler = { userId: String, clientId: String, isEnabled: Boolean, arg: Pointer? ->
+            constantBitRateStateChangeHandler =
+            ConstantBitRateStateChangeHandler { userId: String, clientId: String, isEnabled: Boolean, arg: Pointer? ->
                 callingLogger.i("$TAG -> constantBitRateStateChangeHandler")
             }.keepingStrongReference(),
-            videoReceiveStateHandler = { conversationId: String, userId: String, clientId: String, state: Int, arg: Pointer? ->
+            videoReceiveStateHandler =
+            VideoReceiveStateHandler { conversationId: String, userId: String, clientId: String, state: Int, arg: Pointer? ->
                 callingLogger.i("$TAG -> videoReceiveStateHandler")
             }.keepingStrongReference(),
             arg = null


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When receiving calling messages in the background, the app stays stuck and doesn’t process any new messages, not showing any notifications.

### Causes

This seems to be the case where AVS is initialized, we fetch calling configs from the server but after feeding them to AVS, it never calls `ReadyHandler`, so initialization never completes.

Whilst this was an issue in the past (where FlowManager and MediaManager were not yet initialised), we're not sure yet what could've changed to make this behaviour resurface, and AVS doesn't provide any kind of logging to help.

I’ve been in touch with @z-dule to help understanding AVS a bit better and what could be the cause of it. So it makes the job to find the culprit easier.

@z-dule released AVS 8.2.4, which [adds a bit more logging to the config changes handler,](https://github.com/wireapp/wire-avs/commit/550972646ebee40121e5cffd6fb52552172ad0b3) which can help us identify what’s going on:

```
I/Calling: wcall(0xdcd4c734): config_update: err=0 json=1618 bytes
I/Calling: config(0xe4847024): got ttl of 3600 seconds
I/Calling: config(0xe4847024): got iceservers: 6
I/Calling: config(0xe4847024): got sftservers: 5
I/Calling: config(0xe4847024): sft(0): https://sft3.sft.prod.wire.com:443
I/Calling: config(0xe4847024): sft(1): https://sft4.sft.prod.wire.com:443
I/Calling: config(0xe4847024): sft(2): https://sft1.sft.prod.wire.com:443
I/Calling: config(0xe4847024): sft(3): https://sft2.sft.prod.wire.com:443
I/Calling: config(0xe4847024): sft(4): https://sft5.sft.prod.wire.com:443
D/Calling: wcall(0xdcd4c734): call_config: 6 ice servers first=1 readyh=0xea5c1028
I/Calling: WAPI wcall(0xdcd4c734): calling readyh: 0xea5c1028
I/Calling: WAPI wcall(0xdcd4c734): calling readyh: 0xea5c1028 took: 1657857376266ms
## No more logs! Stuck here
```

I was able to confirm that AVS was calling the `ReadyHandler` but we're not receiving this call for whatever reason.
The absolute lower-level cause is still unclear to me.


### Solutions

As I said, lower-level cause is still unclear to me.

I've experimented using the Memory Profiler to see what was going on, and to check if the references we hold to these handlers are being kept, and so on, etc.

As you can see in the attachments below, I've noticed how the handlers look like any anonymous lambda and I tried to explicitly type them just to see if that would make any difference.
Turns out it did!
The lambdas changed from completely anonymous to `ExternalSyntheticLambda`, and I am not sure how this fixed it.
I'm a bit frustrated as I can't pin-point to what just happened.

I had multiple theories but I couldn't confirm a single one.

But I swear this works:

```
I/Calling: config(0xe4847984): got ttl of 3600 seconds
I/Calling: config(0xe4847984): got iceservers: 6
I/Calling: config(0xe4847984): got sftservers: 5
I/Calling: config(0xe4847984): sft(0): https://sft3.sft.prod.wire.com:443
I/Calling: config(0xe4847984): sft(1): https://sft5.sft.prod.wire.com:443
I/Calling: config(0xe4847984): sft(2): https://sft0.sft.prod.wire.com:443
I/Calling: config(0xe4847984): sft(3): https://sft2.sft.prod.wire.com:443
I/Calling: config(0xe4847984): sft(4): https://sft1.sft.prod.wire.com:443
D/Calling: wcall(0xdcd4a334): call_config: 6 ice servers first=1 readyh=0xea5c1028
I/Calling: WAPI wcall(0xdcd4a334): calling readyh: 0xea5c1028
I/Calling: CallManager -> readyHandler; version=3; arg=null
I/Calling: CallManager - onCallingMessageReceived called
I/Calling: WAPI wcall: set_active_speaker_handler 0xea5c11a8 inst=0xdcd4a334
I/Calling: WAPI wcall: set_participant_changed_handler 0xea5c11c8 inst=0xdcd4a334
D/Calling: CallManager - wcall_set_req_clients_handler() called
I/Calling: WAPI wcall(0xdcd4a334): calling readyh: 0xea5c1028 took: 1657857376272ms
D/Calling: CallManager - wcall_set_participant_changed_handler() called
I/Calling: WAPI wcall: set_quality_handler fn=0xea5c11e8 int=5 inst=0xdcd4a334
I/Calling: WAPI wcall: set_req_clients_handler 0xea5c1208 inst=0xdcd4a334
D/Calling: CallManager - wcall_set_network_quality_handler() called
D/Calling: CallManager - wcall_set_req_clients_handler() called
I/Calling: CallManager - wcall_recv_msg() called
```
### Testing

#### How to Test

1. Run Reloaded with these changes in the background. 
2. Swipe to kill the app.
3. Make a call
4. The app should receive the call

### Attachments

The item `0` in the `strongReferences` below corresponds to the `readyHandler` lambda.

Before the fix:
<img width="564" alt="image" src="https://user-images.githubusercontent.com/9389043/182229809-a0b9834e-3f44-4258-b4ad-65fab5b3b91e.png">


After the fix:
<img width="636" alt="image" src="https://user-images.githubusercontent.com/9389043/182229738-c9931447-d9d5-472b-a94d-8548f280eb8c.png">

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
