### PR TITLE
fix: missing system message when an adding member to a conversation AR-2572

### DIFF
--- a/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/main/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -252,7 +252,7 @@ class ListenGroupCommand : CliktCommand(name = "listen-group") {
 }
 
 class AddMemberToGroupCommand : CliktCommand(name = "add-member") {
-    override fun run() = runBlocking {
+    override fun run(): Unit = runBlocking {
 
         val userSession = currentUserSession()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -541,19 +541,17 @@ internal class ConversationDataSource internal constructor(
                 addParticipantRequest, idMapper.toApiModel(conversationId)
             )
         }.flatMap { response ->
-            userIdList.map { userId ->
+            val memberList = userIdList.map { userId ->
                 // TODO: mapping the user id list to members with a made up role is incorrect and a recipe for disaster
                 Conversation.Member(userId, Conversation.Member.Role.Member)
-            }.let { membersList ->
-                persistMembers(membersList, conversationId)
             }
 
-            val foo = when (response) {
-                is ConversationMemberAddedDTO.Changed -> MemberChangeResult.Changed(response.time)
-                ConversationMemberAddedDTO.Unchanged -> MemberChangeResult.Unchanged
+            persistMembers(memberList, conversationId).map {
+                when (response) {
+                    is ConversationMemberAddedDTO.Changed -> MemberChangeResult.Changed(response.time)
+                    ConversationMemberAddedDTO.Unchanged -> MemberChangeResult.Unchanged
+                }
             }
-
-            Either.Right(foo)
         }
 
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.conversation.AddConversationMembersRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberAddedDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberRemovedDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationAccessInfoDTO
@@ -38,7 +39,6 @@ import com.wire.kalium.network.api.base.authenticated.conversation.model.Convers
 import com.wire.kalium.network.api.base.authenticated.conversation.model.UpdateConversationAccessResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.persistence.dao.ConversationEntity
-import com.wire.kalium.persistence.dao.ConversationEntity.ProtocolInfo
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.persistence.dao.message.MessageDAO
@@ -91,7 +91,7 @@ interface ConversationRepository {
         conversationID: ConversationId
     ): Either<CoreFailure, Unit>
 
-    suspend fun addMembers(userIdList: List<UserId>, conversationID: ConversationId): Either<CoreFailure, Unit>
+    suspend fun addMembers(userIdList: List<UserId>, conversationId: ConversationId): Either<CoreFailure, MemberChangeResult>
     suspend fun deleteMember(userId: UserId, conversationId: ConversationId): Either<CoreFailure, MemberChangeResult>
     suspend fun deleteMembersFromEvent(userIDList: List<UserId>, conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun getOneToOneConversationWithOtherUser(otherUserId: UserId): Either<CoreFailure, Conversation>
@@ -493,23 +493,19 @@ internal class ConversationDataSource internal constructor(
 
     override suspend fun addMembers(
         userIdList: List<UserId>,
-        conversationID: ConversationId
-    ): Either<CoreFailure, Unit> = wrapApiRequest {
-        val users = userIdList.map {
-            idMapper.toApiModel(it)
+        conversationId: ConversationId
+    ): Either<CoreFailure, MemberChangeResult> =
+        detailsById(conversationId).flatMap { conversation ->
+            when (conversation.protocol) {
+                is Conversation.ProtocolInfo.Proteus ->
+                    addMembersToCloudAndStorage(userIdList, conversationId)
+
+                is Conversation.ProtocolInfo.MLS -> {
+                    mlsConversationRepository.addMemberToMLSGroup(conversation.protocol.groupId, userIdList)
+                        .map { MemberChangeResult.Changed(Clock.System.now().toString()) }
+                }
+            }
         }
-        val addParticipantRequest = AddConversationMembersRequest(users, DEFAULT_MEMBER_ROLE)
-        conversationApi.addMember(
-            addParticipantRequest, idMapper.toApiModel(conversationID)
-        )
-    }.flatMap {
-        userIdList.map { userId ->
-            // TODO: mapping the user id list to members with a made up role is incorrect and a recipe for disaster
-            Conversation.Member(userId, Conversation.Member.Role.Member)
-        }.let { membersList ->
-            persistMembers(membersList, conversationID)
-        }
-    }
 
     override suspend fun deleteMember(
         userId: UserId,
@@ -534,6 +530,32 @@ internal class ConversationDataSource internal constructor(
                 }
             }
         }
+
+    private suspend fun addMembersToCloudAndStorage(userIdList: List<UserId>, conversationId: ConversationId) =
+        wrapApiRequest {
+            val users = userIdList.map {
+                idMapper.toApiModel(it)
+            }
+            val addParticipantRequest = AddConversationMembersRequest(users, DEFAULT_MEMBER_ROLE)
+            conversationApi.addMember(
+                addParticipantRequest, idMapper.toApiModel(conversationId)
+            )
+        }.flatMap { response ->
+            userIdList.map { userId ->
+                // TODO: mapping the user id list to members with a made up role is incorrect and a recipe for disaster
+                Conversation.Member(userId, Conversation.Member.Role.Member)
+            }.let { membersList ->
+                persistMembers(membersList, conversationId)
+            }
+
+            val foo = when (response) {
+                is ConversationMemberAddedDTO.Changed -> MemberChangeResult.Changed(response.time)
+                ConversationMemberAddedDTO.Unchanged -> MemberChangeResult.Unchanged
+            }
+
+            Either.Right(foo)
+        }
+
 
     private suspend fun deleteMemberFromCloudAndStorage(userId: UserId, conversationId: ConversationId) =
         wrapApiRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -554,7 +554,6 @@ internal class ConversationDataSource internal constructor(
             }
         }
 
-
     private suspend fun deleteMemberFromCloudAndStorage(userId: UserId, conversationId: ConversationId) =
         wrapApiRequest {
             conversationApi.removeMember(idMapper.toApiModel(userId), idMapper.toApiModel(conversationId))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
@@ -11,7 +11,6 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.fold
 
-
 interface AddMemberToConversationUseCase {
     suspend operator fun invoke(conversationId: ConversationId, userIdList: List<UserId>): Result
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
@@ -33,7 +33,7 @@ class AddMemberToConversationUseCaseImpl(
             if (it is MemberChangeResult.Changed) {
                 /*
                 Backend doesn't forward a member-join message event to the client that add users to a conversation but everyone
-                else on the group. Therefore, we need to map the member deletion api response manually, and create and persist the
+                else on the group. Therefore, we need to map the member add api response manually, and create and persist the
                 member-join system message on these cases
                  */
                 val message = Message.System(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
@@ -1,28 +1,53 @@
 package com.wire.kalium.logic.feature.conversation
 
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
+import com.wire.kalium.logic.data.conversation.MemberChangeResult
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
+
 
 interface AddMemberToConversationUseCase {
-    suspend operator fun invoke(conversationId: ConversationId, userIdList: List<UserId>)
+    suspend operator fun invoke(conversationId: ConversationId, userIdList: List<UserId>): Result
+
+    sealed interface Result {
+        object Success : Result
+        data class Failure(val cause: CoreFailure) : Result
+    }
 }
 
 class AddMemberToConversationUseCaseImpl(
     private val conversationRepository: ConversationRepository,
-    private val mlsConversationRepository: MLSConversationRepository
+    private val selfUserId: UserId,
+    private val persistMessage: PersistMessageUseCase
 ) : AddMemberToConversationUseCase {
-    override suspend fun invoke(conversationId: ConversationId, userIdList: List<UserId>) {
-        // TODO: do we need to filter out self user ?
-        conversationRepository.detailsById(conversationId).flatMap { conversation ->
-            when (conversation.protocol) {
-                is ProtocolInfo.Proteus -> conversationRepository.addMembers(userIdList, conversationId)
-                is ProtocolInfo.MLS ->
-                    mlsConversationRepository.addMemberToMLSGroup(conversation.protocol.groupId, userIdList)
+    override suspend fun invoke(conversationId: ConversationId, userIdList: List<UserId>): AddMemberToConversationUseCase.Result {
+        return conversationRepository.addMembers(userIdList, conversationId).fold({
+            AddMemberToConversationUseCase.Result.Failure(it)
+        }, {
+            if (it is MemberChangeResult.Changed) {
+                /*
+                Backend doesn't forward a member-join message event to the client that add users to a conversation but everyone
+                else on the group. Therefore, we need to map the member deletion api response manually, and create and persist the
+                member-join system message on these cases
+                 */
+                val message = Message.System(
+                    id = uuid4().toString(), // We generate a random uuid for this new system message
+                    content = MessageContent.MemberChange.Added(members = userIdList),
+                    conversationId = conversationId,
+                    date = it.time,
+                    senderUserId = selfUserId,
+                    status = Message.Status.SENT,
+                    visibility = Message.Visibility.VISIBLE
+                )
+                persistMessage(message)
             }
-        }
+            AddMemberToConversationUseCase.Result.Success
+        })
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -78,7 +78,7 @@ class ConversationScope internal constructor(
         get() = CreateGroupConversationUseCase(conversationRepository, syncManager, clientRepository)
 
     val addMemberToConversationUseCase: AddMemberToConversationUseCase
-        get() = AddMemberToConversationUseCaseImpl(conversationRepository, mlsConversationRepository)
+        get() = AddMemberToConversationUseCaseImpl(conversationRepository, selfUserId, persistMessage)
 
     val getOrCreateOneToOneConversationUseCase: GetOrCreateOneToOneConversationUseCase
         get() = GetOrCreateOneToOneConversationUseCase(conversationRepository)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

No system message is inserted when adding a user to a conversation.

### Causes

Not implemented in the `AddMemberToConversationUseCase`

### Solutions

Add the missing implementation and align adding a member with removing a member.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
