### PR TITLE
fix: start call regression

### DIFF
--- a/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/NetworkQualityChangedHandler.kt
+++ b/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/NetworkQualityChangedHandler.kt
@@ -15,7 +15,7 @@ interface NetworkQualityChangedHandler : Callback {
     fun onNetworkQualityChanged(
         conversationId: String,
         userId: String?,
-        clientId: String,
+        clientId: String?,
         quality: Int,
         roundTripTimeInMilliseconds: Int,
         upstreamPacketLossPercentage: Int,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
@@ -10,7 +10,7 @@ class OnNetworkQualityChanged : NetworkQualityChangedHandler {
     override fun onNetworkQualityChanged(
         conversationId: String,
         userId: String?,
-        clientId: String,
+        clientId: String?,
         quality: Int,
         roundTripTimeInMilliseconds: Int,
         upstreamPacketLossPercentage: Int,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
@@ -44,11 +44,12 @@ WHERE
         LIMIT 1
     );
 
-selectLastCallCreationTimeConversationId:
+selectLastClosedCallCreationTimeConversationId:
 SELECT created_at
 FROM Call
 WHERE
     conversation_id = :conversationId
+    AND status = 'CLOSED'
 ORDER BY created_at DESC
 LIMIT 1;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
@@ -88,7 +88,7 @@ internal class CallDAOImpl(
         callsQueries.lastCallStatusByConversationId(conversationId).executeAsOneOrNull()
 
     override suspend fun getLastClosedCallByConversationId(conversationId: QualifiedIDEntity): Flow<String?> =
-        callsQueries.selectLastCallCreationTimeConversationId(conversationId)
+        callsQueries.selectLastClosedCallCreationTimeConversationId(conversationId)
             .asFlow()
             .mapToOneOrNull()
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Not able to start a call.

### Causes (Optional)

`selectLastCallCreationTimeConversationId` was getting last creation time from currently started call and not last closed call.

### Solutions

Add filter to get last closed call and not only last call.

### Testing

#### How to Test

- Open App
- Select a Conversation
- Start a call (everything should work as normal)