### PR TITLE
fix: refactor assets download to avoid OOM exception (AR-2125)

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/AESUtils.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/AESUtils.kt
@@ -110,11 +110,8 @@ internal class AESDecrypt(private val secretKey: AES256Key) {
                 val source = bufferedSource.inputStream().source()
                 val contentBuffer = Buffer()
                 var byteCount: Long
-                while (source.read(contentBuffer, BUFFER_SIZE).also {
-                        byteCount = it
-                        size += byteCount
-                    } != -1L
-                ) {
+                while (source.read(contentBuffer, BUFFER_SIZE).also { byteCount = it } != -1L) {
+                    size += byteCount
                     outputSink.write(contentBuffer, byteCount)
                     outputSink.flush()
                 }

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/AESUtils.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/AESUtils.kt
@@ -110,11 +110,14 @@ internal class AESDecrypt(private val secretKey: AES256Key) {
                 val source = bufferedSource.inputStream().source()
                 val contentBuffer = Buffer()
                 var byteCount: Long
-                while (source.read(contentBuffer, BUFFER_SIZE).also { byteCount = it } != -1L) {
+                while (source.read(contentBuffer, BUFFER_SIZE).also {
+                        byteCount = it
+                        size += byteCount
+                    } != -1L
+                ) {
                     outputSink.write(contentBuffer, byteCount)
                     outputSink.flush()
                 }
-                size = byteCount
                 source.close()
             }
             kaliumLogger.d("WROTE $size bytes")

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/AESUtils.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/AESUtils.kt
@@ -8,6 +8,7 @@ import okio.Source
 import okio.buffer
 import okio.cipherSink
 import okio.cipherSource
+import okio.source
 import java.security.SecureRandom
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
@@ -106,12 +107,15 @@ internal class AESDecrypt(private val secretKey: AES256Key) {
 
             // Decrypt and write the data to given outputPath
             encryptedDataSource.cipherSource(cipher).buffer().use { bufferedSource ->
-                val data = bufferedSource.readByteArray()
-                size = data.size.toLong()
-                outputSink.buffer().use {
-                    it.write(data)
-                    it.flush()
+                val source = bufferedSource.inputStream().source()
+                val contentBuffer = Buffer()
+                var byteCount: Long
+                while (source.read(contentBuffer, BUFFER_SIZE).also { byteCount = it } != -1L) {
+                    outputSink.write(contentBuffer, byteCount)
+                    outputSink.flush()
                 }
+                size = byteCount
+                source.close()
             }
             kaliumLogger.d("WROTE $size bytes")
         } catch (e: Exception) {
@@ -146,3 +150,4 @@ private const val KEY_ALGORITHM_CONFIGURATION = "AES/CBC/PKCS5PADDING"
 private const val IV_SIZE = 16
 private const val AES_BLOCK_SIZE = 16
 private const val AES_KEYGEN_SIZE = 256
+private const val BUFFER_SIZE = 8192L

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/AESUtils.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/AESUtils.kt
@@ -150,4 +150,4 @@ private const val KEY_ALGORITHM_CONFIGURATION = "AES/CBC/PKCS5PADDING"
 private const val IV_SIZE = 16
 private const val AES_BLOCK_SIZE = 16
 private const val AES_KEYGEN_SIZE = 256
-private const val BUFFER_SIZE = 8192L
+private const val BUFFER_SIZE = 1024 * 8L

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -192,13 +192,13 @@ internal class AssetDataSource(
         assetToken: String?,
         encryptionKey: AES256Key? = null
     ): Either<CoreFailure, Path> {
-        val tempFile = kaliumFileSystem.tempFilePath()
-        val tempFileSink = kaliumFileSystem.sink(tempFile)
         return wrapStorageRequest { assetDao.getAssetByKey(assetId.value).firstOrNull() }.fold({
+            val tempFile = kaliumFileSystem.tempFilePath("temp_${assetId.value}")
+            val tempFileSink = kaliumFileSystem.sink(tempFile)
             wrapApiRequest {
                 // Backend sends asset messages with empty asset tokens
                 assetApi.downloadAsset(assetId, assetToken?.ifEmpty { null }, tempFileSink)
-            }.flatMap { _ ->
+            }.flatMap {
                 val encryptedAssetDataSource = kaliumFileSystem.source(tempFile)
 
                 // Decrypt and persist decoded asset onto a persistent asset path

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -197,7 +197,7 @@ internal class AssetDataSource(
         wrapStorageRequest { assetDao.getAssetByKey(assetId.value).firstOrNull() }.fold({
             wrapApiRequest {
                 // Backend sends asset messages with empty asset tokens
-                assetApi.downloadAsset(assetId, assetToken?.ifEmpty { null })
+                assetApi.downloadAsset(assetId, assetToken?.ifEmpty { null } // todo: pass path
             }.flatMap { assetData ->
                 // Copy byte array to temp file and provide it as source
                 val tempFile = kaliumFileSystem.tempFilePath()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -197,9 +197,7 @@ internal class AssetDataSource(
         return wrapStorageRequest { assetDao.getAssetByKey(assetId.value).firstOrNull() }.fold({
             wrapApiRequest {
                 // Backend sends asset messages with empty asset tokens
-                assetApi.downloadAsset(assetId, assetToken?.ifEmpty { null }, tempFileSink).also {
-                    kaliumLogger.d("downloaded")
-                }
+                assetApi.downloadAsset(assetId, assetToken?.ifEmpty { null }, tempFileSink)
             }.flatMap { _ ->
                 val encryptedAssetDataSource = kaliumFileSystem.source(tempFile)
 
@@ -209,10 +207,7 @@ internal class AssetDataSource(
 
                 // Public assets are stored already decrypted on the backend, hence no decryption is needed
                 val assetDataSize = if (encryptionKey != null) {
-                    kaliumLogger.d("starting encryption")
-                    decryptFileWithAES256(encryptedAssetDataSource, decodedAssetSink, encryptionKey).also {
-                        kaliumLogger.d("encryption done")
-                    }
+                    decryptFileWithAES256(encryptedAssetDataSource, decodedAssetSink, encryptionKey)
                 } else
                     kaliumFileSystem.writeData(decodedAssetSink, encryptedAssetDataSource)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -204,7 +204,7 @@ class AssetRepositoryTest {
                 .with(eq(assetKey.value))
                 .wasInvoked(exactly = once)
             verify(assetApi).suspendFunction(assetApi::downloadAsset)
-                .with(matching { it.value == assetKey.value }, eq(null))
+                .with(matching { it.value == assetKey.value }, eq(null), any())
                 .wasInvoked(exactly = once)
             verify(assetDAO)
                 .suspendFunction(assetDAO::insertAsset)
@@ -236,7 +236,7 @@ class AssetRepositoryTest {
                 .with(matching { it == assetKey.value })
                 .wasInvoked(exactly = once)
             verify(assetApi).suspendFunction(assetApi::downloadAsset)
-                .with(matching { it.value == assetKey.value }, eq(null))
+                .with(matching { it.value == assetKey.value }, eq(null), any())
                 .wasInvoked(exactly = once)
 
         }
@@ -263,7 +263,7 @@ class AssetRepositoryTest {
                 .wasInvoked(exactly = once)
 
             verify(assetApi).suspendFunction(assetApi::downloadAsset)
-                .with(matching { it.value == assetKey.value }, eq(null))
+                .with(matching { it.value == assetKey.value }, eq(null), any())
                 .wasNotInvoked()
         }
     }
@@ -352,8 +352,8 @@ class AssetRepositoryTest {
                 withMockedAssetDaoGetByKeyCall(assetKey, null)
                 given(assetApi)
                     .suspendFunction(assetApi::downloadAsset)
-                    .whenInvokedWith(matching { assetId -> assetId.value == assetKey.value }, eq(null))
-                    .thenReturn(NetworkResponse.Success(expectedData, mapOf(), 200))
+                    .whenInvokedWith(matching { assetId -> assetId.value == assetKey.value }, eq(null), any())
+                    .thenReturn(NetworkResponse.Success(Unit, mapOf(), 200))
 
                 given(assetDAO)
                     .suspendFunction(assetDAO::insertAsset)
@@ -378,7 +378,7 @@ class AssetRepositoryTest {
         fun withErrorDownloadResponse(): Arrangement = apply {
             given(assetApi)
                 .suspendFunction(assetApi::downloadAsset)
-                .whenInvokedWith(anything(), anything())
+                .whenInvokedWith(anything(), anything(), anything())
                 .thenReturn(
                     NetworkResponse.Error(
                         KaliumException.ServerError(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/FakeKaliumFileSystem.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/FakeKaliumFileSystem.kt
@@ -28,6 +28,7 @@ class FakeKaliumFileSystem(
     init {
         fakeFileSystem.allowDeletingOpenFiles = true
         fakeFileSystem.allowReadsWhileWriting = true
+        fakeFileSystem.allowWritesWhileWriting = true
         fakeFileSystem.createDirectories(userHomePath)
         fakeFileSystem.createDirectory(dataStoragePaths.cachePath.value.toPath())
         fakeFileSystem.createDirectory(dataStoragePaths.assetStoragePath.value.toPath())

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/asset/AssetApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/asset/AssetApiImpl.kt
@@ -185,4 +185,4 @@ class StreamAssetContent(
     }
 }
 
-private const val BUFFER_SIZE = 1024 * 4L
+private const val BUFFER_SIZE = 1024 * 8L

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/asset/AssetApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/asset/AssetApiImpl.kt
@@ -69,8 +69,6 @@ class AssetApiImpl internal constructor(
             httpClient.prepareGet(buildAssetsPath(assetId)) {
                 assetToken?.let { header(HEADER_ASSET_TOKEN, it) }
             }.execute { httpResponse ->
-                // TODO: write the file to specific path using asset-id as temp name
-                // TODO: return path ? instead of Unit
                 val channel = httpResponse.body<ByteReadChannel>()
                 tempFileSink.use { sink ->
                     while (!channel.isClosedForRead) {
@@ -187,4 +185,4 @@ class StreamAssetContent(
     }
 }
 
-private const val BUFFER_SIZE = 8192L
+private const val BUFFER_SIZE = 1024 * 4L

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -116,6 +116,20 @@ internal interface ApiTest {
         ).websocketClient
     }
 
+    fun mockAssetsHttpClient(
+        responseBody: ByteReadChannel,
+        statusCode: HttpStatusCode,
+        assertion: (HttpRequestData.() -> Unit) = {},
+        headers: Map<String, String>? = null
+    ): AuthenticatedNetworkClient {
+        val mockEngine = createMockEngine(responseBody, statusCode, assertion, headers)
+        return AuthenticatedNetworkClient(
+            engine = mockEngine,
+            sessionManager = TEST_SESSION_NAMAGER,
+            serverMetaDataManager = TestServerMetaDataManager()
+        )
+    }
+
     /**
      * creates an unauthenticated mock Ktor Http client
      * @param responseBody the response body as Json string

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
@@ -104,7 +104,7 @@ class AssetApiTest : ApiTest {
 
         // When
         val assetApi: AssetApi = AssetApiImpl(networkClient)
-        val response = assetApi.downloadAsset(assetId, ASSET_TOKEN)
+        val response = assetApi.downloadAsset(assetId, ASSET_TOKEN, tempFileSink)
 
         // Then
         assertTrue(response.isSuccessful())
@@ -130,7 +130,7 @@ class AssetApiTest : ApiTest {
         // When
         val assetApi: AssetApi = AssetApiImpl(networkClient)
         val assetIdFallback = assetId.copy(domain = "")
-        val response = assetApi.downloadAsset(assetIdFallback, ASSET_TOKEN)
+        val response = assetApi.downloadAsset(assetIdFallback, ASSET_TOKEN, tempFileSink)
 
         // Then
         assertTrue(response.isSuccessful())
@@ -179,7 +179,7 @@ class AssetApiTest : ApiTest {
 
         // When
         val assetApi: AssetApi = AssetApiImpl(networkClient)
-        val response = assetApi.downloadAsset(assetId, ASSET_TOKEN)
+        val response = assetApi.downloadAsset(assetId, ASSET_TOKEN, tempFileSink)
 
         // Then
         assertTrue(response is NetworkResponse.Error)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
@@ -105,6 +105,7 @@ class AssetApiTest : ApiTest {
         // When
         val assetApi: AssetApi = AssetApiImpl(networkClient)
         val response = assetApi.downloadAsset(assetId, ASSET_TOKEN, tempFileSink)
+        // todo: assert response
     }
 
     @Test
@@ -127,7 +128,7 @@ class AssetApiTest : ApiTest {
         val assetApi: AssetApi = AssetApiImpl(networkClient)
         val assetIdFallback = assetId.copy(domain = "")
         val response = assetApi.downloadAsset(assetIdFallback, ASSET_TOKEN, tempFileSink)
-
+        // todo: assert response
     }
 
     @Test
@@ -173,6 +174,7 @@ class AssetApiTest : ApiTest {
         // When
         val assetApi: AssetApi = AssetApiImpl(networkClient)
         val response = assetApi.downloadAsset(assetId, ASSET_TOKEN, tempFileSink)
+        // todo: assert response
     }
 
     companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, the app is crashing by out of memory exception, when we are dealing with big files, ie: > 60 MB
This happens because we were handling `ByteArray` (download and decryption) being an expensive DS for the device to handle.

### Solutions

Change the approach to read the `ByteArray` by chunks and write to a temp file.
On the decryption part, being JVM code, we can handle `InputStream`s =)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
