### PR TITLE
chore: inject self user id into constructor instead of fetching from DB

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -59,7 +59,7 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logger.obfuscateDomain
 
 @Suppress("LongParameterList", "TooManyFunctions")
-actual class CallManagerImpl(
+actual class CallManagerImpl internal constructor(
     private val calling: Calling,
     private val callRepository: CallRepository,
     private val userRepository: UserRepository,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -19,7 +19,7 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import kotlinx.coroutines.Dispatchers
 
 actual class GlobalCallManager(
-    private val appContext: Context
+    appContext: Context
 ) {
 
     private val callManagerHolder = hashMapOf<QualifiedID, CallManager>()
@@ -39,7 +39,7 @@ actual class GlobalCallManager(
      * Get a [CallManager] for a session, shouldn't be instantiated more than one CallManager for a single session.
      */
     @Suppress("LongParameterList")
-    actual fun getCallManagerForClient(
+    internal actual fun getCallManagerForClient(
         userId: QualifiedID,
         callRepository: CallRepository,
         userRepository: UserRepository,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 @Suppress("LongParameterList")
-class OnParticipantListChanged(
+class OnParticipantListChanged internal constructor(
     private val handle: Handle,
     private val calling: Calling,
     private val callRepository: CallRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -142,7 +142,7 @@ interface ConversationRepository {
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
-class ConversationDataSource(
+internal class ConversationDataSource internal constructor (
     private val userRepository: UserRepository,
     private val mlsConversationRepository: MLSConversationRepository,
     private val conversationDAO: ConversationDAO,
@@ -151,6 +151,7 @@ class ConversationDataSource(
     private val clientDAO: ClientDAO,
     private val clientApi: ClientApi,
     private val timeParser: TimeParser,
+    private val selfUserId: UserId,
     private val idMapper: IdMapper = MapperProvider.idMapper(),
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(),
     private val memberMapper: MemberMapper = MapperProvider.memberMapper(),
@@ -185,6 +186,8 @@ class ConversationDataSource(
     }
 
     private suspend fun fetchAllConversationsFromAPI(): Either<NetworkFailure, Unit> {
+        // TODO: mo: I would suggest to use the same approach as in the selfUserId
+
         val selfUserTeamId = userRepository.observeSelfUser().first().teamId
         var hasMore = true
         var lastPagingState: String? = null
@@ -496,7 +499,7 @@ class ConversationDataSource(
                     deleteMemberFromCloudAndStorage(userId, conversationId)
 
                 is Conversation.ProtocolInfo.MLS -> {
-                    if (userId == userRepository.getSelfUserId()) {
+                    if (userId == selfUserId) {
                         deleteMemberFromCloudAndStorage(userId, conversationId).flatMap {
                             mlsConversationRepository.leaveGroup(conversation.protocol.groupId)
                         }
@@ -664,7 +667,7 @@ class ConversationDataSource(
     ): Either<CoreFailure, Unit> {
         return wrapStorageRequest {
             val conversationId = idMapper.fromApiToDao(conversationResponse.id)
-            val selfUserId = userRepository.getSelfUserId()
+            val selfUserId = selfUserId
             // TODO(IMPORTANT!): having an initial value is not the correct approach, the
             //  only valid source for members role is the backend
             //  ---> at the moment the backend doesn't tell us anything about the member role! till then we are setting them as Member

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
@@ -1,13 +1,15 @@
 package com.wire.kalium.logic.data.id
 
+import com.wire.kalium.logic.data.user.User
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 
 interface QualifiedIdMapper {
     fun fromStringToQualifiedID(id: String): QualifiedID
 }
 
-class QualifiedIdMapperImpl(
-    private val userRepository: UserRepository?
+class QualifiedIdMapperImpl internal constructor(
+    private val selfId: UserId?
 ) : QualifiedIdMapper {
     override fun fromStringToQualifiedID(id: String): QualifiedID {
         val components = id.split(VALUE_DOMAIN_SEPARATOR).filter { it.isNotBlank() }
@@ -30,7 +32,7 @@ class QualifiedIdMapperImpl(
         }
     }
 
-    private fun selfUserDomain(): String = userRepository?.getSelfUserId()?.domain ?: ""
+    private fun selfUserDomain(): String = selfId?.domain ?: ""
 }
 
 fun String.toQualifiedID(mapper: QualifiedIdMapper): QualifiedID = mapper.fromStringToQualifiedID(this)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapper.kt
@@ -1,8 +1,6 @@
 package com.wire.kalium.logic.data.id
 
-import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 
 interface QualifiedIdMapper {
     fun fromStringToQualifiedID(id: String): QualifiedID

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -7,7 +7,6 @@ import com.wire.kalium.logic.data.conversation.MemberMapper
 import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
-import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.publicuser.PublicUserMapper
 import com.wire.kalium.logic.data.session.SessionRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -115,7 +115,7 @@ internal object MapperProvider {
     fun connectionMapper(): ConnectionMapper = ConnectionMapperImpl()
     fun userTypeEntityMapper(): UserEntityTypeMapper = UserEntityTypeMapperImpl()
     fun userTypeMapper(): DomainUserTypeMapper = DomainUserTypeMapperImpl()
-    fun qualifiedIdMapper(userRepository: UserRepository): QualifiedIdMapper = QualifiedIdMapperImpl(userRepository)
+    fun qualifiedIdMapper(selfUserId: UserId): QualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
     fun federatedIdMapper(
         userId: UserId,
         qualifiedIdMapper: QualifiedIdMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -62,7 +62,6 @@ import com.wire.kalium.logic.data.user.ConnectionStateMapperImpl
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.data.user.UserMapperImpl
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.user.type.DomainUserTypeMapper
 import com.wire.kalium.logic.data.user.type.DomainUserTypeMapperImpl
 import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -437,7 +437,7 @@ abstract class UserSessionScopeCommon internal constructor(
 
     val qualifiedIdMapper: QualifiedIdMapper get() = MapperProvider.qualifiedIdMapper(userId)
 
-    private val federatedIdMapper: FederatedIdMapper
+    val federatedIdMapper: FederatedIdMapper
         get() = MapperProvider.federatedIdMapper(
             userId,
             qualifiedIdMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -220,7 +220,8 @@ abstract class UserSessionScopeCommon internal constructor(
             userDatabaseProvider.messageDAO,
             userDatabaseProvider.clientDAO,
             authenticatedDataSourceSet.authenticatedNetworkContainer.clientApi,
-            timeParser
+            timeParser,
+            userId
         )
 
     private val messageRepository: MessageRepository
@@ -237,7 +238,8 @@ abstract class UserSessionScopeCommon internal constructor(
             userDatabaseProvider.clientDAO,
             authenticatedDataSourceSet.authenticatedNetworkContainer.selfApi,
             authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi,
-            globalScope.sessionRepository
+            globalScope.sessionRepository,
+            userId
         )
 
     private val teamRepository: TeamRepository
@@ -433,7 +435,7 @@ abstract class UserSessionScopeCommon internal constructor(
             lazy { mlsConversationRepository }
         )
 
-    val qualifiedIdMapper: QualifiedIdMapper get() = MapperProvider.qualifiedIdMapper(userRepository)
+    val qualifiedIdMapper: QualifiedIdMapper get() = MapperProvider.qualifiedIdMapper(userId)
 
     val federatedIdMapper: FederatedIdMapper
         get() = MapperProvider.federatedIdMapper(
@@ -475,16 +477,18 @@ abstract class UserSessionScopeCommon internal constructor(
             userRepository = userRepository,
             callManagerImpl = callManager,
             editTextHandler = MessageTextEditHandler(messageRepository),
-            lastReadContentHandler = LastReadContentHandler(conversationRepository, userRepository),
+            lastReadContentHandler = LastReadContentHandler(conversationRepository, userId),
             clearConversationContentHandler = ClearConversationContentHandler(
                 conversationRepository,
                 userRepository,
-                ClearConversationContentImpl(conversationRepository, assetRepository)
+                ClearConversationContentImpl(conversationRepository, assetRepository),
+                userId
             ),
-            deleteForMeHandler = DeleteForMeHandler(conversationRepository, messageRepository, userRepository),
+            deleteForMeHandler = DeleteForMeHandler(conversationRepository, messageRepository, userId),
             userConfigRepository = userConfigRepository,
             ephemeralNotificationsManager = EphemeralNotificationsManager,
-            pendingProposalScheduler = pendingProposalScheduler
+            pendingProposalScheduler = pendingProposalScheduler,
+            userId
         )
     }
 
@@ -497,7 +501,7 @@ abstract class UserSessionScopeCommon internal constructor(
         )
 
     private val featureConfigEventReceiver: FeatureConfigEventReceiver
-        get() = FeatureConfigEventReceiverImpl(userConfigRepository, userRepository, kaliumConfigs)
+        get() = FeatureConfigEventReceiverImpl(userConfigRepository, userRepository, kaliumConfigs, userId)
 
     private val preKeyRepository: PreKeyRepository
         get() = PreKeyDataSource(
@@ -604,9 +608,9 @@ abstract class UserSessionScopeCommon internal constructor(
         get() = SyncFeatureConfigsUseCaseImpl(
             userConfigRepository,
             featureConfigRepository,
-            userRepository,
             isFileSharingEnabled,
-            kaliumConfigs
+            kaliumConfigs,
+            userId
         )
 
     val team: TeamScope get() = TeamScope(userRepository, teamRepository, conversationRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -15,7 +15,7 @@ import com.wire.kalium.logic.feature.message.MessageSender
 expect class GlobalCallManager {
 
     @Suppress("LongParameterList")
-    fun getCallManagerForClient(
+    internal fun getCallManagerForClient(
         userId: QualifiedID,
         callRepository: CallRepository,
         userRepository: UserRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContent.kt
@@ -9,6 +9,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.AssetId
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.Either
@@ -60,8 +61,8 @@ internal class ClearConversationContentUseCaseImpl(
     private val clearConversationContent: ClearConversationContent,
     private val clientRepository: ClientRepository,
     private val conversationRepository: ConversationRepository,
-    private val userRepository: UserRepository,
-    private val messageSender: MessageSender
+    private val messageSender: MessageSender,
+    private val selfUserId: UserId,
 ) : ClearConversationContentUseCase {
 
     override suspend fun invoke(conversationId: ConversationId): ClearConversationContentUseCase.Result =
@@ -76,7 +77,7 @@ internal class ClearConversationContentUseCaseImpl(
                     ),
                     conversationId = conversationRepository.getSelfConversationId(),
                     date = Clock.System.now().toString(),
-                    senderUserId = userRepository.getSelfUserId(),
+                    senderUserId = selfUserId,
                     senderClientId = currentClientId,
                     status = Message.Status.PENDING,
                     editStatus = Message.EditStatus.NotEdited,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContent.kt
@@ -10,7 +10,6 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -95,9 +95,9 @@ class ConversationScope internal constructor(
     val updateConversationReadDateUseCase: UpdateConversationReadDateUseCase
         get() = UpdateConversationReadDateUseCase(
             conversationRepository,
-            userRepository,
             messageSender,
-            clientRepository
+            clientRepository,
+            selfUserId
         )
 
     val updateConversationAccess: UpdateConversationAccessRoleUseCase
@@ -117,8 +117,8 @@ class ConversationScope internal constructor(
             clearConversationContent = ClearConversationContentImpl(conversationRepository, assetRepository),
             clientRepository,
             conversationRepository,
-            userRepository,
-            messageSender
+            messageSender,
+            selfUserId
         )
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetAllContactsNotInConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetAllContactsNotInConversationUseCase.kt
@@ -6,7 +6,7 @@ import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.fold
 
-class GetAllContactsNotInConversationUseCase(
+class GetAllContactsNotInConversationUseCase internal constructor(
     private val userRepository: UserRepository
 ) {
     suspend operator fun invoke(conversationId: QualifiedID) =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 
-class ObserveConversationMembersUseCase(
+class ObserveConversationMembersUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
     private val userRepository: UserRepository
 ) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -7,7 +7,6 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.flatMap
 import kotlinx.datetime.Clock

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -6,17 +6,18 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.flatMap
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
-class UpdateConversationReadDateUseCase(
+class UpdateConversationReadDateUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
-    private val userRepository: UserRepository,
     private val messageSender: MessageSender,
-    private val clientRepository: ClientRepository
+    private val clientRepository: ClientRepository,
+    private val selfUserId: UserId,
 ) {
 
     suspend operator fun invoke(conversationId: QualifiedID, time: Instant) {
@@ -38,7 +39,7 @@ class UpdateConversationReadDateUseCase(
                 ),
                 conversationId = conversationRepository.getSelfConversationId(),
                 date = Clock.System.now().toString(),
-                senderUserId = userRepository.getSelfUserId(),
+                senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
                 editStatus = Message.EditStatus.NotEdited,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -9,7 +9,6 @@ import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
 import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -8,6 +8,7 @@ import com.wire.kalium.logic.data.featureConfig.ConfigsStatusModel
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
 import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
@@ -29,9 +30,9 @@ internal interface SyncFeatureConfigsUseCase {
 internal class SyncFeatureConfigsUseCaseImpl(
     private val userConfigRepository: UserConfigRepository,
     private val featureConfigRepository: FeatureConfigRepository,
-    private val userRepository: UserRepository,
     private val isFileSharingEnabledUseCase: IsFileSharingEnabledUseCase,
-    private val kaliumConfigs: KaliumConfigs
+    private val kaliumConfigs: KaliumConfigs,
+    private val selfUserId: UserId
 ) : SyncFeatureConfigsUseCase {
     override suspend operator fun invoke(): Either<CoreFailure, Unit> =
         featureConfigRepository.getFeatureConfigs().flatMap {
@@ -75,7 +76,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
 
     private fun checkMLSStatus(featureConfig: MLSModel) {
         val mlsEnabled = featureConfig.status == Status.ENABLED
-        val selfUserIsWhitelisted = featureConfig.allowedUsers.contains(userRepository.getSelfUserId().toPlainID())
+        val selfUserIsWhitelisted = featureConfig.allowedUsers.contains(selfUserId.toPlainID())
         userConfigRepository.setMLSEnabled(mlsEnabled && selfUserIsWhitelisted)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -47,7 +47,7 @@ interface GetNotificationsUseCase {
  * That Flow emits everytime when the list is changed
  */
 @Suppress("LongParameterList")
-class GetNotificationsUseCaseImpl(
+internal class GetNotificationsUseCaseImpl internal constructor(
     private val connectionRepository: ConnectionRepository,
     private val messageRepository: MessageRepository,
     private val userRepository: UserRepository,
@@ -55,7 +55,8 @@ class GetNotificationsUseCaseImpl(
     private val timeParser: TimeParser,
     private val ephemeralNotificationsManager: EphemeralNotificationsMgr,
     private val messageMapper: MessageMapper = MapperProvider.messageMapper(),
-    private val localNotificationMessageMapper: LocalNotificationMessageMapper = MapperProvider.localNotificationMessageMapper()
+    private val localNotificationMessageMapper: LocalNotificationMessageMapper =
+        MapperProvider.localNotificationMessageMapper()
 ) : GetNotificationsUseCase {
 
     @Suppress("LongMethod")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
@@ -19,7 +19,7 @@ interface MessageSendFailureHandler {
     suspend fun handleClientsHaveChangedFailure(sendFailure: ProteusSendMessageFailure): Either<CoreFailure, Unit>
 }
 
-class MessageSendFailureHandlerImpl(
+class MessageSendFailureHandlerImpl internal constructor(
     private val userRepository: UserRepository,
     private val clientRepository: ClientRepository
 ) : MessageSendFailureHandler {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/GetAllContactsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/GetAllContactsUseCase.kt
@@ -10,7 +10,9 @@ interface GetAllContactsUseCase {
     suspend operator fun invoke(): GetAllContactsResult
 }
 
-class GetAllContactsUseCaseImpl(private val userRepository: UserRepository) : GetAllContactsUseCase {
+internal class GetAllContactsUseCaseImpl internal constructor(
+    private val userRepository: UserRepository
+) : GetAllContactsUseCase {
 
     override suspend fun invoke(): GetAllContactsResult =
         userRepository.getAllKnownUsers()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/GetKnownUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/GetKnownUserUseCase.kt
@@ -17,4 +17,3 @@ internal class GetKnownUserUseCaseImpl internal constructor(
     override suspend fun invoke(userId: UserId): Flow<OtherUser?> = userRepository.getKnownUser(userId)
 
 }
-

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/GetKnownUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/GetKnownUserUseCase.kt
@@ -9,9 +9,11 @@ interface GetKnownUserUseCase {
     suspend operator fun invoke(userId: UserId): Flow<OtherUser?>
 }
 
-class GetKnownUserUseCaseImpl(private val userRepository: UserRepository) : GetKnownUserUseCase {
+internal class GetKnownUserUseCaseImpl internal constructor(
+    private val userRepository: UserRepository
+) : GetKnownUserUseCase {
 
-    //TODO(qol): Better handle nullable OtherUser?
+    // TODO(qol): Better handle nullable OtherUser?
     override suspend fun invoke(userId: UserId): Flow<OtherUser?> = userRepository.getKnownUser(userId)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCase.kt
@@ -21,7 +21,7 @@ sealed class SetUserHandleResult {
     }
 }
 
-class SetUserHandleUseCase(
+class SetUserHandleUseCase internal constructor(
     private val userRepository: UserRepository,
     private val validateUserHandle: ValidateUserHandleUseCase,
     private val syncManager: SyncManager

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SyncContactsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SyncContactsUseCase.kt
@@ -8,7 +8,9 @@ interface SyncContactsUseCase {
     suspend operator fun invoke(): Either<CoreFailure, Unit>
 }
 
-class SyncContactsUseCaseImpl(private val userDataSource: UserRepository) : SyncContactsUseCase {
+class SyncContactsUseCaseImpl internal constructor(
+    private val userDataSource: UserRepository
+) : SyncContactsUseCase {
 
     override suspend operator fun invoke(): Either<CoreFailure, Unit> {
         return userDataSource.fetchKnownUsers()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SyncSelfUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/SyncSelfUserUseCase.kt
@@ -4,7 +4,9 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.Either
 
-class SyncSelfUserUseCase(private val userRepository: UserRepository) {
+class SyncSelfUserUseCase internal constructor(
+    private val userRepository: UserRepository
+) {
 
     suspend operator fun invoke(): Either<CoreFailure, Unit> {
         return userRepository.fetchSelfUser()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.logic.feature.user
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserRepository
 
-class UpdateSelfAvailabilityStatusUseCase(
+class UpdateSelfAvailabilityStatusUseCase internal constructor(
     private val userRepository: UserRepository,
 ) {
     suspend operator fun invoke(status: UserAvailabilityStatus) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -76,6 +76,7 @@ internal class ConversationEventReceiverImpl(
     private val userConfigRepository: UserConfigRepository,
     private val ephemeralNotificationsManager: EphemeralNotificationsMgr,
     private val pendingProposalScheduler: PendingProposalScheduler,
+    private val selfUserId: UserId,
     private val idMapper: IdMapper = MapperProvider.idMapper(),
     private val protoContentMapper: ProtoContentMapper = MapperProvider.protoContentMapper(),
 ) : ConversationEventReceiver {
@@ -412,7 +413,7 @@ internal class ConversationEventReceiverImpl(
         when (message) {
             is Message.Regular -> when (val content = message.content) {
                 is MessageContent.Text, is MessageContent.FailedDecryption -> {
-                    val isMessageComingFromOtherClient = message.senderUserId == userRepository.getSelfUserId()
+                    val isMessageComingFromOtherClient = message.senderUserId == selfUserId
 
                     if (isMessageComingFromOtherClient) {
                         // if the message is coming from other client it means

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -3,16 +3,18 @@ package com.wire.kalium.logic.sync.receiver
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.kaliumLogger
 
-interface FeatureConfigEventReceiver : EventReceiver<Event.FeatureConfig>
+internal interface FeatureConfigEventReceiver : EventReceiver<Event.FeatureConfig>
 
-class FeatureConfigEventReceiverImpl(
+internal class FeatureConfigEventReceiverImpl internal constructor(
     private val userConfigRepository: UserConfigRepository,
     private val userRepository: UserRepository,
-    private val kaliumConfigs: KaliumConfigs
+    private val kaliumConfigs: KaliumConfigs,
+    private val selfUserId: UserId
 ) : FeatureConfigEventReceiver {
 
     override suspend fun onEvent(event: Event.FeatureConfig) {
@@ -41,7 +43,7 @@ class FeatureConfigEventReceiverImpl(
 
             is Event.FeatureConfig.MLSUpdated -> {
                 val mlsEnabled = event.model.status == Status.ENABLED
-                val selfUserIsWhitelisted = event.model.allowedUsers.contains(userRepository.getSelfUserId().toPlainID())
+                val selfUserIsWhitelisted = event.model.allowedUsers.contains(selfUserId.toPlainID())
                 userConfigRepository.setMLSEnabled(mlsEnabled && selfUserIsWhitelisted)
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/ClearConversationContentHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/ClearConversationContentHandler.kt
@@ -4,27 +4,29 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.conversation.ClearConversationContent
 
 internal class ClearConversationContentHandler(
     private val conversationRepository: ConversationRepository,
     private val userRepository: UserRepository,
-    private val clearConversationContent: ClearConversationContent
+    private val clearConversationContent: ClearConversationContent,
+    private val selfUserId: UserId
 ) {
 
     suspend fun handle(
         message: Message,
         messageContent: MessageContent.Cleared
     ) {
-        val isMessageComingFromOtherClient = message.senderUserId == userRepository.getSelfUserId()
+        val isMessageComingFromOtherClient = message.senderUserId == selfUserId
         val isMessageDestinedForSelfConversation = conversationRepository.getSelfConversationId() == message.conversationId
 
         if (isMessageComingFromOtherClient && isMessageDestinedForSelfConversation) {
             val conversationId = messageContent.conversationId
                 ?: ConversationId(
                     value = messageContent.unqualifiedConversationId,
-                    domain = userRepository.getSelfUserId().domain
+                    domain = selfUserId.domain
                 )
 
             clearConversationContent(conversationId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/DeleteForMeHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/DeleteForMeHandler.kt
@@ -7,7 +7,6 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.kaliumLogger
 
 internal class DeleteForMeHandler internal constructor(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/DeleteForMeHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/DeleteForMeHandler.kt
@@ -6,13 +6,14 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.kaliumLogger
 
-class DeleteForMeHandler(
+internal class DeleteForMeHandler internal constructor(
     private val conversationRepository: ConversationRepository,
     private val messageRepository: MessageRepository,
-    private val userRepository: UserRepository
+    private val selfUserId: UserId
 ) {
 
     suspend fun handle(
@@ -22,7 +23,7 @@ class DeleteForMeHandler(
         // The conversationId comes with the hidden message[content] only carries the conversationId VALUE,
         // we need to get the DOMAIN from the self conversationId[here is the message.conversationId]
         val conversationId = messageContent.conversationId
-            ?: ConversationId(messageContent.unqualifiedConversationId, userRepository.getSelfUserId().domain)
+            ?: ConversationId(messageContent.unqualifiedConversationId, selfUserId.domain)
 
         if (message.conversationId == conversationRepository.getSelfConversationId())
             messageRepository.deleteMessage(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/LastReadContentHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/LastReadContentHandler.kt
@@ -4,19 +4,20 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 
 // This class handles the messages that arrive when some client has read the conversation.
-class LastReadContentHandler(
+internal class LastReadContentHandler internal constructor(
     private val conversationRepository: ConversationRepository,
-    private val userRepository: UserRepository
+    private val selfUserId: UserId
 ) {
 
     suspend fun handle(
         message: Message,
         messageContent: MessageContent.LastRead
     ) {
-        val isMessageComingFromOtherClient = message.senderUserId == userRepository.getSelfUserId()
+        val isMessageComingFromOtherClient = message.senderUserId == selfUserId
         val isMessageDestinedForSelfConversation = conversationRepository.getSelfConversationId() == message.conversationId
 
         if (isMessageComingFromOtherClient && isMessageDestinedForSelfConversation) {
@@ -24,7 +25,7 @@ class LastReadContentHandler(
             // the conversation on the other device and we can update the read date locally
             // to synchronize the state across the clients.
             val conversationId = messageContent.conversationId
-                ?: ConversationId(messageContent.unqualifiedConversationId, userRepository.getSelfUserId().domain)
+                ?: ConversationId(messageContent.unqualifiedConversationId, selfUserId.domain)
 
             conversationRepository.updateConversationReadDate(
                 qualifiedID = conversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/LastReadContentHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/LastReadContentHandler.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 
 // This class handles the messages that arrive when some client has read the conversation.
 internal class LastReadContentHandler internal constructor(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -208,10 +208,6 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
-
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
             .thenReturn(flowOf(Team("team1", "team_1")))
@@ -276,10 +272,6 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
-
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
             .thenReturn(flowOf(Team("team1", "team_1")))
@@ -338,10 +330,6 @@ class CallRepositoryTest {
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
-
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
 
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
@@ -411,10 +399,6 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
-
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
             .thenReturn(flowOf(Team("team1", "team_1")))
@@ -469,10 +453,6 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
-
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
             .thenReturn(flowOf(Team("team1", "team_1")))
@@ -519,10 +499,6 @@ class CallRepositoryTest {
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
-
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
 
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
@@ -577,10 +553,6 @@ class CallRepositoryTest {
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
-
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
 
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
@@ -639,10 +611,6 @@ class CallRepositoryTest {
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
-
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
 
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
@@ -706,10 +674,6 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
 
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
-
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())
             .thenReturn(flowOf(Team("team1", "team_1")))
@@ -762,10 +726,6 @@ class CallRepositoryTest {
         given(userRepository).suspendFunction(userRepository::getKnownUser)
             .whenInvokedWith(any())
             .thenReturn(flowOf(TestUser.OTHER))
-
-        given(userRepository).function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.USER_ID)
 
         given(teamRepository).suspendFunction(teamRepository::getTeam)
             .whenInvokedWith(any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -116,7 +116,8 @@ class ConversationRepositoryTest {
             messageDAO,
             clientDao,
             clientApi,
-            timeParser
+            timeParser,
+            TestUser.SELF.id
         )
     }
 
@@ -509,11 +510,6 @@ class ConversationRepositoryTest {
             .coroutine { userRepository.observeSelfUser() }
             .then { flowOf(TestUser.SELF) }
 
-        given(userRepository)
-            .function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(TestUser.SELF.id)
-
         given(conversationDAO)
             .suspendFunction(conversationDAO::insertConversation)
             .whenInvokedWith(anything())
@@ -775,7 +771,6 @@ class ConversationRepositoryTest {
             .withDeleteMemberAPISucceed()
             .withSuccessfulMemberDeletion()
             .withSuccessfulLeaveMLSGroup()
-            .withSelfUser(TestUser.SELF.id)
             .arrange()
 
         conversationRepository.deleteMember(TestUser.SELF.id, TestConversation.ID)
@@ -801,7 +796,6 @@ class ConversationRepositoryTest {
             .withConversationProtocolIs(MLS_PROTOCOL_INFO)
             .withDeleteMemberAPISucceed()
             .withSuccessfulMemberDeletion()
-            .withSelfUser(TestUser.SELF.id)
             .withSuccessfulRemoveMemberFromMLSGroup()
             .arrange()
 
@@ -1326,6 +1320,7 @@ class ConversationRepositoryTest {
                 clientDao,
                 clientApi,
                 timeParser,
+                TestUser.SELF.id
             )
 
         fun withSelfUserFlow(selfUserFlow: Flow<SelfUser>) = apply {
@@ -1333,13 +1328,6 @@ class ConversationRepositoryTest {
                 .suspendFunction(userRepository::observeSelfUser)
                 .whenInvoked()
                 .thenReturn(selfUserFlow)
-        }
-
-        fun withSelfUser(selfUser: QualifiedID) = apply {
-            given(userRepository)
-                .function(userRepository::getSelfUserId)
-                .whenInvoked()
-                .thenReturn(selfUser)
         }
 
         fun withInsertConversations() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -6,7 +6,6 @@ import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.PersistenceQualifiedId
-import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.data.id
 
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import io.mockative.Mock
 import io.mockative.classOf
@@ -14,11 +15,13 @@ class QualifiedIdMapperTest {
     @Mock
     private val userRepository = mock(classOf<UserRepository>())
 
+    private val selfUserId = UserId("selfUserId", "selfDomain")
+
     private lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     @BeforeTest
     fun setUp() {
-        qualifiedIdMapper = QualifiedIdMapperImpl(userRepository)
+        qualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
     }
 
     @Test
@@ -27,10 +30,6 @@ class QualifiedIdMapperTest {
         val mockQualifiedIdValue = "mocked-value"
         val mockQualifiedIdDomain = "mocked.domain"
         val correctQualifiedIdString = "$mockQualifiedIdValue@$mockQualifiedIdDomain"
-        given(userRepository)
-            .function(userRepository::getSelfUserId)
-            .whenInvoked()
-            .thenReturn(QualifiedID(mockQualifiedIdValue, mockQualifiedIdDomain))
 
         // When
         val correctQualifiedId = qualifiedIdMapper.fromStringToQualifiedID(correctQualifiedIdString)
@@ -43,12 +42,8 @@ class QualifiedIdMapperTest {
     @Test
     fun givenAStringWithoutDomain_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
         // Given
-        val fallbackDomain = "wire.com"
+        val fallbackDomain = selfUserId.domain
         val conversationId = "conversationId"
-
-        given(userRepository)
-            .invocation { getSelfUserId() }
-            .thenReturn(QualifiedID(conversationId, fallbackDomain))
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -63,12 +58,8 @@ class QualifiedIdMapperTest {
     @Test
     fun givenAStringWithoutDomainThatEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
         // Given
-        val fallbackDomain = "wire.com"
+        val fallbackDomain = selfUserId.domain
         val conversationId = "conversationId@"
-
-        given(userRepository)
-            .invocation { getSelfUserId() }
-            .thenReturn(QualifiedID(conversationId, fallbackDomain))
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -83,12 +74,8 @@ class QualifiedIdMapperTest {
     @Test
     fun givenAValidStringThatStartsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
         // Given
-        val fallbackDomain = "wire.com"
+        val fallbackDomain = selfUserId.domain
         val conversationId = "@conversationId"
-
-        given(userRepository)
-            .invocation { getSelfUserId() }
-            .thenReturn(QualifiedID(conversationId, fallbackDomain))
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
@@ -103,12 +90,8 @@ class QualifiedIdMapperTest {
     @Test
     fun givenAValidStringThatStartsAndEndsWithAtSign_whenMappingToQualifiedId_thenReturnsACorrectQualifiedIDWithAFallbackDomain() {
         // Given
-        val fallbackDomain = "wire.com"
+        val fallbackDomain = selfUserId.domain
         val conversationId = "@conversationId@"
-
-        given(userRepository)
-            .invocation { getSelfUserId() }
-            .thenReturn(QualifiedID(conversationId, fallbackDomain))
 
         // When
         val result = qualifiedIdMapper.fromStringToQualifiedID(conversationId)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
@@ -4,7 +4,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import io.mockative.Mock
 import io.mockative.classOf
-import io.mockative.given
 import io.mockative.mock
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdMapperTest.kt
@@ -1,5 +1,7 @@
 package com.wire.kalium.logic.data.id
 
+import com.wire.kalium.logic.framework.TestUser
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -7,7 +9,7 @@ class QualifiedIdMapperTest {
 
     private val selfUserId = TestUser.USER_ID
 
-    private fun createMapper(selfUserId: QualifiedID = selfUserId): QualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
+    private fun createMapper(selfUserId: QualifiedID = this.selfUserId): QualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
 
     @Test
     fun givenAValidString_whenMappingToQualifiedId_thenCreatesAQualifiedIdWithACorrectValues() = runTest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
@@ -29,10 +29,10 @@ import kotlin.test.assertEquals
 class MessageSendFailureHandlerTest {
 
     @Mock
-    val clientRepository = mock(classOf<ClientRepository>())
+    private val clientRepository = mock(classOf<ClientRepository>())
 
     @Mock
-    val userRepository = mock(classOf<UserRepository>())
+    private val userRepository = mock(classOf<UserRepository>())
 
     private lateinit var messageSendFailureHandler: MessageSendFailureHandler
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -103,7 +103,7 @@ class UserRepositoryTest {
         val sessionRepository = mock(SessionRepository::class)
 
         val userRepository: UserRepository by lazy {
-            UserDataSource(userDAO, metadataDAO, clientDAO, selfApi, userDetailsApi, sessionRepository)
+            UserDataSource(userDAO, metadataDAO, clientDAO, selfApi, userDetailsApi, sessionRepository, TestUser.SELF.id)
         }
 
         init {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCaseTest.kt
@@ -30,7 +30,6 @@ class ClearConversationContentUseCaseTest {
             .withMessageSending(true)
             .withCurrentClientId((true))
             .withGetSelfConversationId()
-            .withGetSelfUserId()
             .arrange()
 
         // when
@@ -63,7 +62,6 @@ class ClearConversationContentUseCaseTest {
             .withCurrentClientId(false)
             .withMessageSending(true)
             .withGetSelfConversationId()
-            .withGetSelfUserId()
             .arrange()
 
         // when
@@ -97,7 +95,6 @@ class ClearConversationContentUseCaseTest {
             .withCurrentClientId(true)
             .withMessageSending(false)
             .withGetSelfConversationId()
-            .withGetSelfUserId()
             .arrange()
 
         // when
@@ -131,7 +128,6 @@ class ClearConversationContentUseCaseTest {
             .withCurrentClientId(true)
             .withMessageSending(true)
             .withGetSelfConversationId()
-            .withGetSelfUserId()
             .arrange()
 
         // when
@@ -204,15 +200,6 @@ class ClearConversationContentUseCaseTest {
             return this
         }
 
-        fun withGetSelfUserId(): Arrangement {
-            given(userRepository)
-                .function(userRepository::getSelfUserId)
-                .whenInvoked()
-                .thenReturn(UserId("someValue", "someDomain"))
-
-            return this
-        }
-
         fun withMessageSending(isSuccessFull: Boolean): Arrangement {
             given(messageSender)
                 .suspendFunction(messageSender::sendMessage)
@@ -226,8 +213,8 @@ class ClearConversationContentUseCaseTest {
             clearConversationContent,
             clientRepository,
             conversationRepository,
-            userRepository,
-            messageSender
+            messageSender,
+            UserId("someValue", "someDomain")
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/GetFeatureConfigsStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/GetFeatureConfigsStatusUseCaseTest.kt
@@ -143,9 +143,9 @@ class GetFeatureConfigsStatusUseCaseTest {
             SyncFeatureConfigsUseCaseImpl(
                 userConfigRepository,
                 featureConfigRepository,
-                userRepository,
                 isFileSharingEnabledUseCase,
-                kaliumConfigs
+                kaliumConfigs,
+                TestUser.SELF.id
             )
 
         fun withSuccessfulResponse(expectedFileSharingModel: FeatureConfigModel): Arrangement {
@@ -166,10 +166,6 @@ class GetFeatureConfigsStatusUseCaseTest {
                 .function(userConfigRepository::setClassifiedDomainsStatus)
                 .whenInvokedWith(any(), any())
                 .thenReturn(Either.Right(Unit))
-            given(userRepository)
-                .function(userRepository::getSelfUserId)
-                .whenInvoked()
-                .thenReturn(TestUser.SELF.id)
             given(featureConfigRepository)
                 .suspendFunction(featureConfigRepository::getFeatureConfigs).whenInvoked()
                 .thenReturn(Either.Right(expectedFileSharingModel))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -183,7 +183,7 @@ class DeleteMessageUseCaseTest {
             .wasInvoked(exactly = once)
     }
 
-    class Arrangement {
+    private class Arrangement {
 
         @Mock
         val messageRepository: MessageRepository = mock(MessageRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -57,7 +57,6 @@ class GetNotificationsUseCaseTest {
                 )
             )
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withConversationsForNotifications(listOf())
             .arrange()
@@ -86,7 +85,6 @@ class GetNotificationsUseCaseTest {
                 )
             )
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withConversationsForNotifications(listOf(entityConversation()))
             .withMessagesByConversationAfterDate { listOf() }
@@ -113,7 +111,6 @@ class GetNotificationsUseCaseTest {
         val (_, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withConversationsForNotifications(listOf(entityConversation()))
             .withMessagesByConversationAfterDate { conversationId ->
@@ -138,7 +135,6 @@ class GetNotificationsUseCaseTest {
         val (_, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withKnownUser()
             .withConversationsForNotifications(listOf(entityConversation()))
@@ -173,7 +169,6 @@ class GetNotificationsUseCaseTest {
     fun givenFewConversationWithMessageLists_thenListOfFewNotifications() = runTest {
         val (_, getNotifications) = Arrangement()
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withKnownUser()
             .withConversationsForNotifications(
@@ -220,7 +215,6 @@ class GetNotificationsUseCaseTest {
         val (arrange, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withKnownUser()
             .withConversationsForNotifications(
@@ -250,7 +244,6 @@ class GetNotificationsUseCaseTest {
         val (arrange, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus(UserAvailabilityStatus.AWAY))
             .withKnownUser()
             .withConversationsForNotifications(listOf(entityConversation()))
@@ -282,7 +275,6 @@ class GetNotificationsUseCaseTest {
         val (arrange, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus(UserAvailabilityStatus.BUSY))
             .withKnownUser()
             .withConversationsForNotifications(listOf(entityConversation()))
@@ -318,7 +310,6 @@ class GetNotificationsUseCaseTest {
     fun givenMutedConversation_whenNewMessageCome_thenNoNotificationsAndNotificationDateUpdated() = runTest {
         val (arrange, getNotifications) = Arrangement()
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withConversationsForNotifications(listOf(entityConversation(mutedStatus = MutedConversationStatus.AllMuted)))
             .withMessagesByConversationAfterDate { conversationId ->
@@ -352,7 +343,6 @@ class GetNotificationsUseCaseTest {
         val (arrange, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(listOf())
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withConversationsForNotifications(listOf(entityConversation(mutedStatus = MutedConversationStatus.OnlyMentionsAllowed)))
             .withMessagesByConversationAfterDate { conversationId ->
@@ -389,7 +379,6 @@ class GetNotificationsUseCaseTest {
         val (_, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(null)
-            .withSelfUserId(MY_ID)
             .withSelfUser(selfUserWithStatus())
             .withKnownUser()
             .withConversationsForNotifications(listOf(entityConversation()))
@@ -419,7 +408,6 @@ class GetNotificationsUseCaseTest {
         val (_, getNotifications) = Arrangement()
             .withConnectionList(listOf(connectionRequest()))
             .withSelfUser(selfUserWithStatus())
-            .withSelfUserId(MY_ID)
             .withKnownUser()
             .withConversationsForNotifications(null)
             .withEphemeralNotification()
@@ -475,15 +463,6 @@ class GetNotificationsUseCaseTest {
                 .suspendFunction(conversationRepository::updateAllConversationsNotificationDate)
                 .whenInvokedWith(any())
                 .then { Either.Right(Unit) }
-        }
-
-        fun withSelfUserId(id: QualifiedID = MY_ID): Arrangement {
-            given(userRepository)
-                .function(userRepository::getSelfUserId)
-                .whenInvoked()
-                .then { id }
-
-            return this
         }
 
         fun withSelfUser(user: SelfUser = selfUserWithStatus()): Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetUserInfoUseCaseTestArrangement.kt
@@ -13,7 +13,7 @@ import io.mockative.given
 import io.mockative.mock
 import kotlinx.coroutines.flow.flowOf
 
-class GetUserInfoUseCaseTestArrangement {
+internal class GetUserInfoUseCaseTestArrangement {
 
     @Mock
     val userRepository: UserRepository = mock(UserRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCaseTest.kt
@@ -227,7 +227,7 @@ class ObserveUserInfoUseCaseTest {
         }
     }
 
-    class ObserveUserInfoUseCaseTestArrangement {
+    private class ObserveUserInfoUseCaseTestArrangement {
 
         @Mock
         val userRepository: UserRepository = mock(UserRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -74,7 +74,6 @@ class ConversationEventReceiverTest {
     @Test
     fun givenNewMessageEvent_whenHandling_shouldAskProteusClientForDecryption() = runTest {
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withProteusClientDecryptingByteArray(decryptedData = byteArrayOf())
             .withProtoContentMapperReturning(any(), ProtoContent.Readable("uuid", MessageContent.Unknown()))
             .withPersistingMessageReturning(Either.Right(Unit))
@@ -117,7 +116,6 @@ class ConversationEventReceiverTest {
         val emptyArray = byteArrayOf()
 
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withProteusClientDecryptingByteArray(decryptedData = emptyArray)
             .withPersistingMessageReturning(Either.Right(Unit))
             .withConversationUpdateConversationReadDate(Either.Right(Unit))
@@ -209,7 +207,6 @@ class ConversationEventReceiverTest {
         val event = TestEvent.memberJoin(members = newMembers)
 
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withPersistingMessageReturning(Either.Right(Unit))
             .withFetchConversationIfUnknownSucceeding()
             .withPersistMembersSucceeding()
@@ -230,7 +227,6 @@ class ConversationEventReceiverTest {
         val event = TestEvent.memberJoin(members = newMembers)
 
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withPersistingMessageReturning(Either.Right(Unit))
             .withFetchConversationIfUnknownSucceeding()
             .withPersistMembersSucceeding()
@@ -251,7 +247,6 @@ class ConversationEventReceiverTest {
         val event = TestEvent.memberJoin(members = newMembers)
 
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withPersistingMessageReturning(Either.Right(Unit))
             .withFetchConversationIfUnknownFailing(NetworkFailure.NoNetworkConnection(null))
             .withPersistMembersSucceeding()
@@ -271,7 +266,6 @@ class ConversationEventReceiverTest {
         val event = TestEvent.memberJoin(members = newMembers)
 
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withPersistingMessageReturning(Either.Right(Unit))
             .withFetchConversationIfUnknownFailing(NetworkFailure.NoNetworkConnection(null))
             .withPersistMembersSucceeding()
@@ -293,7 +287,6 @@ class ConversationEventReceiverTest {
         val event = TestEvent.memberChange(member = updatedMember)
 
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withFetchConversationIfUnknownSucceeding()
             .withUpdateMemberSucceeding()
             .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
@@ -313,7 +306,6 @@ class ConversationEventReceiverTest {
         val event = TestEvent.memberChange(member = updatedMember)
 
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withFetchConversationIfUnknownSucceeding()
             .withUpdateMemberSucceeding()
             .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
@@ -333,7 +325,6 @@ class ConversationEventReceiverTest {
         val event = TestEvent.memberChange(member = updatedMember)
 
         val (arrangement, eventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.USER_ID)
             .withPersistingMessageReturning(Either.Right(Unit))
             .withFetchConversationIfUnknownFailing(NetworkFailure.NoNetworkConnection(null))
             .withUpdateMemberSucceeding()
@@ -434,19 +425,23 @@ class ConversationEventReceiverTest {
             userRepository = userRepository,
             callManagerImpl = lazyOf(callManager),
             editTextHandler = MessageTextEditHandler(messageRepository),
-            lastReadContentHandler = LastReadContentHandler(conversationRepository, userRepository),
+            lastReadContentHandler = LastReadContentHandler(
+                conversationRepository, TestUser.USER_ID
+            ),
             clearConversationContentHandler = ClearConversationContentHandler(
                 conversationRepository = conversationRepository,
                 userRepository = userRepository,
-                clearConversationContent = ClearConversationContentImpl(conversationRepository, assetRepository)
+                clearConversationContent = ClearConversationContentImpl(conversationRepository, assetRepository),
+                TestUser.USER_ID
             ),
             deleteForMeHandler = DeleteForMeHandler(
-                conversationRepository = conversationRepository, messageRepository = messageRepository, userRepository = userRepository
+                conversationRepository = conversationRepository, messageRepository = messageRepository, selfUserId = TestUser.USER_ID
             ),
             userConfigRepository = userConfigRepository,
             ephemeralNotificationsManager = ephemeralNotifications,
             pendingProposalScheduler = pendingProposalScheduler,
             protoContentMapper = protoContentMapper,
+            selfUserId = TestUser.USER_ID
         )
 
         fun withProteusClientDecryptingByteArray(decryptedData: ByteArray) = apply {
@@ -461,13 +456,6 @@ class ConversationEventReceiverTest {
                 .function(protoContentMapper::decodeFromProtobuf)
                 .whenInvokedWith(plainBlobMatcher)
                 .thenReturn(protoContent)
-        }
-
-        fun withSelfUserIdReturning(selfUserId: UserId) = apply {
-            given(userRepository)
-                .function(userRepository::getSelfUserId)
-                .whenInvoked()
-                .thenReturn(selfUserId)
         }
 
         fun withPersistingMessageReturning(result: Either<CoreFailure, Unit>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -27,7 +27,6 @@ class FeatureConfigEventReceiverTest {
     @Test
     fun givenMLSUpdatedEventGrantingAccessForSelfUser_whenProcessingEvent_ThenSetMLSEnabledToTrue() = runTest {
         val (arrangement, featureConfigEventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.SELF.id)
             .withSettingMLSEnabledSuccessful()
             .arrange()
 
@@ -43,7 +42,6 @@ class FeatureConfigEventReceiverTest {
     @Test
     fun givenMLSUpdatedEventRemovingAccessForSelfUser_whenProcessingEvent_ThenSetMLSEnabledToFalse() = runTest {
         val (arrangement, featureConfigEventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.SELF.id)
             .withSettingMLSEnabledSuccessful()
             .arrange()
 
@@ -58,7 +56,6 @@ class FeatureConfigEventReceiverTest {
     @Test
     fun givenMLSUpdatedEventGrantingAccessForSelfUserButStatusIsDisabled_whenProcessingEvent_ThenSetMLSEnabledToFalse() = runTest {
         val (arrangement, featureConfigEventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.SELF.id)
             .withSettingMLSEnabledSuccessful()
             .arrange()
 
@@ -74,7 +71,6 @@ class FeatureConfigEventReceiverTest {
     @Test
     fun givenFileSharingUpdatedEventWithStatusEnabled_whenProcessingEvent_ThenSetFileSharingStatusToTrue() = runTest {
         val (arrangement, featureConfigEventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.SELF.id)
             .withSettingFileSharingEnabledSuccessful()
             .arrange()
 
@@ -90,7 +86,6 @@ class FeatureConfigEventReceiverTest {
     @Test
     fun givenFileSharingUpdatedEventWithStatusDisabled_whenProcessingEvent_ThenSetFileSharingStatusToFalse() = runTest {
         val (arrangment, featureConfigEventReceiver) = Arrangement()
-            .withSelfUserIdReturning(TestUser.SELF.id)
             .withSettingFileSharingEnabledSuccessful()
             .arrange()
 
@@ -117,14 +112,8 @@ class FeatureConfigEventReceiverTest {
             userConfigRepository,
             userRepository,
             kaliumConfigs,
+            TestUser.SELF.id
         )
-
-        fun withSelfUserIdReturning(selfUserId: UserId) = apply {
-            given(userRepository)
-                .function(userRepository::getSelfUserId)
-                .whenInvoked()
-                .thenReturn(selfUserId)
-        }
 
         fun withSettingMLSEnabledSuccessful() = apply {
             given(userConfigRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.featureConfig.ConfigsStatusModel
 import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.Status
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestUser

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -14,7 +14,7 @@ import com.wire.kalium.logic.feature.message.MessageSender
 actual class GlobalCallManager {
 
     @Suppress("LongParameterList")
-    actual fun getCallManagerForClient(
+    internal actual fun getCallManagerForClient(
         userId: QualifiedID,
         callRepository: CallRepository,
         userRepository: UserRepository,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the app is accessing the DB for each time the selfUserId is needed 


### Solutions

inject self user ID into constructor 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
