### PR TITLE
chore: adjust mapping of active speakers to be more optimized

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
@@ -3,8 +3,11 @@ package com.wire.kalium.logic.feature.call.scenario
 import com.sun.jna.Pointer
 import com.wire.kalium.calling.callbacks.ActiveSpeakersHandler
 import com.wire.kalium.calling.types.Handle
+import com.wire.kalium.logic.data.call.CallActiveSpeakers
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 class OnActiveSpeakers(
     private val callRepository: CallRepository,
@@ -12,12 +15,12 @@ class OnActiveSpeakers(
 ) : ActiveSpeakersHandler {
 
     override fun onActiveSpeakersChanged(inst: Handle, conversationId: String, data: String, arg: Pointer?) {
-//         val callActiveSpeakers = Json.decodeFromString<CallActiveSpeakers>(data)
-//         val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
-//
-//         callRepository.updateParticipantsActiveSpeaker(
-//             conversationId = conversationIdWithDomain.toString(),
-//             activeSpeakers = callActiveSpeakers
-//         )
+        val callActiveSpeakers = Json.decodeFromString<CallActiveSpeakers>(data)
+        val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+
+        callRepository.updateParticipantsActiveSpeaker(
+            conversationId = conversationIdWithDomain.toString(),
+            activeSpeakers = callActiveSpeakers
+        )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/ActiveSpeakerMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/ActiveSpeakerMapper.kt
@@ -14,14 +14,15 @@ class ActiveSpeakerMapperImpl : ActiveSpeakerMapper {
     override fun mapParticipantsActiveSpeaker(
         participants: List<Participant>,
         activeSpeakers: CallActiveSpeakers
-    ): List<Participant> = participants.map { participant ->
-        val isSpeaking = activeSpeakers.activeSpeakers.find {
-            it.userId == participant.id.toString() && it.clientId == participant.clientId
-        }?.let {
-            it.audioLevel > 0 && it.audioLevelNow > 0
-        } ?: run { false }
-        participant.copy(
-            isSpeaking = isSpeaking
-        )
+    ): List<Participant> = participants.toMutableList().apply {
+        activeSpeakers.activeSpeakers.forEach { activeSpeaker ->
+            find { participant ->
+                activeSpeaker.userId == participant.id.toString() && activeSpeaker.clientId == participant.clientId
+            }?.let {
+                this[indexOf(it)] = it.copy(
+                    isSpeaking = activeSpeaker.audioLevel > 0 && activeSpeaker.audioLevelNow > 0
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logic for mapping active speakers is very slow.

### Causes (Optional)

We go through every participant first then check if they are active speakers or not.

### Solutions

Go through active speakers first and not participants.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Open App
- Create/Join group call with many participants and let them talk
- See that the app doesn't freeze and (and device)heat as much as before.
- Everything else should look the same as before.