### PR TITLE
refactor: introduce a GroupID type in the logic module

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.message.Message
@@ -89,7 +90,7 @@ data class Conversation(
         }
 
         data class MLS(
-            val groupId: String,
+            val groupId: GroupID,
             val groupState: GroupState,
             val epoch: ULong,
             val keyingMaterialLastUpdate: Instant,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.conversation
 
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.id.TeamId
@@ -95,7 +96,7 @@ internal class ConversationMapperImpl(
     )
 
     override fun fromDaoModel(daoModel: ProposalTimerEntity): ProposalTimer =
-        ProposalTimer(daoModel.groupID, daoModel.firingDate)
+        ProposalTimer(GroupID(daoModel.groupID), daoModel.firingDate)
 
     override fun toDAOAccess(accessList: Set<ConversationAccessDTO>): List<ConversationEntity.Access> = accessList.map {
         when (it) {
@@ -125,7 +126,7 @@ internal class ConversationMapperImpl(
         }
 
     override fun toDAOProposalTimer(proposalTimer: ProposalTimer): ProposalTimerEntity =
-        ProposalTimerEntity(proposalTimer.groupID, proposalTimer.timestamp)
+        ProposalTimerEntity(proposalTimer.groupID.value, proposalTimer.timestamp)
 
     override fun toApiModel(
         name: String?,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.data.conversation
 
-import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.id.TeamId
@@ -96,7 +95,7 @@ internal class ConversationMapperImpl(
     )
 
     override fun fromDaoModel(daoModel: ProposalTimerEntity): ProposalTimer =
-        ProposalTimer(GroupID(daoModel.groupID), daoModel.firingDate)
+        ProposalTimer(idMapper.fromGroupIDEntity(daoModel.groupID), daoModel.firingDate)
 
     override fun toDAOAccess(accessList: Set<ConversationAccessDTO>): List<ConversationEntity.Access> = accessList.map {
         when (it) {
@@ -126,7 +125,7 @@ internal class ConversationMapperImpl(
         }
 
     override fun toDAOProposalTimer(proposalTimer: ProposalTimer): ProposalTimerEntity =
-        ProposalTimerEntity(proposalTimer.groupID.value, proposalTimer.timestamp)
+        ProposalTimerEntity(idMapper.toGroupIDEntity(proposalTimer.groupID), proposalTimer.timestamp)
 
     override fun toApiModel(
         name: String?,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -204,7 +204,7 @@ class ConversationDataSource(
         val conversationEntities = conversations.map { conversationResponse ->
             conversationMapper.fromApiModelToDaoModel(
                 conversationResponse,
-                mlsGroupState = conversationResponse.groupId?.let { mlsGroupState(GroupID(it), originatedFromEvent) },
+                mlsGroupState = conversationResponse.groupId?.let { mlsGroupState(idMapper.fromGroupIDEntity(it), originatedFromEvent) },
                 selfUserTeamId?.let { TeamId(it) }
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
@@ -203,7 +204,7 @@ class ConversationDataSource(
         val conversationEntities = conversations.map { conversationResponse ->
             conversationMapper.fromApiModelToDaoModel(
                 conversationResponse,
-                mlsGroupState = conversationResponse.groupId?.let { mlsGroupState(it, originatedFromEvent) },
+                mlsGroupState = conversationResponse.groupId?.let { mlsGroupState(GroupID(it), originatedFromEvent) },
                 selfUserTeamId?.let { TeamId(it) }
             )
         }
@@ -215,7 +216,7 @@ class ConversationDataSource(
         }
     }
 
-    private suspend fun mlsGroupState(groupId: String, originatedFromEvent: Boolean = false): ConversationEntity.GroupState =
+    private suspend fun mlsGroupState(groupId: GroupID, originatedFromEvent: Boolean = false): ConversationEntity.GroupState =
         mlsConversationRepository.hasEstablishedMLSGroup(groupId).fold({
             throw IllegalStateException(it.toString()) // TODO find a more fitting exception?
         }, { exists ->
@@ -478,18 +479,18 @@ class ConversationDataSource(
             wrapStorageRequest {
                 conversationDAO.insertConversation(conversationEntity)
             }.flatMap {
-                when (conversationEntity.protocolInfo) {
-                    is ProtocolInfo.Proteus -> persistMembersFromConversationResponse(conversationResponse)
-                    is ProtocolInfo.MLS -> persistMembersFromConversationResponseMLS(
+                when (conversation.protocol) {
+                    is Conversation.ProtocolInfo.Proteus -> persistMembersFromConversationResponse(conversationResponse)
+                    is Conversation.ProtocolInfo.MLS -> persistMembersFromConversationResponseMLS(
                         conversationResponse, usersList
                     )
                 }
             }.flatMap {
-                when (conversationEntity.protocolInfo) {
-                    is ProtocolInfo.Proteus -> Either.Right(conversation)
-                    is ProtocolInfo.MLS ->
+                when (conversation.protocol) {
+                    is Conversation.ProtocolInfo.Proteus -> Either.Right(conversation)
+                    is Conversation.ProtocolInfo.MLS ->
                         mlsConversationRepository
-                            .establishMLSGroup((conversationEntity.protocolInfo as ProtocolInfo.MLS).groupId)
+                            .establishMLSGroup(conversation.protocol.groupId)
                             .flatMap { Either.Right(conversation) }
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -125,7 +125,10 @@ class MLSConversationDataSource(
             wrapApiRequest {
                 mlsMessageApi.sendMessage(MLSMessageApi.Message(mlsClient.joinConversation(idMapper.toCryptoModel(groupID), epoch)))
             }.onSuccess {
-                conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE, idMapper.toCryptoModel(groupID))
+                conversationDAO.updateConversationGroupState(
+                    ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
+                    idMapper.toCryptoModel(groupID)
+                )
             }
         }
     }
@@ -249,7 +252,10 @@ class MLSConversationDataSource(
                 client.createConversation(idMapper.toCryptoModel(groupID), clientKeyPackageList)?.let { bundle ->
                     sendCommitBundle(groupID, bundle).flatMap {
                         wrapStorageRequest {
-                            conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.ESTABLISHED, idMapper.toGroupIDEntity(groupID))
+                            conversationDAO.updateConversationGroupState(
+                                ConversationEntity.GroupState.ESTABLISHED,
+                                idMapper.toGroupIDEntity(groupID)
+                            )
                         }
                     }
                 } ?: run {
@@ -260,7 +266,8 @@ class MLSConversationDataSource(
 
     private suspend fun getConversationMembers(groupID: GroupID): Either<StorageFailure, List<UserId>> = wrapStorageRequest {
         val conversationID =
-            conversationDAO.getConversationByGroupID(idMapper.toGroupIDEntity(groupID)).first()?.id ?: return Either.Left(StorageFailure.DataNotFound)
+            conversationDAO.getConversationByGroupID(idMapper.toGroupIDEntity(groupID))
+                .first()?.id ?: return Either.Left(StorageFailure.DataNotFound)
         conversationDAO.getAllMembers(conversationID).first().map { idMapper.fromDaoModel(it.user) }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -8,6 +8,7 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.event.Event.Conversation.MLSWelcome
 import com.wire.kalium.logic.data.event.Event.Conversation.NewMLSMessage
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.user.UserId
@@ -32,24 +33,24 @@ import kotlinx.datetime.Clock
 import kotlin.time.Duration
 
 data class DecryptedMessageBundle(
-    val groupID: String,
+    val groupID: GroupID,
     val message: ByteArray?,
     val commitDelay: Long?
 )
 
 interface MLSConversationRepository {
 
-    suspend fun establishMLSGroup(groupID: String): Either<CoreFailure, Unit>
+    suspend fun establishMLSGroup(groupID: GroupID): Either<CoreFailure, Unit>
     suspend fun establishMLSGroupFromWelcome(welcomeEvent: MLSWelcome): Either<CoreFailure, Unit>
-    suspend fun hasEstablishedMLSGroup(groupID: String): Either<CoreFailure, Boolean>
+    suspend fun hasEstablishedMLSGroup(groupID: GroupID): Either<CoreFailure, Boolean>
     suspend fun messageFromMLSMessage(messageEvent: NewMLSMessage): Either<CoreFailure, DecryptedMessageBundle?>
-    suspend fun addMemberToMLSGroup(groupID: String, userIdList: List<UserId>): Either<CoreFailure, Unit>
-    suspend fun removeMembersFromMLSGroup(groupID: String, userIdList: List<UserId>): Either<CoreFailure, Unit>
-    suspend fun leaveGroup(groupID: String): Either<CoreFailure, Unit>
-    suspend fun requestToJoinGroup(groupID: String, epoch: ULong): Either<CoreFailure, Unit>
-    suspend fun getMLSGroupsRequiringKeyingMaterialUpdate(threshold: Duration): Either<CoreFailure, List<String>>
-    suspend fun updateKeyingMaterial(groupID: String): Either<CoreFailure, Unit>
-    suspend fun commitPendingProposals(groupID: String): Either<CoreFailure, Unit>
+    suspend fun addMemberToMLSGroup(groupID: GroupID, userIdList: List<UserId>): Either<CoreFailure, Unit>
+    suspend fun removeMembersFromMLSGroup(groupID: GroupID, userIdList: List<UserId>): Either<CoreFailure, Unit>
+    suspend fun leaveGroup(groupID: GroupID): Either<CoreFailure, Unit>
+    suspend fun requestToJoinGroup(groupID: GroupID, epoch: ULong): Either<CoreFailure, Unit>
+    suspend fun getMLSGroupsRequiringKeyingMaterialUpdate(threshold: Duration): Either<CoreFailure, List<GroupID>>
+    suspend fun updateKeyingMaterial(groupID: GroupID): Either<CoreFailure, Unit>
+    suspend fun commitPendingProposals(groupID: GroupID): Either<CoreFailure, Unit>
     suspend fun setProposalTimer(timer: ProposalTimer)
     suspend fun observeProposalTimers(): Flow<List<ProposalTimer>>
 }
@@ -75,10 +76,10 @@ class MLSConversationDataSource(
                 ).first()
             }.flatMap { conversation ->
                 if (conversation.protocolInfo is ConversationEntity.ProtocolInfo.MLS) {
-                    val groupID = (conversation.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId
+                    val groupID = GroupID((conversation.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId)
                     Either.Right(
                         mlsClient.decryptMessage(
-                            groupID,
+                            groupID.value,
                             messageEvent.content.decodeBase64Bytes()
                         ).let {
                             DecryptedMessageBundle(
@@ -109,36 +110,36 @@ class MLSConversationDataSource(
             }
         }
 
-    override suspend fun hasEstablishedMLSGroup(groupID: String): Either<CoreFailure, Boolean> {
-        return mlsClientProvider.getMLSClient().flatMap { Either.Right(it.conversationExists(groupID)) }
+    override suspend fun hasEstablishedMLSGroup(groupID: GroupID): Either<CoreFailure, Boolean> {
+        return mlsClientProvider.getMLSClient().flatMap { Either.Right(it.conversationExists(groupID.value)) }
     }
 
-    override suspend fun establishMLSGroup(groupID: String): Either<CoreFailure, Unit> =
+    override suspend fun establishMLSGroup(groupID: GroupID): Either<CoreFailure, Unit> =
         getConversationMembers(groupID).flatMap { members ->
             establishMLSGroup(groupID, members)
         }
 
-    override suspend fun requestToJoinGroup(groupID: String, epoch: ULong): Either<CoreFailure, Unit> {
+    override suspend fun requestToJoinGroup(groupID: GroupID, epoch: ULong): Either<CoreFailure, Unit> {
         kaliumLogger.d("Requesting to re-join MLS group $groupID with epoch $epoch")
         return mlsClientProvider.getMLSClient().flatMap { mlsClient ->
             wrapApiRequest {
-                mlsMessageApi.sendMessage(MLSMessageApi.Message(mlsClient.joinConversation(groupID, epoch)))
+                mlsMessageApi.sendMessage(MLSMessageApi.Message(mlsClient.joinConversation(groupID.value, epoch)))
             }.onSuccess {
-                conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE, groupID)
+                conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE, groupID.value)
             }
         }
     }
 
-    override suspend fun getMLSGroupsRequiringKeyingMaterialUpdate(threshold: Duration): Either<CoreFailure, List<String>> =
+    override suspend fun getMLSGroupsRequiringKeyingMaterialUpdate(threshold: Duration): Either<CoreFailure, List<GroupID>> =
         wrapStorageRequest {
-            conversationDAO.getConversationsByKeyingMaterialUpdate(threshold)
+            conversationDAO.getConversationsByKeyingMaterialUpdate(threshold).map { GroupID(it) }
         }
 
-    override suspend fun updateKeyingMaterial(groupID: String): Either<CoreFailure, Unit> =
+    override suspend fun updateKeyingMaterial(groupID: GroupID): Either<CoreFailure, Unit> =
         mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-            sendCommitBundle(groupID, mlsClient.updateKeyingMaterial(groupID)).flatMap {
+            sendCommitBundle(groupID.value, mlsClient.updateKeyingMaterial(groupID.value)).flatMap {
                     wrapStorageRequest {
-                        conversationDAO.updateKeyingMaterial(groupID, Clock.System.now())
+                        conversationDAO.updateKeyingMaterial(groupID.value, Clock.System.now())
                     }
                 }
             }
@@ -158,12 +159,12 @@ class MLSConversationDataSource(
         }
     }
 
-    override suspend fun commitPendingProposals(groupID: String): Either<CoreFailure, Unit> =
+    override suspend fun commitPendingProposals(groupID: GroupID): Either<CoreFailure, Unit> =
         mlsClientProvider.getMLSClient()
             .flatMap { mlsClient ->
-                sendCommitBundle(groupID, mlsClient.commitPendingProposals(groupID)).flatMap {
+                sendCommitBundle(groupID.value, mlsClient.commitPendingProposals(groupID.value)).flatMap {
                     wrapStorageRequest {
-                        conversationDAO.clearProposalTimer(groupID)
+                        conversationDAO.clearProposalTimer(groupID.value)
                     }
                 }
             }
@@ -176,7 +177,7 @@ class MLSConversationDataSource(
         return conversationDAO.getProposalTimers().map { it.map(conversationMapper::fromDaoModel) }
     }
 
-    override suspend fun addMemberToMLSGroup(groupID: String, userIdList: List<UserId>): Either<CoreFailure, Unit> =
+    override suspend fun addMemberToMLSGroup(groupID: GroupID, userIdList: List<UserId>): Either<CoreFailure, Unit> =
         // TODO: check for federated and non-federated members
         keyPackageRepository.claimKeyPackages(userIdList).flatMap { keyPackages ->
             mlsClientProvider.getMLSClient().flatMap { client ->
@@ -187,14 +188,14 @@ class MLSConversationDataSource(
                             it.keyPackage.decodeBase64Bytes()
                         )
                     }
-                client.addMember(groupID, clientKeyPackageList)?.let { bundle ->
-                    sendCommitBundle(groupID, bundle)
+                client.addMember(groupID.value, clientKeyPackageList)?.let { bundle ->
+                    sendCommitBundle(groupID.value, bundle)
                         .flatMap {
                             wrapStorageRequest {
                                 val list = userIdList.map {
                                     Member(idMapper.toDaoModel(it), Member.Role.Member)
                                 }
-                                conversationDAO.insertMembers(list, groupID)
+                                conversationDAO.insertMembers(list, groupID.value)
                             }
                         }.flatMap {
                         Either.Right(Unit)
@@ -206,7 +207,7 @@ class MLSConversationDataSource(
         }
 
     override suspend fun removeMembersFromMLSGroup(
-        groupID: String,
+        groupID: GroupID,
         userIdList: List<UserId>
     ): Either<CoreFailure, Unit> =
         wrapApiRequest { clientApi.listClientsOfUsers(userIdList.map { idMapper.toApiModel(it) }) }.map { userClientsList ->
@@ -216,12 +217,12 @@ class MLSConversationDataSource(
                 }
             }
             mlsClientProvider.getMLSClient().flatMap { client ->
-                client.removeMember(groupID, usersCryptoQualifiedClientIDs).let { bundle ->
-                    sendCommitBundle(groupID, bundle).flatMap {
+                client.removeMember(groupID.value, usersCryptoQualifiedClientIDs).let { bundle ->
+                    sendCommitBundle(groupID.value, bundle).flatMap {
                         wrapStorageRequest {
                             conversationDAO.deleteMembersByQualifiedID(
                                 userIdList.map { idMapper.toDaoModel(it) },
-                                groupID
+                                groupID.value
                             )
                         }
                     }
@@ -229,12 +230,12 @@ class MLSConversationDataSource(
             }
         }
 
-    override suspend fun leaveGroup(groupID: String) =
+    override suspend fun leaveGroup(groupID: GroupID) =
         mlsClientProvider.getMLSClient().map { mlsClient ->
-            mlsClient.wipeConversation(groupID)
+            mlsClient.wipeConversation(groupID.value)
         }
 
-    private suspend fun establishMLSGroup(groupID: String, members: List<UserId>): Either<CoreFailure, Unit> =
+    private suspend fun establishMLSGroup(groupID: GroupID, members: List<UserId>): Either<CoreFailure, Unit> =
         keyPackageRepository.claimKeyPackages(members).flatMap { keyPackages ->
             mlsClientProvider.getMLSClient().flatMap { client ->
                 val clientKeyPackageList = keyPackages
@@ -245,10 +246,10 @@ class MLSConversationDataSource(
                         )
                     }
 
-                client.createConversation(groupID, clientKeyPackageList)?.let { bundle ->
-                    sendCommitBundle(groupID, bundle).flatMap {
+                client.createConversation(groupID.value, clientKeyPackageList)?.let { bundle ->
+                    sendCommitBundle(groupID.value, bundle).flatMap {
                         wrapStorageRequest {
-                            conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.ESTABLISHED, groupID)
+                            conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.ESTABLISHED, groupID.value)
                         }
                     }
                 } ?: run {
@@ -257,9 +258,9 @@ class MLSConversationDataSource(
             }
         }
 
-    private suspend fun getConversationMembers(groupID: String): Either<StorageFailure, List<UserId>> = wrapStorageRequest {
+    private suspend fun getConversationMembers(groupID: GroupID): Either<StorageFailure, List<UserId>> = wrapStorageRequest {
         val conversationID =
-            conversationDAO.getConversationByGroupID(groupID).first()?.id ?: return Either.Left(StorageFailure.DataNotFound)
+            conversationDAO.getConversationByGroupID(groupID.value).first()?.id ?: return Either.Left(StorageFailure.DataNotFound)
         conversationDAO.getAllMembers(conversationID).first().map { idMapper.fromDaoModel(it.user) }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProposalTimer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProposalTimer.kt
@@ -1,8 +1,9 @@
 package com.wire.kalium.logic.data.conversation
 
+import com.wire.kalium.logic.data.id.GroupID
 import kotlinx.datetime.Instant
 
 data class ProposalTimer(
-    val groupID: String,
+    val groupID: GroupID,
     val timestamp: Instant
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.conversation
 
-import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.persistence.dao.ConversationEntity
 
 interface ProtocolInfoMapper {
@@ -8,12 +9,14 @@ interface ProtocolInfoMapper {
     fun toEntity(protocolInfo: Conversation.ProtocolInfo): ConversationEntity.ProtocolInfo
 }
 
-class ProtocolInfoMapperImpl : ProtocolInfoMapper {
+class ProtocolInfoMapperImpl(
+    val idMapper: IdMapper = MapperProvider.idMapper()
+) : ProtocolInfoMapper {
     override fun fromEntity(protocolInfo: ConversationEntity.ProtocolInfo) =
         when (protocolInfo) {
             is ConversationEntity.ProtocolInfo.Proteus -> Conversation.ProtocolInfo.Proteus
             is ConversationEntity.ProtocolInfo.MLS -> Conversation.ProtocolInfo.MLS(
-                GroupID(protocolInfo.groupId),
+                idMapper.fromGroupIDEntity(protocolInfo.groupId),
                 Conversation.ProtocolInfo.MLS.GroupState.valueOf(protocolInfo.groupState.name),
                 protocolInfo.epoch,
                 protocolInfo.keyingMaterialLastUpdate,
@@ -25,7 +28,7 @@ class ProtocolInfoMapperImpl : ProtocolInfoMapper {
         when (protocolInfo) {
             is Conversation.ProtocolInfo.Proteus -> ConversationEntity.ProtocolInfo.Proteus
             is Conversation.ProtocolInfo.MLS -> ConversationEntity.ProtocolInfo.MLS(
-                protocolInfo.groupId.value,
+                idMapper.toGroupIDEntity(protocolInfo.groupId),
                 ConversationEntity.GroupState.valueOf(protocolInfo.groupState.name),
                 protocolInfo.epoch,
                 protocolInfo.keyingMaterialLastUpdate,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.conversation
 
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.persistence.dao.ConversationEntity
 
 interface ProtocolInfoMapper {
@@ -12,7 +13,7 @@ class ProtocolInfoMapperImpl : ProtocolInfoMapper {
         when (protocolInfo) {
             is ConversationEntity.ProtocolInfo.Proteus -> Conversation.ProtocolInfo.Proteus
             is ConversationEntity.ProtocolInfo.MLS -> Conversation.ProtocolInfo.MLS(
-                protocolInfo.groupId,
+                GroupID(protocolInfo.groupId),
                 Conversation.ProtocolInfo.MLS.GroupState.valueOf(protocolInfo.groupState.name),
                 protocolInfo.epoch,
                 protocolInfo.keyingMaterialLastUpdate,
@@ -24,7 +25,7 @@ class ProtocolInfoMapperImpl : ProtocolInfoMapper {
         when (protocolInfo) {
             is Conversation.ProtocolInfo.Proteus -> ConversationEntity.ProtocolInfo.Proteus
             is Conversation.ProtocolInfo.MLS -> ConversationEntity.ProtocolInfo.MLS(
-                protocolInfo.groupId,
+                protocolInfo.groupId.value,
                 ConversationEntity.GroupState.valueOf(protocolInfo.groupState.name),
                 protocolInfo.epoch,
                 protocolInfo.keyingMaterialLastUpdate,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMapper.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.id
 
 import com.wire.kalium.cryptography.CryptoQualifiedID
+import com.wire.kalium.cryptography.MLSGroupId
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserId
@@ -26,6 +27,10 @@ interface IdMapper {
     fun toStringDaoModel(qualifiedID: QualifiedID): String
     fun fromDtoToDao(qualifiedID: com.wire.kalium.network.api.QualifiedID): PersistenceQualifiedId
     fun toCryptoModel(qualifiedID: QualifiedID): CryptoQualifiedID
+    fun toCryptoModel(groupID: GroupID): MLSGroupId
+    fun toGroupIDEntity(groupID: GroupID): String
+    fun fromGroupIDEntity(groupID: String): GroupID
+    fun fromCryptoModel(groupID: MLSGroupId): GroupID
     fun fromApiToDao(qualifiedID: NetworkQualifiedId): PersistenceQualifiedId
     fun toCryptoQualifiedIDId(qualifiedID: QualifiedID): CryptoQualifiedID
     fun fromProtoModel(qualifiedConversationID: QualifiedConversationId): ConversationId
@@ -50,10 +55,14 @@ internal class IdMapperImpl : IdMapper {
     override fun fromDaoModel(persistenceId: PersistenceQualifiedId) =
         QualifiedID(value = persistenceId.value, domain = persistenceId.domain)
 
+    override fun fromGroupIDEntity(groupID: String): GroupID = GroupID(groupID)
+
     override fun toApiModel(qualifiedID: QualifiedID) = NetworkQualifiedId(value = qualifiedID.value, domain = qualifiedID.domain)
 
     override fun toDaoModel(qualifiedID: QualifiedID): PersistenceQualifiedId =
         PersistenceQualifiedId(value = qualifiedID.value, domain = qualifiedID.domain)
+
+    override fun toGroupIDEntity(groupID: GroupID): String = groupID.value
 
     override fun toStringDaoModel(qualifiedID: QualifiedID): String = "${qualifiedID.value}@${qualifiedID.domain}"
 
@@ -62,6 +71,10 @@ internal class IdMapperImpl : IdMapper {
 
     override fun toCryptoModel(qualifiedID: QualifiedID): CryptoQualifiedID =
         CryptoQualifiedID(value = qualifiedID.value, domain = qualifiedID.domain)
+
+    override fun toCryptoModel(groupID: GroupID): MLSGroupId = groupID.value
+
+    override fun fromCryptoModel(groupID: MLSGroupId): GroupID = GroupID(groupID)
 
     override fun fromApiToDao(qualifiedID: NetworkQualifiedId) =
         PersistenceQualifiedId(value = qualifiedID.value, domain = qualifiedID.domain)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.data.id
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
 
 @Serializable
 data class QualifiedID(
@@ -24,3 +25,6 @@ const val VALUE_DOMAIN_SEPARATOR = '@'
 val FEDERATION_REGEX = """[^@.]+@[^@.]+\.[^@]+""".toRegex()
 
 typealias ConversationId = QualifiedID
+
+@JvmInline
+value class GroupID(val value: String)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.ProposalTimer
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.functional.distinct
@@ -38,7 +39,7 @@ interface PendingProposalScheduler {
      * @param groupID
      * @param date desired time for when proposals should be committed
      */
-    suspend fun scheduleCommit(groupID: String, date: Instant)
+    suspend fun scheduleCommit(groupID: GroupID, date: Instant)
 
 }
 
@@ -98,7 +99,7 @@ internal class PendingProposalSchedulerImpl(
         }
     }
 
-    override suspend fun scheduleCommit(groupID: String, date: Instant) {
+    override suspend fun scheduleCommit(groupID: GroupID, date: Instant) {
         kaliumLogger.d("Scheduling to commit pending proposals in $groupID at $date")
         mlsConversationRepository.value.setProposalTimer(ProposalTimer(groupID, date))
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -17,6 +17,7 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.Message
@@ -357,7 +358,7 @@ internal class ConversationEventReceiverImpl(
             }
     }
 
-    private suspend fun handlePendingProposal(timestamp: Instant, groupId: String, commitDelay: Long) {
+    private suspend fun handlePendingProposal(timestamp: Instant, groupId: GroupID, commitDelay: Long) {
         kaliumLogger.withFeatureId(EVENT_RECEIVER).d("Received MLS proposal, scheduling commit in $commitDelay seconds")
         pendingProposalScheduler.scheduleCommit(
             groupId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -64,7 +64,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.cryptography.CommitBundle
 import com.wire.kalium.cryptography.MLSClient
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
@@ -63,7 +64,7 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::createConversation)
-            .with(eq(Arrangement.GROUP_ID), anything())
+            .with(eq(Arrangement.RAW_GROUP_ID), anything())
             .wasInvoked(once)
 
         verify(arrangement.mlsMessageApi).coroutine { sendWelcomeMessage(MLSMessageApi.WelcomeMessage(Arrangement.WELCOME)) }
@@ -74,7 +75,7 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::commitAccepted)
-            .with(eq(Arrangement.GROUP_ID))
+            .with(eq(Arrangement.RAW_GROUP_ID))
             .wasInvoked(once)
     }
 
@@ -96,7 +97,7 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.conversationDAO)
             .suspendFunction(arrangement.conversationDAO::updateConversationGroupState)
-            .with(eq(ConversationEntity.GroupState.ESTABLISHED), eq(Arrangement.GROUP_ID))
+            .with(eq(ConversationEntity.GroupState.ESTABLISHED), eq(Arrangement.RAW_GROUP_ID))
             .wasInvoked(once)
     }
 
@@ -133,7 +134,7 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::addMember)
-            .with(eq(Arrangement.GROUP_ID), anything())
+            .with(eq(Arrangement.RAW_GROUP_ID), anything())
             .wasInvoked(once)
 
         verify(arrangement.mlsMessageApi).coroutine { sendWelcomeMessage(MLSMessageApi.WelcomeMessage(Arrangement.WELCOME)) }
@@ -144,7 +145,7 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::commitAccepted)
-            .with(eq(Arrangement.GROUP_ID))
+            .with(eq(Arrangement.RAW_GROUP_ID))
             .wasInvoked(once)
 
         verify(arrangement.conversationDAO)
@@ -167,12 +168,12 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::joinConversation)
-            .with(eq(Arrangement.GROUP_ID), eq(Arrangement.EPOCH))
+            .with(eq(Arrangement.RAW_GROUP_ID), eq(Arrangement.EPOCH))
             .wasInvoked(once)
 
         verify(arrangement.conversationDAO)
             .suspendFunction(arrangement.conversationDAO::updateConversationGroupState)
-            .with(eq(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE), eq(Arrangement.GROUP_ID))
+            .with(eq(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE), eq(Arrangement.RAW_GROUP_ID))
             .wasInvoked(once)
     }
 
@@ -190,7 +191,7 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::commitPendingProposals)
-            .with(eq(Arrangement.GROUP_ID))
+            .with(eq(Arrangement.RAW_GROUP_ID))
             .wasInvoked(once)
     }
 
@@ -214,7 +215,7 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::commitAccepted)
-            .with(eq(Arrangement.GROUP_ID))
+            .with(eq(Arrangement.RAW_GROUP_ID))
             .wasInvoked(once)
     }
 
@@ -232,7 +233,7 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.conversationDAO)
             .suspendFunction(arrangement.conversationDAO::clearProposalTimer)
-            .with(eq(Arrangement.GROUP_ID))
+            .with(eq(Arrangement.RAW_GROUP_ID))
             .wasInvoked(once)
     }
 
@@ -272,12 +273,12 @@ class MLSConversationRepositoryTest {
 
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::removeMember)
-            .with(eq(Arrangement.GROUP_ID), anything())
+            .with(eq(Arrangement.RAW_GROUP_ID), anything())
             .wasInvoked(once)
 
         verify(arrangement.conversationDAO)
             .suspendFunction(arrangement.conversationDAO::deleteMembersByQualifiedID, fun2<List<QualifiedIDEntity>, String>())
-            .with(eq(users.map { arrangement.idMapper.toDaoModel(it) }), eq(Arrangement.GROUP_ID))
+            .with(eq(users.map { arrangement.idMapper.toDaoModel(it) }), eq(Arrangement.RAW_GROUP_ID))
             .wasInvoked(once)
 
     }
@@ -377,7 +378,7 @@ class MLSConversationRepositoryTest {
             given(mlsClient)
                 .function(mlsClient::processWelcomeMessage)
                 .whenInvokedWith(anything())
-                .thenReturn(GROUP_ID)
+                .thenReturn(RAW_GROUP_ID)
         }
 
         fun withCommitAcceptedSuccessful() = apply {
@@ -459,7 +460,8 @@ class MLSConversationRepositoryTest {
 
         internal companion object {
             const val EPOCH = 5UL
-            const val GROUP_ID = "groupId"
+            const val RAW_GROUP_ID = "groupId"
+            val GROUP_ID = GroupID(RAW_GROUP_ID)
             val INVALID_REQUEST_ERROR = KaliumException.InvalidRequestError(ErrorResponse(409, "", ""))
             val MEMBERS = listOf(Member(TestUser.ENTITY_ID, Member.Role.Member))
             val KEY_PACKAGE = KeyPackageDTO(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.conversation
 
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.persistence.dao.ConversationEntity
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -40,7 +41,7 @@ class ProtocolInfoMapperTest {
 
     companion object {
         val CONVERSATION_MLS_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
-            "GROUP_ID",
+            GroupID("GROUP_ID"),
             Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED,
             5UL,
             Instant.parse("2021-03-30T15:36:00.000Z"),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -6,7 +6,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.NetworkQualifiedId
 import com.wire.kalium.logic.data.id.PersistenceQualifiedId
-import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.message.MLSMessageApi

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.NetworkQualifiedId
 import com.wire.kalium.logic.data.id.PersistenceQualifiedId
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.message.MLSMessageApi

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -102,7 +103,7 @@ class AddMemberToConversationUseCaseTest {
         fun arrange() = this to addMemberUseCase
 
         companion object {
-            const val mlsGroupId = "mlsGroupId"
+            val mlsGroupId = GroupID("mlsGroupId")
             val proteusProtocolInfo = ProtocolInfo.Proteus
             val mlsProtocolInfo = ProtocolInfo.MLS(
                 mlsGroupId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldFail
@@ -150,7 +151,7 @@ class JoinExistingMLSConversationsUseCaseTest {
 
             val MLS_CONVERSATION1 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
-                    "group1",
+                    GroupID("group1"),
                     Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
                     epoch = 1UL,
                     keyingMaterialLastUpdate = Clock.System.now(),
@@ -160,7 +161,7 @@ class JoinExistingMLSConversationsUseCaseTest {
 
             val MLS_CONVERSATION2 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
-                    "group1",
+                    GroupID("group1"),
                     Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
                     epoch = 1UL,
                     keyingMaterialLastUpdate = Clock.System.now(),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProvider
+import com.wire.kalium.logic.data.id.GroupID
 
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -89,7 +90,7 @@ class UpdateKeyingMaterialsUseCaseTests {
             updateKeyingMaterialThresholdProvider
         )
 
-        fun withOutdatedGroupsReturns(either: Either<CoreFailure, List<String>>) = apply {
+        fun withOutdatedGroupsReturns(either: Either<CoreFailure, List<GroupID>>) = apply {
             given(mlsConversationRepository).suspendFunction(mlsConversationRepository::getMLSGroupsRequiringKeyingMaterialUpdate)
                 .whenInvokedWith(anything())
                 .thenReturn(either)
@@ -108,7 +109,7 @@ class UpdateKeyingMaterialsUseCaseTests {
         fun arrange() = this to updateKeyingMaterialsUseCase
 
         companion object {
-            val OUTDATED_KEYING_MATERIALS_GROUPS = listOf("group1", "group2")
+            val OUTDATED_KEYING_MATERIALS_GROUPS = listOf(GroupID("group1"), GroupID("group2"))
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.conversation.ConversationRepositoryTest
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
@@ -59,7 +60,7 @@ object TestConversation {
     )
 
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
-        ID.copy(value = if (protocolInfo is ProtocolInfo.MLS) protocolInfo.groupId else "GROUP ID"),
+        ID,
         "GROUP Name",
         Conversation.Type.GROUP,
         TestTeam.TEAM_ID,
@@ -153,7 +154,7 @@ object TestConversation {
             time = "2022-03-30T15:36:00.000Z"
         )
 
-    const val GROUP_ID = "mlsGroupId"
+    val GROUP_ID = GroupID("mlsGroupId")
     val ENTITY_ID = QualifiedIDEntity("valueConversation", "domainConversation")
     val ENTITY = ConversationEntity(
         ENTITY_ID,
@@ -191,7 +192,7 @@ object TestConversation {
         Conversation.Type.ONE_ON_ONE,
         TestTeam.TEAM_ID,
         ProtocolInfo.MLS(
-            "group_id",
+            GroupID("group_id"),
             ProtocolInfo.MLS.GroupState.PENDING_JOIN,
             0UL,
             Instant.parse("2021-03-30T15:36:00.000Z"),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Represent group IDs with explicit a GroupID type instead of a String in the logic module. 

### Notes

Having this type would have prevented this bug: https://github.com/wireapp/kalium/pull/844

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
