### PR TITLE
refactor: Separate the logout invocation form the release user session scope from memory

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -16,6 +16,7 @@ import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.server.ObserveServerConfigUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCaseImpl
+import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.session.SessionScope
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
@@ -96,4 +97,5 @@ class GlobalKaliumScope(
         get() = ObservePersistentWebSocketConnectionStatusUseCaseImpl(
             userConfigRepository
         )
+    val deleteSession: DeleteSessionUseCase get() = DeleteSessionUseCase(sessionRepository, userSessionScopeProvider.value)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -580,8 +580,7 @@ abstract class UserSessionScopeCommon internal constructor(
             authenticatedDataSourceSet,
             clientRepository,
             mlsClientProvider,
-            client.deregisterNativePushToken,
-            userSessionScopeProvider
+            client.deregisterNativePushToken
         )
     private val featureConfigRepository: FeatureConfigRepository
         get() = FeatureConfigDataSource(featureConfigApi = authenticatedDataSourceSet.authenticatedNetworkContainer.featureConfigApi)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -25,7 +25,6 @@ class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
     private val clientRepository: ClientRepository,
     private val mlsClientProvider: MLSClientProvider,
     private val deregisterTokenUseCase: DeregisterTokenUseCase,
-    private val userSessionScopeProvider: UserSessionScopeProvider
 ) : LogoutUseCase {
     // TODO(refactor): Maybe we can simplify by taking some of the responsibility away from here.
     //                 Perhaps [UserSessionScope] (or another specialised class) can observe
@@ -34,12 +33,11 @@ class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
         deregisterTokenUseCase()
         logoutRepository.logout()
         logout(reason)
-        clearCrypto()
         if (isHardLogout(reason)) {
+            clearCrypto()
             clearUserStorage()
         }
         updateCurrentSession()
-        clearInMemoryUserSession()
     }
 
     private fun isHardLogout(reason: LogoutReason) = when (reason) {
@@ -47,10 +45,6 @@ class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
         LogoutReason.REMOVED_CLIENT -> false
         LogoutReason.DELETED_ACCOUNT -> false
         LogoutReason.SESSION_EXPIRED -> false
-    }
-
-    private fun clearInMemoryUserSession() {
-        userSessionScopeProvider.delete(userId)
     }
 
     private fun updateCurrentSession() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -7,7 +7,6 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.logout.LogoutRepository
 import com.wire.kalium.logic.data.session.SessionRepository
