### PR TITLE
fix: fail when trying to add a user without key packages to a group AR-2596

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic
 
 import com.wire.kalium.cryptography.exceptions.ProteusException
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
@@ -15,6 +16,12 @@ sealed class CoreFailure {
      * The attempted operation requires that this client is registered.
      */
     object MissingClientRegistration : CoreFailure()
+
+    /**
+     * A user has no key packages available which prevents him/her from being added
+     * to an existing or new conversation.
+     */
+    data class NoKeyPackagesAvailable(val userId: UserId): CoreFailure()
 
     data class Unknown(val rootCause: Throwable?) : CoreFailure()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -21,7 +21,7 @@ sealed class CoreFailure {
      * A user has no key packages available which prevents him/her from being added
      * to an existing or new conversation.
      */
-    data class NoKeyPackagesAvailable(val userId: UserId): CoreFailure()
+    data class NoKeyPackagesAvailable(val userId: UserId) : CoreFailure()
 
     data class Unknown(val rootCause: Throwable?) : CoreFailure()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -331,40 +331,22 @@ class MLSConversationDataSource(
         }
 
     private suspend fun establishMLSGroup(groupID: GroupID, members: List<UserId>): Either<CoreFailure, Unit> =
-        keyPackageRepository.claimKeyPackages(members).flatMap { keyPackages ->
-            mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-                val clientKeyPackageList = keyPackages
-                    .map {
-                        Pair(
-                            CryptoQualifiedClientId(it.clientID, CryptoQualifiedID(it.userId, it.domain)),
-                            it.keyPackage.decodeBase64Bytes()
-                        )
-                    }
-
-                mlsPublicKeysRepository.getKeys().flatMap { publicKeys ->
-                    wrapMLSRequest {
-                        mlsClient.createConversation(
-                            idMapper.toCryptoModel(groupID),
-                            publicKeys.map { mlsPublicKeysMapper.toCrypto(it) }
-                        )
-                    }
-                }.flatMap {
-                    retryOnCommitFailure(groupID) {
-                        wrapMLSRequest {
-                            mlsClient.addMember(idMapper.toCryptoModel(groupID), clientKeyPackageList)
-                        }.flatMap { commitBundle ->
-                            commitBundle?.let {
-                                sendCommitBundle(groupID, it).flatMap {
-                                    wrapStorageRequest {
-                                        conversationDAO.updateConversationGroupState(
-                                            ConversationEntity.GroupState.ESTABLISHED,
-                                            idMapper.toGroupIDEntity(groupID)
-                                        )
-                                    }
-                                }
-                            } ?: Either.Right(Unit)
-                        }
-                    }
+        mlsClientProvider.getMLSClient().flatMap { mlsClient ->
+            mlsPublicKeysRepository.getKeys().flatMap { publicKeys ->
+                wrapMLSRequest {
+                    mlsClient.createConversation(
+                        idMapper.toCryptoModel(groupID),
+                        publicKeys.map { mlsPublicKeysMapper.toCrypto(it) }
+                    )
+                }
+            }.flatMap {
+                addMemberToMLSGroup(groupID, members)
+            }.flatMap {
+                wrapStorageRequest {
+                    conversationDAO.updateConversationGroupState(
+                        ConversationEntity.GroupState.ESTABLISHED,
+                        idMapper.toGroupIDEntity(groupID)
+                    )
                 }
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -11,7 +11,6 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
-import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -45,8 +44,12 @@ class KeyPackageDataSource(
                     keyPackageApi.claimKeyPackages(
                         KeyPackageApi.Param.SkipOwnClient(idMapper.toApiModel(userId), selfClientId.value)
                     )
-                }.map {
-                    it.keyPackages
+                }.flatMap {
+                    if (it.keyPackages.isEmpty()) {
+                        Either.Left(CoreFailure.NoKeyPackagesAvailable(userId))
+                    } else {
+                        Either.Right(it.keyPackages)
+                    }
                 }
             }.foldToEitherWhileRight(emptyList()) { item, acc ->
                 item.flatMap { Either.Right(acc + it) }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -62,6 +62,7 @@ class MLSConversationRepositoryTest {
     fun givenSuccessfulResponses_whenCallingEstablishMLSGroup_thenGroupIsCreatedAndCommitBundleIsSentAndAccepted() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetConversationByGroupIdSuccessful()
+            .withCommitPendingProposalsReturningNothing()
             .withGetAllMembersSuccessful()
             .withClaimKeyPackagesSuccessful()
             .withGetMLSClientSuccessful()
@@ -103,6 +104,7 @@ class MLSConversationRepositoryTest {
     fun givenMlsClientMismatchError_whenCallingEstablishMLSGroup_thenClearCommitAndRetry() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetConversationByGroupIdSuccessful()
+            .withCommitPendingProposalsReturningNothing()
             .withGetAllMembersSuccessful()
             .withClaimKeyPackagesSuccessful()
             .withGetMLSClientSuccessful()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If you try to create a group with a user who don't have any MLS clients the operation would be reported as successful but the user was not actually added to the user MLS group.

### Causes

The request for claiming key packages return an empty list in this case, which was silently ignored because the result is merged into single list of key packages for many users.

### Solutions

Fail the `claimKeyPackages` operation if a user doesn't have any key packages available.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes

We should also persist users after the MLS add operation has successfully finished. This will be handled in different PR though.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
