### PR TITLE
chore: enhancement on not using unnecessary nested transactions

### DIFF
--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -33,13 +33,16 @@ class MessageDAOImpl(private val queries: MessagesQueries) : MessageDAO {
 
     override suspend fun deleteAllMessages() = queries.deleteAllMessages()
 
-    override suspend fun insertMessage(message: MessageEntity) = insertInDB(message)
+    override suspend fun insertMessage(message: MessageEntity) = queries.transaction { insertInDB(message) }
 
     override suspend fun insertMessages(messages: List<MessageEntity>) =
         queries.transaction {
             messages.forEach { insertInDB(it) }
         }
 
+    /**
+     * Be careful and run this operation in ONE wrapping transaction.
+     */
     @Suppress("ComplexMethod", "LongMethod")
     private fun insertInDB(message: MessageEntity) {
         queries.insertMessage(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Small improvement on insert messages side, as per benchmark the numbers with this PR will looks like:

```
Insert messages: WITH multiple transactions (currently 5 nested)
1 try
Took 50.928667ms to insert 100 text messages <==
Took 355.546333ms to query 100 messages

2 try
Took 52.569333ms to insert 100 text messages  <==
Took 433.300708ms to query 100 messages

=========

Insert messages: WITH ONE wrapping transaction

1 try
Took 36.601542ms to insert 100 text messages  <==
Took 428.650584ms to query 100 messages
2 try
Took 35.809708ms to insert 100 text messages  <==
Took 429.112333ms to query 100 messages
3 try
Took 37.497417ms to insert 100 text messages  <==
Took 430.110375ms to query 100 messages
```

Now we are using only one transaction block, and not multiple, because only one is needed to roll back the whole wrapped nested sql transactions.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
