### PR TITLE
fix: crash when starting up UserSessionScope

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -185,6 +185,8 @@ abstract class UserSessionScopeCommon internal constructor(
     private val userSessionScopeProvider: UserSessionScopeProvider,
 ) : CoroutineScope {
 
+    private val userDatabaseProvider: UserDatabaseProvider = authenticatedDataSourceSet.userDatabaseProvider
+
     // TODO: extract client id provider to it's own class and test it
     private var _clientId: ClientId? = null
     private suspend fun clientId(): Either<CoreFailure, ClientId> =
@@ -221,8 +223,6 @@ abstract class UserSessionScopeCommon internal constructor(
 
     private val userConfigRepository: UserConfigRepository
         get() = UserConfigDataSource(authenticatedDataSourceSet.userPrefProvider.userConfigStorage)
-
-    private val userDatabaseProvider: UserDatabaseProvider = authenticatedDataSourceSet.userDatabaseProvider
 
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider
         get() = KeyPackageLimitsProviderImpl(kaliumConfigs)
@@ -337,6 +337,8 @@ abstract class UserSessionScopeCommon internal constructor(
         )
     }
 
+    // TODO: Refactor. These should be passed in the constructor to
+    //       avoid depending on not-yet-initialized fields
     protected abstract val clientConfig: ClientConfig
 
     private val clientRemoteRepository: ClientRemoteRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -201,10 +201,10 @@ abstract class UserSessionScopeCommon internal constructor(
             userId,
             qualifiedIdMapper,
             globalScope.sessionRepository
-        )
+            )
 
     private val clientIdProvider = CurrentClientIdProvider { clientId() }
-    private val selfConversationIdProvider: SelfConversationIdProvider = SelfConversationIdProviderImpl(conversationRepository)
+    private val selfConversationIdProvider: SelfConversationIdProvider by lazy { SelfConversationIdProviderImpl(conversationRepository) }
 
     // TODO: make atomic
     // val _teamId: Atomic<Either<CoreFailure, TeamId?>> = Atomic(Either.Left(CoreFailure.Unknown(Throwable("NotInitialized"))))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Clients are crashing when creating a `UserSessionScope`

### Causes

```
E  FATAL EXCEPTION: main
Process: com.wire.android.dev.debug, PID: 17435
java.lang.NullPointerException: Attempt to invoke virtual method 'com.wire.kalium.persistence.dao.UserDAO com.wire.kalium.persistence.db.UserDatabaseProvider.getUserDAO()' on a null object reference
at com.wire.kalium.logic.feature.UserSessionScopeCommon.getUserRepository(UserSessionScope.kt:276)
at com.wire.kalium.logic.feature.UserSessionScopeCommon.getConversationRepository(UserSessionScope.kt:256)
at com.wire.kalium.logic.feature.UserSessionScopeCommon.<init>(UserSessionScope.kt:207)
at com.wire.kalium.logic.feature.UserSessionScope.<init>(UserSessionScope.kt:29)
at com.wire.kalium.logic.feature.UserSessionScopeProviderImpl.create(UserSessionScopeProviderImpl.kt:76)
at com.wire.kalium.logic.feature.UserSessionScopeProviderCommon$getOrCreate$1.invoke(UserSessionScopeProvider.kt:22)
at com.wire.kalium.logic.feature.UserSessionScopeProviderCommon$getOrCreate$1.invoke(UserSessionScopeProvider.kt:22)
at io.ktor.util.collections.ConcurrentMap$computeIfAbsent$1.invoke(ConcurrentMap.kt:213)
at io.ktor.util.collections.ConcurrentMap.locked(ConcurrentMap.kt:244)
at io.ktor.util.collections.ConcurrentMap.computeIfAbsent(ConcurrentMap.kt:208)
at com.wire.kalium.logic.feature.UserSessionScopeProviderCommon.getOrCreate(UserSessionScopeProvider.kt:22)
at com.wire.kalium.logic.CoreLogic.getSessionScope(CoreLogic.kt:44)
at com.wire.android.di.ClientScopeProvider.getClientScope(ClientScopeProvider.kt:15)
at com.wire.android.ui.authentication.login.LoginViewModel.registerClient(LoginViewModel.kt:92)
at com.wire.android.ui.authentication.login.LoginViewModel.registerClient$default(LoginViewModel.kt:87)
at com.wire.android.ui.authentication.login.email.LoginEmailViewModel$login$1.invokeSuspend(LoginEmailViewModel.kt:89)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:246)
at android.app.ActivityThread.main(ActivityThread.java:8653)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@7ead7d6, Dispatchers.Main.immediate]
```

Due to the order in which the dependencies are declared:
- `selfConversationIdProvider` is initialised eagerly on line `209`, and it requires:
- `conversationRepository`, which requires:
- `userRepository`, which calls:
- `userDatabaseProvider.userDAO`.

However, `userDatabaseProvider` is not initialized yet. It is defined on line `225`.

### Solutions

1. Make `selfConversationIdProvider` lazy. There's no point in initializing it earlier and it's better we start dependencies on-the-fly instead of initializing all the stuff early, making the app initialization slower.
2. Move `userDatabaseProvider` definition up. It doesn't have any dependencies and it's used in multiple places. This way we guarantee it will exist when wanted.

### Testing

Manually tested.

#### How to Test

Create a UserSessionScope.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
