### PR TITLE
fix: kalium using the same master key for all encrypted shared pref f…

### DIFF
--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
@@ -10,9 +10,9 @@ actual class EncryptedSettingsHolder(
     private val applicationContext: Context,
     options: SettingOptions
 ) {
-    private fun getOrCreateMasterKey(): MasterKey =
+    private fun getOrCreateMasterKey(keyAlias: String =  MasterKey.DEFAULT_MASTER_KEY_ALIAS): MasterKey =
         MasterKey
-            .Builder(applicationContext)
+            .Builder(applicationContext, keyAlias)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .setRequestStrongBoxBacked(true)
             .build()
@@ -22,7 +22,7 @@ actual class EncryptedSettingsHolder(
             EncryptedSharedPreferences.create(
                 applicationContext,
                 options.fileName,
-                getOrCreateMasterKey(),
+                getOrCreateMasterKey(options.keyAlias()),
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             )
@@ -30,4 +30,9 @@ actual class EncryptedSettingsHolder(
             applicationContext.getSharedPreferences(options.fileName, Context.MODE_PRIVATE)
         }, false
     )
+}
+
+private fun SettingOptions.keyAlias(): String  = when (this) {
+    is SettingOptions.AppSettings -> "_app_settings_master_key_"
+    is SettingOptions.UserSettings -> "${this.fileName}_master_key_"
 }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmm_settings/EncryptedSettingsHolder.kt
@@ -7,12 +7,12 @@ import com.russhwolf.settings.AndroidSettings
 import com.russhwolf.settings.Settings
 
 actual class EncryptedSettingsHolder(
-    private val applicationContext: Context,
+    applicationContext: Context,
     options: SettingOptions
 ) {
     @get:Synchronized
     actual val encryptedSettings: Settings = AndroidSettings(
-        if (true) {
+        if (options.shouldEncryptData) {
             EncryptedSharedPreferences.create(
                 applicationContext,
                 options.fileName,
@@ -26,14 +26,14 @@ actual class EncryptedSettingsHolder(
     )
 }
 
-private fun SettingOptions.keyAlias(): String  = when (this) {
+private fun SettingOptions.keyAlias(): String = when (this) {
     is SettingOptions.AppSettings -> "_app_settings_master_key_"
     is SettingOptions.UserSettings -> "_${this.fileName}_master_key_"
 }
 
 private object EncryptedSharedPrefUtil {
     @Synchronized
-    fun getOrCreateMasterKey(context: Context, keyAlias: String =  MasterKey.DEFAULT_MASTER_KEY_ALIAS): MasterKey =
+    fun getOrCreateMasterKey(context: Context, keyAlias: String = MasterKey.DEFAULT_MASTER_KEY_ALIAS): MasterKey =
         MasterKey
             .Builder(context, keyAlias)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

fix: kalium using the same master key for all encrypted shared pref files

When creating the master key for encrypted shared preferences kalium was using the same master key for all encrypted shared pref files

### Solutions

pass a different master key alias for each file creates

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
