### PR TITLE
chore: calling target messages logic

### DIFF
--- a/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/SendHandler.kt
+++ b/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/SendHandler.kt
@@ -11,7 +11,7 @@ fun interface SendHandler : Callback {
         conversationId: String,
         userIdSelf: String,
         clientIdSelf: String,
-        userIdDestination: String?,
+        targetRecipientsJson: String?,
         clientIdDestination: String?,
         data: Pointer?,
         length: Size_t,

--- a/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/SendHandler.kt
+++ b/calling/src/androidMain/kotlin/com/wire/kalium/calling/callbacks/SendHandler.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.calling.types.Size_t
 
 /* Send calling message otr data */
 fun interface SendHandler : Callback {
+    @Suppress("LongParameterList")
     fun onSend(
         context: Pointer?,
         conversationId: String,

--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
+import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -61,6 +62,8 @@ class CallManagerTest {
 
     private lateinit var callManagerImpl: CallManagerImpl
 
+    private val callMapper = CallMapperImpl(qualifiedIdMapper)
+
     @BeforeTest
     fun setUp() {
         callManagerImpl = CallManagerImpl(
@@ -73,7 +76,8 @@ class CallManagerTest {
             kaliumDispatchers = dispatcher,
             federatedIdMapper = federatedIdMapper,
             qualifiedIdMapper = qualifiedIdMapper,
-            videoStateChecker = videoStateChecker
+            videoStateChecker = videoStateChecker,
+            callMapper = callMapper
         )
     }
 

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/AvsCallBackError.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/AvsCallBackError.kt
@@ -2,7 +2,8 @@ package com.wire.kalium.logic.feature.call
 
 enum class AvsCallBackError(val value: Int) {
     NONE(0),
-    INVALID_ARGUMENT(1)
+    INVALID_ARGUMENT(1),
+    COULD_NOT_DECODE_ARGUMENT(2)
 }
 
 enum class AvsSFTError(val value: Int) {

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -27,7 +27,6 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.call.scenario.OnActiveSpeakers
 import com.wire.kalium.logic.feature.call.scenario.OnAnsweredCall
 import com.wire.kalium.logic.feature.call.scenario.OnClientsRequest
@@ -69,7 +68,7 @@ actual class CallManagerImpl internal constructor(
     private val conversationRepository: ConversationRepository,
     private val messageSender: MessageSender,
     kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl,
-    private val callMapper: CallMapper = MapperProvider.callMapper(),
+    private val callMapper: CallMapper,
     private val federatedIdMapper: FederatedIdMapper,
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val videoStateChecker: VideoStateChecker
@@ -122,7 +121,8 @@ actual class CallManagerImpl internal constructor(
                 selfUserId,
                 selfClientId,
                 messageSender,
-                scope
+                scope,
+                callMapper
             ).keepingStrongReference(),
             sftRequestHandler = OnSFTRequest(deferredHandle, calling, callRepository, scope).keepingStrongReference(),
             incomingCallHandler = OnIncomingCall(callRepository, callMapper, qualifiedIdMapper, scope).keepingStrongReference(),

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
@@ -7,7 +7,6 @@ import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
@@ -27,6 +27,7 @@ class OnHttpRequest(
     private val messageSender: MessageSender,
     private val callingScope: CoroutineScope
 ) {
+    @Suppress("LongParameterList")
     fun sendHandlerSuccess(
         context: Pointer?,
         messageString: String?,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
@@ -7,11 +7,13 @@ import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.logic.functional.Either
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -30,11 +32,12 @@ class OnHttpRequest(
         messageString: String?,
         conversationId: ConversationId,
         avsSelfUserId: UserId,
-        avsSelfClientId: ClientId
+        avsSelfClientId: ClientId,
+        messageTarget: MessageTarget
     ) {
         callingScope.launch {
             messageString?.let { message ->
-                when (sendCallingMessage(conversationId, avsSelfUserId, avsSelfClientId, message)) {
+                when (sendCallingMessage(conversationId, avsSelfUserId, avsSelfClientId, message, messageTarget)) {
                     is Either.Right -> {
                         callingLogger.i("[OnHttpRequest] -> Success")
                         calling.wcall_resp(
@@ -62,7 +65,8 @@ class OnHttpRequest(
         conversationId: ConversationId,
         userId: UserId,
         clientId: ClientId,
-        data: String
+        data: String,
+        messageTarget: MessageTarget
     ): Either<CoreFailure, Unit> {
         val messageContent = MessageContent.Calling(data)
         val date = Clock.System.now().toString()
@@ -76,6 +80,6 @@ class OnHttpRequest(
             status = Message.Status.SENT,
             editStatus = Message.EditStatus.NotEdited
         )
-        return messageSender.sendMessage(message)
+        return messageSender.sendMessage(message, messageTarget)
     }
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -31,7 +31,6 @@ class OnParticipantListChanged internal constructor(
 
         callingScope.launch {
             val participants = mutableListOf<Participant>()
-            val clients = mutableListOf<CallClient>()
             val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(remoteConversationIdString)
 
             participantsChange.members.map { member ->
@@ -45,8 +44,6 @@ class OnParticipantListChanged internal constructor(
                     )
                     participants.add(updatedParticipant)
                 }
-
-                clients.add(participantMapper.fromCallMemberToCallClient(member))
             }
 
             callRepository.updateCallParticipants(

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -4,7 +4,6 @@ import com.sun.jna.Pointer
 import com.wire.kalium.calling.callbacks.ParticipantChangedHandler
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.callingLogger
-import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallParticipants
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.Participant

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
@@ -6,13 +6,18 @@ import com.wire.kalium.calling.callbacks.SendHandler
 import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.calling.types.Size_t
 import com.wire.kalium.logic.callingLogger
+import com.wire.kalium.logic.data.call.CallClientList
+import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.call.AvsCallBackError
 import com.wire.kalium.logic.feature.call.CallManagerImpl
 import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.feature.message.MessageTarget
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 // TODO(testing): create unit test
 @Suppress("LongParameterList")
@@ -23,14 +28,15 @@ class OnSendOTR(
     private val selfUserId: String,
     private val selfClientId: String,
     private val messageSender: MessageSender,
-    private val callingScope: CoroutineScope
+    private val callingScope: CoroutineScope,
+    private val callMapper: CallMapper
 ) : SendHandler {
     override fun onSend(
         context: Pointer?,
         remoteConversationIdString: String,
         remoteUserIdSelfString: String,
         remoteClientIdSelfString: String,
-        userIdDestination: String?,
+        targetRecipientsJson: String?,
         clientIdDestination: String?,
         data: Pointer?,
         length: Size_t,
@@ -43,15 +49,29 @@ class OnSendOTR(
             callingLogger.i("[OnSendOTR] -> selfClientId: $selfClientId != clientIdSelf: $remoteClientIdSelfString")
             AvsCallBackError.INVALID_ARGUMENT.value
         } else {
-            callingLogger.i("[OnSendOTR] -> Success")
-            OnHttpRequest(handle, calling, messageSender, callingScope).sendHandlerSuccess(
-                context = context,
-                messageString = data?.getString(0, CallManagerImpl.UTF8_ENCODING),
-                conversationId = qualifiedIdMapper.fromStringToQualifiedID(remoteConversationIdString),
-                avsSelfUserId = qualifiedIdMapper.fromStringToQualifiedID(remoteUserIdSelfString),
-                avsSelfClientId = ClientId(remoteClientIdSelfString)
-            )
-            AvsCallBackError.NONE.value
+            try {
+                callingLogger.i("[OnSendOTR] -> Decoding Recipients")
+                val messageTarget = targetRecipientsJson?.let { recipientsJson ->
+                    val callClientList = Json.decodeFromString<CallClientList>(recipientsJson)
+
+                    callingLogger.i("[OnSendOTR] -> Mapping Recipients")
+                    callMapper.toClientMessageTarget(callClientList = callClientList)
+                } ?: MessageTarget.Conversation
+
+                callingLogger.i("[OnSendOTR] -> Success")
+                OnHttpRequest(handle, calling, messageSender, callingScope).sendHandlerSuccess(
+                    context = context,
+                    messageString = data?.getString(0, CallManagerImpl.UTF8_ENCODING),
+                    conversationId = qualifiedIdMapper.fromStringToQualifiedID(remoteConversationIdString),
+                    avsSelfUserId = qualifiedIdMapper.fromStringToQualifiedID(remoteUserIdSelfString),
+                    avsSelfClientId = ClientId(remoteClientIdSelfString),
+                    messageTarget = messageTarget
+                )
+                AvsCallBackError.NONE.value
+            } catch (exception: Exception) {
+                callingLogger.e("[OnSendOTR] -> Error Exception: $exception")
+                AvsCallBackError.COULD_NOT_DECODE_ARGUMENT.value
+            }
         }
     }
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
@@ -31,6 +31,7 @@ class OnSendOTR(
     private val callingScope: CoroutineScope,
     private val callMapper: CallMapper
 ) : SendHandler {
+    @Suppress("TooGenericExceptionCaught")
     override fun onSend(
         context: Pointer?,
         remoteConversationIdString: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -66,7 +66,7 @@ internal class CallDataSource(
     private val userRepository: UserRepository,
     private val teamRepository: TeamRepository,
     private val timeParser: TimeParser,
-    private val callMapper: CallMapper = MapperProvider.callMapper(),
+    private val callMapper: CallMapper,
     private val activeSpeakerMapper: ActiveSpeakerMapper = MapperProvider.activeSpeakerMapper()
 ) : CallRepository {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/CallMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/CallMapper.kt
@@ -3,12 +3,16 @@ package com.wire.kalium.logic.data.call.mapper
 import com.wire.kalium.calling.CallTypeCalling
 import com.wire.kalium.calling.ConversationTypeCalling
 import com.wire.kalium.calling.VideoStateCalling
+import com.wire.kalium.logic.data.call.CallClientList
 import com.wire.kalium.logic.data.call.CallMetadata
 import com.wire.kalium.logic.data.call.CallType
 import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.call.VideoState
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.call.CallStatus
@@ -38,9 +42,13 @@ interface CallMapper {
     fun toConversationType(conversationType: ConversationEntity.Type): Conversation.Type
     fun toCallEntityStatus(callStatus: CallStatus): CallEntity.Status
     fun fromConversationIdToQualifiedIDEntity(conversationId: ConversationId): QualifiedIDEntity
+
+    fun toMessageRecipients(callClientList: CallClientList): List<Recipient>
 }
 
-class CallMapperImpl : CallMapper {
+class CallMapperImpl(
+    private val qualifiedIdMapper: QualifiedIdMapper
+) : CallMapper {
 
     override fun toCallTypeCalling(callType: CallType): CallTypeCalling {
         return when (callType) {
@@ -158,4 +166,31 @@ class CallMapperImpl : CallMapper {
         value = conversationId.value,
         domain = conversationId.domain
     )
+
+    override fun toMessageRecipients(callClientList: CallClientList): List<Recipient> {
+        val recipientsList = mutableListOf<Recipient>()
+
+        for (callClient in callClientList.clients) {
+            val qualifiedUserId = qualifiedIdMapper.fromStringToQualifiedID(callClient.userId)
+            val clientId = ClientId(callClient.clientId)
+            val recipientIndex = recipientsList.indexOfFirst { it.id == qualifiedUserId }
+
+            if (recipientIndex == -1) {
+                recipientsList.add(
+                    Recipient(
+                        id = qualifiedUserId,
+                        clients = mutableListOf(clientId)
+                    )
+                )
+            } else {
+                recipientsList[recipientIndex] = recipientsList[recipientIndex].copy(
+                    clients = recipientsList[recipientIndex].clients.toMutableList().apply {
+                        add(clientId)
+                    }
+                )
+            }
+        }
+
+        return recipientsList
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/CallMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/CallMapper.kt
@@ -16,6 +16,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.call.CallStatus
+import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.call.CallEntity
@@ -43,7 +44,7 @@ interface CallMapper {
     fun toCallEntityStatus(callStatus: CallStatus): CallEntity.Status
     fun fromConversationIdToQualifiedIDEntity(conversationId: ConversationId): QualifiedIDEntity
 
-    fun toMessageRecipients(callClientList: CallClientList): List<Recipient>
+    fun toClientMessageTarget(callClientList: CallClientList): MessageTarget.Client
 }
 
 class CallMapperImpl(
@@ -167,7 +168,7 @@ class CallMapperImpl(
         domain = conversationId.domain
     )
 
-    override fun toMessageRecipients(callClientList: CallClientList): List<Recipient> {
+    override fun toClientMessageTarget(callClientList: CallClientList): MessageTarget.Client {
         val recipientsList = mutableListOf<Recipient>()
 
         for (callClient in callClientList.clients) {
@@ -191,6 +192,8 @@ class CallMapperImpl(
             }
         }
 
-        return recipientsList
+        return MessageTarget.Client(
+            recipients = recipientsList
+        )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/ParticipantMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/ParticipantMapper.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.data.call.mapper
 
-import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallMember
 import com.wire.kalium.logic.data.call.Participant
 import com.wire.kalium.logic.data.call.VideoStateChecker

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/ParticipantMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/ParticipantMapper.kt
@@ -8,7 +8,6 @@ import com.wire.kalium.logic.data.id.QualifiedID
 
 interface ParticipantMapper {
     fun fromCallMemberToParticipant(member: CallMember): Participant
-    fun fromCallMemberToCallClient(member: CallMember): CallClient
 }
 
 class ParticipantMapperImpl(
@@ -30,16 +29,6 @@ class ParticipantMapperImpl(
             isMuted = isMuted == 1,
             isCameraOn = isCameraOn,
             isSharingScreen = isSharingScreen
-        )
-    }
-
-    override fun fromCallMemberToCallClient(member: CallMember): CallClient = with(member) {
-        CallClient(
-            userId = QualifiedID(
-                value = userId.removeDomain(),
-                domain = userId.getDomain()
-            ).toString(),
-            clientId = clientId
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -117,7 +117,8 @@ internal object MapperProvider {
     fun clientMapper(): ClientMapper = ClientMapper(preyKeyMapper(), locationMapper())
     fun conversationStatusMapper(): ConversationStatusMapper = ConversationStatusMapperImpl(idMapper())
     fun protoContentMapper(): ProtoContentMapper = ProtoContentMapperImpl()
-    fun callMapper(): CallMapper = CallMapperImpl()
+    fun qualifiedIdMapper(selfUserId: UserId): QualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
+    fun callMapper(selfUserId: UserId): CallMapper = CallMapperImpl(qualifiedIdMapper(selfUserId))
     fun activeSpeakerMapper(): ActiveSpeakerMapper = ActiveSpeakerMapperImpl()
     fun connectionStatusMapper(): ConnectionStatusMapper = ConnectionStatusMapperImpl()
     fun featureConfigMapper(): FeatureConfigMapper = FeatureConfigMapperImpl()
@@ -125,7 +126,6 @@ internal object MapperProvider {
     fun connectionMapper(): ConnectionMapper = ConnectionMapperImpl()
     fun userTypeEntityMapper(): UserEntityTypeMapper = UserEntityTypeMapperImpl()
     fun userTypeMapper(): DomainUserTypeMapper = DomainUserTypeMapperImpl()
-    fun qualifiedIdMapper(selfUserId: UserId): QualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
     fun federatedIdMapper(
         userId: UserId,
         qualifiedIdMapper: QualifiedIdMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeCommon.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeCommon.kt
@@ -18,6 +18,7 @@ import com.wire.kalium.logic.data.call.CallDataSource
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.VideoStateCheckerImpl
+import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.client.ClientDataSource
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
@@ -203,6 +204,8 @@ abstract class UserSessionScopeCommon internal constructor(
             }
         }
 
+    val callMapper: CallMapper get() = MapperProvider.callMapper(userId)
+
     val qualifiedIdMapper: QualifiedIdMapper get() = MapperProvider.qualifiedIdMapper(userId)
 
     val federatedIdMapper: FederatedIdMapper
@@ -210,7 +213,7 @@ abstract class UserSessionScopeCommon internal constructor(
             userId,
             qualifiedIdMapper,
             globalScope.sessionRepository
-            )
+        )
 
     private val clientIdProvider = CurrentClientIdProvider { clientId() }
     private val selfConversationIdProvider: SelfConversationIdProvider by lazy { SelfConversationIdProviderImpl(conversationRepository) }
@@ -226,6 +229,7 @@ abstract class UserSessionScopeCommon internal constructor(
                 it.teamId
             }
         }
+
     private val selfTeamId = SelfTeamIdProvider { teamId() }
 
     private val userConfigRepository: UserConfigRepository
@@ -342,7 +346,8 @@ abstract class UserSessionScopeCommon internal constructor(
             userRepository = userRepository,
             teamRepository = teamRepository,
             timeParser = timeParser,
-            persistMessage = persistMessage
+            persistMessage = persistMessage,
+            callMapper = callMapper
         )
     }
 
@@ -502,7 +507,8 @@ abstract class UserSessionScopeCommon internal constructor(
             messageSender = messages.messageSender,
             federatedIdMapper = federatedIdMapper,
             qualifiedIdMapper = qualifiedIdMapper,
-            videoStateChecker = videoStateChecker
+            videoStateChecker = videoStateChecker,
+            callMapper = callMapper
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -10,7 +10,6 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 
 expect class GlobalCallManager {
@@ -23,7 +22,7 @@ expect class GlobalCallManager {
         clientRepository: ClientRepository,
         conversationRepository: ConversationRepository,
         messageSender: MessageSender,
-        callMapper: CallMapper = MapperProvider.callMapper(),
+        callMapper: CallMapper,
         federatedIdMapper: FederatedIdMapper,
         qualifiedIdMapper: QualifiedIdMapper,
         videoStateChecker: VideoStateChecker

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallMapperTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class CallMapperTest {
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallMapperTest.kt
@@ -6,6 +6,8 @@ import com.wire.kalium.calling.VideoStateCalling
 import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import com.wire.kalium.logic.feature.call.CallStatus
 import com.wire.kalium.logic.framework.TestCall
 import com.wire.kalium.persistence.dao.call.CallEntity
@@ -16,11 +18,14 @@ import kotlin.test.assertEquals
 
 class CallMapperTest {
 
+    private lateinit var qualifiedIdMapper: QualifiedIdMapper
+
     private lateinit var callMapper: CallMapper
 
     @BeforeTest
     fun setUp() {
-        callMapper = CallMapperImpl()
+        qualifiedIdMapper = QualifiedIdMapperImpl(selfUserId = TestCall.CALLER_ID)
+        callMapper = CallMapperImpl(qualifiedIdMapper = qualifiedIdMapper)
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallMapperTest.kt
@@ -5,16 +5,20 @@ import com.wire.kalium.calling.ConversationTypeCalling
 import com.wire.kalium.calling.VideoStateCalling
 import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import com.wire.kalium.logic.feature.call.CallStatus
+import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.logic.framework.TestCall
 import com.wire.kalium.persistence.dao.call.CallEntity
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class CallMapperTest {
 
@@ -238,5 +242,42 @@ class CallMapperTest {
         assertEquals(VideoStateCalling.PAUSED, resultPaused)
         assertEquals(VideoStateCalling.SCREENSHARE, resultScreenShare)
         assertEquals(VideoStateCalling.UNKNOWN, resultUnknown)
+    }
+
+    @Test
+    fun givenACallClientList_whenMappingToMessageTarget_thenReturnCorrectMessageTargetClients() = runTest {
+        // given
+        val callClientList = CallClientList(
+            clients = listOf(
+                CallClient(
+                    userId = TestCall.CALLER_ID.toString(),
+                    clientId = TestCall.CLIENT_ID_1
+                ),
+                CallClient(
+                    userId = TestCall.CALLER_ID.toString(),
+                    clientId = TestCall.CLIENT_ID_2
+                )
+            )
+        )
+        val expectedMessageTarget = MessageTarget.Client(
+            recipients = listOf(
+                Recipient(
+                    id = TestCall.CALLER_ID,
+                    clients = listOf(
+                        ClientId(TestCall.CLIENT_ID_1),
+                        ClientId(TestCall.CLIENT_ID_2)
+                    )
+                )
+            )
+        )
+
+        // when
+        val result = callMapper.toClientMessageTarget(callClientList)
+
+        // then
+        assertEquals(
+            expectedMessageTarget.recipients,
+            result.recipients
+        )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.data.call
 
 import app.cash.turbine.test
+import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -76,6 +77,8 @@ class CallRepositoryTest {
         stubsUnitByDefault = true
     }
 
+    private val callMapper = CallMapperImpl(qualifiedIdMapper)
+
     private lateinit var callRepository: CallRepository
 
     @BeforeTest
@@ -88,7 +91,8 @@ class CallRepositoryTest {
             userRepository = userRepository,
             teamRepository = teamRepository,
             timeParser = TimeParserImpl(),
-            persistMessage = persistMessage
+            persistMessage = persistMessage,
+            callMapper = callMapper
         )
         given(qualifiedIdMapper).function(qualifiedIdMapper::fromStringToQualifiedID)
             .whenInvokedWith(eq("convId@domainId"))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/ParticipantMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/ParticipantMapperTest.kt
@@ -53,20 +53,6 @@ class ParticipantMapperTest {
         assertEquals(expectedParticipant, participantMap)
     }
 
-    @Test
-    fun whenMappingToCallClient_withCallMember_thenReturnCallMember() = runTest {
-        val callClientMap = participantMapperImpl.fromCallMemberToCallClient(
-            member = DUMMY_CALL_MEMBER
-        )
-
-        val expectedCallClient = CallClient(
-            userId = "dummyId@dummyDomain",
-            clientId = "dummyClientId"
-        )
-
-        assertEquals(expectedCallClient, callClientMap)
-    }
-
     companion object {
         private val DUMMY_CALL_MEMBER = CallMember(
             userId = "dummyId@dummyDomain",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestCall.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestCall.kt
@@ -22,8 +22,8 @@ object TestCall {
         value = "convId",
         domain = "domainId"
     )
-    val CLIENT_ID_1 = "clientId1"
-    val CLIENT_ID_2 = "clientId2"
+    const val CLIENT_ID_1 = "clientId1"
+    const val CLIENT_ID_2 = "clientId2"
 
     fun qualifiedIdEntity(conversationId: ConversationId = CONVERSATION_ID) =
         QualifiedIDEntity(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestCall.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestCall.kt
@@ -22,6 +22,8 @@ object TestCall {
         value = "convId",
         domain = "domainId"
     )
+    val CLIENT_ID_1 = "clientId1"
+    val CLIENT_ID_2 = "clientId2"
 
     fun qualifiedIdEntity(conversationId: ConversationId = CONVERSATION_ID) =
         QualifiedIDEntity(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2571 - Targeted messages not implemented](https://wearezeta.atlassian.net/browse/AR-2571)

This is Part 2 final which contains the logic that parses the target recipients received from AVS to be send as a target message.

### Issues

We were always send OTR messages to all recipients in a conversation.

### Causes (Optional)

There was no parameter for receiving target recipients.

### Solutions

Receive target recipients, parse it and send as parameter to `sendMessage`.

### Dependencies
Can only be merged after:

- [X] #1025