### PR TITLE
refactor: better de-couple incremental sync layers

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncStatus.kt
@@ -8,12 +8,8 @@ sealed interface IncrementalSyncStatus {
 
     object FetchingPendingEvents : IncrementalSyncStatus
 
-    data class Complete(val outcome: IncrementalSyncOutcome) : IncrementalSyncStatus
+    object Live : IncrementalSyncStatus
 
     data class Failed(val failure: CoreFailure) : IncrementalSyncStatus
 
-}
-
-enum class IncrementalSyncOutcome {
-    LIVE, DISCONNECTED_DUE_TO_POLICY
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
@@ -15,6 +15,7 @@ internal interface SlowSyncRepository {
 }
 
 internal class InMemorySlowSyncRepository : SlowSyncRepository {
+    private val logger = kaliumLogger.withFeatureId(SYNC)
     private val _lastFullSyncInstant = MutableStateFlow<Instant?>(null)
     override val lastFullSyncInstant get() = _lastFullSyncInstant.asStateFlow()
 
@@ -22,12 +23,12 @@ internal class InMemorySlowSyncRepository : SlowSyncRepository {
     override val slowSyncStatus: StateFlow<SlowSyncStatus> get() = _slowSyncStatus.asStateFlow()
 
     override fun setLastSlowSyncCompletionInstant(instant: Instant?) {
-        kaliumLogger.withFeatureId(SYNC).i("Updating last slow sync instant: $instant")
+        logger.i("Updating last slow sync instant: $instant")
         _lastFullSyncInstant.value = instant
     }
 
     override fun updateSlowSyncStatus(slowSyncStatus: SlowSyncStatus) {
-        kaliumLogger.withFeatureId(SYNC).i("Updating SLOW sync status: $slowSyncStatus")
+        logger.i("Updating SlowSync status: $slowSyncStatus")
         _slowSyncStatus.value = slowSyncStatus
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManager.kt
@@ -46,7 +46,7 @@ internal class KeyPackageManagerImpl(
         refillKeyPackageJob = refillKeyPackagesScope.launch {
             incrementalSyncRepository.incrementalSyncState.collect { syncState ->
                 ensureActive()
-                if (syncState is IncrementalSyncStatus.Complete) {
+                if (syncState is IncrementalSyncStatus.Live) {
                     refillKeyPackagesIfNeeded()
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
@@ -19,7 +19,7 @@ class ObserveSyncStateUseCase internal constructor(
                 SlowSyncStatus.Pending -> SyncState.Waiting
                 SlowSyncStatus.Complete -> {
                     when (incrementalStatus) {
-                        is IncrementalSyncStatus.Complete -> SyncState.Live
+                        IncrementalSyncStatus.Live -> SyncState.Live
                         is IncrementalSyncStatus.Failed -> SyncState.Failed(incrementalStatus.failure)
                         IncrementalSyncStatus.FetchingPendingEvents -> SyncState.GatheringPendingEvents
                         IncrementalSyncStatus.Pending -> SyncState.GatheringPendingEvents

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -29,7 +29,7 @@ internal class SyncManagerImpl(
 ) : SyncManager {
 
     override suspend fun waitUntilLive() {
-        incrementalSyncRepository.incrementalSyncState.first { it is IncrementalSyncStatus.Complete }
+        incrementalSyncRepository.incrementalSyncState.first { it is IncrementalSyncStatus.Live }
     }
 
     override suspend fun isSlowSyncOngoing(): Boolean = slowSyncRepository.slowSyncStatus.value is SlowSyncStatus.Ongoing

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManager.kt
@@ -1,10 +1,12 @@
 package com.wire.kalium.logic.sync.full
 
+import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncCriteriaProvider
 import com.wire.kalium.logic.sync.SyncCriteriaResolution
+import com.wire.kalium.logic.sync.incremental.IncrementalSyncManager
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -13,6 +15,18 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
+/**
+ * Starts and stops SlowSync based on a set of criteria,
+ * defined in [SyncCriteriaProvider].
+ * Once the criteria are met, this Manager will
+ * take care of running SlowSync.
+ *
+ * Ideally, SlowSync should run only **once** after the
+ * initial log-in / client registration. But [IncrementalSyncManager]
+ * might invalidate this and request a new
+ * SlowSync in case some [Event] is lost.
+ * @see IncrementalSyncManager
+ */
 internal class SlowSyncManager(
     private val syncCriteriaProvider: SyncCriteriaProvider,
     private val slowSyncRepository: SlowSyncRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncWorker.kt
@@ -42,6 +42,8 @@ internal class SlowSyncWorkerImpl(
     private val joinMLSConversations: JoinExistingMLSConversationsUseCase,
 ) : SlowSyncWorker {
 
+    private val logger = kaliumLogger.withFeatureId(SYNC)
+
     override suspend fun performSlowSyncSteps(): Flow<SlowSyncStep> = flow {
 
         suspend fun Either<CoreFailure, Unit>.continueWithStep(
@@ -49,7 +51,7 @@ internal class SlowSyncWorkerImpl(
             step: suspend () -> Either<CoreFailure, Unit>
         ) = flatMap { performStep(slowSyncStep, step) }
 
-        kaliumLogger.withFeatureId(SYNC).d("Sync: Starting SlowSync")
+        logger.d("Starting SlowSync")
         // TODO: to move the feature configs call outside the sync
         syncFeatureConfigs()
         emit(SlowSyncStep.SELF_USER)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -115,27 +115,27 @@ internal class EventGathererImpl(
         }
 
     private suspend fun FlowCollector<Event>.onWebSocketEventReceived(webSocketEvent: WebSocketEvent.BinaryPayloadReceived<Event>) {
-        logger.i("SYNC: Websocket Received binary payload")
+        logger.i("Websocket Received binary payload")
         val event = webSocketEvent.payload
         if (offlineEventBuffer.contains(event)) {
             if (offlineEventBuffer.clearBufferIfLastEventEquals(event)) {
                 // Really live
-                logger.d("SYNC: Removed most recent event from offlineEventBuffer: '${event.id}'")
+                logger.d("Removed most recent event from offlineEventBuffer: '${event.id}'")
             } else {
                 // Really live
-                logger.d("SYNC: Removing event from offlineEventBuffer: ${event.id}")
+                logger.d("Removing event from offlineEventBuffer: ${event.id}")
                 offlineEventBuffer.remove(event)
             }
             logger
-                .d("SYNC: Skipping emit of event from WebSocket because already emitted as offline event ${event.id}")
+                .d("Skipping emit of event from WebSocket because already emitted as offline event ${event.id}")
         } else {
-            logger.d("SYNC: Event never seen before ${event.id} - We are live")
+            logger.d("Event never seen before ${event.id} - We are live")
             emit(event)
         }
     }
 
     private suspend fun FlowCollector<Event>.onWebSocketOpen() {
-        logger.i("SYNC: Websocket Open")
+        logger.i("Websocket Open")
         eventRepository
             .pendingEvents()
             .mapNotNull { offlineEventOrFailure ->
@@ -145,11 +145,11 @@ internal class EventGathererImpl(
                 }
             }
             .collect {
-                logger.i("SYNC: Collecting offline event: ${it.id}")
+                logger.i("Collecting offline event: ${it.id}")
                 offlineEventBuffer.add(it)
                 emit(it)
             }
-        logger.i("SYNC: Offline events collection finished. Collecting Live events.")
+        logger.i("Offline events collection finished. Collecting Live events.")
         _currentSource.value = EventSource.LIVE
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -6,9 +6,7 @@ import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.sync.ConnectionPolicy
-import com.wire.kalium.logic.data.sync.IncrementalSyncOutcome
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
-import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.combine
 import com.wire.kalium.logic.functional.flatMap
@@ -21,6 +19,9 @@ import com.wire.kalium.network.api.notification.WebSocketEvent
 import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
@@ -44,6 +45,8 @@ internal interface EventGatherer {
      * Will stop or keep gathering accordingly to the current [ConnectionPolicy]
      */
     suspend fun gatherEvents(): Flow<Event>
+
+    val currentSource: StateFlow<EventSource>
 }
 
 internal class EventGathererImpl(
@@ -51,10 +54,15 @@ internal class EventGathererImpl(
     private val incrementalSyncRepository: IncrementalSyncRepository
 ) : EventGatherer {
 
+    private val _currentSource = MutableStateFlow(EventSource.PENDING)
+    override val currentSource: StateFlow<EventSource> get() = _currentSource.asStateFlow()
+
     private val offlineEventBuffer = PendingEventsBuffer()
+    private val logger = kaliumLogger.withFeatureId(SYNC)
 
     override suspend fun gatherEvents(): Flow<Event> = flow {
         offlineEventBuffer.clear()
+        _currentSource.value = EventSource.PENDING
         eventRepository.lastEventId().map { eventId ->
             eventRepository.updateLastProcessedEventId(eventId)
         }.flatMap {
@@ -89,7 +97,7 @@ internal class EventGathererImpl(
         is WebSocketEvent.Open -> onWebSocketOpen()
         is WebSocketEvent.BinaryPayloadReceived -> onWebSocketEventReceived(webSocketEvent)
         is WebSocketEvent.Close -> throwOnWebSocketClosed(webSocketEvent)
-        is WebSocketEvent.NonBinaryPayloadReceived -> kaliumLogger.withFeatureId(SYNC).w("Non binary event received on Websocket")
+        is WebSocketEvent.NonBinaryPayloadReceived -> logger.w("Non binary event received on Websocket")
     }
 
     private fun throwOnWebSocketClosed(webSocketEvent: WebSocketEvent.Close<Event>): Nothing =
@@ -107,27 +115,27 @@ internal class EventGathererImpl(
         }
 
     private suspend fun FlowCollector<Event>.onWebSocketEventReceived(webSocketEvent: WebSocketEvent.BinaryPayloadReceived<Event>) {
-        kaliumLogger.withFeatureId(SYNC).i("SYNC: Websocket Received binary payload")
+        logger.i("SYNC: Websocket Received binary payload")
         val event = webSocketEvent.payload
         if (offlineEventBuffer.contains(event)) {
             if (offlineEventBuffer.clearBufferIfLastEventEquals(event)) {
                 // Really live
-                kaliumLogger.withFeatureId(SYNC).d("SYNC: Removed most recent event from offlineEventBuffer: '${event.id}'")
+                logger.d("SYNC: Removed most recent event from offlineEventBuffer: '${event.id}'")
             } else {
                 // Really live
-                kaliumLogger.withFeatureId(SYNC).d("SYNC: Removing event from offlineEventBuffer: ${event.id}")
+                logger.d("SYNC: Removing event from offlineEventBuffer: ${event.id}")
                 offlineEventBuffer.remove(event)
             }
-            kaliumLogger.withFeatureId(SYNC)
+            logger
                 .d("SYNC: Skipping emit of event from WebSocket because already emitted as offline event ${event.id}")
         } else {
-            kaliumLogger.withFeatureId(SYNC).d("SYNC: Event never seen before ${event.id} - We are live")
+            logger.d("SYNC: Event never seen before ${event.id} - We are live")
             emit(event)
         }
     }
 
     private suspend fun FlowCollector<Event>.onWebSocketOpen() {
-        kaliumLogger.withFeatureId(SYNC).i("SYNC: Websocket Open")
+        logger.i("SYNC: Websocket Open")
         eventRepository
             .pendingEvents()
             .mapNotNull { offlineEventOrFailure ->
@@ -137,11 +145,11 @@ internal class EventGathererImpl(
                 }
             }
             .collect {
-                kaliumLogger.withFeatureId(SYNC).i("SYNC: Collecting offline event: ${it.id}")
+                logger.i("SYNC: Collecting offline event: ${it.id}")
                 offlineEventBuffer.add(it)
                 emit(it)
             }
-        kaliumLogger.withFeatureId(SYNC).i("SYNC: Offline events collection finished")
-        incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Complete(IncrementalSyncOutcome.LIVE))
+        logger.i("SYNC: Offline events collection finished. Collecting Live events.")
+        _currentSource.value = EventSource.LIVE
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -29,7 +29,7 @@ internal class EventProcessorImpl(
 ) : EventProcessor {
 
     override suspend fun processEvent(event: Event) {
-        kaliumLogger.withFeatureId(EVENT_RECEIVER).i(message = "SYNC: Processing event ${event.id}")
+        kaliumLogger.withFeatureId(EVENT_RECEIVER).i("Processing event ${event.id}")
         when (event) {
             is Event.Conversation -> conversationEventReceiver.onEvent(event)
             is Event.User -> userEventReceiver.onEvent(event)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventSource.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventSource.kt
@@ -1,0 +1,17 @@
+package com.wire.kalium.logic.sync.incremental
+
+/**
+ * Informs where an event came from.
+ */
+enum class EventSource {
+    /**
+     * Event happened while this client was offline.
+     */
+    PENDING,
+
+    /**
+     * Event received in real-time, in an active
+     * connection with Wire servers.
+     */
+    LIVE
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -2,12 +2,14 @@ package com.wire.kalium.logic.sync.incremental
 
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.KaliumSyncException
+import com.wire.kalium.logic.sync.full.SlowSyncManager
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CancellationException
@@ -20,6 +22,31 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+/**
+ * Starts and Stops Incremental Sync once SlowSync is performed.
+ *
+ * Incremental Sync consists of receiving events, such as:
+ * - Messages
+ * - User Updates (like name, email, avatar)
+ * - Conversation Updates (name, add/remove members)
+ * - Team Updates (new member, name change)
+ * - Feature Flags Updates
+ * And many more.
+ *
+ * Events come from an [EventSource]. Because [EventSource.LIVE] requires
+ * a constant Websocket connection, connectivity changes may drop the
+ * [IncrementalSyncStatus] down to [IncrementalSyncStatus.Failed].
+ *
+ * If an [Event] is lost, _e.g._ when this client becomes offline for
+ * too long, SlowSync will be invalidated and [SlowSyncManager] should
+ * perform a fresh SlowSync.
+ *
+ * This Manager **will** be responsible for retries in case of network
+ * failures or connectivity changes in general.
+ *
+ * @see Event
+ * @see SlowSyncManager
+ */
 internal class IncrementalSyncManager(
     private val slowSyncRepository: SlowSyncRepository,
     private val incrementalSyncWorker: IncrementalSyncWorker,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
 
+/**
+ * Gathers and processes IncrementalSync events.
+ */
 interface IncrementalSyncWorker {
     /**
      * Upon collection, will start collecting and processing events,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -2,14 +2,18 @@ package com.wire.kalium.logic.sync.incremental
 
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 
 interface IncrementalSyncWorker {
     /**
-     * Starts collecting and processing events.
-     * Starting with Pending events, and then Live events
+     * Upon collection, will start collecting and processing events,
+     * emitting the source of current events.
      */
-    suspend fun performIncrementalSync()
+    suspend fun incrementalSyncFlow(): Flow<EventSource>
 }
 
 internal class IncrementalSyncWorkerImpl(
@@ -17,9 +21,16 @@ internal class IncrementalSyncWorkerImpl(
     private val eventProcessor: EventProcessor
 ) : IncrementalSyncWorker {
 
-    override suspend fun performIncrementalSync() {
-        eventGatherer.gatherEvents().cancellable().collect {
-            eventProcessor.processEvent(it)
+    override suspend fun incrementalSyncFlow() = channelFlow {
+        val sourceJob = launch {
+            eventGatherer.currentSource.collect { send(it) }
+        }
+        launch {
+            eventGatherer.gatherEvents().cancellable().collect {
+                eventProcessor.processEvent(it)
+            }
+            // When events are all consumed, cancel the source job to complete the channelFlow
+            sourceJob.cancel()
         }
         kaliumLogger.withFeatureId(SYNC).i("SYNC Finished gathering and processing events")
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 interface IncrementalSyncWorker {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepositoryTest.kt
@@ -29,7 +29,7 @@ class IncrementalSyncRepositoryTest {
     @Test
     fun givenStateIsUpdated_whenGettingTheCurrentSyncState_thenTheResultIsTheUpdatedState() = runTest {
         // Given
-        val updatedState = IncrementalSyncStatus.Complete(IncrementalSyncOutcome.LIVE)
+        val updatedState = IncrementalSyncStatus.Live
         incrementalSyncRepository.updateIncrementalSyncState(updatedState)
 
         // When

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManagerTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManagerTests.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.logic.feature.keypackage
 
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.sync.InMemoryIncrementalSyncRepository
-import com.wire.kalium.logic.data.sync.IncrementalSyncOutcome
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.functional.Either
@@ -32,7 +31,7 @@ class KeyPackageManagerTests {
                 .withLastKeyPackageCountCheck(Clock.System.now())
                 .arrange()
 
-            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Complete(IncrementalSyncOutcome.LIVE))
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
             yield()
         }
 
@@ -45,7 +44,7 @@ class KeyPackageManagerTests {
                 .withUpdateLastKeyPackageCountCheckSuccessful()
                 .arrange()
 
-            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Complete(IncrementalSyncOutcome.LIVE))
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
             yield()
 
             verify(arrangement.refillKeyPackagesUseCase)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -2,45 +2,104 @@ package com.wire.kalium.logic.sync.incremental
 
 import com.wire.kalium.logic.data.sync.InMemorySlowSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.configure
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import okio.IOException
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class IncrementalSyncManagerTest {
 
     @Test
     fun givenSlowSyncIsComplete_whenStartingIncrementalManager_thenShouldStartWorker() = runTest(TestKaliumDispatcher.default) {
+        val sharedFlow = MutableSharedFlow<EventSource>()
+
         val (arrangement, _) = Arrangement()
+            .withWorkerReturning(sharedFlow)
             .arrange()
         arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
 
         advanceUntilIdle()
 
         verify(arrangement.incrementalSyncWorker)
-            .suspendFunction(arrangement.incrementalSyncWorker::performIncrementalSync)
+            .suspendFunction(arrangement.incrementalSyncWorker::incrementalSyncFlow)
             .wasInvoked(exactly = once)
+        assertEquals(1, sharedFlow.subscriptionCount.value)
     }
 
     @Test
     fun givenSlowSyncIsNotComplete_whenStartingIncrementalManager_thenShouldNotStartWorker() = runTest(TestKaliumDispatcher.default) {
+        val sharedFlow = MutableSharedFlow<EventSource>()
+
         val (arrangement, _) = Arrangement()
+            .withWorkerReturning(sharedFlow)
             .arrange()
         arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Pending)
 
         advanceUntilIdle()
 
         verify(arrangement.incrementalSyncWorker)
-            .suspendFunction(arrangement.incrementalSyncWorker::performIncrementalSync)
+            .suspendFunction(arrangement.incrementalSyncWorker::incrementalSyncFlow)
             .wasNotInvoked()
+        assertEquals(0, sharedFlow.subscriptionCount.value)
+    }
+
+    @Test
+    fun givenSlowSyncIsCompleted_whenWorkerEmitsSources_thenShouldUpdateRepositoryWithState() = runTest(TestKaliumDispatcher.default) {
+        val sourceFlow = Channel<EventSource>(Channel.UNLIMITED)
+
+        val (arrangement, _) = Arrangement()
+            .withWorkerReturning(sourceFlow.consumeAsFlow())
+            .arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+        sourceFlow.send(EventSource.PENDING)
+        advanceUntilIdle()
+        verify(arrangement.incrementalSyncRepository)
+            .function(arrangement.incrementalSyncRepository::updateIncrementalSyncState)
+            .with(eq(IncrementalSyncStatus.FetchingPendingEvents))
+            .wasInvoked(exactly = once)
+        sourceFlow.send(EventSource.LIVE)
+        advanceUntilIdle()
+        verify(arrangement.incrementalSyncRepository)
+            .function(arrangement.incrementalSyncRepository::updateIncrementalSyncState)
+            .with(eq(IncrementalSyncStatus.Live))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSlowSyncIsCompleted_whenWorkerThrows_thenShouldUpdateRepositoryWithFailedState() = runTest(TestKaliumDispatcher.default) {
+        val exception = IOException("Oops")
+        val sourceFlow = flow<EventSource> { throw exception }
+
+        val (arrangement, _) = Arrangement()
+            .withWorkerReturning(sourceFlow)
+            .arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+        advanceUntilIdle()
+        verify(arrangement.incrementalSyncRepository)
+            .function(arrangement.incrementalSyncRepository::updateIncrementalSyncState)
+            .with(matching { it is IncrementalSyncStatus.Failed })
+            .wasInvoked(exactly = once)
     }
 
     private class Arrangement {
@@ -48,14 +107,21 @@ class IncrementalSyncManagerTest {
         val slowSyncRepository: SlowSyncRepository = InMemorySlowSyncRepository()
 
         @Mock
-        val incrementalSyncWorker = configure(mock(classOf<IncrementalSyncWorker>())) { stubsUnitByDefault = true }
+        val incrementalSyncWorker = mock(classOf<IncrementalSyncWorker>())
 
         @Mock
-        val incrementalSyncRepository = mock(classOf<IncrementalSyncRepository>())
+        val incrementalSyncRepository = configure(mock(classOf<IncrementalSyncRepository>())) { stubsUnitByDefault = true }
 
         private val incrementalSyncManager = IncrementalSyncManager(
             slowSyncRepository, incrementalSyncWorker, incrementalSyncRepository, TestKaliumDispatcher
         )
+
+        fun withWorkerReturning(sourceFlow: Flow<EventSource>) = apply {
+            given(incrementalSyncWorker)
+                .suspendFunction(incrementalSyncWorker::incrementalSyncFlow)
+                .whenInvoked()
+                .thenReturn(sourceFlow)
+        }
 
         fun arrange() = this to incrementalSyncManager
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The `State` of IncrementalSync is being managed in two places.
`EventGatherer` changes the state of `IncrementalSync`, when the only responsible should be `IncrementalSyncManager`.

### Solutions

Make it so the `EventGatherer` emits what's the source (Pending/Live).
`IncrementalSyncWorker` forwards this, and `IncrementalSyncManager` can collect the current source, changing the state as needed.

> **Note**: With all the pieces in their due places, this should be the last `refactor` PR before actually starting to add the Retry mechanism and connectivity monitoring to better.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
