### PR TITLE
fix(mls): parse time field when sending MLS message AR-2281

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -187,7 +187,7 @@ class MLSConversationDataSource(
                     mlsMessageApi.sendMessage(
                         MLSMessageApi.Message(message)
                     )
-                }
+                }.flatMap { Either.Right(Unit) }
             }.onSuccess {
                 conversationDAO.updateConversationGroupState(
                     ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -90,7 +90,7 @@ interface MessageRepository {
      * @return [Either.Left] of other [CoreFailure] for more generic cases
      */
     suspend fun sendEnvelope(conversationId: ConversationId, envelope: MessageEnvelope): Either<CoreFailure, String>
-    suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, Unit>
+    suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, String>
 
     suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>>
 
@@ -261,9 +261,11 @@ class MessageDataSource(
         })
     }
 
-    override suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, Unit> =
+    override suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, String> =
         wrapApiRequest {
             mlsMessageApi.sendMessage(message)
+        }.flatMap { response ->
+            Either.Right(response.time)
         }
 
     override suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>> = wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -177,7 +177,7 @@ internal class MessageSenderImpl internal constructor(
                 }
                 Either.Left(it)
             }, {
-                Either.Right(message.date) // TODO(mls): return actual server time from the response
+                Either.Right(it)
             })
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.SimpleClientResponse
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageDTO
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
+import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
@@ -51,6 +52,7 @@ import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 
@@ -756,7 +758,7 @@ class MLSConversationRepositoryTest {
             given(mlsMessageApi)
                 .suspendFunction(mlsMessageApi::sendMessage)
                 .whenInvokedWith(anything())
-                .then { NetworkResponse.Success(Unit, emptyMap(), 201) }
+                .then { NetworkResponse.Success(SendMLSMessageResponse(TIME, emptyList()), emptyMap(), 201) }
         }
 
         fun withCommitBundleSuccessful() = apply {
@@ -820,6 +822,7 @@ class MLSConversationRepositoryTest {
         internal companion object {
             const val EPOCH = 5UL
             const val RAW_GROUP_ID = "groupId"
+            val TIME = Clock.System.now().toString()
             val GROUP_ID = GroupID(RAW_GROUP_ID)
             val INVALID_REQUEST_ERROR = KaliumException.InvalidRequestError(ErrorResponse(405, "", ""))
             val MLS_STALE_MESSAGE_ERROR = KaliumException.InvalidRequestError(ErrorResponse(409, "", "mls-stale-message"))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -419,7 +419,10 @@ class MessageSenderTest {
                 .thenReturn(result)
         }
 
-        fun withSendOutgoingMlsMessage(result: Either<CoreFailure, String> = Either.Right(MESSAGE_SENT_TIME), times: Int = Int.MAX_VALUE) = apply {
+        fun withSendOutgoingMlsMessage(
+            result: Either<CoreFailure, String> = Either.Right(MESSAGE_SENT_TIME),
+            times: Int = Int.MAX_VALUE
+        ) = apply {
             var invocationCounter = 0
             given(messageRepository)
                 .suspendFunction(messageRepository::sendMLSMessage)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -35,6 +35,7 @@ import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -418,7 +419,7 @@ class MessageSenderTest {
                 .thenReturn(result)
         }
 
-        fun withSendOutgoingMlsMessage(result: Either<CoreFailure, Unit> = Either.Right(Unit), times: Int = Int.MAX_VALUE) = apply {
+        fun withSendOutgoingMlsMessage(result: Either<CoreFailure, String> = Either.Right(MESSAGE_SENT_TIME), times: Int = Int.MAX_VALUE) = apply {
             var invocationCounter = 0
             given(messageRepository)
                 .suspendFunction(messageRepository::sendMLSMessage)
@@ -487,7 +488,7 @@ class MessageSenderTest {
             }
 
         fun withSendMlsMessage(
-            sendMlsMessageWithResult: Either<CoreFailure, Unit>? = null,
+            sendMlsMessageWithResult: Either<CoreFailure, String>? = null,
         ) = apply {
             withGetMessageById()
             withGetProtocolInfo(protocolInfo = MLS_PROTOCOL_INFO)
@@ -509,6 +510,7 @@ class MessageSenderTest {
                 recipients = listOf(),
                 dataBlob = null
             )
+            val MESSAGE_SENT_TIME = Clock.System.now().toString()
             val TEST_MLS_MESSAGE = MLSMessageApi.Message("message".toByteArray())
             val TEST_CORE_FAILURE = Either.Left(CoreFailure.Unknown(Throwable("an error")))
             val MLS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo.MLS(

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -14,7 +14,7 @@ import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.network.SessionManagerImpl
 import com.wire.kalium.logic.sync.UserSessionWorkSchedulerImpl
-import com.wire.kalium.network.api.v0.authenticated.networkContainer.AuthenticatedNetworkContainerV0
+import com.wire.kalium.network.api.v2.authenticated.networkContainer.AuthenticatedNetworkContainerV2
 import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
@@ -40,7 +40,7 @@ actual class UserSessionScopeProviderImpl(
         val rootFileSystemPath = AssetsStorageFolder("$rootStoragePath/files")
         val rootCachePath = CacheFolder("$rootAccountPath/cache")
         val dataStoragePaths = DataStoragePaths(rootFileSystemPath, rootCachePath)
-        val networkContainer: AuthenticatedNetworkContainer = AuthenticatedNetworkContainerV0(
+        val networkContainer: AuthenticatedNetworkContainer = AuthenticatedNetworkContainerV2(
             SessionManagerImpl(globalScope.sessionRepository, userId, tokenStorage = globalPreferences.authTokenStorage),
             ServerMetaDataManagerImpl(globalScope.serverConfigRepository),
             developmentApiEnabled = kaliumConfigs.developmentApiEnabled

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/MLSMessageApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/MLSMessageApi.kt
@@ -23,7 +23,7 @@ interface MLSMessageApi {
      *
      * @param message MLS Message
      */
-    suspend fun sendMessage(message: Message): NetworkResponse<Unit>
+    suspend fun sendMessage(message: Message): NetworkResponse<SendMLSMessageResponse>
 
     /**
      * Send an MLS welcome message to a client(s) which you've added to a MLS group.

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/SendMLSMessageResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/SendMLSMessageResponse.kt
@@ -1,0 +1,11 @@
+package com.wire.kalium.network.api.base.authenticated.message
+
+import com.wire.kalium.network.api.base.authenticated.notification.EventResponse
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SendMLSMessageResponse(
+    val time: String,
+    val events: List<EventResponse>
+)
+

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MLSMessageApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MLSMessageApiV0.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.network.api.v0.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
+import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
 import com.wire.kalium.network.serialization.Mls
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
@@ -18,7 +19,7 @@ internal open class MLSMessageApiV0 internal constructor(
 
     private val httpClient get() = authenticatedNetworkClient.httpClient
 
-    override suspend fun sendMessage(message: MLSMessageApi.Message): NetworkResponse<Unit> =
+    override suspend fun sendMessage(message: MLSMessageApi.Message): NetworkResponse<SendMLSMessageResponse> =
         wrapKaliumResponse {
             httpClient.post(PATH_MESSAGE) {
                 setBody(message.value)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/MLSMessageApiV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/MLSMessageApiV2.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.network.api.v2.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
+import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
 import com.wire.kalium.network.api.v0.authenticated.MLSMessageApiV0
 import com.wire.kalium.network.serialization.Mls
 import com.wire.kalium.network.utils.NetworkResponse
@@ -17,7 +18,7 @@ internal open class MLSMessageApiV2 internal constructor(
 
     private val httpClient get() = authenticatedNetworkClient.httpClient
 
-    override suspend fun sendMessage(message: MLSMessageApi.Message): NetworkResponse<Unit> =
+    override suspend fun sendMessage(message: MLSMessageApi.Message): NetworkResponse<SendMLSMessageResponse> =
         wrapKaliumResponse {
             httpClient.post(PATH_MESSAGE) {
                 setBody(message.value)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Time field was introduced in V2 for sending MLS messages weren't parsed which could lead to inconsistent message ordering between clients.

### Solutions

Parse it.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
