### PR TITLE
feat: refactor, naming security classification type

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -73,8 +73,8 @@ import com.wire.kalium.logic.feature.connection.ConnectionScope
 import com.wire.kalium.logic.feature.connection.SyncConnectionsUseCase
 import com.wire.kalium.logic.feature.connection.SyncConnectionsUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.ConversationScope
-import com.wire.kalium.logic.feature.conversation.GetConversationClassifiedTypeUseCase
-import com.wire.kalium.logic.feature.conversation.GetConversationClassifiedTypeUseCaseImpl
+import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCase
+import com.wire.kalium.logic.feature.conversation.GetSecurityClassificationTypeUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.JoinExistingMLSConversationsUseCase
 import com.wire.kalium.logic.feature.conversation.SyncConversationsUseCase
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
@@ -604,8 +604,8 @@ abstract class UserSessionScopeCommon(
 
     val connection: ConnectionScope get() = ConnectionScope(connectionRepository, conversationRepository)
 
-    val getConversationClassifiedType: GetConversationClassifiedTypeUseCase
-        get() = GetConversationClassifiedTypeUseCaseImpl(userId, conversationRepository, userConfigRepository)
+    val getSecurityClassificationType: GetSecurityClassificationTypeUseCase
+        get() = GetSecurityClassificationTypeUseCaseImpl(userId, conversationRepository, userConfigRepository)
 
     val kaliumFileSystem: KaliumFileSystem by lazy {
         // Create the cache and asset storage directories

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetSecurityClassificationTypeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetSecurityClassificationTypeUseCase.kt
@@ -11,26 +11,26 @@ import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.firstOrNull
 
-fun interface GetConversationClassifiedTypeUseCase {
+fun interface GetSecurityClassificationTypeUseCase {
     /**
      * Operation that lets compute if a given conversation [conversationId] is classified or not
      *
      * @param conversationId to classify
-     * @return ClassifiedTypeResult with classification type
+     * @return SecurityClassificationTypeResult with classification type
      */
-    suspend operator fun invoke(conversationId: ConversationId): ClassifiedTypeResult
+    suspend operator fun invoke(conversationId: ConversationId): SecurityClassificationTypeResult
 }
 
-internal class GetConversationClassifiedTypeUseCaseImpl(
+internal class GetSecurityClassificationTypeUseCaseImpl(
     private val selfUserId: UserId,
     private val conversationRepository: ConversationRepository,
     private val userConfigRepository: UserConfigRepository
-) : GetConversationClassifiedTypeUseCase {
+) : GetSecurityClassificationTypeUseCase {
 
-    override suspend fun invoke(conversationId: ConversationId): ClassifiedTypeResult {
+    override suspend fun invoke(conversationId: ConversationId): SecurityClassificationTypeResult {
         val classifiedDomainsStatus = userConfigRepository.getClassifiedDomainsStatus().onlyRight().firstOrNull()
         if (classifiedDomainsStatus == null || !classifiedDomainsStatus.isClassifiedDomainsEnabled) {
-            return ClassifiedTypeResult.Success(ClassifiedType.NONE)
+            return SecurityClassificationTypeResult.Success(SecurityClassificationType.NONE)
         }
 
         val selfUserDomain = selfUserId.domain
@@ -41,21 +41,21 @@ internal class GetConversationClassifiedTypeUseCaseImpl(
             }
         }.fold({
             kaliumLogger.e("Unexpected error while calculating conversation classified type $it")
-            ClassifiedTypeResult.Failure(it)
+            SecurityClassificationTypeResult.Failure(it)
         }, { isClassified ->
             when (isClassified) {
-                true -> ClassifiedTypeResult.Success(ClassifiedType.CLASSIFIED)
-                false -> ClassifiedTypeResult.Success(ClassifiedType.NOT_CLASSIFIED)
+                true -> SecurityClassificationTypeResult.Success(SecurityClassificationType.CLASSIFIED)
+                false -> SecurityClassificationTypeResult.Success(SecurityClassificationType.NOT_CLASSIFIED)
             }
         })
     }
 }
 
-sealed interface ClassifiedTypeResult {
-    data class Success(val classifiedType: ClassifiedType) : ClassifiedTypeResult
-    data class Failure(val cause: CoreFailure) : ClassifiedTypeResult
+sealed interface SecurityClassificationTypeResult {
+    data class Success(val classificationType: SecurityClassificationType) : SecurityClassificationTypeResult
+    data class Failure(val cause: CoreFailure) : SecurityClassificationTypeResult
 }
 
-enum class ClassifiedType {
+enum class SecurityClassificationType {
     CLASSIFIED, NOT_CLASSIFIED, NONE
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetSecurityClassificationTypeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetSecurityClassificationTypeUseCase.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.firstOrNull
 
 fun interface GetSecurityClassificationTypeUseCase {
     /**
-     * Operation that lets compute if a given conversation [conversationId] is classified or not
+     * Operation that lets compute if a given conversation [conversationId] in terms of compromising security or not.
      *
      * @param conversationId to classify
      * @return SecurityClassificationTypeResult with classification type

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetSecurityClassificationTypeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetSecurityClassificationTypeUseCaseTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class GetConversationClassifiedTypeUseCaseTest {
+class GetSecurityClassificationTypeUseCaseTest {
 
     @Test
     fun givenAConversationId_WhenNoClassifiedFeatureFlagEnabled_ThenClassificationIsNone() = runTest {
@@ -30,10 +30,10 @@ class GetConversationClassifiedTypeUseCaseTest {
             .withGettingClassifiedDomainsDisabled()
             .arrange()
 
-        val result: ClassifiedTypeResult = getConversationClassifiedType(TestConversation.ID)
+        val result: SecurityClassificationTypeResult = getConversationClassifiedType(TestConversation.ID)
 
-        assertIs<ClassifiedTypeResult.Success>(result)
-        assertEquals(ClassifiedType.NONE, result.classifiedType)
+        assertIs<SecurityClassificationTypeResult.Success>(result)
+        assertEquals(SecurityClassificationType.NONE, result.classificationType)
     }
 
     @Test
@@ -44,10 +44,10 @@ class GetConversationClassifiedTypeUseCaseTest {
                 .withParticipantsResponseDomains(listOf("wire.com", "bella.com"))
                 .arrange()
 
-            val result: ClassifiedTypeResult = getConversationClassifiedType(TestConversation.ID)
+            val result: SecurityClassificationTypeResult = getConversationClassifiedType(TestConversation.ID)
 
-            assertIs<ClassifiedTypeResult.Success>(result)
-            assertEquals(ClassifiedType.CLASSIFIED, result.classifiedType)
+            assertIs<SecurityClassificationTypeResult.Success>(result)
+            assertEquals(SecurityClassificationType.CLASSIFIED, result.classificationType)
         }
 
     @Test
@@ -58,10 +58,10 @@ class GetConversationClassifiedTypeUseCaseTest {
                 .withParticipantsResponseDomains(listOf("anta.com", "bella.com"))
                 .arrange()
 
-            val result: ClassifiedTypeResult = getConversationClassifiedType(TestConversation.ID)
+            val result: SecurityClassificationTypeResult = getConversationClassifiedType(TestConversation.ID)
 
-            assertIs<ClassifiedTypeResult.Success>(result)
-            assertEquals(ClassifiedType.NOT_CLASSIFIED, result.classifiedType)
+            assertIs<SecurityClassificationTypeResult.Success>(result)
+            assertEquals(SecurityClassificationType.NOT_CLASSIFIED, result.classificationType)
         }
 
     @Test
@@ -72,9 +72,9 @@ class GetConversationClassifiedTypeUseCaseTest {
                 .withParticipantsResponseFails()
                 .arrange()
 
-            val result: ClassifiedTypeResult = getConversationClassifiedType(TestConversation.ID)
+            val result: SecurityClassificationTypeResult = getConversationClassifiedType(TestConversation.ID)
 
-            assertIs<ClassifiedTypeResult.Failure>(result)
+            assertIs<SecurityClassificationTypeResult.Failure>(result)
         }
 
     private class Arrangement {
@@ -84,7 +84,7 @@ class GetConversationClassifiedTypeUseCaseTest {
         @Mock
         val userConfigRepository = mock(classOf<UserConfigRepository>())
 
-        private val getConversationClassifiedType = GetConversationClassifiedTypeUseCaseImpl(
+        private val getSecurityClassificationType = GetSecurityClassificationTypeUseCaseImpl(
             selfUserId, conversationRepository, userConfigRepository
         )
 
@@ -118,7 +118,7 @@ class GetConversationClassifiedTypeUseCaseTest {
 
         private fun stubUserIds(domains: List<String>) = domains.map { domain -> UserId(uuid4().toString(), domain) }
 
-        fun arrange() = this to getConversationClassifiedType
+        fun arrange() = this to getSecurityClassificationType
 
         companion object {
             val selfUserId = UserId("someValue", "wire.com")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Rename UseCase and type to indicate better the purpose of the security classification level of a conversation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
