### PR TITLE
fix: incorrect email validation when the email contains a capital letter

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCase.kt
@@ -4,7 +4,6 @@ interface ValidateEmailUseCase {
     operator fun invoke(email: String): Boolean
 }
 
-
 class ValidateEmailUseCaseImpl : ValidateEmailUseCase {
     override operator fun invoke(email: String): Boolean = when {
         isEmailTooShort(email) -> false
@@ -13,7 +12,7 @@ class ValidateEmailUseCaseImpl : ValidateEmailUseCase {
     }
 
     private fun emailCharactersValid(email: String) =
-        email.matches(EMAIL_REGEX)
+        email.lowercase().matches(EMAIL_REGEX)
 
     private fun isEmailTooShort(email: String) = email.length < EMAIL_MIN_LENGTH
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCase.kt
@@ -18,7 +18,7 @@ class ValidateEmailUseCaseImpl : ValidateEmailUseCase {
 
     private companion object {
         private const val EMAIL_MIN_LENGTH = 5
-        private val EMAIL_REGEX = //RFC5322-compliant regex that covers 99.99% of input email addresses. http://emailregex.com/
+        private val EMAIL_REGEX = // RFC5322-compliant regex that covers 99.99% of input email addresses. http://emailregex.com/
             ("(?:[a-z0-9!#\$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#\$%&'*+/=?^_`{|}~-]+)*|\"" +
                     "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@" +
                     "(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?" +

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateEmailUseCaseTest.kt
@@ -36,7 +36,9 @@ class ValidateEmailUseCaseTest {
                 "id-with-dash@domain.com",
                 "a@domain.com",
                 "example-abc@abc-domain.com",
-                "example@s.solutions"
+                "example@s.solutions",
+                "exaMple@S.solutions.COM",
+                "A@DOMAIN.DE"
             )
 
         val INVALID_EMAILS = listOf(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

incorrect email validation when the email contains a capital letter

### Solutions

convert the email to lower case before running the regex


### Testing


- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
