### PR TITLE
fix(mls): database locked error when joining mls conversations

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -183,13 +183,14 @@ abstract class UserSessionScopeCommon(
     private val updateKeyingMaterialThresholdProvider: UpdateKeyingMaterialThresholdProvider
         get() = UpdateKeyingMaterialThresholdProviderImpl(kaliumConfigs)
 
-    private val mlsClientProvider: MLSClientProvider
-        get() = MLSClientProviderImpl(
+    private val mlsClientProvider: MLSClientProvider by lazy {
+        MLSClientProviderImpl(
             "${authenticatedDataSourceSet.authenticatedRootDir}/mls",
             userId,
             clientRepository,
             authenticatedDataSourceSet.kaliumPreferencesSettings
         )
+    }
 
     private val mlsConversationRepository: MLSConversationRepository
         get() = MLSConversationDataSource(


### PR DESCRIPTION
… slow sync

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Slow sync fails with a `KeyStoreException: database is locked` when joining existing MLS conversations.

### Causes

Joining existing MLS conversations is executed in parallel each having its own MlsClient instance so that multiple connections to the underlaying SQLite database is created which is not supported and fails.

### Solutions

Use one shared MlsClient, CoreCrypto has internal locks which makes this safe.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
