### PR TITLE
fix: make OnNetworkQualityChanged userId nullable

### DIFF
--- a/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/NetworkQualityChangedHandler.kt
+++ b/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/NetworkQualityChangedHandler.kt
@@ -12,7 +12,7 @@ import com.sun.jna.Pointer
 interface NetworkQualityChangedHandler : Callback {
     fun onNetworkQualityChanged(
         conversationId: String,
-        userId: String,
+        userId: String?,
         clientId: String,
         quality: Int,
         roundTripTimeInMilliseconds: Int,

--- a/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/NetworkQualityChangedHandler.kt
+++ b/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/NetworkQualityChangedHandler.kt
@@ -10,6 +10,8 @@ import com.sun.jna.Pointer
  * QUALITY_NETWORK_PROBLEM = 4
  */
 interface NetworkQualityChangedHandler : Callback {
+
+    @Suppress("LongParameterList")
     fun onNetworkQualityChanged(
         conversationId: String,
         userId: String?,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
@@ -8,7 +8,7 @@ class OnNetworkQualityChanged : NetworkQualityChangedHandler {
 
     override fun onNetworkQualityChanged(
         conversationId: String,
-        userId: String,
+        userId: String?,
         clientId: String,
         quality: Int,
         roundTripTimeInMilliseconds: Int,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

OnNetworkQualityChanged was throwing a NullPointerException

### Causes (Optional)

`userId` was being received as `null` and it was stated as `not null`.

### Solutions

Make `userId` nullable :)

### Attachments (Optional)

<img src="https://user-images.githubusercontent.com/5890660/185345122-7b0190e3-38d9-46c5-af70-9057c0eee115.png" alt="kalium on network quality changed null pointer exception" />

