### PR TITLE
fix: skipping events when failing to fetch pending events (AR-2302)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.IOException
@@ -200,7 +201,7 @@ class EventGathererTest {
             .withLastEventIdReturning(Either.Right("lastEventId"))
             .withPendingEventsReturning(flowOf(Either.Left(failureCause)))
             .withKeepAliveConnectionPolicy()
-            .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
+            .withLiveEventsReturning(Either.Right(liveEventsChannel.receiveAsFlow()))
             .arrange()
 
         eventGatherer.gatherEvents().test {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

@tmspzz today has lost a few messages while using Reloaded.

Looking through the logs, it seems that the message should have come when fetching pending events.
Repeating the API request, the event was indeed there, however it was never processed.


### Causes

In the logs around the request that should contain the message, the following can be found:

```
08-29 10:22:58.905 V featureId:event_receiver: REQUEST https://prod-nginz-https.wire.com/v1/notifications?size=100&client=redacted&since=79c948d2-2773-11ed-8001-62124d5bb85d 
failed with exception: nl.b: Socket timeout has expired [url=https://prod-nginz-https.wire.com/v1/notifications?size=100&client=629565824ec0c0d5&since=79c948d2-2773-11ed-8001-62124d5bb85d, socket_timeout=unknown] ms
08-29 10:22:58.905 V         : Offline events collection finished. Collecting Live events.
08-29 10:22:58.905 I featureId:event_receiver: Offline events collection finished. Collecting Live events.
08-29 10:22:58.906 V         : Websocket Received binary payload

```

This means that the request for fetching pending events failed, but the failure was being ignored and live events were being processed normally.

It's definitely something odd and rare, as a REST call failed while the websocket was open.

### Solutions

Handle the failure when fetching pending events.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

It's not possible to replicate this consistently in the wild.
Perhaps fiddling with a proxy and blocking some network calls.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
