### PR TITLE
fix(android): crash when getting device name

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/configuration/ClientConfig.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/configuration/ClientConfig.kt
@@ -3,27 +3,28 @@ package com.wire.kalium.logic.configuration
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
-import com.wire.kalium.logic.data.client.DeviceType
 import android.provider.Settings
 import com.wire.kalium.logic.data.client.ClientType
+import com.wire.kalium.logic.data.client.DeviceType
 
 actual class ClientConfig(private val context: Context) {
 
     actual fun deviceType(): DeviceType {
-        if ((context.resources.configuration.screenLayout
-                    and Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE
-        )
-            return DeviceType.Tablet
-        return DeviceType.Phone
+        val screenSize = context.resources.configuration.screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK
+        return if (screenSize >= Configuration.SCREENLAYOUT_SIZE_LARGE)
+            DeviceType.Tablet
+        else
+            DeviceType.Phone
     }
 
-    actual fun deviceModelName(): String = "${Build.MANUFACTURER} ${Build.MODEL}"
+    actual fun deviceModelName(): String = "${Build.BRAND} ${Build.MODEL}"
 
-    actual fun deviceName(): String = Settings.Secure.getString(context.contentResolver, bluetoothName) ?: run { deviceModelName() }
+    actual fun deviceName(): String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+        Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
+    } else {
+        deviceModelName()
+    }
 
     actual fun clientType(): ClientType = ClientType.Permanent
 
-    private companion object {
-        private const val bluetoothName = "bluetooth_name"
-    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When getting the `deviceName` on Android, there's a crash:
```
java.lang.SecurityException: Settings key: <bluetooth_name> is only readable to apps with targetSdkVersion lower than or equal to: 31
        at android.provider.Settings$NameValueCache.getStringForUser(Settings.java:3081)
        at android.provider.Settings$Secure.getStringForUser(Settings.java:6164)
        at android.provider.Settings$Secure.getString(Settings.java:6120)
        at vg.a.d(ClientRemoteRepository.kt:11)
        at ug.e.d(Unknown Source:2)
        at zh.i.a(RegisterClientUseCase.kt:16)
        at com.wire.android.ui.authentication.devices.register.RegisterDeviceViewModel.z(RegisterDeviceViewModel.kt:10)
        at od.g.l(RegisterDeviceViewModel.kt:8)
```

### Causes

As it says, apps targeting SDK 32 or above can't get the `bluetooth_name` string anymore.

### Solutions

Instead of `bluetooth_name`, use `device_name` which is available from API 25 and above. This `device_name` is the one that can be configured in `Settings -> About the phone`.

For APIs older than 25, we can use `BUILD.BRAND BUILD.MODEL` where the Brand is the consumer-readable brand, and model is the phone model.

Using Brand instead of Manufacturer will make sure that the user-known name is displayed. For example, Google Nexus 5 won't show LGE Nexus 5, as LG was the hardware manufacturer.

### Testing

Manually tested on some devices + emulator.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
