### PR TITLE
chore: move mls secret to global pref

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -21,7 +21,6 @@ import com.wire.kalium.persistence.client.AuthTokenStorage
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
-import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 import com.wire.kalium.persistence.kmm_settings.SettingOptions
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.runBlocking
@@ -58,7 +57,6 @@ actual class UserSessionScopeProviderImpl(
                 appContext,
                 SettingOptions.UserSettings(shouldEncryptData = kaliumConfigs.shouldEncryptData, userIDEntity)
             )
-        val userPreferencesSettings = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
         val userDatabaseProvider =
             UserDatabaseProvider(
                 appContext,
@@ -73,7 +71,6 @@ actual class UserSessionScopeProviderImpl(
             proteusClient,
             userSessionWorkScheduler,
             userDatabaseProvider,
-            userPreferencesSettings,
             encryptedSettingsHolder
         )
         return UserSessionScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/AuthenticatedDataSourceSet.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/AuthenticatedDataSourceSet.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.logic.sync.UserSessionWorkScheduler
 import com.wire.kalium.network.AuthenticatedNetworkContainer
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
-import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 
 @Suppress("LongParameterList") // Suppressed as it's an old issue
 class AuthenticatedDataSourceSet(
@@ -14,6 +13,5 @@ class AuthenticatedDataSourceSet(
     val proteusClient: ProteusClient,
     val userSessionWorkScheduler: UserSessionWorkScheduler,
     val userDatabaseProvider: UserDatabaseProvider,
-    val kaliumPreferencesSettings: KaliumPreferencesSettings,
     val encryptedSettingsHolder: EncryptedSettingsHolder
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -193,7 +193,6 @@ abstract class UserSessionScopeCommon internal constructor(
     private val userConfigRepository: UserConfigRepository get() = UserConfigDataSource(userConfigStorage)
 
     private val encryptedSettingsHolder: EncryptedSettingsHolder = authenticatedDataSourceSet.encryptedSettingsHolder
-    private val userPreferencesSettings = authenticatedDataSourceSet.kaliumPreferencesSettings
 
     private val userDatabaseProvider: UserDatabaseProvider = authenticatedDataSourceSet.userDatabaseProvider
 
@@ -208,7 +207,7 @@ abstract class UserSessionScopeCommon internal constructor(
             "${authenticatedDataSourceSet.authenticatedRootDir}/mls",
             userId,
             clientRepository,
-            authenticatedDataSourceSet.kaliumPreferencesSettings
+            globalPreferences
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ClearUserDataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ClearUserDataUseCase.kt
@@ -17,6 +17,5 @@ internal class ClearUserDataUseCaseImpl internal constructor(
     private fun clearUserStorage() {
         authenticatedDataSourceSet.userDatabaseProvider.nuke()
         // exclude clientId clear from this step
-        authenticatedDataSourceSet.kaliumPreferencesSettings.nuke()
     }
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -19,7 +19,6 @@ import com.wire.kalium.persistence.client.AuthTokenStorage
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.kmm_settings.EncryptedSettingsHolder
 import com.wire.kalium.persistence.kmm_settings.KaliumPreferences
-import com.wire.kalium.persistence.kmm_settings.KaliumPreferencesSettings
 import com.wire.kalium.persistence.kmm_settings.SettingOptions
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.runBlocking
@@ -59,7 +58,6 @@ actual class UserSessionScopeProviderImpl(
                 idMapper.toDaoModel(userId)
             )
         )
-        val userPreferencesSettings = KaliumPreferencesSettings(encryptedSettingsHolder.encryptedSettings)
         val userDatabase = UserDatabaseProvider(File(rootStoragePath), KaliumDispatcherImpl.io)
 
         val userDataSource = AuthenticatedDataSourceSet(
@@ -68,7 +66,6 @@ actual class UserSessionScopeProviderImpl(
             proteusClient,
             userSessionWorkScheduler,
             userDatabase,
-            userPreferencesSettings,
             encryptedSettingsHolder
         )
         return UserSessionScope(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

as mls secret already contain the id so we don't need it in user pref and move it to global pref to reduce the shared pref created in the app 

### Solutions

move the mls secret shared pref to global pref

### Testing

#### How to Test

run the app and check where the mls_db_secret_alias been saved in the pref file 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
