### PR TITLE
chore: optimize call participants list changed

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -67,12 +67,15 @@ class OnParticipantListChanged(
                 conversationId = conversationIdWithDomain.toString(),
                 participants = participants
             )
-            calling.wcall_request_video_streams(
-                inst = handle,
-                conversationId = remoteConversationIdString,
-                mode = DEFAULT_REQUEST_VIDEO_STREAMS_MODE,
-                json = CallClientList(clients = clients).toJsonString()
-            )
+
+            if (participants.size >= MINIMUM_PARTICIPANTS_FOR_VIDEO_REQUEST) {
+                calling.wcall_request_video_streams(
+                    inst = handle,
+                    conversationId = remoteConversationIdString,
+                    mode = DEFAULT_REQUEST_VIDEO_STREAMS_MODE,
+                    json = CallClientList(clients = clients).toJsonString()
+                )
+            }
             callingLogger.i(
                 "[onParticipantsChanged] - Total Participants: ${participants.size}" +
                         " | ConversationId: ${remoteConversationIdString.obfuscateId()}"
@@ -88,5 +91,6 @@ class OnParticipantListChanged(
 
     private companion object {
         private const val DEFAULT_REQUEST_VIDEO_STREAMS_MODE = 0
+        private const val MINIMUM_PARTICIPANTS_FOR_VIDEO_REQUEST = 2
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -271,21 +271,23 @@ internal class CallDataSource(
         val callMetadataProfile = _callMetadataProfile.value
         val conversationIdToLog = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
         callMetadataProfile.data[conversationId]?.let { call ->
-            callingLogger.i(
-                "updateCallParticipants() -" +
-                        " conversationId: ${conversationIdToLog.value.obfuscateId()}@${conversationIdToLog.domain.obfuscateDomain()}" +
-                        " with size of: ${participants.size}"
-            )
+            if (call.participants != participants) {
+                callingLogger.i(
+                    "updateCallParticipants() -" +
+                            " conversationId: ${conversationIdToLog.value.obfuscateId()}@${conversationIdToLog.domain.obfuscateDomain()}" +
+                            " with size of: ${participants.size}"
+                )
 
-            val updatedCallMetadata = callMetadataProfile.data.toMutableMap().apply {
-                this[conversationId] = call.copy(
-                    participants = participants, maxParticipants = max(call.maxParticipants, participants.size + 1)
+                val updatedCallMetadata = callMetadataProfile.data.toMutableMap().apply {
+                    this[conversationId] = call.copy(
+                        participants = participants, maxParticipants = max(call.maxParticipants, participants.size + 1)
+                    )
+                }
+
+                _callMetadataProfile.value = callMetadataProfile.copy(
+                    data = updatedCallMetadata
                 )
             }
-
-            _callMetadataProfile.value = callMetadataProfile.copy(
-                data = updatedCallMetadata
-            )
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Call participants list being updated with no real new values.

### Causes (Optional)

Updating participants lists without verifying if the same values are already there thus leading to AR recomposing the call screen.

### Solutions

Verify if new participants is different than old participants and only request video streams if there are 2 or more participants in the call.

### Testing

#### How to Test

- Open App
- Start/Join a call
- Everything should work as before.