### PR TITLE
fix: show message after removing conversation member (AR-2038)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RemoveMemberFromConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RemoveMemberFromConversationUseCaseTest.kt
@@ -27,6 +27,7 @@ class RemoveMemberFromConversationUseCaseTest {
     fun givenMemberAndConversation_WhenRemoveMemberIsSuccessful_ThenReturnSuccess() = runTest {
         val (arrangement, removeMemberUseCase) = Arrangement()
             .withRemoveMemberGroupIs(Either.Right(Unit))
+            .withPersistMessage(Either.Right(Unit))
             .arrange()
 
         val result = removeMemberUseCase(TestConversation.ID, TestConversation.USER_1)
@@ -73,6 +74,13 @@ class RemoveMemberFromConversationUseCaseTest {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::deleteMember)
                 .whenInvokedWith(any(), any())
+                .thenReturn(either)
+        }
+
+        fun withPersistMessage(either: Either<CoreFailure, Unit>) = apply {
+            given(persistMessage)
+                .suspendFunction(persistMessage::invoke)
+                .whenInvokedWith(any())
                 .thenReturn(either)
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Message is only showed when user leaves conversation, but not where we are removing other user from conversation

### Causes (Optional)

### Solutions

Disable checking if selfUser left conversation

