### PR TITLE
chore(calling): disable active speaker for testing

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
@@ -3,11 +3,8 @@ package com.wire.kalium.logic.feature.call.scenario
 import com.sun.jna.Pointer
 import com.wire.kalium.calling.callbacks.ActiveSpeakersHandler
 import com.wire.kalium.calling.types.Handle
-import com.wire.kalium.logic.data.call.CallActiveSpeakers
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 
 class OnActiveSpeakers(
     private val callRepository: CallRepository,
@@ -15,12 +12,12 @@ class OnActiveSpeakers(
 ) : ActiveSpeakersHandler {
 
     override fun onActiveSpeakersChanged(inst: Handle, conversationId: String, data: String, arg: Pointer?) {
-        val callActiveSpeakers = Json.decodeFromString<CallActiveSpeakers>(data)
-        val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
-
-        callRepository.updateParticipantsActiveSpeaker(
-            conversationId = conversationIdWithDomain.toString(),
-            activeSpeakers = callActiveSpeakers
-        )
+//         val callActiveSpeakers = Json.decodeFromString<CallActiveSpeakers>(data)
+//         val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+//
+//         callRepository.updateParticipantsActiveSpeaker(
+//             conversationId = conversationIdWithDomain.toString(),
+//             activeSpeakers = callActiveSpeakers
+//         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

For investigation purposes, we are commenting the part of handling  active speakers in a call


### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
