### PR TITLE
fix: avoid using unfinished API implementations AR-2592

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -282,7 +282,7 @@ class ServerConfigRepositoryTest {
 
         verify(arrangement.backendMetaDataUtil)
             .function(arrangement.backendMetaDataUtil::calculateApiVersion)
-            .with(any(), any(), any())
+            .with(any(), any(), any(), any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
             .function(arrangement.serverConfigDAO::configByLinks)
@@ -419,7 +419,7 @@ class ServerConfigRepositoryTest {
         fun withCalculateApiVersion(result: ServerConfigDTO.MetaData): Arrangement {
             given(backendMetaDataUtil)
                 .function(backendMetaDataUtil::calculateApiVersion)
-                .whenInvokedWith(any(), any(), any())
+                .whenInvokedWith(any(), any(), any(), any())
                 .thenReturn(result)
             return this
         }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/BackendMetaDataUtilTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/BackendMetaDataUtilTest.kt
@@ -18,8 +18,9 @@ class BackendMetaDataUtilTest {
     }
 
     @Test
-    fun givenCommonVersionBetweenAppAndDB_whenCalculateApiVersion_thenTheHighestCommonVersionIsReturned() {
+    fun givenDevelopmentApiDisabled_whenCalculateApiVersion_thenTheHighestCommonVersionDoesNotIncludeServerDevelopmentVersion() {
         val appVersion = setOf(1, 2, 3, 4, 5)
+        val developmentVersion = emptySet<Int>()
         val serverVersion = VersionInfoDTO(listOf(5), "domain.com", false, listOf(0, 1, 2, 3, 4))
         val expected = ServerConfigDTO.MetaData(
             serverVersion.federation,
@@ -27,14 +28,29 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
         assertEquals(expected, actual)
-
     }
 
     @Test
-    fun givenCommonVersionBetweenAppAndDBAndEnabledDevApi_whenCalculateApiVersion_thenTheHighestCommonVersionIsReturned() {
-        val appVersion = setOf(1, 2, 3, 4, 5)
+    fun givenDevelopmentApiDisabled_whenCalculateApiVersion_thenTheHighestCommonVersionDoesNotIncludeAppDevelopmentVersion() {
+        val appVersion = setOf(1, 2, 3, 4)
+        val developmentVersion = setOf(5)
+        val serverVersion = VersionInfoDTO(listOf(6), "domain.com", false, listOf(0, 1, 2, 3, 4, 5))
+        val expected = ServerConfigDTO.MetaData(
+            serverVersion.federation,
+            ApiVersionDTO.Valid(4),
+            serverVersion.domain
+        )
+
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun givenDevelopmentApiEnabled_whenCalculateApiVersion_thenTheHighestCommonVersionIncludesAppDevelopmentVersion() {
+        val appVersion = setOf(1, 2, 3, 4)
+        val developmentVersion = setOf(5)
         val serverVersion = VersionInfoDTO(listOf(5), "domain.com", false, listOf(0, 1, 2, 3, 4))
         val expected = ServerConfigDTO.MetaData(
             serverVersion.federation,
@@ -42,14 +58,14 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, true)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,true)
         assertEquals(expected, actual)
-
     }
 
     @Test
-    fun givenCommonVersionAndEnabledDevApiAndNullDevApiSupported_whenCalculateApiVersion_thenTheHighestCommonVersionIsReturned() {
-        val appVersion = setOf(1, 2, 3, 4, 5)
+    fun givenServerDevelopmentVersionIsNull_whenCalculateApiVersion_thenTheHighestCommonVersionDoesNotIncludeAppDevelopmentVersion() {
+        val appVersion = setOf(1, 2, 3, 4)
+        val developmentVersion = setOf(5)
         val serverVersion = VersionInfoDTO(null, "domain.com", false, listOf(0, 1, 2, 3, 4))
         val expected = ServerConfigDTO.MetaData(
             serverVersion.federation,
@@ -57,14 +73,14 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, true)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion, true)
         assertEquals(expected, actual)
-
     }
 
     @Test
-    fun givenOldBEVersion_whenCalculateApiVersion_thenTheUnknownServerIsReturned() {
+    fun givenServerSupportedVersionIsOutOfRange_whenCalculateApiVersion_thenTheUnknownServerIsReturned() {
         val appVersion = setOf(1, 2, 3)
+        val developmentVersion = emptySet<Int>()
         val serverVersion = VersionInfoDTO(listOf(1), "domain.com", false, listOf(0))
         val expected = ServerConfigDTO.MetaData(
             serverVersion.federation,
@@ -72,26 +88,28 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
         assertEquals(expected, actual)
     }
 
     @Test
-    fun givenOldAppVersion_whenCalculateApiVersion_thenTheUnknownServerIsReturned() {
+    fun givenAppSupportedVersionIsOutOfRange_whenCalculateApiVersion_thenTheUnknownServerIsReturned() {
         val appVersion = setOf(0)
+        val developmentVersion = emptySet<Int>()
         val serverVersion = VersionInfoDTO(listOf(4), "domain.com", false, listOf(1, 2, 3))
         val expected = ServerConfigDTO.MetaData(
             serverVersion.federation,
             ApiVersionDTO.Invalid.New,
             serverVersion.domain
         )
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
         assertEquals(expected, actual)
     }
 
     @Test
-    fun givenAnEmptyServerVersionList_whenCalculateApiVersion_thenTheUnknownServerIsReturned() {
+    fun givenAnEmptyServerSupportedVersionList_whenCalculateApiVersion_thenTheUnknownServerIsReturned() {
         val appVersion = setOf(0)
+        val developmentVersion = emptySet<Int>()
         val serverVersion = VersionInfoDTO(null, "domain.com", false, emptyList<Int>())
         val expected = ServerConfigDTO.MetaData(
             serverVersion.federation,
@@ -99,13 +117,14 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
         assertEquals(expected, actual)
     }
 
     @Test
-    fun givenAnEmptyAppVersionList_whenCalculateApiVersion_thenTheUnknownServerIsReturned() {
+    fun givenAnEmptyAppSupportedVersionList_whenCalculateApiVersion_thenTheUnknownServerIsReturned() {
         val appVersion = emptySet<Int>()
+        val developmentVersion = emptySet<Int>()
         val serverVersion = VersionInfoDTO(null, "domain.com", false, listOf(1, 2, 3))
         val expected = ServerConfigDTO.MetaData(
             serverVersion.federation,
@@ -113,7 +132,7 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
         assertEquals(expected, actual)
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/BackendMetaDataUtilTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/BackendMetaDataUtilTest.kt
@@ -28,7 +28,7 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion, false)
         assertEquals(expected, actual)
     }
 
@@ -43,7 +43,7 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion, false)
         assertEquals(expected, actual)
     }
 
@@ -58,7 +58,7 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,true)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion, true)
         assertEquals(expected, actual)
     }
 
@@ -88,7 +88,7 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion, false)
         assertEquals(expected, actual)
     }
 
@@ -102,7 +102,7 @@ class BackendMetaDataUtilTest {
             ApiVersionDTO.Invalid.New,
             serverVersion.domain
         )
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion, false)
         assertEquals(expected, actual)
     }
 
@@ -117,7 +117,7 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion, false)
         assertEquals(expected, actual)
     }
 
@@ -132,7 +132,7 @@ class BackendMetaDataUtilTest {
             serverVersion.domain
         )
 
-        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion,false)
+        val actual = serverConfigUtil.calculateApiVersion(serverVersion, appVersion, developmentVersion, false)
         assertEquals(expected, actual)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Our app currently has SupportedApiVersions = [0, 1, 2] and BE announces [0, 1] as supported and [2] as supported in development. This means that 2 is currently in development and can get breaking changes at any time. We ship production builds  with `developmentApiEnabled = false` so they will only use version [0, 1].

Now backend releases version 2 and introduces version 3 as the new development version.

Our previously shipped production builds will now switch to use version 2 since that's highest common version but there's no guarantee that the version 2 implementation which shipped in the previous production builds is compatible with the now released version 2 since backend is allowed to break API at any time until it's released.

💣 💣 💣 

### Solutions

Declare supported development versions separately and only consider to use them if `developmentApiEnabled = true`

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
