### PR TITLE
fix: NeedsToRegisterClientUseCase returning true when account is invalid

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -521,7 +521,9 @@ abstract class UserSessionScopeCommon internal constructor(
             mlsClientProvider,
             notificationTokenRepository,
             clientRemoteRepository,
-            authenticatedDataSourceSet.proteusClient
+            authenticatedDataSourceSet.proteusClient,
+            globalScope.sessionRepository,
+            userId
         )
     val conversations: ConversationScope
         get() = ConversationScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -42,9 +42,12 @@ class ClientScope(
         )
     val selfClients: SelfClientsUseCase get() = SelfClientsUseCaseImpl(clientRepository)
     val deleteClient: DeleteClientUseCase get() = DeleteClientUseCaseImpl(clientRepository)
-    val needsToRegisterClient: NeedsToRegisterClientUseCase get() = NeedsToRegisterClientUseCaseImpl(clientRepository, sessionRepository, selfUserId)
-    val registerPushToken: RegisterTokenUseCase get() = RegisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
-    val deregisterNativePushToken: DeregisterTokenUseCase get() = DeregisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
+    val needsToRegisterClient: NeedsToRegisterClientUseCase
+        get() = NeedsToRegisterClientUseCaseImpl(clientRepository, sessionRepository, selfUserId)
+    val registerPushToken: RegisterTokenUseCase
+        get() = RegisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
+    val deregisterNativePushToken: DeregisterTokenUseCase
+        get() = DeregisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
     val mlsKeyPackageCountUseCase: MLSKeyPackageCountUseCase
         get() = MLSKeyPackageCountUseCaseImpl(keyPackageRepository, clientRepository, keyPackageLimitsProvider)
     val refillKeyPackages: RefillKeyPackagesUseCase
@@ -63,7 +66,8 @@ class ClientScope(
             clientRepository
         )
 
