### PR TITLE
fix: make sure token is refreshed before connecting websocket

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApiImpl.kt
@@ -71,6 +71,13 @@ class NotificationApiImpl internal constructor(
     }
 
     override suspend fun listenToLiveEvents(clientId: String): Flow<WebSocketEvent<EventResponse>> = flow {
+        // TODO: Delete this once we can intercept and handle token refresh when connecting WebSocket
+        //       WebSocket requests are not intercept-able, and they throw
+        //       exceptions when the backend returns 401 instead of triggering a token refresh.
+        //       This call to lastNotification will make sure that if the token is expired, it will be refreshed
+        //       before attempting to open the websocket
+        lastNotification(clientId)
+
         authenticatedWebSocketClient
             .createDisposableHttpClient()
             .webSocket({


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the token expires and we attempt to call `listenToLiveEvents.collect()`, we get `java.net.ProtocolException: Expected HTTP 101 response but was '401 Unauthorized'`

### Causes

OkHttp, which runs underneath, expects a protocol upgrade to WebSocket and doesn't handle the errors normally as other Http requests. So the exception leaks through Ktor.

### Solutions

Make another (normal) HTTP call before requesting the token. Because when the token is expired in normal HTTP calls, we handle it properly.
It's dirty 💩. But does the trick.

> **Note**: I'm currently investigating to see how feasible would be to properly handle the response. But given it's a WebSocket call, it's not expected (in code) to handle the response as a HTTP header.

### Testing

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
