### PR TITLE
fix: progress bar indicator for downloading generic assets

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
@@ -30,6 +30,7 @@ interface GetMessageAssetUseCase {
     ): MessageAssetResult
 }
 
+// TODO: refactor this use case or find a way to centralize [Message.DownloadStatus] management
 internal class GetMessageAssetUseCaseImpl(
     private val assetDataSource: AssetRepository,
     private val messageRepository: MessageRepository,
@@ -63,6 +64,9 @@ internal class GetMessageAssetUseCaseImpl(
                     CoreFailure.Unknown(IllegalStateException("The message associated to this id, was not an asset message"))
                 )
             }
+
+            // Start progress bar for generic assets
+            if (!wasDownloaded) updateAssetMessageDownloadStatus(Message.DownloadStatus.DOWNLOAD_IN_PROGRESS, conversationId, messageId)
 
             assetDataSource.fetchPrivateDecodedAsset(
                 assetId = AssetId(assetMetadata.assetKey, assetMetadata.assetKeyDomain.orEmpty()),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
@@ -6,7 +6,6 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED_DOWNLOAD
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_EXTERNALLY
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_INTERNALLY
 import com.wire.kalium.logic.data.message.MessageContent
@@ -74,15 +73,13 @@ internal class GetMessageAssetUseCaseImpl(
                 assetToken = assetMetadata.assetToken,
                 encryptionKey = assetMetadata.encryptionKey
             ).fold({
-                kaliumLogger.e("There was an error downloading asset with id => ${assetMetadata.assetKey}")
-                // Only update the asset download status to failed if it wasn't set as FAILED_DOWNLOAD before. Otherwise it will result in
-                // an endless recursive loop, modifying the message, mapping the value and trying to fetch the asset again.
-                if (assetDownloadStatus != FAILED_DOWNLOAD)
-                    updateAssetMessageDownloadStatus(Message.DownloadStatus.FAILED_DOWNLOAD, conversationId, messageId)
+                kaliumLogger.e("There was an error downloading asset with id => ${assetMetadata.assetKey.obfuscateId()}")
+                // This should be called if there is an issue while downloading the asset
+                updateAssetMessageDownloadStatus(Message.DownloadStatus.FAILED_DOWNLOAD, conversationId, messageId)
                 MessageAssetResult.Failure(it)
             }, { decodedAssetPath ->
                 // Only update the asset download status if it wasn't downloaded before, aka the asset was indeed downloaded while running
-                // this specific use case. Otherwise recursive loop as described above kicks in.
+                // this specific use case. Otherwise, recursive loop as described above kicks in.
                 if (!wasDownloaded)
                     updateAssetMessageDownloadStatus(Message.DownloadStatus.SAVED_INTERNALLY, conversationId, messageId)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

With the refactors made to being able to manage Image Previews sent from other clients, we broke the progress bar indicator, this brings back the indicator (at least for generic assets).

Also was added a correct handling for errors while downloading.

Note: This is an intermedius step, we are going to refactor this use case after the release.

### Attachments (Optional)

https://user-images.githubusercontent.com/5806454/193938510-34945f11-bcd3-4c0c-9fc4-9337f3614341.mov

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
