### PR TITLE
chore: add sync retry mechanism

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
@@ -1,5 +1,7 @@
 package com.wire.kalium.logic.data.sync
 
+import com.wire.kalium.logic.CoreFailure
+
 sealed interface SlowSyncStatus {
 
     object Pending : SlowSyncStatus
@@ -7,6 +9,8 @@ sealed interface SlowSyncStatus {
     object Complete : SlowSyncStatus
 
     data class Ongoing(val currentStep: SlowSyncStep) : SlowSyncStatus
+
+    data class Failed(val failure: CoreFailure) : SlowSyncStatus
 }
 
 enum class SlowSyncStep {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
@@ -15,6 +15,7 @@ class ObserveSyncStateUseCase internal constructor(
     operator fun invoke(): Flow<SyncState> = slowSyncRepository.slowSyncStatus
         .combine(incrementalSyncRepository.incrementalSyncState) { slowStatus, incrementalStatus ->
             when (slowStatus) {
+                is SlowSyncStatus.Failed -> SyncState.Failed(slowStatus.failure)
                 is SlowSyncStatus.Ongoing -> SyncState.SlowSync
                 SlowSyncStatus.Pending -> SyncState.Waiting
                 SlowSyncStatus.Complete -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandler.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.logic.sync
 
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandler.kt
@@ -1,0 +1,36 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+class SyncExceptionHandler(
+    val onCancellation: () -> Unit,
+    val onFailure: (exception: CoreFailure) -> Unit
+) : AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler {
+    private val logger = kaliumLogger.withFeatureId(SYNC)
+
+    override fun handleException(context: CoroutineContext, exception: Throwable) {
+        when (exception) {
+            is CancellationException -> {
+                logger.w("Sync job was cancelled", exception)
+                onCancellation()
+            }
+
+            is KaliumSyncException -> {
+                logger.i("SyncException during events processing", exception)
+                onFailure(exception.coreFailureCause)
+            }
+
+            else -> {
+                logger.i("Sync job failed due to unknown reason", exception)
+                onFailure(CoreFailure.Unknown(exception))
+            }
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandler.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 
-class SyncExceptionHandler(
-    val onCancellation: () -> Unit,
-    val onFailure: (exception: CoreFailure) -> Unit
+internal class SyncExceptionHandler(
+    private val onCancellation: () -> Unit,
+    private val onFailure: (exception: CoreFailure) -> Unit
 ) : AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler {
     private val logger = kaliumLogger.withFeatureId(SYNC)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManager.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.sync.incremental.IncrementalSyncManager
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collectLatest
@@ -38,7 +39,7 @@ internal class SlowSyncManager(
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
-    private val scope = CoroutineScope(kaliumDispatcher.default.limitedParallelism(1))
+    private val scope = CoroutineScope(SupervisorJob() +  kaliumDispatcher.default.limitedParallelism(1))
     private val logger = kaliumLogger.withFeatureId(SYNC)
 
     private val coroutineExceptionHandler = SyncExceptionHandler({

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManager.kt
@@ -39,7 +39,7 @@ internal class SlowSyncManager(
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
-    private val scope = CoroutineScope(SupervisorJob() +  kaliumDispatcher.default.limitedParallelism(1))
+    private val scope = CoroutineScope(SupervisorJob() + kaliumDispatcher.default.limitedParallelism(1))
     private val logger = kaliumLogger.withFeatureId(SYNC)
 
     private val coroutineExceptionHandler = SyncExceptionHandler({

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManager.kt
@@ -7,14 +7,17 @@ import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncCriteriaProvider
 import com.wire.kalium.logic.sync.SyncCriteriaResolution
+import com.wire.kalium.logic.sync.SyncExceptionHandler
 import com.wire.kalium.logic.sync.incremental.IncrementalSyncManager
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Starts and stops SlowSync based on a set of criteria,
@@ -38,8 +41,20 @@ internal class SlowSyncManager(
     private val scope = CoroutineScope(kaliumDispatcher.default.limitedParallelism(1))
     private val logger = kaliumLogger.withFeatureId(SYNC)
 
-    init {
+    private val coroutineExceptionHandler = SyncExceptionHandler({
+        slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Pending)
+    }, {
+        slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Failed(it))
         scope.launch {
+            delay(RETRY_DELAY)
+            startMonitoring()
+        }
+    })
+
+    init { startMonitoring() }
+
+    private fun startMonitoring() {
+        scope.launch(coroutineExceptionHandler) {
             syncCriteriaProvider
                 .syncCriteriaFlow()
                 .distinctUntilChanged()
@@ -64,4 +79,7 @@ internal class SlowSyncManager(
         }
     }
 
+    private companion object {
+        val RETRY_DELAY = 10.seconds
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -38,8 +38,9 @@ import kotlin.time.Duration.Companion.seconds
  * too long, SlowSync will be invalidated and [SlowSyncManager] should
  * perform a fresh SlowSync.
  *
- * This Manager **will** be responsible for retries in case of network
- * failures or connectivity changes in general.
+ * This Manager retries automatically in case of failures,
+ * but still doesn't actively monitor connectivity changes in general,
+ * like when a mobile phone changes from Wi-Fi to Mobile Data, etc.
  *
  * @see Event
  * @see SlowSyncManager

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -1,26 +1,23 @@
 package com.wire.kalium.logic.sync.incremental
 
-import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
-import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.logic.sync.KaliumSyncException
+import com.wire.kalium.logic.sync.SyncExceptionHandler
 import com.wire.kalium.logic.sync.full.SlowSyncManager
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.cancellable
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Starts and Stops Incremental Sync once SlowSync is performed.
@@ -61,29 +58,21 @@ internal class IncrementalSyncManager(
     @OptIn(ExperimentalCoroutinesApi::class)
     private val eventProcessingDispatcher = kaliumDispatcher.default.limitedParallelism(1)
 
-    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        when (throwable) {
-            is CancellationException -> {
-                kaliumLogger.withFeatureId(SYNC).i("Sync job was cancelled")
-                incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
-            }
-
-            is KaliumSyncException -> {
-                kaliumLogger.withFeatureId(SYNC).i("SyncException during events processing", throwable)
-                incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Failed(throwable.coreFailureCause))
-            }
-
-            else -> {
-                kaliumLogger.withFeatureId(SYNC).i("Sync job failed due to unknown reason", throwable)
-                incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Failed(CoreFailure.Unknown(throwable)))
-            }
-            // TODO: Trigger retry depending on failure
+    private val coroutineExceptionHandler = SyncExceptionHandler({
+        incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+    }, {
+        incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Failed(it))
+        syncScope.launch {
+            delay(RETRY_DELAY)
+            startMonitoringForSync()
         }
-    }
+    })
 
     private val syncScope = CoroutineScope(SupervisorJob() + eventProcessingDispatcher)
 
-    init {
+    init { startMonitoringForSync() }
+
+    private fun startMonitoringForSync() {
         syncScope.launch(coroutineExceptionHandler) {
             // TODO: Trigger re-sync when policy changes from DISCONNECT to KEEP_ALIVE
             slowSyncRepository.slowSyncStatus.collectLatest { status ->
@@ -108,5 +97,9 @@ internal class IncrementalSyncManager(
                 }
                 incrementalSyncRepository.updateIncrementalSyncState(newState)
             }
+    }
+
+    private companion object {
+        val RETRY_DELAY = 10.seconds
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandlerTest.kt
@@ -1,0 +1,91 @@
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.logic.CoreFailure
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.test.runTest
+import okio.IOException
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class SyncExceptionHandlerTest {
+
+    @Test
+    fun givenCancellationException_whenHandlingException_thenShouldCallOnCancellation() = runTest {
+        val exception = CancellationException()
+        val (arrangement, syncExceptionHandler) = Arrangement().arrange()
+
+        syncExceptionHandler.handleException(currentCoroutineContext(), exception)
+
+        assertEquals(1, arrangement.onCancellationCalledCount)
+    }
+
+    @Test
+    fun givenCancellationException_whenHandlingException_thenShouldNotCallOnFailure() = runTest {
+        val exception = CancellationException()
+        val (arrangement, syncExceptionHandler) = Arrangement().arrange()
+
+        syncExceptionHandler.handleException(currentCoroutineContext(), exception)
+
+        assertEquals(0, arrangement.onFailureCalledCount)
+    }
+
+    @Test
+    fun givenNonCancellationException_whenHandlingException_thenShouldNotCallOnCancellation() = runTest {
+        val exception = IOException()
+        val (arrangement, syncExceptionHandler) = Arrangement().arrange()
+
+        syncExceptionHandler.handleException(currentCoroutineContext(), exception)
+
+        assertEquals(0, arrangement.onCancellationCalledCount)
+    }
+
+    @Test
+    fun givenNonCancellationException_whenHandlingException_thenShouldCallOnFailure() = runTest {
+        val exception = IOException()
+        val (arrangement, syncExceptionHandler) = Arrangement().arrange()
+
+        syncExceptionHandler.handleException(currentCoroutineContext(), exception)
+
+        assertEquals(1, arrangement.onFailureCalledCount)
+    }
+
+    @Test
+    fun givenSyncException_whenHandlingException_thenShouldCallOnFailureWithCauseCoreFailure() = runTest {
+        val coreFailure = CoreFailure.MissingClientRegistration
+        val exception = KaliumSyncException("Oops", coreFailure)
+        val (arrangement, syncExceptionHandler) = Arrangement().arrange()
+
+        syncExceptionHandler.handleException(currentCoroutineContext(), exception)
+
+        assertContains(arrangement.onFailureCalledArguments, coreFailure)
+    }
+
+    @Test
+    fun givenNonSyncAndNonCancellationException_whenHandlingException_thenShouldCallOnFailureWithUnknownCoreFailure() = runTest {
+        val exception = IOException()
+        val (arrangement, syncExceptionHandler) = Arrangement().arrange()
+
+        syncExceptionHandler.handleException(currentCoroutineContext(), exception)
+
+        assertContains(arrangement.onFailureCalledArguments, CoreFailure.Unknown(exception))
+    }
+
+    private class Arrangement {
+
+        val onFailureCalledArguments = mutableListOf<CoreFailure>()
+        val onFailureCalledCount: Int get() = onFailureCalledArguments.size
+
+        var onCancellationCalledCount = 0
+
+        private val syncExceptionHandler = SyncExceptionHandler({
+            onCancellationCalledCount++
+        }, {
+            onFailureCalledArguments += it
+        })
+
+        fun arrange() = this to syncExceptionHandler
+    }
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/full/SlowSyncManagerTest.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.logic.data.sync.SlowSyncStep
 import com.wire.kalium.logic.sync.SyncCriteriaProvider
 import com.wire.kalium.logic.sync.SyncCriteriaResolution
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
-import com.wire.kalium.logic.test_util.flowThatFailsOnFirstTime
+import com.wire.kalium.logic.util.flowThatFailsOnFirstTime
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.configure

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
-import com.wire.kalium.logic.test_util.flowThatFailsOnFirstTime
+import com.wire.kalium.logic.util.flowThatFailsOnFirstTime
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.configure
@@ -21,10 +21,8 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import okio.IOException
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import com.wire.kalium.logic.test_util.flowThatFailsOnFirstTime
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.configure
@@ -14,6 +15,7 @@ import io.mockative.given
 import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
+import io.mockative.twice
 import io.mockative.verify
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -23,6 +25,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.IOException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -87,11 +90,8 @@ class IncrementalSyncManagerTest {
 
     @Test
     fun givenSlowSyncIsCompleted_whenWorkerThrows_thenShouldUpdateRepositoryWithFailedState() = runTest(TestKaliumDispatcher.default) {
-        val exception = IOException("Oops")
-        val sourceFlow = flow<EventSource> { throw exception }
-
         val (arrangement, _) = Arrangement()
-            .withWorkerReturning(sourceFlow)
+            .withWorkerReturning(flowThatFailsOnFirstTime())
             .arrange()
         arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
 
@@ -99,6 +99,34 @@ class IncrementalSyncManagerTest {
         verify(arrangement.incrementalSyncRepository)
             .function(arrangement.incrementalSyncRepository::updateIncrementalSyncState)
             .with(matching { it is IncrementalSyncStatus.Failed })
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSlowSyncIsCompleted_whenWorkerThrowsNonCancellation_thenShouldRetry() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, _) = Arrangement()
+            .withWorkerReturning(flowThatFailsOnFirstTime())
+            .arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+        advanceUntilIdle()
+
+        verify(arrangement.incrementalSyncWorker)
+            .suspendFunction(arrangement.incrementalSyncWorker::incrementalSyncFlow)
+            .wasInvoked(exactly = twice)
+    }
+
+    @Test
+    fun givenSlowSyncIsCompleted_whenWorkerThrowsCancellation_thenShouldNotRetry() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, _) = Arrangement()
+            .withWorkerReturning(flowThatFailsOnFirstTime(CancellationException("Cancelled")))
+            .arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+        advanceUntilIdle()
+
+        verify(arrangement.incrementalSyncWorker)
+            .suspendFunction(arrangement.incrementalSyncWorker::incrementalSyncFlow)
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/FlowUtils.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/FlowUtils.kt
@@ -1,0 +1,16 @@
+package com.wire.kalium.logic.test_util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import okio.IOException
+
+inline fun <reified T> flowThatFailsOnFirstTime(exception: Throwable = IOException("Oops")): Flow<T> {
+    var hasFailed = false
+    val sourceFlow = flow<T> {
+        if (!hasFailed) {
+            hasFailed = true
+            throw exception
+        }
+    }
+    return sourceFlow
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/FlowUtils.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/FlowUtils.kt
@@ -1,4 +1,4 @@
-package com.wire.kalium.logic.test_util
+package com.wire.kalium.logic.util
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApi.kt
@@ -25,7 +25,7 @@ sealed class WebSocketEvent<BinaryPayloadType> {
         }
     }
 
-    data class Close<BinaryPayloadType>(val cause: Throwable?): WebSocketEvent<BinaryPayloadType>()
+    data class Close<BinaryPayloadType>(val cause: Throwable?) : WebSocketEvent<BinaryPayloadType>()
 }
 
 interface NotificationApi {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Clients drop connection and never recover from it.

### Solutions

Add a retry mechanism to Slow and Incremental syncs.
The retry mechanism is quite simple at the moment:
- A real exception (not cancellation) is thrown
- Wait 10 seconds
- Try again

> **Note**: In the future we can optimise this. Retrying less frequently and observing connectivity changes (like mobile phones moving from Wi-Fi to Mobile Data, for example).
> However, on Android, for example, the WebSocket can be dropped when the app is put into the background or when the screen locks.
> So this delay-retry covers more ground and is more reliable for an initial implementation.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Opening the Reloaded app with these changes:
- Open a conversation
- Receive messages
- Turn Wi-Fi off and on again

##### Expectations:
- The app should keep receiving messages
- The connectivity status bar should go to Yellow on connectivity drop, green and disappear again once connection is re-established

### Attachments

https://user-images.githubusercontent.com/9389043/183217799-e46cbb42-24d6-4b64-9f41-edfb36d6d123.mp4

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
