### PR TITLE
fix(calling): can't join ongoing call (AR-2432)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
@@ -28,7 +28,7 @@ internal class OnClientsRequest(
         callingScope.launch {
             callingLogger.d("[OnClientsRequest] -> ConversationId: $conversationIdString")
             val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationIdString)
-            val conversationRecipients = conversationRepository.getConversationRecipients(
+            val conversationRecipients = conversationRepository.getConversationRecipientsForCalling(
                 conversationId = conversationIdWithDomain
             )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MemberMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MemberMapper.kt
@@ -3,14 +3,17 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.network.api.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.conversation.ConversationMembersResponse
+import com.wire.kalium.network.api.user.client.SimpleClientResponse
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.client.Client
 import com.wire.kalium.logic.data.user.UserId as LogicUserId
 import com.wire.kalium.persistence.dao.Member as PersistedMember
+import com.wire.kalium.network.api.UserId
 
 interface MemberMapper {
     fun fromApiModel(conversationMember: ConversationMemberDTO.Other): Conversation.Member
     fun fromApiModel(conversationMembersResponse: ConversationMembersResponse): MembersInfo
+    fun fromMapOfClientsResponseToRecipients(qualifiedMap: Map<UserId, List<SimpleClientResponse>>): List<Recipient>
     fun fromMapOfClientsEntityToRecipients(qualifiedMap: Map<QualifiedIDEntity, List<Client>>): List<Recipient>
     fun fromMapOfClientsToRecipients(qualifiedMap: Map<LogicUserId, List<Client>>): List<Recipient>
     fun fromApiModelToDaoModel(conversationMembersResponse: ConversationMembersResponse): List<PersistedMember>
@@ -46,6 +49,13 @@ internal class MemberMapperImpl(private val idMapper: IdMapper, private val role
     override fun toDaoModel(member: Conversation.Member): PersistedMember = with(member) {
         PersistedMember(idMapper.toDaoModel(id), roleMapper.toDAO(role))
     }
+
+    override fun fromMapOfClientsResponseToRecipients(qualifiedMap: Map<UserId, List<SimpleClientResponse>>): List<Recipient> =
+        qualifiedMap.entries.map { entry ->
+            val id = idMapper.fromApiModel(entry.key)
+            val clients = entry.value.map(idMapper::fromSimpleClientResponse)
+            Recipient(id, clients)
+        }
 
     override fun fromMapOfClientsEntityToRecipients(qualifiedMap: Map<QualifiedIDEntity, List<Client>>): List<Recipient> =
         qualifiedMap.entries.map { entry ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -219,6 +219,7 @@ abstract class UserSessionScopeCommon internal constructor(
             authenticatedDataSourceSet.authenticatedNetworkContainer.conversationApi,
             userDatabaseProvider.messageDAO,
             userDatabaseProvider.clientDAO,
+            authenticatedDataSourceSet.authenticatedNetworkContainer.clientApi,
             timeParser
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.network.api.conversation.model.UpdateConversationAccessRe
 import com.wire.kalium.network.api.model.ConversationAccessDTO
 import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import com.wire.kalium.network.api.notification.EventContentDTO
+import com.wire.kalium.network.api.user.client.ClientApi
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
@@ -98,6 +99,9 @@ class ConversationRepositoryTest {
     private val clientDao = mock(ClientDAO::class)
 
     @Mock
+    private val clientApi = mock(ClientApi::class)
+
+    @Mock
     private val timeParser: TimeParser = mock(TimeParser::class)
 
     private lateinit var conversationRepository: ConversationRepository
@@ -111,6 +115,7 @@ class ConversationRepositoryTest {
             conversationApi,
             messageDAO,
             clientDao,
+            clientApi,
             timeParser
         )
     }
@@ -1303,6 +1308,9 @@ class ConversationRepositoryTest {
         val clientDao: ClientDAO = mock(ClientDAO::class)
 
         @Mock
+        private val clientApi = mock(ClientApi::class)
+
+        @Mock
         private val messageDAO = configure(mock(MessageDAO::class)) { stubsUnitByDefault = true }
 
         @Mock
@@ -1316,6 +1324,7 @@ class ConversationRepositoryTest {
                 conversationApi,
                 messageDAO,
                 clientDao,
+                clientApi,
                 timeParser,
             )
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Not able to join an ongoing call and we only see current user tile

### Causes (Optional)

Fetching users and their clients from local storage. 

After a fresh instal the db and does not contains user and client ids of different conversation, so when we try to join the call we pass to AVS an empty list of participants

### Solutions

Revert code to retrieve users from backend

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

After a fresh install, try to join an ongoing call

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
