### PR TITLE
fix: crash on paginating messages (AR-1882)

### DIFF
--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumPager.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumPager.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.map
 
 /**
  * Exposes a [pagingDataFlow] that can be used in Android UI components to display paginated data.
- *
  */
 class KaliumPager<RowType : Any, EntityType : Any>(
     private val pager: Pager<Long, RowType>,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There's a crash when updating items on paginated message list on Android

### Causes

Re-using the same `PagingSource` in the `pagingSourceFactory` when creating the `Pager`

### Solutions

Create a new one on demand.

### Testing

N/A

Not really testable without adding UI tests to Kalium's persistence module. Sounds like hell to be honest.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
