### PR TITLE
fix: add isSelfUserMember to `Conversation` and `ConversationDetails.Group` objects [AR-1552]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -135,7 +135,8 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         val hasOngoingCall: Boolean = false,
         val unreadMessagesCount: Long = 0L,
         val unreadMentionsCount: Long = 0L,
-        val lastUnreadMessage: Message?
+        val lastUnreadMessage: Message?,
+        val isSelfUserMember: Boolean = true
     ) : ConversationDetails(conversation)
 
     data class Connection(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -52,7 +52,7 @@ class ConversationScope internal constructor(
         get() = GetConversationUseCase(conversationRepository)
 
     val observeConversationListDetails: ObserveConversationListDetailsUseCase
-        get() = ObserveConversationListDetailsUseCaseImpl(conversationRepository, callRepository)
+        get() = ObserveConversationListDetailsUseCaseImpl(conversationRepository, callRepository, observeIsSelfUserMemberUseCase)
 
     val observeConversationsAndConnectionListUseCase: ObserveConversationsAndConnectionsUseCase
         get() = ObserveConversationsAndConnectionsUseCaseImpl(observeConversationListDetails, observeConnectionList)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -62,9 +62,9 @@ class ObserveConversationListDetailsUseCaseTest {
             .arrange()
 
         // When
-
         observeConversationsUseCase().collect()
 
+        // Then
         with(arrangement) {
             verify(conversationRepository)
                 .suspendFunction(conversationRepository::observeConversationList)
@@ -74,6 +74,7 @@ class ObserveConversationListDetailsUseCaseTest {
 
     @Test
     fun givenSomeConversations_whenObservingDetailsList_thenObserveConversationDetailsShouldBeCalledForEachID() = runTest {
+        // Given
         val selfConversation = TestConversation.SELF
         val groupConversation = TestConversation.GROUP()
         val conversations = listOf(selfConversation, groupConversation)
@@ -95,6 +96,7 @@ class ObserveConversationListDetailsUseCaseTest {
             .withIsSelfUserMember(true)
             .arrange()
 
+        // When
         observeConversationsUseCase().collect()
 
         with(arrangement) {
@@ -109,6 +111,7 @@ class ObserveConversationListDetailsUseCaseTest {
 
     @Test
     fun givenSomeConversationsDetailsAreUpdated_whenObservingDetailsList_thenTheUpdateIsPropagatedThroughTheFlow() = runTest {
+        // Given
         val oneOnOneConversation = TestConversation.ONE_ON_ONE
         val groupConversation = TestConversation.GROUP()
         val conversations = listOf(groupConversation, oneOnOneConversation)
@@ -152,6 +155,7 @@ class ObserveConversationListDetailsUseCaseTest {
             .withIsSelfUserMember(true)
             .arrange()
 
+        // When, Then
         observeConversationsUseCase().test {
             oneOnOneDetailsChannel.send(firstOneOnOneDetails)
 
@@ -169,6 +173,7 @@ class ObserveConversationListDetailsUseCaseTest {
     @Suppress("FunctionNaming")
     @Test
     fun givenAConversationIsAddedToTheList_whenObservingDetailsList_thenTheUpdateIsPropagatedThroughTheFlow() = runTest {
+        // Given
         val groupConversation = TestConversation.GROUP()
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
@@ -193,6 +198,7 @@ class ObserveConversationListDetailsUseCaseTest {
             .withIsSelfUserMember(true)
             .arrange()
 
+        // When, Then
         observeConversationsUseCase().test {
             assertContentEquals(listOf(groupConversationDetails), awaitItem().conversationList)
 
@@ -204,6 +210,7 @@ class ObserveConversationListDetailsUseCaseTest {
     @Suppress("FunctionNaming")
     @Test
     fun givenAnOngoingCall_whenFetchingConversationDetails_thenTheConversationShouldHaveAnOngoingCall() = runTest {
+        // Given
         val groupConversation = TestConversation.GROUP()
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
@@ -237,6 +244,7 @@ class ObserveConversationListDetailsUseCaseTest {
             .withIsSelfUserMember(true)
             .arrange()
 
+        // When, Then
         observeConversationsUseCase().test {
             assertEquals(true, (awaitItem().conversationList[0] as ConversationDetails.Group).hasOngoingCall)
         }
@@ -244,6 +252,7 @@ class ObserveConversationListDetailsUseCaseTest {
 
     @Test
     fun givenAConversationWithoutAnOngoingCall_whenFetchingConversationDetails_thenTheConversationShouldNotHaveAnOngoingCall() = runTest {
+        // Given
         val groupConversation = TestConversation.GROUP()
 
         val groupConversationDetails = ConversationDetails.Group(
@@ -266,6 +275,7 @@ class ObserveConversationListDetailsUseCaseTest {
             .withIsSelfUserMember(true)
             .arrange()
 
+        // When, Then
         observeConversationsUseCase().test {
             assertEquals(false, (awaitItem().conversationList[0] as ConversationDetails.Group).hasOngoingCall)
         }
@@ -274,6 +284,7 @@ class ObserveConversationListDetailsUseCaseTest {
     @Suppress("FunctionNaming")
     @Test
     fun givenConversationDetailsFailure_whenObservingDetailsList_thenIgnoreConversationWithFailure() = runTest {
+        // Given
         val successConversation = TestConversation.ONE_ON_ONE.copy(id = ConversationId("successId", "domain"))
         val successConversationDetails = TestConversationDetails.CONVERSATION_ONE_ONE.copy(conversation = successConversation)
         val failureConversation = TestConversation.ONE_ON_ONE.copy(id = ConversationId("failedId", "domain"))
@@ -287,6 +298,7 @@ class ObserveConversationListDetailsUseCaseTest {
             .withIsSelfUserMember(true)
             .arrange()
 
+        // When, Then
         observeConversationsUseCase().test {
             assertEquals(awaitItem().conversationList, listOf(successConversationDetails))
             awaitComplete()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Since we are allowing users to display conversations that they don't belong to anymore for history reasons, we need to add a flag variable indicating this.


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
