### PR TITLE
fix: some remote requests not including api version

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/contact/search/UserSearchApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/contact/search/UserSearchApiImpl.kt
@@ -12,7 +12,7 @@ class UserSearchApiImpl internal constructor(private val authenticatedNetworkCli
 
     override suspend fun search(userSearchRequest: UserSearchRequest): NetworkResponse<UserSearchResponse> =
         wrapKaliumResponse {
-            httpClient.get("/$PATH_CONTACT_SEARCH") {
+            httpClient.get(PATH_CONTACT_SEARCH) {
                 with(userSearchRequest) {
                     parameter(QUERY_KEY_SEARCH_QUERY, searchQuery)
                     if(domain.isNotBlank()) {
@@ -25,7 +25,6 @@ class UserSearchApiImpl internal constructor(private val authenticatedNetworkCli
 
     private companion object {
         const val PATH_CONTACT_SEARCH = "search/contacts"
-
         const val QUERY_KEY_SEARCH_QUERY = "q"
         const val QUERY_KEY_SIZE = "size"
         const val QUERY_KEY_DOMAIN = "domain"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/message/MessageApiImpl.kt
@@ -58,7 +58,7 @@ class MessageApiImpl internal constructor(
             if (it.status != STATUS_CLIENTS_HAVE_CHANGED) null
             else NetworkResponse.Error(kException = SendMessageError.MissingDeviceError(errorBody = it.body()))
         }) {
-            httpClient.post("$PATH_CONVERSATIONS/$conversationId$PATH_OTR_MESSAGE") {
+            httpClient.post("$PATH_CONVERSATIONS/$conversationId/$PATH_OTR_MESSAGE") {
                 if (queryParameter != null) {
                     parameter(queryParameter, queryParameterValue)
                 }
@@ -100,7 +100,7 @@ class MessageApiImpl internal constructor(
             )
         )
     }) {
-        httpClient.post("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}$PATH_PROTEUS_MESSAGE") {
+        httpClient.post("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_PROTEUS_MESSAGE") {
             setBody(envelopeProtoMapper.encodeToProtobuf(parameters))
             contentType(ContentType.Application.XProtoBuf)
         }
@@ -111,9 +111,9 @@ class MessageApiImpl internal constructor(
             412,
             "Proteus clients have changed"
         )
-        const val PATH_OTR_MESSAGE = "/otr/messages"
-        const val PATH_PROTEUS_MESSAGE = "/proteus/messages"
-        const val PATH_CONVERSATIONS = "/conversations"
+        const val PATH_OTR_MESSAGE = "otr/messages"
+        const val PATH_PROTEUS_MESSAGE = "proteus/messages"
+        const val PATH_CONVERSATIONS = "conversations"
         const val QUERY_IGNORE_MISSING = "ignore_missing"
         const val QUERY_REPORT_MISSING = "report_missing"
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/teams/TeamsApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/teams/TeamsApiImpl.kt
@@ -16,32 +16,32 @@ class TeamsApiImpl internal constructor(private val authenticatedNetworkClient: 
 
     override suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): NetworkResponse<Unit> =
         wrapKaliumResponse {
-            httpClient.delete("/$PATH_TEAMS/$teamId/$PATH_CONVERSATIONS/$conversationId")
+            httpClient.delete("$PATH_TEAMS/$teamId/$PATH_CONVERSATIONS/$conversationId")
         }
 
     override suspend fun getTeamInfo(teamId: TeamId): NetworkResponse<TeamDTO> =
         wrapKaliumResponse {
-            httpClient.get("/$PATH_TEAMS/$teamId")
+            httpClient.get("$PATH_TEAMS/$teamId")
         }
 
     override suspend fun getTeams(size: Int?, option: TeamsApi.GetTeamsOption?): NetworkResponse<TeamsApi.TeamsResponse> =
         wrapKaliumResponse {
             when (option) {
-                is TeamsApi.GetTeamsOption.StartFrom -> httpClient.get("/$PATH_TEAMS") {
+                is TeamsApi.GetTeamsOption.StartFrom -> httpClient.get("$PATH_TEAMS") {
                     size?.let { parameter(QUERY_KEY_SIZE, it) }
                     parameter(QUERY_KEY_START, option.teamId)
                 }
-                is TeamsApi.GetTeamsOption.LimitTo -> httpClient.get("/$PATH_TEAMS") {
+                is TeamsApi.GetTeamsOption.LimitTo -> httpClient.get("$PATH_TEAMS") {
                     size?.let { parameter(QUERY_KEY_SIZE, it) }
                     parameter(QUERY_KEY_IDS, option.teamIds.joinToString(","))
                 }
-                null -> httpClient.get("/$PATH_TEAMS")
+                null -> httpClient.get("$PATH_TEAMS")
             }
         }
 
     override suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?): NetworkResponse<TeamsApi.TeamMemberList> =
         wrapKaliumResponse {
-            httpClient.get("/$PATH_TEAMS/$teamId/$PATH_MEMBERS") {
+            httpClient.get("$PATH_TEAMS/$teamId/$PATH_MEMBERS") {
                 limitTo?.let { parameter("maxResults", it) }
             }
         }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/user/connection/ConnectionApi.kt
@@ -40,7 +40,7 @@ class ConnectionApiImpl internal constructor(private val authenticatedNetworkCli
         }
 
     private companion object {
-        const val PATH_CONNECTIONS = "/list-connections"
-        const val PATH_CONNECTIONS_ENDPOINTS = "/connections"
+        const val PATH_CONNECTIONS = "list-connections"
+        const val PATH_CONNECTIONS_ENDPOINTS = "connections"
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

some remote requests not including API version
e.g.  ```https://staging-nginz-https.zinfra.io/list-connections```

it should be  ```https://staging-nginz-https.zinfra.io/v1/list-connections```

### Causes (Optional)

the default request plugin allows ignoring any default path if the request path have `/` at the beginning, for example the following HTTP client have `https://base.url/` as the base host and `v1` as base path
```kotlin
 val client = HttpClient {
   defaultRequest {
     url("https://base.url/v1/")*
      headers.appendIfNameMissing(HttpHeaders.ContentType, ContentType.Application.Json)
   }
 }
```
when doing a request with `file` as the path, the request URL is precisely what we want `https://base.url/v1/file`
```kotlin
client.get("file")
   // <- requests "https://base.url/v1/file", ContentType = Application.Json
 ```

in case of requesting `/file` the default request plugin will ignore whatever the default path is 
```kotlin
 client.get("/file")
   // <- requests "https://base.url/file", ContentType = Application.Json (no V1)
 ```

and the last case is if we request a full URL or add `//` then both the default host and path will be ignored 
```kotlin
 client.get("//other.host/path")
   // <- requests "https://other.host/path", ContentType = Application.Json
 client.get("https://some.url") { HttpHeaders.ContentType = ContentType.Application.Xml }
   // <- requests "https://some.url/", ContentType = Application.Xml
 ```

### Solutions

remove `/` at the beginning of the request path

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
