### PR TITLE
fix: websocket not receiving messages after some time

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -36,6 +36,7 @@ internal class EventProcessorImpl(
             is Event.FeatureConfig -> featureConfigEventReceiver.onEvent(event)
             is Event.Unknown -> kaliumLogger.withFeatureId(EVENT_RECEIVER).i("Unhandled event id=${event.id}")
         }
+        kaliumLogger.withFeatureId(EVENT_RECEIVER).i("Updating lastProcessedEventId ${event.id}")
         eventRepository.updateLastProcessedEventId(event.id)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -114,6 +114,7 @@ internal class IncrementalSyncManager(
                 }
                 incrementalSyncRepository.updateIncrementalSyncState(newState)
             }
+        kaliumLogger.i("IncrementalSync stopped.")
     }
 
     private companion object {

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -2,5 +2,14 @@ package com.wire.kalium.network
 
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 
-actual fun defaultHttpEngine(): HttpClientEngine = OkHttp.create()
+actual fun defaultHttpEngine(): HttpClientEngine = OkHttp.create {
+    // OkHttp doesn't support configuring ping intervals dynamically,
+    // so they must be set when creating the Engine
+    // See https://youtrack.jetbrains.com/issue/KTOR-4752
+    val client = OkHttpClient.Builder().pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS).build()
+    preconfigured = client
+    webSocketFactory = KaliumWebSocketFactory(client)
+}

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/KaliumWebSocketFactory.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/KaliumWebSocketFactory.kt
@@ -1,0 +1,63 @@
+package com.wire.kalium.network
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+
+/**
+ * Upon request, creates normal [WebSocket], but wraps the listener
+ * to add logging.
+ * @see WrapperListener
+ */
+class KaliumWebSocketFactory(private val okHttpClient: OkHttpClient) : WebSocket.Factory {
+
+    override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
+        val wrapperListener = WrapperListener(listener)
+        return okHttpClient.newWebSocket(request, wrapperListener)
+    }
+
+    /**
+     * Wraps the provided [wrappedListener], keeping the normal behaviour,
+     * but using [kaliumLogger] to log all operations.
+     */
+    inner class WrapperListener(private val wrappedListener: WebSocketListener) : WebSocketListener() {
+        override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+            super.onClosed(webSocket, code, reason)
+            kaliumLogger.v("WEBSOCKET: onClosed($code, $reason)")
+            wrappedListener.onClosed(webSocket, code, reason)
+        }
+
+        override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+            super.onClosing(webSocket, code, reason)
+            kaliumLogger.v("WEBSOCKET: onClosing($code, $reason)")
+            wrappedListener.onClosing(webSocket, code, reason)
+        }
+
+        override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+            super.onFailure(webSocket, t, response)
+            kaliumLogger.v("WEBSOCKET: onFailure($t, $response)")
+            wrappedListener.onFailure(webSocket, t, response)
+        }
+
+        override fun onMessage(webSocket: WebSocket, text: String) {
+            super.onMessage(webSocket, text)
+            kaliumLogger.v("WEBSOCKET: onMessage($text)")
+            wrappedListener.onMessage(webSocket, text)
+        }
+
+        override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+            super.onMessage(webSocket, bytes)
+            kaliumLogger.v("WEBSOCKET: onMessage($bytes)")
+            wrappedListener.onMessage(webSocket, bytes)
+        }
+
+        override fun onOpen(webSocket: WebSocket, response: Response) {
+            super.onOpen(webSocket, response)
+            kaliumLogger.v("WEBSOCKET: onOpen($response)")
+            wrappedListener.onOpen(webSocket, response)
+        }
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
@@ -89,7 +89,11 @@ internal class AuthenticatedWebSocketClient(
                 mls()
                 xprotobuf()
             }
-            install(WebSockets)
+            install(WebSockets) {
+                // Depending on the Engine (OkHttp for example), we might
+                // need to set this value there too, as this here won't work
+                pingInterval = WEBSOCKET_PING_INTERVAL_MILLIS
+            }
         }
 }
 
@@ -128,3 +132,4 @@ internal fun provideBaseHttpClient(
 
 internal fun shouldAddApiVersion(apiVersion: Int): Boolean = apiVersion >= MINIMUM_API_VERSION_TO_ADD
 private const val MINIMUM_API_VERSION_TO_ADD = 1
+internal const val WEBSOCKET_PING_INTERVAL_MILLIS = 30_000L

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
@@ -132,4 +132,4 @@ internal fun provideBaseHttpClient(
 
 internal fun shouldAddApiVersion(apiVersion: Int): Boolean = apiVersion >= MINIMUM_API_VERSION_TO_ADD
 private const val MINIMUM_API_VERSION_TO_ADD = 1
-internal const val WEBSOCKET_PING_INTERVAL_MILLIS = 30_000L
+internal const val WEBSOCKET_PING_INTERVAL_MILLIS = 20_000L


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After some time, the websocket dies. It completely stops receiving messages without any sings of errors, exceptions, or anything else being called.

### Causes

As we do not send messages to the backend, it seems that the backend expects at least some pings every so often to keep the connection alive.
After some time without receiving anything, the backend just leaves the connection in a limbo and doesn't send any more messages through it.

### Solutions

Add a ping every so many seconds.
It seems that @makingthematrix also went through this problem back in 2019 for the Scala app (see [this commit](https://github.com/wireapp/wire-android-sync-engine/commit/8b1866424a26b72e35e6209a7d4b091806faf8f6#diff-6a7a11f3c4ce9a86047f331475ffbf5c3cfec2b1601b5e14297c1694c8869e7fR61)), and 30s has been the magic number that carried the Scala app until now.

Unfortunately OkHttp doesn't handle dynamic pinging, so it must be configured directly into the HttpEngine, and it seems that [the configuration in WebSockets is just ignored if you're using OkHttp](https://youtrack.jetbrains.com/issue/KTOR-4752/Ping-configuration-is-silently-not-respected-when-setting-pingInterval-on-WebSockets-using-OkHttp-engine).

So, even though adding it to OkHttp fixes it for Android and JVM, I've added it to Ktor as well so it also works for other platforms.

> **Note**: During my investigation I also added a lower-level logging to the WebSocket and I guess there's no harm keeping it.

### Testing

Manually tested as we can't yet mock WebSockets using Ktor.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
