### PR TITLE
fix(mls): commit pending proposals

### DIFF
--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
@@ -63,9 +63,14 @@ class MLSClientTest : BaseMLSClientTest() {
     fun givenTwoClients_whenCallingJoinConversation_weCanProcessTheAddProposalMessage() {
         val aliceClient = createClient(ALICE)
         val bobClient = createClient(BOB)
+        val carolClient = createClient(CAROL)
 
-        bobClient.createConversation(MLS_CONVERSATION_ID, emptyList())
-        val proposal = aliceClient.joinConversation(MLS_CONVERSATION_ID, 0UL)
+        val carolKeyPackage = carolClient.generateKeyPackages(1).first()
+        val clientKeyPackageList = listOf(Pair(CAROL.qualifiedClientId, carolKeyPackage))
+
+        bobClient.createConversation(MLS_CONVERSATION_ID, clientKeyPackageList)
+        bobClient.commitAccepted(MLS_CONVERSATION_ID)
+        val proposal = aliceClient.joinConversation(MLS_CONVERSATION_ID, 1UL)
         bobClient.decryptMessage(MLS_CONVERSATION_ID, proposal)
         val welcome = bobClient.commitPendingProposals(MLS_CONVERSATION_ID).welcome
         bobClient.commitAccepted(MLS_CONVERSATION_ID)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -68,10 +68,12 @@ internal class PendingProposalSchedulerImpl(
     }
 
     private suspend fun startCommittingPendingProposals() {
+        kaliumLogger.d("Start listening for pending proposals to commit")
         timers().cancellable().collect() { groupID ->
+            kaliumLogger.d("Committing pending proposals in $groupID")
             mlsConversationRepository.value.commitPendingProposals(groupID)
                 .onFailure {
-                    kaliumLogger.e("Failed to commit pending proposals in $groupID")
+                    kaliumLogger.e("Failed to commit pending proposals in $groupID: $it")
                 }
         }
     }
@@ -97,6 +99,7 @@ internal class PendingProposalSchedulerImpl(
     }
 
     override suspend fun scheduleCommit(groupID: String, date: Instant) {
+        kaliumLogger.d("Scheduling to commit pending proposals in $groupID at $date")
         mlsConversationRepository.value.setProposalTimer(ProposalTimer(groupID, date))
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -142,8 +142,7 @@ class ConversationEventReceiverTest {
     fun givenNewMLSMessageEventWithProposal_whenHandling_thenScheduleProposalTimer() = runTest {
         val eventTimestamp = Clock.System.now()
         val commitDelay: Long = 10
-
-
+        
         val (arrangement, eventReceiver) = Arrangement()
             .withMessageFromMLSMessageReturningProposal(commitDelay)
             .withScheduleCommitSucceeding()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -142,7 +142,7 @@ class ConversationEventReceiverTest {
     fun givenNewMLSMessageEventWithProposal_whenHandling_thenScheduleProposalTimer() = runTest {
         val eventTimestamp = Clock.System.now()
         val commitDelay: Long = 10
-        
+
         val (arrangement, eventReceiver) = Arrangement()
             .withMessageFromMLSMessageReturningProposal(commitDelay)
             .withScheduleCommitSucceeding()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When receiving a pending proposal we schedule a timer to commit it, but the timer never fires.

### Causes

Timer was scheduled for a non-existent group id: "event.conversationId".

### Solutions

Use the  actual group id of the conversation.

### Notes

Could have been avoided with stricter typing. Will introduce a `GroupId` type in a separate refactoring PR. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
