### PR TITLE
fix: add correct handling for conversation delete (AR-2298)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -61,6 +62,7 @@ interface ConversationRepository {
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun fetchConversationIfUnknown(conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun observeById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>>
+    suspend fun getConversationById(conversationId: ConversationId): Conversation?
     suspend fun detailsById(conversationId: ConversationId): Either<StorageFailure, Conversation>
     suspend fun getConversationRecipients(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
     suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, ProtocolInfo>
@@ -399,6 +401,13 @@ class ConversationDataSource(
         conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId)).filterNotNull()
             .map(conversationMapper::fromDaoModel)
             .wrapStorageRequest()
+
+    override suspend fun getConversationById(conversationId: ConversationId): Conversation? =
+        conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId))
+            .map {
+                if (it != null) conversationMapper.fromDaoModel(it)
+                else null
+            }.firstOrNull()
 
     override suspend fun detailsById(conversationId: ConversationId): Either<StorageFailure, Conversation> = wrapStorageRequest {
         conversationDAO.getConversationByQualifiedID(idMapper.toDaoModel(conversationId))?.let {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -404,9 +404,8 @@ class ConversationDataSource(
 
     override suspend fun getConversationById(conversationId: ConversationId): Conversation? =
         conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId))
-            .map {
-                if (it != null) conversationMapper.fromDaoModel(it)
-                else null
+            .map { conversationEntity ->
+                conversationEntity?.let { conversationMapper.fromDaoModel(it) }
             }.firstOrNull()
 
     override suspend fun detailsById(conversationId: ConversationId): Either<StorageFailure, Conversation> = wrapStorageRequest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -69,6 +69,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import com.wire.kalium.network.api.ConversationId as ConversationIdDTO
 import com.wire.kalium.persistence.dao.Member as MemberEntity
@@ -941,112 +943,6 @@ class ConversationRepositoryTest {
         }
     }
 
-//     private class Arrangement {
-//         @Mock
-//         val userRepository: UserRepository = mock(UserRepository::class)
-//
-//         @Mock
-//         val mlsConversationRepository: MLSConversationRepository = mock(MLSConversationRepository::class)
-//
-//         @Mock
-//         val conversationDAO: ConversationDAO = mock(ConversationDAO::class)
-//
-//         @Mock
-//         val conversationApi: ConversationApi = mock(ConversationApi::class)
-//
-//         @Mock
-//         val clientApi: ClientApi = mock(ClientApi::class)
-//
-//         @Mock
-//         val timeParser: TimeParser = mock(TimeParser::class)
-//
-//         val conversationRepository =
-//             ConversationDataSource(userRepository, mlsConversationRepository, conversationDAO, conversationApi, clientApi, timeParser)
-//
-//         fun withApiUpdateAccessRoleReturns(response: NetworkResponse<UpdateConversationAccessResponse>) = apply {
-//             given(conversationApi)
-//                 .suspendFunction(conversationApi::updateAccessRole)
-//                 .whenInvokedWith(any(), any())
-//                 .thenReturn(response)
-//         }
-//
-//         fun withDaoUpdateAccessSuccess() = apply {
-//             given(conversationDAO)
-//                 .suspendFunction(conversationDAO::updateAccess)
-//                 .whenInvokedWith(any(), any(), any())
-//                 .thenReturn(Unit)
-//         }
-//
-//         fun withDaoUpdateAccessThrows(exception: Exception) = apply {
-//             given(conversationDAO)
-//                 .suspendFunction(conversationDAO::updateAccess)
-//                 .whenInvokedWith(any(), any(), any())
-//                 .thenThrow(exception)
-//         }
-//
-//         fun withApiUpdateConversationMemberRoleReturns(response: NetworkResponse<Unit>) = apply {
-//             given(conversationApi)
-//                 .suspendFunction(conversationApi::updateConversationMemberRole)
-//                 .whenInvokedWith(any(), any(), any())
-//                 .thenReturn(response)
-//         }
-//
-//         fun withDaoUpdateConversationMemberRoleSuccess() = apply {
-//             given(conversationDAO)
-//                 .suspendFunction(conversationDAO::updateConversationMemberRole)
-//                 .whenInvokedWith(any(), any(), any())
-//                 .thenReturn(Unit)
-//         }
-//
-//         fun withConversationProtocolIs(protocolInfo: ConversationEntity.ProtocolInfo) = apply {
-//             given(conversationDAO)
-//                 .suspendFunction(conversationDAO::getConversationByQualifiedID)
-//                 .whenInvokedWith(any())
-//                 .thenReturn(TestConversation.GROUP_ENTITY(protocolInfo))
-//         }
-//
-//         fun withDeleteMemberAPISucceed() = apply {
-//             given(conversationApi)
-//                 .suspendFunction(conversationApi::removeMember)
-//                 .whenInvokedWith(any(), any())
-//                 .thenReturn(
-//                     NetworkResponse.Success(
-//                         TestConversation.REMOVE_MEMBER_FROM_CONVERSATION_SUCCESSFUL_RESPONSE,
-//                         mapOf(),
-//                         HttpStatusCode.OK.value
-//                     )
-//                 )
-//         }
-//
-//         fun withDeleteMemberAPIFailed() = apply {
-//             given(conversationApi)
-//                 .suspendFunction(conversationApi::removeMember)
-//                 .whenInvokedWith(any(), any())
-//                 .thenReturn(
-//                     NetworkResponse.Error(
-//                         KaliumException.ServerError(ErrorResponse(500, "error_message", "error_label"))
-//                     )
-//                 )
-//
-//         }
-//
-//         fun withDeleteMemberDaoSucceed() = apply {
-//             given(conversationDAO)
-//                 .suspendFunction(conversationDAO::deleteMemberByQualifiedID)
-//                 .whenInvokedWith(any(), any())
-//                 .thenReturn(Unit)
-//         }
-//
-//         fun withDaoDeleteSucceded() = apply {
-//             given(conversationDAO)
-//                 .suspendFunction(conversationDAO::deleteConversationByQualifiedID)
-//                 .whenInvokedWith(any())
-//                 .thenReturn(Unit)
-//         }
-//
-//         fun arrange() = this to conversationRepository
-//     }
-
     @Test
     fun givenAGroupConversationHasNewMessages_whenGettingConversationDetails_ThenCorrectlyGetUnreadMessageCount() = runTest {
         // given
@@ -1372,6 +1268,24 @@ class ConversationRepositoryTest {
         }
     }
 
+    @Test
+    fun givenAConversationId_WhenTheConversationDoesNotExists_ShouldReturnANullConversation() = runTest {
+        val conversationId = ConversationId("conv_id", "conv_domain")
+        val (_, conversationRepository) = Arrangement().withExpectedConversation().arrange()
+
+        val result = conversationRepository.getConversationById(conversationId)
+        assertNull(result)
+    }
+
+    @Test
+    fun givenAConversationId_WhenTheConversationExists_ShouldReturnAConversationInstance() = runTest {
+        val conversationId = ConversationId("conv_id", "conv_domain")
+        val (_, conversationRepository) = Arrangement().withExpectedConversation(TestConversation.ENTITY).arrange()
+
+        val result = conversationRepository.getConversationById(conversationId)
+        assertNotNull(result)
+    }
+
     private class Arrangement {
         @Mock
         val userRepository: UserRepository = mock(UserRepository::class)
@@ -1523,6 +1437,13 @@ class ConversationRepositoryTest {
                 .suspendFunction(conversationDAO::observeIsUserMember)
                 .whenInvokedWith(any(), any())
                 .thenReturn(expectedIsUserMember)
+        }
+
+        fun withExpectedConversation(conversationEntity: ConversationEntity? = null) = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::observeGetConversationByQualifiedID)
+                .whenInvokedWith(any())
+                .thenReturn(flowOf(conversationEntity))
         }
 
         fun withWhoDeletedMe(deletionAuthor: UserId?) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -286,7 +286,7 @@ class ConversationEventReceiverTest {
     }
 
     @Test
