### PR TITLE
fix: Search with @ crashes the app (QualifierIdMapper crash) [AR-2151]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
@@ -13,7 +13,7 @@ class QualifiedIdMapperImpl(
         val components = id.split(VALUE_DOMAIN_SEPARATOR).filter { it.isNotBlank() }
         val count = id.count { it == VALUE_DOMAIN_SEPARATOR }
         return when {
-            id.isEmpty() -> {
+            id.isEmpty() || components.isEmpty() -> {
                 QualifiedID(value = "", domain = "")
             }
             count > 1 -> {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
@@ -61,7 +61,67 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAValidStringThatStartsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() {
+    fun givenAStringWithoutDomainThatEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
+        // Given
+        val fallbackDomain = "wire.com"
+        val conversationId = "conversationId@"
+
+        given(userRepository)
+            .invocation { getSelfUserId() }
+            .thenReturn(QualifiedID(conversationId, fallbackDomain))
+
+        // When
+        val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+
+        // Then
+        assertEquals(
+            QualifiedID(value = "conversationId", domain = fallbackDomain),
+            result
+        )
+    }
+
+    @Test
+    fun givenAValidStringThatStartsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
+        // Given
+        val fallbackDomain = "wire.com"
+        val conversationId = "@conversationId"
+
+        given(userRepository)
+            .invocation { getSelfUserId() }
+            .thenReturn(QualifiedID(conversationId, fallbackDomain))
+
+        // When
+        val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+
+        // Then
+        assertEquals(
+            QualifiedID(value = "conversationId", domain = fallbackDomain),
+            result
+        )
+    }
+
+    @Test
+    fun givenAValidStringThatStartsAndEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
+        // Given
+        val fallbackDomain = "wire.com"
+        val conversationId = "@conversationId@"
+
+        given(userRepository)
+            .invocation { getSelfUserId() }
+            .thenReturn(QualifiedID(conversationId, fallbackDomain))
+
+        // When
+        val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+
+        // Then
+        assertEquals(
+            QualifiedID(value = "conversationId", domain = fallbackDomain),
+            result
+        )
+    }
+
+    @Test
+    fun givenAValidStringThatStartsWithAtSignAndContainsAnotherAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() {
         // Given
         val conversationId = "@conversationId@dom"
 
@@ -70,7 +130,7 @@ class QualifiedIdMapperTest {
 
         // Then
         assertEquals(
-            QualifiedID(value = "@conversationId", domain = "dom"),
+            QualifiedID(value = "conversationId", domain = "dom"),
             result
         )
     }
@@ -79,6 +139,21 @@ class QualifiedIdMapperTest {
     fun givenAValidStringThatContainsAtSignInTheMiddle_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() {
         // Given
         val conversationId = "convers@ationId@dom"
+
+        // When
+        val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+
+        // Then
+        assertEquals(
+            QualifiedID(value = "convers@ationId", domain = "dom"),
+            result
+        )
+    }
+
+    @Test
+    fun givenAValidStringThatStartsWithAtSignContainsAtSignInTheMiddle_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() {
+        // Given
+        val conversationId = "@convers@ationId@dom"
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
@@ -120,4 +120,19 @@ class QualifiedIdMapperTest {
         )
     }
 
+    @Test
+    fun givenAStringWithOnlyAtSign_whenMappingToQualifiedId_thenReturnsAnEmptyQualifiedID() {
+        // Given
+        val conversationId = "@"
+
+        // When
+        val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+
+        // Then
+        assertEquals(
+            QualifiedID(value = "", domain = ""),
+            result
+        )
+    }
+
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When searching, after typing only "@" the app crashes, after typing "@" with anything else (for instance "@text", "something went wrong" info appears instead of search results.

### Causes (Optional)

QualifiedIdMapper finds the "@" sign, but when splitting the text, components are filtered out because they are empty, so the list of components is empty and it throws an error when trying to get `component.first()`.
QualifiedId is mapped wrongly for "@text" searches, because it sets "text" as both value and domain (`components.first()` and `components.last()` are the same).

### Solutions

Check if the list of components is empty and then return empty QualifiedId.
Differentiate the situation when we have one "@" and text before and after that ("text@text") or not ("@text", "text@").

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
