### PR TITLE
fix(calling): show all clients of current user in the call (AR-2412)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -326,11 +326,8 @@ actual class CallManagerImpl(
     private fun initClientsHandler() {
         scope.launch {
             withCalling {
-                val selfUserId = federatedIdMapper.parseToFederatedId(userId.await())
-
                 val onClientsRequest = OnClientsRequest(
                     calling = calling,
-                    selfUserId = selfUserId,
                     conversationRepository = conversationRepository,
                     federatedIdMapper = federatedIdMapper,
                     qualifiedIdMapper = qualifiedIdMapper,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.launch
 
 internal class OnClientsRequest(
     private val calling: Calling,
-    private val selfUserId: String,
     private val conversationRepository: ConversationRepository,
     private val federatedIdMapper: FederatedIdMapper,
     private val qualifiedIdMapper: QualifiedIdMapper,
@@ -36,7 +35,6 @@ internal class OnClientsRequest(
             conversationRecipients.map { recipients ->
                 callingLogger.d("[OnClientsRequest] -> Mapping ${recipients.size} recipients")
                 recipients
-                    .filter { it.id.value != selfUserId }
                     .flatMap { recipient ->
                         recipient.clients.map { clientId ->
                             CallClient(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- In a conference call, if you join from different client you will not see your other tile in the grid.
- Audio not working if you join an ongoing call started from different client.

### Causes (Optional)

That's because we were not sending current user clients to AVS

### Solutions

Remove the filter that do that

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
