### PR TITLE
feat: add isOnPremises to ServerConfig

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -29,7 +29,8 @@ data class ServerConfig(
         @SerialName("blackListUrl") val blackList: String,
         @SerialName("teamsUrl") val teams: String,
         @SerialName("websiteUrl") val website: String,
-        @SerialName("title") val title: String
+        @SerialName("title") val title: String,
+        @SerialName("is_on_premises") val isOnPremises: Boolean
     ) {
         val forgotPassword: String
             get() = URLBuilder().apply {
@@ -73,7 +74,8 @@ data class ServerConfig(
             teams = """https://teams.wire.com""",
             blackList = """https://clientblacklist.wire.com/prod""",
             website = """https://wire.com""",
-            title = "production"
+            title = "production",
+            isOnPremises = false
         )
 
         val STAGING = Links(
@@ -83,7 +85,8 @@ data class ServerConfig(
             teams = """https://wire-teams-staging.zinfra.io""",
             blackList = """https://clientblacklist.wire.com/staging""",
             website = """https://wire.com""",
-            title = "staging"
+            title = "staging",
+            isOnPremises = false
         )
         val DEFAULT = PRODUCTION
 
@@ -120,6 +123,7 @@ class ServerConfigMapperImpl(
                 Url(links.teams),
                 Url(links.website),
                 links.title,
+                isOnPremises = links.isOnPremises
             ), ServerConfigDTO.MetaData(
                 federation = metaData.federation, apiVersionMapper.toDTO(metaData.commonApiVersion), metaData.domain
             )
@@ -135,6 +139,7 @@ class ServerConfigMapperImpl(
             Url(links.teams),
             Url(links.website),
             title,
+            isOnPremises
         )
     }
 
@@ -148,6 +153,7 @@ class ServerConfigMapperImpl(
                 teams = Url(links.teams),
                 website = Url(links.website),
                 title = links.title,
+                isOnPremises = links.isOnPremises
             ), ServerConfigDTO.MetaData(
                 federation = metaData.federation, commonApiVersion = apiVersionMapper.toDTO(metaData.apiVersion), domain = metaData.domain
             )
@@ -168,6 +174,7 @@ class ServerConfigMapperImpl(
             blackList = blackList.toString(),
             teams = teams.toString(),
             title = title,
+            isOnPremises = isOnPremises
         )
     }
 
@@ -194,6 +201,7 @@ class ServerConfigMapperImpl(
             teams = teams,
             website = website,
             title = title,
+            isOnPremises = isOnPremises
         )
     }
 
