### PR TITLE
feat: handle conversation member change event (AR-2337)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -434,7 +434,8 @@ class ConversationDataSource(
     }
 
     override suspend fun persistMembers(
-        members: List<Conversation.Member>, conversationID: ConversationId
+        members: List<Conversation.Member>,
+        conversationID: ConversationId
     ): Either<CoreFailure, Unit> =
         userRepository.fetchUsersIfUnknownByIds(members.map { it.id }.toSet()).flatMap {
             wrapStorageRequest {
@@ -569,7 +570,8 @@ class ConversationDataSource(
         }
 
     override suspend fun updateConversationNotificationDate(
-        qualifiedID: QualifiedID, date: String
+        qualifiedID: QualifiedID,
+        date: String
     ): Either<StorageFailure, Unit> =
         wrapStorageRequest {
             conversationDAO.updateConversationNotificationDate(idMapper.toDaoModel(qualifiedID), date)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -76,6 +76,11 @@ interface ConversationRepository {
         conversationID: ConversationId
     ): Either<CoreFailure, Unit>
 
+    suspend fun updateMember(
+        member: Conversation.Member,
+        conversationID: ConversationId
+    ): Either<CoreFailure, Unit>
+
     suspend fun addMembers(userIdList: List<UserId>, conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun deleteMember(userId: UserId, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun deleteMembers(userIDList: List<UserId>, conversationID: ConversationId): Either<CoreFailure, Unit>
@@ -420,7 +425,9 @@ class ConversationDataSource(
         conversationDAO.getAllMembers(idMapper.toDaoModel(conversationId)).first().map { idMapper.fromDaoModel(it.user) }
     }
 
-    override suspend fun persistMembers(members: List<Conversation.Member>, conversationID: ConversationId): Either<CoreFailure, Unit> =
+    override suspend fun persistMembers(
+        members: List<Conversation.Member>, conversationID: ConversationId
+    ): Either<CoreFailure, Unit> =
         userRepository.fetchUsersIfUnknownByIds(members.map { it.id }.toSet()).flatMap {
             wrapStorageRequest {
                 conversationDAO.insertMembersWithQualifiedId(
@@ -429,7 +436,15 @@ class ConversationDataSource(
             }
         }
 
-    override suspend fun addMembers(userIdList: List<UserId>, conversationID: ConversationId): Either<CoreFailure, Unit> = wrapApiRequest {
+    override suspend fun updateMember(member: Conversation.Member, conversationID: ConversationId): Either<CoreFailure, Unit> =
+        wrapStorageRequest {
+            conversationDAO.updateMember(memberMapper.toDaoModel(member), idMapper.toDaoModel(conversationID))
+        }
+
+    override suspend fun addMembers(
+        userIdList: List<UserId>,
+        conversationID: ConversationId
+    ): Either<CoreFailure, Unit> = wrapApiRequest {
         val users = userIdList.map {
             idMapper.toApiModel(it)
         }
@@ -482,9 +497,15 @@ class ConversationDataSource(
             }
         })
 
-    override suspend fun deleteMembers(userIDList: List<UserId>, conversationID: ConversationId): Either<CoreFailure, Unit> =
+    override suspend fun deleteMembers(
+        userIDList: List<UserId>,
+        conversationID: ConversationId
+    ): Either<CoreFailure, Unit> =
         wrapStorageRequest {
-            conversationDAO.deleteMembersByQualifiedID(userIDList.map { idMapper.toDaoModel(it) }, idMapper.toDaoModel(conversationID))
+            conversationDAO.deleteMembersByQualifiedID(
+                userIDList.map { idMapper.toDaoModel(it) },
+                idMapper.toDaoModel(conversationID)
+            )
         }
 
     override suspend fun createGroupConversation(
@@ -527,7 +548,9 @@ class ConversationDataSource(
     }
 
     override suspend fun getConversationsForNotifications(): Flow<List<Conversation>> =
-        conversationDAO.getConversationsForNotifications().filterNotNull().map { it.map(conversationMapper::fromDaoModel) }
+        conversationDAO.getConversationsForNotifications()
+            .filterNotNull()
+            .map { it.map(conversationMapper::fromDaoModel) }
 
     override suspend fun getConversationsByGroupState(
         groupState: Conversation.ProtocolInfo.MLS.GroupState
@@ -537,13 +560,20 @@ class ConversationDataSource(
                 .map(conversationMapper::fromDaoModel)
         }
 
-    override suspend fun updateConversationNotificationDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit> =
-        wrapStorageRequest { conversationDAO.updateConversationNotificationDate(idMapper.toDaoModel(qualifiedID), date) }
+    override suspend fun updateConversationNotificationDate(
+        qualifiedID: QualifiedID, date: String
+    ): Either<StorageFailure, Unit> =
+        wrapStorageRequest {
+            conversationDAO.updateConversationNotificationDate(idMapper.toDaoModel(qualifiedID), date)
+        }
 
     override suspend fun updateAllConversationsNotificationDate(date: String): Either<StorageFailure, Unit> =
         wrapStorageRequest { conversationDAO.updateAllConversationsNotificationDate(date) }
 
-    override suspend fun updateConversationModifiedDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit> =
+    override suspend fun updateConversationModifiedDate(
+        qualifiedID: QualifiedID,
+        date: String
+    ): Either<StorageFailure, Unit> =
         wrapStorageRequest { conversationDAO.updateConversationModifiedDate(idMapper.toDaoModel(qualifiedID), date) }
 
     override suspend fun updateAccessInfo(
@@ -586,10 +616,15 @@ class ConversationDataSource(
     override suspend fun getUnreadConversationCount(): Either<StorageFailure, Long> =
         wrapStorageRequest { conversationDAO.getUnreadConversationCount() }
 
-    private suspend fun persistMembersFromConversationResponse(conversationResponse: ConversationResponse): Either<CoreFailure, Unit> {
+    private suspend fun persistMembersFromConversationResponse(
+        conversationResponse: ConversationResponse
+    ): Either<CoreFailure, Unit> {
         return wrapStorageRequest {
             val conversationId = idMapper.fromApiToDao(conversationResponse.id)
-            conversationDAO.insertMembersWithQualifiedId(memberMapper.fromApiModelToDaoModel(conversationResponse.members), conversationId)
+            conversationDAO.insertMembersWithQualifiedId(
+                memberMapper.fromApiModelToDaoModel(conversationResponse.members),
+                conversationId
+            )
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -66,6 +66,13 @@ sealed class Event(open val id: String) {
             val timestampIso: String
         ) : Conversation(id, conversationId)
 
+        data class MemberChanged(
+            override val id: String,
+            override val conversationId: ConversationId,
+            val timestampIso: String,
+            val member: Member,
+        ) : Conversation(id, conversationId)
+
         data class MLSWelcome(
             override val id: String,
             override val conversationId: ConversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -88,7 +88,13 @@ internal object MapperProvider {
     fun sendMessageFailureMapper(): SendMessageFailureMapper = SendMessageFailureMapperImpl()
     fun assetMapper(): AssetMapper = AssetMapperImpl()
     fun encryptionAlgorithmMapper(): EncryptionAlgorithmMapper = EncryptionAlgorithmMapper()
-    fun eventMapper(): EventMapper = EventMapper(idMapper(), memberMapper(), connectionMapper(), featureConfigMapper())
+    fun eventMapper(): EventMapper = EventMapper(
+        idMapper(),
+        memberMapper(),
+        connectionMapper(),
+        featureConfigMapper(),
+        conversationRoleMapper()
+    )
     fun messageMentionMapper(): MessageMentionMapper = MessageMentionMapperImpl(idMapper())
 
     fun preyKeyMapper(): PreKeyMapper = PreKeyMapperImpl()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -87,6 +87,7 @@ internal class ConversationEventReceiverImpl(
             is Event.Conversation.MemberLeave -> handleMemberLeave(event)
             is Event.Conversation.MLSWelcome -> handleMLSWelcome(event)
             is Event.Conversation.NewMLSMessage -> handleNewMLSMessage(event)
+            is Event.Conversation.MemberChanged -> handleMemberChange(event)
         }
     }
 
@@ -307,6 +308,22 @@ internal class ConversationEventReceiverImpl(
             processMessage(message)
         }
         .onFailure { kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member leave event: $it") }
+
+    private suspend fun handleMemberChange(event: Event.Conversation.MemberChanged) =
+        // Attempt to fetch conversation details if needed, as this might be an unknown conversation
+        conversationRepository.fetchConversationIfUnknown(event.conversationId)
+            .run {
+                onSuccess {
+                    kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                        .v("Succeeded fetching conversation details on MemberChange Event: $event")
+                }
+                onFailure {
+                    kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                        .w("Failure fetching conversation details on MemberChange Event: $event")
+                }
+                // Even if unable to fetch conversation details, at least attempt updating the member
+                conversationRepository.updateMember(event.member, event.conversationId)
+            }.onFailure { kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member update event: $it") }
 
     private suspend fun handleMLSWelcome(event: Event.Conversation.MLSWelcome) {
         mlsConversationRepository.establishMLSGroupFromWelcome(event)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -61,7 +61,8 @@ class EventRepositoryTest {
                 ConnectionStatusMapperImpl(),
                 PublicUserMapperImpl(IdMapperImpl(), AvailabilityStatusMapperImpl(), ConnectionStateMapperImpl())
             ),
-            FeatureConfigMapperImpl()
+            FeatureConfigMapperImpl(),
+            ConversationRoleMapperImpl()
         )
 
     private lateinit var eventRepository: EventRepository

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.framework
 
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.user.Connection
@@ -15,6 +16,13 @@ object TestEvent {
         TestUser.USER_ID,
         members,
         "2022-03-30T15:36:00.000Z"
+    )
+
+    fun memberChange(eventId: String = "eventId", member: Member) = Event.Conversation.MemberChanged(
+        eventId,
+        TestConversation.ID,
+        "2022-03-30T15:36:00.000Z",
+        member
     )
 
     fun clientRemove(eventId: String = "eventId", clientId: ClientId) = Event.User.ClientRemove(eventId, clientId)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationEvent.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/conversation/ConversationEvent.kt
@@ -16,3 +16,10 @@ data class ConversationUsers(
     @SerialName("user_ids") val userIds: List<String>,
     @SerialName("qualified_user_ids") val qualifiedUserIds: List<UserId>
 )
+
+@Serializable
+data class ConversationRoleChange(
+    @SerialName("target") val user: String,
+    @SerialName("qualified_target") val qualifiedUserId: UserId,
+    @SerialName("conversation_role") val role: String,
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.network.api.ConversationId
 import com.wire.kalium.network.api.UserId
 import com.wire.kalium.network.api.conversation.ConversationMembers
 import com.wire.kalium.network.api.conversation.ConversationResponse
+import com.wire.kalium.network.api.conversation.ConversationRoleChange
 import com.wire.kalium.network.api.conversation.ConversationUsers
 import com.wire.kalium.network.api.conversation.model.ConversationAccessInfoDTO
 import com.wire.kalium.network.api.featureConfigs.FeatureConfigData
@@ -141,6 +142,16 @@ sealed class EventContentDTO {
             @SerialName("data") val members: ConversationUsers,
             @SerialName("from") val from: String
         ) : Conversation()
+
+        @Serializable
+        @SerialName("conversation.member-update")
+        data class MemberUpdateDTO(
+            @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
+            @SerialName("qualified_from") val qualifiedFrom: UserId,
+            val time: String,
+            @SerialName("from") val from: String,
+            @SerialName("data") val roleChange: ConversationRoleChange,
+            ) : Conversation()
 
         @Serializable
         @SerialName("conversation.mls-welcome")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/EventContentDTO.kt
@@ -150,8 +150,8 @@ sealed class EventContentDTO {
             @SerialName("qualified_from") val qualifiedFrom: UserId,
             val time: String,
             @SerialName("from") val from: String,
-            @SerialName("data") val roleChange: ConversationRoleChange,
-            ) : Conversation()
+            @SerialName("data") val roleChange: ConversationRoleChange
+        ) : Conversation()
 
         @Serializable
         @SerialName("conversation.mls-welcome")

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -99,6 +99,7 @@ interface ConversationDAO {
     suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationEntity>
     suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity)
     suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity)
+    suspend fun updateMember(member: Member, conversationID: QualifiedIDEntity)
     suspend fun insertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity)
     suspend fun insertMembers(memberList: List<Member>, groupId: String)
     suspend fun deleteMemberByQualifiedID(userID: QualifiedIDEntity, conversationID: QualifiedIDEntity)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -200,6 +200,10 @@ class ConversationDAOImpl(
         }
     }
 
+    override suspend fun updateMember(member: Member, conversationID: QualifiedIDEntity) {
+      memberQueries.updateMemberRole(member.role, member.user, conversationID)
+    }
+
     override suspend fun insertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity) {
         memberQueries.transaction {
             for (member: Member in memberList) {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -140,6 +140,16 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenExistingConversation_ThenMemberCanBeUpdated() = runTest {
+        val updatedMember = member1.copy(role = Member.Role.Member)
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertMember(member1, conversationEntity1.id)
+        conversationDAO.updateMember(updatedMember, conversationEntity1.id)
+
+        assertEquals(listOf(updatedMember), conversationDAO.getAllMembers(conversationEntity1.id).first())
+    }
+
+    @Test
     fun givenExistingConversation_ThenAllMembersCanBeRetrieved() = runTest {
         conversationDAO.insertConversation(conversationEntity1)
         conversationDAO.insertMembersWithQualifiedId(listOf(member1, member2), conversationEntity1.id)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
There was an unhandled event for updating member role changes. 

### Solutions

Handle WebSocket event and update member role in local DB

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Update member role in conversation and check if it updates in other device conversation details screen

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like  images, videos, etc. (drag and drop in the text box)_

https://user-images.githubusercontent.com/13151239/190134167-89083665-d0c0-40da-8b8d-cbfd57c9adc1.mov


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
