### PR TITLE
fix: sent messages marked as failed (AR-2005)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -14,6 +14,7 @@ import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.util.TimeParser
+import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import io.mockative.Mock
@@ -179,8 +180,9 @@ class MessageSenderTest {
             assertIs<Either.Left<Unit>>(result)
         }
 
+    // Message was sent, better to keep it as pending, than wrongfully marking it as failed
     @Test
-    fun givenUpdatingMessageStatusToSuccessFails_WhenSendingOutgoingMessage_ThenReturnFailureAndSetMessageStatusToFailed() =
+    fun givenUpdatingMessageStatusToSuccessFails_WhenSendingOutgoingMessage_ThenReturnSuccess() =
         runTest {
             // given
             setupGivenSuccessResults(
@@ -191,14 +193,15 @@ class MessageSenderTest {
             // then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
-                .with(eq(MessageEntity.Status.FAILED), anything(), anything())
+                .with(eq(MessageEntity.Status.SENT), anything(), anything())
                 .wasInvoked(exactly = once)
 
-            assertIs<Either.Left<Unit>>(result)
+            result.shouldSucceed()
         }
 
+    // Message was sent, better to keep it as pending, than wrongfully marking it as failed
     @Test
-    fun givenUpdatingMessageDateFails_WhenSendingOutgoingMessage_ThenReturnFailureAndSetMessageStatusToFailed() =
+    fun givenUpdatingMessageDateFails_WhenSendingOutgoingMessage_ThenMarkMessageAsSentAndReturnSuccess() =
         runTest {
             // given
             setupGivenSuccessResults(
@@ -209,14 +212,15 @@ class MessageSenderTest {
             // then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
-                .with(eq(MessageEntity.Status.FAILED), anything(), anything())
+                .with(eq(MessageEntity.Status.SENT), anything(), anything())
                 .wasInvoked(exactly = once)
 
-            assertIs<Either.Left<Unit>>(result)
+            result.shouldSucceed()
         }
 
+    // Message was sent, better to keep it as pending, than wrongfully marking it as failed
     @Test
-    fun givenUpdatePendingMessagesAddMillisToDate_WhenSendingOutgoingMessage_ThenReturnFailureAndSetMessageStatusToFailed() =
+    fun givenUpdatePendingMessagesAddMillisToDateFails_WhenSendingOutgoingMessage_ThenMarkMessageAsSentAndReturnSuccess() =
         runTest {
             // given
             setupGivenSuccessResults(
@@ -224,13 +228,14 @@ class MessageSenderTest {
             )
             // when
             val result = messageSender.sendPendingMessage(TEST_CONVERSATION_ID, TEST_MESSAGE_UUID)
+
             // then
             verify(messageRepository)
                 .suspendFunction(messageRepository::updateMessageStatus)
-                .with(eq(MessageEntity.Status.FAILED), anything(), anything())
+                .with(eq(MessageEntity.Status.SENT), anything(), anything())
                 .wasInvoked(exactly = once)
 
-            assertIs<Either.Left<Unit>>(result)
+            result.shouldSucceed()
         }
 
     @Test
@@ -258,6 +263,7 @@ class MessageSenderTest {
         assertEquals(failure, result)
     }
 
+    @Suppress("LongParameterList")
     private fun setupGivenSuccessResults(
         getMessageById: Boolean = true,
         getConversationProtocol: Boolean = true,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes sent messages are marked as failed.

### Causes

When a failure occurs in the steps **after** sending messages, like updating the pending messages time, or updating the date of the message in question, the message status is wrongly updated to `FAILED` too.

### Solutions

Ignore the failure in those cases.

### Testing

#### Test Coverage

- [X] I have updated automated test to this contribution

### Notes

This could have the side-effect of wrong sorting of messages, but should be fixed in the near-future with the date-time storage refactoring, where we will store using normalised UTC timestamp.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
