### PR TITLE
fix: do a slow sync before sending assets

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/SendAssetMessageUseCase.kt
@@ -14,6 +14,8 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageEncryptionAlgorithm
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.Either
@@ -57,6 +59,7 @@ internal class SendAssetMessageUseCaseImpl(
     private val clientRepository: ClientRepository,
     private val assetDataSource: AssetRepository,
     private val userRepository: UserRepository,
+    private val slowSyncRepository: SlowSyncRepository,
     private val messageSender: MessageSender
 ) : SendAssetMessageUseCase {
 
@@ -69,6 +72,9 @@ internal class SendAssetMessageUseCaseImpl(
         assetWidth: Int?,
         assetHeight: Int?
     ): SendAssetMessageResult {
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
 
         // Generate the otr asymmetric key that will be used to encrypt the data
         val otrKey = generateRandomAES256Key()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -95,6 +95,7 @@ class MessageScope internal constructor(
             clientRepository,
             assetRepository,
             userRepository,
+            slowSyncRepository,
             messageSender
         )
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

I forgot to add the slow sync before the send asset use case in my PR https://github.com/wireapp/kalium/pull/785

### Solutions

Add slow sync in asset send use case

### Testing

#### How to Test

Unit tests are updated in this PR

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
