### PR TITLE
fix: federation mapper usersession aware (AR-2311)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.configuration.ClientConfigImpl
+import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.asset.DataStoragePaths
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
@@ -16,7 +17,7 @@ import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
  * and it should only override functions/variables from UserSessionScopeCommon
  */
 @Suppress("LongParameterList")
-actual class UserSessionScope(
+actual class UserSessionScope internal constructor(
     private val applicationContext: Context,
     userId: UserId,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet,
@@ -25,7 +26,8 @@ actual class UserSessionScope(
     globalPreferences: KaliumPreferences,
     dataStoragePaths: DataStoragePaths,
     kaliumConfigs: KaliumConfigs,
-    userSessionScopeProvider: UserSessionScopeProvider
+    userSessionScopeProvider: UserSessionScopeProvider,
+    serverConfigRepository: Lazy<ServerConfigRepository>
 ) : UserSessionScopeCommon(
     userId,
     authenticatedDataSourceSet,
@@ -34,7 +36,8 @@ actual class UserSessionScope(
     globalPreferences,
     dataStoragePaths,
     kaliumConfigs,
-    userSessionScopeProvider
+    userSessionScopeProvider,
+    serverConfigRepository
 ) {
 
     override val clientConfig: ClientConfig get() = ClientConfigImpl(applicationContext)

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -83,7 +83,8 @@ actual class UserSessionScopeProviderImpl(
             globalPreferences,
             dataStoragePaths,
             kaliumConfigs,
-            this
+            this,
+            lazy { globalScope.serverConfigRepository }
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -66,7 +66,6 @@ class GlobalKaliumScope(
             unboundNetworkContainer.serverConfigApi,
             globalDatabase.value.serverConfigurationDAO,
             unboundNetworkContainer.remoteVersion,
-            globalPreferences.value
         )
     private val tokenStorage: TokenStorage get() = TokenStorageImpl(globalPreferences.value)
     private val userConfigStorage: UserConfigStorage get() = UserConfigStorageImpl(globalPreferences.value)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
@@ -14,7 +14,6 @@ import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.configuration.ServerConfigApi
 import com.wire.kalium.network.api.versioning.VersionApi
 import com.wire.kalium.persistence.dao_kalium_db.ServerConfigurationDAO
-import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 import io.ktor.http.Url
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -48,7 +47,7 @@ internal interface ServerConfigRepository {
     /**
      * calculate the app/server common api version for a new non stored config and store it locally if the version is valid
      * can return a ServerConfigFailure in case of an invalid version
-     * @param serverConfigResponse
+     * @param links
      * @return ServerConfigFailure in case of an invalid version
      * @return NetworkFailure in case of remote communication error
      * @return StorageFailure in case of DB errors when storing configuration
@@ -75,7 +74,6 @@ internal class ServerConfigDataSource(
     private val api: ServerConfigApi,
     private val dao: ServerConfigurationDAO,
     private val versionApi: VersionApi,
-    private val kaliumPreferences: KaliumPreferences,
     private val serverConfigMapper: ServerConfigMapper = MapperProvider.serverConfigMapper()
 ) : ServerConfigRepository {
 
@@ -133,9 +131,6 @@ internal class ServerConfigDataSource(
             wrapStorageRequest { dao.configById(storedConfigId) }
         }.map {
             serverConfigMapper.fromEntity(it)
-        }.also {
-            kaliumPreferences.putBoolean(FEDERATION_ENABLED, metadata.federation)
-            kaliumPreferences.putString(CURRENT_DOMAIN, metadata.domain)
         }
 
     override suspend fun fetchApiVersionAndStore(links: ServerConfig.Links): Either<CoreFailure, ServerConfig> =
@@ -155,6 +150,3 @@ internal class ServerConfigDataSource(
         .flatMap { wrapApiRequest { versionApi.fetchApiVersion(Url(it.links.api)) } }
         .flatMap { wrapStorageRequest { dao.updateApiVersion(id, it.commonApiVersion.version) } }
 }
-
-const val FEDERATION_ENABLED = "federation_enabled"
-const val CURRENT_DOMAIN = "current_domain"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
@@ -34,10 +34,8 @@ class FederatedIdMapperImpl internal constructor(
         }
     }
 
-    private fun getCurrentDomain() = selfUserId.domain
-
     override suspend fun parseToFederatedId(qualifiedID: QualifiedID): String {
-        kaliumLogger.v("Parsing stringId: $qualifiedID | FederationEnabled? ${isFederationEnabled()} | Domain? ${getCurrentDomain()}")
+        kaliumLogger.v("Parsing stringId: $qualifiedID | FederationEnabled? ${isFederationEnabled()}")
         return if (isFederationEnabled() && qualifiedID.domain.isNotEmpty()) {
             qualifiedID.toString()
         } else {
@@ -47,7 +45,7 @@ class FederatedIdMapperImpl internal constructor(
 
     override suspend fun parseToFederatedId(qualifiedStringID: String): String {
         val parsedQualifiedID = qualifiedIdMapper.fromStringToQualifiedID(qualifiedStringID)
-        kaliumLogger.v("Parsing stringId: $parsedQualifiedID | FederationEnabled? ${isFederationEnabled()} | Domain? ${getCurrentDomain()}")
+        kaliumLogger.v("Parsing stringId: $parsedQualifiedID | FederationEnabled? ${isFederationEnabled()}")
         return if (isFederationEnabled() && parsedQualifiedID.domain.isNotEmpty()) {
             parsedQualifiedID.toString()
         } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
@@ -8,8 +8,8 @@ import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger
 
 interface FederatedIdMapper {
-    fun parseToFederatedId(qualifiedID: QualifiedID): String
-    fun parseToFederatedId(qualifiedStringID: String): String
+    suspend fun parseToFederatedId(qualifiedID: QualifiedID): String
+    suspend fun parseToFederatedId(qualifiedStringID: String): String
 }
 
 /**
@@ -36,7 +36,7 @@ class FederatedIdMapperImpl internal constructor(
 
     private fun getCurrentDomain() = selfUserId.domain
 
-    override fun parseToFederatedId(qualifiedID: QualifiedID): String {
+    override suspend fun parseToFederatedId(qualifiedID: QualifiedID): String {
         kaliumLogger.v("Parsing stringId: $qualifiedID | FederationEnabled? ${isFederationEnabled()} | Domain? ${getCurrentDomain()}")
         return if (isFederationEnabled() && qualifiedID.domain.isNotEmpty()) {
             qualifiedID.toString()
@@ -45,7 +45,7 @@ class FederatedIdMapperImpl internal constructor(
         }
     }
 
-    override fun parseToFederatedId(qualifiedStringID: String): String {
+    override suspend fun parseToFederatedId(qualifiedStringID: String): String {
         val parsedQualifiedID = qualifiedIdMapper.fromStringToQualifiedID(qualifiedStringID)
         kaliumLogger.v("Parsing stringId: $parsedQualifiedID | FederationEnabled? ${isFederationEnabled()} | Domain? ${getCurrentDomain()}")
         return if (isFederationEnabled() && parsedQualifiedID.domain.isNotEmpty()) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
@@ -25,16 +25,13 @@ class FederatedIdMapperImpl internal constructor(
     private val serverConfigRepository: ServerConfigRepository,
 ) : FederatedIdMapper {
 
-    private fun isFederationEnabled(): Boolean {
-        val isFederationEnabled = when (val session = sessionRepository.userSession(selfUserId)) {
-            is Either.Left -> false
-            is Either.Right -> {
-                serverConfigRepository.configByLinks(session.value.serverLinks).fold({ false }, { config ->
-                    config.metaData.federation
-                })
-            }
+    private fun isFederationEnabled() = when (val session = sessionRepository.userSession(selfUserId)) {
+        is Either.Left -> false
+        is Either.Right -> {
+            serverConfigRepository.configByLinks(session.value.serverLinks).fold({ false }, { config ->
+                config.metaData.federation
+            })
         }
-        return isFederationEnabled
     }
 
     private fun getCurrentDomain() = selfUserId.domain

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
@@ -1,10 +1,8 @@
 package com.wire.kalium.logic.data.id
 
-import com.wire.kalium.logic.configuration.server.CURRENT_DOMAIN
 import com.wire.kalium.logic.configuration.server.FEDERATION_ENABLED
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 
 interface FederatedIdMapper {
     fun parseToFederatedId(qualifiedID: QualifiedID): String
@@ -19,12 +17,11 @@ interface FederatedIdMapper {
  */
 class FederatedIdMapperImpl(
     private val userRepository: UserRepository,
-    private val qualifiedIdMapper: QualifiedIdMapper,
-    private val kaliumPreferences: KaliumPreferences,
+    private val qualifiedIdMapper: QualifiedIdMapper
 ) : FederatedIdMapper {
 
     private fun isFederationEnabled() = kaliumPreferences.getBoolean(FEDERATION_ENABLED, false)
-    private fun getCurrentDomain() = kaliumPreferences.getString(CURRENT_DOMAIN) ?: userRepository.getSelfUserId()?.domain
+    private fun getCurrentDomain() = userRepository.getSelfUserId().domain
 
     override fun parseToFederatedId(qualifiedID: QualifiedID): String {
         kaliumLogger.v(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -64,7 +64,6 @@ import com.wire.kalium.logic.data.user.type.DomainUserTypeMapper
 import com.wire.kalium.logic.data.user.type.DomainUserTypeMapperImpl
 import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.data.user.type.UserEntityTypeMapperImpl
-import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 
 internal object MapperProvider {
     fun apiVersionMapper(): ApiVersionMapper = ApiVersionMapperImpl()
@@ -105,7 +104,6 @@ internal object MapperProvider {
     fun federatedIdMapper(
         userRepository: UserRepository,
         qualifiedIdMapper: QualifiedIdMapper,
-        kaliumPreferences: KaliumPreferences
-    ): FederatedIdMapper = FederatedIdMapperImpl(userRepository, qualifiedIdMapper, kaliumPreferences)
+    ): FederatedIdMapper = FederatedIdMapperImpl(userRepository, qualifiedIdMapper)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logic.configuration.server.ApiVersionMapper
 import com.wire.kalium.logic.configuration.server.ApiVersionMapperImpl
 import com.wire.kalium.logic.configuration.server.ServerConfigMapper
 import com.wire.kalium.logic.configuration.server.ServerConfigMapperImpl
+import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.asset.AssetMapper
 import com.wire.kalium.logic.data.asset.AssetMapperImpl
 import com.wire.kalium.logic.data.call.mapper.ActiveSpeakerMapper
@@ -51,12 +52,14 @@ import com.wire.kalium.logic.data.publicuser.PublicUserMapper
 import com.wire.kalium.logic.data.publicuser.PublicUserMapperImpl
 import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.session.SessionMapperImpl
+import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.team.TeamMapper
 import com.wire.kalium.logic.data.team.TeamMapperImpl
 import com.wire.kalium.logic.data.user.AvailabilityStatusMapper
 import com.wire.kalium.logic.data.user.AvailabilityStatusMapperImpl
 import com.wire.kalium.logic.data.user.ConnectionStateMapper
 import com.wire.kalium.logic.data.user.ConnectionStateMapperImpl
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.data.user.UserMapperImpl
 import com.wire.kalium.logic.data.user.UserRepository
@@ -102,8 +105,10 @@ internal object MapperProvider {
     fun userTypeMapper(): DomainUserTypeMapper = DomainUserTypeMapperImpl()
     fun qualifiedIdMapper(userRepository: UserRepository): QualifiedIdMapper = QualifiedIdMapperImpl(userRepository)
     fun federatedIdMapper(
-        userRepository: UserRepository,
+        userId: UserId,
         qualifiedIdMapper: QualifiedIdMapper,
-    ): FederatedIdMapper = FederatedIdMapperImpl(userRepository, qualifiedIdMapper)
+        sessionRepository: SessionRepository,
+        serverConfigRepository: ServerConfigRepository,
+    ): FederatedIdMapper = FederatedIdMapperImpl(userId, qualifiedIdMapper, sessionRepository, serverConfigRepository)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -431,7 +431,7 @@ abstract class UserSessionScopeCommon(
 
     val qualifiedIdMapper: QualifiedIdMapper get() = MapperProvider.qualifiedIdMapper(userRepository)
 
-    val federatedIdMapper: FederatedIdMapper get() = MapperProvider.federatedIdMapper(userRepository, qualifiedIdMapper, globalPreferences)
+    val federatedIdMapper: FederatedIdMapper get() = MapperProvider.federatedIdMapper(userRepository, qualifiedIdMapper)
 
     private val callManager: Lazy<CallManager> = lazy {
         globalCallManager.getCallManagerForClient(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -1,8 +1,6 @@
 package com.wire.kalium.logic.configuration
 
-import com.wire.kalium.logic.configuration.server.CURRENT_DOMAIN
 import com.wire.kalium.logic.configuration.server.CommonApiVersionType
-import com.wire.kalium.logic.configuration.server.FEDERATION_ENABLED
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.configuration.server.ServerConfigDataSource
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
@@ -130,8 +128,6 @@ class ServerConfigRepositoryTest {
             .withApiAversionResponse(expected)
             .withConfigById()
             .withConfigByLinks()
-            .withStoringCurrentDomain()
-            .withStoringFederationEnabled()
             .arrange()
 
         repository.fetchApiVersionAndStore(expected.links).shouldSucceed {
@@ -147,23 +143,12 @@ class ServerConfigRepositoryTest {
             .function(arrangement.serverConfigDAO::configById)
             .with(any())
             .wasInvoked(exactly = once)
-
-        verify(arrangement.kaliumPreferences)
-            .function(arrangement.kaliumPreferences::putBoolean)
-            .with(any(), any())
-            .wasInvoked(exactly = once)
-
-        verify(arrangement.kaliumPreferences)
-            .invocation { arrangement.kaliumPreferences.putString(CURRENT_DOMAIN, "domain1.com") }
-            .wasInvoked(exactly = once)
     }
 
 
     @Test
     fun givenStoredConfig_whenAddingTheSameOneWithNewApiVersionParams_thenStoredOneShouldBeUpdatedAndReturned() {
         val (arrangement, repository) = Arrangement()
-            .withStoringCurrentDomain()
-            .withStoringFederationEnabled(true)
             .withUpdatedServerConfig()
             .arrange()
 
@@ -198,8 +183,6 @@ class ServerConfigRepositoryTest {
         val expected = newServerConfig(1)
         val (arrangement, repository) = Arrangement()
             .withConfigForNewRequest(expected)
-            .withStoringCurrentDomain()
-            .withStoringFederationEnabled()
             .arrange()
 
         repository
@@ -248,7 +231,7 @@ class ServerConfigRepositoryTest {
         val kaliumPreferences = mock(classOf<KaliumPreferences>())
 
         private var serverConfigRepository: ServerConfigRepository =
-            ServerConfigDataSource(serverConfigApi, serverConfigDAO, versionApi, kaliumPreferences)
+            ServerConfigDataSource(serverConfigApi, serverConfigDAO, versionApi)
 
         val serverConfigEntity = newServerConfigEntity(1)
         val expectedServerConfig = newServerConfig(1).copy(
@@ -340,20 +323,6 @@ class ServerConfigRepositoryTest {
                 .whenInvokedWith(any())
                 .then { newServerConfigEntity }
 
-            return this
-        }
-
-        fun withStoringCurrentDomain(domain: String = "domain1.com"): Arrangement {
-            given(kaliumPreferences)
-                .invocation { putString(CURRENT_DOMAIN, domain) }
-                .then { Unit }
-            return this
-        }
-
-        fun withStoringFederationEnabled(enabled: Boolean = false): Arrangement {
-            given(kaliumPreferences)
-                .invocation { putBoolean(FEDERATION_ENABLED, enabled) }
-                .then { Unit }
             return this
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -145,7 +145,6 @@ class ServerConfigRepositoryTest {
             .wasInvoked(exactly = once)
     }
 
-
     @Test
     fun givenStoredConfig_whenAddingTheSameOneWithNewApiVersionParams_thenStoredOneShouldBeUpdatedAndReturned() {
         val (arrangement, repository) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ServerConfigStubs.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ServerConfigStubs.kt
@@ -25,7 +25,7 @@ internal fun newTestServer(id: Int) = ServerConfig(
     )
 )
 
-internal fun newServerConfig(id: Int) = ServerConfig(
+internal fun newServerConfig(id: Int, federationEnabled: Boolean = false) = ServerConfig(
     id = "config-$id",
     links = ServerConfig.Links(
         api = "https://server$id-apiBaseUrl.de",
@@ -40,7 +40,7 @@ internal fun newServerConfig(id: Int) = ServerConfig(
     metaData = ServerConfig.MetaData(
         commonApiVersion = CommonApiVersionType.Valid(id),
         domain = "domain$id.com",
-        federation = false
+        federation = federationEnabled
     )
 )
 

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature
 import com.wire.kalium.logic.AuthenticatedDataSourceSet
 import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.configuration.ClientConfigImpl
+import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.asset.DataStoragePaths
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
@@ -11,7 +12,7 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 
 @Suppress("LongParameterList")
-actual class UserSessionScope(
+actual class UserSessionScope internal constructor(
     userId: UserId,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet,
     sessionRepository: SessionRepository,
@@ -19,7 +20,8 @@ actual class UserSessionScope(
     globalPreferences: KaliumPreferences,
     dataStoragePaths: DataStoragePaths,
     kaliumConfigs: KaliumConfigs,
-    userSessionScopeProvider: UserSessionScopeProvider
+    userSessionScopeProvider: UserSessionScopeProvider,
+    serverConfigRepository: Lazy<ServerConfigRepository>
 ) : UserSessionScopeCommon(
     userId,
     authenticatedDataSourceSet,
@@ -28,7 +30,8 @@ actual class UserSessionScope(
     globalPreferences,
     dataStoragePaths,
     kaliumConfigs,
-    userSessionScopeProvider
+    userSessionScopeProvider,
+    serverConfigRepository
 ) {
     override val clientConfig: ClientConfig get() = ClientConfigImpl()
 

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -79,7 +79,8 @@ actual class UserSessionScopeProviderImpl(
             globalPreferences,
             dataStoragePaths,
             kaliumConfigs,
-            this
+            this,
+            lazy { globalScope.serverConfigRepository }
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Now the feature flag and id mapper for calling is scoped into the global shared preferences.

### Solutions

This mapper and configuration should be scoped per user, so we can support multiple accounts correctly

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
