### PR TITLE
chore(logging): ignore CancellationException when getting member details

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -323,12 +323,14 @@ class ConversationDataSource(
             }
         }
 
-    private fun logMemberDetailsError(conversation: Conversation, error: StorageFailure) = when (error) {
+    private fun logMemberDetailsError(conversation: Conversation, error: StorageFailure): Unit = when (error) {
         is StorageFailure.DataNotFound ->
             kaliumLogger.withFeatureId(CONVERSATIONS).e("DataNotFound when fetching conversation members: $error")
 
         is StorageFailure.Generic -> {
             if (error.rootCause !is CancellationException) {
+                // Ignore CancellationException
+            } else {
                 kaliumLogger.withFeatureId(CONVERSATIONS).e("Failure getting other 1:1 user for $conversation", error.rootCause)
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -334,7 +334,6 @@ class ConversationDataSource(
         }
     }
 
-
     // Deprecated notice, so we can use newer versions of Kalium on Reloaded without breaking things.
     @Deprecated("This doesn't return conversation details", ReplaceWith("detailsById"))
     override suspend fun observeById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>> =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The logs are flooded with `Failure getting other 1:1 user for, CancellationException bla blabla yadda yadda yadda`

### Causes

We log Cancellation Exceptions

### Solutions

Don't.

CancellationExceptions can be ignored.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
