### PR TITLE
chore: sendMessage with recipients parameter

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -9,6 +9,7 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.failure.ProteusSendMessageFailure
+import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
@@ -89,7 +90,7 @@ interface MessageRepository {
      * @return [Either.Left] of a [ProteusSendMessageFailure] if the server rejected the message
      * @return [Either.Left] of other [CoreFailure] for more generic cases
      */
-    suspend fun sendEnvelope(conversationId: ConversationId, envelope: MessageEnvelope): Either<CoreFailure, String>
+    suspend fun sendEnvelope(conversationId: ConversationId, envelope: MessageEnvelope, messageTarget: MessageTarget): Either<CoreFailure, String>
     suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, String>
 
     suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>>
@@ -231,19 +232,29 @@ class MessageDataSource(
             messageDAO.updateMessagesAddMillisToDate(millis, idMapper.toDaoModel(conversationId), MessageEntity.Status.PENDING)
         }
 
-    override suspend fun sendEnvelope(conversationId: ConversationId, envelope: MessageEnvelope): Either<CoreFailure, String> {
+    override suspend fun sendEnvelope(
+        conversationId: ConversationId,
+        envelope: MessageEnvelope,
+        messageTarget: MessageTarget
+    ): Either<CoreFailure, String> {
         val recipientMap = envelope.recipients.associate { recipientEntry ->
             idMapper.toApiModel(recipientEntry.userId) to recipientEntry.clientPayloads.associate { clientPayload ->
                 clientPayload.clientId.value to clientPayload.payload.data
             }
         }
+
+        val messageOption = when (messageTarget) {
+            is MessageTarget.Client -> MessageApi.QualifiedMessageOption.IgnoreAll
+            is MessageTarget.Conversation -> MessageApi.QualifiedMessageOption.ReportAll
+        }
+
         return wrapApiRequest {
             messageApi.qualifiedSendMessage(
                 // TODO(messaging): Handle other MessageOptions, native push, transient and priorities
                 MessageApi.Parameters.QualifiedDefaultParameters(
                     envelope.senderClientId.value,
                     recipientMap, true, MessagePriority.HIGH, false, envelope.dataBlob?.data,
-                    MessageApi.QualifiedMessageOption.ReportAll
+                    messageOption
                 ),
                 idMapper.toApiModel(conversationId),
             )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -90,7 +90,12 @@ interface MessageRepository {
      * @return [Either.Left] of a [ProteusSendMessageFailure] if the server rejected the message
      * @return [Either.Left] of other [CoreFailure] for more generic cases
      */
-    suspend fun sendEnvelope(conversationId: ConversationId, envelope: MessageEnvelope, messageTarget: MessageTarget): Either<CoreFailure, String>
+    suspend fun sendEnvelope(
+        conversationId: ConversationId,
+        envelope: MessageEnvelope,
+        messageTarget: MessageTarget
+    ): Either<CoreFailure, String>
+
     suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, String>
 
     suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>>

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -157,12 +157,9 @@ internal class MessageSenderImpl internal constructor(
         targetRecipients: List<Recipient>?
     ): Either<CoreFailure, String> {
         val conversationId = message.conversationId
+        val target = targetRecipients?.let { Either.Right(it) } ?: conversationRepository.getConversationRecipients(conversationId)
 
-        return targetRecipients?.let {
-            messageEnvelopeCreator.createOutgoingEnvelope(it, message).flatMap { envelope ->
-                trySendingProteusEnvelope(envelope, message)
-            }
-        } ?: conversationRepository.getConversationRecipients(conversationId).flatMap { recipients ->
+        return target.flatMap { recipients ->
             sessionEstablisher.prepareRecipientsForNewOutgoingMessage(recipients).map { recipients }
         }.flatMap { recipients ->
             messageEnvelopeCreator.createOutgoingEnvelope(recipients, message).flatMap { envelope ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -150,9 +150,12 @@ internal class MessageSenderImpl internal constructor(
                 }
             }
         }
-}
+    }
 
-    private suspend fun attemptToSendWithProteus(message: Message.Regular, targetRecipients: List<Recipient>?): Either<CoreFailure, String> {
+    private suspend fun attemptToSendWithProteus(
+        message: Message.Regular,
+        targetRecipients: List<Recipient>?
+    ): Either<CoreFailure, String> {
         val conversationId = message.conversationId
 
         return targetRecipients?.let {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -8,7 +8,6 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.message.Message
@@ -137,7 +136,10 @@ internal class MessageSenderImpl internal constructor(
 
     override suspend fun sendClientDiscoveryMessage(message: Message.Regular): Either<CoreFailure, String> = attemptToSend(message)
 
-    private suspend fun attemptToSend(message: Message.Regular, messageTarget: MessageTarget = MessageTarget.Conversation): Either<CoreFailure, String> {
+    private suspend fun attemptToSend(
+        message: Message.Regular,
+        messageTarget: MessageTarget = MessageTarget.Conversation
+    ): Either<CoreFailure, String> {
         return conversationRepository.getConversationProtocolInfo(message.conversationId).flatMap { protocolInfo ->
             when (protocolInfo) {
                 is Conversation.ProtocolInfo.MLS -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageTarget.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageTarget.kt
@@ -3,6 +3,6 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.data.conversation.Recipient
 
 sealed class MessageTarget {
-    class Client(val recipients: List<Recipient>): MessageTarget()
-    object Conversation: MessageTarget()
+    class Client(val recipients: List<Recipient>) : MessageTarget()
+    object Conversation : MessageTarget()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageTarget.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageTarget.kt
@@ -1,0 +1,8 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.data.conversation.Recipient
+
+sealed class MessageTarget {
+    class Client(val recipients: List<Recipient>): MessageTarget()
+    object Conversation: MessageTarget()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -12,7 +12,6 @@ import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.api.base.authenticated.message.MessageApi
-import com.wire.kalium.network.api.base.authenticated.message.MessagePriority
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.QualifiedIDEntity

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.NetworkQualifiedId
 import com.wire.kalium.logic.data.id.PersistenceQualifiedId
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.api.base.authenticated.message.MessageApi
@@ -122,7 +123,7 @@ class MessageRepositoryTest {
             .withSuccessfulMessageDelivery(timestamp)
             .arrange()
 
-        messageRepository.sendEnvelope(TEST_CONVERSATION_ID, messageEnvelope)
+        messageRepository.sendEnvelope(TEST_CONVERSATION_ID, messageEnvelope, MessageTarget.Conversation)
             .shouldSucceed {
                 assertSame(it, TEST_DATETIME)
             }
@@ -140,7 +141,7 @@ class MessageRepositoryTest {
             .withSuccessfulMessageDelivery(timestamp)
             .arrange()
 
-        messageRepository.sendEnvelope(TEST_CONVERSATION_ID, messageEnvelope)
+        messageRepository.sendEnvelope(TEST_CONVERSATION_ID, messageEnvelope, MessageTarget.Conversation)
             .shouldSucceed {
                 assertSame(it, TEST_DATETIME)
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -14,7 +14,6 @@ import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.api.base.authenticated.message.MessageApi
 import com.wire.kalium.network.api.base.authenticated.message.MessagePriority
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
-import com.wire.kalium.network.api.base.authenticated.message.QualifiedUserToClientToEncMsgMap
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.message.MessageDAO

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCaseTest.kt
@@ -50,7 +50,7 @@ class ClearConversationContentUseCaseTest {
 
             verify(messageSender)
                 .suspendFunction(messageSender::sendMessage)
-                .with(anything())
+                .with(anything(), anything())
                 .wasNotInvoked()
         }
     }
@@ -82,7 +82,7 @@ class ClearConversationContentUseCaseTest {
 
             verify(messageSender)
                 .suspendFunction(messageSender::sendMessage)
-                .with(anything())
+                .with(anything(), anything())
                 .wasNotInvoked()
         }
     }
@@ -115,7 +115,7 @@ class ClearConversationContentUseCaseTest {
 
             verify(messageSender)
                 .suspendFunction(messageSender::sendMessage)
-                .with(anything())
+                .with(anything(), anything())
                 .wasInvoked(Times(1))
         }
     }
@@ -148,7 +148,7 @@ class ClearConversationContentUseCaseTest {
 
             verify(messageSender)
                 .suspendFunction(messageSender::sendMessage)
-                .with(anything())
+                .with(anything(), anything())
                 .wasInvoked(Times(1))
         }
     }
@@ -198,7 +198,7 @@ class ClearConversationContentUseCaseTest {
         fun withMessageSending(isSuccessFull: Boolean): Arrangement {
             given(messageSender)
                 .suspendFunction(messageSender::sendMessage)
-                .whenInvokedWith(anything())
+                .whenInvokedWith(anything(), anything())
                 .thenReturn(if (isSuccessFull) Either.Right(Unit) else Either.Left(CoreFailure.Unknown(Throwable("an error"))))
 
             return this

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -63,7 +63,8 @@ class DeleteMessageUseCaseTest {
             .with(
                 matching { message ->
                     message.conversationId == TEST_CONVERSATION_ID && message.content == deletedMessageContent
-                }
+                },
+                anything()
             )
             .wasInvoked(exactly = once)
         verify(arrangement.messageRepository)
@@ -92,7 +93,7 @@ class DeleteMessageUseCaseTest {
         // then
         verify(arrangement.messageSender)
             .suspendFunction(arrangement.messageSender::sendMessage)
-            .with(anything())
+            .with(anything(), anything())
             .wasNotInvoked()
         verify(arrangement.messageRepository)
             .suspendFunction(arrangement.messageRepository::markMessageAsDeleted)
@@ -131,7 +132,8 @@ class DeleteMessageUseCaseTest {
             .with(
                 matching { message ->
                     message.conversationId == TestUser.SELF.id && message.content == deletedForMeContent
-                }
+                },
+                anything()
             )
             .wasInvoked(exactly = once)
 
@@ -169,7 +171,7 @@ class DeleteMessageUseCaseTest {
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(matching { message ->
                 message.conversationId == TestUser.SELF.id && message.content == deletedForMeContent
-            })
+            }, anything())
             .wasInvoked(exactly = once)
 
         verify(arrangement.assetRepository)
@@ -219,7 +221,7 @@ class DeleteMessageUseCaseTest {
         fun withSendMessageSucceed() = apply {
             given(messageSender)
                 .suspendFunction(messageSender::sendMessage)
-                .whenInvokedWith(anything())
+                .whenInvokedWith(anything(), anything())
                 .thenReturn(Either.Right(Unit))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -9,6 +9,8 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageEnvelope
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
@@ -25,6 +27,7 @@ import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import io.ktor.utils.io.core.toByteArray
 import io.mockative.Mock
+import io.mockative.Times
 import io.mockative.anything
 import io.mockative.configure
 import io.mockative.eq
@@ -347,6 +350,103 @@ class MessageSenderTest {
         }
     }
 
+    @Test
+    fun givenRecipientsForNewOutgoingMessageSucceeds_WhenSendingOutgoingMessage_ThenReturnSuccess() {
+        // given
+        val (arrangement, messageSender) = Arrangement()
+            .withSendProteusMessage()
+            .arrange()
+
+        val message = Message.Regular(
+            id = Arrangement.TEST_MESSAGE_UUID,
+            content = MessageContent.Calling(""),
+            conversationId = Arrangement.TEST_CONVERSATION_ID,
+            date = "1234",
+            senderUserId = UserId("userValue", "userDomain"),
+            senderClientId = ClientId("clientId"),
+            status = Message.Status.SENT,
+            editStatus = Message.EditStatus.NotEdited
+        )
+
+        val messageTarget = MessageTarget.Client(
+            recipients = listOf(
+                Arrangement.TEST_RECIPIENT_1,
+                Arrangement.TEST_RECIPIENT_2
+            )
+        )
+
+        arrangement.testScope.runTest {
+            // when
+            val result = messageSender.sendMessage(
+                message = message,
+                messageTarget = messageTarget
+            )
+
+            // then
+            result.shouldSucceed()
+            verify(arrangement.conversationRepository)
+                .suspendFunction(arrangement.conversationRepository::getConversationRecipients)
+                .with(anything())
+                .wasInvoked(exactly = Times(0))
+
+            verify(arrangement.sessionEstablisher)
+                .suspendFunction(arrangement.sessionEstablisher::prepareRecipientsForNewOutgoingMessage)
+                .with(eq(listOf(Arrangement.TEST_RECIPIENT_1, Arrangement.TEST_RECIPIENT_2)))
+                .wasInvoked(exactly = once)
+
+            verify(arrangement.messageRepository)
+                .suspendFunction(arrangement.messageRepository::sendEnvelope)
+                .with(eq(message.conversationId), anything(), eq(messageTarget))
+                .wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenNoRecipientsForNewOutgoingMessageSucceeds_WhenSendingOutgoingMessage_ThenReturnSuccess() {
+        // given
+        val (arrangement, messageSender) = Arrangement()
+            .withSendProteusMessage()
+            .arrange()
+
+        val message = Message.Regular(
+            id = Arrangement.TEST_MESSAGE_UUID,
+            content = MessageContent.Calling(""),
+            conversationId = Arrangement.TEST_CONVERSATION_ID,
+            date = "1234",
+            senderUserId = UserId("userValue", "userDomain"),
+            senderClientId = ClientId("clientId"),
+            status = Message.Status.SENT,
+            editStatus = Message.EditStatus.NotEdited
+        )
+
+        val messageTarget = MessageTarget.Conversation
+
+        arrangement.testScope.runTest {
+            // when
+            val result = messageSender.sendMessage(
+                message = message,
+                messageTarget = messageTarget
+            )
+
+            // then
+            result.shouldSucceed()
+            verify(arrangement.conversationRepository)
+                .suspendFunction(arrangement.conversationRepository::getConversationRecipients)
+                .with(anything())
+                .wasInvoked(exactly = once)
+
+            verify(arrangement.sessionEstablisher)
+                .suspendFunction(arrangement.sessionEstablisher::prepareRecipientsForNewOutgoingMessage)
+                .with(eq(listOf(Arrangement.TEST_RECIPIENT_1)))
+                .wasInvoked(exactly = once)
+
+            verify(arrangement.messageRepository)
+                .suspendFunction(arrangement.messageRepository::sendEnvelope)
+                .with(eq(message.conversationId), anything(), eq(messageTarget))
+                .wasInvoked(exactly = once)
+        }
+    }
+
     private class Arrangement {
         @Mock
         val messageRepository: MessageRepository = mock(MessageRepository::class)
@@ -573,8 +673,11 @@ class MessageSenderTest {
             )
             val TEST_CONTACT_CLIENT_1 = ClientId("clientId1")
             val TEST_CONTACT_CLIENT_2 = ClientId("clientId2")
+            val TEST_CONTACT_CLIENT_3 = ClientId("clientId3")
             val TEST_MEMBER_1 = UserId("value1", "domain1")
             val TEST_RECIPIENT_1 = Recipient(TEST_MEMBER_1, listOf(TEST_CONTACT_CLIENT_1, TEST_CONTACT_CLIENT_2))
+            val TEST_MEMBER_2 = UserId("value2", "domain2")
+            val TEST_RECIPIENT_2 = Recipient(TEST_MEMBER_2, listOf(TEST_CONTACT_CLIENT_3))
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -351,7 +351,7 @@ class MessageSenderTest {
     }
 
     @Test
-    fun givenRecipientsForNewOutgoingMessageSucceeds_WhenSendingOutgoingMessage_ThenReturnSuccess() {
+    fun givenClientTargets_WhenSendingOutgoingMessage_ThenCallSendEnvelopeWithCorrectTargets() {
         // given
         val (arrangement, messageSender) = Arrangement()
             .withSendProteusMessage()
@@ -402,7 +402,7 @@ class MessageSenderTest {
     }
 
     @Test
-    fun givenNoRecipientsForNewOutgoingMessageSucceeds_WhenSendingOutgoingMessage_ThenReturnSuccess() {
+    fun givenConversationTarget_WhenSendingOutgoingMessage_ThenCallSendEnvelopeWithCorrectTargets() {
         // given
         val (arrangement, messageSender) = Arrangement()
             .withSendProteusMessage()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -453,7 +453,7 @@ class MessageSenderTest {
         fun withSendEnvelope(result: Either<CoreFailure, String> = Either.Right("date")) = apply {
             given(messageRepository)
                 .suspendFunction(messageRepository::sendEnvelope)
-                .whenInvokedWith(anything(), anything())
+                .whenInvokedWith(anything(), anything(), anything())
                 .thenReturn(result)
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2571 - Targeted messages not implemented](https://wearezeta.atlassian.net/browse/AR-2571)

This is only `PART 1`, another part will follow where this changes are properly used.

### Issues

We were always send OTR messages to all recipients in a conversation.

### Causes (Optional)

There was no parameter for receiving target recipients.

### Solutions

Add target recipients as parameter.