### PR TITLE
fix: event role member missing (AR-2523)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -109,11 +109,11 @@ sealed class Event(open val id: String) {
             }
         }
 
-        data class MemberChanged(
+        open class MemberChanged(
             override val id: String,
             override val conversationId: ConversationId,
             val timestampIso: String,
-            val member: Member,
+            val member: Member?,
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
                 return "id: ${id.obfuscateId()} " +
@@ -121,6 +121,11 @@ sealed class Event(open val id: String) {
                         "member: $member timestampIso: $timestampIso"
             }
         }
+
+        data class IgnoredMemberChanged(
+            override val id: String,
+            override val conversationId: ConversationId
+        ) : MemberChanged(id, conversationId, "", null)
 
         data class MLSWelcome(
             override val id: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -144,15 +144,21 @@ class EventMapper(
     private fun memberUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MemberUpdateDTO
-    ) = Event.Conversation.MemberChanged(
-        id = id,
-        conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
-        timestampIso = eventContentDTO.time,
-        member = Conversation.Member(
-            id = idMapper.fromApiModel(eventContentDTO.roleChange.qualifiedUserId),
-            role = roleMapper.fromApi(eventContentDTO.roleChange.role)
-        ),
-    )
+    ): Event.Conversation.MemberChanged {
+        return if (eventContentDTO.roleChange.role.isNullOrEmpty()) {
+            Event.Conversation.IgnoredMemberChanged(id, idMapper.fromApiModel(eventContentDTO.qualifiedConversation))
+        } else {
+            Event.Conversation.MemberChanged(
+                id = id,
+                conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+                timestampIso = eventContentDTO.time,
+                member = Conversation.Member(
+                    id = idMapper.fromApiModel(eventContentDTO.roleChange.qualifiedUserId),
+                    role = roleMapper.fromApi(eventContentDTO.roleChange.role.orEmpty())
+                ),
+            )
+        }
+    }
 
     private fun featureConfig(
         id: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -322,7 +322,7 @@ internal class ConversationEventReceiverImpl(
 
     private suspend fun handleMemberChange(event: Event.Conversation.MemberChanged) {
         if (event is Event.Conversation.IgnoredMemberChanged) {
-            logger.w("failure member role is not present: $event")
+            logger.w("failure? member role is missing from event: $event")
             return
         } else {
             // Attempt to fetch conversation details if needed, as this might be an unknown conversation
@@ -335,8 +335,8 @@ internal class ConversationEventReceiverImpl(
                         logger.w("Failure fetching conversation details on MemberChange Event: $event")
                     }
                     // Even if unable to fetch conversation details, at least attempt updating the member
-                    event.member?.let { conversationRepository.updateMemberFromEvent(it, event.conversationId) }
-                }?.onFailure { logger.e("$TAG - failure on member update event: $it") }
+                    conversationRepository.updateMemberFromEvent(event.member!!, event.conversationId)
+                }.onFailure { logger.e("$TAG - failure on member update event: $it") }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -84,6 +84,8 @@ internal class ConversationEventReceiverImpl(
     private val protoContentMapper: ProtoContentMapper = MapperProvider.protoContentMapper(),
 ) : ConversationEventReceiver {
 
+    private val logger by lazy { kaliumLogger.withFeatureId(EVENT_RECEIVER) }
+
     override suspend fun onEvent(event: Event.Conversation) {
         when (event) {
             is Event.Conversation.NewMessage -> handleNewMessage(event)
@@ -158,13 +160,13 @@ internal class ConversationEventReceiverImpl(
             .flatMap { plainMessageBlob -> getReadableMessageContent(plainMessageBlob, event) }
             .onFailure {
                 when (it) {
-                    is CoreFailure.Unknown -> kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                    is CoreFailure.Unknown -> logger
                         .e("$TAG - UnknownFailure when processing message: $it", it.rootCause)
 
-                    is ProteusFailure -> kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                    is ProteusFailure -> logger
                         .e("$TAG - ProteusFailure when processing message: $it", it.proteusException)
 
-                    else -> kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - Failure when processing message: $it")
+                    else -> logger.e("$TAG - Failure when processing message: $it")
                 }
                 handleFailedProteusDecryptedMessage(event)
             }.onSuccess { readableContent ->
@@ -218,7 +220,7 @@ internal class ConversationEventReceiverImpl(
     ) = when (val protoContent = protoContentMapper.decodeFromProtobuf(plainMessageBlob)) {
         is ProtoContent.Readable -> Either.Right(protoContent)
         is ProtoContent.ExternalMessageInstructions -> event.encryptedExternalContent?.let {
-            kaliumLogger.withFeatureId(EVENT_RECEIVER).d("Solving external content '$protoContent', EncryptedData='$it'")
+            logger.d("Solving external content '$protoContent', EncryptedData='$it'")
             solveExternalContentForProteusMessage(protoContent, event.encryptedExternalContent)
         } ?: run {
             val rootCause = IllegalArgumentException("Null external content when processing external message instructions.")
@@ -231,7 +233,7 @@ internal class ConversationEventReceiverImpl(
         externalData: EncryptedData
     ): Either<CoreFailure, ProtoContent.Readable> = wrapCryptoRequest {
         val decryptedExternalMessage = decryptDataWithAES256(externalData, AES256Key(externalInstructions.otrKey)).data
-        kaliumLogger.withFeatureId(EVENT_RECEIVER).d("ExternalMessage - Decrypted external message content: '$decryptedExternalMessage'")
+        logger.d("ExternalMessage - Decrypted external message content: '$decryptedExternalMessage'")
         PlainMessageBlob(decryptedExternalMessage)
     }.map(protoContentMapper::decodeFromProtobuf).flatMap { decodedProtobuf ->
         if (decodedProtobuf !is ProtoContent.Readable) {
@@ -274,18 +276,18 @@ internal class ConversationEventReceiverImpl(
     private suspend fun handleNewConversation(event: Event.Conversation.NewConversation) =
         conversationRepository.insertConversationFromEvent(event).flatMap {
             conversationRepository.updateConversationModifiedDate(event.conversationId, Clock.System.now().toString())
-        }.onFailure { kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on new conversation event: $it") }
+        }.onFailure { logger.e("$TAG - failure on new conversation event: $it") }
 
     private suspend fun handleMemberJoin(event: Event.Conversation.MemberJoin) =
         // Attempt to fetch conversation details if needed, as this might be an unknown conversation
         conversationRepository.fetchConversationIfUnknown(event.conversationId)
             .run {
                 onSuccess {
-                    kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                    logger.withFeatureId(EVENT_RECEIVER)
                         .v("Succeeded fetching conversation details on MemberJoin Event: $event")
                 }
                 onFailure {
-                    kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                    logger.withFeatureId(EVENT_RECEIVER)
                         .w("Failure fetching conversation details on MemberJoin Event: $event")
                 }
                 // Even if unable to fetch conversation details, at least attempt adding the member
@@ -301,7 +303,7 @@ internal class ConversationEventReceiverImpl(
                     visibility = Message.Visibility.VISIBLE
                 )
                 processMessage(message) // TODO(exception-handling): processMessage exceptions are not caught
-            }.onFailure { kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member join event: $it") }
+            }.onFailure { logger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member join event: $it") }
 
     private suspend fun handleMemberLeave(event: Event.Conversation.MemberLeave) = conversationRepository
         .deleteMembersFromEvent(event.removedList, event.conversationId)
@@ -322,39 +324,38 @@ internal class ConversationEventReceiverImpl(
             )
             processMessage(message)
         }
-        .onFailure { kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member leave event: $it") }
+        .onFailure { logger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member leave event: $it") }
 
     private suspend fun handleMemberChange(event: Event.Conversation.MemberChanged) {
         if (event is Event.Conversation.IgnoredMemberChanged) {
-            kaliumLogger.withFeatureId(EVENT_RECEIVER).w("Failure member role is : $event")
+            logger.w("failure member role is not present: $event")
             return
         } else {
             // Attempt to fetch conversation details if needed, as this might be an unknown conversation
             conversationRepository.fetchConversationIfUnknown(event.conversationId)
                 .run {
                     onSuccess {
-                        kaliumLogger.withFeatureId(EVENT_RECEIVER)
-                            .v("Succeeded fetching conversation details on MemberChange Event: $event")
+                        logger.v("Succeeded fetching conversation details on MemberChange Event: $event")
                     }
                     onFailure {
-                        kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                        logger.withFeatureId(EVENT_RECEIVER)
                             .w("Failure fetching conversation details on MemberChange Event: $event")
                     }
                     // Even if unable to fetch conversation details, at least attempt updating the member
                     event.member?.let { conversationRepository.updateMemberFromEvent(it, event.conversationId) }
-                }?.onFailure { kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member update event: $it") }
+                }?.onFailure { logger.e("$TAG - failure on member update event: $it") }
         }
     }
 
     private suspend fun handleMLSWelcome(event: Event.Conversation.MLSWelcome) {
         mlsConversationRepository.establishMLSGroupFromWelcome(event)
-            .onFailure { kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on MLS welcome event: $it") }
+            .onFailure { logger.e("$TAG - failure on MLS welcome event: $it") }
     }
 
     private suspend fun handleNewMLSMessage(event: Event.Conversation.NewMLSMessage) =
         mlsConversationRepository.messageFromMLSMessage(event)
             .onFailure {
-                kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on MLS message: $it")
+                logger.e("$TAG - failure on MLS message: $it")
                 handleFailedMLSDecryptedMessage(event)
             }.onSuccess { bundle ->
                 if (bundle == null) return@onSuccess
@@ -387,22 +388,22 @@ internal class ConversationEventReceiverImpl(
         if (conversation != null) {
             conversationRepository.deleteConversation(event.conversationId)
                 .onFailure { coreFailure ->
-                    kaliumLogger.withFeatureId(EVENT_RECEIVER).e("$TAG - Error deleting the contents of a conversation $coreFailure")
+                    logger.e("$TAG - Error deleting the contents of a conversation $coreFailure")
                 }.onSuccess {
                     val senderUser = userRepository.observeUser(event.senderUserId).firstOrNull()
                     val dataNotification = EphemeralConversationNotification(event, conversation, senderUser)
                     ephemeralNotificationsManager.scheduleNotification(dataNotification)
-                    kaliumLogger.withFeatureId(EVENT_RECEIVER).d("$TAG - Deleted the conversation ${event.conversationId}")
+                    logger.d("$TAG - Deleted the conversation ${event.conversationId}")
                 }
         } else {
-            kaliumLogger.withFeatureId(EVENT_RECEIVER).d("$TAG - Skipping conversation delete event already handled")
+            logger.d("$TAG - Skipping conversation delete event already handled")
         }
     }
 
     private suspend fun handleRenamedConversation(event: Event.Conversation.RenamedConversation) {
         conversationRepository.updateConversationName(event.conversationId, event.conversationName, event.timestampIso)
             .onSuccess {
-                kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                logger
                     .d("$TAG - The Conversation was renamed: ${event.conversationId.toString().obfuscateId()}")
                 val message = Message.System(
                     id = event.id,
@@ -415,13 +416,13 @@ internal class ConversationEventReceiverImpl(
                 persistMessage(message)
             }
             .onFailure { coreFailure ->
-                kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                logger
                     .e("$TAG - Error renaming the conversation [${event.conversationId.toString().obfuscateId()}] $coreFailure")
             }
     }
 
     private suspend fun handlePendingProposal(timestamp: Instant, groupId: GroupID, commitDelay: Long) {
-        kaliumLogger.withFeatureId(EVENT_RECEIVER).d("Received MLS proposal, scheduling commit in $commitDelay seconds")
+        logger.d("Received MLS proposal, scheduling commit in $commitDelay seconds")
         pendingProposalScheduler.scheduleCommit(
             groupId,
             timestamp.plus(commitDelay.seconds)
@@ -431,12 +432,12 @@ internal class ConversationEventReceiverImpl(
     private suspend fun processSignaling(senderUserId: UserId, signaling: MessageContent.Signaling) {
         when (signaling) {
             MessageContent.Ignored -> {
-                kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                logger
                     .i(message = "$TAG Ignored Signaling Message received: $signaling")
             }
 
             is MessageContent.Availability -> {
-                kaliumLogger.withFeatureId(EVENT_RECEIVER)
+                logger
                     .i(message = "$TAG Availability status update received: ${signaling.status}")
                 userRepository.updateOtherUserAvailabilityStatus(senderUserId, signaling.status)
             }
@@ -446,7 +447,7 @@ internal class ConversationEventReceiverImpl(
     // TODO(qol): split this function so it's easier to maintain
     @Suppress("ComplexMethod", "LongMethod")
     private suspend fun processMessage(message: Message) {
-        kaliumLogger.withFeatureId(EVENT_RECEIVER).i(message = "$TAG Message received: $message")
+        logger.i(message = "$TAG Message received: $message")
 
         when (message) {
             is Message.Regular -> when (val content = message.content) {
@@ -456,7 +457,7 @@ internal class ConversationEventReceiverImpl(
                 is MessageContent.DeleteMessage -> handleDeleteMessage(content, message)
                 is MessageContent.DeleteForMe -> deleteForMeHandler.handle(message, content)
                 is MessageContent.Calling -> {
-                    kaliumLogger.withFeatureId(EVENT_RECEIVER).d("$TAG - MessageContent.Calling")
+                    logger.d("$TAG - MessageContent.Calling")
                     callManagerImpl.value.onCallingMessageReceived(
                         message = message,
                         content = content
@@ -466,7 +467,7 @@ internal class ConversationEventReceiverImpl(
                 is MessageContent.TextEdited -> editTextHandler.handle(message, content)
                 is MessageContent.LastRead -> lastReadContentHandler.handle(message, content)
                 is MessageContent.Unknown -> {
-                    kaliumLogger.withFeatureId(EVENT_RECEIVER).i(message = "Unknown Message received: $message")
+                    logger.i(message = "Unknown Message received: $message")
                     persistMessage(message)
                 }
 
@@ -476,7 +477,7 @@ internal class ConversationEventReceiverImpl(
 
             is Message.System -> when (message.content) {
                 is MessageContent.MemberChange -> {
-                    kaliumLogger.withFeatureId(EVENT_RECEIVER).i(message = "System MemberChange Message received: $message")
+                    logger.i(message = "System MemberChange Message received: $message")
                     persistMessage(message)
                 }
             }
@@ -552,7 +553,7 @@ internal class ConversationEventReceiverImpl(
                             )
                         )
                             .onFailure {
-                                kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.ASSETS)
+                                logger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.ASSETS)
                                     .w("delete messageToRemove asset locally failure: $it")
                             }
                     }
@@ -561,7 +562,7 @@ internal class ConversationEventReceiverImpl(
                 messageUuid = content.messageId,
                 conversationId = message.conversationId
             )
-        } else kaliumLogger.withFeatureId(EVENT_RECEIVER).i(message = "Delete message sender is not verified: $message")
+        } else logger.i(message = "Delete message sender is not verified: $message")
     }
 
     private companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -160,12 +160,8 @@ internal class ConversationEventReceiverImpl(
             .flatMap { plainMessageBlob -> getReadableMessageContent(plainMessageBlob, event) }
             .onFailure {
                 when (it) {
-                    is CoreFailure.Unknown -> logger
-                        .e("$TAG - UnknownFailure when processing message: $it", it.rootCause)
-
-                    is ProteusFailure -> logger
-                        .e("$TAG - ProteusFailure when processing message: $it", it.proteusException)
-
+                    is CoreFailure.Unknown -> logger.e("$TAG - UnknownFailure when processing message: $it", it.rootCause)
+                    is ProteusFailure -> logger.e("$TAG - ProteusFailure when processing message: $it", it.proteusException)
                     else -> logger.e("$TAG - Failure when processing message: $it")
                 }
                 handleFailedProteusDecryptedMessage(event)
@@ -283,12 +279,10 @@ internal class ConversationEventReceiverImpl(
         conversationRepository.fetchConversationIfUnknown(event.conversationId)
             .run {
                 onSuccess {
-                    logger.withFeatureId(EVENT_RECEIVER)
-                        .v("Succeeded fetching conversation details on MemberJoin Event: $event")
+                    logger.v("Succeeded fetching conversation details on MemberJoin Event: $event")
                 }
                 onFailure {
-                    logger.withFeatureId(EVENT_RECEIVER)
-                        .w("Failure fetching conversation details on MemberJoin Event: $event")
+                    logger.w("Failure fetching conversation details on MemberJoin Event: $event")
                 }
                 // Even if unable to fetch conversation details, at least attempt adding the member
                 conversationRepository.persistMembers(event.members, event.conversationId)
@@ -303,7 +297,7 @@ internal class ConversationEventReceiverImpl(
                     visibility = Message.Visibility.VISIBLE
                 )
                 processMessage(message) // TODO(exception-handling): processMessage exceptions are not caught
-            }.onFailure { logger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member join event: $it") }
+            }.onFailure { logger.e("$TAG - failure on member join event: $it") }
 
     private suspend fun handleMemberLeave(event: Event.Conversation.MemberLeave) = conversationRepository
         .deleteMembersFromEvent(event.removedList, event.conversationId)
@@ -324,7 +318,7 @@ internal class ConversationEventReceiverImpl(
             )
             processMessage(message)
         }
-        .onFailure { logger.withFeatureId(EVENT_RECEIVER).e("$TAG - failure on member leave event: $it") }
+        .onFailure { logger.e("$TAG - failure on member leave event: $it") }
 
     private suspend fun handleMemberChange(event: Event.Conversation.MemberChanged) {
         if (event is Event.Conversation.IgnoredMemberChanged) {
@@ -338,8 +332,7 @@ internal class ConversationEventReceiverImpl(
                         logger.v("Succeeded fetching conversation details on MemberChange Event: $event")
                     }
                     onFailure {
-                        logger.withFeatureId(EVENT_RECEIVER)
-                            .w("Failure fetching conversation details on MemberChange Event: $event")
+                        logger.w("Failure fetching conversation details on MemberChange Event: $event")
                     }
                     // Even if unable to fetch conversation details, at least attempt updating the member
                     event.member?.let { conversationRepository.updateMemberFromEvent(it, event.conversationId) }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -24,6 +24,11 @@ object TestEvent {
         member
     )
 
+    fun memberChangeIgnored(eventId: String = "eventId") = Event.Conversation.IgnoredMemberChanged(
+        eventId,
+        TestConversation.ID,
+    )
+
     fun clientRemove(eventId: String = "eventId", clientId: ClientId) = Event.User.ClientRemove(eventId, clientId)
     fun userDelete(eventId: String = "eventId", userId: UserId) = Event.User.UserDelete(eventId, userId)
     fun updateUser(eventId: String = "eventId", userId: UserId) = Event.User.Update(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationEvent.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationEvent.kt
@@ -21,7 +21,7 @@ data class ConversationUsers(
 data class ConversationRoleChange(
     @SerialName("target") val user: String,
     @SerialName("qualified_target") val qualifiedUserId: UserId,
-    @SerialName("conversation_role") val role: String,
+    @SerialName("conversation_role") val role: String?,
 )
 
 @Serializable


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR fixes the corner case (under investigation) when we receive a member change event, and this comes without role (accordingly to swagger is not optional).

### Causes (Optional)

```
exception: ap.d: Field 'conversation_role' is required for type with serial name 'com.wire.kalium.network.api.base.authenticated.conversation.ConversationRoleChange', but it was missing
```

### Solutions

Make the field optional, and handle the event only if the value is present, log anyway the warning about this event.
After confirming with Backend team, we should either, leave it as it is in this PR, or rollback, to have the field not nullable,

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
