### PR TITLE
chore: upgrade android build tools to 7.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ buildscript {
 
     dependencies {
         // keeping this here to allow AS to automatically update
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.2.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("app.cash.sqldelight:gradle-plugin:$sqlDelightVersion")
         classpath("com.wire:carthage-gradle-plugin:$carthageVersion")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This required Gradle Wrapper 7.3.3+, so Gradle Wrapper is now 7.5.1

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When building the Android app, we get lots of warnings:

```
We recommend using a newer Android Gradle plugin to use compileSdk = 32

This Android Gradle plugin (7.0.4) was tested up to compileSdk = 31

This warning can be suppressed by adding
    android.suppressUnsupportedCompileSdk=32
to this project's gradle.properties

The build will continue, but you are strongly encouraged to update your project to
use a newer Android Gradle Plugin that has been tested with compileSdk = 32
```

### Solutions

Upgrade Android Gradle Plugin
This also requires a newer Gradle Wrapper version, which was updated too

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
