### PR TITLE
fix: basic handling to not break sync on user update event

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -265,12 +265,7 @@ sealed class Event(open val id: String) {
         ) : User(id) {
             override fun toString(): String {
                 return "id: ${id.obfuscateId()} " +
-                        "userId: $userId " +
-                        "accentId: $accentId " +
-                        "ssoIdDeleted: $ssoIdDeleted " +
-                        "name: $name" +
-                        "handle: $handle" +
-                        "email: $email"
+                        "userId: ${userId.orEmpty().obfuscateId()} "
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -256,15 +256,20 @@ sealed class Event(open val id: String) {
 
         data class Update(
             override val id: String,
-            val userId: String,
-            val accentId: Int,
-            val ssoIdDeleted: Boolean
+            val userId: String?,
+            val accentId: Int?,
+            val ssoIdDeleted: Boolean?,
+            val name: String?,
+            val handle: String?,
+            val email: String?,
         ) : User(id) {
             override fun toString(): String {
                 return "id: ${id.obfuscateId()} " +
                         "userId: $userId " +
                         "accentId: $accentId " +
-                        "ssoIdDeleted: $ssoIdDeleted"
+                        "name: $name" +
+                        "handle: $handle" +
+                        "email: $email"
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -267,6 +267,7 @@ sealed class Event(open val id: String) {
                 return "id: ${id.obfuscateId()} " +
                         "userId: $userId " +
                         "accentId: $accentId " +
+                        "ssoIdDeleted: $ssoIdDeleted " +
                         "name: $name" +
                         "handle: $handle" +
                         "email: $email"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -240,7 +240,10 @@ class EventMapper(
         id = id,
         userId = event.userData.nonQualifiedUserId,
         accentId = event.userData.accentId,
-        ssoIdDeleted = event.userData.ssoIdDeleted
+        ssoIdDeleted = event.userData.ssoIdDeleted,
+        name = event.userData.name,
+        handle = event.userData.handle,
+        email = event.userData.email,
     )
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -24,7 +24,7 @@ class UserEventReceiverImpl(
             is Event.User.NewConnection -> handleNewConnection(event)
             is Event.User.ClientRemove -> handleClientRemove(event)
             is Event.User.UserDelete -> handleUserDelete(event)
-            is Event.User.Update -> TODO()
+            is Event.User.Update ->  kaliumLogger.w("Not handled yet, WIP: $event")
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -24,7 +24,7 @@ class UserEventReceiverImpl(
             is Event.User.NewConnection -> handleNewConnection(event)
             is Event.User.ClientRemove -> handleClientRemove(event)
             is Event.User.UserDelete -> handleUserDelete(event)
-            is Event.User.Update ->  kaliumLogger.w("Not handled yet, WIP: $event")
+            is Event.User.Update -> kaliumLogger.w("Not handled yet, WIP: $event")
         }
     }
 
@@ -40,13 +40,13 @@ class UserEventReceiverImpl(
     }
 
     private suspend fun handleUserDelete(event: Event.User.UserDelete) {
-            if (selfUserId == event.userId) {
-                logoutUseCase(LogoutReason.DELETED_ACCOUNT)
-            } else {
-                /* TODO: handle a connection delete their account:
-                    update connection, conversations[member left, 1:1 show as the connection is deleted and... */
-            }
+        if (selfUserId == event.userId) {
+            logoutUseCase(LogoutReason.DELETED_ACCOUNT)
+        } else {
+            /* TODO: handle a connection delete their account:
+                update connection, conversations[member left, 1:1 show as the connection is deleted and... */
         }
+    }
 
     private companion object {
         const val TAG = "UserEventReceiver"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/user/ClientEventsData.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/notification/user/ClientEventsData.kt
@@ -22,6 +22,9 @@ data class RemoveClientEventData(
 @Serializable
 data class UserUpdateEventData(
     @SerialName("id") val nonQualifiedUserId: NonQualifiedUserId,
-    @SerialName("accent_id") val accentId: Int,
-    @SerialName("sso_id_deleted") val ssoIdDeleted: Boolean
+    @SerialName("accent_id") val accentId: Int?,
+    @SerialName("name") val name: String?,
+    @SerialName("handle") val handle: String?,
+    @SerialName("email") val email: String?,
+    @SerialName("sso_id_deleted") val ssoIdDeleted: Boolean?
 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Now we are crashing the app when receiving a user update event, this will handle basic infrastructure code to not crash sync and from this built the proper handling

### Causes (Optional)

Not finish the sync process when you receive a user update event


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
