### PR TITLE
fix: improve error handling on MLS commits - part 2 AR-2286

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -80,12 +80,7 @@ actual class MLSClientImpl actual constructor(
 
     override fun createConversation(
         groupId: MLSGroupId,
-        members: List<Pair<CryptoQualifiedClientId, MLSKeyPackage>>
-    ): AddMemberCommitBundle? {
-        val invitees = members.map {
-            Invitee(toUByteList(it.first.toString()), toUByteList(it.second))
-        }
-
+    ) {
         val conf = ConversationConfiguration(
             emptyList(),
             CiphersuiteName.MLS_128_DHKEMX25519_AES128GCM_SHA256_ED25519,
@@ -95,12 +90,6 @@ actual class MLSClientImpl actual constructor(
 
         val groupIdAsBytes = toUByteList(groupId.decodeBase64Bytes())
         coreCrypto.createConversation(groupIdAsBytes, conf)
-
-        return if (members.isEmpty()) {
-            null
-        } else {
-            toAddMemberCommitBundle(coreCrypto.addClientsToConversation(groupIdAsBytes, invitees))
-        }
     }
 
     override fun wipeConversation(groupId: MLSGroupId) {

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
@@ -100,14 +100,10 @@ interface MLSClient {
      * Create a new MLS conversation
      *
      * @param groupId MLS group ID provided by BE
-     * @param members list of clients with a claimed key package for each client.
-     *
-     * @return commit bundle, which needs to be sent to the distribution service.
      */
     fun createConversation(
-        groupId: MLSGroupId,
-        members: List<Pair<CryptoQualifiedClientId, MLSKeyPackage>>
-    ): AddMemberCommitBundle?
+        groupId: MLSGroupId
+    )
 
     fun wipeConversation(groupId: MLSGroupId)
 

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
@@ -32,7 +32,7 @@ class MLSClientTest : BaseMLSClientTest() {
     @Test
     fun givenNewConversation_whenCallingConversationEpoch_ReturnZeroEpoch() {
         val mlsClient = createClient(ALICE)
-        mlsClient.createConversation(MLS_CONVERSATION_ID, emptyList())
+        mlsClient.createConversation(MLS_CONVERSATION_ID)
         assertEquals(0UL, mlsClient.conversationEpoch(MLS_CONVERSATION_ID))
     }
 
@@ -43,7 +43,8 @@ class MLSClientTest : BaseMLSClientTest() {
 
         val aliceKeyPackage = aliceClient.generateKeyPackages(1).first()
         val clientKeyPackageList = listOf(Pair(ALICE.qualifiedClientId, aliceKeyPackage))
-        val welcome = bobClient.createConversation(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
+        bobClient.createConversation(MLS_CONVERSATION_ID)
+        val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
         bobClient.commitAccepted(MLS_CONVERSATION_ID)
         val conversationId = aliceClient.processWelcomeMessage(welcome)
 
@@ -60,7 +61,8 @@ class MLSClientTest : BaseMLSClientTest() {
 
         val aliceKeyPackage = aliceClient.generateKeyPackages(1).first()
         val clientKeyPackageList = listOf(Pair(ALICE.qualifiedClientId, aliceKeyPackage))
-        val welcome = bobClient.createConversation(MLS_CONVERSATION_ID, clientKeyPackageList)!!.welcome
+        bobClient.createConversation(MLS_CONVERSATION_ID)
+        val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)!!.welcome
         val conversationId = aliceClient.processWelcomeMessage(welcome)
 
         assertEquals(MLS_CONVERSATION_ID, conversationId)
@@ -75,7 +77,8 @@ class MLSClientTest : BaseMLSClientTest() {
         val carolKeyPackage = carolClient.generateKeyPackages(1).first()
         val clientKeyPackageList = listOf(Pair(CAROL.qualifiedClientId, carolKeyPackage))
 
-        bobClient.createConversation(MLS_CONVERSATION_ID, clientKeyPackageList)
+        bobClient.createConversation(MLS_CONVERSATION_ID)
+        bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)
         bobClient.commitAccepted(MLS_CONVERSATION_ID)
         val proposal = aliceClient.joinConversation(MLS_CONVERSATION_ID, 1UL)
         bobClient.decryptMessage(MLS_CONVERSATION_ID, proposal)
@@ -94,7 +97,8 @@ class MLSClientTest : BaseMLSClientTest() {
         val clientKeyPackageList = listOf(
             Pair(ALICE.qualifiedClientId, aliceClient.generateKeyPackages(1).first())
         )
-        val welcome = bobClient.createConversation(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
+        bobClient.createConversation(MLS_CONVERSATION_ID)
+        val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
         bobClient.commitAccepted(MLS_CONVERSATION_ID)
         val conversationId = aliceClient.processWelcomeMessage(welcome)
 
@@ -112,7 +116,7 @@ class MLSClientTest : BaseMLSClientTest() {
         val clientKeyPackageList = listOf(
             Pair(ALICE.qualifiedClientId, aliceClient.generateKeyPackages(1).first())
         )
-        bobClient.createConversation(MLS_CONVERSATION_ID, emptyList())
+        bobClient.createConversation(MLS_CONVERSATION_ID)
         val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
         bobClient.commitAccepted((MLS_CONVERSATION_ID))
         val conversationId = aliceClient.processWelcomeMessage(welcome)
@@ -126,7 +130,8 @@ class MLSClientTest : BaseMLSClientTest() {
         val bobClient = createClient(BOB)
         val carolClient = createClient(CAROL)
 
-        val welcome = bobClient.createConversation(
+        bobClient.createConversation(MLS_CONVERSATION_ID)
+        val welcome = bobClient.addMember(
             MLS_CONVERSATION_ID,
             listOf(Pair(ALICE.qualifiedClientId, aliceClient.generateKeyPackages(1).first()))
         )?.welcome!!
@@ -152,7 +157,8 @@ class MLSClientTest : BaseMLSClientTest() {
             Pair(ALICE.qualifiedClientId, aliceClient.generateKeyPackages(1).first()),
             Pair(CAROL.qualifiedClientId, carolClient.generateKeyPackages(1).first())
         )
-        val welcome = bobClient.createConversation(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
+        bobClient.createConversation(MLS_CONVERSATION_ID)
+        val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
         bobClient.commitAccepted(MLS_CONVERSATION_ID)
         val conversationId = aliceClient.processWelcomeMessage(welcome)
 

--- a/cryptography/src/iosX64Main/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/cryptography/src/iosX64Main/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -38,10 +38,7 @@ actual class MLSClientImpl actual constructor(
         TODO("Not yet implemented")
     }
 
-    override fun createConversation(
-        groupId: MLSGroupId,
-        members: List<Pair<CryptoQualifiedClientId, MLSKeyPackage>>
-    ): AddMemberCommitBundle? {
+    override fun createConversation(groupId: MLSGroupId) {
         TODO("Not yet implemented")
     }
 

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -39,10 +39,7 @@ actual class MLSClientImpl actual constructor(
         TODO("Not yet implemented")
     }
 
-    override fun createConversation(
-        groupId: MLSGroupId,
-        members: List<Pair<CryptoQualifiedClientId, MLSKeyPackage>>
-    ): AddMemberCommitBundle? {
+    override fun createConversation(groupId: MLSGroupId) {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If we receive a `mls-client-mismatch` error when establishing an MLS group we fail the operation even though we can recover. 

### Solutions

We receive a `mls-client-mismatch` if we didn't include all the clients of a user when adding or removing a group member. Not including all the clients is a race condition, which we can recover from by re-trying the add operation.

Change MLSClient API so that we don't add any members when creating the MLS group locally.  That way we can retry the second step where we add the members to the group by wrapping the the operation in a `retryOnCommitFailure`.

### Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/862

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
