### PR TITLE
fix: improve performance of fetching metadata from the database

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
@@ -1,13 +1,13 @@
 package com.wire.kalium.logic.data.id
 
-import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.data.user.UserId
 
 interface QualifiedIdMapper {
     fun fromStringToQualifiedID(id: String): QualifiedID
 }
 
 class QualifiedIdMapperImpl(
-    private val userRepository: UserRepository?
+    private val selfUserId: UserId
 ) : QualifiedIdMapper {
     override fun fromStringToQualifiedID(id: String): QualifiedID {
         val components = id.split(VALUE_DOMAIN_SEPARATOR).filter { it.isNotBlank() }
@@ -30,7 +30,7 @@ class QualifiedIdMapperImpl(
         }
     }
 
-    private fun selfUserDomain(): String = userRepository?.getSelfUserId()?.domain ?: ""
+    private fun selfUserDomain(): String = selfUserId.domain
 }
 
 fun String.toQualifiedID(mapper: QualifiedIdMapper): QualifiedID = mapper.fromStringToQualifiedID(this)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -49,7 +49,10 @@ interface UserRepository {
     suspend fun fetchUsersByIds(ids: Set<UserId>): Either<CoreFailure, Unit>
     suspend fun fetchUsersIfUnknownByIds(ids: Set<UserId>): Either<CoreFailure, Unit>
     suspend fun observeSelfUser(): Flow<SelfUser>
-    fun getSelfUserId(): QualifiedID
+
+    @Deprecated("SelfUserID should be injected in the constructor, as it's available in UserSessionScope")
+    suspend fun getSelfUserId(): QualifiedID
+
     suspend fun updateSelfUser(newName: String? = null, newAccent: Int? = null, newAssetId: String? = null): Either<CoreFailure, SelfUser>
     suspend fun getSelfUser(): SelfUser?
     suspend fun updateSelfHandle(handle: String): Either<NetworkFailure, Unit>
@@ -83,11 +86,12 @@ internal class UserDataSource(
     private val userTypeMapper: DomainUserTypeMapper = MapperProvider.userTypeMapper()
 ) : UserRepository {
 
-    override fun getSelfUserId(): QualifiedID {
+    @Deprecated("SelfUserID should be injected in the constructor, as it's available in UserSessionScope")
+    override suspend fun getSelfUserId(): QualifiedID {
         return idMapper.fromDaoModel(getSelfUserIDEntity())
     }
 
-    private fun getSelfUserIDEntity(): QualifiedIDEntity {
+    private suspend fun getSelfUserIDEntity(): QualifiedIDEntity {
         val encodedValue = metadataDAO.valueByKey(SELF_USER_ID_KEY)
         return encodedValue?.let { Json.decodeFromString<QualifiedIDEntity>(it) }
             ?: run { throw IllegalStateException() }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -115,7 +115,7 @@ internal object MapperProvider {
     fun connectionMapper(): ConnectionMapper = ConnectionMapperImpl()
     fun userTypeEntityMapper(): UserEntityTypeMapper = UserEntityTypeMapperImpl()
     fun userTypeMapper(): DomainUserTypeMapper = DomainUserTypeMapperImpl()
-    fun qualifiedIdMapper(userRepository: UserRepository): QualifiedIdMapper = QualifiedIdMapperImpl(userRepository)
+    fun qualifiedIdMapper(selfUserId: UserId): QualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
     fun federatedIdMapper(
         userId: UserId,
         qualifiedIdMapper: QualifiedIdMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -45,9 +45,9 @@ import com.wire.kalium.logic.data.message.SendMessageFailureMapper
 import com.wire.kalium.logic.data.message.SendMessageFailureMapperImpl
 import com.wire.kalium.logic.data.notification.LocalNotificationMessageMapper
 import com.wire.kalium.logic.data.notification.LocalNotificationMessageMapperImpl
+import com.wire.kalium.logic.data.prekey.PreKeyListMapper
 import com.wire.kalium.logic.data.prekey.PreKeyMapper
 import com.wire.kalium.logic.data.prekey.PreKeyMapperImpl
-import com.wire.kalium.logic.data.prekey.PreKeyListMapper
 import com.wire.kalium.logic.data.publicuser.PublicUserMapper
 import com.wire.kalium.logic.data.publicuser.PublicUserMapperImpl
 import com.wire.kalium.logic.data.session.SessionMapper
@@ -62,7 +62,6 @@ import com.wire.kalium.logic.data.user.ConnectionStateMapperImpl
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.data.user.UserMapperImpl
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.user.type.DomainUserTypeMapper
 import com.wire.kalium.logic.data.user.type.DomainUserTypeMapperImpl
 import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -433,9 +433,9 @@ abstract class UserSessionScopeCommon internal constructor(
             lazy { mlsConversationRepository }
         )
 
-    val qualifiedIdMapper: QualifiedIdMapper get() = MapperProvider.qualifiedIdMapper(userRepository)
+    val qualifiedIdMapper: QualifiedIdMapper get() = MapperProvider.qualifiedIdMapper(userId)
 
-    val federatedIdMapper: FederatedIdMapper
+    private val federatedIdMapper: FederatedIdMapper
         get() = MapperProvider.federatedIdMapper(
             userId,
             qualifiedIdMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -73,7 +73,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
         }
     }
 
-    private fun checkMLSStatus(featureConfig: MLSModel) {
+    private suspend fun checkMLSStatus(featureConfig: MLSModel) {
         val mlsEnabled = featureConfig.status == Status.ENABLED
         val selfUserIsWhitelisted = featureConfig.allowedUsers.contains(userRepository.getSelfUserId().toPlainID())
         userConfigRepository.setMLSEnabled(mlsEnabled && selfUserIsWhitelisted)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -19,7 +19,7 @@ class FeatureConfigEventReceiverImpl(
         handleFeatureConfigEvent(event)
     }
 
-    private fun handleFeatureConfigEvent(event: Event.FeatureConfig) {
+    private suspend fun handleFeatureConfigEvent(event: Event.FeatureConfig) {
         when (event) {
             is Event.FeatureConfig.FileSharingUpdated -> {
                 if (kaliumConfigs.fileRestrictionEnabled) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -51,6 +51,7 @@ import kotlin.test.assertTrue
 
 @Suppress("LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
+// TODO: Refactor using Arrangement pattern
 class CallRepositoryTest {
 
     @Mock
@@ -208,7 +209,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -276,7 +277,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -339,7 +340,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -411,7 +412,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -469,7 +470,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -520,7 +521,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -578,7 +579,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -640,7 +641,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -706,7 +707,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 
@@ -763,7 +764,7 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
+        given(userRepository).suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.USER_ID)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -78,6 +78,7 @@ import com.wire.kalium.persistence.dao.Member as MemberEntity
 
 @Suppress("LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
+// TODO: Refactor using Arrangement pattern
 class ConversationRepositoryTest {
 
     @Mock
@@ -510,7 +511,7 @@ class ConversationRepositoryTest {
             .then { flowOf(TestUser.SELF) }
 
         given(userRepository)
-            .function(userRepository::getSelfUserId)
+            .suspendFunction(userRepository::getSelfUserId)
             .whenInvoked()
             .thenReturn(TestUser.SELF.id)
 
@@ -1337,7 +1338,7 @@ class ConversationRepositoryTest {
 
         fun withSelfUser(selfUser: QualifiedID) = apply {
             given(userRepository)
-                .function(userRepository::getSelfUserId)
+                .suspendFunction(userRepository::getSelfUserId)
                 .whenInvoked()
                 .thenReturn(selfUser)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
@@ -1,36 +1,22 @@
 package com.wire.kalium.logic.data.id
 
-import com.wire.kalium.logic.data.user.UserRepository
-import io.mockative.Mock
-import io.mockative.classOf
-import io.mockative.given
-import io.mockative.mock
-import kotlin.test.BeforeTest
+import com.wire.kalium.logic.framework.TestUser
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class QualifiedIdMapperTest {
 
-    @Mock
-    private val userRepository = mock(classOf<UserRepository>())
-
-    private lateinit var qualifiedIdMapper: QualifiedIdMapper
-
-    @BeforeTest
-    fun setUp() {
-        qualifiedIdMapper = QualifiedIdMapperImpl(userRepository)
-    }
+    private fun createMapper(selfUserId: QualifiedID = TestUser.USER_ID): QualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
 
     @Test
-    fun givenAValidString_whenMappingToQualifiedId_thenCreatesAQualifiedIdWithACorrectValues() {
+    fun givenAValidString_whenMappingToQualifiedId_thenCreatesAQualifiedIdWithACorrectValues() = runTest {
         // Given
         val mockQualifiedIdValue = "mocked-value"
         val mockQualifiedIdDomain = "mocked.domain"
         val correctQualifiedIdString = "$mockQualifiedIdValue@$mockQualifiedIdDomain"
-        given(userRepository)
-            .function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(QualifiedID(mockQualifiedIdValue, mockQualifiedIdDomain))
+
+        val qualifiedIdMapper = createMapper(QualifiedID(mockQualifiedIdValue, mockQualifiedIdDomain))
 
         // When
         val correctQualifiedId = qualifiedIdMapper.fromStringToQualifiedID(correctQualifiedIdString)
@@ -41,14 +27,12 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAStringWithoutDomain_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
+    fun givenAStringWithoutDomain_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() = runTest {
         // Given
         val fallbackDomain = "wire.com"
         val conversationId = "conversationId"
 
-        given(userRepository)
-            .invocation { getSelfUserId() }
-            .thenReturn(QualifiedID(conversationId, fallbackDomain))
+        val qualifiedIdMapper = createMapper(QualifiedID(conversationId, fallbackDomain))
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -61,14 +45,12 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAStringWithoutDomainThatEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
+    fun givenAStringWithoutDomainThatEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() = runTest {
         // Given
         val fallbackDomain = "wire.com"
         val conversationId = "conversationId@"
 
-        given(userRepository)
-            .invocation { getSelfUserId() }
-            .thenReturn(QualifiedID(conversationId, fallbackDomain))
+        val qualifiedIdMapper = createMapper(QualifiedID(conversationId, fallbackDomain))
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -81,14 +63,12 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAValidStringThatStartsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
+    fun givenAValidStringThatStartsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() = runTest {
         // Given
         val fallbackDomain = "wire.com"
         val conversationId = "@conversationId"
 
-        given(userRepository)
-            .invocation { getSelfUserId() }
-            .thenReturn(QualifiedID(conversationId, fallbackDomain))
+        val qualifiedIdMapper = createMapper(QualifiedID(conversationId, fallbackDomain))
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -101,29 +81,29 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAValidStringThatStartsAndEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
-        // Given
-        val fallbackDomain = "wire.com"
-        val conversationId = "@conversationId@"
+    fun givenAValidStringThatStartsAndEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() =
+        runTest {
+            // Given
+            val fallbackDomain = "wire.com"
+            val conversationId = "@conversationId@"
 
-        given(userRepository)
-            .invocation { getSelfUserId() }
-            .thenReturn(QualifiedID(conversationId, fallbackDomain))
+            val qualifiedIdMapper = createMapper(QualifiedID(conversationId, fallbackDomain))
 
-        // When
-        val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
+            // When
+            val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
 
-        // Then
-        assertEquals(
-            QualifiedID(value = "conversationId", domain = fallbackDomain),
-            result
-        )
-    }
+            // Then
+            assertEquals(
+                QualifiedID(value = "conversationId", domain = fallbackDomain),
+                result
+            )
+        }
 
     @Test
-    fun givenAValidStringThatStartsWithAtSignAndContainsAnotherAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() {
+    fun givenAValidStringThatStartsWithAtSignAndContainsAnotherAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() = runTest {
         // Given
         val conversationId = "@conversationId@dom"
+        val qualifiedIdMapper = createMapper()
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -136,9 +116,10 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAValidStringThatContainsAtSignInTheMiddle_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() {
+    fun givenAValidStringThatContainsAtSignInTheMiddle_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() = runTest {
         // Given
         val conversationId = "convers@ationId@dom"
+        val qualifiedIdMapper = createMapper()
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -151,9 +132,10 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAValidStringThatStartsWithAtSignContainsAtSignInTheMiddle_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() {
+    fun givenAValidStringThatStartsWithAtSignContainsAtSignInTheMiddle_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() = runTest {
         // Given
         val conversationId = "@convers@ationId@dom"
+        val qualifiedIdMapper = createMapper()
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -166,9 +148,10 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAValidStringThatEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() {
+    fun givenAValidStringThatEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedID() = runTest {
         // Given
         val conversationId = "conversationId@@dom"
+        val qualifiedIdMapper = createMapper()
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -181,9 +164,10 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAnEmptyString_whenMappingToQualifiedId_thenReturnsAnEmptyQualifiedID() {
+    fun givenAnEmptyString_whenMappingToQualifiedId_thenReturnsAnEmptyQualifiedID() = runTest {
         // Given
         val conversationId = ""
+        val qualifiedIdMapper = createMapper()
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -196,9 +180,10 @@ class QualifiedIdMapperTest {
     }
 
     @Test
-    fun givenAStringWithOnlyAtSign_whenMappingToQualifiedId_thenReturnsAnEmptyQualifiedID() {
+    fun givenAStringWithOnlyAtSign_whenMappingToQualifiedId_thenReturnsAnEmptyQualifiedID() = runTest {
         // Given
         val conversationId = "@"
+        val qualifiedIdMapper = createMapper()
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -134,7 +134,7 @@ class UserRepositoryTest {
 
         fun withGetSelfUserId(): Arrangement {
             given(metadataDAO)
-                .function(metadataDAO::valueByKey)
+                .suspendFunction(metadataDAO::valueByKey)
                 .whenInvokedWith(any())
                 .thenReturn(
                     """

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCaseTest.kt
@@ -206,7 +206,7 @@ class ClearConversationContentUseCaseTest {
 
         fun withGetSelfUserId(): Arrangement {
             given(userRepository)
-                .function(userRepository::getSelfUserId)
+                .suspendFunction(userRepository::getSelfUserId)
                 .whenInvoked()
                 .thenReturn(UserId("someValue", "someDomain"))
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/GetFeatureConfigsStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/GetFeatureConfigsStatusUseCaseTest.kt
@@ -167,7 +167,7 @@ class GetFeatureConfigsStatusUseCaseTest {
                 .whenInvokedWith(any(), any())
                 .thenReturn(Either.Right(Unit))
             given(userRepository)
-                .function(userRepository::getSelfUserId)
+                .suspendFunction(userRepository::getSelfUserId)
                 .whenInvoked()
                 .thenReturn(TestUser.SELF.id)
             given(featureConfigRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -479,7 +479,7 @@ class GetNotificationsUseCaseTest {
 
         fun withSelfUserId(id: QualifiedID = MY_ID): Arrangement {
             given(userRepository)
-                .function(userRepository::getSelfUserId)
+                .suspendFunction(userRepository::getSelfUserId)
                 .whenInvoked()
                 .then { id }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -465,7 +465,7 @@ class ConversationEventReceiverTest {
 
         fun withSelfUserIdReturning(selfUserId: UserId) = apply {
             given(userRepository)
-                .function(userRepository::getSelfUserId)
+                .suspendFunction(userRepository::getSelfUserId)
                 .whenInvoked()
                 .thenReturn(selfUserId)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -121,7 +121,7 @@ class FeatureConfigEventReceiverTest {
 
         fun withSelfUserIdReturning(selfUserId: UserId) = apply {
             given(userRepository)
-                .function(userRepository::getSelfUserId)
+                .suspendFunction(userRepository::getSelfUserId)
                 .whenInvoked()
                 .thenReturn(selfUserId)
         }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -187,7 +187,7 @@ actual class UserDatabaseProvider(
         get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)
 
     actual val metadataDAO: MetadataDAO
-        get() = MetadataDAOImpl(database.metadataQueries)
+        get() = MetadataDAOImpl(database.metadataQueries, LRUCache(METADATA_CACHE_SIZE), databaseScope)
 
     actual val clientDAO: ClientDAO
         get() = ClientDAOImpl(database.clientsQueries)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAO.kt
@@ -6,5 +6,5 @@ interface MetadataDAO {
     suspend fun insertValue(value: String, key: String)
     suspend fun deleteValue(key: String)
     suspend fun valueByKeyFlow(key: String): Flow<String?>
-    fun valueByKey(key: String): String?
+    suspend fun valueByKey(key: String): String?
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
@@ -3,9 +3,18 @@ package com.wire.kalium.persistence.dao
 import com.squareup.sqldelight.runtime.coroutines.asFlow
 import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.MetadataQueries
+import com.wire.kalium.persistence.cache.Cache
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.shareIn
 
-class MetadataDAOImpl(private val metadataQueries: MetadataQueries) : MetadataDAO {
+class MetadataDAOImpl internal constructor(
+    private val metadataQueries: MetadataQueries,
+    private val metadataCache: Cache<String, Flow<String?>>,
+    private val databaseScope: CoroutineScope
+) : MetadataDAO {
 
     override suspend fun insertValue(value: String, key: String) {
         metadataQueries.insertValue(key, value)
@@ -15,11 +24,13 @@ class MetadataDAOImpl(private val metadataQueries: MetadataQueries) : MetadataDA
         metadataQueries.deleteValue(key)
     }
 
-    override suspend fun valueByKeyFlow(key: String): Flow<String?> {
-        return metadataQueries.selectValueByKey(key).asFlow().mapToOneOrNull()
+    override suspend fun valueByKeyFlow(key: String): Flow<String?> = metadataCache.get(key) {
+        metadataQueries.selectValueByKey(key)
+            .asFlow()
+            .mapToOneOrNull()
+            .shareIn(databaseScope, SharingStarted.Lazily, 1)
     }
 
-    override fun valueByKey(key: String): String? =
-        metadataQueries.selectValueByKey(key).executeAsOneOrNull()
+    override suspend fun valueByKey(key: String): String? = valueByKeyFlow(key).first()
 
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.persistence.dao.message.MessageDAO
 import kotlin.jvm.JvmInline
 
 internal const val USER_CACHE_SIZE = 125
+internal const val METADATA_CACHE_SIZE = 30
 @JvmInline
 value class UserDBSecret(val value: ByteArray)
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageTest.kt
@@ -21,12 +21,12 @@ class ClientRegistrationStorageTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenNoClientIdWasSaved_whenGettingTheCurrentClientId_thenResultShouldBeNull() = runTest {
+    fun givenNoClientIdWasSaved_whenGettingTheCurrentClientId_thenResultShouldBeNull() = runTest(dispatcher) {
         assertNull(clientRegistrationStorage.getRegisteredClientId())
     }
 
     @Test
-    fun givenAnClientIdWasSaved_whenGettingTheCurrentClientId_thenTheSavedIdShouldBeReturned() = runTest {
+    fun givenAnClientIdWasSaved_whenGettingTheCurrentClientId_thenTheSavedIdShouldBeReturned() = runTest(dispatcher) {
         val testId = "😎ClientId"
         clientRegistrationStorage.setRegisteredClientId(testId)
 
@@ -36,7 +36,7 @@ class ClientRegistrationStorageTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenTheLastIdWasUpdatedMultipleTimes_whenGettingTheCurrentClientId_thenTheLatestIdShouldBeReturned() = runTest {
+    fun givenTheLastIdWasUpdatedMultipleTimes_whenGettingTheCurrentClientId_thenTheLatestIdShouldBeReturned() = runTest(dispatcher) {
         val latestId = "sold"
         clientRegistrationStorage.setRegisteredClientId("give it once")
         clientRegistrationStorage.setRegisteredClientId("give it twice")
@@ -48,7 +48,7 @@ class ClientRegistrationStorageTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenTheCurrentIdExisted_andWasCleared_whenGettingTheCurrentClientId_thenNullShouldBeReturned() = runTest {
+    fun givenTheCurrentIdExisted_andWasCleared_whenGettingTheCurrentClientId_thenNullShouldBeReturned() = runTest(dispatcher) {
         clientRegistrationStorage.setRegisteredClientId("give it once")
         clientRegistrationStorage.clearRegisteredClientId()
 
@@ -58,12 +58,12 @@ class ClientRegistrationStorageTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenNoClientIdWasSaved_whenGettingTheRetainedClientId_thenResultShouldBeNull() = runTest {
+    fun givenNoClientIdWasSaved_whenGettingTheRetainedClientId_thenResultShouldBeNull() = runTest(dispatcher) {
         assertNull(clientRegistrationStorage.getRetainedClientId())
     }
 
     @Test
-    fun givenAnClientIdWasSaved_whenGettingTheRetainedClientId_thenTheSavedIdShouldBeReturned() = runTest {
+    fun givenAnClientIdWasSaved_whenGettingTheRetainedClientId_thenTheSavedIdShouldBeReturned() = runTest(dispatcher) {
         val testId = "😎ClientId"
         clientRegistrationStorage.setRegisteredClientId(testId)
 
@@ -73,7 +73,7 @@ class ClientRegistrationStorageTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenTheLastIdWasUpdatedMultipleTimes_whenGettingTheRetainedClientId_thenTheLatestIdShouldBeReturned() = runTest {
+    fun givenTheLastIdWasUpdatedMultipleTimes_whenGettingTheRetainedClientId_thenTheLatestIdShouldBeReturned() = runTest(dispatcher) {
         val latestId = "sold"
         clientRegistrationStorage.setRegisteredClientId("give it once")
         clientRegistrationStorage.setRegisteredClientId("give it twice")
@@ -85,7 +85,7 @@ class ClientRegistrationStorageTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenTheCurrentIdExisted_andWasCleared_whenGettingTheRetainedClientId_thenTheLatestIdShouldBeReturned() = runTest {
+    fun givenTheCurrentIdExisted_andWasCleared_whenGettingTheRetainedClientId_thenTheLatestIdShouldBeReturned() = runTest(dispatcher) {
         val testId = "😎ClientId"
         clientRegistrationStorage.setRegisteredClientId(testId)
         clientRegistrationStorage.clearRegisteredClientId()
@@ -96,7 +96,7 @@ class ClientRegistrationStorageTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenTheRetainedIdExisted_andWasCleared_whenGettingTheRetainedClientId_thenNullShouldBeReturned() = runTest {
+    fun givenTheRetainedIdExisted_andWasCleared_whenGettingTheRetainedClientId_thenNullShouldBeReturned() = runTest(dispatcher) {
         val testId = "😎ClientId"
         clientRegistrationStorage.setRegisteredClientId(testId)
         clientRegistrationStorage.clearRetainedClientId()

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MetadataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MetadataDAOTest.kt
@@ -1,7 +1,6 @@
 package com.wire.kalium.persistence.dao
 
 import com.wire.kalium.persistence.BaseDatabaseTest
-import com.wire.kalium.persistence.db.UserDatabaseProvider
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -9,7 +8,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class MetadataDAOTest: BaseDatabaseTest() {
+class MetadataDAOTest : BaseDatabaseTest() {
 
     private val value1 = "value1"
     private val value2 = "value2"

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MetadataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MetadataDAOTest.kt
@@ -11,42 +11,43 @@ import kotlin.test.assertNull
 
 class MetadataDAOTest: BaseDatabaseTest() {
 
-    val value1 = "value1"
-    val value2 = "value2"
+    private val value1 = "value1"
+    private val value2 = "value2"
 
-    val key1 = "key1"
-    val key2 = "key2"
+    private val key1 = "key1"
+    private val key2 = "key2"
 
-    lateinit var db: UserDatabaseProvider
+    private lateinit var metadataDAO: MetadataDAO
 
     @BeforeTest
     fun setUp() {
         deleteDatabase()
-        db = createDatabase()
+        val db = createDatabase()
+        metadataDAO = db.metadataDAO
     }
 
     @Test
-    fun givenNonExistingKey_thenValueCanBeStored() = runTest {
-        db.metadataDAO.insertValue(value1, key1)
-        assertEquals(value1, db.metadataDAO.valueByKeyFlow(key1).first())
+    fun givenNonExistingKey_thenValueCanBeStored() = runTest(dispatcher) {
+        metadataDAO.insertValue(value1, key1)
+        assertEquals(value1, metadataDAO.valueByKeyFlow(key1).first())
     }
 
     @Test
-    fun givenExistingKey_thenExistingValueCanBeOverwritten() = runTest {
-        db.metadataDAO.insertValue(value1, key1)
-        db.metadataDAO.insertValue(value2, key1)
-        assertEquals(value2, db.metadataDAO.valueByKeyFlow(key1).first())
+    fun givenExistingKey_thenExistingValueCanBeOverwritten() = runTest(dispatcher) {
+        metadataDAO.insertValue(value1, key1)
+        metadataDAO.insertValue(value2, key1)
+        assertEquals(value2, metadataDAO.valueByKeyFlow(key1).first())
     }
 
     @Test
-    fun givenExistingKey_thenValueCanBeRetrieved() = runTest {
-        db.metadataDAO.insertValue(value1, key1)
-        assertEquals(value1, db.metadataDAO.valueByKeyFlow(key1).first())
+    fun givenExistingKey_thenValueCanBeRetrieved() = runTest(dispatcher) {
+        metadataDAO.insertValue(value1, key1)
+        assertEquals(value1, metadataDAO.valueByKeyFlow(key1).first())
     }
 
     @Test
-    fun giveNonExistingKey_thenNullValueWillBeReturned() = runTest {
-        db.metadataDAO.insertValue(value1, key1)
-        assertNull(db.metadataDAO.valueByKeyFlow(key2).first())
+    fun giveNonExistingKey_thenNullValueWillBeReturned() = runTest(dispatcher) {
+        metadataDAO.insertValue(value1, key1)
+        assertNull(metadataDAO.valueByKeyFlow(key2).first())
     }
 }

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -154,7 +154,7 @@ actual class UserDatabaseProvider(
         get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)
 
     actual val metadataDAO: MetadataDAO
-        get() = MetadataDAOImpl(database.metadataQueries)
+        get() = MetadataDAOImpl(database.metadataQueries, LRUCache(METADATA_CACHE_SIZE), databaseScope)
 
     actual val clientDAO: ClientDAO
         get() = ClientDAOImpl(database.clientsQueries)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseProvider.kt
@@ -166,7 +166,7 @@ actual class UserDatabaseProvider(private val storePath: File, dispatcher: Corou
         get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)
 
     actual val metadataDAO: MetadataDAO
-        get() = MetadataDAOImpl(database.metadataQueries)
+        get() = MetadataDAOImpl(database.metadataQueries, LRUCache(METADATA_CACHE_SIZE), databaseScope)
 
     actual val clientDAO: ClientDAO
         get() = ClientDAOImpl(database.clientsQueries)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We query the DB too often for simple stuff like UserID, ClientID, and also for TimeStamp keys.

### Causes

- To most, lack of caching. We should keep these values in memory, especially considering that they hardly change.
- For UserId, it's something static that does NOT change after the creation of `UserSessionScope`, so this should be injected into entities that need it.

### Solutions

- Deprecate `UserRepository.getSelfUserId`, so we start injecting `selfUserId`.

Had to make `getSelfUserId` suspendable to use the cache. This also required some changes in the code that was calling it.

- Cache the Metadata using the same approach used in #915.


### Testing

N/A
Caching is already covered in tests.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
