### PR TITLE
feat(connections): refactor db connections and more (AR-2510)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapper.kt
@@ -10,12 +10,11 @@ import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.user.connection.ConnectionDTO
 import com.wire.kalium.persistence.dao.ConnectionEntity
-import com.wire.kalium.persistence.dao.UserEntity
 
 interface ConnectionMapper {
     fun fromApiToDao(state: ConnectionDTO): ConnectionEntity
-    fun fromDaoToModel(state: ConnectionEntity, otherUser: UserEntity?): Connection
-    fun fromDaoToConnectionDetails(state: ConnectionEntity, otherUser: UserEntity?): ConversationDetails
+    fun fromDaoToModel(connection: ConnectionEntity): Connection
+    fun fromDaoToConnectionDetails(connection: ConnectionEntity): ConversationDetails
     fun fromApiToModel(state: ConnectionDTO): Connection
     fun modelToDao(state: Connection): ConnectionEntity
 }
@@ -36,24 +35,26 @@ internal class ConnectionMapperImpl(
         toId = state.toId,
     )
 
-    override fun fromDaoToModel(state: ConnectionEntity, otherUser: UserEntity?): Connection = Connection(
-        conversationId = state.conversationId,
-        from = state.from,
-        lastUpdate = state.lastUpdate,
-        qualifiedConversationId = idMapper.fromDaoModel(state.qualifiedConversationId),
-        qualifiedToId = idMapper.fromDaoModel(state.qualifiedToId),
-        status = statusMapper.fromDaoModel(state.status),
-        toId = state.toId,
-        fromUser = otherUser?.let { publicUserMapper.fromDaoModelToPublicUser(it) }
-    )
+    override fun fromDaoToModel(connection: ConnectionEntity) = with(connection) {
+        Connection(
+            conversationId = conversationId,
+            from = from,
+            lastUpdate = lastUpdate,
+            qualifiedConversationId = idMapper.fromDaoModel(qualifiedConversationId),
+            qualifiedToId = idMapper.fromDaoModel(qualifiedToId),
+            status = statusMapper.fromDaoModel(status),
+            toId = toId,
+            fromUser = otherUser?.let { publicUserMapper.fromDaoModelToPublicUser(it) }
+        )
+    }
 
