### PR TITLE
feat: fix crash when hanging up and no connection

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnConfigRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnConfigRequest.kt
@@ -4,15 +4,15 @@ import com.sun.jna.Pointer
 import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.callbacks.CallConfigRequestHandler
 import com.wire.kalium.calling.types.Handle
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.feature.call.AvsCallBackError
-import com.wire.kalium.logic.feature.call.CallManagerImpl
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-//TODO(testing): create unit test
+// TODO(testing): create unit test
 class OnConfigRequest(
     private val calling: Calling,
     private val callRepository: CallRepository,
@@ -21,20 +21,18 @@ class OnConfigRequest(
     override fun onConfigRequest(inst: Handle, arg: Pointer?): Int {
         callingLogger.i("[OnConfigRequest] - STARTED")
         callingScope.launch {
-            val config = callRepository.getCallConfigResponse(limit = null)
+            callRepository.getCallConfigResponse(limit = null)
                 .fold({
                     callingLogger.i("[OnConfigRequest] - Error: $it")
-                    TODO("Not yet implemented.")
-                }, {
-                    it
+                    // TODO("Not yet implemented.")
+                }, { config ->
+                    calling.wcall_config_update(
+                        inst = inst,
+                        error = 0, // TODO(calling): http error from internal json
+                        jsonString = config
+                    )
+                    callingLogger.i("[OnConfigRequest] - wcall_config_update()")
                 })
-
-            calling.wcall_config_update(
-                inst = inst,
-                error = 0, // TODO(calling): http error from internal json
-                jsonString = config
-            )
-            callingLogger.i("[OnConfigRequest] - wcall_config_update()")
         }
 
         return AvsCallBackError.NONE.value

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnConfigRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnConfigRequest.kt
@@ -4,7 +4,6 @@ import com.sun.jna.Pointer
 import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.callbacks.CallConfigRequestHandler
 import com.wire.kalium.calling.types.Handle
-import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.feature.call.AvsCallBackError
@@ -24,7 +23,7 @@ class OnConfigRequest(
             callRepository.getCallConfigResponse(limit = null)
                 .fold({
                     callingLogger.i("[OnConfigRequest] - Error: $it")
-                    // TODO("Not yet implemented.")
+                    // TODO: Add a better way to handle the Core Failure?
                 }, { config ->
                     calling.wcall_config_update(
                         inst = inst,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When handling the client being offline when initiating the call, I noticed that if the call is hanged up while having no internet connection, the app was crashing. After debugging some code, it boiled down to the `OnConfigRequest` class, that was hitting a `NotImplementedError`. I patched it temporarily, but a more elaborated solution would be added in the near future.

### Dependencies (Optional)

A subsequent PR in AR project will be raised containing this fix.

### Testing

#### Test Coverage (Optional)

Tests will need to be added to the `OnConfigRequest` class on a separate PR

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
