### PR TITLE
fix(conversation-list):  handle call-on-ongoing state correctly in conversationList View

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -160,7 +160,7 @@ LEFT JOIN Connection ON Connection.qualified_conversation = Conversation.qualifi
          OR Connection.status = "NOT_CONNECTED"
          AND Conversation.type IS "CONNECTION_PENDING")
 LEFT JOIN User AS connection_user ON Connection.qualified_to = connection_user.qualified_id
-LEFT JOIN Call ON Call.id IS (SELECT MAX(id) FROM Call WHERE Call.conversation_id = Conversation.qualified_id) AND Call.status IS "STILL_ONGOING";
+LEFT JOIN Call ON Call.created_at IS (SELECT MAX(created_at) FROM Call WHERE Call.conversation_id = Conversation.qualified_id AND Call.status IS "STILL_ONGOING") AND Call.status IS "STILL_ONGOING";
 
 selectAllConversationDetails:
 SELECT * FROM ConversatonDetails


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Refactored the view select to handle more edge cases of the call status.
The left join for calls was:` LEFT JOIN Call ON Call.id IS (SELECT MAX(id) FROM Call WHERE Call.conversation_id = Conversation.qualified_id) AND Call.status IS "STILL_ONGOING";`

lets assume we have this data in the Call table:
<img width="1145" alt="Screenshot 2022-09-27 at 12 59 08" src="https://user-images.githubusercontent.com/9512842/192508372-18f20280-09ac-4a52-af6c-cd90ee27e83b.png">

The below query will return null as call status for that specific group! because the max id is the `CLOSED` call and since it's closed we don't consider it!

But we need to return the call as ongoing if there is one! so change the query to cover this case.


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
