### PR TITLE
fix: Slow Sync not recovering from failure

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.user.logout.LogoutApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 
 interface LogoutRepository {
 
@@ -35,7 +35,7 @@ internal class LogoutDataSource(
 
     private val logoutEventsChannel = Channel<LogoutReason>(capacity = Channel.CONFLATED)
 
-    override suspend fun observeLogout(): Flow<LogoutReason> = logoutEventsChannel.consumeAsFlow()
+    override suspend fun observeLogout(): Flow<LogoutReason> = logoutEventsChannel.receiveAsFlow()
 
     override suspend fun onLogout(reason: LogoutReason) = logoutEventsChannel.send(reason)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.network.api.user.logout.LogoutApi
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.mock
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When SlowSync fails due to whatever reason, it doesn't try again.

### Causes

#### Context

We observe LogoutReason to see if we can perform SlowSync or not. If the User has logged out or has a pending logout, we don't perform SlowSync

#### Back to the cause

LogoutReason is being stored in a Channel and we are calling `consumeAsFlow()` which means that if the collection throws an exception, the original channel is closed.

### Solutions

Replace `consumeAsFlow()` with `receiveAsFlow()`, which doesn't affect the upstream channel.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Drop your internet connection right after opening Reloaded.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
