### PR TITLE
feat: deleted conversations events (AR-2040)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -96,6 +96,7 @@ interface ConversationRepository {
     ): Either<CoreFailure, Unit>
 
     suspend fun updateConversationMemberRole(conversationId: ConversationId, userId: UserId, role: Member.Role): Either<CoreFailure, Unit>
+    suspend fun deleteConversation(conversationId: ConversationId): Either<CoreFailure, Unit>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -536,6 +537,10 @@ class ConversationDataSource(
                 role = conversationRoleMapper.toDAO(role)
             )
         }
+    }
+
+    override suspend fun deleteConversation(conversationId: ConversationId) = wrapStorageRequest {
+        conversationDAO.deleteConversationByQualifiedID(idMapper.toDaoModel(conversationId))
     }
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -70,6 +70,13 @@ sealed class Event(open val id: String) {
             val message: String,
             val timestampIso: String = Clock.System.now().toString()
         ) : Conversation(id, conversationId)
+
+        data class DeletedConversation(
+            override val id: String,
+            override val conversationId: ConversationId,
+            val senderUserId: UserId,
+            val timestampIso: String,
+        ) : Conversation(id, conversationId)
     }
 
     sealed class FeatureConfig(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -17,7 +17,7 @@ class EventMapper(
     private val memberMapper: MemberMapper,
     private val connectionMapper: ConnectionMapper
 ) {
-
+    @Suppress("ComplexMethod")
     fun fromDTO(eventResponse: EventResponse): List<Event> {
         // TODO(edge-case): Multiple payloads in the same event have the same ID, is this an issue when marking lastProcessedEventId?
         val id = eventResponse.id

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -32,6 +32,7 @@ class EventMapper(
                 is EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO -> featureConfig(id, eventContentDTO)
                 is EventContentDTO.User.NewClientDTO, EventContentDTO.Unknown -> Event.Unknown(id)
                 is EventContentDTO.Conversation.AccessUpdate -> Event.Unknown(id) // TODO: update it after logic code is merged
+                is EventContentDTO.Conversation.DeletedConversationDTO -> conversationDeleted(id, eventContentDTO)
             }
         } ?: listOf()
     }
@@ -117,5 +118,15 @@ class EventMapper(
         featureConfigUpdatedDTO: EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO
     ) = Event.FeatureConfig.FeatureConfigUpdated(
         id, featureConfigUpdatedDTO.name.name, featureConfigUpdatedDTO.data.status.name
+    )
+
+    private fun conversationDeleted(
+        id: String,
+        deletedConversationDTO: EventContentDTO.Conversation.DeletedConversationDTO
+    ) = Event.Conversation.DeletedConversation(
+        id = id,
+        conversationId = idMapper.fromApiModel(deletedConversationDTO.qualifiedConversation),
+        senderUserId = idMapper.fromApiModel(deletedConversationDTO.qualifiedFrom),
+        timestampIso = deletedConversationDTO.time
     )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
 import com.wire.kalium.util.DelicateKaliumApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.fold
@@ -249,7 +248,8 @@ class MessageDataSource(
 
     override suspend fun deleteAllMessagesForConversation(conversationId: ConversationId): Either<CoreFailure, Unit> =
         wrapStorageRequest {
-            messageDAO.getMessagesByConversationId(idMapper.toDaoModel(conversationId)).collect { messageDAO.deleteMessages(it) }
+            val messages = messageDAO.getMessagesByConversationId(idMapper.toDaoModel(conversationId))
+            messageDAO.deleteMessages(messages)
         }
 
     override suspend fun updateTextMessageContent(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -94,7 +94,6 @@ interface MessageRepository {
         newMessageId: String
     ): Either<CoreFailure, Unit>
 
-    suspend fun deleteAllMessagesForConversation(conversationId: ConversationId): Either<CoreFailure, Unit>
 }
 
 // TODO: suppress TooManyFunctions for now, something we need to fix in the future
@@ -241,12 +240,6 @@ class MessageDataSource(
     ): Either<CoreFailure, Unit> =
         wrapStorageRequest {
             messageDAO.updateMessageId(idMapper.toDaoModel(conversationId), oldMessageId, newMessageId)
-        }
-
-    override suspend fun deleteAllMessagesForConversation(conversationId: ConversationId): Either<CoreFailure, Unit> =
-        wrapStorageRequest {
-            val messages = messageDAO.getMessagesByConversationId(idMapper.toDaoModel(conversationId))
-            messageDAO.deleteMessages(messages)
         }
 
     override suspend fun updateTextMessageContent(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -12,7 +12,6 @@ import com.wire.kalium.logic.failure.ProteusSendMessageFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.wrapApiRequest
@@ -27,8 +26,6 @@ import com.wire.kalium.persistence.dao.message.MessageEntityContent
 import com.wire.kalium.util.DelicateKaliumApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
 
 @Suppress("TooManyFunctions")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -273,13 +273,12 @@ class ConversationEventReceiverImpl(
             }
 
     private suspend fun handleDeletedConversation(event: Event.Conversation.DeletedConversation) =
-        messageRepository.deleteAllMessagesForConversation(event.conversationId)
+        conversationRepository.deleteConversation(event.conversationId)
             .onFailure { coreFailure ->
                 kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - Error deleting the contents of a conversation $coreFailure")
                 Either.Left(coreFailure)
             }.onSuccess {
-                kaliumLogger.withFeatureId(EVENT_RECEIVER).d("$TAG - Deleting the conversation $event")
-                conversationRepository.deleteConversation(event.conversationId)
+                kaliumLogger.withFeatureId(EVENT_RECEIVER).d("$TAG - Deleted the conversation ${event.conversationId}")
             }
 
     private suspend fun processSignaling(senderUserId: UserId, signaling: MessageContent.Signaling) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -276,7 +276,6 @@ class ConversationEventReceiverImpl(
         conversationRepository.deleteConversation(event.conversationId)
             .onFailure { coreFailure ->
                 kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - Error deleting the contents of a conversation $coreFailure")
-                Either.Left(coreFailure)
             }.onSuccess {
                 kaliumLogger.withFeatureId(EVENT_RECEIVER).d("$TAG - Deleted the conversation ${event.conversationId}")
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiver.kt
@@ -63,6 +63,7 @@ class ConversationEventReceiverImpl(
         when (event) {
             is Event.Conversation.NewMessage -> handleNewMessage(event)
             is Event.Conversation.NewConversation -> handleNewConversation(event)
+            is Event.Conversation.DeletedConversation -> handleDeletedConversation(event)
             is Event.Conversation.MemberJoin -> handleMemberJoin(event)
             is Event.Conversation.MemberLeave -> handleMemberLeave(event)
             is Event.Conversation.MLSWelcome -> handleMLSWelcome(event)
@@ -273,6 +274,11 @@ class ConversationEventReceiverImpl(
                     content = protoContent
                 )
             }
+
+    private suspend fun handleDeletedConversation(event: Event.Conversation.DeletedConversation): Either<CoreFailure, Unit> {
+        kaliumLogger.withFeatureId(EVENT_RECEIVER).d("Receiving event $event")
+        return Either.Right(Unit)
+    }
 
     private fun processSignaling(signaling: MessageContent.Signaling) {
         when (signaling) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -204,6 +204,31 @@ class MessageRepositoryTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenAConversationId_whenDeletingAllMessages_thenShouldBeRemovedLocally() = runTest {
+        given(idMapper)
+            .function(idMapper::toDaoModel)
+            .whenInvokedWith(anything())
+            .then { TEST_QUALIFIED_ID_ENTITY }
+
+        given(messageDAO)
+            .suspendFunction(messageDAO::getMessagesByConversationId)
+            .whenInvokedWith(eq(TEST_QUALIFIED_ID_ENTITY))
+            .then { listOf(TEST_MESSAGE_ENTITY) }
+
+        messageRepository.deleteAllMessagesForConversation(TEST_CONVERSATION_ID).shouldSucceed()
+
+        verify(messageDAO)
+            .suspendFunction(messageDAO::getMessagesByConversationId)
+            .with(eq(TEST_QUALIFIED_ID_ENTITY))
+            .wasInvoked(once)
+
+        verify(messageDAO)
+            .suspendFunction(messageDAO::deleteMessages)
+            .with(eq(listOf(TEST_MESSAGE_ENTITY)))
+            .wasInvoked(once)
+    }
+
     private companion object {
         val TEST_QUALIFIED_ID_ENTITY = PersistenceQualifiedId("value", "domain")
         val TEST_NETWORK_QUALIFIED_ID_ENTITY = NetworkQualifiedId("value", "domain")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -204,31 +204,6 @@ class MessageRepositoryTest {
             .wasInvoked(exactly = once)
     }
 
-    @Test
-    fun givenAConversationId_whenDeletingAllMessages_thenShouldBeRemovedLocally() = runTest {
-        given(idMapper)
-            .function(idMapper::toDaoModel)
-            .whenInvokedWith(anything())
-            .then { TEST_QUALIFIED_ID_ENTITY }
-
-        given(messageDAO)
-            .suspendFunction(messageDAO::getMessagesByConversationId)
-            .whenInvokedWith(eq(TEST_QUALIFIED_ID_ENTITY))
-            .then { listOf(TEST_MESSAGE_ENTITY) }
-
-        messageRepository.deleteAllMessagesForConversation(TEST_CONVERSATION_ID).shouldSucceed()
-
-        verify(messageDAO)
-            .suspendFunction(messageDAO::getMessagesByConversationId)
-            .with(eq(TEST_QUALIFIED_ID_ENTITY))
-            .wasInvoked(once)
-
-        verify(messageDAO)
-            .suspendFunction(messageDAO::deleteMessages)
-            .with(eq(listOf(TEST_MESSAGE_ENTITY)))
-            .wasInvoked(once)
-    }
-
     private companion object {
         val TEST_QUALIFIED_ID_ENTITY = PersistenceQualifiedId("value", "domain")
         val TEST_NETWORK_QUALIFIED_ID_ENTITY = NetworkQualifiedId("value", "domain")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -30,4 +30,11 @@ object TestEvent {
             toId = "told?"
         )
     )
+
+    fun deletedConversation(eventId: String = "eventId") = Event.Conversation.DeletedConversation(
+        eventId,
+        TestConversation.ID,
+        TestUser.USER_ID,
+        "2022-03-30T15:36:00.000Z"
+    )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ConversationEventReceiverTest.kt
@@ -257,18 +257,12 @@ class ConversationEventReceiverTest {
     fun givenADeletedConversationEvent_whenHandlingIt_thenShouldDeleteTheConversationAndItsContent() = runTest {
         val event = TestEvent.deletedConversation()
         val (arrangement, eventReceiver) = Arrangement()
-            .withDeletingMessagesSucceeding()
             .withDeletingConversationSucceeding()
             .arrange()
 
         eventReceiver.onEvent(event)
 
         with(arrangement) {
-            verify(messageRepository)
-                .suspendFunction(messageRepository::deleteAllMessagesForConversation)
-                .with(eq(TestConversation.ID))
-                .wasInvoked(exactly = once)
-
             verify(conversationRepository)
                 .suspendFunction(conversationRepository::deleteConversation)
                 .with(eq(TestConversation.ID))
@@ -400,13 +394,6 @@ class ConversationEventReceiverTest {
             encryptedContent,
             encryptedExternalContent
         )
-
-        fun withDeletingMessagesSucceeding(conversationId: ConversationId = TestConversation.ID) = apply {
-            given(messageRepository)
-                .suspendFunction(messageRepository::deleteAllMessagesForConversation)
-                .whenInvokedWith((eq(conversationId)))
-                .thenReturn(Either.Right(Unit))
-        }
 
         fun withDeletingConversationSucceeding(conversationId: ConversationId = TestConversation.ID) = apply {
             given(conversationRepository)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
@@ -90,6 +90,14 @@ sealed class EventContentDTO {
             val time: String,
             @SerialName("data") val message: String,
         ) : Conversation()
+
+        @Serializable
+        @SerialName("conversation.delete")
+        data class DeletedConversationDTO(
+            @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
+            @SerialName("qualified_from") val qualifiedFrom: UserId,
+            val time: String
+        ) : Conversation()
     }
 
     @Serializable

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -237,6 +237,9 @@ SELECT * FROM Message ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;
 selectById:
 SELECT * FROM Message WHERE id = ? AND conversation_id = ?;
 
+selectAllMessagesByConversationId:
+SELECT * FROM Message WHERE conversation_id = ?;
+
 selectByConversationIdAndVisibility:
 SELECT * FROM Message WHERE conversation_id = ? AND visibility IN ? ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -19,7 +19,7 @@ CREATE TABLE Message (
       last_edit_timestamp TEXT ,
       visibility TEXT AS MessageEntity.Visibility NOT NULL DEFAULT 'visible',
 
-      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id),
+      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE,
       FOREIGN KEY (sender_user_id) REFERENCES User(qualified_id),
       PRIMARY KEY (id, conversation_id)
 );
@@ -236,9 +236,6 @@ SELECT * FROM Message ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;
 
 selectById:
 SELECT * FROM Message WHERE id = ? AND conversation_id = ?;
-
-selectAllMessagesByConversationId:
-SELECT * FROM Message WHERE conversation_id = ?;
 
 selectByConversationIdAndVisibility:
 SELECT * FROM Message WHERE conversation_id = ? AND visibility IN ? ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -8,7 +8,7 @@ interface MessageDAO {
     suspend fun deleteMessage(id: String, conversationsId: QualifiedIDEntity)
     suspend fun updateAssetDownloadStatus(downloadStatus: MessageEntity.DownloadStatus, id: String, conversationId: QualifiedIDEntity)
     suspend fun markMessageAsDeleted(id: String, conversationsId: QualifiedIDEntity)
-    suspend fun markAsEdited(editTimeStamp: String,conversationId: QualifiedIDEntity, id: String)
+    suspend fun markAsEdited(editTimeStamp: String, conversationId: QualifiedIDEntity, id: String)
     suspend fun deleteAllMessages()
     suspend fun insertMessage(message: MessageEntity)
     suspend fun insertMessages(messages: List<MessageEntity>)
@@ -18,17 +18,21 @@ interface MessageDAO {
     suspend fun updateMessagesAddMillisToDate(millis: Long, conversationId: QualifiedIDEntity, status: MessageEntity.Status)
     suspend fun getMessagesFromAllConversations(limit: Int, offset: Int): Flow<List<MessageEntity>>
     suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?>
+    suspend fun getMessagesByConversationId(conversationId: QualifiedIDEntity): Flow<List<MessageEntity>>
+    suspend fun deleteMessages(messages: List<MessageEntity>)
     suspend fun getMessagesByConversationAndVisibility(
         conversationId: QualifiedIDEntity,
         limit: Int,
         offset: Int,
         visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.values().toList()
     ): Flow<List<MessageEntity>>
+
     suspend fun getMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,
         date: String,
         visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.values().toList()
     ): Flow<List<MessageEntity>>
+
     suspend fun getAllPendingMessagesFromUser(userId: UserIDEntity): List<MessageEntity>
     suspend fun updateTextMessageContent(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -18,8 +18,6 @@ interface MessageDAO {
     suspend fun updateMessagesAddMillisToDate(millis: Long, conversationId: QualifiedIDEntity, status: MessageEntity.Status)
     suspend fun getMessagesFromAllConversations(limit: Int, offset: Int): Flow<List<MessageEntity>>
     suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?>
-    suspend fun getMessagesByConversationId(conversationId: QualifiedIDEntity): List<MessageEntity>
-    suspend fun deleteMessages(messages: List<MessageEntity>)
     suspend fun getMessagesByConversationAndVisibility(
         conversationId: QualifiedIDEntity,
         limit: Int,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -18,7 +18,7 @@ interface MessageDAO {
     suspend fun updateMessagesAddMillisToDate(millis: Long, conversationId: QualifiedIDEntity, status: MessageEntity.Status)
     suspend fun getMessagesFromAllConversations(limit: Int, offset: Int): Flow<List<MessageEntity>>
     suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?>
-    suspend fun getMessagesByConversationId(conversationId: QualifiedIDEntity): Flow<List<MessageEntity>>
+    suspend fun getMessagesByConversationId(conversationId: QualifiedIDEntity): List<MessageEntity>
     suspend fun deleteMessages(messages: List<MessageEntity>)
     suspend fun getMessagesByConversationAndVisibility(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -10,10 +10,10 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.ASSET
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.MEMBER_CHANGE
+import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.MISSED_CALL
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.RESTRICTED_ASSET
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.TEXT
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.UNKNOWN
-import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.MISSED_CALL
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -23,9 +23,9 @@ import kotlinx.coroutines.flow.map
 import com.wire.kalium.persistence.Message as SQLDelightMessage
 import com.wire.kalium.persistence.MessageAssetContent as SQLDelightMessageAssetContent
 import com.wire.kalium.persistence.MessageMemberChangeContent as SQLDelightMessageMemberChangeContent
+import com.wire.kalium.persistence.MessageMissedCallContent as SQLDelightMessageMissedCallContent
 import com.wire.kalium.persistence.MessageTextContent as SQLDelightMessageTextContent
 import com.wire.kalium.persistence.MessageUnknownContent as SQLDelightMessageUnknownContent
-import com.wire.kalium.persistence.MessageMissedCallContent as SQLDelightMessageMissedCallContent
 
 class MessageMapper {
     fun toModel(msg: SQLDelightMessage, content: MessageEntityContent): MessageEntity = when (content) {
@@ -40,6 +40,7 @@ class MessageMapper {
             editStatus = mapEditStatus(msg.last_edit_timestamp),
             visibility = msg.visibility
         )
+
         is MessageEntityContent.System -> MessageEntity.System(
             content = content,
             id = msg.id,
@@ -131,6 +132,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
                     conversation_id = message.conversationId,
                     text_body = content.messageBody
                 )
+
                 is MessageEntityContent.RestrictedAsset -> queries.insertMessageRestrictedAssetContent(
                     message_id = message.id,
                     conversation_id = message.conversationId,
@@ -138,6 +140,7 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
                     asset_size = content.assetSizeInBytes,
                     asset_name = content.assetName ?: ""
                 )
+
                 is MessageEntityContent.Asset -> queries.insertMessageAssetContent(
                     message_id = message.id,
                     conversation_id = message.conversationId,
@@ -156,18 +159,21 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
                     asset_duration_ms = content.assetDurationMs,
                     asset_normalized_loudness = content.assetNormalizedLoudness
                 )
+
                 is MessageEntityContent.Unknown -> queries.insertMessageUnknownContent(
                     message_id = message.id,
                     conversation_id = message.conversationId,
                     unknown_encoded_data = content.encodedData,
                     unknown_type_name = content.typeName
                 )
+
                 is MessageEntityContent.MemberChange -> queries.insertMemberChangeMessage(
                     message_id = message.id,
                     conversation_id = message.conversationId,
                     member_change_list = content.memberUserIdList,
                     member_change_type = content.memberChangeType
                 )
+
                 is MessageEntityContent.MissedCall -> queries.insertMissedCallMessage(
                     message_id = message.id,
                     conversation_id = message.conversationId,
@@ -208,6 +214,20 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             .asFlow()
             .mapToOneOrNull()
             .flatMapLatest { it?.toMessageEntityFlow() ?: flowOf(null) }
+
+    override suspend fun getMessagesByConversationId(conversationId: QualifiedIDEntity) =
+        queries.selectAllMessagesByConversationId(conversationId)
+            .asFlow()
+            .mapToList()
+            .toMessageEntityListFlow()
+
+    override suspend fun deleteMessages(messages: List<MessageEntity>) {
+        queries.transaction {
+            messages.forEach {
+                queries.deleteMessageById(it.id)
+            }
+        }
+    }
 
     override suspend fun getMessagesByConversationAndVisibility(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -217,9 +217,8 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
 
     override suspend fun getMessagesByConversationId(conversationId: QualifiedIDEntity) =
         queries.selectAllMessagesByConversationId(conversationId)
-            .asFlow()
-            .mapToList()
-            .toMessageEntityListFlow()
+            .executeAsList()
+            .mapNotNull { it.toMessageEntity() }
 
     override suspend fun deleteMessages(messages: List<MessageEntity>) {
         queries.transaction {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -215,19 +215,6 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
             .mapToOneOrNull()
             .flatMapLatest { it?.toMessageEntityFlow() ?: flowOf(null) }
 
-    override suspend fun getMessagesByConversationId(conversationId: QualifiedIDEntity) =
-        queries.selectAllMessagesByConversationId(conversationId)
-            .executeAsList()
-            .mapNotNull { it.toMessageEntity() }
-
-    override suspend fun deleteMessages(messages: List<MessageEntity>) {
-        queries.transaction {
-            messages.forEach {
-                queries.deleteMessageById(it.id)
-            }
-        }
-    }
-
     override suspend fun getMessagesByConversationAndVisibility(
         conversationId: QualifiedIDEntity,
         limit: Int,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Given that, we are not handling the current events for when a user deletes a conversation. We are adding this event handler that will allow us to react and delete all contents related to a conversation (ie: messages, assets)

Note: Tests are coming in upcoming commits.

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