-import com.wire.kalium.logic.feature.UserSessionScopeProvider
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCase
 import com.wire.kalium.logic.functional.isLeft
 import com.wire.kalium.logic.functional.onSuccess

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCase.kt
@@ -1,0 +1,18 @@
+package com.wire.kalium.logic.feature.session
+
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScopeProvider
+
+/**
+ * This class is responsible for deleting a user session and freeing up all the resources.
+ */
+class DeleteSessionUseCase internal constructor(
+    private val sessionRepository: SessionRepository,
+    private val userSessionScopeProvider: UserSessionScopeProvider
+) {
+    operator fun invoke(userId: UserId) {
+        sessionRepository.deleteSession(userId)
+        userSessionScopeProvider.delete(userId)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCase.kt
@@ -1,8 +1,11 @@
 package com.wire.kalium.logic.feature.session
 
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScopeProvider
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.onSuccess
 
 /**
  * This class is responsible for deleting a user session and freeing up all the resources.
@@ -11,8 +14,17 @@ class DeleteSessionUseCase internal constructor(
     private val sessionRepository: SessionRepository,
     private val userSessionScopeProvider: UserSessionScopeProvider
 ) {
-    operator fun invoke(userId: UserId) {
-        sessionRepository.deleteSession(userId)
-        userSessionScopeProvider.delete(userId)
+    operator fun invoke(userId: UserId) = sessionRepository.deleteSession(userId)
+        .onSuccess {
+            userSessionScopeProvider.delete(userId)
+        }.fold({
+            Result.Failure(it)
+        }, {
+            Result.Success
+        })
+
+    sealed class Result {
+        object Success : Result()
+        data class Failure(val cause: StorageFailure) : Result()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/GetSessionsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/GetSessionsUseCase.kt
@@ -23,12 +23,4 @@ class GetSessionsUseCase(
 
     fun getUserSession(userId: UserId) =
         sessionRepository.userSession(userId)
-
-    fun deleteInvalidSession(userId: UserId) {
-        sessionRepository.userSession(userId).map {
-            if (it.token is AuthSession.Token.Invalid)
-                sessionRepository.deleteSession(userId)
-        }
-    }
-
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/GetSessionsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/GetSessionsUseCase.kt
@@ -3,9 +3,7 @@ package com.wire.kalium.logic.feature.session
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.logic.functional.map
 
 class GetSessionsUseCase(
     private val sessionRepository: SessionRepository

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
@@ -62,7 +62,6 @@ class DeleteSessionUseCaseTest {
             .with(any())
             .wasNotInvoked()
 
-
         verify(arrange.userSessionScopeProvider)
             .function(arrange.userSessionScopeProvider::delete)
             .with(any())
@@ -84,6 +83,10 @@ class DeleteSessionUseCaseTest {
                 .whenInvokedWith(eq(userId))
                 .thenReturn(Either.Right(Unit))
 
+            given(userSessionScopeProvider)
+                .function(userSessionScopeProvider::delete)
+                .whenInvokedWith(eq(userId))
+                .thenReturn(Unit)
             return this
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
@@ -60,7 +60,7 @@ class DeleteSessionUseCaseTest {
         verify(arrange.sessionRepository)
             .function(arrange.sessionRepository::deleteSession)
             .with(any())
-            .wasNotInvoked()
+            .wasInvoked(exactly = once)
 
         verify(arrange.userSessionScopeProvider)
             .function(arrange.userSessionScopeProvider::delete)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
@@ -1,0 +1,105 @@
+package com.wire.kalium.logic.feature.session
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScopeProvider
+import com.wire.kalium.logic.functional.Either
+import io.ktor.utils.io.errors.IOException
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class DeleteSessionUseCaseTest {
+
+    @Test
+    fun givenSuccess_WhenDeletingSessionLocally_thenSuccessAndResourcesAreFreed() {
+
+        val userId = UserId("userId", "domain")
+        val (arrange, deleteSessionUseCase) = Arrangement()
+            .withSessionDeleteSuccess(userId)
+            .arrange()
+
+        deleteSessionUseCase(userId).also { result ->
+            assertEquals(DeleteSessionUseCase.Result.Success, result)
+        }
+
+        verify(arrange.sessionRepository)
+            .function(arrange.sessionRepository::deleteSession)
+            .with(eq(userId))
+            .wasInvoked(exactly = once)
+
+
+        verify(arrange.userSessionScopeProvider)
+            .function(arrange.userSessionScopeProvider::delete)
+            .with(eq(userId))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenFailure_WhenDeletingSessionLocally_thenReturnFailureAndResourcesAreNotFreed() {
+
+        val userId = UserId("userId", "domain")
+        val error = StorageFailure.Generic(IOException("Failed to delete session"))
+        val (arrange, deleteSessionUseCase) = Arrangement()
+            .withSessionDeleteFailure(userId, error)
+            .arrange()
+
+        deleteSessionUseCase(userId).also { result ->
+            assertIs<DeleteSessionUseCase.Result.Failure>(result)
+            assertEquals(error, result.cause)
+        }
+
+        verify(arrange.sessionRepository)
+            .function(arrange.sessionRepository::deleteSession)
+            .with(any())
+            .wasNotInvoked()
+
+
+        verify(arrange.userSessionScopeProvider)
+            .function(arrange.userSessionScopeProvider::delete)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+
+    private class Arrangement {
+        @Mock
+        val sessionRepository: SessionRepository = mock(classOf<SessionRepository>())
+
+        @Mock
+        val userSessionScopeProvider: UserSessionScopeProvider = mock(classOf<UserSessionScopeProvider>())
+
+        val deleteSessionUseCase = DeleteSessionUseCase(sessionRepository, userSessionScopeProvider)
+
+
+        fun withSessionDeleteSuccess(userId: UserId): Arrangement = apply {
+            given(sessionRepository)
+                .function(sessionRepository::deleteSession)
+                .whenInvokedWith(eq(userId))
+                .thenReturn(Either.Right(Unit))
+
+            return this
+        }
+
+        fun withSessionDeleteFailure(userId: UserId, error: StorageFailure): Arrangement = apply {
+            given(sessionRepository)
+                .function(sessionRepository::deleteSession)
+                .whenInvokedWith(eq(userId))
+                .thenReturn(Either.Left(error))
+
+            return this
+        }
+
+        fun arrange() = this to deleteSessionUseCase
+    }
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
@@ -37,7 +37,6 @@ class DeleteSessionUseCaseTest {
             .with(eq(userId))
             .wasInvoked(exactly = once)
 
-
         verify(arrange.userSessionScopeProvider)
             .function(arrange.userSessionScopeProvider::delete)
             .with(eq(userId))
@@ -70,7 +69,6 @@ class DeleteSessionUseCaseTest {
             .wasNotInvoked()
     }
 
-
     private class Arrangement {
         @Mock
         val sessionRepository: SessionRepository = mock(classOf<SessionRepository>())
@@ -79,7 +77,6 @@ class DeleteSessionUseCaseTest {
         val userSessionScopeProvider: UserSessionScopeProvider = mock(classOf<UserSessionScopeProvider>())
 
         val deleteSessionUseCase = DeleteSessionUseCase(sessionRepository, userSessionScopeProvider)
-
 
         fun withSessionDeleteSuccess(userId: UserId): Arrangement = apply {
             given(sessionRepository)
@@ -101,5 +98,4 @@ class DeleteSessionUseCaseTest {
 
         fun arrange() = this to deleteSessionUseCase
     }
-
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

some times consumer clients need to do something after the logout before the session can be deleted e.g. navigation to a different screen


### Solutions

Separate the logout invocation form the release user session scope from memory, and create `DeleteSessionUsecase` to handle the delete and the release of in memory user session

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
