### PR TITLE
fix: update IncrementalSyncState state to pending after executing while policy allows (AR-2437)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.transformWhile
 
@@ -111,6 +110,7 @@ internal class EventGathererImpl(
             null -> logger.i("Websocket closed normally")
             is IOException ->
                 throw KaliumSyncException("Websocket disconnected", NetworkFailure.NoNetworkConnection(cause))
+
             else ->
                 throw KaliumSyncException("Unknown Websocket error: $cause, message: ${cause.message}", CoreFailure.Unknown(cause))
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.transformWhile
 
@@ -76,6 +77,8 @@ internal class EventGathererImpl(
             // throw so it is handled by coroutineExceptionHandler
             throw KaliumSyncException("Failure when gathering events", it)
         }
+        // When it ends, reset source back to PENDING
+        _currentSource.value = EventSource.PENDING
     }
 
     private suspend fun FlowCollector<Event>.handleWebSocketEventsWhilePolicyAllows(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -89,7 +89,6 @@ internal class IncrementalSyncManager(
                     // START SYNC. The ConnectionPolicy doesn't matter the first time
                     kaliumLogger.i("$TAG Starting IncrementalSync, as SlowSync is completed")
                     doIncrementalSyncWhilePolicyAllows()
-                    incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
                     kaliumLogger.i("$TAG IncrementalSync finished normally. Starting to observe ConnectionPolicy upgrade")
                     observeConnectionPolicyUpgrade()
                 }
@@ -119,6 +118,7 @@ internal class IncrementalSyncManager(
                 }
                 incrementalSyncRepository.updateIncrementalSyncState(newState)
             }
+        incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
         kaliumLogger.i("$TAG IncrementalSync stopped.")
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -16,7 +16,6 @@ import io.mockative.given
 import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
-import io.mockative.times
 import io.mockative.twice
 import io.mockative.verify
 import kotlinx.coroutines.channels.Channel
@@ -178,6 +177,51 @@ class IncrementalSyncManagerTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenDisconnectPolicy_whenWorkerCompletes_thenShouldUpdateIncrementalSyncStatusToPending() = runTest(TestKaliumDispatcher.default) {
+        val connectionPolicyState = MutableStateFlow(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+
+        val (arrangement, _) = Arrangement()
+            .withWorkerReturning(emptyFlow())
+            .withConnectionPolicyReturning(connectionPolicyState)
+            .arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+        advanceUntilIdle()
+
+        verify(arrangement.incrementalSyncRepository)
+            .suspendFunction(arrangement.incrementalSyncRepository::updateIncrementalSyncState)
+            .with(eq(IncrementalSyncStatus.Pending))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenPolicyUpAndDowngrade_whenWorkerTheSecondTime_thenShouldUpdateIncrementalSyncStatusToPendingAgain() =
+        runTest(TestKaliumDispatcher.default) {
+            val connectionPolicyState = MutableStateFlow(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+
+            val (arrangement, _) = Arrangement()
+                .withWorkerReturning(emptyFlow())
+                .withConnectionPolicyReturning(connectionPolicyState)
+                .arrange()
+            arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+            advanceUntilIdle()
+
+            // Upgrade
+            connectionPolicyState.value = ConnectionPolicy.KEEP_ALIVE
+            advanceUntilIdle()
+
+            // Downgrade
+            connectionPolicyState.value = ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS
+            advanceUntilIdle()
+
+            verify(arrangement.incrementalSyncRepository)
+                .suspendFunction(arrangement.incrementalSyncRepository::updateIncrementalSyncState)
+                .with(eq(IncrementalSyncStatus.Pending))
+                .wasInvoked(exactly = twice)
+        }
+
     private class Arrangement {
 
         val slowSyncRepository: SlowSyncRepository = InMemorySlowSyncRepository()
@@ -188,9 +232,11 @@ class IncrementalSyncManagerTest {
         @Mock
         val incrementalSyncRepository = configure(mock(classOf<IncrementalSyncRepository>())) { stubsUnitByDefault = true }
 
-        private val incrementalSyncManager = IncrementalSyncManager(
-            slowSyncRepository, incrementalSyncWorker, incrementalSyncRepository, TestKaliumDispatcher
-        )
+        private val incrementalSyncManager by lazy {
+            IncrementalSyncManager(
+                slowSyncRepository, incrementalSyncWorker, incrementalSyncRepository, TestKaliumDispatcher
+            )
+        }
 
         fun withWorkerReturning(sourceFlow: Flow<EventSource>) = apply {
             given(incrementalSyncWorker)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After fetching pending events, and the `ConnectionPolicy` is `DISCONNECT_AFTER_PENDING_EVENTS`, `SyncState` stays on `LIVE`.

This is unintuitive and is a problem on Reloaded, because Reloaded does:
```kotlin
upgradePolicy()
waitUntilLive()
downgradePolicy()
```

However, takes a few CPU cycles until `IncrementalSyncManager` collects the change in `ConnectionPolicy`, and during this short time the `IncrementalSyncStatus` is still `LIVE`.

Which means that `waitUntilLive` returns immediatelly.

Reloaded would need to put an arbitrary delay between `upgradePolicy()` and `waitUntilLive()` in order to properly wait until Sync finishes.

### Solutions

Make sure that **every time** that incremental sync stops, the state goes back to `Pending`.
This way, when performing `waitUntilLive`, the state won't be falsely reported as `LIVE` and return immediatelly.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
