### PR TITLE
feat(conversation): handle sync failure when creating group conversation (AR-2146)

### DIFF
--- a/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.feature.client.DeleteClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase.RegisterClientParam
 import com.wire.kalium.logic.feature.client.SelfClientsResult
+import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
 import com.wire.kalium.logic.feature.conversation.GetConversationsUseCase
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesResult
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsResult
@@ -149,8 +150,8 @@ class CreateGroupCommand : CliktCommand(name = "create-group") {
             ConversationOptions(protocol = ConversationOptions.Protocol.MLS)
         )
         when (result) {
-            is Either.Right -> echo("group created successfully")
-            is Either.Left -> throw PrintMessage("group creation failed: ${result.value}")
+            is CreateGroupConversationUseCase.Result.Success -> echo("group created successfully")
+            else -> throw PrintMessage("group creation failed: $result")
         }
     }
 

--- a/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -34,7 +34,6 @@ import com.wire.kalium.logic.feature.publicuser.GetAllContactsResult
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
-import com.wire.kalium.logic.functional.Either
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.first

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
@@ -1,30 +1,77 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase.Result
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.datetime.Clock
 
+/**
+ * Creates a group conversation.
+ * Will wait for sync to finish or fail if it is pending,
+ * and return one [Result].
+ */
 class CreateGroupConversationUseCase(
     private val conversationRepository: ConversationRepository,
     private val syncManager: SyncManager,
     private val clientRepository: ClientRepository
 ) {
-    suspend operator fun invoke(name: String, userIdList: List<UserId>, options: ConversationOptions): Either<CoreFailure, Conversation> {
-        syncManager.waitUntilLive()
-        return clientRepository.currentClientId().flatMap { clientId ->
+
+    /**
+     * @param name the name of the conversation
+     * @param userIdList list of members
+     * @param options settings that customise the conversation
+     */
+    suspend operator fun invoke(name: String, userIdList: List<UserId>, options: ConversationOptions): Result =
+        syncManager.waitUntilLiveOrFailure().flatMap {
+            clientRepository.currentClientId()
+        }.flatMap { clientId ->
             conversationRepository.createGroupConversation(name, userIdList, options.copy(creatorClientId = clientId.value))
-                .flatMap { conversation ->
-                    conversationRepository.updateConversationModifiedDate(conversation.id, Clock.System.now().toString())
-                        .map { conversation }
-                }
-        }
+        }.flatMap { conversation ->
+            conversationRepository.updateConversationModifiedDate(conversation.id, Clock.System.now().toString())
+                .map { conversation }
+        }.fold({
+            if (it is NetworkFailure.NoNetworkConnection) {
+                Result.SyncFailure
+            } else {
+                Result.UnknownFailure(it)
+            }
+        }, {
+            Result.Success(it)
+        })
+
+    sealed interface Result {
+        /**
+         * Conversation created successfully.
+         */
+        class Success(
+            /**
+             * Details of the newly created conversation
+             */
+            val conversation: Conversation
+        ) : Result
+
+        /**
+         * There was a failure trying to Sync with the server
+         */
+        object SyncFailure : Result
+
+        /**
+         * Other, unknown failure.
+         */
+        class UnknownFailure(
+            /**
+             * The root cause of the failure
+             */
+            val cause: CoreFailure
+        ) : Result
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, the `CreateGroupConversationUseCase` will hang indeterminately until Sync is performed.

### Solutions

Like in #814, use the new `waitUntilLiveOrFailure` function.
Also, instead of `Either`, which is not iOS-friendly, use a custom `Result` class for it.

> **Note**: This is a breaking change, so a PR in Reloaded is needed to handle this, which I'll be soon working on.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
