### PR TITLE
feat: unread mentions count [AR-2278]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -123,7 +123,8 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         val connectionState: ConnectionState,
         val legalHoldStatus: LegalHoldStatus,
         val userType: UserType,
-        val unreadMessagesCount: Long,
+        val unreadMessagesCount: Long = 0L,
+        val unreadMentionsCount: Long = 0L,
         val lastUnreadMessage: Message?
     ) : ConversationDetails(conversation)
 
@@ -131,7 +132,8 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         override val conversation: Conversation,
         val legalHoldStatus: LegalHoldStatus,
         val hasOngoingCall: Boolean = false,
-        val unreadMessagesCount: Long,
+        val unreadMessagesCount: Long = 0L,
+        val unreadMentionsCount: Long = 0L,
         val lastUnreadMessage: Message?
     ) : ConversationDetails(conversation)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -36,6 +36,7 @@ interface ConversationMapper {
     fun toApiModel(accessRole: Conversation.AccessRole): ConversationAccessRoleDTO
     fun toApiModel(protocol: ConversationOptions.Protocol): ConvProtocol
     fun toApiModel(name: String?, members: List<UserId>, teamId: String?, options: ConversationOptions): CreateConversationRequest
+    @Suppress("LongParameterList")
     fun toConversationDetailsOneToOne(
         conversation: Conversation,
         otherUser: OtherUser,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -41,6 +41,7 @@ interface ConversationMapper {
         otherUser: OtherUser,
         selfUser: SelfUser,
         unreadMessageCount: Long,
+        unreadMentionsCount: Long,
         lastUnreadMessage: Message?
     ): ConversationDetails.OneOne
 }
@@ -152,6 +153,7 @@ internal class ConversationMapperImpl(
         otherUser: OtherUser,
         selfUser: SelfUser,
         unreadMessageCount: Long,
+        unreadMentionsCount: Long,
         lastUnreadMessage: Message?
     ): ConversationDetails.OneOne {
         return ConversationDetails.OneOne(
@@ -162,6 +164,7 @@ internal class ConversationMapperImpl(
             legalHoldStatus = LegalHoldStatus.DISABLED,
             userType = otherUser.userType,
             unreadMessagesCount = unreadMessageCount,
+            unreadMentionsCount = unreadMentionsCount,
             lastUnreadMessage = lastUnreadMessage
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -11,6 +11,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageMapper
+import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.di.MapperProvider
@@ -20,6 +21,7 @@ import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.isLeft
 import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.functional.mapRight
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -40,6 +42,7 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -277,64 +280,88 @@ class ConversationDataSource(
         when (conversation.type) {
             Conversation.Type.SELF -> flowOf(Either.Right(ConversationDetails.Self(conversation)))
             // TODO(user-metadata): get actual legal hold status
-            Conversation.Type.GROUP -> flowOf(
-                Either.Right(
-                    ConversationDetails.Group(
-                        conversation = conversation,
-                        legalHoldStatus = LegalHoldStatus.DISABLED,
-                        unreadMessagesCount = getUnreadMessageCount(conversation),
-                        lastUnreadMessage = getLastUnreadMessage(conversation),
-                    )
-                )
-            )
-
+            Conversation.Type.GROUP -> getGroupConversationDetailsFlow(conversation)
             Conversation.Type.CONNECTION_PENDING, Conversation.Type.ONE_ON_ONE -> getOneToOneConversationDetailsFlow(conversation)
         }
 
-    private suspend fun getLastUnreadMessage(conversation: Conversation): Message? {
-        return messageDAO.getLastUnreadMessage(
-            idMapper.toDaoModel(
-                conversation.id
-            )
-        )?.let {
-            messageMapper.fromEntityToMessage(it)
-        }
+    private suspend fun observeLastUnreadMessage(conversation: Conversation): Flow<Message?> =
+        messageDAO.observeLastUnreadMessage(idMapper.toDaoModel(conversation.id))
+            .map { it?.let { messageMapper.fromEntityToMessage(it) } }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun getGroupConversationDetailsFlow(conversation: Conversation): Flow<Either<StorageFailure, ConversationDetails>> {
+        return userRepository.observeSelfUser()
+            .flatMapLatest { selfUser ->
+                combine(
+                    observeUnreadMessageCount(conversation),
+                    observeLastUnreadMessage(conversation),
+                    observeUnreadMentionsCount(conversation, selfUser.id)
+                ) { unreadMessageCount: Long, lastUnreadMessage: Message?, unreadMentionsCount: Long ->
+                    Either.Right(
+                        ConversationDetails.Group(
+                            conversation = conversation,
+                            legalHoldStatus = LegalHoldStatus.DISABLED,
+                            unreadMessagesCount = unreadMessageCount,
+                            unreadMentionsCount = unreadMentionsCount,
+                            lastUnreadMessage = lastUnreadMessage,
+                        )
+                    )
+                }
+            }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun getOneToOneConversationDetailsFlow(conversation: Conversation): Flow<Either<StorageFailure, ConversationDetails>> {
-        val selfUser = userRepository.observeSelfUser().first()
-        return getConversationMembers(conversation.id)
-            .map { members -> members.firstOrNull { itemId -> itemId != selfUser.id } }
-            .fold(
-                { storageFailure ->
-                    logMemberDetailsError(conversation, storageFailure)
-                    flowOf(Either.Left(storageFailure))
-                },
-                { otherUserId ->
-                    flowOf(otherUserId)
-                        .flatMapLatest { if (it != null) userRepository.getKnownUser(it) else flowOf(it) }
-                        .wrapStorageRequest()
-                        .map {
-                            it.map { otherUser ->
+        return observeConversationMembers(conversation.id)
+            .combine(userRepository.observeSelfUser())
+            { members, selfUser -> selfUser to members.firstOrNull { item -> item.id != selfUser.id } }
+            .flatMapLatest { (selfUser, otherMember) ->
+                val otherUserFlow = if (otherMember != null) userRepository.getKnownUser(otherMember.id) else flowOf(otherMember)
+                otherUserFlow
+                    .wrapStorageRequest()
+                    .mapRight { selfUser to it }
+            }
+            .flatMapLatest {
+                it.fold(
+                    { storageFailure ->
+                        logMemberDetailsError(conversation, storageFailure)
+                        flowOf(Either.Left(storageFailure))
+                    },
+                    { (selfUser, otherUser) ->
+                        combine(
+                            observeUnreadMessageCount(conversation),
+                            observeLastUnreadMessage(conversation),
+                            observeUnreadMentionsCount(conversation, selfUser.id)
+                        ) { unreadMessageCount: Long, lastUnreadMessage: Message?, unreadMentionsCount: Long ->
+                            Either.Right(
                                 conversationMapper.toConversationDetailsOneToOne(
                                     conversation = conversation,
                                     otherUser = otherUser,
                                     selfUser = selfUser,
-                                    unreadMessageCount = getUnreadMessageCount(conversation),
-                                    lastUnreadMessage = getLastUnreadMessage(conversation)
+                                    unreadMessageCount = unreadMessageCount,
+                                    unreadMentionsCount = unreadMentionsCount,
+                                    lastUnreadMessage = lastUnreadMessage
                                 )
-                            }
+                            )
                         }
-                }
-            )
+                    }
+                )
+            }
     }
 
-    private suspend fun getUnreadMessageCount(conversation: Conversation): Long {
+    private suspend fun observeUnreadMessageCount(conversation: Conversation): Flow<Long> {
         return if (conversation.supportsUnreadMessageCount && hasNewMessages(conversation)) {
-            messageDAO.getUnreadMessageCount(idMapper.toDaoModel(conversation.id))
+            messageDAO.observeUnreadMessageCount(idMapper.toDaoModel(conversation.id))
         } else {
-            0
+            flowOf(0L)
+        }
+    }
+
+    private suspend fun observeUnreadMentionsCount(conversation: Conversation, userId: UserId): Flow<Long> {
+        return if (conversation.supportsUnreadMessageCount && hasNewMessages(conversation)) {
+            messageDAO.observeUnreadMentionsCount(idMapper.toDaoModel(conversation.id), idMapper.toDaoModel(userId))
+        } else {
+            flowOf(0L)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -43,6 +43,7 @@ import com.wire.kalium.persistence.dao.message.MessageDAO
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -306,7 +307,7 @@ class ConversationDataSource(
                             lastUnreadMessage = lastUnreadMessage,
                         )
                     )
-                }
+                }.distinctUntilChanged()
             }
     }
 
@@ -344,14 +345,14 @@ class ConversationDataSource(
                                     lastUnreadMessage = lastUnreadMessage
                                 )
                             )
-                        }
+                        }.distinctUntilChanged()
                     }
                 )
             }
     }
 
     private suspend fun observeUnreadMessageCount(conversation: Conversation): Flow<Long> {
-        return if (conversation.supportsUnreadMessageCount && hasNewMessages(conversation)) {
+        return if (conversation.supportsUnreadMessageCount) {
             messageDAO.observeUnreadMessageCount(idMapper.toDaoModel(conversation.id))
         } else {
             flowOf(0L)
@@ -359,7 +360,7 @@ class ConversationDataSource(
     }
 
     private suspend fun observeUnreadMentionsCount(conversation: Conversation, userId: UserId): Flow<Long> {
-        return if (conversation.supportsUnreadMessageCount && hasNewMessages(conversation)) {
+        return if (conversation.supportsUnreadMessageCount) {
             messageDAO.observeUnreadMentionsCount(idMapper.toDaoModel(conversation.id), idMapper.toDaoModel(userId))
         } else {
             flowOf(0L)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -288,6 +288,7 @@ class ConversationDataSource(
     private suspend fun observeLastUnreadMessage(conversation: Conversation): Flow<Message?> =
         messageDAO.observeLastUnreadMessage(idMapper.toDaoModel(conversation.id))
             .map { it?.let { messageMapper.fromEntityToMessage(it) } }
+            .distinctUntilChanged()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun getGroupConversationDetailsFlow(conversation: Conversation): Flow<Either<StorageFailure, ConversationDetails>> {
@@ -307,8 +308,8 @@ class ConversationDataSource(
                             lastUnreadMessage = lastUnreadMessage,
                         )
                     )
-                }.distinctUntilChanged()
-            }
+                }
+            }.distinctUntilChanged()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -345,10 +346,10 @@ class ConversationDataSource(
                                     lastUnreadMessage = lastUnreadMessage
                                 )
                             )
-                        }.distinctUntilChanged()
+                        }
                     }
                 )
