### PR TITLE
fix: fetching server config does not handle version unsupported error

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -4,7 +4,9 @@ import com.wire.kalium.logic.configuration.server.CommonApiVersionType
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.configuration.server.ServerConfigDataSource
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
+import com.wire.kalium.logic.failure.ServerConfigFailure
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.logic.util.stubs.newServerConfig
 import com.wire.kalium.logic.util.stubs.newServerConfigDTO
@@ -15,6 +17,7 @@ import com.wire.kalium.network.tools.ApiVersionDTO
 import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
+import com.wire.kalium.persistence.model.ServerConfigEntity
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -77,7 +80,9 @@ class ServerConfigRepositoryTest {
 
     @Test
     fun givenStoredConfig_thenItCanBeRetrievedById() {
-        val (arrangement, repository) = Arrangement().withConfigById().arrange()
+        val (arrangement, repository) = Arrangement()
+            .withConfigById(newServerConfigEntity(1))
+            .arrange()
         val expected = newServerConfig(1)
 
         val actual = repository.configById(expected.id)
@@ -93,7 +98,9 @@ class ServerConfigRepositoryTest {
     @Test
     fun givenStoredConfig_thenItCanBeDeleted() {
         val serverConfigId = "1"
-        val (arrangement, repository) = Arrangement().withConfigById().arrange()
+        val (arrangement, repository) = Arrangement()
+            .withConfigById(newServerConfigEntity(1))
+            .arrange()
 
         val actual = repository.deleteById(serverConfigId)
 
@@ -107,7 +114,9 @@ class ServerConfigRepositoryTest {
     @Test
     fun givenStoredConfig_whenDeleting_thenItCanBeDeleted() {
         val serverConfig = newServerConfig(1)
-        val (arrangement, repository) = Arrangement().withConfigById().arrange()
+        val (arrangement, repository) = Arrangement()
+            .withConfigById(newServerConfigEntity(1))
+            .arrange()
 
         val actual = repository.delete(serverConfig)
 
@@ -121,10 +130,13 @@ class ServerConfigRepositoryTest {
     @Test
     fun givenValidCompatibleApiVersion_whenStoringConfigLocally_thenConfigIsStored() = runTest {
         val expected = newServerConfig(1)
+        val expectedDTO = newServerConfigDTO(1)
+
+        val expectedEntity = newServerConfigEntity(1)
         val (arrangement, repository) = Arrangement()
-            .withApiAversionResponse(expected)
-            .withConfigById()
-            .withConfigByLinks()
+            .withApiAversionResponse(expectedDTO.metaData)
+            .withConfigById(expectedEntity)
+            .withConfigByLinks(null)
             .arrange()
 
         repository.fetchApiVersionAndStore(expected.links).shouldSucceed {
@@ -149,15 +161,17 @@ class ServerConfigRepositoryTest {
 
     @Test
     fun givenInValidCompatibleApiVersion_whenStoringConfigLocally_thenErrorIsPropagated() = runTest {
-        val expected = newServerConfig(1).copy(metaData = ServerConfig.MetaData(false, CommonApiVersionType.Unknown, "domain") )
+        val expected = newServerConfig(1).copy(metaData = ServerConfig.MetaData(false, CommonApiVersionType.Unknown, "domain"))
+        val expectedMetaDataDTO = ServerConfigDTO.MetaData(false, ApiVersionDTO.Invalid.Unknown, "domain")
+        val expectedEntity = newServerConfigEntity(1).copy(metaData = ServerConfigEntity.MetaData(false, -2, "domain"))
+
         val (arrangement, repository) = Arrangement()
-            .withApiAversionResponse(expected)
-            .withConfigById()
-            .withConfigByLinks()
+            .withApiAversionResponse(expectedMetaDataDTO)
+            .withConfigByLinks(expectedEntity)
             .arrange()
 
-        repository.fetchApiVersionAndStore(expected.links).shouldSucceed {
-            assertEquals(expected, it)
+        repository.fetchApiVersionAndStore(expected.links).shouldFail() {
+            assertEquals(ServerConfigFailure.UnknownServerVersion, it)
         }
 
         verify(arrangement.versionApi)
@@ -168,7 +182,12 @@ class ServerConfigRepositoryTest {
         verify(arrangement.serverConfigDAO)
             .function(arrangement.serverConfigDAO::configById)
             .with(any())
-            .wasInvoked(exactly = once)
+            .wasNotInvoked()
+
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::configByLinks)
+            .with(any(), any(), any())
+            .wasNotInvoked()
 
         verify(arrangement.serverConfigDAO)
             .function(arrangement.serverConfigDAO::insert)
@@ -298,19 +317,19 @@ class ServerConfigRepositoryTest {
             return this
         }
 
-        fun withConfigById(): Arrangement {
+        fun withConfigById(serverConfig: ServerConfigEntity): Arrangement {
             given(serverConfigDAO)
                 .function(serverConfigDAO::configById)
                 .whenInvokedWith(any())
-                .then { newServerConfigEntity(1) }
+                .then { serverConfig }
             return this
         }
 
-        fun withConfigByLinks(): Arrangement {
+        fun withConfigByLinks(serverConfigEntity: ServerConfigEntity?): Arrangement {
             given(serverConfigDAO)
                 .function(serverConfigDAO::configByLinks)
                 .whenInvokedWith(any(), any(), any())
-                .thenReturn(null)
+                .thenReturn(serverConfigEntity)
             return this
         }
 
@@ -320,16 +339,11 @@ class ServerConfigRepositoryTest {
             return this
         }
 
-        fun withApiAversionResponse(serverConfig: ServerConfig = newServerConfig(1)): Arrangement {
-            val versionInfoDTO = ServerConfigDTO.MetaData(
-                domain = serverConfig.metaData.domain,
-                federation = serverConfig.metaData.federation,
-                commonApiVersion = ApiVersionDTO.Valid(1)
-            )
+        fun withApiAversionResponse(serverConfigDTO: ServerConfigDTO.MetaData): Arrangement {
             given(versionApi)
                 .suspendFunction(versionApi::fetchApiVersion)
                 .whenInvokedWith(any())
-                .then { NetworkResponse.Success(versionInfoDTO, mapOf(), 200) }
+                .then { NetworkResponse.Success(serverConfigDTO, mapOf(), 200) }
 
             return this
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -140,6 +140,40 @@ class ServerConfigRepositoryTest {
             .function(arrangement.serverConfigDAO::configById)
             .with(any())
             .wasInvoked(exactly = once)
+
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::insert)
+            .with(any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenInValidCompatibleApiVersion_whenStoringConfigLocally_thenErrorIsPropagated() = runTest {
+        val expected = newServerConfig(1).copy(metaData = ServerConfig.MetaData(false, CommonApiVersionType.Unknown, "domain") )
+        val (arrangement, repository) = Arrangement()
+            .withApiAversionResponse(expected)
+            .withConfigById()
+            .withConfigByLinks()
+            .arrange()
+
+        repository.fetchApiVersionAndStore(expected.links).shouldSucceed {
+            assertEquals(expected, it)
+        }
+
+        verify(arrangement.versionApi)
+            .suspendFunction(arrangement.versionApi::fetchApiVersion)
+            .with(any())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::configById)
+            .with(any())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::insert)
+            .with(any())
+            .wasNotInvoked()
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

fetching server config does not handle version unsupported error


### Solutions

handle version not supported errors and add unit tests

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
