### PR TITLE
feat: expose GetMessageByIdUseCase (AR-1882)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -557,7 +557,6 @@ abstract class UserSessionScopeCommon internal constructor(
             slowSyncRepository,
             messageSendingScheduler,
             timeParser,
-            kaliumFileSystem
         )
     val users: UserScope
         get() = UserScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetMessageByIdUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetMessageByIdUseCase.kt
@@ -7,14 +7,15 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
 
 /**
  * Provides a way to get a full message using its [ConversationId] and message ID coordinates.
  */
-class GetMessageByIdUseCase(
+class GetMessageByIdUseCase internal constructor(
     private val messageRepository: MessageRepository,
-    private val dispatchers: KaliumDispatcher
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
     suspend operator fun invoke(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.connection.ConnectionRepository
@@ -43,7 +42,6 @@ class MessageScope internal constructor(
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
     private val timeParser: TimeParser,
-    private val kaliumFileSystem: KaliumFileSystem
 ) {
 
     private val messageSendFailureHandler: MessageSendFailureHandler
@@ -88,6 +86,9 @@ class MessageScope internal constructor(
             slowSyncRepository,
             messageSender
         )
+
+    val getMessageById: GetMessageByIdUseCase
+        get() = GetMessageByIdUseCase(messageRepository)
 
     val sendAssetMessage: SendAssetMessageUseCase
         get() = SendAssetMessageUseCaseImpl(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The new GetMessageByIdUseCase is not visible by consumers of Kalium

### Causes

I forgot in #885 🤦🏼‍♂️ 

### Solutions

Expose it in `MessageScope`

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
