### PR TITLE
chore: obfuscate sensitive data in manually logs 

### DIFF
--- a/logger/src/commonMain/kotlin/com/wire/kalium/logger/Extensions.kt
+++ b/logger/src/commonMain/kotlin/com/wire/kalium/logger/Extensions.kt
@@ -1,0 +1,13 @@
+package com.wire.kalium.logger
+
+
+private const val START_INDEX = 0
+private const val END_INDEX = 9
+
+fun String.obfuscateId(): String {
+    return if (this.length >= 9) {
+        this.substring(START_INDEX, END_INDEX)
+    } else {
+        this
+    }
+}

--- a/logger/src/commonMain/kotlin/com/wire/kalium/logger/Extensions.kt
+++ b/logger/src/commonMain/kotlin/com/wire/kalium/logger/Extensions.kt
@@ -1,11 +1,10 @@
 package com.wire.kalium.logger
 
-
 private const val START_INDEX = 0
 private const val END_INDEX = 9
 
 fun String.obfuscateId(): String {
-    return if (this.length >= 9) {
+    return if (this.length >= END_INDEX) {
         this.substring(START_INDEX, END_INDEX)
     } else {
         this

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -30,15 +30,15 @@ sealed class Message(
         override fun toString(): String {
             val message: String = when (content) {
                 is MessageContent.Text -> {
-                    "${id.obfuscateId()} ${conversationId.value.obfuscateId()}@${conversationId.domain}" +
-                            "$date ${senderUserId.value.obfuscateId()} $status $visibility ${senderClientId.value.obfuscateId()}" +
-                            "$editStatus"
+                    "id: ${id.obfuscateId()} conversationId:${conversationId.value.obfuscateId()}@${conversationId.domain}" +
+                            "date:$date senderUserId:${senderUserId.value.obfuscateId()} status:$status visibility:$visibility " +
+                            "senderClientId${senderClientId.value.obfuscateId()} editStatus:$editStatus"
                 }
 
                 else -> {
-                    "${id.obfuscateId()} $content ${conversationId.value.obfuscateId()}@${conversationId.domain}" +
-                            "$date ${senderUserId.value.obfuscateId()} $status $visibility ${senderClientId.value.obfuscateId()}" +
-                            "$editStatus"
+                    "id:${id.obfuscateId()} content:$content conversationId:${conversationId.value.obfuscateId()}@${conversationId.domain}" +
+                            "date:$date senderUserId:${senderUserId.value.obfuscateId()} status:$status visibility:$visibility " +
+                            "senderClientId${senderClientId.value.obfuscateId()} editStatus:$editStatus"
                 }
             }
             return message
@@ -55,8 +55,8 @@ sealed class Message(
         override val visibility: Visibility = Visibility.VISIBLE
     ) : Message(id, content, conversationId, date, senderUserId, status, visibility) {
         override fun toString(): String {
-            return "${id.obfuscateId()} $content ${conversationId.value.obfuscateId()}@${conversationId.domain}" +
-                    "$date ${senderUserId.value.obfuscateId()} $status $visibility"
+            return "id:${id.obfuscateId()} content:$content conversationId:${conversationId.value.obfuscateId()}@${conversationId.domain}" +
+                    "date:$date senderUserId:${senderUserId.value.obfuscateId()} status:$status visibility:$visibility"
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -36,7 +36,8 @@ sealed class Message(
                 }
 
                 else -> {
-                    "id:${id.obfuscateId()} content:$content conversationId:${conversationId.value.obfuscateId()}@${conversationId.domain}" +
+                    "id:${id.obfuscateId()} content:$content " +
+                            "conversationId:${conversationId.value.obfuscateId()}@${conversationId.domain}" +
                             "date:$date senderUserId:${senderUserId.value.obfuscateId()} status:$status visibility:$visibility " +
                             "senderClientId${senderClientId.value.obfuscateId()} editStatus:$editStatus"
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.message
 
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
@@ -24,8 +25,25 @@ sealed class Message(
         override val status: Status,
         override val visibility: Visibility = Visibility.VISIBLE,
         val senderClientId: ClientId,
-        val editStatus : EditStatus
-    ) : Message(id, content, conversationId, date, senderUserId, status, visibility)
+        val editStatus: EditStatus
+    ) : Message(id, content, conversationId, date, senderUserId, status, visibility) {
+        override fun toString(): String {
+            val message: String = when (content) {
+                is MessageContent.Text -> {
+                    "${id.obfuscateId()} ${conversationId.value.obfuscateId()}@${conversationId.domain}" +
+                            "$date ${senderUserId.value.obfuscateId()} $status $visibility ${senderClientId.value.obfuscateId()}" +
+                            "$editStatus"
+                }
+
+                else -> {
+                    "${id.obfuscateId()} $content ${conversationId.value.obfuscateId()}@${conversationId.domain}" +
+                            "$date ${senderUserId.value.obfuscateId()} $status $visibility ${senderClientId.value.obfuscateId()}" +
+                            "$editStatus"
+                }
+            }
+            return message
+        }
+    }
 
     data class System(
         override val id: String,
@@ -35,7 +53,12 @@ sealed class Message(
         override val senderUserId: UserId,
         override val status: Status,
         override val visibility: Visibility = Visibility.VISIBLE
-    ) : Message(id, content, conversationId, date, senderUserId, status, visibility)
+    ) : Message(id, content, conversationId, date, senderUserId, status, visibility) {
+        override fun toString(): String {
+            return "${id.obfuscateId()} $content ${conversationId.value.obfuscateId()}@${conversationId.domain}" +
+                    "$date ${senderUserId.value.obfuscateId()} $status $visibility"
+        }
+    }
 
     enum class Status {
         PENDING, SENT, READ, FAILED
@@ -43,7 +66,7 @@ sealed class Message(
 
     sealed class EditStatus {
         object NotEdited : EditStatus()
-        data class Edited (val lastTimeStamp : String) : EditStatus()
+        data class Edited(val lastTimeStamp: String) : EditStatus()
     }
 
     enum class DownloadStatus {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -85,7 +85,7 @@ class ProtoContentMapperImpl(
         )
 
     override fun decodeFromProtobuf(encodedContent: PlainMessageBlob): ProtoContent {
-        var genericMessage = GenericMessage.decodeFromByteArray(encodedContent.data)
+        val genericMessage = GenericMessage.decodeFromByteArray(encodedContent.data)
         val protobufModel = genericMessage.content
         when (protobufModel) {
             is GenericMessage.Content.Text -> {
@@ -94,10 +94,11 @@ class ProtoContentMapperImpl(
             }
 
             else -> {
-                genericMessage = genericMessage.copy(
-                    messageId = genericMessage.messageId.obfuscateId()
+                var messageToLog = genericMessage
+                messageToLog = messageToLog.copy(
+                    messageId = messageToLog.messageId.obfuscateId()
                 )
-                kaliumLogger.d("Received message $genericMessage")
+                kaliumLogger.d("Received message $messageToLog")
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.feature.asset
 
 import com.wire.kalium.cryptography.utils.AES256Key
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -34,7 +35,7 @@ internal class GetMessageAssetUseCaseImpl(
         messageId: String
     ): MessageAssetResult =
         messageRepository.getMessageById(conversationId = conversationId, messageUuid = messageId).fold({
-            kaliumLogger.e("There was an error retrieving the asset message $messageId")
+            kaliumLogger.e("There was an error retrieving the asset message ${messageId.obfuscateId()}")
             MessageAssetResult.Failure(it)
         }, { message ->
             val assetMetadata = when (val content = message.content) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
@@ -58,7 +58,7 @@ internal class GetMessageAssetUseCaseImpl(
             }
             assetDataSource.fetchPrivateDecodedAsset(
                 assetId = AssetId(assetMetadata.assetKey, assetMetadata.assetKeyDomain.orEmpty()),
-                assetName= assetMetadata.assetName,
+                assetName = assetMetadata.assetName,
                 assetToken = assetMetadata.assetToken,
                 encryptionKey = assetMetadata.encryptionKey
             ).fold({

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
@@ -244,7 +244,6 @@ public class KaliumKtorCustomLogging private constructor(
                     plugin.doneLogging()
                 }
             }
-
             ResponseObserver.install(ResponseObserver(observer), scope)
         }
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.network
 
+import com.wire.kalium.logger.obfuscateId
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.HttpClientPlugin
@@ -251,7 +252,7 @@ public class KaliumKtorCustomLogging private constructor(
 
 @Suppress("TooGenericExceptionCaught")
 private fun obfuscateAndLogMessage(text: String) {
-     try {
+    try {
         val obj = (Json.decodeFromString(text) as JsonElement)
         if (obj.jsonArray.size > 0) {
             obj.jsonArray.map {
@@ -273,24 +274,22 @@ fun logObfuscatedJsonElement(obj: JsonElement) {
                 kaliumLogger.v("${it.key} : ******")
             }
             sensitiveJsonIdKeys.contains(it.key.lowercase()) -> {
-                kaliumLogger.v("${it.key} : ${it.value.toString().substring(START_INDEX, END_INDEX)}")
+                kaliumLogger.v("${it.key} : ${it.value.toString().obfuscateId()}")
             }
             sensitiveJsonObjects.contains(it.key.lowercase()) -> {
                 logObfuscatedJsonElement(it.value)
             }
             else -> {
-                kaliumLogger.e("${it.key} : ${it.value}")
+                kaliumLogger.v("${it.key} : ${it.value}")
             }
         }
     }
 
 }
 
-private val sensitiveJsonKeys by lazy { listOf("password", "authorization") }
+private val sensitiveJsonKeys by lazy { listOf("password", "authorization", "set-cookie") }
 private val sensitiveJsonIdKeys by lazy { listOf("conversation", "id", "user", "team") }
 private val sensitiveJsonObjects by lazy { listOf("qualified_id") }
-private const val START_INDEX = 0
-private const val END_INDEX = 9
 
 /**
  * Configure and install [Logging] in [HttpClient].


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

in some places we were logging some sensitive information like the message content 


### Solutions

updated the to string method and some logic when we log the message, and obfuscate the ids to follow our standards


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
