### PR TITLE
fix: failure when updating session tokens

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -31,7 +31,7 @@ class SessionManagerImpl(
             TODO("IMPORTANT! Not yet implemented")
         }, {
             // TODO: make the function return null when the update fails and delete the type casting
-            sessionMapper.toSessionDTO(it as AuthSession.Session.Valid)
+            sessionMapper.toSessionDTO(it?.session as AuthSession.Session.Valid)
         })
 
     override suspend fun onSessionExpired() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Kalium is failing when refreshing tokens.

### Causes

The following exception is thrown
```
java.lang.ClassCastException: com.wire.kalium.logic.feature.auth.AuthSession cannot be cast to com.wire.kalium.logic.feature.auth.AuthSession$Session$Valid
```

When performing this cast below:
```kt
// TODO: make the function return null when the update fails and delete the type casting
            sessionMapper.toSessionDTO(it as AuthSession.Session.Valid)
```

### Solutions

Unpack the `session` before casting. So it can be cast correctly: `it?.session as AuthSession.Session.Valid`

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
