### PR TITLE
fix: join a call with video enabled by default

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -59,7 +59,7 @@ class CallsScope internal constructor(
 
     val answerCall: AnswerCallUseCase get() = AnswerCallUseCaseImpl(callManager)
 
-    val endCall: EndCallUseCase get() = EndCallUseCase(callManager, KaliumDispatcherImpl)
+    val endCall: EndCallUseCase get() = EndCallUseCase(callManager, callRepository, KaliumDispatcherImpl)
 
     val rejectCall: RejectCallUseCase get() = RejectCallUseCase(callManager)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.feature.call.usecase
 
+import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.util.KaliumDispatcher
@@ -8,10 +9,12 @@ import kotlinx.coroutines.withContext
 
 class EndCallUseCase(
     private val callManager: Lazy<CallManager>,
+    private val callRepository: CallRepository,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
     suspend operator fun invoke(conversationId: ConversationId) = withContext(dispatchers.io) {
         callManager.value.endCall(conversationId)
+        callRepository.updateIsCameraOnById(conversationId.toString(), false)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/EndCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/EndCallUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import io.mockative.Mock
@@ -19,11 +20,14 @@ class EndCallUseCaseTest {
     @Mock
     private val callManager = mock(classOf<CallManager>())
 
+    @Mock
+    private val callRepository = mock(classOf<CallRepository>())
+
     private lateinit var endCall: EndCallUseCase
 
     @BeforeTest
     fun setup() {
-        endCall = EndCallUseCase(lazy { callManager })
+        endCall = EndCallUseCase(lazy { callManager }, callRepository)
     }
 
     @Test
@@ -35,11 +39,21 @@ class EndCallUseCaseTest {
             .whenInvokedWith(eq(conversationId))
             .thenDoNothing()
 
+        given(callRepository)
+            .function(callRepository::updateIsCameraOnById)
+            .whenInvokedWith(eq(conversationId.toString()), eq(false))
+            .thenDoNothing()
+
         endCall.invoke(conversationId)
 
         verify(callManager)
             .suspendFunction(callManager::endCall)
             .with(eq(conversationId))
+            .wasInvoked(once)
+
+        verify(callRepository)
+            .function(callRepository::updateIsCameraOnById)
+            .with(eq(conversationId.toString()), eq(false))
             .wasInvoked(once)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When you end a call and you camera is on at that time, next time you join the call you will join with camera on

### Solutions

We need to set camera state to false when ending the call

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

1. In a group call turn on your camera and then end the call
2. join the same call again, you should join with camera off

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
