### PR TITLE
feat(mls-conversation): lower update keying materials threshold for debug builds (AR-2163)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/UpdateKeyingMaterialThresholdProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/UpdateKeyingMaterialThresholdProvider.kt
@@ -5,14 +5,14 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 
-interface UpdateKeyingMaterialsThresholdProvider {
+interface UpdateKeyingMaterialThresholdProvider {
 
     val keyingMaterialUpdateThreshold: Duration
 }
 
-class UpdateKeyingMaterialsThresholdProviderImpl(
+class UpdateKeyingMaterialThresholdProviderImpl(
     private val kaliumConfigs: KaliumConfigs
-) : UpdateKeyingMaterialsThresholdProvider {
+) : UpdateKeyingMaterialThresholdProvider {
 
     override val keyingMaterialUpdateThreshold: Duration
         get() = if (kaliumConfigs.lowerKeyingMaterialsUpdateThreshold)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/UpdateKeyingMaterialsThresholdProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/UpdateKeyingMaterialsThresholdProvider.kt
@@ -1,0 +1,28 @@
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
+
+interface UpdateKeyingMaterialsThresholdProvider {
+
+    val keyingMaterialUpdateThreshold: Duration
+}
+
+class UpdateKeyingMaterialsThresholdProviderImpl(
+    private val kaliumConfigs: KaliumConfigs
+) : UpdateKeyingMaterialsThresholdProvider {
+
+    override val keyingMaterialUpdateThreshold: Duration
+        get() = if (kaliumConfigs.lowerKeyingMaterialsUpdateThreshold)
+            KEYING_MATERIAL_UPDATE_THRESHOLD_LOW
+        else
+            KEYING_MATERIAL_UPDATE_THRESHOLD
+
+    companion object {
+        // TODO: there are some edge cases and optimisations points to consider for M5-> please see: https://wearezeta.atlassian.net/browse/AR-1633
+        internal val KEYING_MATERIAL_UPDATE_THRESHOLD = 90.days
+        internal val KEYING_MATERIAL_UPDATE_THRESHOLD_LOW = 1.minutes
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -24,6 +24,8 @@ import com.wire.kalium.logic.data.conversation.ConversationDataSource
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationDataSource
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProvider
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProviderImpl
 import com.wire.kalium.logic.data.event.EventDataSource
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigDataSource
@@ -173,6 +175,9 @@ abstract class UserSessionScopeCommon(
 
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider
         get() = KeyPackageLimitsProviderImpl(kaliumConfigs)
+
+    private val updateKeyingMaterialsThresholdProvider: UpdateKeyingMaterialsThresholdProvider
+        get() = UpdateKeyingMaterialsThresholdProviderImpl(kaliumConfigs)
 
     private val mlsClientProvider: MLSClientProvider
         get() = MLSClientProviderImpl(
@@ -501,7 +506,8 @@ abstract class UserSessionScopeCommon(
             clientRepository,
             userId,
             persistMessage,
-            teamRepository
+            teamRepository,
+            updateKeyingMaterialsThresholdProvider
         )
     val messages: MessageScope
         get() = MessageScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -24,8 +24,8 @@ import com.wire.kalium.logic.data.conversation.ConversationDataSource
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationDataSource
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProvider
-import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProviderImpl
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProvider
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProviderImpl
 import com.wire.kalium.logic.data.event.EventDataSource
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigDataSource
@@ -176,8 +176,8 @@ abstract class UserSessionScopeCommon(
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider
         get() = KeyPackageLimitsProviderImpl(kaliumConfigs)
 
-    private val updateKeyingMaterialsThresholdProvider: UpdateKeyingMaterialsThresholdProvider
-        get() = UpdateKeyingMaterialsThresholdProviderImpl(kaliumConfigs)
+    private val updateKeyingMaterialThresholdProvider: UpdateKeyingMaterialThresholdProvider
+        get() = UpdateKeyingMaterialThresholdProviderImpl(kaliumConfigs)
 
     private val mlsClientProvider: MLSClientProvider
         get() = MLSClientProviderImpl(
@@ -507,7 +507,7 @@ abstract class UserSessionScopeCommon(
             userId,
             persistMessage,
             teamRepository,
-            updateKeyingMaterialsThresholdProvider
+            updateKeyingMaterialThresholdProvider
         )
     val messages: MessageScope
         get() = MessageScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -509,7 +509,7 @@ abstract class UserSessionScopeCommon(
             messageSender,
             teamRepository,
             userId,
-            persistMessage
+            persistMessage,
             updateKeyingMaterialThresholdProvider
         )
     val messages: MessageScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -34,7 +34,7 @@ class ConversationScope(
     private val clientRepository: ClientRepository,
     private val selfUserId: UserId,
     private val persistMessage: PersistMessageUseCase,
-    private val teamRepository: TeamRepository
+    private val teamRepository: TeamRepository,
     private val updateKeyingMaterialsThresholdProvider: UpdateKeyingMaterialsThresholdProvider
 ) {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -5,7 +5,7 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProvider
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProvider
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
@@ -35,7 +35,7 @@ class ConversationScope(
     private val selfUserId: UserId,
     private val persistMessage: PersistMessageUseCase,
     private val teamRepository: TeamRepository,
-    private val updateKeyingMaterialsThresholdProvider: UpdateKeyingMaterialsThresholdProvider
+    private val updateKeyingMaterialThresholdProvider: UpdateKeyingMaterialThresholdProvider
 ) {
 
     val getSelfUser: GetSelfUserUseCase get() = GetSelfUserUseCase(userRepository)
@@ -101,6 +101,6 @@ class ConversationScope(
         get() = RemoveMemberFromConversationUseCaseImpl(conversationRepository, selfUserId, persistMessage)
 
     val updateMLSGroupsKeyingMaterials: UpdateKeyingMaterialsUseCase
-        get() = UpdateKeyingMaterialsUseCaseImpl(mlsConversationRepository, updateKeyingMaterialsThresholdProvider)
+        get() = UpdateKeyingMaterialsUseCaseImpl(mlsConversationRepository, updateKeyingMaterialThresholdProvider)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -16,12 +16,12 @@ import com.wire.kalium.logic.feature.connection.ObserveConnectionListUseCase
 import com.wire.kalium.logic.feature.connection.ObserveConnectionListUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.UpdateKeyingMaterialsUseCase
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.UpdateKeyingMaterialsUseCaseImpl
+import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCaseImpl
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCaseImpl
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
-import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.sync.SyncManager
 
 @Suppress("LongParameterList")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProvider
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
@@ -34,6 +35,7 @@ class ConversationScope(
     private val selfUserId: UserId,
     private val persistMessage: PersistMessageUseCase,
     private val teamRepository: TeamRepository
+    private val updateKeyingMaterialsThresholdProvider: UpdateKeyingMaterialsThresholdProvider
 ) {
 
     val getSelfUser: GetSelfUserUseCase get() = GetSelfUserUseCase(userRepository)
@@ -99,6 +101,6 @@ class ConversationScope(
         get() = RemoveMemberFromConversationUseCaseImpl(conversationRepository, selfUserId, persistMessage)
 
     val updateMLSGroupsKeyingMaterials: UpdateKeyingMaterialsUseCase
-        get() = UpdateKeyingMaterialsUseCaseImpl(mlsConversationRepository)
+        get() = UpdateKeyingMaterialsUseCaseImpl(mlsConversationRepository, updateKeyingMaterialsThresholdProvider)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCase.kt
@@ -2,9 +2,9 @@ package com.wire.kalium.logic.feature.conversation.keyingmaterials
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProvider
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
-import kotlin.time.Duration.Companion.days
 
 sealed class UpdateKeyingMaterialsResult {
 
@@ -17,20 +17,19 @@ interface UpdateKeyingMaterialsUseCase {
     suspend operator fun invoke(): UpdateKeyingMaterialsResult
 }
 
-// TODO: there are some edge cases and optimisations points to consider for M5-> please see: https://wearezeta.atlassian.net/browse/AR-1633
-internal val KEYING_MATERIAL_UPDATE_THRESHOLD = 90.days
-
 class UpdateKeyingMaterialsUseCaseImpl(
-    val mlsConversationRepository: MLSConversationRepository
+    val mlsConversationRepository: MLSConversationRepository,
+    private val updateKeyingMaterialsThresholdProvider: UpdateKeyingMaterialsThresholdProvider
 ) : UpdateKeyingMaterialsUseCase {
     override suspend fun invoke(): UpdateKeyingMaterialsResult =
-        mlsConversationRepository.getMLSGroupsRequiringKeyingMaterialUpdate(KEYING_MATERIAL_UPDATE_THRESHOLD).map { groups ->
-            groups.onEach { groupId ->
-                mlsConversationRepository.updateKeyingMaterial(groupId)
-            }
-        }.fold(
-            { UpdateKeyingMaterialsResult.Failure(it) },
-            { UpdateKeyingMaterialsResult.Success }
-        )
+        mlsConversationRepository
+            .getMLSGroupsRequiringKeyingMaterialUpdate(updateKeyingMaterialsThresholdProvider.keyingMaterialUpdateThreshold).map { groups ->
+                groups.onEach { groupId ->
+                    mlsConversationRepository.updateKeyingMaterial(groupId)
+                }
+            }.fold(
+                { UpdateKeyingMaterialsResult.Failure(it) },
+                { UpdateKeyingMaterialsResult.Success }
+            )
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCase.kt
@@ -2,7 +2,7 @@ package com.wire.kalium.logic.feature.conversation.keyingmaterials
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProvider
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProvider
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 
@@ -19,11 +19,11 @@ interface UpdateKeyingMaterialsUseCase {
 
 class UpdateKeyingMaterialsUseCaseImpl(
     val mlsConversationRepository: MLSConversationRepository,
-    private val updateKeyingMaterialsThresholdProvider: UpdateKeyingMaterialsThresholdProvider
+    private val updateKeyingMaterialThresholdProvider: UpdateKeyingMaterialThresholdProvider
 ) : UpdateKeyingMaterialsUseCase {
     override suspend fun invoke(): UpdateKeyingMaterialsResult =
         mlsConversationRepository
-            .getMLSGroupsRequiringKeyingMaterialUpdate(updateKeyingMaterialsThresholdProvider.keyingMaterialUpdateThreshold).map { groups ->
+            .getMLSGroupsRequiringKeyingMaterialUpdate(updateKeyingMaterialThresholdProvider.keyingMaterialUpdateThreshold).map { groups ->
                 groups.onEach { groupId ->
                     mlsConversationRepository.updateKeyingMaterial(groupId)
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -18,6 +18,7 @@ data class KaliumConfigs(
     val fileRestrictionEnabled: Boolean = false,
     val shouldEncryptData: Boolean = true,
     val lowerKeyPackageLimits: Boolean = false,
+    val lowerKeyingMaterialsUpdateThreshold: Boolean = false,
     val customUrlScheme: String = "",
     val fileRestrictionList: String = "",
     val httpProxyPort: String = "",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.days
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UpdateKeyingMaterialsUseCaseTests {
@@ -27,6 +28,7 @@ class UpdateKeyingMaterialsUseCaseTests {
         val (arrangement, updateKeyingMaterialsUseCase) = Arrangement()
             .withOutdatedGroupsReturns(Either.Right(Arrangement.OUTDATED_KEYING_MATERIALS_GROUPS))
             .withUpdateKeyingMaterials()
+            .withKeyingMaterialThreshold()
             .arrange()
 
         val actual = updateKeyingMaterialsUseCase()
@@ -44,6 +46,7 @@ class UpdateKeyingMaterialsUseCaseTests {
         val (arrangement, updateKeyingMaterialsUseCase) = Arrangement()
             .withOutdatedGroupsReturns(Either.Right(listOf()))
             .withUpdateKeyingMaterials()
+            .withKeyingMaterialThreshold()
             .arrange()
 
         val actual = updateKeyingMaterialsUseCase()
@@ -61,6 +64,7 @@ class UpdateKeyingMaterialsUseCaseTests {
         val (arrangement, updateKeyingMaterialsUseCase) = Arrangement()
             .withOutdatedGroupsReturns(Either.Left(StorageFailure.DataNotFound))
             .withUpdateKeyingMaterials()
+            .withKeyingMaterialThreshold()
             .arrange()
 
         val actual = updateKeyingMaterialsUseCase()
@@ -89,6 +93,10 @@ class UpdateKeyingMaterialsUseCaseTests {
             given(mlsConversationRepository).suspendFunction(mlsConversationRepository::getMLSGroupsRequiringKeyingMaterialUpdate)
                 .whenInvokedWith(anything())
                 .thenReturn(either)
+        }
+
+        fun withKeyingMaterialThreshold() = apply {
+            given(updateKeyingMaterialsThresholdProvider).invocation { keyingMaterialUpdateThreshold }.thenReturn(1.days)
         }
 
         fun withUpdateKeyingMaterials() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.conversation.keyingmaterials
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProvider
 
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -76,8 +77,12 @@ class UpdateKeyingMaterialsUseCaseTests {
         @Mock
         val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
 
+        @Mock
+        val updateKeyingMaterialsThresholdProvider = mock(classOf<UpdateKeyingMaterialsThresholdProvider>())
+
         private var updateKeyingMaterialsUseCase = UpdateKeyingMaterialsUseCaseImpl(
-            mlsConversationRepository
+            mlsConversationRepository,
+            updateKeyingMaterialsThresholdProvider
         )
 
         fun withOutdatedGroupsReturns(either: Either<CoreFailure, List<String>>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.logic.feature.conversation.keyingmaterials
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialsThresholdProvider
+import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProvider
 
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -82,11 +82,11 @@ class UpdateKeyingMaterialsUseCaseTests {
         val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
 
         @Mock
-        val updateKeyingMaterialsThresholdProvider = mock(classOf<UpdateKeyingMaterialsThresholdProvider>())
+        val updateKeyingMaterialThresholdProvider = mock(classOf<UpdateKeyingMaterialThresholdProvider>())
 
         private var updateKeyingMaterialsUseCase = UpdateKeyingMaterialsUseCaseImpl(
             mlsConversationRepository,
-            updateKeyingMaterialsThresholdProvider
+            updateKeyingMaterialThresholdProvider
         )
 
         fun withOutdatedGroupsReturns(either: Either<CoreFailure, List<String>>) = apply {
@@ -96,7 +96,7 @@ class UpdateKeyingMaterialsUseCaseTests {
         }
 
         fun withKeyingMaterialThreshold() = apply {
-            given(updateKeyingMaterialsThresholdProvider).invocation { keyingMaterialUpdateThreshold }.thenReturn(1.days)
+            given(updateKeyingMaterialThresholdProvider).invocation { keyingMaterialUpdateThreshold }.thenReturn(1.days)
         }
 
         fun withUpdateKeyingMaterials() = apply {


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Make updateKeyingMaterialsThreshold lower for debug builds to make it easier to test.
### Issues

The reals threshold is 90 days! and that makes it hard to test by the QA, but by this change it would be 1 minute for debug builds.

### Causes (Optional)

Help the QA to test MLS Conversations behaviours.

### Solutions

Lower the value for debug builds.

### Dependencies (Optional)

Release with AR PR.

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Create an MLS conversation, then go to the conversation details, remember the keying material update value, close the app and open it after one minute. after the sync check the group details again the keying materials update value should be changed.

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
