### PR TITLE
fix(mls): commit pending proposal before sending an MLS message AR-2568

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -73,7 +73,7 @@ interface ConversationRepository {
     suspend fun detailsById(conversationId: ConversationId): Either<StorageFailure, Conversation>
     suspend fun getConversationRecipients(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
     suspend fun getConversationRecipientsForCalling(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
-    suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, ProtocolInfo>
+    suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, Conversation.ProtocolInfo>
     suspend fun observeConversationMembers(conversationID: ConversationId): Flow<List<Conversation.Member>>
     suspend fun requestToJoinMLSGroup(conversation: Conversation): Either<CoreFailure, Unit>
 
@@ -170,6 +170,7 @@ internal class ConversationDataSource internal constructor(
     private val memberMapper: MemberMapper = MapperProvider.memberMapper(),
     private val conversationStatusMapper: ConversationStatusMapper = MapperProvider.conversationStatusMapper(),
     private val conversationRoleMapper: ConversationRoleMapper = MapperProvider.conversationRoleMapper(),
+    private val protocolInfoMapper: ProtocolInfoMapper = MapperProvider.protocolInfoMapper(),
     private val messageMapper: MessageMapper = MapperProvider.messageMapper()
 ) : ConversationRepository {
 
@@ -457,9 +458,11 @@ internal class ConversationDataSource internal constructor(
         }
     }
 
-    override suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, ProtocolInfo> =
+    override suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, Conversation.ProtocolInfo> =
         wrapStorageRequest {
-            conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId)).first()?.protocolInfo
+            conversationDAO.observeGetConversationByQualifiedID(idMapper.toDaoModel(conversationId)).first()?.protocolInfo?.let {
+                protocolInfoMapper.fromEntity(it)
+            }
         }
 
     override suspend fun observeConversationMembers(conversationID: ConversationId): Flow<List<Conversation.Member>> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -263,56 +263,60 @@ class MLSConversationDataSource(
     }
 
     override suspend fun addMemberToMLSGroup(groupID: GroupID, userIdList: List<UserId>): Either<CoreFailure, Unit> =
-        retryOnCommitFailure(groupID) {
-            // TODO: check for federated and non-federated members
-            keyPackageRepository.claimKeyPackages(userIdList).flatMap { keyPackages ->
-                mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-                    val clientKeyPackageList = keyPackages
-                        .map {
-                            Pair(
-                                CryptoQualifiedClientId(it.clientID, CryptoQualifiedID(it.userId, it.domain)),
-                                it.keyPackage.decodeBase64Bytes()
-                            )
-                        }
+        commitPendingProposals(groupID).flatMap {
+            retryOnCommitFailure(groupID) {
+                // TODO: check for federated and non-federated members
+                keyPackageRepository.claimKeyPackages(userIdList).flatMap { keyPackages ->
+                    mlsClientProvider.getMLSClient().flatMap { mlsClient ->
+                        val clientKeyPackageList = keyPackages
+                            .map {
+                                Pair(
+                                    CryptoQualifiedClientId(it.clientID, CryptoQualifiedID(it.userId, it.domain)),
+                                    it.keyPackage.decodeBase64Bytes()
+                                )
+                            }
 
-                    wrapMLSRequest {
-                        mlsClient.addMember(idMapper.toCryptoModel(groupID), clientKeyPackageList)
-                    }.flatMap { commitBundle ->
-                        commitBundle?.let {
-                            sendCommitBundle(groupID, it)
-                                .flatMap {
-                                    wrapStorageRequest {
-                                        val list = userIdList.map {
-                                            Member(idMapper.toDaoModel(it), Member.Role.Member)
+                        wrapMLSRequest {
+                            mlsClient.addMember(idMapper.toCryptoModel(groupID), clientKeyPackageList)
+                        }.flatMap { commitBundle ->
+                            commitBundle?.let {
+                                sendCommitBundle(groupID, it)
+                                    .flatMap {
+                                        wrapStorageRequest {
+                                            val list = userIdList.map {
+                                                Member(idMapper.toDaoModel(it), Member.Role.Member)
+                                            }
+                                            conversationDAO.insertMembers(list, idMapper.toGroupIDEntity(groupID))
                                         }
-                                        conversationDAO.insertMembers(list, idMapper.toGroupIDEntity(groupID))
                                     }
-                                }
-                        } ?: Either.Right(Unit)
+                            } ?: Either.Right(Unit)
+                        }
                     }
                 }
             }
         }
 
     override suspend fun removeMembersFromMLSGroup(groupID: GroupID, userIdList: List<UserId>): Either<CoreFailure, Unit> =
-        retryOnCommitFailure(groupID) {
-            wrapApiRequest { clientApi.listClientsOfUsers(userIdList.map { idMapper.toApiModel(it) }) }.map { userClientsList ->
-                val usersCryptoQualifiedClientIDs = userClientsList.flatMap { userClients ->
-                    userClients.value.map { userClient ->
-                        CryptoQualifiedClientId(userClient.id, idMapper.toCryptoQualifiedIDId(idMapper.fromApiModel(userClients.key)))
+        commitPendingProposals(groupID).flatMap {
+            retryOnCommitFailure(groupID) {
+                wrapApiRequest { clientApi.listClientsOfUsers(userIdList.map { idMapper.toApiModel(it) }) }.map { userClientsList ->
+                    val usersCryptoQualifiedClientIDs = userClientsList.flatMap { userClients ->
+                        userClients.value.map { userClient ->
+                            CryptoQualifiedClientId(userClient.id, idMapper.toCryptoQualifiedIDId(idMapper.fromApiModel(userClients.key)))
+                        }
                     }
-                }
-                return@retryOnCommitFailure mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-                    wrapMLSRequest {
-                        mlsClient.removeMember(idMapper.toCryptoModel(groupID), usersCryptoQualifiedClientIDs)
-                    }.flatMap {
-                        sendCommitBundle(groupID, it)
-                    }.flatMap {
-                        wrapStorageRequest {
-                            conversationDAO.deleteMembersByQualifiedID(
-                                userIdList.map { idMapper.toDaoModel(it) },
-                                idMapper.toGroupIDEntity(groupID)
-                            )
+                    return@retryOnCommitFailure mlsClientProvider.getMLSClient().flatMap { mlsClient ->
+                        wrapMLSRequest {
+                            mlsClient.removeMember(idMapper.toCryptoModel(groupID), usersCryptoQualifiedClientIDs)
+                        }.flatMap {
+                            sendCommitBundle(groupID, it)
+                        }.flatMap {
+                            wrapStorageRequest {
+                                conversationDAO.deleteMembersByQualifiedID(
+                                    userIdList.map { idMapper.toDaoModel(it) },
+                                    idMapper.toGroupIDEntity(groupID)
+                                )
+                            }
                         }
                     }
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.conversation.ConversationStatusMapper
 import com.wire.kalium.logic.data.conversation.ConversationStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.MemberMapper
 import com.wire.kalium.logic.data.conversation.MemberMapperImpl
+import com.wire.kalium.logic.data.conversation.ProtocolInfoMapper
 import com.wire.kalium.logic.data.conversation.ProtocolInfoMapperImpl
 import com.wire.kalium.logic.data.event.EventMapper
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapper
@@ -132,5 +133,7 @@ internal object MapperProvider {
     ): FederatedIdMapper = FederatedIdMapperImpl(userId, qualifiedIdMapper, sessionRepository)
 
     fun mlsPublicKeyMapper(): MLSPublicKeysMapper = MLSPublicKeysMapperImpl()
+
+    fun protocolInfoMapper(): ProtocolInfoMapper = ProtocolInfoMapperImpl()
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -611,6 +611,7 @@ abstract class UserSessionScopeCommon internal constructor(
             clientIdProvider,
             messageRepository,
             conversationRepository,
+            mlsConversationRepository,
             clientRepository,
             authenticatedDataSourceSet.proteusClient,
             mlsClientProvider,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
@@ -2,6 +2,8 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.message.ProtoContentMapper
@@ -15,7 +17,7 @@ import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 interface MLSMessageCreator {
 
     suspend fun createOutgoingMLSMessage(
-        groupId: String,
+        groupId: GroupID,
         message: Message.Regular
     ): Either<CoreFailure, MLSMessageApi.Message>
 
@@ -24,13 +26,14 @@ interface MLSMessageCreator {
 class MLSMessageCreatorImpl(
     private val mlsClientProvider: MLSClientProvider,
     private val protoContentMapper: ProtoContentMapper = MapperProvider.protoContentMapper(),
+    private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : MLSMessageCreator {
 
-    override suspend fun createOutgoingMLSMessage(groupId: String, message: Message.Regular): Either<CoreFailure, MLSMessageApi.Message> {
+    override suspend fun createOutgoingMLSMessage(groupId: GroupID, message: Message.Regular): Either<CoreFailure, MLSMessageApi.Message> {
         return mlsClientProvider.getMLSClient().flatMap { mlsClient ->
             kaliumLogger.i("Creating outgoing MLS message (groupID = $groupId)")
             val content = protoContentMapper.encodeToProtobuf(ProtoContent.Readable(message.id, message.content))
-            wrapMLSRequest { MLSMessageApi.Message(mlsClient.encryptMessage(groupId, content.data)) }
+            wrapMLSRequest { MLSMessageApi.Message(mlsClient.encryptMessage(idMapper.toCryptoModel(groupId), content.data)) }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -39,6 +40,7 @@ class MessageScope internal constructor(
     private val currentClientIdProvider: CurrentClientIdProvider,
     internal val messageRepository: MessageRepository,
     private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
     private val clientRepository: ClientRepository,
     private val proteusClient: ProteusClient,
     private val mlsClientProvider: MLSClientProvider,
@@ -75,6 +77,7 @@ class MessageScope internal constructor(
         get() = MessageSenderImpl(
             messageRepository,
             conversationRepository,
+            mlsConversationRepository,
             syncManager,
             messageSendFailureHandler,
             sessionEstablisher,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -4,9 +4,12 @@ import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.MESSAGES
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageEnvelope
 import com.wire.kalium.logic.data.message.MessageRepository
@@ -21,7 +24,6 @@ import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.util.TimeParser
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isMlsStaleMessage
-import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
@@ -77,6 +79,7 @@ interface MessageSender {
 internal class MessageSenderImpl internal constructor(
     private val messageRepository: MessageRepository,
     private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
     private val syncManager: SyncManager,
     private val messageSendFailureHandler: MessageSendFailureHandler,
     private val sessionEstablisher: SessionEstablisher,
@@ -136,11 +139,11 @@ internal class MessageSenderImpl internal constructor(
     private suspend fun attemptToSend(message: Message.Regular): Either<CoreFailure, String> {
         return conversationRepository.getConversationProtocolInfo(message.conversationId).flatMap { protocolInfo ->
             when (protocolInfo) {
-                is ConversationEntity.ProtocolInfo.MLS -> {
+                is Conversation.ProtocolInfo.MLS -> {
                     attemptToSendWithMLS(protocolInfo.groupId, message)
                 }
 
-                is ConversationEntity.ProtocolInfo.Proteus -> {
+                is Conversation.ProtocolInfo.Proteus -> {
                     // TODO(messaging): make this thread safe (per user)
                     attemptToSendWithProteus(message)
                 }
@@ -164,21 +167,23 @@ internal class MessageSenderImpl internal constructor(
      *
      * Will handle re-trying on "mls-stale-message" after we are live again or fail if we are not syncing.
      */
-    private suspend fun attemptToSendWithMLS(groupId: String, message: Message.Regular): Either<CoreFailure, String> =
-        mlsMessageCreator.createOutgoingMLSMessage(groupId, message).flatMap { mlsMessage ->
-            messageRepository.sendMLSMessage(message.conversationId, mlsMessage).fold({
-                if (it is NetworkFailure.ServerMiscommunication && it.kaliumException is KaliumException.InvalidRequestError) {
-                    if (it.kaliumException.isMlsStaleMessage()) {
-                        logger.w("Encrypted MLS message for outdated epoch '${message.id}', re-trying..")
-                        return syncManager.waitUntilLiveOrFailure().flatMap {
-                            attemptToSend(message)
+    private suspend fun attemptToSendWithMLS(groupId: GroupID, message: Message.Regular): Either<CoreFailure, String> =
+        mlsConversationRepository.commitPendingProposals(groupId).flatMap {
+            mlsMessageCreator.createOutgoingMLSMessage(groupId, message).flatMap { mlsMessage ->
+                messageRepository.sendMLSMessage(message.conversationId, mlsMessage).fold({
+                    if (it is NetworkFailure.ServerMiscommunication && it.kaliumException is KaliumException.InvalidRequestError) {
+                        if (it.kaliumException.isMlsStaleMessage()) {
+                            logger.w("Encrypted MLS message for outdated epoch '${message.id}', re-trying..")
+                            return syncManager.waitUntilLiveOrFailure().flatMap {
+                                attemptToSend(message)
+                            }
                         }
                     }
-                }
-                Either.Left(it)
-            }, {
-                Either.Right(message.date) // TODO(mls): return actual server time from the response
-            })
+                    Either.Left(it)
+                }, {
+                    Either.Right(message.date) // TODO(mls): return actual server time from the response
+                })
+            }
         }
 
     /**

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreatorTest.kt
@@ -2,8 +2,10 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.cryptography.MLSClient
 import com.wire.kalium.logic.data.client.MLSClientProvider
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.message.PlainMessageBlob
 import com.wire.kalium.logic.data.message.ProtoContentMapper
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldSucceed
@@ -42,7 +44,7 @@ class MLSMessageCreatorTest {
         given(mlsClientProvider)
             .suspendFunction(mlsClientProvider::getMLSClient)
             .whenInvokedWith(anything())
-            .then { Either.Right(MLS_CLIENT)}
+            .then { Either.Right(MLS_CLIENT) }
 
         given(MLS_CLIENT)
             .function(MLS_CLIENT::encryptMessage)
@@ -59,12 +61,13 @@ class MLSMessageCreatorTest {
 
         verify(MLS_CLIENT)
             .function(MLS_CLIENT::encryptMessage)
-            .with(eq(GROUP_ID), eq(plainData))
+            .with(eq(CRYPTO_GROUP_ID), eq(plainData))
             .wasInvoked(once)
     }
 
     private companion object {
-        const val GROUP_ID = "groupId"
+        val GROUP_ID = GroupID("groupId")
+        val CRYPTO_GROUP_ID = MapperProvider.idMapper().toCryptoModel(GroupID("groupId"))
         val MLS_CLIENT = mock(classOf<MLSClient>())
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -4,8 +4,11 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.Recipient
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.message.MessageEnvelope
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
@@ -19,7 +22,6 @@ import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.model.ErrorResponse
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import io.ktor.utils.io.core.toByteArray
 import io.mockative.Mock
@@ -162,6 +164,7 @@ class MessageSenderTest {
 
         // given
         val (arrangement, messageSender) = Arrangement()
+            .withCommitPendingProposals()
             .withSendMlsMessage(sendMlsMessageWithResult = Either.Left(CoreFailure.Unknown(Throwable("some exception"))))
             .arrange()
 
@@ -280,6 +283,7 @@ class MessageSenderTest {
     fun givenReceivingStaleMessageError_whenSendingMlsMessage_thenRetryAfterSyncIsLive() {
         // given
         val (arrangement, messageSender) = Arrangement()
+            .withCommitPendingProposals()
             .withSendMlsMessage()
             .withSendOutgoingMlsMessage(Either.Left(Arrangement.MLS_STALE_MESSAGE_FAILURE), times = 1)
             .withWaitUntilLiveOrFailure()
@@ -299,9 +303,32 @@ class MessageSenderTest {
     }
 
     @Test
+    fun givenPendingProposals_whenSendingMlsMessage_thenProposalsAreCommitted() {
+        // given
+        val (arrangement, messageSender) = Arrangement()
+            .withCommitPendingProposals()
+            .withSendMlsMessage()
+            .withSendOutgoingMlsMessage()
+            .arrange()
+
+        arrangement.testScope.runTest {
+            // when
+            val result = messageSender.sendPendingMessage(Arrangement.TEST_CONVERSATION_ID, Arrangement.TEST_MESSAGE_UUID)
+
+            // then
+            result.shouldSucceed()
+            verify(arrangement.mlsConversationRepository)
+                .suspendFunction(arrangement.mlsConversationRepository::commitPendingProposals)
+                .with(eq(Arrangement.GROUP_ID))
+                .wasInvoked(once)
+        }
+    }
+
+    @Test
     fun givenReceivingStaleMessageError_whenSendingMlsMessage_thenGiveUpIfSyncIsPending() {
         // given
         val (arrangement, messageSender) = Arrangement()
+            .withCommitPendingProposals()
             .withSendMlsMessage(sendMlsMessageWithResult = Either.Left(Arrangement.MLS_STALE_MESSAGE_FAILURE))
             .withWaitUntilLiveOrFailure(failing = true)
             .arrange()
@@ -330,6 +357,9 @@ class MessageSenderTest {
         val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
 
         @Mock
+        val mlsConversationRepository: MLSConversationRepository = mock(MLSConversationRepository::class)
+
+        @Mock
         val sessionEstablisher = mock(SessionEstablisher::class)
 
         @Mock
@@ -352,6 +382,7 @@ class MessageSenderTest {
         fun arrange() = this to MessageSenderImpl(
             messageRepository = messageRepository,
             conversationRepository = conversationRepository,
+            mlsConversationRepository = mlsConversationRepository,
             syncManager = syncManager,
             messageSendFailureHandler = messageSendFailureHandler,
             sessionEstablisher = sessionEstablisher,
@@ -369,7 +400,7 @@ class MessageSenderTest {
                 .thenReturn(if (failing) TEST_CORE_FAILURE else Either.Right(TestMessage.TEXT_MESSAGE))
         }
 
-        fun withGetProtocolInfo(protocolInfo: ConversationEntity.ProtocolInfo = ConversationEntity.ProtocolInfo.Proteus) = apply {
+        fun withGetProtocolInfo(protocolInfo: Conversation.ProtocolInfo = Conversation.ProtocolInfo.Proteus) = apply {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::getConversationProtocolInfo)
                 .whenInvokedWith(anything())
@@ -393,6 +424,13 @@ class MessageSenderTest {
         fun withPrepareRecipientsForNewOutgoingMessage(failing: Boolean = false) = apply {
             given(sessionEstablisher)
                 .suspendFunction(sessionEstablisher::prepareRecipientsForNewOutgoingMessage)
+                .whenInvokedWith(anything())
+                .thenReturn(if (failing) TEST_CORE_FAILURE else Either.Right(Unit))
+        }
+
+        fun withCommitPendingProposals(failing: Boolean = false) = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::commitPendingProposals)
                 .whenInvokedWith(anything())
                 .thenReturn(if (failing) TEST_CORE_FAILURE else Either.Right(Unit))
         }
@@ -511,12 +549,13 @@ class MessageSenderTest {
             )
             val TEST_MLS_MESSAGE = MLSMessageApi.Message("message".toByteArray())
             val TEST_CORE_FAILURE = Either.Left(CoreFailure.Unknown(Throwable("an error")))
-            val MLS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo.MLS(
-                "groupId",
-                ConversationEntity.GroupState.ESTABLISHED,
+            val GROUP_ID = GroupID("groupId")
+            val MLS_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
+                GROUP_ID,
+                Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED,
                 0UL,
                 Instant.DISTANT_PAST,
-                ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             )
             val MLS_STALE_MESSAGE_FAILURE = NetworkFailure.ServerMiscommunication(
                 KaliumException.InvalidRequestError(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We would attempt do operations like adding a user to an MLS group without first committing any pending proposals.

### Solutions

Always commit any pending proposals before:
- Sending an application message
- Adding a user
- Removing a suer

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
