### PR TITLE
fix: wait until live in discardCommitAndRetry strategy AR-2586

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -414,7 +414,9 @@ class MLSConversationDataSource(
             wrapMLSRequest {
                 mlsClient.clearPendingCommit(idMapper.toCryptoModel(groupID))
             }.flatMap {
-                operation()
+                syncManager.waitUntilLiveOrFailure().flatMap {
+                    operation()
+                }
             }
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -112,6 +112,7 @@ class MLSConversationRepositoryTest {
             .withSendWelcomeMessageSuccessful()
             .withSendMLSMessageFailing(Arrangement.MLS_CLIENT_MISMATCH_ERROR, times = 1)
             .withClearPendingCommitSuccessful()
+            .withWaitUntilLiveSuccessful()
             .withCommitAcceptedSuccessful()
             .withUpdateConversationGroupStateSuccessful()
             .arrange()
@@ -122,6 +123,11 @@ class MLSConversationRepositoryTest {
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::clearPendingCommit)
             .with(eq(Arrangement.RAW_GROUP_ID))
+            .wasInvoked(once)
+
+        verify(arrangement.syncManager)
+            .function(arrangement.syncManager::waitUntilLiveOrFailure)
+            .with()
             .wasInvoked(once)
 
         verify(arrangement.mlsMessageApi).coroutine { sendMessage(MLSMessageApi.Message(Arrangement.COMMIT)) }
@@ -253,6 +259,7 @@ class MLSConversationRepositoryTest {
             .withSendWelcomeMessageSuccessful()
             .withSendMLSMessageFailing(Arrangement.MLS_CLIENT_MISMATCH_ERROR, times = 1)
             .withClearPendingCommitSuccessful()
+            .withWaitUntilLiveSuccessful()
             .withCommitAcceptedSuccessful()
             .withInsertMemberSuccessful()
             .arrange()
@@ -263,6 +270,11 @@ class MLSConversationRepositoryTest {
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::clearPendingCommit)
             .with(eq(Arrangement.RAW_GROUP_ID))
+            .wasInvoked(once)
+
+        verify(arrangement.syncManager)
+            .function(arrangement.syncManager::waitUntilLiveOrFailure)
+            .with()
             .wasInvoked(once)
 
         verify(arrangement.mlsMessageApi).coroutine { sendMessage(MLSMessageApi.Message(Arrangement.COMMIT)) }
@@ -542,6 +554,7 @@ class MLSConversationRepositoryTest {
             .withSendWelcomeMessageSuccessful()
             .withUpdateConversationGroupStateSuccessful()
             .withClearPendingCommitSuccessful()
+            .withWaitUntilLiveSuccessful()
             .withCommitAcceptedSuccessful()
             .withDeleteMembersSuccessful()
             .arrange()
@@ -553,6 +566,11 @@ class MLSConversationRepositoryTest {
         verify(arrangement.mlsClient)
             .function(arrangement.mlsClient::clearPendingCommit)
             .with(eq(Arrangement.RAW_GROUP_ID))
+            .wasInvoked(once)
+
+        verify(arrangement.syncManager)
+            .function(arrangement.syncManager::waitUntilLiveOrFailure)
+            .with()
             .wasInvoked(once)
 
         verify(arrangement.mlsMessageApi).coroutine { sendMessage(MLSMessageApi.Message(Arrangement.COMMIT)) }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When running the discard commit & retry strategy when re-trying a failed commit we didn't wait until we've received all incoming events before re-trying.

### Solutions

Wait for all incoming events to finish syncing before re-trying.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
