### PR TITLE
fix(conversation): show conv after accept connection (AR-2553)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -236,8 +236,16 @@ internal class ConnectionDataSource(
                 )
             }
 
+            ACCEPTED -> {
+                kaliumLogger.i("INSERT CONVERSATION FROM CONNECTION NOT ENGAGED FOR $connection")
+                conversationDAO.updateConversationType(
+                    idMapper.toDaoModel(connection.qualifiedConversationId),
+                    ConversationEntity.Type.ONE_ON_ONE
+                )
+            }
+
             NOT_CONNECTED, BLOCKED, IGNORED, CANCELLED,
-            MISSING_LEGALHOLD_CONSENT, ACCEPTED -> {
+            MISSING_LEGALHOLD_CONSENT -> {
                 kaliumLogger.i("INSERT CONVERSATION FROM CONNECTION NOT ENGAGED FOR $connection")
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionStatusMapper.kt
@@ -66,7 +66,7 @@ internal class ConnectionStatusMapperImpl : ConnectionStatusMapper {
         ConnectionEntity.State.MISSING_LEGALHOLD_CONSENT -> ConnectionState.MISSING_LEGALHOLD_CONSENT
         ConnectionEntity.State.ACCEPTED -> ConnectionState.ACCEPTED
         ConnectionEntity.State.NOT_CONNECTED -> ConnectionState.NOT_CONNECTED
-        else -> ConnectionState.ACCEPTED
+        null -> ConnectionState.ACCEPTED
     }
 
     override fun toDaoModel(state: ConnectionState): ConnectionEntity.State = when (state) {

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -225,7 +225,7 @@ UPDATE Conversation
 SET name = ?, last_modified_date = ?
 WHERE qualified_id = ?;
 
-revokeOneOnOneConversationWithDeletedUser:
+updateConversationType:
 UPDATE Conversation
 SET type = ?
 WHERE qualified_id = ?;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -167,7 +167,7 @@ SELECT * FROM ConversatonDetails
 WHERE type IS NOT "SELF" AND
 (type IS "GROUP" AND (name IS NOT NULL OR otherUserId IS NOT NULL) --filter deleted groups after first sync
 OR (type IS NOT "GROUP" AND otherUserId IS NOT NULL)) -- show other conversation- todo: problem here! if the sync wasn't succesful the the user seems to be null!
-ORDER BY lastModifiedDate DESC, name ASC;
+ORDER BY lastModifiedDate DESC, name COLLATE NOCASE ASC;
 
 selectAllConversations:
 SELECT * FROM Conversation WHERE type IS NOT 'CONNECTION_PENDING' ORDER BY last_modified_date DESC, name ASC;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -164,6 +164,7 @@ interface ConversationDAO {
     suspend fun observeIsUserMember(conversationId: QualifiedIDEntity, userId: UserIDEntity): Flow<Boolean>
     suspend fun whoDeletedMeInConversation(conversationId: QualifiedIDEntity, selfUserIdString: String): UserIDEntity?
     suspend fun updateConversationName(conversationId: QualifiedIDEntity, conversationName: String, timestamp: String)
+    suspend fun updateConversationType(conversationID: QualifiedIDEntity, type: ConversationEntity.Type)
     suspend fun revokeOneOnOneConversationsWithDeletedUser(userId: UserIDEntity)
 
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -340,6 +340,7 @@ class ConversationDAOImpl(
             if (recordDidNotExist) {
                 userQueries.insertOrIgnoreUserIdWithConnectionStatus(member.user, status)
             }
+            conversationQueries.updateConversationType(ConversationEntity.Type.ONE_ON_ONE, conversationID)
             memberQueries.insertMember(member.user, conversationID, member.role)
         }
     }
@@ -438,10 +439,14 @@ class ConversationDAOImpl(
         conversationQueries.updateConversationName(conversationName, timestamp, conversationId)
     }
 
+    override suspend fun updateConversationType(conversationID: QualifiedIDEntity, type: ConversationEntity.Type) {
+        conversationQueries.updateConversationType(type, conversationID)
+    }
+
     override suspend fun revokeOneOnOneConversationsWithDeletedUser(userId: UserIDEntity) {
         conversationQueries.transaction {
             val conversationId = memberQueries.selectConversationByMember(userId).executeAsOne().conversation
-            conversationQueries.revokeOneOnOneConversationWithDeletedUser(ConversationEntity.Type.GROUP, conversationId)
+            conversationQueries.updateConversationType(ConversationEntity.Type.GROUP, conversationId)
             memberQueries.deleteUserFromConversations(userId)
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
After accepting the connection, we need to update the conversation type to one-on-one!

### Issues

Conversation/Connection after accepting it by the second user was still as Connection-pending.

### Causes (Optional)

Missing logic.

### Solutions

Updated the conversation type in related places.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
