### PR TITLE
fix(conversation): order of sent connections in convo list (AR-2543)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -224,7 +224,7 @@ internal class ConversationMapperImpl(
                         )
                     },
                     userType = domainUserTypeMapper.fromUserTypeEntity(userType),
-                    lastModifiedDate = lastModifiedDate,
+                    lastModifiedDate = lastModifiedDate.orEmpty(),
                     connection = Connection(
                         conversationId = id.value,
                         from = "",

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -95,7 +95,10 @@ CASE (Conversation.type)
     WHEN "ONE_ON_ONE" THEN User.team
     ELSE Conversation.team_id
     END AS teamId,
-Conversation.last_modified_date AS lastModifiedDate,
+CASE (Conversation.type)
+        WHEN "CONNECTION_PENDING" THEN Connection.last_update
+        ELSE Conversation.last_modified_date
+        END AS lastModifiedDate,
 Conversation.last_read_date AS lastReadDate,
 CASE (Conversation.type)
     WHEN "ONE_ON_ONE" THEN  User.user_availability_status

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -74,7 +74,7 @@ data class ConversationViewEntity(
     val previewAssetId: QualifiedIDEntity?,
     val mutedStatus: ConversationEntity.MutedStatus,
     val teamId: String?,
-    val lastModifiedDate: String,
+    val lastModifiedDate: String?,
     val lastReadDate: String,
     val userAvailabilityStatus: UserAvailabilityStatusEntity?,
     val userType: UserTypeEntity?,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -54,7 +54,7 @@ private class ConversationMapper {
         previewAssetId: QualifiedIDEntity?,
         mutedStatus: ConversationEntity.MutedStatus,
         teamId: String?,
-        lastModifiedDate: String,
+        lastModifiedDate: String?,
         lastReadDate: String,
         userAvailabilityStatus: UserAvailabilityStatusEntity?,
         userType: UserTypeEntity?,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Exposed the connection lastUpdateTime in the conversationsList view
### Issues

In the view we were considering the lastUpdate date time only for conversation, now we expose that field from the connection if the conversation type is a connection-pending.

### Causes (Optional)

The ordre of the connections in the conversations was not correct.

### Solutions

By exposing the connectionDate in the query, the order now is fixed.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
