### PR TITLE
chore: add www-authenticate header for all platforms

### DIFF
--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -2,29 +2,5 @@ package com.wire.kalium.network
 
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
-import okhttp3.Interceptor
-import okhttp3.Request
-import okhttp3.Response
 
-actual fun defaultHttpEngine(): HttpClientEngine {
-    return OkHttp.create {
-        addInterceptor(object : Interceptor {
-            override fun intercept(chain: Interceptor.Chain): Response {
-                return chain.request().let { checkedRequest -> chain.proceed(checkedRequest) }.handleUnauthorizedResponse()
-            }
-        })
-    }
-}
-
-/**
- * Ktor need "WWW-Authenticate" to be set by BE in-order for the tokens refresh to work
- * see issue https://youtrack.jetbrains.com/issue/KTOR-2806
- * BE does not set "WWW-Authenticate"
- *
- * checks for 401 response -> add WWW-Authenticate header
- */
-private fun Response.handleUnauthorizedResponse(): Response =
-    when (this.code == 401) {
-        true -> this.newBuilder().addHeader("WWW-Authenticate", "Bearer").build()
-        false -> this
-    }
+actual fun defaultHttpEngine(): HttpClientEngine = OkHttp.create()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -9,10 +9,22 @@ import com.wire.kalium.network.exceptions.isInvalidCredentials
 import com.wire.kalium.network.exceptions.isUnknownClient
 import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.call.HttpClientCall
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.statement.HttpReceivePipeline
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.utils.buildHeaders
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpProtocolVersion
+import io.ktor.http.HttpStatusCode
+import io.ktor.util.InternalAPI
+import io.ktor.util.date.GMTDate
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.coroutines.CoroutineContext
 
 interface SessionManager {
     fun session(): Pair<SessionDTO, ServerConfigDTO.Links>
@@ -26,6 +38,9 @@ interface SessionManager {
 }
 
 fun HttpClientConfig<*>.installAuth(sessionManager: SessionManager) {
+    install("Add_WWW-Authenticate_Header") {
+        addWWWAuthenticateHeaderIfNeeded()
+    }
     install(Auth) {
         bearer {
             // memory cache the tokens
@@ -60,6 +75,30 @@ fun HttpClientConfig<*>.installAuth(sessionManager: SessionManager) {
                     }
                 }
             }
+        }
+    }
+}
+
+@OptIn(InternalAPI::class)
+private fun HttpClient.addWWWAuthenticateHeaderIfNeeded() {
+    receivePipeline.intercept(HttpReceivePipeline.Before) { response ->
+        if (response.status == HttpStatusCode.Unauthorized) {
+            val headers = buildHeaders {
+                appendAll(response.headers)
+                append(HttpHeaders.WWWAuthenticate, "Bearer")
+            }
+            proceedWith(
+                object : HttpResponse() {
+                    override val call: HttpClientCall = response.call
+                    override val status: HttpStatusCode = response.status
+                    override val version: HttpProtocolVersion = response.version
+                    override val requestTime: GMTDate = response.requestTime
+                    override val responseTime: GMTDate = response.responseTime
+                    override val content: ByteReadChannel = response.content
+                    override val headers get() = headers
+                    override val coroutineContext: CoroutineContext = response.coroutineContext
+                }
+            )
         }
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/network/session/SessionManagerTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/network/session/SessionManagerTest.kt
@@ -1,0 +1,77 @@
+package com.wire.kalium.network.session
+
+import com.wire.kalium.api.TEST_BACKEND_CONFIG
+import com.wire.kalium.api.tools.testCredentials
+import com.wire.kalium.network.api.SessionDTO
+import com.wire.kalium.network.api.model.AccessTokenDTO
+import com.wire.kalium.network.api.model.RefreshTokenDTO
+import com.wire.kalium.network.tools.ServerConfigDTO
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.request.get
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SessionManagerTest {
+
+    @Test
+    fun givenClientWithAuth_whenServerReturns401_thenShouldAddBearerWWWAuthHeader() = runTest {
+        val sessionManager = createFakeSessionManager()
+
+        var didFail = false
+        val mockEngine = MockEngine() {
+            // Fail only the first time, so the test can
+            // proceed when sessionManager is called again
+            if (!didFail) {
+                didFail = true
+                respondError(status = HttpStatusCode.Unauthorized)
+            } else {
+                respondOk()
+            }
+        }
+
+        val client = HttpClient(mockEngine) {
+            installAuth(sessionManager)
+            expectSuccess = false
+        }
+
+        val response = client.get(TEST_BACKEND_CONFIG.links.api)
+
+        assertEquals("Bearer", response.headers[HttpHeaders.WWWAuthenticate])
+    }
+
+    @Test
+    fun givenClientWithAuth_whenServerReturnsOK_thenShouldNotAddBearerWWWAuthHeader() = runTest {
+        val sessionManager = createFakeSessionManager()
+
+        val mockEngine = MockEngine() {
+            respondOk()
+        }
+
+        val client = HttpClient(mockEngine) {
+            installAuth(sessionManager)
+            expectSuccess = false
+        }
+
+        val response = client.get(TEST_BACKEND_CONFIG.links.api)
+
+        assertNull(response.headers[HttpHeaders.WWWAuthenticate])
+    }
+
+    private fun createFakeSessionManager() = object : SessionManager {
+        override fun session(): Pair<SessionDTO, ServerConfigDTO.Links> = testCredentials to TEST_BACKEND_CONFIG.links
+
+        override fun updateLoginSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO =
+            testCredentials
+
+        override suspend fun onSessionExpired() = TODO("Not yet implemented")
+
+        override suspend fun onClientRemoved() = TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Ktor requires the server to send a `WWW-Authenticate` header with `Bearer` value so it will refresh the tokens.

Wire servers don't return this, so we manually add this Header in order to get Ktor to refresh the token.

We have this implemented directly in our `OkHttp` creation, but this means that only JVM and Android were covered with this.

### Solutions

Since Ktor 2.0.0, it's possible to overwrite header values, as seen in [this PR](https://github.com/ktorio/ktor/pull/2522/files#diff-5acc2ecf72dfc4fd8710d98c274fada09eee9859cd1adb3936bf4396c982a0e6).

This means all platforms can be covered with this Header fix.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
