### PR TITLE
feat(calling): handle sync failure when starting a call (AR-2145)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -188,6 +188,7 @@ actual class CallManagerImpl(
         withCalling {
             val avsCallType = callMapper.toCallTypeCalling(callType)
             val avsConversationType = callMapper.toConversationTypeCalling(conversationType)
+            // TODO: Handle response. Possible failure?
             wcall_start(
                 deferredHandle.await(),
                 federatedIdMapper.parseToFederatedId(conversationId),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -571,6 +571,7 @@ abstract class UserSessionScopeCommon(
             userRepository,
             flowManagerService,
             mediaManagerService,
+            syncManager
         )
 
     val connection: ConnectionScope get() = ConnectionScope(connectionRepository, conversationRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
+import com.wire.kalium.logic.sync.SyncManager
 
 @Suppress("LongParameterList")
 class CallsScope internal constructor(
@@ -30,6 +31,7 @@ class CallsScope internal constructor(
     private val userRepository: UserRepository,
     private val flowManagerService: FlowManagerService,
     private val mediaManagerService: MediaManagerService,
+    private val syncManager: SyncManager
 ) {
 
     val allCallsWithSortedParticipants: GetAllCallsWithSortedParticipantsUseCase
@@ -52,7 +54,7 @@ class CallsScope internal constructor(
             callRepository = callRepository,
         )
 
-    val startCall: StartCallUseCase get() = StartCallUseCase(callManager)
+    val startCall: StartCallUseCase get() = StartCallUseCase(callManager, syncManager)
 
     val answerCall: AnswerCallUseCase get() = AnswerCallUseCaseImpl(callManager)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
@@ -4,20 +4,48 @@ import com.wire.kalium.logic.data.call.CallType
 import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase.Result
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.sync.SyncManager
+import kotlin.Boolean
+import kotlin.Lazy
 
-class StartCallUseCase(private val callManager: Lazy<CallManager>) {
+/**
+ * Attempts to start a call.
+ * Will wait for sync to finish or fail if it is pending,
+ * and return one [Result].
+ */
+class StartCallUseCase internal constructor(
+    private val callManager: Lazy<CallManager>,
+    private val syncManager: SyncManager
+) {
 
     suspend operator fun invoke(
         conversationId: ConversationId,
         callType: CallType = CallType.AUDIO,
         conversationType: ConversationType,
         isAudioCbr: Boolean = false
-    ) {
+    ) = syncManager.waitUntilLiveOrFailure().fold({
+        Result.SyncFailure
+    }, {
         callManager.value.startCall(
             conversationId = conversationId,
             callType = callType,
             conversationType = conversationType,
             isAudioCbr = isAudioCbr
         )
+        Result.Success
+    })
+
+    sealed interface Result {
+        /**
+         * Call started successfully
+         */
+        object Success : Result
+
+        /**
+         * Failed to start a call as Sync is not yet performed
+         */
+        object SyncFailure : Result
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.sync.SyncManager
 
 @Suppress("LongParameterList")
-class ConversationScope(
+class ConversationScope internal constructor(
     private val conversationRepository: ConversationRepository,
     private val connectionRepository: ConnectionRepository,
     private val userRepository: UserRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
@@ -12,7 +12,7 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.datetime.Clock
 
-class CreateGroupConversationUseCase(
+class CreateGroupConversationUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
     private val syncManager: SyncManager,
     private val clientRepository: ClientRepository

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/StartCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/StartCallUseCaseTest.kt
@@ -1,48 +1,110 @@
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.call.CallType
 import com.wire.kalium.logic.data.call.ConversationType
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.SyncManager
 import io.mockative.Mock
+import io.mockative.any
 import io.mockative.classOf
+import io.mockative.configure
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
-import io.mockative.thenDoNothing
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 
 class StartCallUseCaseTest {
 
-    @Mock
-    private val callManager = mock(classOf<CallManager>())
-
-    private lateinit var startCall: StartCallUseCase
-
-    @BeforeTest
-    fun setup() {
-        startCall = StartCallUseCase(lazy{ callManager })
-    }
-
     @Test
-    fun givenCallingParams_whenRunningUseCase_thenInvokeStartCallOnce() = runTest {
-        val conversationId = ConversationId("someone", "wire.com")
+    fun givenCallingParamsAndSyncSucceeds_whenRunningUseCase_thenInvokeStartCallOnce() = runTest {
+        val conversationId = TestConversation.ID
 
-        given(callManager)
-            .suspendFunction(callManager::startCall)
-            .whenInvokedWith(eq(conversationId), eq(CallType.AUDIO), eq(ConversationType.OneOnOne), eq(false))
-            .thenDoNothing()
+        val (arrangement, startCall) = Arrangement()
+            .withWaitingForSyncSucceeding()
+            .arrange()
 
         startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
 
-        verify(callManager)
-            .suspendFunction(callManager::startCall)
+        verify(arrangement.callManager)
+            .suspendFunction(arrangement.callManager::startCall)
             .with(eq(conversationId), eq(CallType.AUDIO), eq(ConversationType.OneOnOne), eq(false))
             .wasInvoked(once)
     }
 
+    @Test
+    fun givenCallingParamsAndSyncSucceeds_whenRunningUseCase_thenReturnSuccess() = runTest {
+        val conversationId = TestConversation.ID
+
+        val (_, startCall) = Arrangement()
+            .withWaitingForSyncSucceeding()
+            .arrange()
+
+        val result = startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
+
+        assertIs<StartCallUseCase.Result.Success>(result)
+    }
+
+    @Test
+    fun givenCallingParamsAndSyncFails_whenRunningUseCase_thenStartCallIsNotInvoked() = runTest {
+        val conversationId = TestConversation.ID
+
+        val (arrangement, startCall) = Arrangement()
+            .withWaitingForSyncFailing()
+            .arrange()
+
+        startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
+
+        verify(arrangement.callManager)
+            .suspendFunction(arrangement.callManager::startCall)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenCallingParamsAndSyncFails_whenRunningUseCase_thenShouldReturnSyncFailure() = runTest {
+        val conversationId = TestConversation.ID
+
+        val (_, startCall) = Arrangement()
+            .withWaitingForSyncFailing()
+            .arrange()
+
+        val result = startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
+
+        assertIs<StartCallUseCase.Result.SyncFailure>(result)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val callManager = configure(mock(classOf<CallManager>())) { stubsUnitByDefault = true }
+
+        @Mock
+        val syncManager = mock(classOf<SyncManager>())
+
+        private val startCallUseCase = StartCallUseCase(
+            lazy { callManager }, syncManager
+        )
+
+        fun withWaitingForSyncSucceeding() = withSyncReturning(Either.Right(Unit))
+
+        fun withWaitingForSyncFailing() = withSyncReturning(Either.Left(NetworkFailure.NoNetworkConnection(null)))
+
+        private fun withSyncReturning(result: Either<CoreFailure, Unit>) = apply {
+            given(syncManager)
+                .suspendFunction(syncManager::waitUntilLiveOrFailure)
+                .whenInvoked()
+                .then { result }
+        }
+
+        fun arrange() = this to startCallUseCase
+
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When starting a call, the `StartCallUseCase` hangs when Sync is not `LIVE`

### Causes

`callManager.startCall()` will trigger a `MessageSend` which will wait indeterminately until `Sync` is done.

### Solutions

Use the new `waitUntilLiveOrFailure` so we fail if Sync fails too.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
