### PR TITLE
fix: passwords with less than 6 chars resulting to server error

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.auth.login.LoginRepository
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isBadRequest
 import com.wire.kalium.network.exceptions.isInvalidCredentials
 
 sealed class AuthenticationResult {
@@ -70,7 +71,8 @@ internal class LoginUseCaseImpl(
     }
 
     private fun handleServerMiscommunication(error: NetworkFailure.ServerMiscommunication): AuthenticationResult.Failure {
-        return if (error.kaliumException is KaliumException.InvalidRequestError && error.kaliumException.isInvalidCredentials()) {
+        return if (error.kaliumException is KaliumException.InvalidRequestError &&
+            (error.kaliumException.isInvalidCredentials() || error.kaliumException.isBadRequest())) {
             AuthenticationResult.Failure.InvalidCredentials
         } else {
             AuthenticationResult.Failure.Generic(error)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isBadRequest
 import com.wire.kalium.network.exceptions.isInvalidCredentials
 import com.wire.kalium.network.exceptions.isMissingAuth
 
@@ -27,6 +28,7 @@ class DeleteClientUseCaseImpl(private val clientRepository: ClientRepository) : 
             when {
                 failure.kaliumException.isInvalidCredentials() -> DeleteClientResult.Failure.InvalidCredentials
                 failure.kaliumException.isMissingAuth() -> DeleteClientResult.Failure.PasswordAuthRequired
+                failure.kaliumException.isBadRequest() -> DeleteClientResult.Failure.InvalidCredentials
                 else -> DeleteClientResult.Failure.Generic(failure)
             }
         else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -16,6 +16,7 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isBadRequest
 import com.wire.kalium.network.exceptions.isInvalidCredentials
 import com.wire.kalium.network.exceptions.isMissingAuth
 import com.wire.kalium.network.exceptions.isTooManyClients
@@ -77,6 +78,7 @@ class RegisterClientUseCaseImpl(
                             failure.kaliumException.isTooManyClients() -> RegisterClientResult.Failure.TooManyClients
                             failure.kaliumException.isMissingAuth() -> RegisterClientResult.Failure.PasswordAuthRequired
                             failure.kaliumException.isInvalidCredentials() -> RegisterClientResult.Failure.InvalidCredentials
+                            failure.kaliumException.isBadRequest() -> RegisterClientResult.Failure.InvalidCredentials
                             else -> RegisterClientResult.Failure.Generic(failure)
                         }
                     else RegisterClientResult.Failure.Generic(failure)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -225,7 +225,6 @@ class LoginUseCaseTest {
                 .wasNotInvoked()
         }
 
-
     @Test
     fun givenBadRequest_whenLoggingIn_thenReturnInvalidCredentials() =
         runTest {
@@ -296,7 +295,6 @@ class LoginUseCaseTest {
                 TEST_VALID_AUTH_SESSION,
                 TEST_SERVER_CONFIG.links
             )
-
         val TEST_SSO_ID = SsoId("scim_external", "subject", null)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -225,6 +225,60 @@ class LoginUseCaseTest {
                 .wasNotInvoked()
         }
 
+
+    @Test
+    fun givenBadRequest_whenLoggingIn_thenReturnInvalidCredentials() =
+        runTest {
+            val badRequestFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.badRequest)
+            given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
+            given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
+                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("") }
+            given(loginRepository).coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT) }
+                .then { Either.Left(badRequestFailure) }
+
+            given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
+            given(validateUserHandleUseCase).invocation { invoke(TEST_HANDLE) }
+                .then { ValidateUserHandleResult.Valid(TEST_HANDLE) }
+            given(loginRepository).coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT) }
+                .then { Either.Left(badRequestFailure) }
+
+            // email
+            val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT)
+            assertEquals(loginEmailResult, AuthenticationResult.Failure.InvalidCredentials)
+
+            verify(validateEmailUseCase)
+                .invocation { invoke(TEST_EMAIL) }
+                .wasInvoked(exactly = once)
+            verify(validateUserHandleUseCase)
+                .function(validateUserHandleUseCase::invoke)
+                .with(any()).wasNotInvoked()
+            verify(loginRepository).coroutine {
+                loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT)
+            }.wasInvoked(exactly = once)
+            verify(loginRepository)
+                .suspendFunction(loginRepository::loginWithHandle)
+                .with(any(), any(), any())
+                .wasNotInvoked()
+
+            // user handle
+            val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT)
+            assertEquals(loginHandleResult, AuthenticationResult.Failure.InvalidCredentials)
+
+            verify(validateEmailUseCase)
+                .invocation { invoke(TEST_HANDLE) }
+                .wasInvoked(exactly = once)
+            verify(validateUserHandleUseCase)
+                .invocation { invoke(TEST_HANDLE) }
+                .wasInvoked(exactly = once)
+            verify(loginRepository).coroutine {
+                loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT)
+            }.wasInvoked(exactly = once)
+            verify(loginRepository)
+                .suspendFunction(loginRepository::loginWithEmail)
+                .with(any(), any(), any())
+                .wasNotInvoked()
+        }
+
     private companion object {
         const val TEST_EMAIL = "email@fu-berlin.de"
         const val TEST_HANDLE = "cool_user"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCaseTest.kt
@@ -90,6 +90,19 @@ class DeleteClientUseCaseTest {
         assertIs<DeleteClientResult.Failure.PasswordAuthRequired>(result)
     }
 
+    @Test
+    fun givenRepositoryDeleteClientFailsDueToBadRequest_whenDeleting_thenInvalidCredentialsErrorShouldBeReturned() = runTest {
+        val badRequest = NetworkFailure.ServerMiscommunication(TestNetworkException.badRequest)
+        given(clientRepository)
+            .suspendFunction(clientRepository::deleteClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(badRequest) }
+
+        val result = deleteClient(DELETE_CLIENT_PARAMETERS)
+
+        assertIs<DeleteClientResult.Failure.InvalidCredentials>(result)
+    }
+
     private companion object {
         val CLIENT = TestClient.CLIENT
         val DELETE_CLIENT_PARAMETERS = DeleteClientParam("pass", CLIENT.id)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -412,6 +412,30 @@ class RegisterClientUseCaseTest {
         assertEquals(failure, result.genericFailure)
     }
 
+
+    @Test
+    fun givenRepositoryRegistrationFailsDueBadRequest_whenRegistering_thenInvalidCredentialsErrorShouldBeReturned() = runTest {
+        val badRequestFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.badRequest)
+        given(clientRepository)
+            .suspendFunction(clientRepository::registerClient)
+            .whenInvokedWith(anything())
+            .then { Either.Left(badRequestFailure) }
+
+        val result = registerClient(RegisterClientUseCase.RegisterClientParam(TEST_PASSWORD, TEST_CAPABILITIES))
+
+        assertIs<RegisterClientResult.Failure.InvalidCredentials>(result)
+
+        verify(preKeyRepository)
+            .suspendFunction(preKeyRepository::generateNewPreKeys)
+            .with(any(), any())
+            .wasInvoked(exactly = once)
+
+        verify(preKeyRepository)
+            .function(preKeyRepository::generateNewLastKey)
+            .wasInvoked(exactly = once)
+    }
+
+
     private companion object {
         const val KEY_PACKAGE_LIMIT = 100
         const val KEY_PACKAGE_THRESHOLD = 0.5F

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -412,7 +412,6 @@ class RegisterClientUseCaseTest {
         assertEquals(failure, result.genericFailure)
     }
 
-
     @Test
     fun givenRepositoryRegistrationFailsDueBadRequest_whenRegistering_thenInvalidCredentialsErrorShouldBeReturned() = runTest {
         val badRequestFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.badRequest)
@@ -434,7 +433,6 @@ class RegisterClientUseCaseTest {
             .function(preKeyRepository::generateNewLastKey)
             .wasInvoked(exactly = once)
     }
-
 
     private companion object {
         const val KEY_PACKAGE_LIMIT = 100

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
@@ -20,6 +20,10 @@ object TestNetworkException {
         ErrorResponse(403, message = "missing auth", label = "missing-auth")
     )
 
+    val badRequest = KaliumException.InvalidRequestError(
+        ErrorResponse(400, message = "bad request", label = "bad-request")
+    )
+
     val invalidCredentials = KaliumException.InvalidRequestError(
         ErrorResponse(403, message = "invalid credentials", label = "invalid-credentials")
     )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

passwords with less than 6 chars resulting to server error

### Causes (Optional)

the server has a different response for this case


### Solutions

map the server response for short passwords to invalid credentials 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
