### PR TITLE
fix: QualifiedIdMapper crashes

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
@@ -11,21 +11,25 @@ class QualifiedIdMapperImpl(
 ) : QualifiedIdMapper {
     override fun fromStringToQualifiedID(id: String): QualifiedID {
         val components = id.split(VALUE_DOMAIN_SEPARATOR).filter { it.isNotBlank() }
-
         val count = id.count { it == VALUE_DOMAIN_SEPARATOR }
-        if (id.isEmpty()) {
-            QualifiedID(value = "", domain = "")
-        }
-        return if (count > 1) {
-            val value = id.substringBeforeLast(VALUE_DOMAIN_SEPARATOR)
-            val domain = id.substringAfterLast(VALUE_DOMAIN_SEPARATOR)
-            QualifiedID(value = value, domain = domain)
-
-        } else if (count == 1) {
-            QualifiedID(value = components.first(), domain = components.last())
-        } else {
-            val selfUserDomain = userRepository?.getSelfUserId()?.domain ?: run { "" }
-            QualifiedID(value = components.first(), domain = selfUserDomain)
+        return when {
+            id.isEmpty() -> {
+                QualifiedID(value = "", domain = "")
+            }
+            count > 1 -> {
+                val value = id.substringBeforeLast(VALUE_DOMAIN_SEPARATOR)
+                val domain = id.substringAfterLast(VALUE_DOMAIN_SEPARATOR)
+                QualifiedID(value = value, domain = domain)
+            }
+            count == 1 -> {
+                QualifiedID(value = components.first(), domain = components.last())
+            }
+            else -> {
+                val selfUserDomain = userRepository?.getSelfUserId()?.domain ?: run { "" }
+                QualifiedID(value = components.first(), domain = selfUserDomain)
+            }
         }
     }
 }
+
+fun String.toQualifiedID(mapper: QualifiedIdMapper): QualifiedID = mapper.fromStringToQualifiedID(this)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
@@ -105,4 +105,19 @@ class QualifiedIdMapperTest {
         )
     }
 
+    @Test
+    fun givenAnEmptyString_whenMappingToQualifiedId_thenReturnsAnEmptyQualifiedID() {
+        // Given
+        val conversationId = ""
+
+        // When
+        val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+
+        // Then
+        assertEquals(
+            QualifiedID(value = "", domain = ""),
+            result
+        )
+    }
+
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

QualifiedIdMapper doesn't handle properly empty string parameter.

### Causes (Optional)

No `return` for the `if` that should handle it.

### Solutions

Changed to `return when...` and all cases handled in this single place.
Added extension function for easier use.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
