### PR TITLE
chore: upgrade kotlinx serialization plugin

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ import org.gradle.kotlin.dsl.version
 import org.gradle.plugin.use.PluginDependenciesSpec
 
 object Versions {
-    val kotlin = KotlinVersion.CURRENT.toString()
+    const val kotlin = "1.7.10"
     const val activityCompose = "1.3.1"
     const val appCompat = "1.1.0"
     const val cliKt = "3.3.0"

--- a/cryptography/build.gradle.kts
+++ b/cryptography/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     Plugins.androidLibrary(this)
     Plugins.multiplatform(this)
     Plugins.serialization(this)
+    println("KOTLIN VERSION = ${Versions.kotlin}")
     Plugins.carthage(this)
 }
 

--- a/cryptography/build.gradle.kts
+++ b/cryptography/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     Plugins.androidLibrary(this)
     Plugins.multiplatform(this)
     Plugins.serialization(this)
-    println("KOTLIN VERSION = ${Versions.kotlin}")
     Plugins.carthage(this)
 }
 
@@ -31,7 +30,7 @@ android {
         }
         ndkBuild {
             ndkVersion = Android.Ndk.version
-            //path(File("src/androidMain/jni/Android.mk"))
+            // path(File("src/androidMain/jni/Android.mk"))
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Unlike the rest of the project, kotlinx-serialization plugin is using Kotlin 1.5.31, instead of 1.7.10.

### Causes

We're using the version of the embedded Kotlin runtime that Gradle runs, instead of the specified 1.7.10 that we want.

### Solutions

Set a hard-coded version of 1.7.10 for kotlinx-serialization

### Testing

N/A


----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
