### PR TITLE
fix: app crash when call after login

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -33,7 +33,7 @@ actual class UserSessionScopeProviderImpl(
     private val globalPreferences: GlobalPrefProvider,
     private val globalCallManager: GlobalCallManager,
     private val idMapper: IdMapper
-) : UserSessionScopeProviderCommon() {
+) : UserSessionScopeProviderCommon(globalCallManager) {
 
     override fun create(userId: UserId): UserSessionScope {
         val rootAccountPath = "$rootPath/${userId.domain}/${userId.value}"

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -6,23 +6,27 @@ import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.ENVIRONMENT_DEFAULT
 import com.wire.kalium.calling.callbacks.LogHandler
 import com.wire.kalium.logic.callingLogger
-import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
+import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
+import io.ktor.util.collections.ConcurrentMap
 import kotlinx.coroutines.Dispatchers
 
 actual class GlobalCallManager(
     appContext: Context
 ) {
 
-    private val callManagerHolder = hashMapOf<QualifiedID, CallManager>()
+    private val callManagerHolder: ConcurrentMap<QualifiedID, CallManager> by lazy {
+        ConcurrentMap()
+    }
 
     private val calling by lazy {
         Calling.INSTANCE.apply {
@@ -65,6 +69,10 @@ actual class GlobalCallManager(
         ).also {
             callManagerHolder[userId] = it
         }
+    }
+
+    actual fun removeInMemoryCallingManagerForUser(userId: UserId) {
+        callManagerHolder.remove(userId)
     }
 
     // Initialize it eagerly, so it's already initialized when `calling` is initialized

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.feature
 
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.GlobalCallManager
 import io.ktor.util.collections.ConcurrentMap
 
 interface UserSessionScopeProvider {
@@ -9,7 +10,9 @@ interface UserSessionScopeProvider {
     fun delete(userId: UserId)
 }
 
-abstract class UserSessionScopeProviderCommon : UserSessionScopeProvider {
+abstract class UserSessionScopeProviderCommon(
+    private val globalCallManager: GlobalCallManager
+) : UserSessionScopeProvider {
 
     private val userScopeStorage: ConcurrentMap<UserId, UserSessionScope> by lazy {
         ConcurrentMap()
@@ -21,6 +24,7 @@ abstract class UserSessionScopeProviderCommon : UserSessionScopeProvider {
     override fun get(userId: UserId): UserSessionScope? = userScopeStorage.get(userId)
 
     override fun delete(userId: UserId) {
+        globalCallManager.removeInMemoryCallingManagerForUser(userId)
         userScopeStorage.remove(userId)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -8,6 +8,7 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.message.MessageSender
@@ -28,6 +29,7 @@ expect class GlobalCallManager {
         videoStateChecker: VideoStateChecker
     ): CallManager
 
+    fun removeInMemoryCallingManagerForUser(userId: UserId)
     fun getFlowManager(): FlowManagerService
     fun getMediaManager(): MediaManagerService
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -31,7 +31,7 @@ actual class UserSessionScopeProviderImpl(
     private val globalPreferences: GlobalPrefProvider,
     private val globalCallManager: GlobalCallManager,
     private val idMapper: IdMapper
-) : UserSessionScopeProviderCommon() {
+) : UserSessionScopeProviderCommon(globalCallManager) {
 
     override fun create(userId: UserId): UserSessionScope {
         val rootAccountPath = "$rootPath/${userId.domain}/${userId.value}"

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -28,7 +28,9 @@ actual class GlobalCallManager {
         videoStateChecker: VideoStateChecker
     ): CallManager = CallManagerImpl()
 
-    actual fun removeInMemoryCallingManagerForUser(userId: UserId) {} // todo how to delete it in JVM ?
+    actual fun removeInMemoryCallingManagerForUser(userId: UserId) {
+        // todo how to delete it in JVM ?
+    }
     actual fun getFlowManager(): FlowManagerService = FlowManagerServiceImpl()
     actual fun getMediaManager(): MediaManagerService = MediaManagerServiceImpl()
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -1,13 +1,14 @@
 package com.wire.kalium.logic.feature.call
 
-import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
+import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSender
 
@@ -27,6 +28,7 @@ actual class GlobalCallManager {
         videoStateChecker: VideoStateChecker
     ): CallManager = CallManagerImpl()
 
+    actual fun removeInMemoryCallingManagerForUser(userId: UserId) {} // todo how to delete it in JVM ?
     actual fun getFlowManager(): FlowManagerService = FlowManagerServiceImpl()
     actual fun getMediaManager(): MediaManagerService = MediaManagerServiceImpl()
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when we logout and login again without closing tha app , if we try to make the call the app will crash

### Causes (Optional)
the call manager was keeping the reference of the user id even after clear the user session provider

(we might need to update the call manager to be client related here )

### Solutions

clear the user from the call manager holder whenever we logout


### Testing

#### How to Test

login , logout , login again without close the app , try to make  a call 


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
