### PR TITLE
fix: save settings in rootPath on JVM instead of os-specific location

### DIFF
--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -46,6 +46,7 @@ actual class CoreLogic(
     override val globalPreferences: Lazy<KaliumPreferences> = lazy {
         KaliumPreferencesSettings(
             EncryptedSettingsHolder(
+                rootPath,
                 SettingOptions.AppSettings(
                     shouldEncryptData = kaliumConfigs.shouldEncryptData
                 )
@@ -73,6 +74,7 @@ actual class CoreLogic(
 
             val userSessionWorkScheduler = UserSessionWorkSchedulerImpl(userId)
             val encryptedSettingsHolder = EncryptedSettingsHolder(
+                rootPath,
                 SettingOptions.UserSettings(
                     shouldEncryptData = kaliumConfigs.shouldEncryptData,
                     idMapper.toDaoModel(userId)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/PackagePathProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/PackagePathProvider.kt
@@ -1,8 +1,0 @@
-package com.wire.kalium;
-
-/**
- * IMPORTANT: this class only exist to provide a permanent package path for
- * the Java Preferences API and must **NOT** be moved to a different package.
- * Doing so will result in data loss for users.
- */
-internal class PackagePathProvider

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
@@ -5,6 +5,7 @@ import com.russhwolf.settings.JvmPropertiesSettings
 import com.russhwolf.settings.Settings
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileWriter
 import java.nio.file.Paths
 import java.util.Properties
 
@@ -22,7 +23,7 @@ actual class EncryptedSettingsHolder(
     val properties = createOrLoad(rootPath, file)
 
     // TODO(jvm): JvmPreferencesSettings is not encrypted
-    actual val encryptedSettings: Settings = JvmPropertiesSettings(properties)
+    actual val encryptedSettings: Settings = JvmPropertiesSettings(properties) { onModify(it, file) }
 
     private fun createOrLoad(rootPath: String, file: File): Properties {
         val properties = Properties()
@@ -33,5 +34,9 @@ actual class EncryptedSettingsHolder(
         }
         properties.load(FileInputStream(file))
         return properties
+    }
+
+    private fun onModify(properties: Properties, file: File) {
+        properties.store(FileWriter(file), "Store values to properties file")
     }
 }

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
@@ -1,10 +1,12 @@
 package com.wire.kalium.persistence.kmm_settings
 
 import com.russhwolf.settings.ExperimentalSettingsImplementation
-import com.russhwolf.settings.JvmPreferencesSettings
+import com.russhwolf.settings.JvmPropertiesSettings
 import com.russhwolf.settings.Settings
-import com.wire.kalium.PackagePathProvider
-import java.util.prefs.Preferences
+import java.io.File
+import java.io.FileInputStream
+import java.nio.file.Paths
+import java.util.Properties
 
 /**
  * the java implementation is not yet encrypted
@@ -12,9 +14,24 @@ import java.util.prefs.Preferences
 
 @OptIn(ExperimentalSettingsImplementation::class)
 actual class EncryptedSettingsHolder(
+    rootPath: String,
     options: SettingOptions
 ) {
-    private val preferences: Preferences = Preferences.userNodeForPackage(PackagePathProvider::class.java).node(options.fileName)
+
+    val file: File = File(Paths.get(rootPath, options.fileName).toString())
+    val properties = createOrLoad(rootPath, file)
+
     // TODO(jvm): JvmPreferencesSettings is not encrypted
-    actual val encryptedSettings: Settings = JvmPreferencesSettings(preferences)
+    actual val encryptedSettings: Settings = JvmPropertiesSettings(properties)
+
+    private fun createOrLoad(rootPath: String, file: File): Properties {
+        val properties = Properties()
+        File(rootPath).mkdirs()
+        if (!file.exists()) {
+            System.out.println(file.absolutePath)
+            file.createNewFile()
+        }
+        properties.load(FileInputStream(file))
+        return properties
+    }
 }

--- a/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/EncryptedSettingsHolderTest.kt
+++ b/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/EncryptedSettingsHolderTest.kt
@@ -1,0 +1,56 @@
+package com.wire.kalium.persistence
+
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
+import com.wire.kalium.persistence.kmm_settings.SettingOptions
+import org.junit.Test
+import java.io.FileInputStream
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.Properties
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EncryptedSettingsHolderTest {
+
+    @Test
+    fun givenJvmPropertiesSettings_WhenUserSettingsAreChanged_ThenItIsStoredInFile() {
+        val rootPath = Files.createTempDirectory("test-rootPath").toString()
+        val userIDEntity = QualifiedIDEntity("user", "domain")
+
+        val encryptedSettingsHolder = EncryptedSettingsHolder(
+            rootPath,
+            SettingOptions.UserSettings(
+                shouldEncryptData = false,
+                userIDEntity
+            )
+        )
+        encryptedSettingsHolder.encryptedSettings.putString("test-key", "test-value")
+
+        val expectedSettingsFile = Paths.get(rootPath, "user-pref-${userIDEntity.value}-${userIDEntity.domain}").toFile()
+        assertTrue(expectedSettingsFile.exists(), "User settings file was not created")
+        val actualProperties = Properties()
+        actualProperties.load(FileInputStream(expectedSettingsFile))
+        assertEquals(actualProperties.getProperty("test-key"), "test-value", "User settings file contains wrong property")
+    }
+
+    @Test
+    fun givenJvmPropertiesSettings_WhenAppSettingsAreChanged_ThenItIsStoredInFile() {
+        val rootPath = Files.createTempDirectory("test-rootPath").toString()
+
+        val encryptedSettingsHolder = EncryptedSettingsHolder(
+            rootPath,
+            SettingOptions.AppSettings(
+                shouldEncryptData = false
+            )
+        )
+        encryptedSettingsHolder.encryptedSettings.putString("test-key", "test-value")
+
+        val expectedSettingsFile = Paths.get(rootPath, "app-preference").toFile()
+        assertTrue(expectedSettingsFile.exists(), "App settings file was not created")
+        val actualProperties = Properties()
+        actualProperties.load(FileInputStream(expectedSettingsFile))
+        assertEquals(actualProperties.getProperty("test-key"), "test-value", "App settings file contains wrong property")
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The `rootPath` parameter given to CoreLogic is not fully respected when running kalium on JVM. This means that deleting the `~/.kalium` directory does not delete all persistent state from former sessions.

In the JVM implementation of EncryptedSettingsHolder a third-party libary is used which saves app settings to a different location depending of the OS. On macOS this is a plist file in ~/Library/ and on Windows this is saved in the registry.

### Causes

`JvmPreferencesSettings` is used in `EncryptedSettingsHolder` 

### Solutions

Additionally to `JvmPreferencesSettings` the library also provides `JvmPropertiesSettings` which saves the settings into a properties file instead. The loading and storing needs additional implementation though. This PR adds implementation that saves app settings and user settings into property files in `rootPath` so that this is fully respected.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

Two automated tests are added in this PR

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
