### PR TITLE
chore: add a way to wait until sync fails or completes (AR-1947)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -1,9 +1,13 @@
 package com.wire.kalium.logic.sync
 
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.functional.Either
+import kotlinx.coroutines.flow.combineTransform
 import kotlinx.coroutines.flow.first
 
 interface SyncManager {
@@ -19,6 +23,14 @@ interface SyncManager {
      */
     suspend fun waitUntilLive()
 
+    /**
+     * If Sync is ongoing, suspends the caller until it reaches a terminal state.
+     *
+     * @return [CoreFailure] in case Sync was not started or reached a failure, or
+     * [Unit] in case [IncrementalSyncStatus.Live] is reached.
+     */
+    suspend fun waitUntilLiveOrFailure(): Either<CoreFailure, Unit>
+
     suspend fun isSlowSyncOngoing(): Boolean
     suspend fun isSlowSyncCompleted(): Boolean
 }
@@ -31,6 +43,23 @@ internal class SyncManagerImpl(
     override suspend fun waitUntilLive() {
         incrementalSyncRepository.incrementalSyncState.first { it is IncrementalSyncStatus.Live }
     }
+
+    override suspend fun waitUntilLiveOrFailure(): Either<NetworkFailure.NoNetworkConnection, Unit> = slowSyncRepository.slowSyncStatus
+        .combineTransform(incrementalSyncRepository.incrementalSyncState) { slowSyncState, incrementalSyncState ->
+            val didSlowSyncFail = slowSyncState is SlowSyncStatus.Pending || slowSyncState is SlowSyncStatus.Failed
+            val didIncrementalSyncFail = incrementalSyncState is IncrementalSyncStatus.Failed
+            val didSyncFail = didSlowSyncFail || didIncrementalSyncFail
+            if (didSyncFail) { emit(false) }
+
+            val isSyncComplete = incrementalSyncState is IncrementalSyncStatus.Live
+            if (isSyncComplete) { emit(true) }
+        }.first().let { didWaitingSucceed ->
+            if (didWaitingSucceed) {
+                Either.Right(Unit)
+            } else {
+                Either.Left(NetworkFailure.NoNetworkConnection(null))
+            }
+        }
 
     override suspend fun isSlowSyncOngoing(): Boolean = slowSyncRepository.slowSyncStatus.value is SlowSyncStatus.Ongoing
     override suspend fun isSlowSyncCompleted(): Boolean =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncManagerTest.kt
@@ -1,15 +1,141 @@
 package com.wire.kalium.logic.sync
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.sync.InMemoryIncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.InMemorySlowSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
-import io.mockative.given
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import com.wire.kalium.logic.data.sync.SlowSyncStep
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class SyncManagerTest {
+
+    @Test
+    fun givenSlowSyncIsPending_whenWaitingUntilLiveOrFailure_thenShouldReturnFailure() = runTest {
+        val (arrangement, syncManager) = Arrangement().arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Pending)
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+
+        val result = syncManager.waitUntilLiveOrFailure()
+
+        result.shouldFail()
+    }
+
+    @Test
+    fun givenSlowSyncFailed_whenWaitingUntilLiveOrFailure_thenShouldReturnFailure() = runTest {
+        val (arrangement, syncManager) = Arrangement().arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Failed(CoreFailure.MissingClientRegistration))
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+
+        val result = syncManager.waitUntilLiveOrFailure()
+
+        result.shouldFail()
+    }
+
+    @Test
+    fun givenIncrementalSyncFailedAndSlowSyncIsComplete_whenWaitingUntilLiveOrFailure_thenShouldReturnFailure() = runTest {
+        val (arrangement, syncManager) = Arrangement().arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+        val failedState = IncrementalSyncStatus.Failed(CoreFailure.MissingClientRegistration)
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(failedState)
+
+        val result = syncManager.waitUntilLiveOrFailure()
+
+        result.shouldFail()
+    }
+
+    @Test
+    fun givenSlowSyncIsBeingPerformedAndFails_whenWaitingUntilLiveOrFailure_thenShouldWaitAndThenFail() = runTest {
+        val (arrangement, syncManager) = Arrangement().arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Ongoing(SlowSyncStep.CONNECTIONS))
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+
+        val result = async {
+            syncManager.waitUntilLiveOrFailure()
+        }
+        advanceUntilIdle()
+        assertTrue { result.isActive }
+
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Failed(CoreFailure.MissingClientRegistration))
+        advanceUntilIdle()
+        result.await().shouldFail()
+    }
+
+    @Test
+    fun givenSlowSyncIsBeingPerformedAndSucceedsButIncrementalFails_whenWaitingUntilLiveOrFailure_thenShouldWaitAndThenFail() = runTest {
+        val (arrangement, syncManager) = Arrangement().arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Ongoing(SlowSyncStep.CONNECTIONS))
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+
+        val result = async {
+            syncManager.waitUntilLiveOrFailure()
+        }
+        advanceUntilIdle()
+        assertTrue { result.isActive }
+
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+        val failure = IncrementalSyncStatus.Failed(CoreFailure.MissingClientRegistration)
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(failure)
+        advanceUntilIdle()
+        result.await().shouldFail()
+    }
+
+    @Test
+    fun givenSlowSyncIsCompleteAndIncrementalSyncIsOngoing_whenWaitingUntilLiveOrFailure_thenShouldWaitUntilCompleteReturnSucceed() =
+        runTest {
+            val (arrangement, syncManager) = Arrangement().arrange()
+            arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+
+            val result = async {
+                syncManager.waitUntilLiveOrFailure()
+            }
+            advanceUntilIdle()
+            assertTrue { result.isActive }
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.FetchingPendingEvents)
+            advanceUntilIdle()
+            assertTrue { result.isActive }
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+            advanceUntilIdle()
+            assertTrue { result.isCompleted }
+
+            result.await().shouldSucceed()
+        }
+
+    @Test
+    fun givenSlowSyncIsCompleteAndIncrementalSyncIsOngoingButFails_whenWaitingUntilLiveOrFailure_thenShouldWaitUntilFailure() =
+        runTest {
+            val (arrangement, syncManager) = Arrangement().arrange()
+            arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+
+            val result = async {
+                syncManager.waitUntilLiveOrFailure()
+            }
+            advanceUntilIdle()
+            assertTrue { result.isActive }
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.FetchingPendingEvents)
+            advanceUntilIdle()
+            assertTrue { result.isActive }
+
+            val failure = IncrementalSyncStatus.Failed(CoreFailure.MissingClientRegistration)
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(failure)
+            advanceUntilIdle()
+            assertTrue { result.isCompleted }
+
+            result.await().shouldFail()
+        }
 
     @Suppress("unused")
     private class Arrangement {
@@ -17,17 +143,6 @@ class SyncManagerTest {
         val slowSyncRepository: SlowSyncRepository = InMemorySlowSyncRepository()
 
         val incrementalSyncRepository: IncrementalSyncRepository = InMemoryIncrementalSyncRepository()
-
-        fun withSlowSyncRepositoryReturning(slowSyncStatusFlow: StateFlow<SlowSyncStatus>) = apply {
-            given(slowSyncRepository)
-                .getter(slowSyncRepository::slowSyncStatus)
-                .whenInvoked()
-                .thenReturn(slowSyncStatusFlow)
-        }
-
-        fun withSlowSyncComplete() = apply {
-            withSlowSyncRepositoryReturning(MutableStateFlow(SlowSyncStatus.Complete))
-        }
 
         private val syncManager = SyncManagerImpl(
             slowSyncRepository, incrementalSyncRepository


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For some UseCases, like creating a group conversation or starting a call, we must be `Live`.
However currently there's only one way to wait until Sync does something, which is `waitUntilLive`.

If the client is offline, these UseCases will be hanging forever without any feedback.

### Solutions

Create a new "wait until" function, that can return either success or failure.

This function will:
- Wait if Sync is in progress
- Return failure if Sync is Failed or Pending
- Return success if Sync is Live

The idea is to start using this, instead of `waitUntilLive` for UseCases that require the user to be Live.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
