### PR TITLE
feat: federation resilient users mapping (AR-2097)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
@@ -59,7 +59,8 @@ class PublicUserMapperImpl(
         completePicture = userEntity.completeAssetId?.let { idMapper.fromDaoModel(it) },
         availabilityStatus = availabilityStatusMapper.fromDaoAvailabilityStatusToModel(userEntity.availabilityStatus),
         userType = domainUserTypeMapper.fromUserTypeEntity(userEntity.userType),
-        botService = userEntity.botService?.let { BotService(it.id, it.provider) }
+        botService = userEntity.botService?.let { BotService(it.id, it.provider) },
+        deleted = userEntity.deleted
     )
 
     override fun fromUserDetailResponseWithUsertype(
@@ -78,7 +79,8 @@ class PublicUserMapperImpl(
             ?.let { idMapper.toQualifiedAssetId(it.key, userDetailResponse.id.domain) },
         availabilityStatus = UserAvailabilityStatus.NONE,
         userType = userType,
-        botService = userDetailResponse.service?.let { BotService(it.id, it.provider) }
+        botService = userDetailResponse.service?.let { BotService(it.id, it.provider) },
+        deleted = userDetailResponse.deleted ?: false
     )
 
     override fun fromUserApiToEntityWithConnectionStateAndUserTypeEntity(
@@ -101,6 +103,7 @@ class PublicUserMapperImpl(
         availabilityStatus = UserAvailabilityStatusEntity.NONE,
         userType = userTypeEntity,
         botService = userDetailResponse.service?.let { BotEntity(it.id, it.provider) },
+        deleted = userDetailResponse.deleted ?: false
     )
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -103,7 +103,8 @@ internal class UserMapperImpl(
             },
             availabilityStatus = UserAvailabilityStatusEntity.NONE,
             userType = userTypeEntity ?: UserTypeEntity.INTERNAL,
-            botService = userProfileDTO.service?.let { BotEntity(it.id, it.provider) }
+            botService = userProfileDTO.service?.let { BotEntity(it.id, it.provider) },
+            deleted = userProfileDTO.deleted ?: false
         )
     }
 
@@ -161,6 +162,7 @@ internal class UserMapperImpl(
             availabilityStatus = UserAvailabilityStatusEntity.NONE,
             userType = UserTypeEntity.INTERNAL,
             botService = null,
+            deleted = false
         )
     }
 
@@ -178,6 +180,7 @@ internal class UserMapperImpl(
             availabilityStatus = UserAvailabilityStatusEntity.NONE,
             userType = UserTypeEntity.INTERNAL,
             botService = null,
+            deleted = userDTO.deleted ?: false
         )
     }
 