-            }
+            }.distinctUntilChanged()
     }
 
     private suspend fun observeUnreadMessageCount(conversation: Conversation): Flow<Long> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -11,7 +11,6 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageMapper
-import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.di.MapperProvider
@@ -313,8 +312,9 @@ class ConversationDataSource(
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun getOneToOneConversationDetailsFlow(conversation: Conversation): Flow<Either<StorageFailure, ConversationDetails>> {
         return observeConversationMembers(conversation.id)
-            .combine(userRepository.observeSelfUser())
-            { members, selfUser -> selfUser to members.firstOrNull { item -> item.id != selfUser.id } }
+            .combine(userRepository.observeSelfUser()) { members, selfUser ->
+                selfUser to members.firstOrNull { item -> item.id != selfUser.id }
+            }
             .flatMapLatest { (selfUser, otherMember) ->
                 val otherUserFlow = if (otherMember != null) userRepository.getKnownUser(otherMember.id) else flowOf(otherMember)
                 otherUserFlow

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMapper.kt
@@ -10,6 +10,7 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.model.SsoIdEntity
 import com.wire.kalium.persistence.dao.client.Client
 import com.wire.kalium.protobuf.messages.QualifiedConversationId
+import com.wire.kalium.protobuf.messages.QualifiedUserId
 import com.wire.kalium.network.api.UserId as NetworkUserId
 
 internal typealias NetworkQualifiedId = com.wire.kalium.network.api.QualifiedID
@@ -30,6 +31,8 @@ interface IdMapper {
     fun toCryptoQualifiedIDId(qualifiedID: QualifiedID): CryptoQualifiedID
     fun fromProtoModel(qualifiedConversationID: QualifiedConversationId): ConversationId
     fun toProtoModel(conversationId: ConversationId): QualifiedConversationId
+    fun fromProtoUserId(qualifiedUserId: QualifiedUserId): QualifiedID
+    fun toProtoUserId(userId: UserId): QualifiedUserId
     fun toQualifiedAssetId(value: String, domain: String = ""): QualifiedID
     fun toQualifiedAssetIdEntity(value: String, domain: String = ""): PersistenceQualifiedId
     fun toSsoId(userSsoIdDTO: UserSsoIdDTO?): SsoId?
@@ -74,6 +77,11 @@ internal class IdMapperImpl : IdMapper {
 
     override fun toProtoModel(conversationId: ConversationId): QualifiedConversationId =
         QualifiedConversationId(conversationId.value, conversationId.domain)
+    override fun fromProtoUserId(qualifiedUserId: QualifiedUserId): UserId =
+        UserId(qualifiedUserId.id, qualifiedUserId.domain)
+
+    override fun toProtoUserId(userId: UserId): QualifiedUserId =
+        QualifiedUserId(userId.value, userId.domain)
 
     override fun toQualifiedAssetId(value: String, domain: String) = QualifiedID(value, domain)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -13,11 +13,18 @@ sealed class MessageContent {
     sealed class Signaling : FromProto()
 
     // client message content types
-    data class Text(val value: String) : Regular()
+    data class Text(
+        val value: String,
+        val mentions: List<MessageMention> = listOf()
+    ) : Regular()
     data class Calling(val value: String) : Regular()
     data class Asset(val value: AssetContent) : Regular()
     data class DeleteMessage(val messageId: String) : Regular()
-    data class TextEdited(val editMessageId: String, val newContent: String) : Regular()
+    data class TextEdited(
+        val editMessageId: String,
+        val newContent: String,
+        val newMentions: List<MessageMention> = listOf()
+        ) : Regular()
     data class RestrictedAsset(
         val mimeType: String,
         val sizeInBytes: Long,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -17,6 +17,7 @@ sealed class MessageContent {
         val value: String,
         val mentions: List<MessageMention> = listOf()
     ) : Regular()
+
     data class Calling(val value: String) : Regular()
     data class Asset(val value: AssetContent) : Regular()
     data class DeleteMessage(val messageId: String) : Regular()
@@ -24,7 +25,8 @@ sealed class MessageContent {
         val editMessageId: String,
         val newContent: String,
         val newMentions: List<MessageMention> = listOf()
-        ) : Regular()
+    ) : Regular()
+
     data class RestrictedAsset(
         val mimeType: String,
         val sizeInBytes: Long,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -23,7 +23,8 @@ interface MessageMapper {
 class MessageMapperImpl(
     private val idMapper: IdMapper,
     private val memberMapper: MemberMapper,
-    private val assetMapper: AssetMapper = MapperProvider.assetMapper()
+    private val assetMapper: AssetMapper = MapperProvider.assetMapper(),
+    private val messageMentionMapper: MessageMentionMapper = MapperProvider.messageMentionMapper()
 ) : MessageMapper {
 
     override fun fromMessageToEntity(message: Message): MessageEntity {
@@ -121,7 +122,10 @@ class MessageMapperImpl(
 
     @Suppress("ComplexMethod")
     private fun MessageContent.Regular.toMessageEntityContent(): MessageEntityContent.Regular = when (this) {
-        is MessageContent.Text -> MessageEntityContent.Text(messageBody = this.value)
+        is MessageContent.Text -> MessageEntityContent.Text(
+            messageBody = this.value,
+            mentions = this.mentions.map { messageMentionMapper.fromModelToDao(it) }
+        )
         is MessageContent.Asset -> with(this.value) {
             val assetWidth = when (metadata) {
                 is Image -> metadata.width
@@ -191,7 +195,10 @@ class MessageMapperImpl(
     }
 
     private fun MessageEntityContent.Regular.toMessageContent(hidden: Boolean): MessageContent.Regular = when (this) {
-        is MessageEntityContent.Text -> MessageContent.Text(this.messageBody)
+        is MessageEntityContent.Text -> MessageContent.Text(
+            value = this.messageBody,
+            mentions = this.mentions.map { messageMentionMapper.fromDaoToModel(it) }
+        )
         is MessageEntityContent.Asset -> MessageContent.Asset(
             MapperProvider.assetMapper().fromAssetEntityToAssetContent(this)
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMention.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMention.kt
@@ -18,9 +18,7 @@ interface MessageMentionMapper {
     fun fromModelToProto(mention: MessageMention): Mention
 }
 
-class MessageMentionMapperImpl(
-    private val idMapper: IdMapper
-    ) : MessageMentionMapper {
+class MessageMentionMapperImpl(private val idMapper: IdMapper) : MessageMentionMapper {
 
     override fun fromDaoToModel(mention: MessageEntity.Mention): MessageMention {
         return MessageMention(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMention.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMention.kt
@@ -1,0 +1,52 @@
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.protobuf.messages.Mention
+
+data class MessageMention(
+    val start: Int,
+    val length: Int,
+    val userId: UserId?
+)
+
+interface MessageMentionMapper {
+    fun fromDaoToModel(mention: MessageEntity.Mention): MessageMention
+    fun fromModelToDao(mention: MessageMention): MessageEntity.Mention
+    fun fromProtoToModel(mention: Mention): MessageMention
+    fun fromModelToProto(mention: MessageMention): Mention
+}
+
+class MessageMentionMapperImpl(
+    private val idMapper: IdMapper
+    ) : MessageMentionMapper {
+
+    override fun fromDaoToModel(mention: MessageEntity.Mention): MessageMention {
+        return MessageMention(
+            start = mention.start,
+            length = mention.length,
+            userId = mention.userId?.let { idMapper.fromDaoModel(it) }
+        )
+    }
+
+    override fun fromModelToDao(mention: MessageMention): MessageEntity.Mention {
+        return MessageEntity.Mention(
+            start = mention.start,
+            length = mention.length,
+            userId = mention.userId?.let { idMapper.toDaoModel(it) }
+        )
+    }
+
+    override fun fromProtoToModel(mention: Mention): MessageMention = MessageMention(
+        start = mention.start,
+        length = mention.length,
+        userId = mention.qualifiedUserId?.let { idMapper.fromProtoUserId(it) }
+    )
+
+    override fun fromModelToProto(mention: MessageMention): Mention = Mention(
+        start = mention.start,
+        length = mention.length,
+        qualifiedUserId = mention.userId?.let { idMapper.toProtoUserId(it) }
+    )
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -104,7 +104,7 @@ class ProtoContentMapperImpl(
         val readableContent = when (val protoContent = genericMessage.content) {
             is GenericMessage.Content.Text -> MessageContent.Text(
                 protoContent.value.content,
-                protoContent.value.mentions.map { messageMentionMapper.fromProtoToModel(it) }
+                protoContent.value.mentions.map { messageMentionMapper.fromProtoToModel(it) }.filterNotNull()
             )
             is GenericMessage.Content.Asset -> {
                 // Backend sends some preview asset messages just with img metadata and no keys or asset id, so we need to overwrite one with the other one
@@ -129,7 +129,7 @@ class ProtoContentMapperImpl(
                         MessageContent.TextEdited(
                             replacingMessageId,
                             editContent.value.content,
-                            editContent.value.mentions.map { messageMentionMapper.fromProtoToModel(it) }
+                            editContent.value.mentions.map { messageMentionMapper.fromProtoToModel(it) }.filterNotNull()
                         )
                     }
                     // TODO: for now we do not implement it

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -38,6 +38,8 @@ import com.wire.kalium.logic.data.location.LocationMapper
 import com.wire.kalium.logic.data.message.EncryptionAlgorithmMapper
 import com.wire.kalium.logic.data.message.MessageMapper
 import com.wire.kalium.logic.data.message.MessageMapperImpl
+import com.wire.kalium.logic.data.message.MessageMentionMapper
+import com.wire.kalium.logic.data.message.MessageMentionMapperImpl
 import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.message.ProtoContentMapperImpl
 import com.wire.kalium.logic.data.message.SendMessageFailureMapper
@@ -86,6 +88,7 @@ internal object MapperProvider {
     fun assetMapper(): AssetMapper = AssetMapperImpl()
     fun encryptionAlgorithmMapper(): EncryptionAlgorithmMapper = EncryptionAlgorithmMapper()
     fun eventMapper(): EventMapper = EventMapper(idMapper(), memberMapper(), connectionMapper(), featureConfigMapper())
+    fun messageMentionMapper(): MessageMentionMapper = MessageMentionMapperImpl(idMapper())
 
     fun preyKeyMapper(): PreKeyMapper = PreKeyMapperImpl()
     fun preKeyListMapper(): PreKeyListMapper = PreKeyListMapper(preyKeyMapper())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -214,22 +214,11 @@ class GetNotificationsUseCaseImpl(
             allMuted(conversationMutedStatus, selfUser) -> false
             onlyMentionsAllowed(conversationMutedStatus, selfUser) -> {
                 when (val content = message.content) {
-                    is MessageContent.Text -> {
-                        val containsSelfUserName = selfUser.name?.let { selfUsername ->
-                            content.value.contains("@$selfUsername")
-                        } ?: false
-                        val containsSelfHandle = selfUser.handle?.let { selfHandle ->
-                            content.value.contains("@$selfHandle")
-                        } ?: false
-
-                        containsSelfUserName or containsSelfHandle
-                    }
-
+                    is MessageContent.Text -> content.mentions.firstOrNull { it.userId == selfUser.id } != null
                     is MessageContent.MissedCall -> true
                     else -> false
                 }
             }
-
             allNotificationsAllowed(conversationMutedStatus, selfUser) -> true
             else -> false
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/MessageTextEditHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/MessageTextEditHandler.kt
@@ -12,8 +12,7 @@ class MessageTextEditHandler(private val messageRepository: MessageRepository) {
         messageContent: MessageContent.TextEdited
     ) = messageRepository.updateTextMessageContent(
         conversationId = message.conversationId,
-        messageId = messageContent.editMessageId,
-        newTextContent = messageContent.newContent
+        messageContent = messageContent
     ).flatMap {
         messageRepository.markMessageAsEdited(
             messageUuid = messageContent.editMessageId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -1097,7 +1097,7 @@ class ConversationRepositoryTest {
     }
 
     @Test
-    fun givenAGroupConversationHasNotNewMessages_whenGettingConversationDetails_ThenDoNoGetMessageCount() = runTest {
+    fun givenAGroupConversationHasNotNewMessages_whenGettingConversationDetails_ThenReturnZeroUnreadMessageCount() = runTest {
         // given
         val conversationEntityFlow = flowOf(
             TestConversation.ENTITY.copy(
@@ -1116,9 +1116,19 @@ class ConversationRepositoryTest {
             .thenReturn(false)
 
         given(messageDAO)
+            .suspendFunction(messageDAO::observeUnreadMessageCount)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(0))
+
+        given(messageDAO)
+            .suspendFunction(messageDAO::observeUnreadMentionsCount)
+            .whenInvokedWith(any(), any())
+            .thenReturn(flowOf(0))
+
+        given(messageDAO)
             .suspendFunction(messageDAO::observeLastUnreadMessage)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(TEST_MESSAGE_ENTITY))
+            .thenReturn(flowOf(null))
 
         given(userRepository)
             .coroutine { userRepository.observeSelfUser() }
@@ -1130,22 +1140,14 @@ class ConversationRepositoryTest {
 
             assertIs<Either.Right<ConversationDetails.Group>>(conversationDetail)
             assertTrue { conversationDetail.value.unreadMessagesCount == 0L }
+            assertTrue { conversationDetail.value.lastUnreadMessage == null }
 
             awaitComplete()
         }
-
-        verify(messageDAO)
-            .suspendFunction(messageDAO::observeUnreadMessageCount)
-            .with(anything())
-            .wasNotInvoked()
-        verify(messageDAO)
-            .suspendFunction(messageDAO::observeUnreadMentionsCount)
-            .with(anything(), anything())
-            .wasNotInvoked()
     }
 
     @Test
-    fun givenAOneToOneConversationHasNotNewMessages_whenGettingConversationDetails_ThenDoNoGetMessageCount() = runTest {
+    fun givenAOneToOneConversationHasNotNewMessages_whenGettingConversationDetails_ThenReturnZeroUnreadMessageCount() = runTest {
         // given
         val conversationEntityFlow = flowOf(
             TestConversation.ENTITY.copy(
@@ -1178,6 +1180,16 @@ class ConversationRepositoryTest {
             .thenReturn(flowOf(TestUser.OTHER))
 
         given(messageDAO)
+            .suspendFunction(messageDAO::observeUnreadMessageCount)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(0))
+
+        given(messageDAO)
+            .suspendFunction(messageDAO::observeUnreadMentionsCount)
+            .whenInvokedWith(any(), any())
+            .thenReturn(flowOf(0))
+
+        given(messageDAO)
             .suspendFunction(messageDAO::observeLastUnreadMessage)
             .whenInvokedWith(any())
             .thenReturn(flowOf(null))
@@ -1193,15 +1205,6 @@ class ConversationRepositoryTest {
 
             awaitComplete()
         }
-
-        verify(messageDAO)
-            .suspendFunction(messageDAO::observeUnreadMessageCount)
-            .with(anything())
-            .wasNotInvoked()
-        verify(messageDAO)
-            .suspendFunction(messageDAO::observeUnreadMentionsCount)
-            .with(anything(), anything())
-            .wasNotInvoked()
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -15,6 +15,7 @@ import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageEncryptionAlgorithm
+import com.wire.kalium.logic.data.message.MessageMention
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.notification.LocalNotificationCommentType
 import com.wire.kalium.logic.data.notification.LocalNotificationConversation
@@ -289,7 +290,9 @@ class GetNotificationsUseCaseTest {
                 listOf(
                     entityTextMessage(conversationId, otherUserId(), "0"),
                     entityTextMessage(conversationId, otherUserId(), "1"),
-                    entityTextMessage(conversationId, otherUserId(), "2", MessageContent.Text(mentionMessageText))
+                    entityTextMessage(conversationId, otherUserId(), "2",
+                        MessageContent.Text(mentionMessageText, listOf(MessageMention(0, 7, MY_ID)))
+                    )
                 )
             }
             .arrange()
@@ -356,7 +359,9 @@ class GetNotificationsUseCaseTest {
                 listOf(
                     entityTextMessage(conversationId, otherUserId(), "0"),
                     entityTextMessage(conversationId, otherUserId(), "1"),
-                    entityTextMessage(conversationId, otherUserId(), "2", MessageContent.Text(mentionMessageText))
+                    entityTextMessage(conversationId, otherUserId(), "2",
+                        MessageContent.Text(mentionMessageText, listOf(MessageMention(0, 7, MY_ID)))
+                    )
                 )
             }
             .withKnownUser()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MessageTextEditHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MessageTextEditHandlerTest.kt
@@ -42,12 +42,13 @@ class MessageTextEditHandlerTest {
 
         val mockMessageContent = MessageContent.TextEdited(
             editMessageId = "someId",
-            newContent = "some new content"
+            newContent = "some new content",
+            newMentions = listOf()
         )
 
         given(messageRepository)
             .suspendFunction(messageRepository::updateTextMessageContent)
-            .whenInvokedWith(anything(), anything(), anything())
+            .whenInvokedWith(anything(), anything())
             .thenReturn(Either.Right(Unit))
 
         given(messageRepository)
@@ -64,7 +65,7 @@ class MessageTextEditHandlerTest {
         // then
         verify(messageRepository)
             .suspendFunction(messageRepository::updateTextMessageContent)
-            .with(eq(mockMessage.conversationId), eq(mockMessageContent.editMessageId), eq(mockMessageContent.newContent))
+            .with(eq(mockMessage.conversationId), eq(mockMessageContent))
             .wasInvoked(exactly = once)
 
         verify(messageRepository)

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -14,6 +14,7 @@ import com.wire.kalium.persistence.Message
 import com.wire.kalium.persistence.MessageAssetContent
 import com.wire.kalium.persistence.MessageFailedToDecryptContent
 import com.wire.kalium.persistence.MessageMemberChangeContent
+import com.wire.kalium.persistence.MessageMention
 import com.wire.kalium.persistence.MessageMissedCallContent
 import com.wire.kalium.persistence.MessageRestrictedAssetContent
 import com.wire.kalium.persistence.MessageTextContent
@@ -132,6 +133,12 @@ actual class UserDatabaseProvider(
                 conversation_idAdapter = QualifiedIDAdapter(),
                 member_change_listAdapter = QualifiedIDListAdapter(),
                 member_change_typeAdapter = EnumColumnAdapter()
+            ),
+            MessageMention.Adapter(
+                conversation_idAdapter = QualifiedIDAdapter(),
+                user_idAdapter = QualifiedIDAdapter(),
+                startAdapter = IntColumnAdapter,
+                lengthAdapter = IntColumnAdapter
             ),
             MessageMissedCallContent.Adapter(
                 conversation_idAdapter = QualifiedIDAdapter(),

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -126,4 +126,4 @@ isUserMember:
 SELECT user FROM Member WHERE conversation = ? AND user = ?;
 
 whoDeletedMeInConversation:
-SELECT sender_user_id FROM Message WHERE id IN (SELECT message_id FROM MessageMemberChangeContent WHERE conversation_id = :conversation_id AND member_change_type = "REMOVED" AND member_change_list LIKE :self_user_id) ORDER BY DateTime(date) DESC LIMIT 1;
+SELECT sender_user_id FROM Message WHERE id IN (SELECT message_id FROM MessageMemberChangeContent WHERE conversation_id = :conversation_id AND member_change_type = "REMOVED" AND member_change_list LIKE ('%' || :self_user_id || '%')) ORDER BY DateTime(date) DESC LIMIT 1;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -21,6 +21,18 @@ CREATE TABLE Message (
       PRIMARY KEY (id, conversation_id)
 );
 
+CREATE TABLE MessageMention (
+      message_id TEXT NOT NULL,
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+
+      start INTEGER AS Int NOT NULL,
+      length INTEGER AS Int NOT NULL,
+      user_id TEXT AS QualifiedIDEntity,
+
+      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      PRIMARY KEY (message_id, conversation_id, start) -- there should not be any overlapping mentions
+);
+
 CREATE TABLE MessageTextContent (
       message_id TEXT NOT NULL,
       conversation_id TEXT AS QualifiedIDEntity NOT NULL,
@@ -118,6 +130,9 @@ DELETE FROM Message;
 deleteMessage:
 DELETE FROM Message WHERE  id = ? AND conversation_id = ?;
 
+deleteMessageMentions:
+DELETE FROM MessageMention WHERE  message_id = ? AND conversation_id = ?;
+
 deleteMessageById:
 DELETE FROM Message WHERE  id = ?;
 
@@ -151,6 +166,15 @@ sender_user_id = excluded.sender_user_id,
 sender_client_id = excluded.sender_client_id,
 status = excluded.status,
 visibility = excluded.visibility;
+
+insertMessageMention:
+INSERT INTO MessageMention(message_id, conversation_id, start, length, user_id)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(message_id, conversation_id, start) DO UPDATE SET
+message_id = excluded.message_id,
+start = excluded.start,
+length = excluded.length,
+user_id = excluded.user_id;
 
 insertMessageTextContent:
 INSERT INTO MessageTextContent(message_id, conversation_id, text_body)
@@ -260,6 +284,9 @@ SELECT * FROM Message WHERE conversation_id = ? AND visibility IN ? AND Datetime
 selectMessagesFromUserByStatus:
 SELECT * FROM Message WHERE sender_user_id = ? AND status = ?;
 
+selectMessageMentions:
+SELECT * FROM MessageMention WHERE message_id = ? AND conversation_id = ?;
+
 selectMessageTextContent:
 SELECT * FROM MessageTextContent WHERE message_id = ? AND conversation_id = ?;
 
@@ -290,5 +317,13 @@ LIMIT  1;
 
 getUnreadMessageCount:
 SELECT COUNT() FROM Message AS message
-WHERE message.conversation_id
-IS :conversation_id AND (DateTime(message.date) > (SELECT DateTime(last_read_date) FROM Conversation WHERE qualified_id IS :conversation_id));
+WHERE message.conversation_id IS :conversation_id
+AND (DateTime(message.date) > (SELECT DateTime(last_read_date) FROM Conversation WHERE qualified_id IS :conversation_id))
+AND message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL');
+
+getUnreadMentionsCount:
+SELECT COUNT(DISTINCT message.id) FROM Message AS message
+WHERE message.conversation_id IS :conversation_id
+AND (DateTime(message.date) > (SELECT DateTime(last_read_date) FROM Conversation WHERE qualified_id IS :conversation_id))
+AND message.content_type IN ('TEXT')
+AND message.id IN (SELECT message_id FROM MessageMention WHERE user_id = :user_id);

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -27,7 +27,7 @@ CREATE TABLE MessageMention (
 
       start INTEGER AS Int NOT NULL,
       length INTEGER AS Int NOT NULL,
-      user_id TEXT AS QualifiedIDEntity,
+      user_id TEXT AS QualifiedIDEntity NOT NULL,
 
       FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
       PRIMARY KEY (message_id, conversation_id, start) -- there should not be any overlapping mentions

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -38,11 +38,16 @@ interface MessageDAO {
         newTextContent: MessageEntityContent.Text
     )
 
-    suspend fun getLastUnreadMessage(
+    suspend fun observeLastUnreadMessage(
         conversationID: QualifiedIDEntity
-    ): MessageEntity?
+    ): Flow<MessageEntity?>
 
-    suspend fun getUnreadMessageCount(
+    suspend fun observeUnreadMessageCount(
         conversationId: QualifiedIDEntity
-    ): Long
+    ): Flow<Long>
+
+    suspend fun observeUnreadMentionsCount(
+        conversationId: QualifiedIDEntity,
+        userId: UserIDEntity
+    ): Flow<Long>
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -20,6 +20,7 @@ import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.UNKNOWN
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -299,12 +300,15 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
     override suspend fun observeLastUnreadMessage(
         conversationID: QualifiedIDEntity
     ): Flow<MessageEntity?> = queries.getLastUnreadMessage(conversationID).asFlow().mapToOneOrNull().map { it?.toMessageEntity() }
+        .distinctUntilChanged()
 
     override suspend fun observeUnreadMessageCount(conversationId: QualifiedIDEntity): Flow<Long> =
         queries.getUnreadMessageCount(conversationId).asFlow().mapToOneOrDefault(0L)
+            .distinctUntilChanged()
 
     override suspend fun observeUnreadMentionsCount(conversationId: QualifiedIDEntity, userId: UserIDEntity): Flow<Long> =
         queries.getUnreadMentionsCount(conversationId, userId).asFlow().mapToOneOrDefault(0L)
+            .distinctUntilChanged()
 
     private fun contentTypeOf(content: MessageEntityContent): MessageEntity.ContentType = when (content) {
         is MessageEntityContent.Text -> TEXT

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -325,8 +325,9 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
 
     private fun SQLDelightMessage.toMessageEntityFlow() = when (this.content_type) {
         TEXT -> queries.selectMessageTextContent(this.id, this.conversation_id).asFlow().mapToOneOrNull()
-            .combine(queries.selectMessageMentions(this.id, this.conversation_id).asFlow().mapToList())
-            { content, mentions -> content?.let { mapper.toModel(content, mentions) } ?: defaultMessageEntityContent }
+            .combine(queries.selectMessageMentions(this.id, this.conversation_id).asFlow().mapToList()) { content, mentions ->
+                content?.let { mapper.toModel(content, mentions) } ?: defaultMessageEntityContent
+            }
         ASSET -> this.queryOneOrDefaultFlow(queries::selectMessageAssetContent, mapper::toModel)
         KNOCK -> flowOf(MessageEntityContent.Knock(false))
         MEMBER_CHANGE -> this.queryOneOrDefaultFlow(queries::selectMessageMemberChangeContent, mapper::toModel)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -90,7 +90,7 @@ sealed class MessageEntity(
     data class Mention(
         val start: Int,
         val length: Int,
-        val userId: QualifiedIDEntity?
+        val userId: QualifiedIDEntity
     )
 }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -86,6 +86,12 @@ sealed class MessageEntity(
     enum class Visibility {
         VISIBLE, DELETED, HIDDEN
     }
+
+    data class Mention(
+        val start: Int,
+        val length: Int,
+        val userId: QualifiedIDEntity?
+    )
 }
 
 sealed class MessageEntityContent {
@@ -94,7 +100,10 @@ sealed class MessageEntityContent {
 
     sealed class System : MessageEntityContent()
 
-    data class Text(val messageBody: String) : Regular()
+    data class Text(
+        val messageBody: String,
+        val mentions: List<MessageEntity.Mention> = listOf()
+    ) : Regular()
 
     data class Asset(
         val assetSizeInBytes: Long,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -489,11 +489,13 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         messageDAO.insertMessages(message)
 
-        // when
-        val result = messageDAO.getUnreadMessageCount(conversationId)
-
-        // then
-        assertEquals(9L, result)
+        launch(UnconfinedTestDispatcher(testScheduler)) {
+            // when
+            messageDAO.observeUnreadMessageCount(conversationId).test {
+                // then
+                assertEquals(9L, awaitItem())
+            }
+        }
     }
 
     @Test
@@ -525,11 +527,13 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         messageDAO.insertMessages(message)
 
-        // when
-        val result = messageDAO.getUnreadMessageCount(conversationId)
-
-        // then
-        assertEquals(0L, result)
+        launch(UnconfinedTestDispatcher(testScheduler)) {
+            // when
+            messageDAO.observeUnreadMessageCount(conversationId).test {
+                // then
+                assertEquals(0L, awaitItem())
+            }
+        }
     }
 
     @Test
@@ -602,7 +606,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.setProposalTimer(proposalTimer2)
 
         // then
-         assertEquals(listOf(proposalTimer2), conversationDAO.getProposalTimers().first())
+        assertEquals(listOf(proposalTimer2), conversationDAO.getProposalTimers().first())
     }
 
     @Test

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.persistence.Message
 import com.wire.kalium.persistence.MessageAssetContent
 import com.wire.kalium.persistence.MessageFailedToDecryptContent
 import com.wire.kalium.persistence.MessageMemberChangeContent
+import com.wire.kalium.persistence.MessageMention
 import com.wire.kalium.persistence.MessageMissedCallContent
 import com.wire.kalium.persistence.MessageRestrictedAssetContent
 import com.wire.kalium.persistence.MessageTextContent
@@ -100,6 +101,12 @@ actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
                 conversation_idAdapter = QualifiedIDAdapter(),
                 member_change_listAdapter = QualifiedIDListAdapter(),
                 member_change_typeAdapter = EnumColumnAdapter()
+            ),
+            MessageMention.Adapter(
+                conversation_idAdapter = QualifiedIDAdapter(),
+                user_idAdapter = QualifiedIDAdapter(),
+                startAdapter = IntColumnAdapter,
+                lengthAdapter = IntColumnAdapter
             ),
             MessageMissedCallContent.Adapter(
                 conversation_idAdapter = QualifiedIDAdapter(),

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -13,6 +13,7 @@ import com.wire.kalium.persistence.Message
 import com.wire.kalium.persistence.MessageAssetContent
 import com.wire.kalium.persistence.MessageFailedToDecryptContent
 import com.wire.kalium.persistence.MessageMemberChangeContent
+import com.wire.kalium.persistence.MessageMention
 import com.wire.kalium.persistence.MessageMissedCallContent
 import com.wire.kalium.persistence.MessageRestrictedAssetContent
 import com.wire.kalium.persistence.MessageTextContent
@@ -114,6 +115,12 @@ actual class UserDatabaseProvider(private val storePath: File) {
                 conversation_idAdapter = QualifiedIDAdapter(),
                 member_change_listAdapter = QualifiedIDListAdapter(),
                 member_change_typeAdapter = EnumColumnAdapter()
+            ),
+            MessageMention.Adapter(
+                conversation_idAdapter = QualifiedIDAdapter(),
+                user_idAdapter = QualifiedIDAdapter(),
+                startAdapter = IntColumnAdapter,
+                lengthAdapter = IntColumnAdapter
             ),
             MessageMissedCallContent.Adapter(
                 conversation_idAdapter = QualifiedIDAdapter(),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

To make unread message badges work well with different types of muting conversations, we need to have the option to observe not only unread messages count, but also unread mentions count. The problem is that we only use very simplified way of checking if the message contains mentions (checking if the text of the message contains the username or handle) which works for notifications but in order to count messages containing mentions it's better to create a desired db query rather than take all messages and check their contents one by one.

### Solutions

Created new table to store message mentions which are taken from the proto of `Text` message type. Implemented a query to count unread messages with mentions and added as a field in `Conversation`. Changed the way such values are taken to make sure Flows are used and we can observe changes .

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
