### PR TITLE
fix: wait for slow sync before certain use cases

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -509,6 +509,7 @@ abstract class UserSessionScopeCommon(
             userRepository,
             assetRepository,
             syncManager,
+            slowSyncRepository,
             messageSendingScheduler,
             timeParser,
             kaliumFileSystem

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
 
+@Suppress("LongParameterList")
 class DeleteMessageUseCase internal constructor(
     private val messageRepository: MessageRepository,
     private val userRepository: UserRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -11,6 +11,8 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.Either
@@ -22,17 +24,22 @@ import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
 
-class DeleteMessageUseCase(
+class DeleteMessageUseCase internal constructor(
     private val messageRepository: MessageRepository,
     private val userRepository: UserRepository,
     private val clientRepository: ClientRepository,
     private val assetRepository: AssetRepository,
+    private val slowSyncRepository: SlowSyncRepository,
     private val messageSender: MessageSender,
     private val idMapper: IdMapper
 ) {
 
-    suspend operator fun invoke(conversationId: ConversationId, messageId: String, deleteForEveryone: Boolean): Either<CoreFailure, Unit> =
-        messageRepository.getMessageById(conversationId, messageId).map { message ->
+    suspend operator fun invoke(conversationId: ConversationId, messageId: String, deleteForEveryone: Boolean): Either<CoreFailure, Unit> {
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
+
+        return messageRepository.getMessageById(conversationId, messageId).map { message ->
             when (message.status) {
                 Message.Status.FAILED -> messageRepository.deleteMessage(messageId, conversationId)
                 else -> {
@@ -66,6 +73,7 @@ class DeleteMessageUseCase(
                 }
             }
         }
+    }
 
     private suspend fun deleteMessageAsset(message: Message) {
         (message.content as? MessageContent.Asset)?.value?.remoteData?.let { assetToRemove ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
-import com.wire.kalium.persistence.dao.message.MessageEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
@@ -3,15 +3,25 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 
-class GetRecentMessagesUseCase(private val messageRepository: MessageRepository) {
+class GetRecentMessagesUseCase internal constructor(
+    private val messageRepository: MessageRepository,
+    private val slowSyncRepository: SlowSyncRepository) {
 
     suspend operator fun invoke(
         conversationId: ConversationId,
         limit: Int = 100,
         offset: Int = 0,
         visibility: List<Message.Visibility> = Message.Visibility.values().toList()
-    ): Flow<List<Message>> = messageRepository.getMessagesByConversationIdAndVisibility(conversationId, limit, offset, visibility)
+    ): Flow<List<Message>> {
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
+        return messageRepository.getMessagesByConversationIdAndVisibility(conversationId, limit, offset, visibility)
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetRecentMessagesUseCase.kt
@@ -10,7 +10,8 @@ import kotlinx.coroutines.flow.first
 
 class GetRecentMessagesUseCase internal constructor(
     private val messageRepository: MessageRepository,
-    private val slowSyncRepository: SlowSyncRepository) {
+    private val slowSyncRepository: SlowSyncRepository
+) {
 
     suspend operator fun invoke(
         conversationId: ConversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -16,6 +16,7 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCaseImpl
 import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.message.ProtoContentMapperImpl
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCaseImpl
@@ -27,7 +28,7 @@ import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.util.TimeParser
 
 @Suppress("LongParameterList")
-class MessageScope(
+class MessageScope internal constructor(
     private val connectionRepository: ConnectionRepository,
     private val userId: QualifiedID,
     internal val messageRepository: MessageRepository,
@@ -39,6 +40,7 @@ class MessageScope(
     private val userRepository: UserRepository,
     private val assetRepository: AssetRepository,
     private val syncManager: SyncManager,
+    private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
     private val timeParser: TimeParser,
     private val kaliumFileSystem: KaliumFileSystem
@@ -83,6 +85,7 @@ class MessageScope(
             persistMessage,
             userRepository,
             clientRepository,
+            slowSyncRepository,
             messageSender
         )
 
@@ -101,7 +104,11 @@ class MessageScope(
             messageRepository
         )
 
-    val getRecentMessages: GetRecentMessagesUseCase get() = GetRecentMessagesUseCase(messageRepository)
+    val getRecentMessages: GetRecentMessagesUseCase
+        get() = GetRecentMessagesUseCase(
+            messageRepository,
+            slowSyncRepository
+        )
 
     val deleteMessage: DeleteMessageUseCase
         get() = DeleteMessageUseCase(
@@ -109,6 +116,7 @@ class MessageScope(
             userRepository,
             clientRepository,
             assetRepository,
+            slowSyncRepository,
             messageSender,
             idMapper
         )
@@ -118,6 +126,7 @@ class MessageScope(
             persistMessage,
             userRepository,
             clientRepository,
+            slowSyncRepository,
             messageSender
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -7,6 +7,8 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
@@ -15,14 +17,19 @@ import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
 
-class SendKnockUseCase(
+class SendKnockUseCase internal constructor(
     private val persistMessage: PersistMessageUseCase,
     private val userRepository: UserRepository,
     private val clientRepository: ClientRepository,
+    private val slowSyncRepository: SlowSyncRepository,
     private val messageSender: MessageSender
 ) {
 
     suspend operator fun invoke(conversationId: ConversationId, hotKnock: Boolean): Either<CoreFailure, Unit> {
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
+
         val selfUser = userRepository.observeSelfUser().first()
 
         val generatedMessageUuid = uuid4().toString()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -25,7 +25,6 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.anything
-import io.mockative.classOf
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.matching

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageEncryptionAlgorithm
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
@@ -23,6 +24,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.anything
+import io.mockative.classOf
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.matching
@@ -190,6 +192,9 @@ class DeleteMessageUseCaseTest {
         val clientRepository: ClientRepository = mock(ClientRepository::class)
 
         @Mock
+        private val slowSyncRepository = mock(SlowSyncRepository::class)
+
+        @Mock
         val messageSender: MessageSender = mock(MessageSender::class)
 
         @Mock
@@ -202,6 +207,7 @@ class DeleteMessageUseCaseTest {
             userRepository,
             clientRepository,
             assetRepository,
+            slowSyncRepository,
             messageSender,
             idMapper
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
@@ -44,7 +45,7 @@ class SendKnockUserCaseTest {
     private class Arrangement {
 
         @Mock
-        val persistMessage = mock(classOf<PersistMessageUseCase>())
+        private val persistMessage = mock(classOf<PersistMessageUseCase>())
 
         @Mock
         private val userRepository = mock(classOf<UserRepository>())
@@ -53,7 +54,10 @@ class SendKnockUserCaseTest {
         private val clientRepository = mock(classOf<ClientRepository>())
 
         @Mock
-        val messageSender = mock(classOf<MessageSender>())
+        private val slowSyncRepository = mock(classOf<SlowSyncRepository>())
+
+        @Mock
+        private val messageSender = mock(classOf<MessageSender>())
 
         val someClientId = ClientId("some-client-id")
 
@@ -95,6 +99,7 @@ class SendKnockUserCaseTest {
             persistMessage,
             userRepository,
             clientRepository,
+            slowSyncRepository,
             messageSender
         )
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
@@ -18,6 +19,8 @@ import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -61,6 +64,8 @@ class SendKnockUserCaseTest {
 
         val someClientId = ClientId("some-client-id")
 
+        val completeStateFlow = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
+
         private fun fakeSelfUser() = SelfUser(
             UserId("some_id", "some_domain"),
             "some_name",
@@ -88,6 +93,10 @@ class SendKnockUserCaseTest {
                 .suspendFunction(persistMessage::invoke)
                 .whenInvokedWith(any())
                 .thenReturn(Either.Right(Unit))
+            given(slowSyncRepository)
+                .getter(slowSyncRepository::slowSyncStatus)
+                .whenInvoked()
+                .thenReturn(completeStateFlow)
             given(messageSender)
                 .suspendFunction(messageSender::sendPendingMessage)
                 .whenInvokedWith(any(), any())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

With @vitorhugods we discovered that my first sent message after login did not arrive because it was send before the sync after the login did not finish.

### Solutions

To prevent this we now wait for the slow sync on certain use cases.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