-    val observeCurrentClientId: ObserveCurrentClientIdUseCase get() = ObserveCurrentClientIdUseCaseImpl(clientRepository)
+    val observeCurrentClientId: ObserveCurrentClientIdUseCase
+        get() = ObserveCurrentClientIdUseCaseImpl(clientRepository)
 
     val clearClientData: ClearClientDataUseCase
         get() = ClearClientDataUseCaseImpl(clientRepository, mlsClientProvider, proteusClient)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -8,6 +8,8 @@ import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCase
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCaseImpl
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCase
@@ -26,7 +28,9 @@ class ClientScope(
     private val mlsClientProvider: MLSClientProvider,
     private val notificationTokenRepository: NotificationTokenRepository,
     private val clientRemoteRepository: ClientRemoteRepository,
-    private val proteusClient: ProteusClient
+    private val proteusClient: ProteusClient,
+    private val sessionRepository: SessionRepository,
+    private val selfUserId: UserId
 ) {
     val register: RegisterClientUseCase
         get() = RegisterClientUseCaseImpl(
@@ -38,7 +42,7 @@ class ClientScope(
         )
     val selfClients: SelfClientsUseCase get() = SelfClientsUseCaseImpl(clientRepository)
     val deleteClient: DeleteClientUseCase get() = DeleteClientUseCaseImpl(clientRepository)
-    val needsToRegisterClient: NeedsToRegisterClientUseCase get() = NeedsToRegisterClientUseCaseImpl(clientRepository)
+    val needsToRegisterClient: NeedsToRegisterClientUseCase get() = NeedsToRegisterClientUseCaseImpl(clientRepository, sessionRepository, selfUserId)
     val registerPushToken: RegisterTokenUseCase get() = RegisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
     val deregisterNativePushToken: DeregisterTokenUseCase get() = DeregisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
     val mlsKeyPackageCountUseCase: MLSKeyPackageCountUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCase.kt
@@ -1,13 +1,28 @@
 package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.AccountInfo
 import com.wire.kalium.logic.functional.fold
 
 interface NeedsToRegisterClientUseCase {
     suspend operator fun invoke(): Boolean
 }
 
-class NeedsToRegisterClientUseCaseImpl(private val clientRepository: ClientRepository) : NeedsToRegisterClientUseCase {
+class NeedsToRegisterClientUseCaseImpl(
+    private val clientRepository: ClientRepository,
+    private val sessionRepository: SessionRepository,
+    private val selfUserId: UserId
+) : NeedsToRegisterClientUseCase {
     override suspend fun invoke(): Boolean =
-        clientRepository.currentClientId().fold({ true }, { false })
+        sessionRepository.userAccountInfo(selfUserId).fold(
+            { true },
+            {
+                when (it) {
+                    is AccountInfo.Invalid -> false
+                    is AccountInfo.Valid -> clientRepository.currentClientId().fold({ true }, { false })
+                }
+            }
+        )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
@@ -99,10 +99,8 @@ class NeedsToRegisterClientUseCaseTest {
         @Mock
         val sessionRepository = mock(SessionRepository::class)
 
-
         private var needsToRegisterClientUseCase: NeedsToRegisterClientUseCase =
             NeedsToRegisterClientUseCaseImpl(clientRepository, sessionRepository, selfUserId)
-
 
         fun withCurrentClientId(result: Either<StorageFailure, ClientId>) = apply {
             given(clientRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
@@ -1,58 +1,122 @@
 package com.wire.kalium.logic.feature.client
 
-import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.AccountInfo
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
+import io.mockative.any
 import io.mockative.classOf
 import io.mockative.configure
 import io.mockative.given
 import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NeedsToRegisterClientUseCaseTest {
 
-    @Mock
-    private val clientRepository = configure(mock(classOf<ClientRepository>())) {
-        stubsUnitByDefault = true
-    }
+    @Test
+    fun givenAccountIsInvalid_thenReturnFalse() = runTest {
 
-    private lateinit var needsToRegisterClientUseCase: NeedsToRegisterClientUseCase
+        val (arrangement, needsToRegisterClient) = Arrangement()
+            .withUserAccountInfo(Either.Right(AccountInfo.Invalid(selfUserId, LogoutReason.SESSION_EXPIRED)))
+            .arrange()
+        needsToRegisterClient().also {
+            assertEquals(false, it)
+        }
 
-    @BeforeTest
-    fun setup() {
-        needsToRegisterClientUseCase = NeedsToRegisterClientUseCaseImpl(clientRepository)
+        verify(arrangement.sessionRepository)
+            .suspendFunction(arrangement.sessionRepository::userAccountInfo)
+            .with(any())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.clientRepository)
+            .suspendFunction(arrangement.clientRepository::currentClientId)
+            .wasNotInvoked()
     }
 
     @Test
-    fun givenClientIdIsRegistered_thenReturnFalse() = runTest {
-        given(clientRepository)
-            .suspendFunction(clientRepository::currentClientId)
-            .whenInvoked()
-            .then { Either.Right(CLIENT_ID) }
+    fun givenAccountIsValidAndThereISNoClient_thenReturnTrue() = runTest {
 
-        val actual = needsToRegisterClientUseCase.invoke()
-        assertEquals(actual, false)
+        val (arrangement, needsToRegisterClient) = Arrangement()
+            .withUserAccountInfo(Either.Right(AccountInfo.Valid(selfUserId)))
+            .withCurrentClientId(Either.Left(StorageFailure.DataNotFound))
+            .arrange()
+        needsToRegisterClient().also {
+            assertEquals(true, it)
+        }
+
+        verify(arrangement.sessionRepository)
+            .suspendFunction(arrangement.sessionRepository::userAccountInfo)
+            .with(any())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.clientRepository)
+            .suspendFunction(arrangement.clientRepository::currentClientId)
+            .wasInvoked(exactly = once)
     }
 
     @Test
-    fun givenClientIdIsNotRegistered_thenReturnTrue() = runTest {
-        given(clientRepository)
-            .suspendFunction(clientRepository::currentClientId)
-            .whenInvoked()
-            .then { Either.Left(CoreFailure.MissingClientRegistration) }
+    fun givenAccountIsValidAndClientIsRegistered_thenReturnFalse() = runTest {
 
-        val actual = needsToRegisterClientUseCase.invoke()
-        assertEquals(actual, true)
+        val (arrangement, needsToRegisterClient) = Arrangement()
+            .withUserAccountInfo(Either.Right(AccountInfo.Valid(selfUserId)))
+            .withCurrentClientId(Either.Right(ClientId("client-id")))
+            .arrange()
+        needsToRegisterClient().also {
+            assertEquals(false, it)
+        }
+
+        verify(arrangement.sessionRepository)
+            .suspendFunction(arrangement.sessionRepository::userAccountInfo)
+            .with(any())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.clientRepository)
+            .suspendFunction(arrangement.clientRepository::currentClientId)
+            .wasInvoked(exactly = once)
     }
 
     private companion object {
-        val CLIENT_ID: ClientId = ClientId("client_id")
+        val selfUserId = UserId("selfUserId", "selfUserDomain")
+    }
+
+    private class Arrangement {
+        @Mock
+        val clientRepository = configure(mock(classOf<ClientRepository>())) {
+            stubsUnitByDefault = true
+        }
+
+        @Mock
+        val sessionRepository = mock(SessionRepository::class)
+
+
+        private var needsToRegisterClientUseCase: NeedsToRegisterClientUseCase =
+            NeedsToRegisterClientUseCaseImpl(clientRepository, sessionRepository, selfUserId)
+
+
+        fun withCurrentClientId(result: Either<StorageFailure, ClientId>) = apply {
+            given(clientRepository)
+                .suspendFunction(clientRepository::currentClientId)
+                .whenInvoked()
+                .then { result }
+        }
+
+        suspend fun withUserAccountInfo(result: Either<StorageFailure, AccountInfo>) = apply {
+            given(sessionRepository)
+                .coroutine { userAccountInfo(selfUserId) }
+                .then { result }
+        }
+
+        fun arrange() = this to needsToRegisterClientUseCase
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

NeedsToRegisterClientUseCase returning true when account is invalid

### Solutions

check the account status before deciding if a client need to be registred or not

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
