### PR TITLE
fix: login using username with dots [AR-2417]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -60,7 +60,7 @@ internal class LoginUseCaseImpl internal constructor(
                 loginRepository.loginWithEmail(cleanUserIdentifier, password, shouldPersistClient)
             }
 
-            validateUserHandleUseCase(cleanUserIdentifier).isValid -> {
+            validateUserHandleUseCase(cleanUserIdentifier).isValidAllowingDots -> {
                 loginRepository.loginWithHandle(cleanUserIdentifier, password, shouldPersistClient)
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCase.kt
@@ -6,12 +6,18 @@ interface ValidateUserHandleUseCase {
 
 class ValidateUserHandleUseCaseImpl : ValidateUserHandleUseCase {
     override operator fun invoke(handle: String): ValidateUserHandleResult {
-        val handleWithoutInvalidCharacters = handle.replace(Regex(HANDLE_FORBIDDEN_CHARACTERS_REGEX), "")
-        val hasValidCharacters = handle == handleWithoutInvalidCharacters
+        val forbiddenCharactersRegex = Regex(HANDLE_FORBIDDEN_CHARACTERS_REGEX)
+        val handleWithoutInvalidCharacters = handle.replace(forbiddenCharactersRegex, "")
+        val hasOnlyValidCharacters = handle == handleWithoutInvalidCharacters
         val tooShort = handleWithoutInvalidCharacters.length < HANDLE_MIN_LENGTH
         val tooLong = handleWithoutInvalidCharacters.length > HANDLE_MAX_LENGTH
         return when {
-            !hasValidCharacters -> ValidateUserHandleResult.Invalid.InvalidCharacters(handleWithoutInvalidCharacters)
+            !hasOnlyValidCharacters -> {
+                val allCharactersUsed = handle.toCharArray().distinct()
+                val validCharactersUsed = handleWithoutInvalidCharacters.toCharArray().distinct()
+                val invalidCharactersUsed = allCharactersUsed.minus(validCharactersUsed.toSet())
+                ValidateUserHandleResult.Invalid.InvalidCharacters(handleWithoutInvalidCharacters, invalidCharactersUsed)
+            }
             tooShort -> ValidateUserHandleResult.Invalid.TooShort(handleWithoutInvalidCharacters)
             tooLong -> ValidateUserHandleResult.Invalid.TooLong(handleWithoutInvalidCharacters)
             else -> ValidateUserHandleResult.Valid(handle)
@@ -28,9 +34,18 @@ class ValidateUserHandleUseCaseImpl : ValidateUserHandleUseCase {
 sealed class ValidateUserHandleResult(val handle: String) {
     class Valid(handle: String) : ValidateUserHandleResult(handle)
     sealed class Invalid(handleWithoutInvalidCharacters: String) : ValidateUserHandleResult(handleWithoutInvalidCharacters) {
-        class InvalidCharacters(handleWithoutInvalidCharacters: String) : Invalid(handleWithoutInvalidCharacters)
+        class InvalidCharacters(
+            handleWithoutInvalidCharacters: String,
+            val invalidCharactersUsed: List<Char>
+        ) : Invalid(handleWithoutInvalidCharacters)
+
         class TooShort(handleWithoutInvalidCharacters: String) : Invalid(handleWithoutInvalidCharacters)
         class TooLong(handleWithoutInvalidCharacters: String) : Invalid(handleWithoutInvalidCharacters)
     }
+
     val isValid: Boolean get() = this is Valid
+
+    // in some cases there is still possible to create a handle with dots so we have to allow it in some cases, e.g. login
+    val isValidAllowingDots: Boolean
+        get() = this is Valid || (this is Invalid.InvalidCharacters && this.invalidCharactersUsed == listOf('.'))
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidateUserHandleUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.feature.auth
 
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class ValidateUserHandleUseCaseTest {
@@ -47,6 +48,22 @@ class ValidateUserHandleUseCaseTest {
     fun givenAValidUserHandleUseCaseIsInvoked_whenHandleIsTooShortAndHasInvaledChar_thenReturnHandleWithoutInvalidChars() {
         val result = validateUserHandleUseCase("$")
         assertTrue { result is ValidateUserHandleResult.Invalid.InvalidCharacters && result.handle == "" }
+    }
+
+    @Test
+    fun givenUserHandleContainsDots_whenValidating_thenReturnProperValues() {
+        val handleWithDot = "user.name"
+        val result = validateUserHandleUseCase(handleWithDot)
+        assertFalse { result.isValid }
+        assertTrue { result.isValidAllowingDots }
+    }
+
+    @Test
+    fun givenUserHandleContainsInvalidCharacters_whenValidating_thenReturnListOfInvalidCharacters() {
+        val handleWithDot = "user.name!with?invalid,characters"
+        val result = validateUserHandleUseCase(handleWithDot)
+        assertIs<ValidateUserHandleResult.Invalid.InvalidCharacters>(result)
+        assertTrue { result.invalidCharactersUsed.toSet() == listOf('.', '!', '?', ',').toSet() }
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SetUserHandleUseCaseTest.kt
@@ -147,7 +147,7 @@ class SetUserHandleUseCaseTest {
         given(validateHandleUseCase)
             .function(validateHandleUseCase::invoke)
             .whenInvokedWith(any())
-            .then { ValidateUserHandleResult.Invalid.InvalidCharacters("") }
+            .then { ValidateUserHandleResult.Invalid.InvalidCharacters("", listOf()) }
         given(syncManager)
             .coroutine { syncManager.isSlowSyncOngoing() }
             .then { false }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we have a username which contains a dot, and try to login with this username, then we receive an error on login page. In some cases there is still possible to create a handle with dots (on web when creating a new account).

### Solutions

Allow dots when validating the user handle in some cases, at least when logging in.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create an account with user handle with dots and try to log in using it.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
