### PR TITLE
fix(connection): show sent/received connections in conversation list (AR-2541)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -236,7 +236,8 @@ internal class ConnectionDataSource(
                 )
             }
 
-            else -> {
+            NOT_CONNECTED, BLOCKED, IGNORED, CANCELLED,
+            MISSING_LEGALHOLD_CONSENT, ACCEPTED -> {
                 kaliumLogger.i("INSERT CONVERSATION FROM CONNECTION NOT ENGAGED FOR $connection")
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -236,7 +236,9 @@ internal class ConnectionDataSource(
                 )
             }
 
-            else -> {}
+            else -> {
+                kaliumLogger.i("INSERT CONVERSATION FROM CONNECTION NOT ENGAGED FOR $connection")
+            }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -299,7 +299,8 @@ abstract class UserSessionScopeCommon internal constructor(
             authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi,
             userDatabaseProvider.userDAO,
             userId,
-            selfTeamId
+            selfTeamId,
+            conversationRepository
         )
 
     private val userSearchApiWrapper: UserSearchApiWrapper = UserSearchApiWrapperImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.connection
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
@@ -101,6 +102,7 @@ class ConnectionRepositoryTest {
             .withSuccessfulGetConversationById(arrangement.stubConversationID1)
             .withSuccessfulCreateConnectionResponse(userId)
             .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
+            .withFetchConversationSucceed()
 
         // when
         val result = connectionRepository.sendUserConnection(UserId(userId.value, userId.domain))
@@ -120,6 +122,11 @@ class ConnectionRepositoryTest {
             .suspendFunction(arrangement.userDetailsApi::getUserInfo)
             .with(any())
             .wasInvoked(once)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::fetchConversations)
+            .wasNotInvoked()
+
     }
 
     @Test
@@ -130,6 +137,7 @@ class ConnectionRepositoryTest {
         arrangement
             .withSuccessfulFetchSelfUserConnectionsResponse(arrangement.stubUserProfileDTO)
             .withErrorOnCreateConnectionResponse(userId)
+            .withFetchConversationSucceed()
 
         // when
         val result = connectionRepository.sendUserConnection(UserId(userId.value, userId.domain))
@@ -143,6 +151,9 @@ class ConnectionRepositoryTest {
         verify(arrangement.conversationDAO)
             .suspendFunction(arrangement.conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
             .with(any(), any(), any())
+            .wasNotInvoked()
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::fetchConversations)
             .wasNotInvoked()
     }
 
@@ -158,6 +169,7 @@ class ConnectionRepositoryTest {
             .withSuccessfulGetConversationById(arrangement.stubConversationID1)
             .withErrorOnPersistingConnectionResponse(userId)
             .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
+            .withFetchConversationSucceed()
 
         // when
         val result = connectionRepository.sendUserConnection(UserId(userId.value, userId.domain))
@@ -175,6 +187,9 @@ class ConnectionRepositoryTest {
             .suspendFunction(arrangement.userDAO::insertUser)
             .with(any())
             .wasInvoked(once)
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::fetchConversations)
+            .wasNotInvoked()
     }
 
     @Test
@@ -274,6 +289,9 @@ class ConnectionRepositoryTest {
         val conversationDAO = configure(mock(classOf<ConversationDAO>())) { stubsUnitByDefault = true }
 
         @Mock
+        val conversationRepository = configure(mock(classOf<ConversationRepository>())) { stubsUnitByDefault = true }
+
+        @Mock
         val connectionDAO = configure(mock(classOf<ConnectionDAO>())) { stubsUnitByDefault = true }
 
         @Mock
@@ -295,7 +313,8 @@ class ConnectionRepositoryTest {
             userDetailsApi = userDetailsApi,
             userDAO = userDAO,
             selfUserId = TestUser.SELF.id,
-            selfTeamIdProvider = selfTeamIdProvider
+            selfTeamIdProvider = selfTeamIdProvider,
+            conversationRepository = conversationRepository
         )
 
         val stubConnectionOne = ConnectionDTO(
@@ -356,11 +375,20 @@ class ConnectionRepositoryTest {
         val stubConversationID1 = QualifiedIDEntity("conversationId1", "domain")
         val stubConversationID2 = QualifiedIDEntity("conversationId2", "domain")
 
-        fun withSelfUserTeamId(either: Either<CoreFailure, TeamId?>) {
+        fun withSelfUserTeamId(either: Either<CoreFailure, TeamId?>): Arrangement {
             given(selfTeamIdProvider)
                 .suspendFunction(selfTeamIdProvider::invoke)
                 .whenInvoked()
-                .then { either }
+                .then{ either }
+            return this
+        }
+
+        fun withFetchConversationSucceed(): Arrangement {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::fetchConversation)
+                .whenInvokedWith(any())
+                .then { Either.Right(Unit) }
+            return this
         }
 
         fun withSuccessfulCreateConnectionResponse(userId: NetworkUserId): Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -379,7 +379,7 @@ class ConnectionRepositoryTest {
             given(selfTeamIdProvider)
                 .suspendFunction(selfTeamIdProvider::invoke)
                 .whenInvoked()
-                .then{ either }
+                .then { either }
             return this
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Inserting the conversation when we want to persist a connection request[received or sent]

### Issues
Following the changes we did for the conversation list, now we're relying on a select that it's a result of a join of Conversation and Connection tables, when we send a connection or receive one, we only insert the related data into the Connection table. In the end the conversation list view wasn't concluding the connections data because there wasn't any conversation to survive the join!
### Causes (Optional)
Change of structure.

### Solutions

Insert the conversation object alongside of the persisting the connection request [either sent or received]
- for sent connections, we fetch the conversation details by id from the server and the persist it!
-for received connections, there is an issue! the server won't allow us to fetch the conversation details for that connection, because we're not a member of that conversation yet[before accepting the conversation]!
Solution? create the object locally and insert in the conversation table.

### Dependencies (Optional)

Update AR release branch to point to this branch.

Needs releases with:

- [] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
