### PR TITLE
feat(mls): commit pending proposals

### DIFF
--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
@@ -62,7 +62,7 @@ interface MLSClient {
      *
      * @param groupId MLS group ID for an existing conversation
      *
-     * @return commit message and a welcome message if an add proposal was pending.
+     * @return commit bundle, which needs to be sent to the distribution service.
      */
     fun updateKeyingMaterial(groupId: MLSGroupId): CommitBundle
 
@@ -72,7 +72,7 @@ interface MLSClient {
      * @param groupId MLS group ID for an existing conversation
      * @param epoch current epoch for the conversation
      *
-     * @return proposal for being added to the conversation
+     * @return proposal, which needs to be sent to the distribution service.
      */
     fun joinConversation(
         groupId: MLSGroupId,
@@ -94,7 +94,7 @@ interface MLSClient {
      * @param groupId MLS group ID provided by BE
      * @param members list of clients with a claimed key package for each client.
      *
-     * @return handshake & welcome message
+     * @return commit bundle, which needs to be sent to the distribution service.
      */
     fun createConversation(
         groupId: MLSGroupId,
@@ -118,6 +118,8 @@ interface MLSClient {
 
     /**
      * Create a commit for any pending proposals
+     *
+     * @return commit bundle, which needs to be sent to the distribution service.
      */
     fun commitPendingProposals(groupId: MLSGroupId): CommitBundle
 
@@ -142,7 +144,7 @@ interface MLSClient {
      * @param groupId MLS group where the message was received
      * @param message application message or handshake message
      *
-     * @return decrypted message in case of an application message.
+     * @return decrypted message bundle, which contains the decrypted message.
      */
     fun decryptMessage(
         groupId: MLSGroupId,
@@ -155,7 +157,7 @@ interface MLSClient {
      * @param groupId MLS group
      * @param members list of clients with a claimed key package for each client.
      *
-     * * @return handshake & welcome message
+     * * @return commit bundle, which needs to be sent to the distribution service.
      */
     fun addMember(
         groupId: MLSGroupId,
@@ -168,7 +170,7 @@ interface MLSClient {
      * @param groupId MLS group
      * @param members list of clients
      *
-     * @return handshake message
+     * @return commit bundle, which needs to be sent to the distribution service.
      */
     fun removeMember(
         groupId: MLSGroupId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -45,6 +45,7 @@ interface ConversationMapper {
     ): ConversationDetails.OneOne
 }
 
+@Suppress("TooManyFunctions")
 internal class ConversationMapperImpl(
     private val idMapper: IdMapper,
     private val conversationStatusMapper: ConversationStatusMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -19,15 +19,18 @@ import com.wire.kalium.persistence.dao.ConversationEntity.GroupState
 import com.wire.kalium.persistence.dao.ConversationEntity.Protocol
 import com.wire.kalium.persistence.dao.ConversationEntity.ProtocolInfo
 import kotlinx.datetime.Clock
+import com.wire.kalium.persistence.dao.ProposalTimerEntity
 import kotlinx.datetime.Instant
 
 interface ConversationMapper {
     fun fromApiModelToDaoModel(apiModel: ConversationResponse, mlsGroupState: GroupState?, selfUserTeamId: TeamId?): ConversationEntity
     fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol
     fun fromDaoModel(daoModel: ConversationEntity): Conversation
+    fun fromDaoModel(daoModel: ProposalTimerEntity): ProposalTimer
     fun toDAOAccess(accessList: Set<ConversationAccessDTO>): List<ConversationEntity.Access>
     fun toDAOAccessRole(accessRoleList: Set<ConversationAccessRoleDTO>): List<ConversationEntity.AccessRole>
     fun toDAOGroupState(groupState: Conversation.ProtocolInfo.MLS.GroupState): GroupState
+    fun toDAOProposalTimer(proposalTimer: ProposalTimer): ProposalTimerEntity
     fun toApiModel(access: Conversation.Access): ConversationAccessDTO
     fun toApiModel(accessRole: Conversation.AccessRole): ConversationAccessRoleDTO
     fun toApiModel(protocol: ConversationOptions.Protocol): ConvProtocol
@@ -88,6 +91,9 @@ internal class ConversationMapperImpl(
         accessRole = daoModel.accessRole.map { it.toDAO() }
     )
 
+    override fun fromDaoModel(daoModel: ProposalTimerEntity): ProposalTimer =
+        ProposalTimer(daoModel.groupID, daoModel.firingDate)
+
     override fun toDAOAccess(accessList: Set<ConversationAccessDTO>): List<ConversationEntity.Access> = accessList.map {
         when (it) {
             ConversationAccessDTO.PRIVATE -> ConversationEntity.Access.PRIVATE
@@ -114,6 +120,9 @@ internal class ConversationMapperImpl(
             Conversation.ProtocolInfo.MLS.GroupState.PENDING_WELCOME_MESSAGE -> GroupState.PENDING_WELCOME_MESSAGE
             Conversation.ProtocolInfo.MLS.GroupState.PENDING_CREATION -> GroupState.PENDING_CREATION
         }
+
+    override fun toDAOProposalTimer(proposalTimer: ProposalTimer): ProposalTimerEntity =
+        ProposalTimerEntity(proposalTimer.groupID, proposalTimer.timestamp)
 
     override fun toApiModel(
         name: String?,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.cryptography.CommitBundle
 import com.wire.kalium.cryptography.CryptoQualifiedClientId
 import com.wire.kalium.cryptography.CryptoQualifiedID
+import com.wire.kalium.cryptography.DecryptedMessageBundle
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
@@ -35,7 +36,7 @@ interface MLSConversationRepository {
     suspend fun establishMLSGroup(groupID: String): Either<CoreFailure, Unit>
     suspend fun establishMLSGroupFromWelcome(welcomeEvent: Event.Conversation.MLSWelcome): Either<CoreFailure, Unit>
     suspend fun hasEstablishedMLSGroup(groupID: String): Either<CoreFailure, Boolean>
-    suspend fun messageFromMLSMessage(messageEvent: Event.Conversation.NewMLSMessage): Either<CoreFailure, ByteArray?>
+    suspend fun messageFromMLSMessage(messageEvent: Event.Conversation.NewMLSMessage): Either<CoreFailure, DecryptedMessageBundle?>
     suspend fun addMemberToMLSGroup(groupID: String, userIdList: List<UserId>): Either<CoreFailure, Unit>
     suspend fun removeMembersFromMLSGroup(groupID: String, userIdList: List<UserId>): Either<CoreFailure, Unit>
     suspend fun requestToJoinGroup(groupID: String, epoch: ULong): Either<CoreFailure, Unit>
@@ -57,7 +58,7 @@ class MLSConversationDataSource(
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper()
 ) : MLSConversationRepository {
 
-    override suspend fun messageFromMLSMessage(messageEvent: Event.Conversation.NewMLSMessage): Either<CoreFailure, ByteArray?> =
+    override suspend fun messageFromMLSMessage(messageEvent: Event.Conversation.NewMLSMessage): Either<CoreFailure, DecryptedMessageBundle?> =
         mlsClientProvider.getMLSClient().flatMap { mlsClient ->
             wrapStorageRequest {
                 conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(messageEvent.conversationId)).first()
@@ -67,7 +68,7 @@ class MLSConversationDataSource(
                         mlsClient.decryptMessage(
                             (conversation.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
                             messageEvent.content.decodeBase64Bytes()
-                        ).message
+                        )
                     )
                 } else {
                     Either.Right(null)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -46,6 +46,7 @@ interface MLSConversationRepository {
     suspend fun observeProposalTimers(): Flow<List<ProposalTimer>>
 }
 
+@Suppress("TooManyFunctions", "LongParameterList")
 class MLSConversationDataSource(
     private val keyPackageRepository: KeyPackageRepository,
     private val mlsClientProvider: MLSClientProvider,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProposalTimer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProposalTimer.kt
@@ -1,7 +1,5 @@
 package com.wire.kalium.logic.data.conversation
 
-import com.wire.kalium.cryptography.MLSGroupId
-import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.datetime.Instant
 
 data class ProposalTimer(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProposalTimer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProposalTimer.kt
@@ -1,0 +1,10 @@
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.cryptography.MLSGroupId
+import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.datetime.Instant
+
+data class ProposalTimer(
+    val groupID: String,
+    val timestamp: Instant
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -88,6 +88,8 @@ import com.wire.kalium.logic.feature.message.MessageSendFailureHandlerImpl
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.MessageSenderImpl
 import com.wire.kalium.logic.feature.message.MessageSendingScheduler
+import com.wire.kalium.logic.feature.message.PendingProposalScheduler
+import com.wire.kalium.logic.feature.message.PendingProposalSchedulerImpl
 import com.wire.kalium.logic.feature.message.SessionEstablisher
 import com.wire.kalium.logic.feature.message.SessionEstablisherImpl
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCase
@@ -403,6 +405,12 @@ abstract class UserSessionScopeCommon(
             lazy { conversations.updateMLSGroupsKeyingMaterials }
         )
 
+    private val pendingProposalScheduler: PendingProposalScheduler =
+        PendingProposalSchedulerImpl(
+            incrementalSyncRepository,
+            lazy { mlsConversationRepository }
+        )
+
     val qualifiedIdMapper: QualifiedIdMapper get() = MapperProvider.qualifiedIdMapper(userRepository)
 
     val federatedIdMapper: FederatedIdMapper get() = MapperProvider.federatedIdMapper(userRepository, qualifiedIdMapper, globalPreferences)
@@ -442,7 +450,8 @@ abstract class UserSessionScopeCommon(
             callManager,
             messageTextEditHandler,
             userConfigRepository,
-            EphemeralNotificationsManager
+            EphemeralNotificationsManager,
+            pendingProposalScheduler
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -54,10 +54,10 @@ internal class PendingProposalSchedulerImpl(
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     private val dispatcher = kaliumDispatcher.default.limitedParallelism(1)
-    private val refillKeyPackagesScope = CoroutineScope(SupervisorJob() + dispatcher)
+    private val commitPendingProposalsScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
-        refillKeyPackagesScope.launch() {
+        commitPendingProposalsScope.launch() {
             incrementalSyncRepository.incrementalSyncState.collectLatest { syncState ->
                 ensureActive()
                 if (syncState == IncrementalSyncStatus.Live) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -59,7 +59,6 @@ internal class PendingProposalSchedulerImpl(
     init {
         refillKeyPackagesScope.launch() {
             incrementalSyncRepository.incrementalSyncState.collectLatest { syncState ->
-                println("collecting syncState: $syncState")
                 ensureActive()
                 if (syncState == IncrementalSyncStatus.Live) {
                     startCommittingPendingProposals()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -46,7 +46,7 @@ internal class PendingProposalSchedulerImpl(
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val mlsConversationRepository: Lazy<MLSConversationRepository>,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
-    ) : PendingProposalScheduler {
+) : PendingProposalScheduler {
 
     /**
      * A dispatcher with limited parallelism of 1.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -1,0 +1,104 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.ProposalTimer
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.functional.distinct
+import com.wire.kalium.logic.functional.flatten
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Schedule pending MLS proposals in a conversation to be committed at a given
+ * date. The scheduling persisted and resumes automatically.
+ *
+ * This is desirable since all clients in an MLS group a collaborating
+ * on committing pending proposals, and we want to avoid the scenario of everyone
+ * committing pending proposals at same time.
+ */
+interface PendingProposalScheduler {
+
+    /**
+     * Schedule to commit pending proposals in a given MLS group.
+     *
+     * @param groupID
+     * @param date desired time for when proposals should be committed
+     */
+    suspend fun scheduleCommit(groupID: String, date: Instant)
+
+}
+
+internal class PendingProposalSchedulerImpl(
+    private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val mlsConversationRepository: Lazy<MLSConversationRepository>,
+    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
+    ) : PendingProposalScheduler {
+
+    /**
+     * A dispatcher with limited parallelism of 1.
+     * This means using this dispatcher only a single coroutine will be processed at a time.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = kaliumDispatcher.default.limitedParallelism(1)
+
+    private val refillKeyPackagesScope = CoroutineScope(dispatcher)
+
+    private var refillKeyPackageJob: Job? = null
+
+    init {
+        refillKeyPackageJob = refillKeyPackagesScope.launch {
+            incrementalSyncRepository.incrementalSyncState.collect { syncState ->
+                ensureActive()
+                if (syncState == IncrementalSyncStatus.Live) {
+                    startCommittingPendingProposals()
+                } else {
+                    refillKeyPackageJob?.cancel()
+                    refillKeyPackageJob = null
+                }
+            }
+        }
+    }
+
+    private suspend fun startCommittingPendingProposals() {
+        timers().cancellable().collect() { groupID ->
+            mlsConversationRepository.value.commitPendingProposals(groupID)
+                .onFailure {
+                    kaliumLogger.e("Failed to commit pending proposals in $groupID")
+                }
+        }
+    }
+
+    private suspend fun timers() = channelFlow {
+        mlsConversationRepository.value.observeProposalTimers()
+            .flatten()
+            .distinct()
+            .collect { timer ->
+                launch {
+                    val secondsUntilFiring = timer.timestamp.minus(Clock.System.now())
+                    if (secondsUntilFiring.inWholeSeconds > 0) {
+                        kotlinx.coroutines.delay(secondsUntilFiring)
+                        send(timer.groupID)
+                    } else {
+                        send(timer.groupID)
+                    }
+            }
+        }
+    }
+
+    override suspend fun scheduleCommit(groupID: String, date: Instant) {
+        mlsConversationRepository.value.setProposalTimer(ProposalTimer(groupID, date))
+    }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Flow.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Flow.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.functional
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
@@ -23,10 +24,7 @@ fun <T1, T2> Flow<T1>.combine(flow: Flow<T2>): Flow<Pair<T1, T2>> = combine(flow
 
 suspend fun <T> Flow<List<T>>.flatten() = flatMapConcat { it.asFlow() }
 
-fun <T> Flow<T>.distinct(): Flow<T> = flow {
+fun <T> Flow<T>.distinct(): Flow<T> {
     val past = mutableSetOf<T>()
-    collect {
-        val isNew = past.add(it)
-        if (isNew) emit(it)
-    }
+    return filter { past.add(it) }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Flow.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Flow.kt
@@ -1,8 +1,10 @@
 package com.wire.kalium.logic.functional
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
 
 suspend inline fun <A, B> Collection<A>.flatMapFromIterable(
@@ -18,3 +20,13 @@ suspend inline fun <A, B> Collection<A>.flatMapFromIterable(
 }
 
 fun <T1, T2> Flow<T1>.combine(flow: Flow<T2>): Flow<Pair<T1, T2>> = combine(flow) { t1, t2 -> t1 to t2 }
+
+suspend fun <T> Flow<List<T>>.flatten() = flatMapConcat { it.asFlow() }
+
+fun <T> Flow<T>.distinct(): Flow<T> = flow {
+    val past = mutableSetOf<T>()
+    collect {
+        val isNew = past.add(it)
+        if (isNew) emit(it)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -46,16 +46,12 @@ import com.wire.kalium.logic.sync.receiver.message.DeleteForMeHandler
 import com.wire.kalium.logic.sync.receiver.message.LastReadContentHandler
 import com.wire.kalium.logic.sync.receiver.message.MessageTextEditHandler
 import com.wire.kalium.logic.util.Base64
-import com.wire.kalium.logic.util.TimeParser
 import com.wire.kalium.logic.wrapCryptoRequest
 import io.ktor.utils.io.core.toByteArray
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.datetime.Clock
-import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
-import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Duration.Companion.seconds
 
 interface ConversationEventReceiver : EventReceiver<Event.Conversation>
@@ -357,7 +353,7 @@ internal class ConversationEventReceiverImpl(
             }
     }
 
-    private suspend fun handlePendingProposal(event: Event.Conversation.NewMLSMessage, commitDelay: Long ) {
+    private suspend fun handlePendingProposal(event: Event.Conversation.NewMLSMessage, commitDelay: Long) {
         pendingProposalScheduler.scheduleCommit(
             "event.conversationId",
             event.timestampIso.toInstant().plus(commitDelay.seconds)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PendingProposalSchedulerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PendingProposalSchedulerTest.kt
@@ -1,0 +1,135 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.ProposalTimer
+import com.wire.kalium.logic.data.sync.InMemoryIncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+class PendingProposalSchedulerTest {
+
+    @Test
+    fun givenConversation_onScheduleCommit_thenProposalTimerIsScheduled() = runTest {
+        val (arrangement, pendingProposalsScheduler) = Arrangement()
+            .withScheduleProposalTimerSuccessful()
+            .arrange()
+
+        pendingProposalsScheduler.scheduleCommit(Arrangement.PROPOSAL_TIMER.groupID, Arrangement.PROPOSAL_TIMER.timestamp)
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::setProposalTimer)
+            .with(eq(Arrangement.PROPOSAL_TIMER))
+    }
+
+    @Test
+    fun givenExpiredProposalTimer_whenSyncFinishes_thenPendingProposalsIsCommitted() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, pendingProposalsScheduler) = Arrangement()
+            .withScheduledProposalTimers(listOf(ProposalTimer(TestConversation.GROUP_ID, Arrangement.INSTANT_PAST)))
+            .withCommitPendingProposalsSuccessful()
+            .arrange()
+
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+        yield()
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::commitPendingProposals)
+            .with(eq(TestConversation.GROUP_ID))
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenNonExpiredProposalTimer_whenSyncFinishes_thenPendingProposalIsNotCommitted() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, pendingProposalsScheduler) = Arrangement()
+            .withScheduledProposalTimers(listOf(ProposalTimer(TestConversation.GROUP_ID, Arrangement.INSTANT_NEAR_FUTURE)))
+            .withCommitPendingProposalsSuccessful()
+            .arrange()
+
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+        yield()
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::commitPendingProposals)
+            .with(eq(TestConversation.GROUP_ID))
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenNonExpiredProposalTimer_whenSyncFinishesAndWeWait_thenPendingProposalIsCommitted() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, pendingProposalsScheduler) = Arrangement()
+            .withScheduledProposalTimers(listOf(ProposalTimer(TestConversation.GROUP_ID, Arrangement.INSTANT_NEAR_FUTURE)))
+            .withCommitPendingProposalsSuccessful()
+            .arrange()
+
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+        yield()
+        advanceUntilIdle()
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::commitPendingProposals)
+            .with(eq(TestConversation.GROUP_ID))
+            .wasInvoked(once)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val incrementalSyncRepository = InMemoryIncrementalSyncRepository()
+
+        @Mock
+        val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
+
+        val pendingProposalScheduler = PendingProposalSchedulerImpl(
+            incrementalSyncRepository,
+            lazy { mlsConversationRepository },
+            TestKaliumDispatcher
+        )
+
+        fun arrange() = this to pendingProposalScheduler
+
+        fun withScheduleProposalTimerSuccessful() = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::setProposalTimer)
+                .whenInvokedWith(any())
+                .thenReturn(Unit)
+        }
+
+        fun withCommitPendingProposalsSuccessful() = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::commitPendingProposals)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withScheduledProposalTimers(timers: List<ProposalTimer>) = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::observeProposalTimers)
+                .whenInvoked()
+                .thenReturn(flowOf(timers))
+        }
+
+        companion object {
+            val INSTANT_PAST = Instant.DISTANT_PAST
+            val INSTANT_NEAR_FUTURE = Clock.System.now().plus(5.seconds)
+            val INSTANT_FUTURE = Instant.DISTANT_FUTURE
+            val PROPOSAL_TIMER = ProposalTimer(TestConversation.GROUP_ID, INSTANT_FUTURE)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -152,6 +152,7 @@ object TestConversation {
             time = "2022-03-30T15:36:00.000Z"
         )
 
+    val GROUP_ID = "mlsGroupId"
     val ENTITY_ID = QualifiedIDEntity("valueConversation", "domainConversation")
     val ENTITY = ConversationEntity(
         ENTITY_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -153,7 +153,7 @@ object TestConversation {
             time = "2022-03-30T15:36:00.000Z"
         )
 
-    val GROUP_ID = "mlsGroupId"
+    const val GROUP_ID = "mlsGroupId"
     val ENTITY_ID = QualifiedIDEntity("valueConversation", "domainConversation")
     val ENTITY = ConversationEntity(
         ENTITY_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.message.EphemeralNotificationsMgr
+import com.wire.kalium.logic.feature.message.PendingProposalScheduler
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversationDetails
@@ -277,7 +278,6 @@ class ConversationEventReceiverTest {
                 .wasInvoked(exactly = once)
         }
     }
-
     private class Arrangement {
         @Mock
         val proteusClient = mock(classOf<ProteusClient>())
@@ -312,6 +312,9 @@ class ConversationEventReceiverTest {
         @Mock
         private val ephemeralNotifications = mock(classOf<EphemeralNotificationsMgr>())
 
+        @Mock
+        private val pendingProposalScheduler = mock(classOf<PendingProposalScheduler>())
+
         private val conversationEventReceiver: ConversationEventReceiver = ConversationEventReceiverImpl(
             proteusClient,
             persistMessage,
@@ -322,9 +325,10 @@ class ConversationEventReceiverTest {
             userRepository,
             lazyOf(callManager),
             MessageTextEditHandler(messageRepository),
+            userConfigRepository,
+            ephemeralNotifications,
+            pendingProposalScheduler,
             protoContentMapper = protoContentMapper,
-            userConfigRepository = userConfigRepository,
-            ephemeralNotificationsManager = ephemeralNotifications
         )
 
         fun withProteusClientDecryptingByteArray(decryptedData: ByteArray) = apply {
@@ -441,4 +445,5 @@ class ConversationEventReceiverTest {
 
         fun arrange() = this to conversationEventReceiver
     }
+
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -10,6 +10,7 @@ CREATE TABLE Conversation (
     mls_group_id TEXT,
     mls_group_state TEXT AS ConversationEntity.GroupState NOT NULL,
     mls_epoch INTEGER DEFAULT 0 NOT NULL,
+    mls_proposal_timer TEXT,
     protocol TEXT AS ConversationEntity.Protocol NOT NULL,
     muted_status TEXT AS ConversationEntity.MutedStatus DEFAULT "ALL_ALLOWED" NOT NULL,
     muted_time INTEGER DEFAULT 0 NOT NULL,
@@ -112,7 +113,6 @@ SELECT COUNT() FROM Message AS message WHERE  message.conversation_id IS :conver
 getUnreadConversationCount:
 SELECT COUNT() FROM Conversation AS conversation WHERE DateTime(conversation.last_modified_date) > DateTime(conversation.last_read_date);
 
-
 updateAccess:
 UPDATE Conversation SET access_list= ?, access_role_list = ? WHERE qualified_id = ?;
 
@@ -121,3 +121,13 @@ UPDATE Conversation SET mls_last_keying_material_update= ? WHERE mls_group_id = 
 
 selectByKeyingMaterialUpdate:
 SELECT mls_group_id FROM Conversation WHERE mls_group_state = ? AND protocol = ? AND mls_last_keying_material_update - ? <0 AND mls_group_id IS NOT NULL;
+
+updateProposalTimer:
+UPDATE Conversation SET mls_proposal_timer = COALESCE(mls_proposal_timer, ?) WHERE mls_group_id = ?;
+
+clearProposalTimer:
+UPDATE Conversation SET mls_proposal_timer = NULL WHERE mls_group_id = ?;
+
+selectProposalTimers:
+SELECT mls_group_id, mls_proposal_timer FROM Conversation WHERE mls_group_id IS NOT NULL AND mls_proposal_timer IS NOT NULL;
+

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -57,6 +57,11 @@ data class Member(
     }
 }
 
+data class ProposalTimerEntity(
+    val groupID: String,
+    val firingDate: Instant
+)
+
 interface ConversationDAO {
     suspend fun getSelfConversationId(): QualifiedIDEntity
     suspend fun insertConversation(conversationEntity: ConversationEntity)
@@ -106,4 +111,7 @@ interface ConversationDAO {
     suspend fun updateConversationMemberRole(conversationId: QualifiedIDEntity, userId: UserIDEntity, role: Member.Role)
     suspend fun updateKeyingMaterial(groupId: String, timestamp: Instant)
     suspend fun getConversationsByKeyingMaterialUpdate(threshold: Duration): List<String>
+    suspend fun setProposalTimer(proposalTimer: ProposalTimerEntity)
+    suspend fun clearProposalTimer(groupID: String)
+    suspend fun getProposalTimers(): Flow<List<ProposalTimerEntity>>
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 import kotlin.time.Duration
 import com.wire.kalium.persistence.Conversation as SQLDelightConversation
 import com.wire.kalium.persistence.Member as SQLDelightMember
@@ -293,4 +294,19 @@ class ConversationDAOImpl(
             ConversationEntity.Protocol.MLS,
             Clock.System.now().epochSeconds.minus(threshold.inWholeSeconds)
         ).executeAsList()
+
+    override suspend fun setProposalTimer(proposalTimer: ProposalTimerEntity) {
+        conversationQueries.updateProposalTimer(proposalTimer.firingDate.toString(), proposalTimer.groupID)
+    }
+
+    override suspend fun clearProposalTimer(groupID: String) {
+        conversationQueries.clearProposalTimer(groupID)
+    }
+
+    override suspend fun getProposalTimers(): Flow<List<ProposalTimerEntity>> {
+        return conversationQueries.selectProposalTimers()
+            .asFlow()
+            .mapToList()
+            .map { list -> list.map { ProposalTimerEntity(it.mls_group_id, it.mls_proposal_timer.toInstant()) } }
+    }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -648,6 +648,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         assertEquals(listOf(proposalTimer2, proposalTimer3), conversationDAO.getProposalTimers().first())
     }
 
+    @Test
     fun givenSeveralRemoveMemberMessages_whenCallingWhoRemovedMe_itReturnsTheCorrectValue() = runTest {
         // Given
         val mySelfMember = member2
@@ -857,7 +858,13 @@ class ConversationDAOTest : BaseDatabaseTest() {
         val member1 = Member(user1.id, Member.Role.Admin)
         val member2 = Member(user2.id, Member.Role.Member)
         val member3 = Member(user3.id, Member.Role.Admin)
-        val proposalTimer2 = ProposalTimerEntity((conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId, Instant.DISTANT_FUTURE)
-        val proposalTimer3 = ProposalTimerEntity((conversationEntity3.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId, Instant.DISTANT_FUTURE)
+        val proposalTimer2 = ProposalTimerEntity(
+            (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
+            Instant.DISTANT_FUTURE
+        )
+        val proposalTimer3 = ProposalTimerEntity(
+            (conversationEntity3.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
+            Instant.DISTANT_FUTURE
+        )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -595,7 +595,6 @@ class ConversationDAOTest : BaseDatabaseTest() {
         }
 
     @Test
-<<<<<<< HEAD
     fun givenConversation_whenUpdatingProposalTimer_thenItIsUpdated() = runTest {
         // given
         conversationDAO.insertConversation(conversationEntity2)
@@ -647,7 +646,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         // then
         assertEquals(listOf(proposalTimer2, proposalTimer3), conversationDAO.getProposalTimers().first())
-=======
+    }
+
     fun givenSeveralRemoveMemberMessages_whenCallingWhoRemovedMe_itReturnsTheCorrectValue() = runTest {
         // Given
         val mySelfMember = member2
@@ -764,7 +764,6 @@ class ConversationDAOTest : BaseDatabaseTest() {
         )
 
         assertFalse(isMember)
->>>>>>> develop
     }
 
     private companion object {
@@ -857,12 +856,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         val member1 = Member(user1.id, Member.Role.Admin)
         val member2 = Member(user2.id, Member.Role.Member)
-<<<<<<< HEAD
-
+        val member3 = Member(user3.id, Member.Role.Admin)
         val proposalTimer2 = ProposalTimerEntity((conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId, Instant.DISTANT_FUTURE)
         val proposalTimer3 = ProposalTimerEntity((conversationEntity3.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId, Instant.DISTANT_FUTURE)
-=======
-        val member3 = Member(user3.id, Member.Role.Admin)
->>>>>>> develop
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -589,6 +589,60 @@ class ConversationDAOTest : BaseDatabaseTest() {
             assertEquals(listOf(outdatedGroupId2), conversationDAO.getConversationsByKeyingMaterialUpdate(90.days))
         }
 
+    @Test
+    fun givenConversation_whenUpdatingProposalTimer_thenItIsUpdated() = runTest {
+        // given
+        conversationDAO.insertConversation(conversationEntity2)
+
+        // when
+        conversationDAO.setProposalTimer(proposalTimer2)
+
+        // then
+         assertEquals(listOf(proposalTimer2), conversationDAO.getProposalTimers().first())
+    }
+
+    @Test
+    fun givenConversationWithExistingProposalTimer_whenUpdatingProposalTimer_thenItIsNotUpdated() = runTest {
+        // given
+        val initialFiringDate = Instant.DISTANT_FUTURE
+        val updatedFiringDate = Instant.DISTANT_PAST
+        val groupID = (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId
+        conversationDAO.insertConversation(conversationEntity2)
+        conversationDAO.setProposalTimer(ProposalTimerEntity(groupID, initialFiringDate))
+
+        // when
+        conversationDAO.setProposalTimer(ProposalTimerEntity(groupID, updatedFiringDate))
+
+        // then
+        assertEquals(initialFiringDate, conversationDAO.getProposalTimers().first()[0].firingDate)
+    }
+
+    @Test
+    fun givenConversationWithExistingProposalTimer_whenClearingProposalTimer_thenItIsUpdated() = runTest {
+        // given
+        conversationDAO.insertConversation(conversationEntity2)
+        conversationDAO.setProposalTimer(proposalTimer2)
+
+        // when
+        conversationDAO.clearProposalTimer(proposalTimer2.groupID)
+
+        // then
+        assertEquals(emptyList(), conversationDAO.getProposalTimers().first())
+    }
+
+    @Test
+    fun givenConversationsWithExistingProposalTimer_whenGettingProposalTimers_thenAllTimersAreReturned() = runTest {
+        // given
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity2)
+        conversationDAO.insertConversation(conversationEntity3)
+        conversationDAO.setProposalTimer(proposalTimer2)
+        conversationDAO.setProposalTimer(proposalTimer3)
+
+        // then
+        assertEquals(listOf(proposalTimer2, proposalTimer3), conversationDAO.getProposalTimers().first())
+    }
+
     private companion object {
         val user1 = newUserEntity(id = "1")
         val user2 = newUserEntity(id = "2")
@@ -675,5 +729,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         val member1 = Member(user1.id, Member.Role.Admin)
         val member2 = Member(user2.id, Member.Role.Member)
+
+        val proposalTimer2 = ProposalTimerEntity((conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId, Instant.DISTANT_FUTURE)
+        val proposalTimer3 = ProposalTimerEntity((conversationEntity3.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId, Instant.DISTANT_FUTURE)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Commit pending proposals as described in https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/601522340/Use+Case+Committing+pending+proposals+MLS

Summary:
When we receive a MLS proposal, indicated by a non null `commitDelay` when decrypting a incoming MLS message. We schedule a timer on the conversation to run at message-timestamp + commit-delay. The `PendingProposalScheduler` is observing if timers expire or have expired in the past when app is `Live` and it stops observing whenever the connection drops.

When a timer expire we try commit any pending proposals and clear the timer. If we fail commit the pending proposal we don't clear the timer and we'll do another attempt the next time the app goes Live.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Needs BE support to be deployed before this can be tested.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
