### PR TITLE
fix: storing user client from MessageSendFailureHandler crashes the app

### DIFF
--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -745,6 +745,8 @@ debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@4.3.2:
   version "4.3.2"
@@ -1565,11 +1567,6 @@ mocha@9.1.2:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
 ms@2.1.2:
   version "2.1.2"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -72,9 +72,9 @@ class ClientMapper(
         DeviceType.Unknown -> DeviceTypeDTO.Unknown
     }
 
-    fun fromOtherUsersClientsDTO(otherUsersClients: List<OtherUserClientsItem>): List<OtherUserClients> =
+    fun fromOtherUsersClientsDTO(otherUsersClients: List<OtherUserClientsItem>): List<OtherUserClient> =
         otherUsersClients.map {
-            OtherUserClients(DeviceType.valueOf(it.deviceType.name), it.id)
+            OtherUserClient(DeviceType.valueOf(it.deviceType.name), it.id)
         }
 
     private fun fromDeviceTypeDTO(deviceTypeDTO: DeviceTypeDTO): DeviceType = when (deviceTypeDTO) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
@@ -55,7 +55,7 @@ enum class ClientCapability {
     LegalHoldImplicitConsent;
 }
 
-data class OtherUserClients(
+data class OtherUserClient(
     val deviceType: DeviceType,
     val id: String
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -30,10 +30,12 @@ interface ClientRepository {
     suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit>
     suspend fun selfListOfClients(): Either<NetworkFailure, List<Client>>
     suspend fun clientInfo(clientId: ClientId /* = com.wire.kalium.logic.data.id.PlainId */): Either<NetworkFailure, Client>
-    suspend fun saveNewClients(userId: UserId, clients: List<ClientId>, deviceType: List<DeviceType>?): Either<CoreFailure, Unit>
+    suspend fun saveNewClients(userId: UserId, clients: List<OtherUserClient>): Either<StorageFailure, Unit>
+    suspend fun saveNewClients(userId: UserId, clients: List<ClientId>): Either<StorageFailure, Unit>
+
     suspend fun registerToken(body: PushTokenBody): Either<NetworkFailure, Unit>
     suspend fun deregisterToken(token: String): Either<NetworkFailure, Unit>
-    suspend fun getClientsByUserId(userId: UserId): Either<StorageFailure, List<OtherUserClients>>
+    suspend fun getClientsByUserId(userId: UserId): Either<StorageFailure, List<OtherUserClient>>
 }
 
 class ClientDataSource(
@@ -81,9 +83,16 @@ class ClientDataSource(
     override suspend fun registerMLSClient(clientId: ClientId, publicKey: ByteArray): Either<CoreFailure, Unit> =
         clientRemoteRepository.registerMLSClient(clientId, publicKey.encodeBase64())
 
-    override suspend fun saveNewClients(userId: UserId, clients: List<ClientId>, deviceType: List<DeviceType>?): Either<CoreFailure, Unit> =
+    override suspend fun saveNewClients(userId: UserId, clients: List<ClientId>): Either<StorageFailure, Unit> =
         userMapper.toUserIdPersistence(userId).let { userEntity ->
-            clients.map { ClientEntity(userEntity, it.value, deviceType?.get(clients.indexOf(it))?.name) }.let { clientEntityList ->
+            clients.map { ClientEntity(userEntity, it.value, null) }.let { clientEntityList ->
+                wrapStorageRequest { clientDAO.insertClients(clientEntityList) }
+            }
+        }
+
+    override suspend fun saveNewClients(userId: UserId, clients: List<OtherUserClient>): Either<StorageFailure, Unit> =
+        userMapper.toUserIdPersistence(userId).let { userEntity ->
+            clients.map { ClientEntity(userEntity, it.id, it.deviceType.name) }.let { clientEntityList ->
                 wrapStorageRequest { clientDAO.insertClients(clientEntityList) }
             }
         }
@@ -91,7 +100,7 @@ class ClientDataSource(
     override suspend fun registerToken(body: PushTokenBody): Either<NetworkFailure, Unit> = clientRemoteRepository.registerToken(body)
     override suspend fun deregisterToken(token: String): Either<NetworkFailure, Unit> = clientRemoteRepository.deregisterToken(token)
 
-    override suspend fun getClientsByUserId(userId: UserId): Either<StorageFailure, List<OtherUserClients>> =
+    override suspend fun getClientsByUserId(userId: UserId): Either<StorageFailure, List<OtherUserClient>> =
         wrapStorageRequest {
             clientDAO.getClientsOfUserByQualifiedID(idMapper.toDaoModel(userId))
         }.map { clientsList ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
@@ -5,7 +5,7 @@ import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientMapper
 import com.wire.kalium.logic.data.client.DeleteClientParam
-import com.wire.kalium.logic.data.client.OtherUserClients
+import com.wire.kalium.logic.data.client.OtherUserClient
 import com.wire.kalium.logic.data.client.RegisterClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.IdMapper
@@ -27,7 +27,7 @@ interface ClientRemoteRepository {
     suspend fun fetchSelfUserClients(): Either<NetworkFailure, List<Client>>
     suspend fun registerToken(body: PushTokenBody): Either<NetworkFailure, Unit>
     suspend fun deregisterToken(pid: String): Either<NetworkFailure, Unit>
-    suspend fun fetchOtherUserClients(userId: UserId): Either<NetworkFailure, List<OtherUserClients>>
+    suspend fun fetchOtherUserClients(userId: UserId): Either<NetworkFailure, List<OtherUserClient>>
 }
 
 class ClientRemoteDataSource(
@@ -65,7 +65,7 @@ class ClientRemoteDataSource(
         clientApi.deregisterToken(pid)
     }
 
-    override suspend fun fetchOtherUserClients(userId: UserId): Either<NetworkFailure, List<OtherUserClients>> =
+    override suspend fun fetchOtherUserClients(userId: UserId): Either<NetworkFailure, List<OtherUserClient>> =
         wrapApiRequest { clientApi.otherUserClients(idMapper.toNetworkUserId(userId)) }.map { otherUserClientsItems ->
             clientMapper.fromOtherUsersClientsDTO(otherUserClientsItems)
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -1,7 +1,7 @@
 package com.wire.kalium.logic.data.user
 
 import com.wire.kalium.logic.data.client.DeviceType
-import com.wire.kalium.logic.data.client.OtherUserClients
+import com.wire.kalium.logic.data.client.OtherUserClient
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
@@ -60,7 +60,7 @@ interface UserMapper {
         permissionsCode: Int?,
     ): UserEntity
 
-    fun fromOtherUsersClientsDTO(otherUsersClients: List<Client>): List<OtherUserClients>
+    fun fromOtherUsersClientsDTO(otherUsersClients: List<Client>): List<OtherUserClient>
 }
 
 internal class UserMapperImpl(
@@ -220,8 +220,8 @@ internal class UserMapperImpl(
             deleted = false
         )
 
-    override fun fromOtherUsersClientsDTO(otherUsersClients: List<Client>): List<OtherUserClients> =
+    override fun fromOtherUsersClientsDTO(otherUsersClients: List<Client>): List<OtherUserClient> =
         otherUsersClients.map {
-            OtherUserClients(DeviceType.valueOf(it.deviceType ?: ""), it.id)
+            OtherUserClient(DeviceType.valueOf(it.deviceType ?: ""), it.id)
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetOtherUserClientsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetOtherUserClientsUseCase.kt
@@ -2,7 +2,7 @@ package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.client.OtherUserClients
+import com.wire.kalium.logic.data.client.OtherUserClient
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.fold
 
@@ -25,7 +25,7 @@ internal class GetOtherUserClientsUseCaseImpl(
 }
 
 sealed class GetOtherUserClientsResult {
-    class Success(val otherUserClients: List<OtherUserClients>) : GetOtherUserClientsResult()
+    class Success(val otherUserClients: List<OtherUserClient>) : GetOtherUserClientsResult()
 
     sealed class Failure : GetOtherUserClientsResult() {
         object UserNotFound : Failure()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUserClientsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUserClientsUseCase.kt
@@ -22,6 +22,6 @@ internal class PersistOtherUserClientsUseCaseImpl(
         clientRemoteRepository.fetchOtherUserClients(userId).fold({
             kaliumLogger.withFeatureId(CLIENTS).e("Failure while fetching other users clients $it")
         }, { clientList ->
-            clientRepository.saveNewClients(userId, clientList)
+            clientRepository.storeUserClientList(userId, clientList)
         })
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUserClientsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUserClientsUseCase.kt
@@ -23,13 +23,7 @@ internal class PersistOtherUserClientsUseCaseImpl(
     override suspend operator fun invoke(userId: UserId): Unit =
         clientRemoteRepository.fetchOtherUserClients(userId).fold({
             kaliumLogger.withFeatureId(CLIENTS).e("Failure while fetching other users clients $it")
-        }, { otherUserClients ->
-            val clientIdList = arrayListOf<ClientId>()
-            val deviceTypesList = arrayListOf<DeviceType>()
-            otherUserClients.map {
-                clientIdList.add(ClientId(it.id))
-                deviceTypesList.add(it.deviceType)
-            }
-            clientRepository.saveNewClients(userId, clientIdList, deviceTypesList)
+        }, { clientList ->
+            clientRepository.saveNewClients(userId, clientList)
         })
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUserClientsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUserClientsUseCase.kt
@@ -2,9 +2,7 @@ package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.CLIENTS
 import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.client.DeviceType
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
-import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
@@ -29,7 +29,7 @@ class MessageSendFailureHandlerImpl(
         //TODO(optimization): remove clients from conversation
         userRepository.fetchUsersByIds(sendFailure.missingClientsOfUsers.keys).flatMap {
             sendFailure.missingClientsOfUsers.entries.foldToEitherWhileRight(Unit) { entry, _ ->
-                clientRepository.saveNewClients(entry.key, entry.value, listOf())
+                clientRepository.saveNewClients(entry.key, entry.value)
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
@@ -29,8 +29,7 @@ class MessageSendFailureHandlerImpl(
         //TODO(optimization): remove clients from conversation
         userRepository.fetchUsersByIds(sendFailure.missingClientsOfUsers.keys).flatMap {
             sendFailure.missingClientsOfUsers.entries.foldToEitherWhileRight(Unit) { entry, _ ->
-                clientRepository.saveNewClients(entry.key, entry.value)
+                clientRepository.storeUserClientIdList(entry.key, entry.value)
             }
         }
-
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
 import com.wire.kalium.persistence.dao.client.ClientDAO
+import io.mockative.ConfigurationApi
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -34,6 +35,7 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -42,6 +44,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertSame
 
+@ExperimentalCoroutinesApi
+@ConfigurationApi
 class ClientRepositoryTest {
 
     @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.prekey
 
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
@@ -20,6 +21,7 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
+import okio.IOException
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -55,8 +57,8 @@ class MessageSendFailureHandlerTest {
             .thenReturn(Either.Right(Unit))
 
         given(clientRepository)
-            .suspendFunction(clientRepository::saveNewClients)
-            .whenInvokedWith(any(), any(), any())
+            .suspendFunction(clientRepository::storeUserClientIdList)
+            .whenInvokedWith(any(), any())
             .thenReturn(Either.Right(Unit))
 
         messageSendFailureHandler.handleClientsHaveChangedFailure(failureData)
@@ -78,20 +80,20 @@ class MessageSendFailureHandlerTest {
             .thenReturn(Either.Right(Unit))
 
         given(clientRepository)
-            .suspendFunction(clientRepository::saveNewClients)
-            .whenInvokedWith(any(), any(), any())
+            .suspendFunction(clientRepository::storeUserClientIdList)
+            .whenInvokedWith(any(), any())
             .thenReturn(Either.Right(Unit))
 
         messageSendFailureHandler.handleClientsHaveChangedFailure(failureData)
 
         verify(clientRepository)
-            .suspendFunction(clientRepository::saveNewClients)
-            .with(eq(userOne.first), eq(userOne.second), any())
+            .suspendFunction(clientRepository::storeUserClientIdList)
+            .with(eq(userOne.first), eq(userOne.second))
             .wasInvoked(once)
 
         verify(clientRepository)
-            .suspendFunction(clientRepository::saveNewClients)
-            .with(eq(userTwo.first), eq(userTwo.second), any())
+            .suspendFunction(clientRepository::storeUserClientIdList)
+            .with(eq(userTwo.first), eq(userTwo.second))
             .wasInvoked(once)
     }
 
@@ -112,14 +114,14 @@ class MessageSendFailureHandlerTest {
 
     @Test
     fun givenRepositoryFailsToAddClientsToContacts_whenHandlingClientsHaveChangedFailure_thenFailureShouldBePropagated() = runTest {
-        val failure = NETWORK_ERROR
+        val failure = StorageFailure.Generic(IOException())
         given(userRepository)
             .suspendFunction(userRepository::fetchUsersByIds)
             .whenInvokedWith(any())
             .thenReturn(Either.Right(Unit))
         given(clientRepository)
-            .suspendFunction(clientRepository::saveNewClients)
-            .whenInvokedWith(any(), any(), any())
+            .suspendFunction(clientRepository::storeUserClientIdList)
+            .whenInvokedWith(any(), any())
             .thenReturn(Either.Left(failure))
         val failureData = ProteusSendMessageFailure(mapOf(userOne), mapOf(), mapOf())
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
@@ -46,7 +46,6 @@ class MessageSendFailureHandlerTest {
         userTwo = UserId("userId2", "bella.wire") to listOf(ClientId("clientId2"), ClientId("secondClientId2"))
     }
 
-
     @Test
     fun givenMissingClients_whenHandlingClientsHaveChangedFailure_thenUsersThatControlTheseClientsShouldBeFetched() = runTest {
         val failureData = ProteusSendMessageFailure(missingClientsOfUsers = mapOf(userOne, userTwo), mapOf(), mapOf())
@@ -68,7 +67,6 @@ class MessageSendFailureHandlerTest {
             .with(eq(failureData.missingClientsOfUsers.keys))
             .wasInvoked(once)
     }
-
 
     @Test
     fun givenMissingContactsAndClients_whenHandlingClientsHaveChangedFailureThenClientsShouldBeAddedToContacts() = runTest {
@@ -96,7 +94,6 @@ class MessageSendFailureHandlerTest {
             .with(eq(userTwo.first), eq(userTwo.second))
             .wasInvoked(once)
     }
-
 
     @Test
     fun givenRepositoryFailsToFetchContacts_whenHandlingClientsHaveChangedFailure_thenFailureShouldBePropagated() = runTest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOtherUserClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOtherUserClientsUseCaseTest.kt
@@ -13,10 +13,12 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+@ExperimentalCoroutinesApi
 class GetOtherUserClientsUseCaseTest {
     @Test
     fun givenASuccessfulRepositoryResponse_whenInvokingTheUseCase_thenSuccessResultIsReturned() = runTest {
@@ -71,7 +73,8 @@ class GetOtherUserClientsUseCaseTest {
                 .thenReturn(Either.Right(expectedResponse))
 
             given(clientRepository)
-                .suspendFunction(clientRepository::saveNewClients).whenInvokedWith(any(), any(), any())
+                .suspendFunction(clientRepository::storeUserClientList)
+                .whenInvokedWith(any(), any())
                 .thenReturn(Either.Right(Unit))
             return this
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOtherUserClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOtherUserClientsUseCaseTest.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.logic.feature.client
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.DeviceType
-import com.wire.kalium.logic.data.client.OtherUserClients
+import com.wire.kalium.logic.data.client.OtherUserClient
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -23,7 +23,7 @@ class GetOtherUserClientsUseCaseTest {
         // Given
         val userId = UserId("123", "wire.com")
         val otherUserClients = listOf(
-            OtherUserClients(DeviceType.Phone, "111"), OtherUserClients(DeviceType.Desktop, "2222")
+            OtherUserClient(DeviceType.Phone, "111"), OtherUserClient(DeviceType.Desktop, "2222")
         )
         val (arrangement, getOtherUsersClientsUseCase) = Arrangement()
             .withSuccessfulResponse(otherUserClients)
@@ -65,7 +65,7 @@ class GetOtherUserClientsUseCaseTest {
 
         val getOtherUserClientsUseCaseImpl = GetOtherUserClientsUseCaseImpl(clientRepository)
 
-        fun withSuccessfulResponse(expectedResponse: List<OtherUserClients>): Arrangement {
+        fun withSuccessfulResponse(expectedResponse: List<OtherUserClient>): Arrangement {
             given(clientRepository)
                 .suspendFunction(clientRepository::getClientsByUserId).whenInvokedWith(any())
                 .thenReturn(Either.Right(expectedResponse))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUsersClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUsersClientsUseCaseTest.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.logic.feature.client
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.DeviceType
-import com.wire.kalium.logic.data.client.OtherUserClients
+import com.wire.kalium.logic.data.client.OtherUserClient
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
@@ -12,6 +12,7 @@ import com.wire.kalium.network.exceptions.KaliumException
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
+import io.mockative.fun2
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
@@ -26,17 +27,22 @@ class PersistOtherUsersClientsUseCaseTest {
         // Given
         val userId = UserId("123", "wire.com")
         val otherUserClients = listOf(
-            OtherUserClients(DeviceType.Phone, "111"), OtherUserClients(DeviceType.Desktop, "2222")
+            OtherUserClient(DeviceType.Phone, "111"), OtherUserClient(DeviceType.Desktop, "2222")
         )
         val (arrangement, getOtherUsersClientsUseCase) = Arrangement()
-            .withSuccessfulResponse(otherUserClients)
+            .withSuccessfulResponse(userId, otherUserClients)
             .arrange()
 
         // When
-        getOtherUsersClientsUseCase.invoke(userId)
+        getOtherUsersClientsUseCase(userId)
 
         verify(arrangement.clientRemoteRepository)
             .suspendFunction(arrangement.clientRemoteRepository::fetchOtherUserClients).with(any())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.clientRepository)
+            .suspendFunction(arrangement.clientRepository::saveNewClients, fun2<UserId, List<OtherUserClient>>())
+            .with(any(), any())
             .wasInvoked(exactly = once)
 
     }
@@ -70,14 +76,15 @@ class PersistOtherUsersClientsUseCaseTest {
 
         val persistOtherUserClientsUseCase = PersistOtherUserClientsUseCaseImpl(clientRemoteRepository, clientRepository)
 
-        fun withSuccessfulResponse(expectedResponse: List<OtherUserClients>): Arrangement {
+        suspend fun withSuccessfulResponse(userId: UserId, expectedResponse: List<OtherUserClient>): Arrangement {
             given(clientRemoteRepository)
                 .suspendFunction(clientRemoteRepository::fetchOtherUserClients).whenInvokedWith(any())
                 .thenReturn(Either.Right(expectedResponse))
 
             given(clientRepository)
-                .suspendFunction(clientRepository::saveNewClients).whenInvokedWith(any(), any(), any())
+                .coroutine { clientRepository.saveNewClients(userId, expectedResponse) }
                 .thenReturn(Either.Right(Unit))
+
             return this
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUsersClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/PersistOtherUsersClientsUseCaseTest.kt
@@ -41,7 +41,7 @@ class PersistOtherUsersClientsUseCaseTest {
             .wasInvoked(exactly = once)
 
         verify(arrangement.clientRepository)
-            .suspendFunction(arrangement.clientRepository::saveNewClients, fun2<UserId, List<OtherUserClient>>())
+            .suspendFunction(arrangement.clientRepository::storeUserClientList, fun2<UserId, List<OtherUserClient>>())
             .with(any(), any())
             .wasInvoked(exactly = once)
 
@@ -82,7 +82,7 @@ class PersistOtherUsersClientsUseCaseTest {
                 .thenReturn(Either.Right(expectedResponse))
 
             given(clientRepository)
-                .coroutine { clientRepository.saveNewClients(userId, expectedResponse) }
+                .coroutine { clientRepository.storeUserClientList(userId, expectedResponse) }
                 .thenReturn(Either.Right(Unit))
 
             return this

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -18,8 +18,10 @@ deleteClientsOfUser:
 DELETE FROM Client WHERE user_id = ?;
 
 insertClient:
-INSERT OR IGNORE INTO Client(user_id, id,device_type)
-VALUES(?, ?,?);
+INSERT INTO Client(user_id, id,device_type)
+VALUES(?, ?,?)
+ON CONFLICT(id, user_id) DO UPDATE SET
+device_type = coalesce(excluded.device_type, device_type);
 
 selectAllClients:
 SELECT * FROM Client;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -18,10 +18,8 @@ deleteClientsOfUser:
 DELETE FROM Client WHERE user_id = ?;
 
 insertClient:
-INSERT INTO Client(user_id, id,device_type)
-VALUES(?, ?,?)
-ON CONFLICT(id, user_id) DO UPDATE SET
-device_type = excluded.device_type;
+INSERT OR IGNORE INTO Client(user_id, id,device_type)
+VALUES(?, ?,?);
 
 selectAllClients:
 SELECT * FROM Client;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

storing user client from MessageSendFailureHandler crashes the app

### Causes (Optional)

in kalium there are 2 places where a user clients are stored locally 
1. MessageSendFailureHandler
2. PersistOtherUserClientsUseCase
the only difference is in case of 1 we don't get the client type, but we do have it in case 2
Therefore, we had one function to handle both cases

```kotlin
    override suspend fun saveNewClients(userId: UserId, clients: List<ClientId>, deviceType: List<DeviceType>?): Either<CoreFailure, Unit> =
        userMapper.toUserIdPersistence(userId).let { userEntity ->
            clients.map { ClientEntity(userEntity, it.value, deviceType?.get(clients.indexOf(it))?.name) }.let { clientEntityList ->
                wrapStorageRequest { clientDAO.insertClients(clientEntityList) }
            }
        }
```

and from MessageSendFailureHandler `clientRepo.saveNewClients` was called with empty list for the device type instead of null

and when the device type list is empty the app will crash when executing `deviceType?.get(clients.indexOf(it))?.name` and KaBoom IndexOutOfBoundsException


### Solutions

Splitting the saveUserClient info 2 functions 

```kotlin
    suspend fun saveNewClients(userId: UserId, clients: List<OtherUserClient>): Either<StorageFailure, Unit>
    suspend fun saveNewClients(userId: UserId, clients: List<ClientId>): Either<StorageFailure, Unit>
```

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