@@ -209,5 +212,6 @@ internal class UserMapperImpl(
             availabilityStatus = UserAvailabilityStatusEntity.NONE,
             userType = userEntityTypeMapper.teamRoleCodeToUserType(permissionsCode),
             botService = null,
+            deleted = false
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
@@ -99,8 +99,16 @@ data class OtherUser(
     override val completePicture: UserAssetId?,
     val userType: UserType,
     override val availabilityStatus: UserAvailabilityStatus,
-    val botService: BotService?
-) : User()
+    val botService: BotService?,
+    val deleted: Boolean
+) : User() {
+
+    /**
+     * convenience computed field to obtain the unavailable users
+     */
+    val isUnavailableUser
+        get() = !deleted && name.orEmpty().isEmpty()
+}
 
 data class BotService(
     val id: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -16,7 +16,9 @@ import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.user.details.ListUserRequest
@@ -122,7 +124,10 @@ internal class UserDataSource(
                 } else {
                     it.value.forEach { userId ->
                         wrapApiRequest { userDetailsApi.getUserInfo(idMapper.toApiModel(userId)) }
-                            .flatMap { userProfileDTO -> persistUsers(listOf(userProfileDTO)) }
+                            .fold(
+                                { kaliumLogger.w("Ignoring external users details") },
+                                { userProfileDTO -> persistUsers(listOf(userProfileDTO)) }
+                            )
                     }
                     Either.Right(Unit)
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -114,7 +114,7 @@ internal class UserDataSource(
 
     override suspend fun fetchUsersByIds(ids: Set<UserId>): Either<CoreFailure, Unit> {
         val selfUserDomain = getSelfUserIDEntity().domain
-        val results: List<Either<CoreFailure, Unit>> = ids.groupBy { it.domain }
+        ids.groupBy { it.domain }
             .map {
                 val usersOnSameDomain = it.key == selfUserDomain
                 if (usersOnSameDomain) {
@@ -133,7 +133,7 @@ internal class UserDataSource(
                 }
             }
 
-        return results.firstOrNull { it is Either.Left } ?: Either.Right(Unit)
+        return Either.Right(Unit)
     }
 
     private suspend fun persistUsers(listUserProfileDTO: List<UserProfileDTO>) =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -146,7 +146,7 @@ internal class UserDataSource(
                 teamMembers.map { userProfileDTO ->
                     userMapper.fromApiModelWithUserTypeEntityToDaoModel(
                         userProfileDTO = userProfileDTO,
-                        null
+                        userTypeEntity = null
                     )
                 }
             )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -16,6 +16,7 @@ import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -143,7 +144,7 @@ internal class UserDataSource(
                     }
                 )
             }
-        }
+        })
 
     private fun isTeamMember(
         selfUserTeamId: String?,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SyncContactsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SyncContactsUseCase.kt
@@ -1,8 +1,14 @@
 package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.team.Result
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isFederationError
 
 interface SyncContactsUseCase {
     suspend operator fun invoke(): Either<CoreFailure, Unit>
@@ -11,7 +17,18 @@ interface SyncContactsUseCase {
 class SyncContactsUseCaseImpl(private val userDataSource: UserRepository) : SyncContactsUseCase {
 
     override suspend operator fun invoke(): Either<CoreFailure, Unit> {
-        return userDataSource.fetchKnownUsers()
+        return userDataSource.fetchKnownUsers().fold({ coreFailure ->
+            val a = when {
+                coreFailure is NetworkFailure.ServerMiscommunication && coreFailure.kaliumException is KaliumException.ServerError
+                        && coreFailure.kaliumException.isFederationError() -> kaliumLogger.e("aaaa!")
+                // todo: change this to proper failure mapping
+                // todo: simplify this check or extract
+                else -> Result.Failure.GenericFailure(coreFailure)
+            }
+            Either.Left(coreFailure)
+        }, {
+            Either.Right(Unit)
+        })
     }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SyncContactsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SyncContactsUseCase.kt
@@ -1,14 +1,8 @@
 package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.feature.team.Result
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.network.exceptions.isFederationError
 
 interface SyncContactsUseCase {
     suspend operator fun invoke(): Either<CoreFailure, Unit>
@@ -17,18 +11,7 @@ interface SyncContactsUseCase {
 class SyncContactsUseCaseImpl(private val userDataSource: UserRepository) : SyncContactsUseCase {
 
     override suspend operator fun invoke(): Either<CoreFailure, Unit> {
-        return userDataSource.fetchKnownUsers().fold({ coreFailure ->
-            val a = when {
-                coreFailure is NetworkFailure.ServerMiscommunication && coreFailure.kaliumException is KaliumException.ServerError
-                        && coreFailure.kaliumException.isFederationError() -> kaliumLogger.e("aaaa!")
-                // todo: change this to proper failure mapping
-                // todo: simplify this check or extract
-                else -> Result.Failure.GenericFailure(coreFailure)
-            }
-            Either.Left(coreFailure)
-        }, {
-            Either.Right(Unit)
-        })
+        return userDataSource.fetchKnownUsers()
     }
 
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -355,7 +355,8 @@ class ConnectionRepositoryTest {
             completeAssetId = null,
             availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
             userType = UserTypeEntity.EXTERNAL,
-            botService = null
+            botService = null,
+            false
         )
 
         val stubSelfUser = SelfUser(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -356,7 +356,7 @@ class ConnectionRepositoryTest {
             availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
             userType = UserTypeEntity.EXTERNAL,
             botService = null,
-            false
+            deleted = false
         )
 
         val stubSelfUser = SelfUser(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -458,6 +458,7 @@ class SearchUserRepositoryTest {
             userType = UserType.FEDERATED,
             connectionStatus = ConnectionState.NOT_CONNECTED,
             botService = null,
+            deleted = false
         )
 
         val CONTACT_SEARCH_RESPONSE = UserSearchResponse(
@@ -500,7 +501,8 @@ class SearchUserRepositoryTest {
             completeAssetId = null,
             availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
             userType = UserTypeEntity.EXTERNAL,
-            botService = null
+            botService = null,
+            deleted = false
         )
 
         val SELF_USER = SelfUser(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
@@ -480,7 +480,8 @@ class UserSearchApiWrapperTest {
                 completeAssetId = null,
                 availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
                 userType = UserTypeEntity.EXTERNAL,
-                botService = null
+                botService = null,
+                deleted = false
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -160,7 +160,8 @@ class TeamRepositoryTest {
             completeAssetId = null,
             availabilityStatus = UserAvailabilityStatusEntity.NONE,
             userType = UserTypeEntity.EXTERNAL,
-            botService = null
+            botService = null,
+            deleted = false
         )
 
         given(teamsApi)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
@@ -61,6 +61,7 @@ class UserMapperTest {
             availabilityStatus = UserAvailabilityStatusEntity.NONE,
             userType = UserTypeEntity.INTERNAL,
             botService = null,
+            deleted = false
         )
         val (_, userMapper) = Arrangement().arrange()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -4,10 +4,8 @@ import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.QualifiedID
-import com.wire.kalium.network.api.user.details.ListUserRequest
 import com.wire.kalium.network.api.user.details.UserDetailsApi
 import com.wire.kalium.network.api.user.details.UserProfileDTO
-import com.wire.kalium.network.api.user.details.qualifiedIds
 import com.wire.kalium.network.api.user.self.SelfApi
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.MetadataDAO
@@ -80,8 +78,8 @@ class UserRepositoryTest {
         userRepository.fetchUsersIfUnknownByIds(requestedUserIds).shouldSucceed()
 
         verify(arrangement.userDetailsApi)
-            .suspendFunction(arrangement.userDetailsApi::getMultipleUsers)
-            .with(eq(ListUserRequest.qualifiedIds(listOf(QualifiedID(value = missingUserId.value, domain = missingUserId.domain)))))
+            .suspendFunction(arrangement.userDetailsApi::getUserInfo)
+            .with(eq(QualifiedID("id2", "domain2")))
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetAllContactsNotInTheConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetAllContactsNotInTheConversationUseCaseTest.kt
@@ -67,6 +67,7 @@ class GetAllContactsNotInTheConversationUseCaseTest {
                     availabilityStatus = UserAvailabilityStatus.AVAILABLE,
                     userType = UserType.INTERNAL,
                     botService = null,
+                    deleted = false
                 ),
                 OtherUser(
                     id = QualifiedID("someAllContactsValue1", "someAllContactsDomain1"),
@@ -82,6 +83,7 @@ class GetAllContactsNotInTheConversationUseCaseTest {
                     availabilityStatus = UserAvailabilityStatus.AVAILABLE,
                     userType = UserType.INTERNAL,
                     botService = null,
+                    deleted = false
                 )
             )
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -129,6 +129,7 @@ class SearchKnownUserUseCaseTest {
             availabilityStatus = UserAvailabilityStatus.NONE,
             userType = UserType.EXTERNAL,
             botService = null,
+            deleted = false
         )
 
         val (_, searchKnownUsersUseCase) = Arrangement()
@@ -279,6 +280,7 @@ class SearchKnownUserUseCaseTest {
                                 availabilityStatus = UserAvailabilityStatus.NONE,
                                 userType = UserType.EXTERNAL,
                                 botService = null,
+                                deleted = false
                             )
                         )
                     )
@@ -310,6 +312,7 @@ class SearchKnownUserUseCaseTest {
                     availabilityStatus = UserAvailabilityStatus.NONE,
                     userType = UserType.FEDERATED,
                     botService = null,
+                    deleted = false
                 )
             )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserDirectoryUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserDirectoryUseCaseTest.kt
@@ -94,6 +94,7 @@ class SearchUserDirectoryUseCaseTest {
                         availabilityStatus = UserAvailabilityStatus.NONE,
                         userType =  UserType.EXTERNAL,
                         botService = null,
+                        deleted = false
                     )
                 }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
@@ -227,6 +227,7 @@ class SearchUserUseCaseTest {
                     availabilityStatus = UserAvailabilityStatus.NONE,
                     userType = UserType.FEDERATED,
                     botService = null,
+                    deleted = false
                 )
             }
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -53,6 +53,7 @@ object TestUser {
         availabilityStatus = UserAvailabilityStatus.NONE,
         userType = UserType.EXTERNAL,
         botService = null,
+        deleted = false
     )
 
     val ENTITY = UserEntity(
@@ -69,6 +70,7 @@ object TestUser {
         availabilityStatus = UserAvailabilityStatusEntity.NONE,
         userType = UserTypeEntity.EXTERNAL,
         botService = null,
+        deleted = false
     )
 
     val USER_PROFILE_DTO = UserProfileDTO(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -1,4 +1,5 @@
 @file:Suppress("TooManyFunctions")
+
 package com.wire.kalium.network.exceptions
 
 import com.wire.kalium.network.api.ErrorResponse
@@ -7,6 +8,7 @@ import com.wire.kalium.network.api.message.SendMessageResponse
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.BAD_REQUEST
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.BLACKLISTED_EMAIL
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.DOMAIN_BLOCKED_FOR_REGISTRATION
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.FEDERATION_FAILURE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.HANDLE_EXISTS
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_CODE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_CREDENTIALS
@@ -128,4 +130,8 @@ fun KaliumException.InvalidRequestError.isOperationDenied(): Boolean {
 
 fun KaliumException.InvalidRequestError.isMlsStaleMessage(): Boolean {
     return errorResponse.label == MLS_STALE_MESSAGE
+}
+
+fun KaliumException.ServerError.isFederationError(): Boolean {
+    return errorResponse.label == FEDERATION_FAILURE
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -1,7 +1,5 @@
 package com.wire.kalium.network.exceptions
 
-import com.wire.kalium.network.api.ErrorResponse
-
 internal object NetworkErrorLabel {
     const val TOO_MANY_CLIENTS = "too-many-clients"
     const val INVALID_CREDENTIALS = "invalid-credentials"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -1,5 +1,7 @@
 package com.wire.kalium.network.exceptions
 
+import com.wire.kalium.network.api.ErrorResponse
+
 internal object NetworkErrorLabel {
     const val TOO_MANY_CLIENTS = "too-many-clients"
     const val INVALID_CREDENTIALS = "invalid-credentials"
@@ -23,6 +25,7 @@ internal object NetworkErrorLabel {
     const val MLS_UNSUPPORTED_PROPOSAL = "mls-unsupported-proposal"
     const val MLS_KEY_PACKAGE_REF_NOT_FOUND = "mls-key-package-ref-not-found"
     const val UNKNOWN_CLIENT = "unknown-client"
+    const val FEDERATION_FAILURE = "federation-remote-error"
 
     object KaliumCustom {
         const val MISSING_REFRESH_TOKEN = "missing-refresh_token"

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -4,6 +4,7 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity;
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity;
 import com.wire.kalium.persistence.dao.UserTypeEntity;
 import kotlin.Int;
+import kotlin.Boolean;
 
 CREATE TABLE User (
     qualified_id TEXT AS QualifiedIDEntity NOT NULL PRIMARY KEY,
@@ -18,7 +19,8 @@ CREATE TABLE User (
     complete_asset_id TEXT AS QualifiedIDEntity,
     user_availability_status TEXT AS UserAvailabilityStatusEntity NOT NULL DEFAULT 'NONE',
     user_type TEXT AS UserTypeEntity NOT NULL DEFAULT 'INTERNAL',
-    bot_service TEXT AS BotEntity
+    bot_service TEXT AS BotEntity,
+    deleted INTEGER AS Boolean NOT NULL DEFAULT 0
 );
 
 deleteAllUsers:
@@ -28,8 +30,8 @@ deleteUser:
 DELETE FROM User WHERE qualified_id = ?;
 
 insertUser:
-INSERT INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service, deleted)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
 handle = excluded.handle,
@@ -41,7 +43,8 @@ connection_status = excluded.connection_status,
 preview_asset_id = excluded.preview_asset_id,
 complete_asset_id = excluded.complete_asset_id,
 user_type = excluded.user_type,
-bot_service = excluded.bot_service;
+bot_service = excluded.bot_service,
+deleted = excluded.deleted;
 
 updateUser:
 UPDATE User

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -32,7 +32,8 @@ data class UserEntity(
     // later, when API start supporting it, it should be added into API model too
     val availabilityStatus: UserAvailabilityStatusEntity,
     val userType: UserTypeEntity,
-    val botService: BotEntity?
+    val botService: BotEntity?,
+    val deleted: Boolean
 )
 
 data class BotEntity(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -23,7 +23,8 @@ class UserMapper {
             completeAssetId = user.complete_asset_id,
             availabilityStatus = user.user_availability_status,
             userType = user.user_type,
-            botService = user.bot_service
+            botService = user.bot_service,
+            deleted = user.deleted
         )
     }
 }
@@ -48,7 +49,8 @@ class UserDAOImpl(
             user.previewAssetId,
             user.completeAssetId,
             user.userType,
-            user.botService
+            user.botService,
+            user.deleted
         )
     }
 
@@ -81,7 +83,8 @@ class UserDAOImpl(
                         user.previewAssetId,
                         user.completeAssetId,
                         user.userType,
-                        user.botService
+                        user.botService,
+                        user.deleted
                     )
                 }
             }
@@ -118,7 +121,8 @@ class UserDAOImpl(
                         user.previewAssetId,
                         user.completeAssetId,
                         user.userType,
-                        user.botService
+                        user.botService,
+                        user.deleted
                     )
                 }
             }
@@ -143,7 +147,8 @@ class UserDAOImpl(
                         user.previewAssetId,
                         user.completeAssetId,
                         user.userType,
-                        user.botService
+                        user.botService,
+                        user.deleted
                     )
                 }
             }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -71,6 +71,7 @@ class UserDAOTest : BaseDatabaseTest() {
             UserAvailabilityStatusEntity.NONE,
             UserTypeEntity.INTERNAL,
             botService = null,
+            false
         )
         db.userDAO.updateSelfUser(updatedUser1)
         val result = db.userDAO.getUserByQualifiedID(user1.id).first()
@@ -93,7 +94,8 @@ class UserDAOTest : BaseDatabaseTest() {
             UserAssetIdEntity("asset2", "domain"),
             UserAvailabilityStatusEntity.NONE,
             UserTypeEntity.INTERNAL,
-            botService = null
+            botService = null,
+            false
         )
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
@@ -119,7 +121,8 @@ class UserDAOTest : BaseDatabaseTest() {
             null,
             UserAvailabilityStatusEntity.NONE,
             UserTypeEntity.INTERNAL,
-            botService = null
+            botService = null,
+            false
         )
 
         val result = db.userDAO.getUserByQualifiedID(user1.id)
@@ -198,7 +201,8 @@ class UserDAOTest : BaseDatabaseTest() {
                     null,
                     UserAvailabilityStatusEntity.NONE,
                     UserTypeEntity.INTERNAL,
-                    botService = null
+                    botService = null,
+                    false
                 ),
                 UserEntity(
                     id = QualifiedIDEntity("5", "wire.com"),
@@ -213,7 +217,8 @@ class UserDAOTest : BaseDatabaseTest() {
                     null,
                     UserAvailabilityStatusEntity.NONE,
                     UserTypeEntity.INTERNAL,
-                    botService = null
+                    botService = null,
+                    false
                 )
             )
             val mockUsers = commonEmailUsers + notCommonEmailUsers

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -218,7 +218,7 @@ class UserDAOTest : BaseDatabaseTest() {
                     UserAvailabilityStatusEntity.NONE,
                     UserTypeEntity.INTERNAL,
                     botService = null,
-                    false
+                    deleted = false
                 )
             )
             val mockUsers = commonEmailUsers + notCommonEmailUsers

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
@@ -21,7 +21,7 @@ fun newUserEntity(id: String = "test") =
         UserAvailabilityStatusEntity.NONE,
         UserTypeEntity.INTERNAL,
         botService = null,
-        false
+        deleted = false
     )
 
 fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
@@ -39,5 +39,5 @@ fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
         UserAvailabilityStatusEntity.NONE,
         UserTypeEntity.INTERNAL,
         botService = null,
-        false
+        deleted = false
     )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
@@ -20,7 +20,8 @@ fun newUserEntity(id: String = "test") =
         null,
         UserAvailabilityStatusEntity.NONE,
         UserTypeEntity.INTERNAL,
-        botService = null
+        botService = null,
+        false
     )
 
 fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
@@ -37,5 +38,6 @@ fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
         null,
         UserAvailabilityStatusEntity.NONE,
         UserTypeEntity.INTERNAL,
-        botService = null
+        botService = null,
+        false
     )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In case we are not able to get info for federated users, we need to still be able to log in or interact with the app.
To handle users fetching, we are doing the following with this PR:

- Split the fetch of users details on sync process, ie: for same backend as self user, we fetch a list `/list-users` for other backends, fetch one by one `/user/domain/id` and assume `Success`.
- Add the mapping when users are deleted, so we can know if the user is not deleted and doesn't have a name, we can map "unavailable user" label.

**Note:**
IMHO: The ideal case, would be that this endpoint on the backend side, returns the same strategy as with conversations, namely. A list of: found, failed, not-found users. Without having to add all this logic on every client.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
