### PR TITLE
fix: team owner name not visible [AR-2424]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCase.kt
@@ -58,7 +58,7 @@ internal class GetUserInfoUseCaseImpl(
      * @see [UserType]
      */
     private suspend fun getOtherUserTeam(otherUser: OtherUser): Either<CoreFailure, Team?> {
-        return if (otherUser.teamId != null && (otherUser.userType == UserType.INTERNAL || otherUser.userType == UserType.OWNER)) {
+        return if (otherUser.teamId != null && otherUser.userType in listOf(UserType.INTERNAL, UserType.OWNER)) {
             val localTeam = teamRepository.getTeam(otherUser.teamId).firstOrNull()
 
             if (localTeam == null) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCase.kt
@@ -58,7 +58,7 @@ internal class GetUserInfoUseCaseImpl(
      * @see [UserType]
      */
     private suspend fun getOtherUserTeam(otherUser: OtherUser): Either<CoreFailure, Team?> {
-        return if (otherUser.teamId != null && otherUser.userType == UserType.INTERNAL) {
+        return if (otherUser.teamId != null && (otherUser.userType == UserType.INTERNAL || otherUser.userType == UserType.OWNER)) {
             val localTeam = teamRepository.getTeam(otherUser.teamId).firstOrNull()
 
             if (localTeam == null) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
@@ -79,7 +79,7 @@ internal class ObserveUserInfoUseCaseImpl(
      * @see [UserType]
      */
     private suspend fun observeOtherUserTeam(otherUser: OtherUser): Flow<Either<CoreFailure, Team?>> {
-        return if (otherUser.teamId != null && otherUser.userType == UserType.INTERNAL) {
+        return if (otherUser.teamId != null && (otherUser.userType == UserType.INTERNAL || otherUser.userType == UserType.OWNER)) {
             teamRepository.getTeam(otherUser.teamId).map { localTeam ->
                 if (localTeam == null) {
                     teamRepository.fetchTeamById(otherUser.teamId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
@@ -79,7 +79,7 @@ internal class ObserveUserInfoUseCaseImpl(
      * @see [UserType]
      */
     private suspend fun observeOtherUserTeam(otherUser: OtherUser): Flow<Either<CoreFailure, Team?>> {
-        return if (otherUser.teamId != null && (otherUser.userType == UserType.INTERNAL || otherUser.userType == UserType.OWNER)) {
+        return if (otherUser.teamId != null && otherUser.userType in listOf(UserType.INTERNAL, UserType.OWNER)) {
             teamRepository.getTeam(otherUser.teamId).map { localTeam ->
                 if (localTeam == null) {
                     teamRepository.fetchTeamById(otherUser.teamId)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Team owner profile doesn't show the team name

### Causes (Optional)

we were checking for the member only from the user type when we try to get the team details

### Solutions

add extra condition to get the team details for the team owner as well while fetching the user profile info



### Testing


#### How to Test

open team owner profile, so now you should see their team name

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
