### PR TITLE
fix: group calls white screen

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSFTRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSFTRequest.kt
@@ -24,8 +24,12 @@ class OnSFTRequest(
 ) : SFTRequestHandler {
     override fun onSFTRequest(ctx: Pointer?, url: String, data: Pointer?, length: Size_t, arg: Pointer?): Int {
         callingLogger.i("[OnSFTRequest] -> Start")
+
+        val dataString = data?.getString(0, CallManagerImpl.UTF8_ENCODING)
+        callingLogger.i("[OnSFTRequest] -> Connecting to SFT Server: $url")
+        callingLogger.i("[OnSFTRequest] -> Connecting to SFT Server with data: $dataString")
+
         callingScope.launch {
-            val dataString = data?.getString(0, CallManagerImpl.UTF8_ENCODING)
             dataString?.let {
                 val responseData = callRepository.connectToSFT(
                     url = url,


### PR DESCRIPTION
…ast data

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2179 - Group Calls stuck in white screen](https://wearezeta.atlassian.net/browse/AR-2179)

### Issues

When joining group call, the user would get stuck in white screen.

### Causes (Optional)

Due to receiving a data Pointer in SFT Callback, when really working with it inside the scope, it would get toasted because the Pointer data would no more exist correctly then having an error when trying to connect to SFT servers.

### Solutions

Move logic of data Pointer to outside of calling scope when handling it.


### Testing

#### How to Test

- Uninstall App
- Install App (needs to be a fresh install as it was always happening on first call)
- Login
- Receive Call and accept it
- User should not be stuck in white screen anymore.