### PR TITLE
fix: app not able to retrieve server meta data from local

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -115,12 +115,12 @@ class ServerConfigMapperImpl(
     override fun toDTO(serverConfig: ServerConfig): ServerConfigDTO = with(serverConfig) {
         ServerConfigDTO(
             id = id, links = ServerConfigDTO.Links(
-                Url(links.api),
-                Url(links.accounts),
-                Url(links.webSocket),
-                Url(links.blackList),
-                Url(links.teams),
-                Url(links.website),
+                links.api,
+                links.accounts,
+                links.webSocket,
+                links.blackList,
+                links.teams,
+                links.website,
                 links.title,
                 isOnPremises = links.isOnPremises
             ), ServerConfigDTO.MetaData(
@@ -131,12 +131,12 @@ class ServerConfigMapperImpl(
 
     override fun toDTO(links: ServerConfig.Links): ServerConfigDTO.Links = with(links) {
         ServerConfigDTO.Links(
-            Url(links.api),
-            Url(links.accounts),
-            Url(links.webSocket),
-            Url(links.blackList),
-            Url(links.teams),
-            Url(links.website),
+            links.api,
+            links.accounts,
+            links.webSocket,
+            links.blackList,
+            links.teams,
+            links.website,
             title,
             isOnPremises
         )
@@ -145,12 +145,12 @@ class ServerConfigMapperImpl(
     override fun toDTO(serverConfigEntity: ServerConfigEntity): ServerConfigDTO = with(serverConfigEntity) {
         ServerConfigDTO(
             id = id, links = ServerConfigDTO.Links(
-                api = Url(links.api),
-                accounts = Url(links.accounts),
-                webSocket = Url(links.webSocket),
-                blackList = Url(links.blackList),
-                teams = Url(links.teams),
-                website = Url(links.website),
+                api = links.api,
+                accounts = links.accounts,
+                webSocket = links.webSocket,
+                blackList = links.blackList,
+                teams = links.teams,
+                website = links.website,
                 title = links.title,
                 isOnPremises = links.isOnPremises
             ), ServerConfigDTO.MetaData(
@@ -165,12 +165,12 @@ class ServerConfigMapperImpl(
 
     override fun fromDTO(links: ServerConfigDTO.Links): ServerConfig.Links = with(links) {
         ServerConfig.Links(
-            api = api.toString(),
-            website = website.toString(),
-            webSocket = webSocket.toString(),
-            accounts = accounts.toString(),
-            blackList = blackList.toString(),
-            teams = teams.toString(),
+            api = api,
+            website = website,
+            webSocket = webSocket,
+            accounts = accounts,
+            blackList = blackList,
+            teams = teams,
             title = title,
             isOnPremises = isOnPremises
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
@@ -43,12 +43,12 @@ class ServerConfigMapperTest {
                 ServerConfigDTO(
                     id = id,
                     ServerConfigDTO.Links(
-                        Url(links.api),
-                        Url(links.accounts),
-                        Url(links.webSocket),
-                        Url(links.blackList),
-                        Url(links.teams),
-                        Url(links.website),
+                        links.api,
+                        links.accounts,
+                        links.webSocket,
+                        links.blackList,
+                        links.teams,
+                        links.website,
                         links.title,
                         links.isOnPremises
                     ),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
@@ -12,7 +12,6 @@ import com.wire.kalium.logic.util.stubs.newServerConfigEntity
 import com.wire.kalium.network.tools.ApiVersionDTO
 import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.persistence.model.ServerConfigEntity
-import io.ktor.http.Url
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.given

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigTest.kt
@@ -16,7 +16,7 @@ class ServerConfigTest {
 
     @Test
     fun whenCreatingForgotPasswordUrl_thenItsCorrect() {
-        val expected =  serverConfig.accounts + "forgot"
+        val expected =  serverConfig.accounts + "/forgot"
         serverConfig.forgotPassword.also { actual ->
             assertEquals(expected, actual)
         }
@@ -24,7 +24,7 @@ class ServerConfigTest {
 
     @Test
     fun whenTOSUrl_thenItsCorrect() {
-        val expected =  serverConfig.website + "pricing"
+        val expected =  serverConfig.website + "/pricing"
         serverConfig.pricing.also { actual ->
             assertEquals(expected, actual)
         }
@@ -32,7 +32,7 @@ class ServerConfigTest {
 
     @Test
     fun whenPricingUrl_thenItsCorrect() {
-        val expected =  serverConfig.website + "legal"
+        val expected =  serverConfig.website + "/legal"
         serverConfig.tos.also { actual ->
             assertEquals(expected, actual)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ServerConfigStubs.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ServerConfigStubs.kt
@@ -5,17 +5,16 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.network.tools.ApiVersionDTO
 import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.persistence.model.ServerConfigEntity
-import io.ktor.http.Url
 
 internal fun newTestServer(id: Int) = ServerConfig(
     id = "config-$id",
     links = ServerConfig.Links(
-        api = "https://server$id-apiBaseUrl.de/",
-        accounts = "https://server$id-accountBaseUrl.de/",
-        webSocket = "https://server$id-webSocketBaseUrl.de/",
-        blackList = "https://server$id-blackListUrl.de/",
-        teams = "https://server$id-teamsUrl.de/",
-        website = "https://server$id-websiteUrl.de/",
+        api = "https://server$id-apiBaseUrl.de",
+        accounts = "https://server$id-accountBaseUrl.de",
+        webSocket = "https://server$id-webSocketBaseUrl.de",
+        blackList = "https://server$id-blackListUrl.de",
+        teams = "https://server$id-teamsUrl.de",
+        website = "https://server$id-websiteUrl.de",
         title = "server$id-title",
         false
     ),
@@ -29,12 +28,12 @@ internal fun newTestServer(id: Int) = ServerConfig(
 internal fun newServerConfig(id: Int) = ServerConfig(
     id = "config-$id",
     links = ServerConfig.Links(
-        api = "https://server$id-apiBaseUrl.de/",
-        accounts = "https://server$id-accountBaseUrl.de/",
-        webSocket = "https://server$id-webSocketBaseUrl.de/",
-        blackList = "https://server$id-blackListUrl.de/",
-        teams = "https://server$id-teamsUrl.de/",
-        website = "https://server$id-websiteUrl.de/",
+        api = "https://server$id-apiBaseUrl.de",
+        accounts = "https://server$id-accountBaseUrl.de",
+        webSocket = "https://server$id-webSocketBaseUrl.de",
+        blackList = "https://server$id-blackListUrl.de",
+        teams = "https://server$id-teamsUrl.de",
+        website = "https://server$id-websiteUrl.de",
         title = "server$id-title",
         false
     ),
@@ -48,12 +47,12 @@ internal fun newServerConfig(id: Int) = ServerConfig(
 internal fun newServerConfigEntity(id: Int) = ServerConfigEntity(
     id = "config-$id",
     links = ServerConfigEntity.Links(
-        api = "https://server$id-apiBaseUrl.de/",
-        accounts = "https://server$id-accountBaseUrl.de/",
-        webSocket = "https://server$id-webSocketBaseUrl.de/",
-        blackList = "https://server$id-blackListUrl.de/",
-        teams = "https://server$id-teamsUrl.de/",
-        website = "https://server$id-websiteUrl.de/",
+        api = "https://server$id-apiBaseUrl.de",
+        accounts = "https://server$id-accountBaseUrl.de",
+        webSocket = "https://server$id-webSocketBaseUrl.de",
+        blackList = "https://server$id-blackListUrl.de",
+        teams = "https://server$id-teamsUrl.de",
+        website = "https://server$id-websiteUrl.de",
         title = "server$id-title",
         false
     ),
@@ -67,12 +66,12 @@ internal fun newServerConfigEntity(id: Int) = ServerConfigEntity(
 internal fun newServerConfigDTO(id: Int) = ServerConfigDTO(
     id = "config-$id",
     links = ServerConfigDTO.Links(
-        api = Url("https://server$id-apiBaseUrl.de"),
-        accounts = Url("https://server$id-accountBaseUrl.de"),
-        webSocket = Url("https://server$id-webSocketBaseUrl.de"),
-        blackList = Url("https://server$id-blackListUrl.de"),
-        teams = Url("https://server$id-teamsUrl.de"),
-        website = Url("https://server$id-websiteUrl.de"),
+        api = "https://server$id-apiBaseUrl.de",
+        accounts = "https://server$id-accountBaseUrl.de",
+        webSocket = "https://server$id-webSocketBaseUrl.de",
+        blackList = "https://server$id-blackListUrl.de",
+        teams = "https://server$id-teamsUrl.de",
+        website = "https://server$id-websiteUrl.de",
         title = "server$id-title",
         false
     ),

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/configuration/ServerConfigApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/configuration/ServerConfigApi.kt
@@ -30,12 +30,12 @@ class ServerConfigApiImpl internal constructor(
             }
         }.mapSuccess {
             ServerConfigDTO.Links(
-                api = Url(it.endpoints.apiBaseUrl),
-                accounts = Url(it.endpoints.accountsBaseUrl),
-                webSocket = Url(it.endpoints.webSocketBaseUrl),
-                blackList = Url(it.endpoints.blackListUrl),
-                website = Url(it.endpoints.websiteUrl),
-                teams = Url(it.endpoints.teamsUrl),
+                api = it.endpoints.apiBaseUrl,
+                accounts = it.endpoints.accountsBaseUrl,
+                webSocket = it.endpoints.webSocketBaseUrl,
+                blackList = it.endpoints.blackListUrl,
+                website = it.endpoints.websiteUrl,
+                teams = it.endpoints.teamsUrl,
                 title = it.title,
                 isOnPremises = true
             )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApiImpl.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/NotificationApiImpl.kt
@@ -14,6 +14,7 @@ import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.http.Url
 import io.ktor.websocket.Frame
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -81,7 +82,7 @@ class NotificationApiImpl internal constructor(
         authenticatedWebSocketClient
             .createDisposableHttpClient()
             .webSocket({
-                setWSSUrl(serverLinks.webSocket, PATH_AWAIT)
+                setWSSUrl(Url(serverLinks.webSocket), PATH_AWAIT)
                 parameter(CLIENT_QUERY_KEY, clientId)
             }, {
                 emitWebSocketEvents(this)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/tools/ServerConfigDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/tools/ServerConfigDTO.kt
@@ -1,7 +1,5 @@
 package com.wire.kalium.network.tools
 
-import io.ktor.http.Url
-
 data class ServerConfigDTO(
     val id: String,
     val links: Links,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/tools/ServerConfigDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/tools/ServerConfigDTO.kt
@@ -8,12 +8,12 @@ data class ServerConfigDTO(
     val metaData: MetaData
 ) {
     data class Links(
-        val api: Url,
-        val accounts: Url,
-        val webSocket: Url,
-        val blackList: Url,
-        val teams: Url,
-        val website: Url,
+        val api: String,
+        val accounts: String,
+        val webSocket: String,
+        val blackList: String,
+        val teams: String,
+        val website: String,
         val title: String,
         val isOnPremises: Boolean
     )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/WireDefaultRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/WireDefaultRequest.kt
@@ -207,7 +207,7 @@ fun HttpClientConfig<*>.installWireDefaultRequest(
 
                 fetchAndStoreMetadata = {
                     val versionApi = VersionApiImpl(provideBaseHttpClient(defaultHttpEngine()))
-                    when (val result = versionApi.fetchApiVersion(backendLinks.api)) {
+                    when (val result = versionApi.fetchApiVersion(Url(backendLinks.api))) {
                         is NetworkResponse.Success ->
                             serverMetaDataManager.storeServerConfig(
                                 backendLinks, result.value
@@ -221,7 +221,7 @@ fun HttpClientConfig<*>.installWireDefaultRequest(
                 buildDefaultRequest = {
                     header(HttpHeaders.ContentType, ContentType.Application.Json)
                     with(it) {
-                        val apiBaseUrl = links.api
+                        val apiBaseUrl = Url(links.api)
                         // enforce https as url protocol
                         url.protocol = URLProtocol.HTTPS
                         // add the default host

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/TestUtil.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/TestUtil.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.api
 
 import com.wire.kalium.network.tools.ApiVersionDTO
 import com.wire.kalium.network.tools.ServerConfigDTO
-import io.ktor.http.Url
 
 val TEST_BACKEND_CONFIG =
     ServerConfigDTO(

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/TestUtil.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/TestUtil.kt
@@ -8,12 +8,12 @@ val TEST_BACKEND_CONFIG =
     ServerConfigDTO(
         id = "id",
         ServerConfigDTO.Links(
-            Url("https://test.api.com"),
-            Url("https://test.account.com"),
-            Url("https://test.ws.com"),
-            Url("https://test.blacklist"),
-            Url("https://test.teams.com"),
-            Url("https://test.wire.com"),
+            "https://test.api.com",
+            "https://test.account.com",
+            "https://test.ws.com",
+            "https://test.blacklist",
+            "https://test.teams.com",
+            "https://test.wire.com",
             "Test Title",
             false
         ),
@@ -26,12 +26,12 @@ val TEST_BACKEND_CONFIG =
 
 val TEST_BACKEND_LINKS =
     ServerConfigDTO.Links(
-        Url("https://test.api.com"),
-        Url("https://test.account.com"),
-        Url("https://test.ws.com"),
-        Url("https://test.blacklist"),
-        Url("https://test.teams.com"),
-        Url("https://test.wire.com"),
+        "https://test.api.com",
+        "https://test.account.com",
+        "https://test.ws.com",
+        "https://test.blacklist",
+        "https://test.teams.com",
+        "https://test.wire.com",
         "Test Title",
         false
     )

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/SSOLoginApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/SSOLoginApiTest.kt
@@ -37,14 +37,16 @@ class SSOLoginApiTest : ApiTest {
 
         assertIs<NetworkResponse.Success<String>>(actual)
         assertEquals(expectedPath, Url(actual.value).encodedPathAndQuery)
-        assertEquals("${TEST_BACKEND.links.api.protocolWithAuthority}$expectedPath", actual.value)
+        assertEquals("${Url(TEST_BACKEND.links.api).protocolWithAuthority}$expectedPath", actual.value)
     }
 
     @Test
     fun givenBEResponseSuccess_whenCallingInitiateSSOEndpointWithRedirect_thenRequestConfiguredCorrectly() = runTest {
         val uuid = "uuid"
-        val param = SSOLoginApi.InitiateParam.WithRedirect(uuid = uuid, success = "wire://success", error = "wire://error")
-        val expectedPathAndQuery = "$PATH_SSO_INITIATE/$uuid?success_redirect=wire%3A%2F%2Fsuccess&error_redirect=wire%3A%2F%2Ferror"
+        val param =
+            SSOLoginApi.InitiateParam.WithRedirect(uuid = uuid, success = "wire://success", error = "wire://error")
+        val expectedPathAndQuery =
+            "$PATH_SSO_INITIATE/$uuid?success_redirect=wire%3A%2F%2Fsuccess&error_redirect=wire%3A%2F%2Ferror"
         val networkClient = mockUnauthenticatedNetworkClient(
             "",
             statusCode = HttpStatusCode.OK,
@@ -58,7 +60,7 @@ class SSOLoginApiTest : ApiTest {
 
         assertIs<NetworkResponse.Success<String>>(actual)
         assertEquals(expectedPathAndQuery, Url(actual.value).encodedPathAndQuery)
-        assertEquals("${TEST_BACKEND.links.api.protocolWithAuthority}$expectedPathAndQuery", actual.value)
+        assertEquals("${Url(TEST_BACKEND.links.api).protocolWithAuthority}$expectedPathAndQuery", actual.value)
     }
 
     @Test

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/SSOLoginApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/user/login/SSOLoginApiTest.kt
@@ -81,7 +81,6 @@ class SSOLoginApiTest : ApiTest {
         assertIs<NetworkResponse.Success<String>>(actual)
     }
 
-
     private companion object {
         const val PATH_SSO_INITIATE = "/sso/initiate-login"
         const val PATH_SSO_FINALIZE = "/sso/finalize-login"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

app showing server error when login

### Causes (Optional)

app not able to fetch server metadata from local DB

### Solutions

fixed it

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
