### PR TITLE
fix(feature-config): handle missing mls configuration

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -54,7 +54,6 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
             Status.DISABLED
         )
 
-
     override fun fromDTO(data: FeatureConfigData.AppLock): AppLockModel =
         AppLockModel(
             AppLockConfigModel(data.config.enforceAppLock, data.config.inactivityTimeoutSecs),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -8,7 +8,7 @@ import com.wire.kalium.network.api.featureConfigs.FeatureFlagStatusDTO
 interface FeatureConfigMapper {
     fun fromDTO(featureConfigResponse: FeatureConfigResponse): FeatureConfigModel
     fun fromDTO(status: FeatureFlagStatusDTO): Status
-    fun fromDTO(data: FeatureConfigData.MLS): MLSModel
+    fun fromDTO(data: FeatureConfigData.MLS?): MLSModel
     fun fromDTO(data: FeatureConfigData.AppLock): AppLockModel
     fun fromDTO(data: FeatureConfigData.ClassifiedDomains): ClassifiedDomainsModel
     fun fromDTO(data: FeatureConfigData.SelfDeletingMessages): SelfDeletingMessagesModel
@@ -43,11 +43,17 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
             FeatureFlagStatusDTO.DISABLED -> Status.DISABLED
         }
 
-    override fun fromDTO(data: FeatureConfigData.MLS): MLSModel =
-        MLSModel(
-            data.config.protocolToggleUsers.map { PlainId(it) },
-            fromDTO(data.status)
+    override fun fromDTO(data: FeatureConfigData.MLS?): MLSModel =
+        data?.let {
+            MLSModel(
+                it.config.protocolToggleUsers.map { userId -> PlainId(userId) },
+                fromDTO(it.status)
+            )
+        } ?: MLSModel(
+            listOf(),
+            Status.DISABLED
         )
+
 
     override fun fromDTO(data: FeatureConfigData.AppLock): AppLockModel =
         AppLockModel(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -16,6 +16,7 @@ data class KaliumConfigs(
     val isSafeLoggingEnabled: Boolean = false,
     val enableBlacklist: Boolean = false,
     val fileRestrictionEnabled: Boolean = false,
+    // Disabling db-encryption will crash on android-api level below 30
     val shouldEncryptData: Boolean = true,
     val lowerKeyPackageLimits: Boolean = false,
     val lowerKeyingMaterialsUpdateThreshold: Boolean = false,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/featureConfigs/FeatureConfigResponse.kt
@@ -32,7 +32,7 @@ data class FeatureConfigResponse(
     @SerialName("validateSAMLemails")
     val validateSAMLEmails: FeatureConfigData.ValidateSAMLEmails,
     @SerialName("mls")
-    val mls: FeatureConfigData.MLS
+    val mls: FeatureConfigData.MLS?
 )
 
 @Serializable


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Make MLS data config in FeatureConfig API nullable and set a default value as disabled if it is null.

### Issues

If the mls configurations is not set for a team the backend will not send the data for that key at all!

### Causes (Optional)

Break the sync.

### Solutions

Make mls data config nullable.


### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Fix the connection issue on federated environments without mls config.


----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
