### PR TITLE
fix: slow performance when fetching user IDs repeatedly (AR-2435)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 import com.wire.kalium.persistence.kmm_settings.SettingOptions
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.runBlocking
 
 @Suppress("LongParameterList")
@@ -63,7 +64,8 @@ actual class UserSessionScopeProviderImpl(
                 appContext,
                 userIDEntity,
                 SecurityHelper(globalPreferences).userDBSecret(userId),
-                kaliumConfigs.shouldEncryptData
+                kaliumConfigs.shouldEncryptData,
+                KaliumDispatcherImpl.io
             )
         val userDataSource = AuthenticatedDataSourceSet(
             rootAccountPath,

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 import com.wire.kalium.persistence.kmm_settings.SettingOptions
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.runBlocking
 import java.io.File
 
@@ -59,7 +60,7 @@ actual class UserSessionScopeProviderImpl(
             )
         )
         val userPreferencesSettings = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
-        val userDatabase = UserDatabaseProvider(File(rootStoragePath))
+        val userDatabase = UserDatabaseProvider(File(rootStoragePath), KaliumDispatcherImpl.io)
 
         val userDataSource = AuthenticatedDataSourceSet(
             rootAccountPath,

--- a/persistence/src/androidAndroidTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/androidAndroidTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -6,9 +6,13 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.UserDBSecret
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.util.FileNameUtil
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 
 actual open class BaseDatabaseTest actual constructor() {
     private val userId = UserIDEntity("78dd6502-ab84-40f7-a8b3-1e7e1eb4cc8c", "user_12_domain")
+
+    protected actual val dispatcher: TestDispatcher = StandardTestDispatcher()
 
     actual fun deleteDatabase() {
         val context: Context = ApplicationProvider.getApplicationContext()
@@ -19,7 +23,8 @@ actual open class BaseDatabaseTest actual constructor() {
         return UserDatabaseProvider(
             ApplicationProvider.getApplicationContext(),
             userId,
-            UserDBSecret("db_secret".toByteArray())
+            UserDBSecret("db_secret".toByteArray()),
+            dispatcher = dispatcher
         )
     }
 }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.persistence.MessageTextContent
 import com.wire.kalium.persistence.MessageUnknownContent
 import com.wire.kalium.persistence.User
 import com.wire.kalium.persistence.UserDatabase
+import com.wire.kalium.persistence.cache.LRUCache
 import com.wire.kalium.persistence.dao.BotServiceAdapter
 import com.wire.kalium.persistence.dao.ConnectionDAO
 import com.wire.kalium.persistence.dao.ConnectionDAOImpl
@@ -48,13 +49,18 @@ import com.wire.kalium.persistence.dao.client.ClientDAOImpl
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import net.sqlcipher.database.SupportFactory
 
 actual class UserDatabaseProvider(
     private val context: Context,
     userId: UserIDEntity,
     passphrase: UserDBSecret,
-    encrypt: Boolean = true
+    encrypt: Boolean = true,
+    dispatcher: CoroutineDispatcher
 ) {
     private val dbName = FileNameUtil.userDBName(userId)
     private val driver: AndroidSqliteDriver
@@ -92,8 +98,10 @@ actual class UserDatabaseProvider(
                 statusAdapter = EnumColumnAdapter(),
                 conversation_typeAdapter = EnumColumnAdapter()
             ),
-            Client.Adapter(user_idAdapter = QualifiedIDAdapter,
-                device_typeAdapter = EnumColumnAdapter()),
+            Client.Adapter(
+                user_idAdapter = QualifiedIDAdapter,
+                device_typeAdapter = EnumColumnAdapter()
+            ),
             Connection.Adapter(
                 qualified_conversationAdapter = QualifiedIDAdapter,
                 qualified_toAdapter = QualifiedIDAdapter,
@@ -167,8 +175,10 @@ actual class UserDatabaseProvider(
         )
     }
 
+    private val databaseScope = CoroutineScope(SupervisorJob() + dispatcher)
+
     actual val userDAO: UserDAO
-        get() = UserDAOImpl(database.usersQueries)
+        get() = UserDAOImpl(database.usersQueries, LRUCache(100), databaseScope)
 
     actual val connectionDAO: ConnectionDAO
         get() = ConnectionDAOImpl(database.connectionsQueries, database.conversationsQueries)
@@ -195,6 +205,7 @@ actual class UserDatabaseProvider(
         get() = TeamDAOImpl(database.teamsQueries)
 
     actual fun nuke(): Boolean {
+        databaseScope.cancel()
         driver.close()
         return context.deleteDatabase(dbName)
     }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -178,7 +178,7 @@ actual class UserDatabaseProvider(
     private val databaseScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     actual val userDAO: UserDAO
-        get() = UserDAOImpl(database.usersQueries, LRUCache(100), databaseScope)
+        get() = UserDAOImpl(database.usersQueries, LRUCache(USER_CACHE_SIZE), databaseScope)
 
     actual val connectionDAO: ConnectionDAO
         get() = ConnectionDAOImpl(database.connectionsQueries, database.conversationsQueries)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/cache/LRUCache.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/cache/LRUCache.kt
@@ -1,0 +1,58 @@
+package com.wire.kalium.persistence.cache
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal interface Cache<Key : Any, Value> {
+    suspend fun get(key: Key, producer: suspend (key: Key) -> Value): Value
+    suspend fun remove(key: Key)
+}
+
+internal class LRUCache<Key : Any, Value : Any>(
+    private val maxSize: Int
+) : Cache<Key, Value> {
+
+    init {
+        require(maxSize > 0) { "Can't initialize a LRUCache with a negative max size" }
+    }
+
+    private val mutex = Mutex()
+
+    private val storage = hashMapOf<Key, Value>()
+
+    /**
+     * Stores the order in which keys to access values were used.
+     * The first value contains the key accessed the longest ago, while
+     * the last value contains the most recently accessed key.
+     */
+    private val keyAccessLogbook = mutableSetOf<Key>()
+
+    override suspend fun get(key: Key, producer: suspend (key: Key) -> Value): Value =
+        mutex.withLock {
+            val value = storage.getOrPut(key) { producer(key) }
+            recordAccess(key)
+            while (storage.size > maxSize) {
+                val leastRecentlyAccessedKey = keyAccessLogbook.first()
+                storage.remove(leastRecentlyAccessedKey)
+                keyAccessLogbook.remove(leastRecentlyAccessedKey)
+            }
+            value
+        }
+
+    private fun recordAccess(key: Key) {
+        keyAccessLogbook.insertOrMoveToLastPosition(key)
+    }
+
+    override suspend fun remove(key: Key): Unit = mutex.withLock {
+        storage.remove(key)
+    }
+
+    /**
+     * Adds or reorders an element to the set,
+     * putting it into the last position.
+     */
+    private fun <T> MutableSet<T>.insertOrMoveToLastPosition(element: T) {
+        remove(element)
+        add(element)
+    }
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -4,8 +4,12 @@ import com.squareup.sqldelight.runtime.coroutines.asFlow
 import com.squareup.sqldelight.runtime.coroutines.mapToList
 import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.UsersQueries
+import com.wire.kalium.persistence.cache.Cache
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted.Companion.Lazily
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import com.wire.kalium.persistence.User as SQLDelightUser
 
 class UserMapper {
@@ -30,8 +34,10 @@ class UserMapper {
 }
 
 @Suppress("TooManyFunctions")
-class UserDAOImpl(
-    private val userQueries: UsersQueries
+class UserDAOImpl internal constructor(
+    private val userQueries: UsersQueries,
+    private val userCache: Cache<UserIDEntity, Flow<UserEntity?>>,
+    private val databaseScope: CoroutineScope
 ) : UserDAO {
 
     val mapper = UserMapper()
@@ -172,11 +178,12 @@ class UserDAOImpl(
         .mapToList()
         .map { entryList -> entryList.map(mapper::toModel) }
 
-    override suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?> {
-        return userQueries.selectByQualifiedId(listOf(qualifiedID))
+    override suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?> = userCache.get(qualifiedID) {
+        userQueries.selectByQualifiedId(listOf(qualifiedID))
             .asFlow()
             .mapToOneOrNull()
             .map { it?.let { mapper.toModel(it) } }
+            .shareIn(databaseScope, Lazily, 1)
     }
 
     override suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): List<UserEntity> {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -11,6 +11,7 @@ import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import kotlin.jvm.JvmInline
 
+internal const val USER_CACHE_SIZE = 125
 @JvmInline
 value class UserDBSecret(val value: ByteArray)
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -1,9 +1,11 @@
 package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.db.UserDatabaseProvider
+import kotlinx.coroutines.test.TestDispatcher
 
 expect open class BaseDatabaseTest() {
 
+    protected val dispatcher: TestDispatcher
     fun deleteDatabase()
     fun createDatabase(): UserDatabaseProvider
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/cache/LRUCacheTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/cache/LRUCacheTest.kt
@@ -1,0 +1,96 @@
+package com.wire.kalium.persistence.cache
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LRUCacheTest {
+
+    @Test
+    fun givenAnElementIsCached_whenGettingTheSecondTime_shouldExecuteTheProviderLambdaOnlyTheFirstTime() = runTest {
+        val cache = createCache(100)
+        val itemKey = 42
+        var providerExecCount = 0
+
+        cache.get(itemKey) {
+            providerExecCount++
+            "Number one"
+        }
+        assertEquals(1, providerExecCount)
+
+        cache.get(itemKey) { error("This should not be executed as the item is already cached") }
+        assertEquals(1, providerExecCount)
+    }
+
+    @Test
+    fun givenAKeyAndProvider_whenInvokingTheProvider_shouldPassTheKeyAsParameter() = runTest {
+        val cache = createCache(100)
+        val itemKey = 42
+        var providerExecCount = 0
+
+        cache.get(itemKey) {
+            assertEquals(itemKey, it)
+            providerExecCount++
+            "Number one"
+        }
+        assertEquals(1, providerExecCount)
+    }
+
+    @Test
+    fun givenAnElementIsCached_whenGettingItsValue_shouldReturnTheProvidedValue() = runTest {
+        val cache = createCache(100)
+        val itemKey = 42
+        val expectedElement = "I'm expected"
+
+        val result = cache.get(itemKey) { expectedElement }
+        assertEquals(expectedElement, result)
+    }
+
+    @Test
+    fun givenAnElementIsRemoved_whenGettingItsValueTheSecondTime_shouldInvokeTheProviderLambda() = runTest {
+        val cache = createCache(100)
+        val itemKey = 42
+        cache.get(itemKey) { "Zio" }
+
+        cache.remove(itemKey)
+        val secondResult = cache.get(itemKey) { "Expected Value" }
+
+        val thirdResult = cache.get(itemKey) { "Zia" }
+
+        assertEquals(secondResult, thirdResult)
+    }
+
+    @Test
+    fun givenTheCacheCountExceedsTheLimit_whenGettingAnExpiredValue_shouldInvokeTheNewProvider() = runTest {
+        val limit = 10
+        val cache = createCache(limit)
+        val itemsToExpire = 2
+        val expectedElement = "The replacement"
+
+        repeat(limit + itemsToExpire) { index ->
+            cache.get(index) { "The originals" }
+        }
+        val result = cache.get(0) { expectedElement }
+
+        assertEquals(expectedElement, result)
+    }
+
+    @Test
+    fun givenTheCacheCountExceedsTheLimit_whenGettingARecentValue_shouldNotInvokeTheNewProvider() = runTest {
+        val limit = 10
+        val cache = createCache(limit)
+        val itemsToExpire = 2
+        val expectedElement = "The originals"
+
+        repeat(limit + itemsToExpire) { index ->
+            cache.get(index) { expectedElement }
+        }
+        val result = cache.get(itemsToExpire + 1) {
+            error("Should not invoke this, as the item was not expired")
+        }
+
+        assertEquals(expectedElement, result)
+    }
+
+    private fun createCache(size: Int) = LRUCache<Int, String>(size)
+}

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -183,7 +183,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversation_ThenUserTableShouldBeUpdatedOnlyAndNotReplaced() = runTest {
+    fun givenExistingConversation_ThenUserTableShouldBeUpdatedOnlyAndNotReplaced() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity1)
         userDAO.insertUser(user1.copy(connectionStatus = ConnectionEntity.State.NOT_CONNECTED))
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
@@ -36,7 +36,7 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenUserExists_whenInsertingMember_thenOriginalUserDetailsAreKept() = runTest {
+    fun givenUserExists_whenInsertingMember_thenOriginalUserDetailsAreKept() = runTest(dispatcher) {
         userDAO.insertUser(user1)
 
         conversationDAO.insertConversation(conversationEntity1)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -34,14 +35,14 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenUser_ThenUserCanBeInserted() = runTest {
+    fun givenUser_ThenUserCanBeInserted() = runTest(dispatcher) {
         db.userDAO.insertUser(user1)
         val result = db.userDAO.getUserByQualifiedID(user1.id).first()
         assertEquals(result, user1)
     }
 
     @Test
-    fun givenListOfUsers_ThenMultipleUsersCanBeInsertedAtOnce() = runTest {
+    fun givenListOfUsers_ThenMultipleUsersCanBeInsertedAtOnce() = runTest(dispatcher) {
         db.userDAO.upsertUsers(listOf(user1, user2, user3))
         val result1 = db.userDAO.getUserByQualifiedID(user1.id).first()
         val result2 = db.userDAO.getUserByQualifiedID(user2.id).first()
@@ -52,7 +53,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingUser_ThenUserCanBeDeleted() = runTest {
+    fun givenExistingUser_ThenUserCanBeDeleted() = runTest(dispatcher) {
         db.userDAO.insertUser(user1)
         db.userDAO.deleteUserByQualifiedID(user1.id)
         val result = db.userDAO.getUserByQualifiedID(user1.id).first()
@@ -60,7 +61,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingUser_ThenUserCanBeUpdated() = runTest {
+    fun givenExistingUser_ThenUserCanBeUpdated() = runTest(dispatcher) {
         db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
             user1.id,
@@ -84,35 +85,11 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenListOfUsers_ThenUserCanBeQueriedByName() = runTest {
+    fun givenRetrievedUser_ThenUpdatesArePropagatedThroughFlow() = runTest(dispatcher) {
+        val collectedValues = mutableListOf<UserEntity?>()
+
         db.userDAO.insertUser(user1)
-        val updatedUser1 = UserEntity(
-            user1.id,
-            "John Doe",
-            "johndoe",
-            "email1",
-            "phone1",
-            1,
-            "team",
-            ConnectionEntity.State.ACCEPTED,
-            UserAssetIdEntity("asset1", "domain"),
-            UserAssetIdEntity("asset2", "domain"),
-            UserAvailabilityStatusEntity.NONE,
-            UserTypeEntity.STANDARD,
-            botService = null,
-            false
-        )
 
-        val result = db.userDAO.getUserByQualifiedID(user1.id)
-        assertEquals(user1, result.first())
-
-        db.userDAO.updateSelfUser(updatedUser1)
-        assertEquals(updatedUser1, result.first())
-    }
-
-    @Test
-    fun givenRetrievedUser_ThenUpdatesArePropagatedThroughFlow() = runTest {
-        db.userDAO.insertUser(user1)
         val updatedUser1 = UserEntity(
             user1.id,
             "John Doe",
@@ -130,15 +107,18 @@ class UserDAOTest : BaseDatabaseTest() {
             false
         )
 
-        val result = db.userDAO.getUserByQualifiedID(user1.id)
-        assertEquals(user1, result.first())
-
-        db.userDAO.updateSelfUser(updatedUser1)
-        assertEquals(updatedUser1, result.first())
+        db.userDAO.getUserByQualifiedID(user1.id).take(2).collect() {
+            collectedValues.add(it)
+            if (collectedValues.size == 1) {
+                db.userDAO.updateSelfUser(updatedUser1)
+            }
+        }
+        assertEquals(user1, collectedValues[0])
+        assertEquals(updatedUser1, collectedValues[1])
     }
 
     @Test
-    fun givenAExistingUsers_WhenQueriedUserByUserEmail_ThenResultsIsEqualToThatUser() = runTest {
+    fun givenAExistingUsers_WhenQueriedUserByUserEmail_ThenResultsIsEqualToThatUser() = runTest(dispatcher) {
         // given
         val user1 = USER_ENTITY_1
         val user2 = USER_ENTITY_2.copy(email = "uniqueEmailForUser2")
@@ -162,7 +142,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenAExistingUsers_WhenQueriedUserByName_ThenResultsIsEqualToThatUser(): TestResult {
-        return runTest {
+        return runTest(dispatcher) {
             // given
             val user1 = USER_ENTITY_1
             val user2 = USER_ENTITY_3
@@ -185,7 +165,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAExistingUsers_WhenQueriedUserByHandle_ThenResultsIsEqualToThatUser() = runTest {
+    fun givenAExistingUsers_WhenQueriedUserByHandle_ThenResultsIsEqualToThatUser() = runTest(dispatcher) {
         // given
         val user1 = USER_ENTITY_1.copy(name = "uniqueNameFor User1")
         val user2 = USER_ENTITY_2
@@ -204,7 +184,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenAExistingUsersWithCommonEmailPrefix_WhenQueriedWithThatEmailPrefix_ThenResultIsEqualToTheUsersWithCommonEmailPrefix() =
-        runTest {
+        runTest(dispatcher) {
             // given
             val commonEmailPrefix = "commonEmail"
 
@@ -264,7 +244,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
     // when entering
     @Test
-    fun givenAExistingUsers_WhenQueriedWithNonExistingEmail_ThenReturnNoResults() = runTest {
+    fun givenAExistingUsers_WhenQueriedWithNonExistingEmail_ThenReturnNoResults() = runTest(dispatcher) {
         // given
         val mockUsers = listOf(USER_ENTITY_1, USER_ENTITY_2, USER_ENTITY_3)
         db.userDAO.upsertUsers(mockUsers)
@@ -286,7 +266,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAExistingUsers_whenQueriedWithCommonEmailPrefix_ThenResultsUsersEmailContainsThatPrefix() = runTest {
+    fun givenAExistingUsers_whenQueriedWithCommonEmailPrefix_ThenResultsUsersEmailContainsThatPrefix() = runTest(dispatcher) {
         // given
         val commonEmailPrefix = "commonEmail"
 
@@ -310,7 +290,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAExistingUsers_whenQueriedWithCommonHandlePrefix_ThenResultsUsersHandleContainsThatPrefix() = runTest {
+    fun givenAExistingUsers_whenQueriedWithCommonHandlePrefix_ThenResultsUsersHandleContainsThatPrefix() = runTest(dispatcher) {
         // given
         val commonHandlePrefix = "commonHandle"
 
@@ -334,7 +314,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAExistingUsers_whenQueriedWithCommonNamePrefix_ThenResultsUsersNameContainsThatPrefix() = runTest {
+    fun givenAExistingUsers_whenQueriedWithCommonNamePrefix_ThenResultsUsersNameContainsThatPrefix() = runTest(dispatcher) {
         // given
         val commonNamePrefix = "commonName"
 
@@ -359,7 +339,7 @@ class UserDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenAExistingUsers_whenQueriedWithCommonPrefixForNameHandleAndEmail_ThenResultsUsersNameHandleAndEmailContainsThatPrefix() =
-        runTest {
+        runTest(dispatcher) {
             // given
             val commonPrefix = "common"
 
@@ -382,7 +362,7 @@ class UserDAOTest : BaseDatabaseTest() {
         }
 
     @Test
-    fun givenAExistingUsers_whenQueried_ThenResultsUsersAreConnected() = runTest {
+    fun givenAExistingUsers_whenQueried_ThenResultsUsersAreConnected() = runTest(dispatcher) {
         // given
         val commonPrefix = "common"
 
@@ -411,7 +391,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAConnectedExistingUsersAndNonConnected_whenQueried_ThenResultsUsersAreConnected() = runTest {
+    fun givenAConnectedExistingUsersAndNonConnected_whenQueried_ThenResultsUsersAreConnected() = runTest(dispatcher) {
         // given
         val commonPrefix = "common"
 
@@ -439,7 +419,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAConnectedExistingUserAndNonConnected_whenQueried_ThenResultIsTheConnectedUser() = runTest {
+    fun givenAConnectedExistingUserAndNonConnected_whenQueried_ThenResultIsTheConnectedUser() = runTest(dispatcher) {
         // given
         val commonPrefix = "common"
 
@@ -469,7 +449,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenTheListOfUser_whenQueriedByHandle_ThenResultContainsOnlyTheUserHavingTheHandleAndAreConnected() = runTest {
+    fun givenTheListOfUser_whenQueriedByHandle_ThenResultContainsOnlyTheUserHavingTheHandleAndAreConnected() = runTest(dispatcher) {
         val expectedResult = listOf(
             USER_ENTITY_1.copy(handle = "@someHandle"),
             USER_ENTITY_4.copy(handle = "@someHandle1")
@@ -500,7 +480,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAExistingUsers_whenUpdatingTheirValues_ThenResultsIsEqualToThatUserButWithFieldsModified() = runTest {
+    fun givenAExistingUsers_whenUpdatingTheirValues_ThenResultsIsEqualToThatUserButWithFieldsModified() = runTest(dispatcher) {
         // given
         val newNameA = "new user naming a"
         val newNameB = "new user naming b"
@@ -517,7 +497,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAExistingUsers_whenUpdatingTheirValuesAndRecordNotExists_ThenResultsOneUpdatedAnotherInserted() = runTest {
+    fun givenAExistingUsers_whenUpdatingTheirValuesAndRecordNotExists_ThenResultsOneUpdatedAnotherInserted() = runTest(dispatcher) {
         // given
         val newNameA = "new user naming a"
         db.userDAO.insertUser(user1)
@@ -532,7 +512,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAExistingUsers_whenUpsertingTeamMembers_ThenResultsOneUpdatedAnotherInserted() = runTest {
+    fun givenAExistingUsers_whenUpsertingTeamMembers_ThenResultsOneUpdatedAnotherInserted() = runTest(dispatcher) {
         // given
         val newTeamId = "new user team id"
         db.userDAO.insertUser(user1)
@@ -547,7 +527,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenATeamMember_whenUpsertingTeamMember_ThenUserTypeShouldStayTheSame() = runTest {
+    fun givenATeamMember_whenUpsertingTeamMember_ThenUserTypeShouldStayTheSame() = runTest(dispatcher) {
         // given
         val externalMember = user1.copy(userType = UserTypeEntity.EXTERNAL)
         db.userDAO.upsertTeamMembersTypes(listOf(externalMember))
@@ -559,7 +539,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAExistingUsers_whenUpsertingUsers_ThenResultsOneUpdatedAnotherInsertedWithNoConnectionStatusOverride() = runTest {
+    fun givenAExistingUsers_whenUpsertingUsers_ThenResultsOneUpdatedAnotherInsertedWithNoConnectionStatusOverride() = runTest(dispatcher) {
         // given
         val newTeamId = "new team id"
         db.userDAO.insertUser(user1.copy(connectionStatus = ConnectionEntity.State.ACCEPTED))
@@ -575,7 +555,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenListOfUsers_WhenGettingListOfUsers_ThenMatchingUsersAreReturned() = runTest {
+    fun givenListOfUsers_WhenGettingListOfUsers_ThenMatchingUsersAreReturned() = runTest(dispatcher) {
         val users = listOf(user1, user2)
         val requestedIds = (users + user3).map { it.id }
         db.userDAO.upsertUsers(users)

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -148,7 +148,7 @@ actual class UserDatabaseProvider(
 
     private val databaseScope = CoroutineScope(SupervisorJob() + dispatcher)
     actual val userDAO: UserDAO
-        get() = UserDAOImpl(database.usersQueries, LRUCache(100), databaseScope)
+        get() = UserDAOImpl(database.usersQueries, LRUCache(USER_CACHE_SIZE), databaseScope)
 
     actual val conversationDAO: ConversationDAO
         get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -19,6 +19,7 @@ import com.wire.kalium.persistence.MessageTextContent
 import com.wire.kalium.persistence.MessageUnknownContent
 import com.wire.kalium.persistence.User
 import com.wire.kalium.persistence.UserDatabase
+import com.wire.kalium.persistence.cache.LRUCache
 import com.wire.kalium.persistence.dao.BotServiceAdapter
 import com.wire.kalium.persistence.dao.ConnectionDAO
 import com.wire.kalium.persistence.dao.ConnectionDAOImpl
@@ -46,8 +47,15 @@ import com.wire.kalium.persistence.dao.client.ClientDAOImpl
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 
-actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
+actual class UserDatabaseProvider(
+    userId: UserIDEntity,
+    passphrase: String,
+    dispatcher: CoroutineDispatcher
+) {
 
     val database: UserDatabase
 
@@ -138,8 +146,9 @@ actual class UserDatabaseProvider(userId: UserIDEntity, passphrase: String) {
         driver.execute(null, "PRAGMA foreign_keys=ON", 0)
     }
 
+    private val databaseScope = CoroutineScope(SupervisorJob() + dispatcher)
     actual val userDAO: UserDAO
-        get() = UserDAOImpl(database.usersQueries)
+        get() = UserDAOImpl(database.usersQueries, LRUCache(100), databaseScope)
 
     actual val conversationDAO: ConversationDAO
         get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)

--- a/persistence/src/iosX64Test/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/iosX64Test/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -4,13 +4,13 @@ import co.touchlab.sqliter.DatabaseFileContext.deleteDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.util.FileNameUtil
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 
 actual open class BaseDatabaseTest actual constructor() {
     private val userId = UserIDEntity("78dd6502-ab84-40f7-a8b3-1e7e1eb4cc8c", "user_12_domain")
 
-    protected actual val dispatcher: CoroutineDispatcher = StandardTestDispatcher()
+    protected actual val dispatcher: TestDispatcher = StandardTestDispatcher()
 
     actual fun deleteDatabase() {
         deleteDatabase(FileNameUtil.userDBName(userId))

--- a/persistence/src/iosX64Test/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/iosX64Test/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -4,16 +4,20 @@ import co.touchlab.sqliter.DatabaseFileContext.deleteDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.util.FileNameUtil
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 
 actual open class BaseDatabaseTest actual constructor() {
     private val userId = UserIDEntity("78dd6502-ab84-40f7-a8b3-1e7e1eb4cc8c", "user_12_domain")
+
+    protected actual val dispatcher: CoroutineDispatcher = StandardTestDispatcher()
 
     actual fun deleteDatabase() {
         deleteDatabase(FileNameUtil.userDBName(userId))
     }
 
     actual fun createDatabase(): UserDatabaseProvider {
-        return UserDatabaseProvider(userId, "123456789")
+        return UserDatabaseProvider(userId, "123456789", dispatcher)
     }
 
 }

--- a/persistence/src/jsTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/jsTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -1,12 +1,12 @@
 package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.db.UserDatabaseProvider
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 
 actual open class BaseDatabaseTest actual constructor() {
 
-    protected actual val dispatcher: CoroutineDispatcher = StandardTestDispatcher()
+    protected actual val dispatcher: TestDispatcher = StandardTestDispatcher()
 
     actual fun deleteDatabase() {
         // TODO delete test database

--- a/persistence/src/jsTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/jsTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -1,8 +1,12 @@
 package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.db.UserDatabaseProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 
 actual open class BaseDatabaseTest actual constructor() {
+
+    protected actual val dispatcher: CoroutineDispatcher = StandardTestDispatcher()
 
     actual fun deleteDatabase() {
         // TODO delete test database

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -157,7 +157,7 @@ actual class UserDatabaseProvider(private val storePath: File, dispatcher: Corou
 
     private val databaseScope = CoroutineScope(SupervisorJob() + dispatcher)
     actual val userDAO: UserDAO
-        get() = UserDAOImpl(database.usersQueries, LRUCache(100), databaseScope)
+        get() = UserDAOImpl(database.usersQueries, LRUCache(USER_CACHE_SIZE), databaseScope)
 
     actual val connectionDAO: ConnectionDAO
         get() = ConnectionDAOImpl(database.connectionsQueries, database.conversationsQueries)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -20,6 +20,7 @@ import com.wire.kalium.persistence.MessageTextContent
 import com.wire.kalium.persistence.MessageUnknownContent
 import com.wire.kalium.persistence.User
 import com.wire.kalium.persistence.UserDatabase
+import com.wire.kalium.persistence.cache.LRUCache
 import com.wire.kalium.persistence.dao.BotServiceAdapter
 import com.wire.kalium.persistence.dao.ConnectionDAO
 import com.wire.kalium.persistence.dao.ConnectionDAOImpl
@@ -45,10 +46,13 @@ import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.persistence.dao.client.ClientDAOImpl
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageDAOImpl
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import java.io.File
 import java.util.Properties
 
-actual class UserDatabaseProvider(private val storePath: File) {
+actual class UserDatabaseProvider(private val storePath: File, dispatcher: CoroutineDispatcher) {
 
     private val database: UserDatabase
 
@@ -74,8 +78,10 @@ actual class UserDatabaseProvider(private val storePath: File) {
                 statusAdapter = EnumColumnAdapter(),
                 conversation_typeAdapter = EnumColumnAdapter()
             ),
-            Client.Adapter(user_idAdapter = QualifiedIDAdapter,
-                device_typeAdapter = EnumColumnAdapter()),
+            Client.Adapter(
+                user_idAdapter = QualifiedIDAdapter,
+                device_typeAdapter = EnumColumnAdapter()
+            ),
             Connection.Adapter(
                 qualified_conversationAdapter = QualifiedIDAdapter,
                 qualified_toAdapter = QualifiedIDAdapter,
@@ -149,8 +155,9 @@ actual class UserDatabaseProvider(private val storePath: File) {
         )
     }
 
+    private val databaseScope = CoroutineScope(SupervisorJob() + dispatcher)
     actual val userDAO: UserDAO
-        get() = UserDAOImpl(database.usersQueries)
+        get() = UserDAOImpl(database.usersQueries, LRUCache(100), databaseScope)
 
     actual val connectionDAO: ConnectionDAO
         get() = ConnectionDAOImpl(database.connectionsQueries, database.conversationsQueries)

--- a/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -9,7 +9,7 @@ actual open class BaseDatabaseTest actual constructor() {
 
     protected actual val dispatcher: TestDispatcher = StandardTestDispatcher()
 
-    private val databaseFile  = Files.createTempDirectory("test-storage").toFile().resolve("test.db")
+    private val databaseFile = Files.createTempDirectory("test-storage").toFile().resolve("test.db")
 
     actual fun deleteDatabase() {
         databaseFile.delete()

--- a/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -1,9 +1,13 @@
 package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.db.UserDatabaseProvider
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 import java.nio.file.Files
 
 actual open class BaseDatabaseTest actual constructor() {
+
+    protected actual val dispatcher: TestDispatcher = StandardTestDispatcher()
 
     private val databaseFile  = Files.createTempDirectory("test-storage").toFile().resolve("test.db")
 
@@ -12,7 +16,7 @@ actual open class BaseDatabaseTest actual constructor() {
     }
 
     actual fun createDatabase(): UserDatabaseProvider {
-        return UserDatabaseProvider(databaseFile)
+        return UserDatabaseProvider(databaseFile, dispatcher = dispatcher)
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

## Issues

Reloaded is querying a lot of User Details in a sequence, which contributes with DB connections deadlocking when multiple operations are being performed.

## Solutions

A simple LRU Cache to store the flows of `UserEntity` in the DAO.

This way:
- We have a single instance of `Flow<UserEntity>` for each UserId, as long as the cache isn't full.
- When the query is invalidated, we make sure that **only one** request to the DB will be made to fetch the updated details even if we have multiple observers for the same User.

As visible in `UserDAOImpl`, this `LRUCache` can be easily used for other entities if we want, like `Conversation` and `Team` for example.

## Benchmark

I've done a benchmark comparing before and after adding this in-memory LRU cache.
I've ran the same benchmark multiple times getting similar results. The result below was picked in one of the runs without any reason in particular.

<details>
  <summary>Description of the benchmark</summary>

Test Setup:
- Create 1000 users
- From these users, create a list of 10 random qualified IDs, called `idsToFetch`
- Insert all the users into the DB

In each test:
- Start measuring time
- Take one ID from the `idsToFetch` list
- Select 3 times the same user ID
- Take the next ID from the list, until all IDs were fetched 3 times.
- Stop measuring time

The code of the test, without including the setup, was this:

```kotlin
fun selectWithCaching() = runTest {
    measureTime {
        idsToFetch.forEach { userId ->
            repeat(TIMES_PER_USER) {
                measureTime {
                    userDAO.getUserByQualifiedID(userId).first()
                }.also {
                    println("Took $it to get $userId")
                }
            }
        }
    }.also {
        println(
            "Took $it to select $USERS_TO_FETCH random users from a table of $USER_COUNT; " +
                    "Selecting each user $TIMES_PER_USER times"
        )
    }
}
```

</details>


<details>
  <summary>Results WITHOUT cache</summary>

```
Took 12.694ms to get QualifiedIDEntity(value=userId18, domain=userDomain)
Took 1.638300ms to get QualifiedIDEntity(value=userId18, domain=userDomain)
Took 1.513400ms to get QualifiedIDEntity(value=userId18, domain=userDomain)
Took 1.609600ms to get QualifiedIDEntity(value=userId105, domain=userDomain)
Took 1.875300ms to get QualifiedIDEntity(value=userId105, domain=userDomain)
Took 1.546400ms to get QualifiedIDEntity(value=userId105, domain=userDomain)
Took 1.801600ms to get QualifiedIDEntity(value=userId427, domain=userDomain)
Took 1.557900ms to get QualifiedIDEntity(value=userId427, domain=userDomain)
Took 1.592900ms to get QualifiedIDEntity(value=userId427, domain=userDomain)
Took 1.504800ms to get QualifiedIDEntity(value=userId177, domain=userDomain)
Took 1.620700ms to get QualifiedIDEntity(value=userId177, domain=userDomain)
Took 1.4ms to get QualifiedIDEntity(value=userId177, domain=userDomain)
Took 1.882600ms to get QualifiedIDEntity(value=userId150, domain=userDomain)
Took 1.499800ms to get QualifiedIDEntity(value=userId150, domain=userDomain)
Took 1.518900ms to get QualifiedIDEntity(value=userId150, domain=userDomain)
Took 1.557900ms to get QualifiedIDEntity(value=userId840, domain=userDomain)
Took 1.651500ms to get QualifiedIDEntity(value=userId840, domain=userDomain)
Took 2.344800ms to get QualifiedIDEntity(value=userId840, domain=userDomain)
Took 1.829600ms to get QualifiedIDEntity(value=userId938, domain=userDomain)
Took 1.644800ms to get QualifiedIDEntity(value=userId938, domain=userDomain)
Took 1.616400ms to get QualifiedIDEntity(value=userId938, domain=userDomain)
Took 1.665ms to get QualifiedIDEntity(value=userId777, domain=userDomain)
Took 1.862ms to get QualifiedIDEntity(value=userId777, domain=userDomain)
Took 1.997100ms to get QualifiedIDEntity(value=userId777, domain=userDomain)
Took 1.813900ms to get QualifiedIDEntity(value=userId419, domain=userDomain)
Took 1.385800ms to get QualifiedIDEntity(value=userId419, domain=userDomain)
Took 1.608100ms to get QualifiedIDEntity(value=userId419, domain=userDomain)
Took 1.597300ms to get QualifiedIDEntity(value=userId209, domain=userDomain)
Took 1.927400ms to get QualifiedIDEntity(value=userId209, domain=userDomain)
Took 1.750200ms to get QualifiedIDEntity(value=userId209, domain=userDomain)
Took 66.082400ms to select 10 random users from a table of 1000; Selecting each user 3 times
```
</details>


<details>
  <summary>Results WITH cache</summary>

```
Took 68.205700ms to get QualifiedIDEntity(value=userId967, domain=userDomain)
Took 147.7us to get QualifiedIDEntity(value=userId967, domain=userDomain)
Took 147.2us to get QualifiedIDEntity(value=userId967, domain=userDomain)
Took 3.056200ms to get QualifiedIDEntity(value=userId750, domain=userDomain)
Took 198.2us to get QualifiedIDEntity(value=userId750, domain=userDomain)
Took 75.7us to get QualifiedIDEntity(value=userId750, domain=userDomain)
Took 3.936300ms to get QualifiedIDEntity(value=userId370, domain=userDomain)
Took 119us to get QualifiedIDEntity(value=userId370, domain=userDomain)
Took 78.3us to get QualifiedIDEntity(value=userId370, domain=userDomain)
Took 3.278100ms to get QualifiedIDEntity(value=userId728, domain=userDomain)
Took 70.8us to get QualifiedIDEntity(value=userId728, domain=userDomain)
Took 207.2us to get QualifiedIDEntity(value=userId728, domain=userDomain)
Took 2.750600ms to get QualifiedIDEntity(value=userId617, domain=userDomain)
Took 174.6us to get QualifiedIDEntity(value=userId617, domain=userDomain)
Took 256.6us to get QualifiedIDEntity(value=userId617, domain=userDomain)
Took 3.035900ms to get QualifiedIDEntity(value=userId366, domain=userDomain)
Took 48.9us to get QualifiedIDEntity(value=userId366, domain=userDomain)
Took 37.3us to get QualifiedIDEntity(value=userId366, domain=userDomain)
Took 3.111900ms to get QualifiedIDEntity(value=userId570, domain=userDomain)
Took 55.1us to get QualifiedIDEntity(value=userId570, domain=userDomain)
Took 196.7us to get QualifiedIDEntity(value=userId570, domain=userDomain)
Took 2.511800ms to get QualifiedIDEntity(value=userId659, domain=userDomain)
Took 51.4us to get QualifiedIDEntity(value=userId659, domain=userDomain)
Took 41.9us to get QualifiedIDEntity(value=userId659, domain=userDomain)
Took 2.454900ms to get QualifiedIDEntity(value=userId803, domain=userDomain)
Took 50.6us to get QualifiedIDEntity(value=userId803, domain=userDomain)
Took 66.7us to get QualifiedIDEntity(value=userId803, domain=userDomain)
Took 2.633500ms to get QualifiedIDEntity(value=userId565, domain=userDomain)
Took 159.8us to get QualifiedIDEntity(value=userId565, domain=userDomain)
Took 97.7us to get QualifiedIDEntity(value=userId565, domain=userDomain)
Took 110.000400ms to select 10 random users from a table of 1000; Selecting each user 3 times
```
</details>

### Conclusion

Even though there's clearly an overhead when fetching for the very first time, and a smaller but also visible overhead when fetching a new user for the first time, without cache we are not able to query faster than a low 1ms for each user.

However, with cache, subsequent calls to the same user are an order of magnitude faster, taking just a few dozens us, and it has the added benefit of **not spending DB connections**.

The applications we are developing Kalium for definitely will request the same user more than once, and it's an added benefit of using Kalium, that we can offer a multiplatform and centralised caching logic out of the box.

## Tests

### Test Coverage

- [X] I have added automated test to this contribution

## Attachments

Android Reloaded scrolls smoothly and is able to receive messages faster now.

https://user-images.githubusercontent.com/9389043/190835939-6858019e-89d5-4f9f-b21b-d53f95f6eb61.mp4

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
