### PR TITLE
fix: network error when uploading an image [AR-2349]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -150,7 +150,9 @@ internal class AssetDataSource(
     ): Either<CoreFailure, UploadedAssetId> =
         assetMapper.toMetadataApiModel(uploadAssetData, kaliumFileSystem).let { metaData ->
             wrapApiRequest {
-                val dataSource = kaliumFileSystem.source(uploadAssetData.tempEncryptedDataPath)
+                val dataSource = {
+                    kaliumFileSystem.source(uploadAssetData.tempEncryptedDataPath)
+                }
 
                 // we should also consider for avatar images, the compression for preview vs complete picture
                 assetApi.uploadAsset(metaData, dataSource, uploadAssetData.dataSize)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/tools/json/api/asset/AssetApiTest.kt
@@ -29,7 +29,7 @@ class AssetApiTest : ApiTest {
         val fileSystem = FakeFileSystem()
         val assetMetadata = AssetMetadataRequest("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
         val encryptedData = "some-data".encodeToByteArray()
-        val encryptedDataSource = getDummyDataSource(fileSystem, encryptedData)
+        val encryptedDataSource = { getDummyDataSource(fileSystem, encryptedData) }
         val networkClient = mockAuthenticatedNetworkClient(
             VALID_ASSET_UPLOAD_RESPONSE.rawJson,
             statusCode = HttpStatusCode.Created,
@@ -64,7 +64,7 @@ class AssetApiTest : ApiTest {
         val fileSystem = FakeFileSystem()
         val assetMetadata = AssetMetadataRequest("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
         val encryptedData = "some-data".encodeToByteArray()
-        val encryptedDataSource = getDummyDataSource(fileSystem, encryptedData)
+        val encryptedDataSource = { getDummyDataSource(fileSystem, encryptedData) }
         val networkClient = mockAuthenticatedNetworkClient(
             INVALID_ASSET_UPLOAD_RESPONSE.rawJson,
             statusCode = HttpStatusCode.BadRequest,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes when the user wants to send an image, he gets a network error.

### Causes (Optional)

When the token is refreshed, the repeated initial request gets 500, because the `Source` with file data is already closed.

### Solutions

Change `fileContentStream` to be a lambda.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### How to Test

Try to send an image message after leaving the app for some time.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