-    override fun fromDaoToConnectionDetails(connection: ConnectionEntity, otherUser: UserEntity?): ConversationDetails {
-        return ConversationDetails.Connection(
-            conversationId = idMapper.fromDaoModel(connection.qualifiedConversationId),
+    override fun fromDaoToConnectionDetails(connection: ConnectionEntity): ConversationDetails = with(connection) {
+        ConversationDetails.Connection(
+            conversationId = idMapper.fromDaoModel(qualifiedConversationId),
             otherUser = otherUser?.let { publicUserMapper.fromDaoModelToPublicUser(it) },
             userType = otherUser?.let { userTypeMapper.fromUserTypeEntity(it.userType) } ?: UserType.GUEST,
-            lastModifiedDate = connection.lastUpdate,
-            connection = fromDaoToModel(connection, otherUser),
+            lastModifiedDate = lastUpdate,
+            connection = fromDaoToModel(this),
             protocolInfo = ProtocolInfo.Proteus,
             // TODO(qol): need to be refactored
             access = emptyList(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -149,7 +149,6 @@ internal class ConnectionDataSource(
         }
     }
 
-
     override suspend fun observeConnectionRequestsForNotification(): Flow<List<ConversationDetails>> {
         return connectionDAO.getConnectionRequestsForNotification()
             .map {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -64,8 +64,8 @@ internal class ConnectionDataSource(
     private val connectionApi: ConnectionApi,
     private val userDetailsApi: UserDetailsApi,
     private val userDAO: UserDAO,
-    private val selfUser: UserId,
-    private val selfUserTeamId: SelfTeamIdProvider,
+    private val selfUserId: UserId,
+    private val selfTeamIdProvider: SelfTeamIdProvider,
     private val idMapper: IdMapper = MapperProvider.idMapper(),
     private val connectionStatusMapper: ConnectionStatusMapper = MapperProvider.connectionStatusMapper(),
     private val connectionMapper: ConnectionMapper = MapperProvider.connectionMapper(),
@@ -185,7 +185,7 @@ internal class ConnectionDataSource(
     ) = wrapStorageRequest {
         connectionDAO.insertConnection(connectionMapper.modelToDao(connection))
     }.flatMap {
-        selfUserTeamId.invoke().flatMap { teamId ->
+        selfTeamIdProvider().flatMap { teamId ->
             // This can fail, but the connection will be there and get synced in worst case scenario in next SlowSync
             wrapApiRequest {
                 userDetailsApi.getUserInfo(idMapper.toApiModel(connection.qualifiedToId))
@@ -198,7 +198,7 @@ internal class ConnectionDataSource(
                             otherUserDomain = userProfileDTO.id.domain,
                             selfUserTeamId = teamId?.value,
                             otherUserTeamId = userProfileDTO.teamId,
-                            selfUserDomain = selfUser.domain,
+                            selfUserDomain = selfUserId.domain,
                             isService = userProfileDTO.service != null
                         )
                     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.data.featureConfig.FeatureConfigDataSource
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.keypackage.KeyPackageDataSource
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProviderImpl
@@ -116,6 +117,8 @@ import com.wire.kalium.logic.feature.user.SyncSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UserScope
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.isRight
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import com.wire.kalium.logic.sync.SetConnectionPolicyUseCase
@@ -162,6 +165,11 @@ expect class UserSessionScope : UserSessionScopeCommon
 fun interface CurrentClientIdProvider {
     suspend operator fun invoke(): Either<CoreFailure, ClientId>
 }
+
+fun interface SelfTeamIdProvider {
+    suspend operator fun invoke(): Either<CoreFailure, TeamId?>
+}
+
 
 @Suppress("LongParameterList")
 abstract class UserSessionScopeCommon internal constructor(
@@ -275,7 +283,8 @@ abstract class UserSessionScopeCommon internal constructor(
             authenticatedDataSourceSet.authenticatedNetworkContainer.connectionApi,
             authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi,
             userDatabaseProvider.userDAO,
-            userDatabaseProvider.metadataDAO
+            userId,
+            selfTeamId
         )
 
     private val userSearchApiWrapper: UserSearchApiWrapper = UserSearchApiWrapperImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -170,7 +170,6 @@ fun interface SelfTeamIdProvider {
     suspend operator fun invoke(): Either<CoreFailure, TeamId?>
 }
 
-
 @Suppress("LongParameterList")
 abstract class UserSessionScopeCommon internal constructor(
     private val userId: UserId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapperTest.kt
@@ -47,7 +47,7 @@ class ConnectionMapperTest {
         val (arrangement, mapper) = Arrangement().arrange()
 
         // when
-        val connectionEntity = mapper.fromDaoToModel(arrangement.stubConnectionEntity, null)
+        val connectionEntity = mapper.fromDaoToModel(arrangement.stubConnectionEntity)
 
         // then
         assertEquals(ConnectionState.ACCEPTED, connectionEntity.status)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -3,8 +3,6 @@ package com.wire.kalium.logic.data.connection
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.ConnectionState
-import com.wire.kalium.logic.data.user.SelfUser
-import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.SelfTeamIdProvider
 import com.wire.kalium.logic.framework.TestConversation

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -260,7 +260,6 @@ class ConnectionRepositoryTest {
         val (arrangement, connectionRepository) = Arrangement().arrange()
         arrangement.withErrorUpdatingConnectionStatusResponse(userId)
 
-
         // when
         val result = connectionRepository.updateConnectionStatus(UserId(userId.value, userId.domain), ConnectionState.PENDING)
 
@@ -343,8 +342,6 @@ class ConnectionRepositoryTest {
             service = null
         )
 
-        val stubJsonQualifiedId = """{"value":"test" , "domain":"test" }"""
-
         val stubUserEntity = UserEntity(
             id = QualifiedIDEntity("value", "domain"),
             name = null,
@@ -360,20 +357,6 @@ class ConnectionRepositoryTest {
             userType = UserTypeEntity.EXTERNAL,
             botService = null,
             deleted = false
-        )
-
-        val stubSelfUser = SelfUser(
-            id = com.wire.kalium.logic.data.id.QualifiedID("someValue", "someId"),
-            name = null,
-            handle = null,
-            email = null,
-            phone = null,
-            accentId = 0,
-            teamId = null,
-            connectionStatus = ConnectionState.NOT_CONNECTED,
-            previewPicture = null,
-            completePicture = null,
-            availabilityStatus = UserAvailabilityStatus.AVAILABLE,
         )
 
         val stubConversationID1 = QualifiedIDEntity("conversationId1", "domain")
@@ -471,7 +454,6 @@ class ConnectionRepositoryTest {
             given(conversationDAO)
                 .suspendFunction(conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
                 .whenInvokedWith(any(), any(), any())
-
 
             given(userDAO).suspendFunction(userDAO::getUserByQualifiedID)
                 .whenInvokedWith(any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
@@ -60,11 +60,6 @@ class SearchUserUseCaseTest {
         searchPublicUsersUseCase = SearchPublicUsersUseCaseImpl(searchUserRepository, connectionRepository, qualifiedIdMapper)
 
         given(connectionRepository)
-            .suspendFunction(connectionRepository::getConnectionRequests)
-            .whenInvoked()
-            .thenReturn(listOf())
-
-        given(connectionRepository)
             .suspendFunction(connectionRepository::observeConnectionList)
             .whenInvoked()
             .thenReturn(flowOf(listOf()))

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
@@ -1,6 +1,5 @@
 import com.wire.kalium.persistence.dao.ConnectionEntity;
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
-import kotlin.Int;
 import kotlin.Boolean;
 
 CREATE TABLE Connection (
@@ -13,9 +12,6 @@ CREATE TABLE Connection (
     status TEXT AS ConnectionEntity.State NOT NULL DEFAULT 'NOT_CONNECTED',
     should_notify INTEGER AS Boolean DEFAULT 1
 );
-
-deleteAllConnections:
-DELETE FROM Connection;
 
 deleteConnection:
 DELETE FROM Connection WHERE qualified_conversation = ?;
@@ -41,10 +37,7 @@ getConnections:
 SELECT * FROM Connection;
 
 selectConnectionRequests:
-SELECT * FROM Connection WHERE status = 'SENT' OR status = 'PENDING' OR status = 'IGNORED';
+SELECT * FROM Connection LEFT JOIN User ON Connection.qualified_to == User.qualified_id WHERE status = 'SENT' OR status = 'PENDING' OR status = 'IGNORED';
 
 selectConnectionsForNotification:
-SELECT * FROM Connection WHERE status = 'PENDING' AND should_notify = 1;
-
-selectChanges:
-SELECT changes();
+SELECT * FROM Connection LEFT JOIN User ON Connection.qualified_to == User.qualified_id WHERE status = 'PENDING' AND should_notify = 1;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
@@ -10,7 +10,8 @@ data class ConnectionEntity(
     val qualifiedToId: QualifiedIDEntity,
     val status: State,
     val toId: String,
-    val shouldNotify: Boolean? = null
+    val shouldNotify: Boolean? = null,
+    val otherUser: UserEntity? = null
 ) {
 
     enum class State {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
@@ -20,7 +20,7 @@ private class ConnectionMapper {
         toId = state.to_id,
         shouldNotify = state.should_notify
     )
-
+    @Suppress("FunctionParameterNaming", "LongParameterList")
     fun toModel(
         from_id: String,
         conversation_id: String,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
@@ -5,6 +5,7 @@ import com.squareup.sqldelight.runtime.coroutines.mapToList
 import com.wire.kalium.persistence.Connection as SQLDelightConnection
 import com.wire.kalium.persistence.ConnectionsQueries
 import com.wire.kalium.persistence.ConversationsQueries
+import com.wire.kalium.persistence.util.requireField
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -19,6 +20,57 @@ private class ConnectionMapper {
         toId = state.to_id,
         shouldNotify = state.should_notify
     )
+
+    fun toModel(
+        from_id: String,
+        conversation_id: String,
+        qualified_conversation: QualifiedIDEntity,
+        to_id: String,
+        last_update: String,
+        qualified_to: QualifiedIDEntity,
+        status: ConnectionEntity.State,
+        should_notify: Boolean?,
+        qualified_id: QualifiedIDEntity?,
+        name: String?,
+        handle: String?,
+        email: String?,
+        phone: String?,
+        accent_id: Int?,
+        team: String?,
+        connection_status: ConnectionEntity.State?,
+        preview_asset_id: QualifiedIDEntity?,
+        complete_asset_id: QualifiedIDEntity?,
+        user_availability_status: UserAvailabilityStatusEntity?,
+        user_type: UserTypeEntity?,
+        bot_service: BotEntity?,
+        deleted: Boolean?
+    ): ConnectionEntity = ConnectionEntity(
+        conversationId = conversation_id,
+        from = from_id,
+        lastUpdate = last_update,
+        qualifiedConversationId = qualified_conversation,
+        qualifiedToId = qualified_to,
+        status = status,
+        toId = to_id,
+        shouldNotify = should_notify,
+        otherUser = if (qualified_id != null) UserEntity(
+            id = qualified_id,
+            name = name,
+            handle = handle,
+            email = email,
+            phone = phone,
+            accentId = accent_id.requireField("accent_id"),
+            team = team,
+            connectionStatus = connection_status.requireField("connection_status"),
+            previewAssetId = preview_asset_id,
+            completeAssetId = complete_asset_id,
+            availabilityStatus = user_availability_status.requireField("user_availability_status"),
+            userType = user_type.requireField("user_type"),
+            botService = bot_service,
+            deleted = deleted.requireField("deleted"),
+        ) else null
+    )
+
 }
 
 class ConnectionDAOImpl(
@@ -35,10 +87,9 @@ class ConnectionDAOImpl(
     }
 
     override suspend fun getConnectionRequests(): Flow<List<ConnectionEntity>> {
-        return connectionsQueries.selectConnectionRequests()
+        return connectionsQueries.selectConnectionRequests(connectionMapper::toModel)
             .asFlow()
             .mapToList()
-            .map { it.map(connectionMapper::toModel) }
     }
 
     override suspend fun insertConnection(connectionEntity: ConnectionEntity) {
@@ -81,10 +132,9 @@ class ConnectionDAOImpl(
     }
 
     override suspend fun getConnectionRequestsForNotification(): Flow<List<ConnectionEntity>> {
-        return connectionsQueries.selectConnectionsForNotification()
+        return connectionsQueries.selectConnectionsForNotification(connectionMapper::toModel)
             .asFlow()
             .mapToList()
-            .map { it.map(connectionMapper::toModel) }
     }
 
     override suspend fun updateNotificationFlag(flag: Boolean, userId: QualifiedIDEntity) {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.UserTypeEntity
+import com.wire.kalium.persistence.util.requireField
 
 @Suppress("LongParameterList")
 object MessageMapper {
@@ -155,9 +156,5 @@ object MessageMapper {
             visibility,
             it
         )
-    }
-
-    private inline fun <reified T> T?.requireField(fieldName: String): T = requireNotNull(this) {
-        "Fild $fieldName null when unpacking message content"
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/util/MapperUtil.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/util/MapperUtil.kt
@@ -1,0 +1,5 @@
+package com.wire.kalium.persistence.util
+
+inline fun <reified T> T?.requireField(fieldName: String): T = requireNotNull(this) {
+    "Field $fieldName null when unpacking db content"
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Due to the DB performance issues, we found some places where we were querying the database nested in other queries.
- Injected the selfUserId instead of querying it every time
- Injected the teamId instead of querying it every time

When we fetch the connection, we need the other user info as well; we were fetching those data by querying the user info by the userId that exists in the connection; replace it with a join query, and now we return the userInfo with the connection data directly from the database.

### Issues
- Queries nested in other queries in the DAO layer instead of joins on the db level
- Queries nested in other queries in the DAO layer instead of injecting the cached values like the selfUserId


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
