### PR TITLE
fix: app crash when logout while getting messages [AR-1840]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -34,7 +34,8 @@ class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
         logoutRepository.logout()
         sessionRepository.logout(userId = userId, reason)
         if (reason == LogoutReason.SELF_HARD_LOGOUT) {
-            delay(CLEAR_DATA_DELAY) // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
+            // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
+            delay(CLEAR_DATA_DELAY)
             clearClientDataUseCase()
             clearUserDataUseCase() // this clears also current client id
         } else {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when we press log out in the app if we were getting messages at that same time , the app crash due to web socket didn't close 


### Solutions

delay the logout till the websocket closes 


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