@@ -207,7 +215,14 @@ class ServerConfigMapperImpl(
 
     override fun fromEntity(serverConfigEntityLinks: ServerConfigEntity.Links): ServerConfig.Links = with(serverConfigEntityLinks) {
         ServerConfig.Links(
-            api = api, accounts = accounts, webSocket = webSocket, blackList = blackList, teams = teams, website = website, title = title
+            api = api,
+            accounts = accounts,
+            webSocket = webSocket,
+            blackList = blackList,
+            teams = teams,
+            website = website,
+            title = title,
+            isOnPremises = isOnPremises
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -96,7 +96,6 @@ data class ServerConfig(
     }
 }
 
-
 interface ServerConfigMapper {
     fun toDTO(serverConfig: ServerConfig): ServerConfigDTO
     fun toDTO(links: ServerConfig.Links): ServerConfigDTO.Links
@@ -159,7 +158,6 @@ class ServerConfigMapperImpl(
             )
         )
     }
-
 
     override fun fromDTO(wireServer: ServerConfigDTO): ServerConfig = with(wireServer) {
         ServerConfig(id = id, links = fromDTO(links), metaData = fromDTO(metaData))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
@@ -120,6 +120,7 @@ internal class ServerConfigDataSource(
                         blackListUrl = links.blackList,
                         teamsUrl = links.teams,
                         websiteUrl = links.website,
+                        isOnPremises = links.isOnPremises,
                         title = links.title,
                         federation = metadata.federation,
                         domain = metadata.domain,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
@@ -50,6 +50,7 @@ class ServerConfigMapperTest {
                         Url(links.teams),
                         Url(links.website),
                         links.title,
+                        links.isOnPremises
                     ),
                     ServerConfigDTO.MetaData(
                         metaData.federation,
@@ -78,6 +79,7 @@ class ServerConfigMapperTest {
                         links.teams,
                         links.website,
                         links.title,
+                        links.isOnPremises
                     ),
                     ServerConfig.MetaData(
                         metaData.federation,
@@ -106,6 +108,7 @@ class ServerConfigMapperTest {
                         links.teams,
                         links.website,
                         links.title,
+                        links.isOnPremises
                     ),
                     ServerConfigEntity.MetaData(
                         metaData.federation,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionMapperTest.kt
@@ -66,7 +66,7 @@ class SessionMapperTest {
     fun givenAnAuthSession_whenMappingToPersistenceSession_thenValuesAreMappedCorrectly() {
         val authSession: AuthSession = randomAuthSession()
         val serverConfigEntity = with(authSession.serverLinks) {
-            ServerConfigEntity.Links(api, accounts, webSocket, blackList, teams, website, title)
+            ServerConfigEntity.Links(api, accounts, webSocket, blackList, teams, website, title, isOnPremises)
         }
 
         given(idMapper).invocation { toDaoModel(authSession.session.userId) }
@@ -95,7 +95,7 @@ class SessionMapperTest {
     fun givenAPersistenceSession_whenMappingFromPersistenceSession_thenValuesAreMappedCorrectly() {
         val authSessionEntity: AuthSessionEntity.Valid = randomPersistenceSession()
         val serverLinks = with(authSessionEntity.serverLinks) {
-            ServerConfig.Links(api, accounts, webSocket, blackList, teams, website, title)
+            ServerConfig.Links(api, accounts, webSocket, blackList, teams, website, title, isOnPremises)
         }
 
         given(idMapper).invocation { fromDaoModel(authSessionEntity.userId) }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ServerConfigStubs.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ServerConfigStubs.kt
@@ -82,5 +82,3 @@ internal fun newServerConfigDTO(id: Int) = ServerConfigDTO(
         domain = "domain$id.com",
     )
 )
-
-

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ServerConfigStubs.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ServerConfigStubs.kt
@@ -16,7 +16,8 @@ internal fun newTestServer(id: Int) = ServerConfig(
         blackList = "https://server$id-blackListUrl.de/",
         teams = "https://server$id-teamsUrl.de/",
         website = "https://server$id-websiteUrl.de/",
-        title = "server$id-title"
+        title = "server$id-title",
+        false
     ),
     metaData = ServerConfig.MetaData(
         commonApiVersion = CommonApiVersionType.Valid(id),
@@ -34,7 +35,8 @@ internal fun newServerConfig(id: Int) = ServerConfig(
         blackList = "https://server$id-blackListUrl.de/",
         teams = "https://server$id-teamsUrl.de/",
         website = "https://server$id-websiteUrl.de/",
-        title = "server$id-title"
+        title = "server$id-title",
+        false
     ),
     metaData = ServerConfig.MetaData(
         commonApiVersion = CommonApiVersionType.Valid(id),
@@ -53,6 +55,7 @@ internal fun newServerConfigEntity(id: Int) = ServerConfigEntity(
         teams = "https://server$id-teamsUrl.de/",
         website = "https://server$id-websiteUrl.de/",
         title = "server$id-title",
+        false
     ),
     metaData = ServerConfigEntity.MetaData(
         apiVersion = id,
@@ -70,7 +73,8 @@ internal fun newServerConfigDTO(id: Int) = ServerConfigDTO(
         blackList = Url("https://server$id-blackListUrl.de"),
         teams = Url("https://server$id-teamsUrl.de"),
         website = Url("https://server$id-websiteUrl.de"),
-        title = "server$id-title"
+        title = "server$id-title",
+        false
     ),
     ServerConfigDTO.MetaData(
         false,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/configuration/ServerConfigApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/configuration/ServerConfigApi.kt
@@ -36,7 +36,8 @@ class ServerConfigApiImpl internal constructor(
                 blackList = Url(it.endpoints.blackListUrl),
                 website = Url(it.endpoints.websiteUrl),
                 teams = Url(it.endpoints.teamsUrl),
-                title = it.title
+                title = it.title,
+                isOnPremises = true
             )
         }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/tools/ServerConfigDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/tools/ServerConfigDTO.kt
@@ -14,7 +14,8 @@ data class ServerConfigDTO(
         val blackList: Url,
         val teams: Url,
         val website: Url,
-        val title: String
+        val title: String,
+        val isOnPremises: Boolean
     )
 
     data class MetaData(

--- a/persistence/src/commonMain/db_global/com/wire/kalium/persistence/ServerConfiguration.sq
+++ b/persistence/src/commonMain/db_global/com/wire/kalium/persistence/ServerConfiguration.sq
@@ -10,6 +10,7 @@ CREATE TABLE ServerConfiguration (
     blackListUrl TEXT NOT NULL,
     teamsUrl TEXT NOT NULL,
     websiteUrl TEXT NOT NULL,
+    isOnPremises INTEGER AS Boolean NOT NULL,
     domain TEXT UNIQUE,
     commonApiVersion INTEGER AS Int NOT NULL,
     federation INTEGER AS Boolean NOT NULL,
@@ -20,8 +21,8 @@ deleteById:
 DELETE FROM ServerConfiguration WHERE id = ?;
 
 insert:
-INSERT OR IGNORE INTO ServerConfiguration(id, apiBaseUrl, accountBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title, federation, domain, commonApiVersion)
-VALUES( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT OR IGNORE INTO ServerConfiguration(id, apiBaseUrl, accountBaseUrl, webSocketBaseUrl, blackListUrl, teamsUrl, websiteUrl, title, isOnPremises, federation, domain, commonApiVersion)
+VALUES( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateApiVersion:
 UPDATE ServerConfiguration SET commonApiVersion = ? WHERE id = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao_kalium_db/ServerConfigurationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao_kalium_db/ServerConfigurationDAO.kt
@@ -19,7 +19,8 @@ internal class ServerConfigMapper() {
                 blackList = blackListUrl,
                 teams = teamsUrl,
                 website = websiteUrl,
-                title = title
+                title = title,
+                isOnPremises = isOnPremises
             ),
             ServerConfigEntity.MetaData(
                 federation = federation,
@@ -50,6 +51,7 @@ interface ServerConfigurationDAO {
         val teamsUrl: String,
         val websiteUrl: String,
         val title: String,
+        val isOnPremises: Boolean,
         val federation: Boolean,
         val domain: String?,
         val commonApiVersion: Int
@@ -61,7 +63,6 @@ class ServerConfigurationDAOImpl(private val queries: ServerConfigurationQueries
 
     override fun deleteById(id: String) = queries.deleteById(id)
 
-    @Suppress("LongParameterList")
     override fun insert(
         insertData: ServerConfigurationDAO.InsertData
     ) = with(insertData) {
@@ -74,6 +75,7 @@ class ServerConfigurationDAOImpl(private val queries: ServerConfigurationQueries
             teamsUrl,
             websiteUrl,
             title,
+            isOnPremises,
             federation,
             domain,
             commonApiVersion

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/model/AuthSessionEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/model/AuthSessionEntity.kt
@@ -18,7 +18,8 @@ data class ServerConfigEntity(
         @SerialName("blackListUrl") val blackList: String,
         @SerialName("teamsUrl") val teams: String,
         @SerialName("websiteUrl") val website: String,
-        @SerialName("title") val title: String
+        @SerialName("title") val title: String,
+        @SerialName("is_on_premises") val isOnPremises: Boolean
     )
 
     @Serializable

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao_kalium_db/ServerConfigurationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao_kalium_db/ServerConfigurationDAOTest.kt
@@ -165,7 +165,8 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
                     title = links.title,
                     federation = metaData.federation,
                     domain = metaData.domain,
-                    commonApiVersion = metaData.apiVersion
+                    commonApiVersion = metaData.apiVersion,
+                    isOnPremises = false
                 )
             )
         }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ServerConfigStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ServerConfigStubs.kt
@@ -11,7 +11,8 @@ internal fun newServerConfig(id: Int) = ServerConfigEntity(
         blackList = "https://server$id-blackListUrl.de",
         teams = "https://server$id-teamsUrl.de",
         website = "https://server$id-websiteUrl.de",
-        title = "server$id-title"
+        title = "server$id-title",
+        isOnPremises = false
     ),
     ServerConfigEntity.MetaData(
         federation = false,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

there is no way to tell if a stored server config is built into the app or was stored with a deep link

### Solutions

add isOnPremesis to `ServerConfig` data class and set it to true when retrieving the server config value from a deep link

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
