### PR TITLE
feat(migration): add server config use case [AR-2384]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -22,6 +22,8 @@ import com.wire.kalium.logic.feature.server.FetchApiVersionUseCase
 import com.wire.kalium.logic.feature.server.FetchApiVersionUseCaseImpl
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.server.ObserveServerConfigUseCase
+import com.wire.kalium.logic.feature.server.StoreServerConfigUseCase
+import com.wire.kalium.logic.feature.server.StoreServerConfigUseCaseImpl
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCaseImpl
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
@@ -105,6 +107,7 @@ class GlobalKaliumScope(
     val fetchApiVersion: FetchApiVersionUseCase get() = FetchApiVersionUseCaseImpl(serverConfigRepository)
     val observeServerConfig: ObserveServerConfigUseCase get() = ObserveServerConfigUseCase(serverConfigRepository)
     val updateApiVersions: UpdateApiVersionsUseCase get() = UpdateApiVersionsUseCaseImpl(serverConfigRepository)
+    val storeServerConfig: StoreServerConfigUseCase get() = StoreServerConfigUseCaseImpl(serverConfigRepository)
 
     val saveNotificationToken: SaveNotificationTokenUseCase
         get() = SaveNotificationTokenUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -71,6 +71,7 @@ class GlobalKaliumScope(
             unboundNetworkContainer.serverConfigApi,
             globalDatabase.value.serverConfigurationDAO,
             unboundNetworkContainer.remoteVersion,
+            kaliumConfigs.developmentApiEnabled
         )
 
     val sessionRepository: SessionRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -66,6 +66,14 @@ data class ServerConfig(
         @SerialName("domain") val domain: String?
     )
 
+    @Serializable
+    data class VersionInfo(
+        @SerialName("domain") val domain: String?,
+        @SerialName("federation") val federation: Boolean,
+        @SerialName("supported") val supported: List<Int>,
+        @SerialName("development") val developmentSupported: List<Int>?,
+    )
+
     companion object {
         val PRODUCTION = Links(
             api = """https://prod-nginz-https.wire.com""",

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
@@ -86,6 +86,7 @@ internal class ServerConfigDataSource(
     private val dao: ServerConfigurationDAO,
     private val versionApi: VersionApi,
     private val developmentApiEnabled: Boolean,
+    private val backendMetaDataUtil: BackendMetaDataUtil = BackendMetaDataUtilImpl,
     private val serverConfigMapper: ServerConfigMapper = MapperProvider.serverConfigMapper(),
     private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : ServerConfigRepository {
@@ -147,7 +148,7 @@ internal class ServerConfigDataSource(
         }
 
     override fun storeConfig(links: ServerConfig.Links, versionInfo: ServerConfig.VersionInfo): Either<StorageFailure, ServerConfig> {
-        val metaData = BackendMetaDataUtilImpl.calculateApiVersion(
+        val metaData = backendMetaDataUtil.calculateApiVersion(
             versionInfoDTO = VersionInfoDTO(
                 developmentSupported = versionInfo.developmentSupported,
                 domain = versionInfo.domain,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
@@ -1,0 +1,28 @@
+package com.wire.kalium.logic.feature.server
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.configuration.server.ServerConfigRepository
+import com.wire.kalium.logic.functional.fold
+
+fun interface StoreServerConfigUseCase {
+    suspend operator fun invoke(links: ServerConfig.Links, versionInfo: ServerConfig.VersionInfo): StoreServerConfigResult
+}
+
+internal class StoreServerConfigUseCaseImpl(
+    private val configRepository: ServerConfigRepository
+) : StoreServerConfigUseCase {
+
+    override suspend fun invoke(links: ServerConfig.Links, versionInfo: ServerConfig.VersionInfo): StoreServerConfigResult =
+        configRepository.storeConfig(links, versionInfo)
+            .fold({ StoreServerConfigResult.Failure.Generic(it) }, { StoreServerConfigResult.Success(it) })
+}
+
+sealed class StoreServerConfigResult {
+    // TODO: change to return the id only so we are now passing the whole config object around in the app
+    class Success(val serverConfig: ServerConfig) : StoreServerConfigResult()
+
+    sealed class Failure : StoreServerConfigResult() {
+        class Generic(val genericFailure: CoreFailure) : Failure()
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.logic.util.stubs.newServerConfig
 import com.wire.kalium.logic.util.stubs.newServerConfigDTO
 import com.wire.kalium.logic.util.stubs.newServerConfigEntity
+import com.wire.kalium.network.BackendMetaDataUtil
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApi
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApi
 import com.wire.kalium.network.tools.ApiVersionDTO
@@ -207,6 +208,51 @@ class ServerConfigRepositoryTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenStoredConfigLinksAndVersionInfoData_whenAddingNewOne_thenCommonApiShouldBeCalculatedAndConfigShouldBeStored() {
+        val expectedServerConfig = newServerConfig(1)
+        val expectedServerConfigDTO = newServerConfigDTO(1)
+        val expectedVersionInfo = ServerConfig.VersionInfo(
+            expectedServerConfig.metaData.domain,
+            expectedServerConfig.metaData.federation,
+            listOf(expectedServerConfig.metaData.commonApiVersion.version),
+            null
+        )
+        val (arrangement, repository) = Arrangement()
+            .withConfigForNewRequest(expectedServerConfig)
+            .withCalculateApiVersion(expectedServerConfigDTO.metaData)
+            .arrange()
+
+        repository
+            .storeConfig(expectedServerConfig.links, expectedVersionInfo)
+            .shouldSucceed { assertEquals(it, expectedServerConfig) }
+
+        verify(arrangement.backendMetaDataUtil)
+            .function(arrangement.backendMetaDataUtil::calculateApiVersion)
+            .with(any(), any(), any())
+            .wasInvoked(exactly = once)
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::configByLinks)
+            .with(any(), any(), any())
+            .wasInvoked(exactly = once)
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::insert)
+            .with(any())
+            .wasInvoked(exactly = once)
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::updateApiVersion)
+            .with(any(), any())
+            .wasNotInvoked()
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::setFederationToTrue)
+            .with(any())
+            .wasNotInvoked()
+        verify(arrangement.serverConfigDAO)
+            .function(arrangement.serverConfigDAO::configById)
+            .with(any())
+            .wasInvoked(exactly = once)
+    }
+
     private class Arrangement {
         val SERVER_CONFIG_URL = "https://test.test/test.json"
         val SERVER_CONFIG_RESPONSE = newServerConfigDTO(1)
@@ -223,8 +269,11 @@ class ServerConfigRepositoryTest {
         @Mock
         val versionApi = mock(classOf<VersionApi>())
 
+        @Mock
+        val backendMetaDataUtil = mock(classOf<BackendMetaDataUtil>())
+
         private var serverConfigRepository: ServerConfigRepository =
-            ServerConfigDataSource(serverConfigApi, serverConfigDAO, versionApi)
+            ServerConfigDataSource(serverConfigApi, serverConfigDAO, versionApi, true, backendMetaDataUtil)
 
         val serverConfigEntity = newServerConfigEntity(1)
         val expectedServerConfig = newServerConfig(1).copy(
@@ -316,6 +365,14 @@ class ServerConfigRepositoryTest {
                 .whenInvokedWith(any())
                 .then { newServerConfigEntity }
 
+            return this
+        }
+
+        fun withCalculateApiVersion(result: ServerConfigDTO.MetaData): Arrangement {
+            given(backendMetaDataUtil)
+                .function(backendMetaDataUtil::calculateApiVersion)
+                .whenInvokedWith(any(), any(), any())
+                .thenReturn(result)
             return this
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is no way to save the config having all the necessary data. Currently there is only one that fetches the API version but all that data can be retrieved during the migration to be simply stored.

### Solutions

Implement a new use case that takes `ServerConfig.Links` and `VersionInfo`, calculates the common version and persists the config.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
