### PR TITLE
fix: running regex matching twice in network log interceptor

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.network
 
-import com.wire.kalium.logger.ObfuscateUtil.obfuscateLogMessage
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.HttpClientPlugin
@@ -161,7 +160,7 @@ public class KaliumKtorCustomLogging private constructor(
         GlobalScope.launch(Dispatchers.Unconfined) {
             val text = channel.tryReadText(charset) ?: "[request body omitted]"
             kaliumLogger.v("BODY START")
-            kaliumLogger.v(obfuscateLogMessage(text))
+            kaliumLogger.v(text)
             kaliumLogger.v("BODY END")
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. app is doing expensive operations to obfuscate logs 
2. logs obfuscate running twice for network requests.

### Solutions

1. (out of the scope of this PR) we need to find a cheaper way to obfuscate logs 
2. run the logs obfuscate only once 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
