### PR TITLE
feat(cli): support passing a server config URL for environment option CL-61

### DIFF
--- a/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -160,7 +160,9 @@ class LoginCommand : CliktCommand(name = "login") {
 
     private val email: String by option(help = "Account email").prompt("email", promptSuffix = ": ")
     private val password: String by option(help = "Account password").prompt("password", promptSuffix = ": ", hideInput = true)
-    private val environment: String? by option(help = "Choose backend environment: can be production, staging or an URL to a JSON server configuration")
+    private val environment: String? by option(
+        help = "Choose backend environment: can be production, staging or an URL to a server configuration"
+    )
 
     private suspend fun serverConfig(): ServerConfig.Links {
         return environment?.let { env ->


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Support connecting the CLI to any server by accepting a server config URL for the environment option:

login --environment https://nginz-https.anta.wire.link/deeplink.json

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
