### PR TITLE
fix: adjust asset upload to change in backend v2 api

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/AssetApiV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/AssetApiV2.kt
@@ -1,13 +1,37 @@
 package com.wire.kalium.network.api.v2.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.asset.AssetMetadataRequest
+import com.wire.kalium.network.api.base.authenticated.asset.AssetResponse
 import com.wire.kalium.network.api.base.model.AssetId
 import com.wire.kalium.network.api.v0.authenticated.AssetApiV0
+import com.wire.kalium.network.api.v0.authenticated.StreamAssetContent
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import okio.Source
 
 internal open class AssetApiV2 internal constructor(
-    authenticatedNetworkClient: AuthenticatedNetworkClient
+    private val authenticatedNetworkClient: AuthenticatedNetworkClient
 ) : AssetApiV0(authenticatedNetworkClient) {
     override fun buildAssetsPath(assetId: AssetId): String = "$PATH_ASSETS/${assetId.domain}/${assetId.value}"
+
+    private val httpClient get() = authenticatedNetworkClient.httpClient
+
+    override suspend fun uploadAsset(
+        metadata: AssetMetadataRequest,
+        encryptedDataSource: () -> Source,
+        encryptedDataSize: Long
+    ): NetworkResponse<AssetResponse> =
+        wrapKaliumResponse {
+            httpClient.post(PATH_ASSETS) {
+                contentType(ContentType.MultiPart.Mixed)
+                setBody(StreamAssetContent(metadata, encryptedDataSize, encryptedDataSource))
+            }
+        }
 
     private companion object {
         const val PATH_ASSETS = "assets"

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v2/AssetApiV2Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v2/AssetApiV2Test.kt
@@ -1,20 +1,83 @@
 package com.wire.kalium.api.v2
 
 import com.wire.kalium.api.ApiTest
+import com.wire.kalium.model.asset.AssetUploadResponseJson
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
+import com.wire.kalium.network.api.base.authenticated.asset.AssetMetadataRequest
 import com.wire.kalium.network.api.base.model.AssetId
+import com.wire.kalium.network.api.base.model.AssetRetentionType
 import com.wire.kalium.network.api.v2.authenticated.AssetApiV2
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import okio.Source
 import okio.blackholeSink
+import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AssetApiV2Test : ApiTest {
+
+    @Test
+    fun givenAValidAssetUploadApiRequest_whenCallingTheAssetUploadApiEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
+        // Given
+        val fileSystem = FakeFileSystem()
+        val assetMetadata = AssetMetadataRequest("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
+        val encryptedData = "some-data".encodeToByteArray()
+        val encryptedDataSource = { getDummyDataSource(fileSystem, encryptedData) }
+        val networkClient = mockAuthenticatedNetworkClient(
+            VALID_ASSET_UPLOAD_RESPONSE.rawJson,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertPost()
+                assertNoQueryParams()
+                assertAuthorizationHeaderExist()
+                assertPathEqual(PATH_ASSETS)
+            }
+        )
+
+        // When
+        val assetApi: AssetApi = AssetApiV2(networkClient)
+        val response = assetApi.uploadAsset(assetMetadata, encryptedDataSource, encryptedData.size.toLong())
+
+        // Then
+        assertTrue(response.isSuccessful())
+        assertEquals(response.value, VALID_ASSET_UPLOAD_RESPONSE.serializableData)
+    }
+
+    @Test
+    fun givenAnInvalidAssetUploadApiRequest_whenCallingTheAssetUploadApiEndpoint_theRequestShouldContainAnError() = runTest {
+        // Given
+        val fileSystem = FakeFileSystem()
+        val assetMetadata = AssetMetadataRequest("image/jpeg", true, AssetRetentionType.ETERNAL, "md5-hash")
+        val encryptedData = "some-data".encodeToByteArray()
+        val encryptedDataSource = { getDummyDataSource(fileSystem, encryptedData) }
+        val networkClient = mockAuthenticatedNetworkClient(
+            INVALID_ASSET_UPLOAD_RESPONSE.rawJson,
+            statusCode = HttpStatusCode.BadRequest,
+            assertion = {
+                assertPost()
+                assertNoQueryParams()
+                assertAuthorizationHeaderExist()
+                assertPathEqual(PATH_ASSETS)
+            }
+        )
+
+        // When
+        val assetApi: AssetApi = AssetApiV2(networkClient)
+        val response = assetApi.uploadAsset(assetMetadata, encryptedDataSource, encryptedData.size.toLong())
+
+        // Then
+        assertTrue(response is NetworkResponse.Error)
+        assertTrue(response.kException is KaliumException.InvalidRequestError)
+    }
 
     @Test
     fun givenAValidAssetDownloadApiRequest_whenCallingTheAssetDownloadApiEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
@@ -63,12 +126,22 @@ class AssetApiV2Test : ApiTest {
         assertTrue(response.isSuccessful())
     }
 
+    private fun getDummyDataSource(fileSystem: FakeFileSystem, dummyData: ByteArray): Source {
+        val dummyPath = "some-data-path".toPath()
+        fileSystem.write(dummyPath) {
+            write(dummyData)
+        }
+        return fileSystem.source(dummyPath)
+    }
+
     companion object {
         const val PATH_ASSETS = "/assets"
         const val HEADER_ASSET_TOKEN = "Asset-Token"
         const val ASSET_KEY = "3-1-e7788668-1b22-488a-b63c-acede42f771f"
         const val ASSET_DOMAIN = "wire.com"
         const val ASSET_TOKEN = "assetToken"
+        val VALID_ASSET_UPLOAD_RESPONSE = AssetUploadResponseJson.valid
+        val INVALID_ASSET_UPLOAD_RESPONSE = AssetUploadResponseJson.invalid
         val assetId: AssetId = AssetId(ASSET_KEY, ASSET_DOMAIN)
         val tempFileSink = blackholeSink()
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Asset upload on staging backend broke with 502 error.

### Causes (Optional)

The current code uploaded assets to `staging-nginz-https.zinfra.io/v2/ass****/v3` but the API on staging backend recently changed to `staging-nginz-https.zinfra.io/v2/ass****`

### Solutions

Using correct path for v2 api.

### Testing

Testing was done through kalium-testservice. Uploading assets works again after using the fix.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
