### PR TITLE
feat: ObserveUserInfoUseCase

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
@@ -63,8 +63,7 @@ internal class ObserveUserInfoUseCaseImpl(
                     } else {
                         ObserveOtherUserResult(getKnownUserError = storageFailure)
                     }
-                })
-                { ObserveOtherUserResult(success = it) }
+                }) { ObserveOtherUserResult(success = it) }
             }
             .filter {
                 // false here means there was StorageFailure.DataNotFound during userRepository.getKnownUser,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
@@ -1,0 +1,83 @@
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.team.Team
+import com.wire.kalium.logic.data.team.TeamRepository
+import com.wire.kalium.logic.data.user.OtherUser
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.foldEither
+import com.wire.kalium.logic.functional.mapLeft
+import com.wire.kalium.logic.wrapStorageRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.firstOrNull
+
+/**
+ * Use case that allows observing the user details of a user locally,
+ * or request it from API and save to DB, if there is no local data for such user.
+ */
+fun interface ObserveUserInfoUseCase {
+    /**
+     * Use case [GetUserInfoUseCase] operation
+     *
+     * @param userId the target user identifier
+     * @return a [GetUserInfoResult] indicating the operation result
+     */
+    suspend operator fun invoke(userId: UserId): Flow<GetUserInfoResult>
+}
+
+internal class ObserveUserInfoUseCaseImpl(
+    private val userRepository: UserRepository,
+    private val teamRepository: TeamRepository
+) : ObserveUserInfoUseCase {
+
+    override suspend fun invoke(userId: UserId): Flow<GetUserInfoResult> {
+        return observeOtherUser(userId)
+            .foldEither({ GetUserInfoResult.Failure }) { otherUser ->
+                getOtherUserTeam(otherUser).fold(
+                    { GetUserInfoResult.Failure },
+                    { team -> GetUserInfoResult.Success(otherUser, team) })
+            }
+    }
+
+    private suspend fun observeOtherUser(userId: UserId): Flow<Either<CoreFailure, OtherUser>> {
+        return userRepository.getKnownUser(userId)
+            .wrapStorageRequest()
+            .mapLeft { storageFailure ->
+                if (storageFailure is StorageFailure.DataNotFound) {
+                    userRepository.fetchUsersByIds(setOf(userId))
+                        .fold({ it }) { storageFailure }
+                } else {
+                    storageFailure
+                }
+            }
+            .filter { either ->
+                // We don't want to pass DataNotFound Error forward, cause in that case we'll fetch data from API
+                either.fold({ it !is StorageFailure.DataNotFound }) { true }
+            }
+    }
+
+    /**
+     * Users are allowed to fetch team details only if they are members of the same team
+     * @see [UserType]
+     */
+    private suspend fun getOtherUserTeam(otherUser: OtherUser): Either<CoreFailure, Team?> {
+        return if (otherUser.teamId != null && otherUser.userType == UserType.INTERNAL) {
+            val localTeam = teamRepository.getTeam(otherUser.teamId).firstOrNull()
+
+            if (localTeam == null) {
+                teamRepository.fetchTeamById(otherUser.teamId)
+            } else {
+                Either.Right(localTeam)
+            }
+        } else {
+            Either.Right(null)
+        }
+    }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -39,6 +39,7 @@ class UserScope internal constructor(
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
     val getSelfUser: GetSelfUserUseCase get() = GetSelfUserUseCase(userRepository)
+    val observeUserInfo: ObserveUserInfoUseCase get() = ObserveUserInfoUseCaseImpl(userRepository, teamRepository)
     val uploadUserAvatar: UploadUserAvatarUseCase get() = UploadUserAvatarUseCaseImpl(userRepository, assetRepository)
     val searchUsers: SearchUsersUseCase get() = SearchUsersUseCaseImpl(searchUserRepository, connectionRepository, qualifiedIdMapper)
     val searchKnownUsers: SearchKnownUsersUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/EitherFlow.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/EitherFlow.kt
@@ -2,6 +2,8 @@ package com.wire.kalium.logic.functional
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 fun <L, R> Flow<Either<L, R>>.onlyRight(): Flow<R> = filter { it.isRight() }.map { (it as Either.Right<R>).value }
@@ -12,5 +14,7 @@ fun <L, R, T> Flow<Either<L, R>>.mapLeft(block: suspend (L) -> T): Flow<Either<T
 fun <L, R, T> Flow<Either<L, R>>.mapRight(block: suspend (R) -> T): Flow<Either<L, T>> =
     map { it.fold({ l -> Either.Left(l) }) { r -> Either.Right(block(r)) } }
 
-fun <L, R, T : Any> Flow<Either<L, R>>.foldEither(fnL: suspend (L) -> T, fnR: suspend (R) -> T): Flow<T> =
-    map { it.fold({ l -> fnL(l) }, { r -> fnR(r) }) }
+fun <L, R> Flow<Either<L, R>>.mapToRightOr(value: R): Flow<R> = map { it.getOrElse(value) }
+
+fun <L, R, T> Flow<Either<L, R>>.flatMapRightWithEither(block: suspend (R) -> Flow<Either<L, T>>): Flow<Either<L, T>> =
+    flatMapLatest { it.fold({ l -> flowOf(Either.Left(l)) }) { r -> block(r) } }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/EitherFlow.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/EitherFlow.kt
@@ -5,3 +5,12 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 
 fun <L, R> Flow<Either<L, R>>.onlyRight(): Flow<R> = filter { it.isRight() }.map { (it as Either.Right<R>).value }
+
+fun <L, R, T> Flow<Either<L, R>>.mapLeft(block: suspend (L) -> T): Flow<Either<T, R>> =
+    map { it.fold({ l -> Either.Left(block(l)) }) { r -> Either.Right(r) } }
+
+fun <L, R, T> Flow<Either<L, R>>.mapRight(block: suspend (R) -> T): Flow<Either<L, T>> =
+    map { it.fold({ l -> Either.Left(l) }) { r -> Either.Right(block(r)) } }
+
+fun <L, R, T : Any> Flow<Either<L, R>>.foldEither(fnL: suspend (L) -> T, fnR: suspend (R) -> T): Flow<T> =
+    map { it.fold({ l -> fnL(l) }, { r -> fnR(r) }) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/EitherFlow.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/EitherFlow.kt
@@ -14,7 +14,37 @@ fun <L, R, T> Flow<Either<L, R>>.mapLeft(block: suspend (L) -> T): Flow<Either<T
 fun <L, R, T> Flow<Either<L, R>>.mapRight(block: suspend (R) -> T): Flow<Either<L, T>> =
     map { it.fold({ l -> Either.Left(l) }) { r -> Either.Right(block(r)) } }
 
+/**
+ * map Flow<Either<L, R>> to the Flow<R>.
+ * @param value that Flow emits if original Either.isLeft = true
+ *
+ * Example1:
+ * `flowOf(Either.Right(1)).mapToRightOr(0)` will emit 1
+ *
+ * Example2:
+ * `flowOf(Either.Left("Error")).mapToRightOr(0)` will emit 0
+ */
 fun <L, R> Flow<Either<L, R>>.mapToRightOr(value: R): Flow<R> = map { it.getOrElse(value) }
 
+/**
+ * [flatMapLatest] the Flow<Either<L, R>> into Flow<Either<L, T>>.
+ * @param block function to run on Either.Right value and that returns Flow<Either<L, T>>
+ *
+ * Usecase for it:
+ * we have 2 functions both of it returns Flow<Either> but one of it is depends on the Right value from the other
+ * and we need to combine Right values from both of it, or emit 1 error (Either.Left) if it occurs on any step.
+ * Use that fun to have better code style.
+ *
+ * Example:
+ *
+ * fun getUserId(): Either<Error, ID>
+ * fun getFriendsFroUser(userId: ID): Either<Error, List<String>>
+ *
+ * data class MeWithFriends(val myId: ID, val friends: List<String>)
+ *
+ * val observeMeWithFriends: Flow<Either<Error, MeWithFriends>>  =
+ *       getUserId().flatMapRightWithEither { id -> getFriendsFroUser(id).mapRight { MeWithFriends(id, it) }}
+ *
+ */
 fun <L, R, T> Flow<Either<L, R>>.flatMapRightWithEither(block: suspend (R) -> Flow<Either<L, T>>): Flow<Either<L, T>> =
     flatMapLatest { it.fold({ l -> flowOf(Either.Left(l)) }) { r -> block(r) } }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCaseTest.kt
@@ -1,0 +1,337 @@
+package com.wire.kalium.logic.feature.user
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.team.Team
+import com.wire.kalium.logic.data.team.TeamRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ObserveUserInfoUseCaseTest {
+
+    private val arrangement = ObserveUserInfoUseCaseTestArrangement()
+
+    @Test
+    fun givenAUserIdWhichIsInDB_whenInvokingObserveUserInfo_thenShouldReturnsSuccessResult() = runTest {
+        // given
+        val (arrangement, useCase) = arrangement
+            .withSuccessfulUserRetrieveFromDB()
+            .withSuccessfulTeamRetrieve(localTeamPresent = true)
+            .arrange()
+
+        useCase(userId).test {
+            val result = awaitItem()
+            assertEquals(TestUser.OTHER, (result as GetUserInfoResult.Success).otherUser)
+
+            with(arrangement) {
+                verify(userRepository)
+                    .suspendFunction(userRepository::fetchUsersByIds)
+                    .with(any())
+                    .wasNotInvoked()
+            }
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenAUserIdWhichIsNotInDB_whenInvokingObserveUserInfo_thenFetchKnownUsersIsCalled() = runTest {
+        // given
+        val (arrangement, useCase) = arrangement
+            .withFailingUserRetrieveFromDB()
+            .withSuccessfulTeamRetrieve(localTeamPresent = true)
+            .withSuccessfulUserFetching()
+            .arrange()
+
+        useCase(userId).test {
+            awaitComplete()
+
+            with(arrangement) {
+                verify(userRepository)
+                    .suspendFunction(userRepository::fetchUsersByIds)
+                    .with(any())
+                    .wasInvoked(once)
+            }
+
+        }
+    }
+
+    @Test
+    fun givenAUserIdWhichIsNotInDBAndFetchUsersByIdsReturnsError_whenInvokingObserveUserInfo_thenErrorIsPropagated() = runTest {
+        // given
+        val (arrangement, useCase) = arrangement
+            .withFailingUserRetrieveFromDB()
+            .withSuccessfulTeamRetrieve(localTeamPresent = true)
+            .withFailingUserFetching()
+            .arrange()
+
+        useCase(userId).test {
+            val result = awaitItem()
+
+            assertIs<GetUserInfoResult.Failure>(result)
+
+            with(arrangement) {
+                verify(userRepository)
+                    .suspendFunction(userRepository::fetchUsersByIds)
+                    .with(any())
+                    .wasInvoked(once)
+            }
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenAUserWithNoTeam_WhenGettingDetails_thenShouldReturnSuccessResultAndDoNotRetrieveTeam() = runTest {
+        // given
+        val (arrangement, useCase) = arrangement
+            .withSuccessfulUserRetrieveFromDB(hasTeam = false)
+            .arrange()
+
+        // when
+        useCase(userId).test {
+            val result = awaitItem()
+
+            // then
+            assertEquals(TestUser.OTHER.copy(teamId = null), (result as GetUserInfoResult.Success).otherUser)
+
+            with(arrangement) {
+                verify(userRepository)
+                    .suspendFunction(userRepository::getKnownUser)
+                    .with(eq(userId))
+                    .wasInvoked(once)
+
+                verify(teamRepository)
+                    .suspendFunction(teamRepository::getTeam)
+                    .with(any())
+                    .wasNotInvoked()
+            }
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenAInternalUserWithTeamNotExistingLocally_WhenGettingDetails_thenShouldReturnSuccessResultAndGetRemoteUserTeam() = runTest {
+        // given
+        val (arrangement, useCase) = arrangement
+            .withSuccessfulUserRetrieveFromDB(userType = UserType.INTERNAL)
+            .withSuccessfulTeamRetrieve(localTeamPresent = false)
+            .arrange()
+
+        // when
+        useCase(userId).test {
+            val result = awaitItem()
+
+            // then
+            assertEquals(TestUser.OTHER.copy(userType = UserType.INTERNAL), (result as GetUserInfoResult.Success).otherUser)
+
+            with(arrangement) {
+                verify(userRepository)
+                    .suspendFunction(userRepository::getKnownUser)
+                    .with(eq(userId))
+                    .wasInvoked(once)
+
+                verify(teamRepository)
+                    .suspendFunction(teamRepository::getTeam)
+                    .with(any())
+                    .wasInvoked(once)
+
+                verify(teamRepository)
+                    .suspendFunction(teamRepository::fetchTeamById)
+                    .with(any())
+                    .wasInvoked(once)
+            }
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenAUserWithTeamNotExistingLocally_WhenGettingDetails_DoNotGetTheTeamDetails() =
+        runTest {
+            // given
+            val (arrangement, useCase) = arrangement
+                .withFailingUserRetrieveFromDB()
+                .withSuccessfulUserFetching()
+                .withFailingTeamRetrieve()
+                .arrange()
+            // when
+            useCase(userId).test {
+                with(arrangement) {
+                    verify(userRepository)
+                        .suspendFunction(userRepository::getKnownUser)
+                        .with(eq(userId))
+                        .wasInvoked(once)
+
+                    verify(teamRepository)
+                        .suspendFunction(teamRepository::getTeam)
+                        .with(any())
+                        .wasNotInvoked()
+
+                    verify(teamRepository)
+                        .suspendFunction(teamRepository::fetchTeamById)
+                        .with(any())
+                        .wasInvoked()
+                }
+                awaitComplete()
+            }
+        }
+
+    @Test
+    fun givenAInternalUserWithTeamNotExistingLocallyAndFetchingTeamFails_WhenGettingDetails_ThenPropagateTheFailure() = runTest {
+        // given
+
+        val (arrangement, useCase) = arrangement
+            .withSuccessfulUserRetrieveFromDB(userType = UserType.INTERNAL)
+            .withFailingTeamRetrieve()
+            .arrange()
+
+        // when
+        useCase(userId).test {
+            val result = awaitItem()
+
+            // then
+            assertIs<GetUserInfoResult.Failure>(result)
+
+            with(arrangement) {
+                verify(userRepository)
+                    .suspendFunction(userRepository::getKnownUser)
+                    .with(eq(userId))
+                    .wasInvoked(once)
+
+                verify(teamRepository)
+                    .suspendFunction(teamRepository::getTeam)
+                    .with(any())
+                    .wasInvoked(once)
+
+                verify(teamRepository)
+                    .suspendFunction(teamRepository::fetchTeamById)
+                    .with(any())
+                    .wasInvoked(once)
+            }
+            awaitComplete()
+        }
+    }
+
+    class ObserveUserInfoUseCaseTestArrangement {
+
+        @Mock
+        val userRepository: UserRepository = mock(UserRepository::class)
+
+        @Mock
+        val teamRepository: TeamRepository = mock(TeamRepository::class)
+
+        fun withSuccessfulUserRetrieveFromDB(
+            hasTeam: Boolean = true,
+            userType: UserType = UserType.EXTERNAL
+        ): ObserveUserInfoUseCaseTestArrangement {
+            given(userRepository)
+                .suspendFunction(userRepository::getKnownUser)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    flowOf(
+                        if (hasTeam) TestUser.OTHER.copy(userType = userType) else TestUser.OTHER.copy(
+                            teamId = null,
+                            userType = userType
+                        )
+                    )
+                )
+
+            return this
+        }
+
+        fun withFailingUserRetrieveFromDB(): ObserveUserInfoUseCaseTestArrangement {
+            given(userRepository)
+                .suspendFunction(userRepository::getKnownUser)
+                .whenInvokedWith(any())
+                .thenReturn(flowOf(null))
+
+            return this
+        }
+
+        fun withFailingUserFetching(): ObserveUserInfoUseCaseTestArrangement {
+            given(userRepository)
+                .suspendFunction(userRepository::fetchUsersByIds)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("fetchUsersByIds error"))))
+
+            return this
+        }
+
+        fun withSuccessfulUserFetching(): ObserveUserInfoUseCaseTestArrangement {
+            given(userRepository)
+                .suspendFunction(userRepository::fetchUsersByIds)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+
+            return this
+        }
+
+        fun withSuccessfulTeamRetrieve(
+            localTeamPresent: Boolean = true,
+        ): ObserveUserInfoUseCaseTestArrangement {
+            given(teamRepository)
+                .suspendFunction(teamRepository::getTeam)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    flowOf(
+                        if (!localTeamPresent) null
+                        else team
+                    )
+                )
+
+            if (!localTeamPresent) {
+                given(teamRepository)
+                    .suspendFunction(teamRepository::fetchTeamById)
+                    .whenInvokedWith(any())
+                    .thenReturn(Either.Right(team))
+            }
+
+            return this
+        }
+
+        fun withFailingTeamRetrieve(): ObserveUserInfoUseCaseTestArrangement {
+            given(teamRepository)
+                .suspendFunction(teamRepository::getTeam)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    flowOf(null)
+                )
+
+            given(teamRepository)
+                .suspendFunction(teamRepository::fetchTeamById)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    Either.Left(CoreFailure.Unknown(RuntimeException("some error")))
+                )
+
+            return this
+        }
+
+        fun arrange(): Pair<ObserveUserInfoUseCaseTestArrangement, ObserveUserInfoUseCase> {
+            return this to ObserveUserInfoUseCaseImpl(userRepository, teamRepository)
+        }
+
+        private companion object {
+            val team = Team("teamId", "teamName")
+        }
+    }
+
+    private companion object {
+        val userId = UserId("some_user", "some_domain")
+    }
+}


### PR DESCRIPTION
## Needed for  [Task-1593](https://wearezeta.atlassian.net/browse/AR-1593)

# What's new in this PR?

`ObserveUserInfoUseCase` that allows to observe UserInfo changes and fetch it from API if there is no such one in DB

### Issues

No such UseCase

### Causes (Optional)

It wasn't created 

### Solutions

Create it
