### PR TITLE
fix: asset issues [AR-2552]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -36,10 +36,9 @@ sealed class Message(
                 }
 
                 is MessageContent.Asset -> {
-                    contentString =
-                        "content: {name: ${content.value.name}, sizeInBytes:${content.value.sizeInBytes}, mimeType:${content.value.mimeType}" +
-                                ", metaData : ${content.value.metadata}, downloadStatus: ${content.value.downloadStatus}, uploadStatus: " +
-                                "${content.value.uploadStatus}}, remoteData - otrKeySize: ${content.value.remoteData.otrKey.size}"
+                    contentString = "content: {name: ${content.value.name}, sizeInBytes:${content.value.sizeInBytes}, mimeType: ${
+                        content.value.mimeType}, metaData : ${content.value.metadata}, downloadStatus: ${content.value.downloadStatus}, " +
+                            "uploadStatus: ${content.value.uploadStatus}}, remoteData - otrKeySize: ${content.value.remoteData.otrKey.size}"
                 }
 
                 is MessageContent.RestrictedAsset -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -36,9 +36,10 @@ sealed class Message(
                 }
 
                 is MessageContent.Asset -> {
-                    contentString = "content:{sizeInBytes:${content.value.sizeInBytes}, mimeType:${content.value.mimeType}, metaData : " +
-                            "${content.value.metadata}, downloadStatus: ${content.value.downloadStatus}, " +
-                            "uploadStatus: ${content.value.uploadStatus}}"
+                    contentString =
+                        "content: {name: ${content.value.name}, sizeInBytes:${content.value.sizeInBytes}, mimeType:${content.value.mimeType}" +
+                                ", metaData : ${content.value.metadata}, downloadStatus: ${content.value.downloadStatus}, uploadStatus: " +
+                                "${content.value.uploadStatus}}, remoteData - otrKeySize: ${content.value.remoteData.otrKey.size}"
                 }
 
                 is MessageContent.RestrictedAsset -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -479,7 +479,6 @@ internal class ConversationEventReceiverImpl(
 
     private suspend fun handleAssetMessage(message: Message.Regular) {
         val content = message.content as MessageContent.Asset
-        logger.i(message = "$TAG Handling Asset Message with content: $content")
         userConfigRepository.isFileSharingEnabled().onSuccess {
             if (it.isFileSharingEnabled != null && it.isFileSharingEnabled) {
                 processNonRestrictedAssetMessage(message)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There were some problems not being able to display asset messages that were sent from AR. The main issue was that in AR we were just sending one full message containing all the asset metadata as well as the encryption keys. However, Web/Mac clients, were sending 2 messages, one with the preview data and empty decryption keys, and another one with the decryption keys but empty metadata. Now we will be supporting both ways of sending/receiving asset messages.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
