### PR TITLE
fix: delete conversation locally after remote deletion

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -568,7 +568,7 @@ abstract class UserSessionScopeCommon(
             kaliumConfigs
         )
 
-    val team: TeamScope get() = TeamScope(userRepository, teamRepository)
+    val team: TeamScope get() = TeamScope(userRepository, teamRepository, conversationRepository)
 
     val calls: CallsScope
         get() = CallsScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -70,7 +70,7 @@ class ConversationScope internal constructor(
         get() = ObserveIsSelfUserMemberUseCaseImpl(conversationRepository, selfUserId)
 
     val deleteTeamConversation: DeleteTeamConversationUseCase
-        get() = DeleteTeamConversationUseCaseImpl(getSelfTeamUseCase, teamRepository)
+        get() = DeleteTeamConversationUseCaseImpl(getSelfTeamUseCase, teamRepository, conversationRepository)
 
     val createGroupConversation: CreateGroupConversationUseCase
         get() = CreateGroupConversationUseCase(conversationRepository, syncManager, clientRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCase.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.feature.team
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.functional.fold
@@ -20,7 +21,8 @@ fun interface DeleteTeamConversationUseCase {
 
 internal class DeleteTeamConversationUseCaseImpl(
     val getSelfTeam: GetSelfTeamUseCase,
-    val teamRepository: TeamRepository
+    val teamRepository: TeamRepository,
+    val conversationRepository: ConversationRepository,
 ) : DeleteTeamConversationUseCase {
 
     override suspend fun invoke(conversationId: ConversationId): Result {
@@ -30,6 +32,7 @@ internal class DeleteTeamConversationUseCaseImpl(
                 .fold({
                     Result.Failure.GenericFailure(it)
                 }, {
+                    conversationRepository.deleteConversation(conversationId)
                     Result.Success
                 })
         } ?: Result.Failure.NoTeamFailure

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/TeamScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/TeamScope.kt
@@ -1,11 +1,13 @@
 package com.wire.kalium.logic.feature.team
 
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserRepository
 
 class TeamScope internal constructor(
     private val userRepository: UserRepository,
     private val teamRepository: TeamRepository,
+    private val conversationRepository: ConversationRepository,
 ) {
     val getSelfTeamUseCase: GetSelfTeamUseCase
         get() = GetSelfTeamUseCaseImpl(
@@ -17,5 +19,6 @@ class TeamScope internal constructor(
         get() = DeleteTeamConversationUseCaseImpl(
             getSelfTeam = getSelfTeamUseCase,
             teamRepository = teamRepository,
+            conversationRepository = conversationRepository,
         )
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fix to manally delete the conversation locally when is removed, this was originated because the new endpoints for deletion are not triggering any events.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
