### PR TITLE
chore: add slow sync state and completion storage

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
@@ -1,0 +1,33 @@
+package com.wire.kalium.logic.data.sync
+
+import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
+import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.datetime.Instant
+
+internal interface SlowSyncRepository {
+    val lastFullSyncInstant: StateFlow<Instant?>
+    val slowSyncStatus: StateFlow<SlowSyncStatus>
+    fun setLastSlowSyncCompletionInstant(instant: Instant?)
+    fun updateSlowSyncStatus(slowSyncStatus: SlowSyncStatus)
+}
+
+internal class InMemorySlowSyncRepository : SlowSyncRepository {
+    private val _lastFullSyncInstant = MutableStateFlow<Instant?>(null)
+    override val lastFullSyncInstant get() = _lastFullSyncInstant.asStateFlow()
+
+    private val _slowSyncStatus = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Pending)
+    override val slowSyncStatus: StateFlow<SlowSyncStatus> get() = _slowSyncStatus.asStateFlow()
+
+    override fun setLastSlowSyncCompletionInstant(instant: Instant?) {
+        kaliumLogger.withFeatureId(SYNC).i("Updating last slow sync instant: $instant")
+        _lastFullSyncInstant.value = instant
+    }
+
+    override fun updateSlowSyncStatus(slowSyncStatus: SlowSyncStatus) {
+        kaliumLogger.withFeatureId(SYNC).i("Updating SLOW sync status: $slowSyncStatus")
+        _slowSyncStatus.value = slowSyncStatus
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
@@ -1,0 +1,19 @@
+package com.wire.kalium.logic.data.sync
+
+sealed interface SlowSyncStatus {
+
+    object Pending : SlowSyncStatus
+
+    object Complete : SlowSyncStatus
+
+    data class Ongoing(val currentStep: SlowSyncStep) : SlowSyncStatus
+}
+
+enum class SlowSyncStep {
+    SELF_USER,
+    CONVERSATIONS,
+    CONNECTIONS,
+    SELF_TEAM,
+    CONTACTS,
+    JOINING_MLS_CONVERSATIONS,
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
@@ -1,0 +1,90 @@
+package com.wire.kalium.logic.data.sync
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+
+class SlowSyncRepositoryTest {
+
+    private lateinit var slowSyncRepository: SlowSyncRepository
+
+    @BeforeTest
+    fun setup() {
+        slowSyncRepository = InMemorySlowSyncRepository()
+    }
+
+    @Test
+    fun givenInstantIsUpdated_whenGettingTheLastSlowSyncInstant_thenShouldReturnTheNewState() = runTest {
+        val instant = Clock.System.now()
+        slowSyncRepository.setLastSlowSyncCompletionInstant(instant)
+
+        val currentInstant = slowSyncRepository.lastFullSyncInstant.value
+
+        assertEquals(instant, currentInstant)
+    }
+
+    @Test
+    fun givenLastInstantWasNeverSet_whenGettingLastInstant_thenTheStateIsNull() = runTest {
+        // Empty Given
+
+        val state = slowSyncRepository.lastFullSyncInstant
+
+        assertNull(state.value)
+    }
+
+    @Test
+    fun givenAnInstantIsUpdated_whenObservingTheLastSlowSyncInstant_thenTheNewStateIsPropagatedForObservers() = runTest {
+        val firstInstant = Clock.System.now()
+        slowSyncRepository.setLastSlowSyncCompletionInstant(firstInstant)
+
+        slowSyncRepository.lastFullSyncInstant.test {
+            assertEquals(firstInstant, awaitItem())
+
+            val secondInstant = firstInstant.plus(10.seconds)
+            slowSyncRepository.setLastSlowSyncCompletionInstant(secondInstant)
+            assertEquals(secondInstant, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenStatusWasNeverUpdated_whenGettingStatus_thenTheStateIsPending() = runTest {
+        // Empty Given
+
+        val currentState = slowSyncRepository.slowSyncStatus.value
+
+        assertEquals(SlowSyncStatus.Pending, currentState)
+    }
+
+    @Test
+    fun givenStatusIsUpdated_whenGettingStatus_thenTheStateIsAlsoUpdated() = runTest {
+        val newStatus = SlowSyncStatus.Ongoing(SlowSyncStep.CONVERSATIONS)
+        slowSyncRepository.updateSlowSyncStatus(newStatus)
+
+        val currentState = slowSyncRepository.slowSyncStatus.value
+
+        assertEquals(newStatus, currentState)
+    }
+
+    @Test
+    fun givenStatusIsUpdated_whenObservingStatus_thenTheChangesArePropagated() = runTest {
+        val firstStatus = SlowSyncStatus.Ongoing(SlowSyncStep.CONVERSATIONS)
+        slowSyncRepository.updateSlowSyncStatus(firstStatus)
+
+        slowSyncRepository.slowSyncStatus.test {
+            assertEquals(firstStatus, awaitItem())
+
+            val secondStep = SlowSyncStatus.Complete
+            slowSyncRepository.updateSlowSyncStatus(secondStep)
+            assertEquals(secondStep, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

SlowSync happens every time

### Causes

We don't handle all incremental sync events. So we need to perform SlowSync every so often.

### Solutions

Even though we still can't stay without performing SlowSync for long, we can build the base for the future and allow further progress with Sync retrying mechanisms in a realistic way.

In this PR: 
- Add a way to store SlowSync status

Currently in memory only, so SlowSync will happen again once the client is re-launched.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
