### PR TITLE
fix: mapping correctly failure and conversations not found (AR-1819)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -1191,7 +1191,7 @@ class ConversationRepositoryTest {
 
         val CONVERSATION_RESPONSE_DTO = ConversationResponseDTO(
             conversationsFound = listOf(CONVERSATION_RESPONSE),
-            conversationsFailed = listOf(CONVERSATION_RESPONSE.copy(id = ConversationIdDTO("failedId", "someDomain"))),
+            conversationsFailed = listOf(ConversationIdDTO("failedId", "someDomain")),
             conversationsNotFound = emptyList()
         )
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationPagingResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationPagingResponse.kt
@@ -14,6 +14,6 @@ data class ConversationPagingResponse(
 @Serializable
 data class ConversationResponseDTO(
     @SerialName("found") val conversationsFound: List<ConversationResponse>,
-    @SerialName("not_found") val conversationsNotFound: List<ConversationResponse>,
-    @SerialName("failed") val conversationsFailed: List<ConversationResponse>,
+    @SerialName("not_found") val conversationsNotFound: List<ConversationId>,
+    @SerialName("failed") val conversationsFailed: List<ConversationId>,
 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In Federated environments (multiple backends) we need to ignore conversations that are not being able to fetched when some backends are down.

### Causes (Optional)

Add correct mapping of failed and not found conversations, this returns a list of qualified ids, since we don't know any other info.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
