### PR TITLE
chore: cleanup and improve logs related to notifications being stuck on reloaded (AR-2437)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -426,6 +426,7 @@ internal class ConversationDataSource internal constructor (
             .map(conversationMapper::fromDaoModel)
             .wrapStorageRequest()
 
+    // TODO: refactor. 3 Ways different ways to return conversation details?!
     override suspend fun getConversationById(conversationId: ConversationId): Conversation? =
         conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId))
             .map { conversationEntity ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncStatus.kt
@@ -4,12 +4,20 @@ import com.wire.kalium.logic.CoreFailure
 
 sealed interface IncrementalSyncStatus {
 
-    object Pending : IncrementalSyncStatus
+    object Pending : IncrementalSyncStatus {
+        override fun toString(): String = "PENDING"
+    }
 
-    object FetchingPendingEvents : IncrementalSyncStatus
+    object FetchingPendingEvents : IncrementalSyncStatus {
+        override fun toString() = "FETCHING_PENDING_EVENTS"
+    }
 
-    object Live : IncrementalSyncStatus
+    object Live : IncrementalSyncStatus {
+        override fun toString() = "LIVE"
+    }
 
-    data class Failed(val failure: CoreFailure) : IncrementalSyncStatus
+    data class Failed(val failure: CoreFailure) : IncrementalSyncStatus {
+        override fun toString() = "FAILED, cause: '$failure'"
+    }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -1,18 +1,22 @@
 package com.wire.kalium.logic.feature.call.usecase
 
+import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.CALLING
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.Call
-import com.wire.kalium.logic.functional.flatMapFromIterable
-import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.functional.nullableFold
+import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 
 interface GetIncomingCallsUseCase {
     suspend operator fun invoke(): Flow<List<Call>>
@@ -35,41 +39,60 @@ internal class GetIncomingCallsUseCaseImpl internal constructor(
     private val conversationRepository: ConversationRepository,
 ) : GetIncomingCallsUseCase {
 
+    private val logger
+        get() = kaliumLogger.withFeatureId(CALLING)
+
     override suspend operator fun invoke(): Flow<List<Call>> {
         return observeIncomingCallsIfUserStatusAllows()
             .onlyCallsInNotMutedConversations()
             .distinctUntilChanged()
+            .onEach { calls ->
+                val callIds = calls.map { call -> call.conversationId }.joinToString()
+                logger.d("$TAG; Emitting result calls: $callIds")
+            }
     }
 
     private suspend fun observeIncomingCallsIfUserStatusAllows(): Flow<List<Call>> =
         userRepository.observeSelfUser()
             .flatMapLatest {
+
                 // if user is AWAY we don't show any IncomingCalls
-                if (it.availabilityStatus == UserAvailabilityStatus.AWAY) flowOf(listOf())
-                else callRepository.incomingCallsFlow().distinctUntilChanged { old, new ->
-                    old.firstOrNull()?.conversationId == new.firstOrNull()?.conversationId
-                }
+                if (it.availabilityStatus == UserAvailabilityStatus.AWAY) {
+                    logger.d("$TAG; Ignoring possible calls based user's status")
+                    flowOf(listOf())
+                } else callRepository.incomingCallsFlow()
+                    .onEach { calls ->
+                        val callIds = calls.map { call -> call.conversationId }.joinToString()
+                        logger.d("$TAG; Found calls: $callIds")
+                    }
+                    .distinctUntilChanged { old, new ->
+                        old.firstOrNull()?.conversationId == new.firstOrNull()?.conversationId
+                    }
             }
 
     private fun Flow<List<Call>>.onlyCallsInNotMutedConversations(): Flow<List<Call>> =
-        flatMapLatest { calls ->
-            calls
-                .flatMapFromIterable { call ->
-                    // getting ConversationDetails for each Call
-                    conversationRepository.observeById(call.conversationId)
-                        .map { it.getOrElse(null) }
-                }
-                .map { conversations ->
-                    val allowedConversations = conversations
-                        .filter { conversationDetails ->
-                            // don't display call if ConversationDetails for it were not found
-                            conversationDetails != null &&
-                                    // don't display call if that Conversation is muted
-                                    conversationDetails.mutedStatus != MutedConversationStatus.AllMuted
-                        }
-                        .map { it!!.id }
+        map { calls ->
+            logger.d("$TAG; Filtering not muted conversations")
 
-                    calls.filter { allowedConversations.contains(it.conversationId) }
-                }
+            // Filter calls if ConversationDetails for it were not found
+            val allowedConversations = calls.mapNotNull { call ->
+                conversationRepository.detailsById(call.conversationId).nullableFold({ null }, { it })
+            }.filter { conversationDetails ->
+                // Don't display call if that Conversation is muted
+                conversationDetails.mutedStatus != MutedConversationStatus.AllMuted
+            }.map { it.id }
+
+            calls.filter { allowedConversations.contains(it.conversationId) }
+        }.onEach { calls ->
+            val callIds = calls.map { call -> call.conversationId }.joinToString()
+            logger.d("$TAG; Filtered calls: $callIds")
         }
+
+    private fun List<ConversationId>.joinToString(): String = joinToString(prefix = "(", postfix = ")") {
+        it.toString().obfuscateId()
+    }
+
+    private companion object {
+        const val TAG = "IncomingCallsUseCase"
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.sync
 
-import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
@@ -56,10 +55,14 @@ internal class SyncManagerImpl(
             val didSlowSyncFail = slowSyncState is SlowSyncStatus.Pending || slowSyncState is SlowSyncStatus.Failed
             val didIncrementalSyncFail = incrementalSyncState is IncrementalSyncStatus.Failed
             val didSyncFail = didSlowSyncFail || didIncrementalSyncFail
-            if (didSyncFail) { emit(false) }
+            if (didSyncFail) {
+                emit(false)
+            }
 
             val isSyncComplete = incrementalSyncState is IncrementalSyncStatus.Live
-            if (isSyncComplete) { emit(true) }
+            if (isSyncComplete) {
+                emit(true)
+            }
         }.first().let { didWaitingSucceed ->
             if (didWaitingSucceed) {
                 logger.d("Waiting until live or failure succeeded")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -1,5 +1,7 @@
 package com.wire.kalium.logic.sync
 
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
@@ -7,6 +9,7 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.combineTransform
 import kotlinx.coroutines.flow.first
 
@@ -40,12 +43,16 @@ internal class SyncManagerImpl(
     private val incrementalSyncRepository: IncrementalSyncRepository,
 ) : SyncManager {
 
+    private val logger
+        get() = kaliumLogger.withFeatureId(SYNC)
+
     override suspend fun waitUntilLive() {
         incrementalSyncRepository.incrementalSyncState.first { it is IncrementalSyncStatus.Live }
     }
 
     override suspend fun waitUntilLiveOrFailure(): Either<NetworkFailure.NoNetworkConnection, Unit> = slowSyncRepository.slowSyncStatus
         .combineTransform(incrementalSyncRepository.incrementalSyncState) { slowSyncState, incrementalSyncState ->
+            logger.d("Waiting until or failure. Current status: slowSync: $slowSyncState; incrementalSync: $incrementalSyncState")
             val didSlowSyncFail = slowSyncState is SlowSyncStatus.Pending || slowSyncState is SlowSyncStatus.Failed
             val didIncrementalSyncFail = incrementalSyncState is IncrementalSyncStatus.Failed
             val didSyncFail = didSlowSyncFail || didIncrementalSyncFail
@@ -55,8 +62,10 @@ internal class SyncManagerImpl(
             if (isSyncComplete) { emit(true) }
         }.first().let { didWaitingSucceed ->
             if (didWaitingSucceed) {
+                logger.d("Waiting until live or failure succeeded")
                 Either.Right(Unit)
             } else {
+                logger.d("Waiting until live or failure failed")
                 Either.Left(NetworkFailure.NoNetworkConnection(null))
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Call Notifications on Reloaded are stuck.

### Causes

Not sure yet. Still investigating.
One possible blocking point can be in `GetIncomingCallsUseCase`:

For each `call` in the list, we call `conversationRepository.observeById`.

However, `observeById` has a `filterNotNull` operator which means that if we pass a conversation that doesn't exist, it will stay there blocked for ever.

### Solutions

Add logs.

Clear up the code a bit and replace `observeById` with `detailsById` which doesn't hang in case the conversation doesn't exist. This _probably_ doesn't fix anything, but at least clears up a bit.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
