### PR TITLE
fix: app crash when open profile [AR-2450]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -10,14 +10,17 @@ import com.wire.kalium.network.api.user.client.ClientTypeDTO
 import com.wire.kalium.network.api.user.client.DeviceTypeDTO
 import com.wire.kalium.network.api.user.client.RegisterClientRequest
 import com.wire.kalium.network.api.user.client.SimpleClientResponse
+import com.wire.kalium.persistence.dao.client.DeviceTypeEntity
 
 class ClientMapper(
     private val preyKeyMapper: PreKeyMapper,
-    private val locationMapper: LocationMapper,
-    private val clientConfig: ClientConfig
+    private val locationMapper: LocationMapper
 ) {
 
-    fun toRegisterClientRequest(param: RegisterClientParam): RegisterClientRequest = RegisterClientRequest(
+    fun toRegisterClientRequest(
+        clientConfig: ClientConfig,
+        param: RegisterClientParam
+    ): RegisterClientRequest = RegisterClientRequest(
         password = param.password,
         lastKey = preyKeyMapper.toPreKeyDTO(param.lastKey),
         label = clientConfig.deviceName(),
@@ -83,5 +86,21 @@ class ClientMapper(
         DeviceTypeDTO.Desktop -> DeviceType.Desktop
         DeviceTypeDTO.LegalHold -> DeviceType.LegalHold
         DeviceTypeDTO.Unknown -> DeviceType.Unknown
+    }
+
+    fun fromDeviceTypeEntity(deviceTypeEntity: DeviceTypeEntity?): DeviceType = when (deviceTypeEntity) {
+        DeviceTypeEntity.Phone -> DeviceType.Phone
+        DeviceTypeEntity.Tablet -> DeviceType.Tablet
+        DeviceTypeEntity.Desktop -> DeviceType.Desktop
+        DeviceTypeEntity.LegalHold -> DeviceType.LegalHold
+        DeviceTypeEntity.Unknown, null -> DeviceType.Unknown
+    }
+
+    fun toDeviceTypeEntity(deviceTypeEntity: DeviceType): DeviceTypeEntity = when (deviceTypeEntity) {
+        DeviceType.Phone -> DeviceTypeEntity.Phone
+        DeviceType.Tablet -> DeviceTypeEntity.Tablet
+        DeviceType.Desktop -> DeviceTypeEntity.Desktop
+        DeviceType.LegalHold -> DeviceTypeEntity.LegalHold
+        DeviceType.Unknown -> DeviceTypeEntity.Unknown
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.mapLeft
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.user.pushToken.PushTokenBody
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
@@ -68,8 +69,10 @@ class ClientDataSource(
             .map { ClientId(it) }
             .mapLeft {
                 if (it is StorageFailure.DataNotFound) {
+                    kaliumLogger.e("Data Not Found for Registered Client Id")
                     CoreFailure.MissingClientRegistration
                 } else {
+                    kaliumLogger.e("Failure when getting Registered Client Id")
                     it
                 }
             }
@@ -79,8 +82,10 @@ class ClientDataSource(
             .map { ClientId(it) }
             .mapLeft {
                 if (it is StorageFailure.DataNotFound) {
+                    kaliumLogger.e("Data Not Found for Retained Client Id")
                     CoreFailure.MissingClientRegistration
                 } else {
+                    kaliumLogger.e("Failure when getting Retained Client Id")
                     it
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -40,13 +40,15 @@ interface ClientRepository {
     suspend fun deregisterToken(token: String): Either<NetworkFailure, Unit>
     suspend fun getClientsByUserId(userId: UserId): Either<StorageFailure, List<OtherUserClient>>
 }
+
 @Suppress("TooManyFunctions", "INAPPLICABLE_JVM_NAME")
 class ClientDataSource(
     private val clientRemoteRepository: ClientRemoteRepository,
     private val clientRegistrationStorage: ClientRegistrationStorage,
     private val clientDAO: ClientDAO,
     private val userMapper: UserMapper = MapperProvider.userMapper(),
-    private val idMapper: IdMapper = MapperProvider.idMapper()
+    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val clientMapper: ClientMapper = MapperProvider.clientMapper()
 ) : ClientRepository {
     override suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client> {
         return clientRemoteRepository.registerClient(param)
@@ -64,12 +66,24 @@ class ClientDataSource(
     override suspend fun currentClientId(): Either<CoreFailure, ClientId> =
         wrapStorageRequest { clientRegistrationStorage.getRegisteredClientId() }
             .map { ClientId(it) }
-            .mapLeft { if (it is StorageFailure.DataNotFound) { CoreFailure.MissingClientRegistration } else { it } }
+            .mapLeft {
+                if (it is StorageFailure.DataNotFound) {
+                    CoreFailure.MissingClientRegistration
+                } else {
+                    it
+                }
+            }
 
     override suspend fun retainedClientId(): Either<CoreFailure, ClientId> =
         wrapStorageRequest { clientRegistrationStorage.getRetainedClientId() }
             .map { ClientId(it) }
-            .mapLeft { if (it is StorageFailure.DataNotFound) { CoreFailure.MissingClientRegistration } else { it } }
+            .mapLeft {
+                if (it is StorageFailure.DataNotFound) {
+                    CoreFailure.MissingClientRegistration
+                } else {
+                    it
+                }
+            }
 
     override suspend fun observeCurrentClientId(): Flow<ClientId?> =
         clientRegistrationStorage.observeRegisteredClientId().map { rawClientId ->
@@ -98,9 +112,10 @@ class ClientDataSource(
                 wrapStorageRequest { clientDAO.insertClients(clientEntityList) }
             }
         }
+
     override suspend fun storeUserClientList(userId: UserId, clients: List<OtherUserClient>): Either<StorageFailure, Unit> =
         userMapper.toUserIdPersistence(userId).let { userEntity ->
-            clients.map { ClientEntity(userEntity, it.id, it.deviceType.name) }.let { clientEntityList ->
+            clients.map { ClientEntity(userEntity, it.id, clientMapper.toDeviceTypeEntity(it.deviceType)) }.let { clientEntityList ->
                 wrapStorageRequest { clientDAO.insertClients(clientEntityList) }
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
@@ -35,12 +35,12 @@ interface ClientRemoteRepository {
 class ClientRemoteDataSource(
     private val clientApi: ClientApi,
     private val clientConfig: ClientConfig,
-    private val clientMapper: ClientMapper = MapperProvider.clientMapper(clientConfig),
+    private val clientMapper: ClientMapper = MapperProvider.clientMapper(),
     private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : ClientRemoteRepository {
 
     override suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client> =
-        wrapApiRequest { clientApi.registerClient(clientMapper.toRegisterClientRequest(param)) }
+        wrapApiRequest { clientApi.registerClient(clientMapper.toRegisterClientRequest(clientConfig, param)) }
             .map { clientResponse -> clientMapper.fromClientResponse(clientResponse) }
 
     override suspend fun registerMLSClient(clientId: ClientId, publicKey: String): Either<NetworkFailure, Unit> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -1,6 +1,6 @@
 package com.wire.kalium.logic.data.user
 
-import com.wire.kalium.logic.data.client.DeviceType
+import com.wire.kalium.logic.data.client.ClientMapper
 import com.wire.kalium.logic.data.client.OtherUserClient
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.TeamId
@@ -65,6 +65,7 @@ interface UserMapper {
 
 internal class UserMapperImpl(
     private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val clientMapper: ClientMapper = MapperProvider.clientMapper(),
     private val availabilityStatusMapper: AvailabilityStatusMapper = MapperProvider.availabilityStatusMapper(),
     private val connectionStateMapper: ConnectionStateMapper = MapperProvider.connectionStateMapper(),
     private val userEntityTypeMapper: UserEntityTypeMapper = MapperProvider.userTypeEntityMapper()
@@ -220,16 +221,8 @@ internal class UserMapperImpl(
             deleted = false
         )
 
-    private fun fromDeviceTypeString(deviceType: String): DeviceType = when (deviceType) {
-        "phone" -> DeviceType.Phone
-        "tablet" -> DeviceType.Tablet
-        "desktop" -> DeviceType.Desktop
-        "legalHold" -> DeviceType.LegalHold
-        else -> DeviceType.Unknown
-    }
-
     override fun fromOtherUsersClientsDTO(otherUsersClients: List<Client>): List<OtherUserClient> =
         otherUsersClients.map {
-            OtherUserClient(fromDeviceTypeString(it.deviceType?.lowercase() ?: ""), it.id)
+            OtherUserClient(clientMapper.fromDeviceTypeEntity(it.deviceType), it.id)
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -21,8 +21,8 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.UserEntity
 import com.wire.kalium.persistence.dao.UserTypeEntity
-import com.wire.kalium.persistence.dao.UserIDEntity as UserIdEntity
 import com.wire.kalium.persistence.dao.client.Client
+import com.wire.kalium.persistence.dao.UserIDEntity as UserIdEntity
 
 interface UserMapper {
     fun fromDtoToSelfUser(userDTO: UserDTO): SelfUser
@@ -220,8 +220,16 @@ internal class UserMapperImpl(
             deleted = false
         )
 
+    private fun fromDeviceTypeString(deviceType: String): DeviceType = when (deviceType) {
+        "phone" -> DeviceType.Phone
+        "tablet" -> DeviceType.Tablet
+        "desktop" -> DeviceType.Desktop
+        "legalHold" -> DeviceType.LegalHold
+        else -> DeviceType.Unknown
+    }
+
     override fun fromOtherUsersClientsDTO(otherUsersClients: List<Client>): List<OtherUserClient> =
         otherUsersClients.map {
-            OtherUserClient(DeviceType.valueOf(it.deviceType ?: ""), it.id)
+            OtherUserClient(fromDeviceTypeString(it.deviceType?.lowercase() ?: ""), it.id)
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -76,7 +76,11 @@ internal object MapperProvider {
     fun sessionMapper(): SessionMapper = SessionMapperImpl(idMapper())
     fun availabilityStatusMapper(): AvailabilityStatusMapper = AvailabilityStatusMapperImpl()
     fun connectionStateMapper(): ConnectionStateMapper = ConnectionStateMapperImpl()
-    fun userMapper(): UserMapper = UserMapperImpl(idMapper(), availabilityStatusMapper(), connectionStateMapper(), userTypeEntityMapper())
+    fun userMapper(): UserMapper = UserMapperImpl(
+        idMapper(),
+        clientMapper(), availabilityStatusMapper(), connectionStateMapper(), userTypeEntityMapper()
+    )
+
     fun teamMapper(): TeamMapper = TeamMapperImpl()
     fun messageMapper(): MessageMapper = MessageMapperImpl(idMapper(), memberMapper())
     fun memberMapper(): MemberMapper = MemberMapperImpl(idMapper(), conversationRoleMapper())
@@ -95,12 +99,13 @@ internal object MapperProvider {
         featureConfigMapper(),
         conversationRoleMapper()
     )
+
     fun messageMentionMapper(): MessageMentionMapper = MessageMentionMapperImpl(idMapper())
 
     fun preyKeyMapper(): PreKeyMapper = PreKeyMapperImpl()
     fun preKeyListMapper(): PreKeyListMapper = PreKeyListMapper(preyKeyMapper())
     fun locationMapper(): LocationMapper = LocationMapper()
-    fun clientMapper(clientConfig: ClientConfig): ClientMapper = ClientMapper(preyKeyMapper(), locationMapper(), clientConfig)
+    fun clientMapper(): ClientMapper = ClientMapper(preyKeyMapper(), locationMapper())
     fun conversationStatusMapper(): ConversationStatusMapper = ConversationStatusMapperImpl(idMapper())
     fun protoContentMapper(): ProtoContentMapper = ProtoContentMapperImpl()
     fun callMapper(): CallMapper = CallMapperImpl()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.di
 
-import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.configuration.server.ApiVersionMapper
 import com.wire.kalium.logic.configuration.server.ApiVersionMapperImpl
 import com.wire.kalium.logic.configuration.server.ServerConfigMapper

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -92,7 +92,8 @@ actual class UserDatabaseProvider(
                 statusAdapter = EnumColumnAdapter(),
                 conversation_typeAdapter = EnumColumnAdapter()
             ),
-            Client.Adapter(user_idAdapter = QualifiedIDAdapter),
+            Client.Adapter(user_idAdapter = QualifiedIDAdapter,
+                device_typeAdapter = EnumColumnAdapter()),
             Connection.Adapter(
                 qualified_conversationAdapter = QualifiedIDAdapter,
                 qualified_toAdapter = QualifiedIDAdapter,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -1,9 +1,10 @@
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+import com.wire.kalium.persistence.dao.client.DeviceTypeEntity;
 
 CREATE TABLE Client (
     user_id TEXT AS QualifiedIDEntity NOT NULL,
     id TEXT NOT NULL,
-    device_type TEXT,
+    device_type TEXT AS DeviceTypeEntity,
     FOREIGN KEY (user_id) REFERENCES User(qualified_id) ON DELETE CASCADE,
     PRIMARY KEY (user_id, id)
 );

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
@@ -6,8 +6,16 @@ import kotlinx.coroutines.flow.Flow
 data class Client(
     val userId: QualifiedIDEntity,
     val id: String,
-    val deviceType: String?
+    val deviceType: DeviceTypeEntity?
 )
+
+enum class DeviceTypeEntity {
+    Phone,
+    Tablet,
+    Desktop,
+    LegalHold,
+    Unknown;
+}
 
 interface ClientDAO {
     suspend fun insertClient(client: Client)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -104,7 +104,7 @@ class ClientDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenClientWithDeviceIsStored_whenInsertingTheSameClientWithNullType_thenTypeIsNotOverwritten() = runTest {
-        val insertClientWithType = Client(user.id, "id1", deviceType = "Tablet")
+        val insertClientWithType = Client(user.id, "id1", deviceType = DeviceTypeEntity.Tablet)
         val insertClientWithNullType = insertClientWithType.copy(deviceType = null)
         userDAO.insertUser(user)
         clientDAO.insertClients(listOf(insertClientWithType))

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -60,7 +60,10 @@ actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
                 statusAdapter = EnumColumnAdapter(),
                 conversation_typeAdapter = EnumColumnAdapter()
             ),
-            Client.Adapter(user_idAdapter = QualifiedIDAdapter),
+            Client.Adapter(
+                user_idAdapter = QualifiedIDAdapter,
+                device_typeAdapter = EnumColumnAdapter()
+            ),
             Connection.Adapter(
                 qualified_conversationAdapter = QualifiedIDAdapter,
                 qualified_toAdapter = QualifiedIDAdapter,

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -74,7 +74,8 @@ actual class UserDatabaseProvider(private val storePath: File) {
                 statusAdapter = EnumColumnAdapter(),
                 conversation_typeAdapter = EnumColumnAdapter()
             ),
-            Client.Adapter(user_idAdapter = QualifiedIDAdapter),
+            Client.Adapter(user_idAdapter = QualifiedIDAdapter,
+                device_typeAdapter = EnumColumnAdapter()),
             Connection.Adapter(
                 qualified_conversationAdapter = QualifiedIDAdapter,
                 qualified_toAdapter = QualifiedIDAdapter,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App crash due to  No enum constant client.DeviceType  exception


### Solutions

create a mapper for device type to map the values from the entity to the Device type 



### Testing


#### How to Test
open a random user profiles and check that it should not crash 


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