-    fun givenADeletedConversationEvent_whenHandlingIt_thenShouldDeleteTheConversationAndItsContent() = runTest {
+    fun givenADeletedConversationEvent_whenHandlingItAndNotExists_thenShouldSkipTheDeletion() = runTest {
         val event = TestEvent.deletedConversation()
         val (arrangement, eventReceiver) = Arrangement()
             .withEphemeralNotificationEnqueue()
@@ -306,7 +306,7 @@ class ConversationEventReceiverTest {
     }
 
     @Test
-    fun givenADeletedConversationEvent_whenHandlingItAndNotExists_thenShouldSkipTheDeletion() = runTest {
+    fun givenADeletedConversationEvent_whenHandlingIt_thenShouldDeleteTheConversationAndItsContent() = runTest {
         val event = TestEvent.deletedConversation()
         val (arrangement, eventReceiver) = Arrangement()
             .withEphemeralNotificationEnqueue()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -324,8 +324,7 @@ class ConversationEventReceiverTest {
                 .wasInvoked(exactly = once)
         }
     }
-
-
+    
     private class Arrangement {
         @Mock
         val proteusClient = mock(classOf<ProteusClient>())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -324,7 +324,7 @@ class ConversationEventReceiverTest {
                 .wasInvoked(exactly = once)
         }
     }
-    
+
     private class Arrangement {
         @Mock
         val proteusClient = mock(classOf<ProteusClient>())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, when we are getting the conversation delete event, can be already handled in background, or during the sync process, so whenever when we are trying to delete this conversation the flow was not terminating creating an infinite wait state.

### Solutions

Provide a query, repo level, that allow us to get a Nullable conversation and with that, handle it in the correct way in the `ConversationEventReceiver`

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

The STR are in the current ticket https://wearezeta.atlassian.net/browse/AR-2298

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
