### PR TITLE
fix: update self availability hanging when sync fails (AR-2147)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
@@ -2,16 +2,13 @@ package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.sync.SyncManager
 
 class UpdateSelfAvailabilityStatusUseCase(
     private val userRepository: UserRepository,
-    private val syncManager: SyncManager
 ) {
     suspend operator fun invoke(status: UserAvailabilityStatus) {
         // TODO: Handle possibility of being offline. Storing the broadcast to be sent when Sync is done.
-        //       For now, any "offline failure" can be ignored, as we do not broadcast the availability to other devices or users.
-        syncManager.waitUntilLiveOrFailure()
+        //       For now, we don't need Sync, as we do not broadcast the availability to other devices or users.
         userRepository.updateSelfUserAvailabilityStatus(status)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
@@ -9,9 +9,9 @@ class UpdateSelfAvailabilityStatusUseCase(
     private val syncManager: SyncManager
 ) {
     suspend operator fun invoke(status: UserAvailabilityStatus) {
-        if (syncManager.isSlowSyncOngoing()) {
-            syncManager.waitUntilLive()
-        }
+        // TODO: Handle possibility of being offline. Storing the broadcast to be sent when Sync is done.
+        //       For now, any "offline failure" can be ignored, as we do not broadcast the availability to other devices or users.
+        syncManager.waitUntilLiveOrFailure()
         userRepository.updateSelfUserAvailabilityStatus(status)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -56,7 +56,7 @@ class UserScope internal constructor(
     val getUserInfo: GetUserInfoUseCase get() = GetUserInfoUseCaseImpl(userRepository, teamRepository)
     val updateSelfAvailabilityStatus: UpdateSelfAvailabilityStatusUseCase
         get() =
-            UpdateSelfAvailabilityStatusUseCase(userRepository, syncManager)
+            UpdateSelfAvailabilityStatusUseCase(userRepository)
     val getAllContactsNotInConversation: GetAllContactsNotInConversationUseCase
         get() = GetAllContactsNotInConversationUseCase(userRepository)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes when Sync fails, the `UpdateSelfAvailabilityStatusUseCase` keeps hanging for ever.

### Causes

We're waiting for Sync to be completed, which may take a long time in case it fails.

### Solutions

We don't need to wait for sync as we don't broadcast the availability status yet, we can just ignore the failure in this case and update locally only.

In the future, we can handle this more gracefully, by:
- Using `waitUntilLiveOrFailure`, which may return an error, AND/OR
- Scheduling the broadcast to be sent once Sync is Live.

### Testing

Removed code, no need for new tests.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
