### PR TITLE
fix: resolution of generated protobuf code

### DIFF
--- a/protobuf/build.gradle.kts
+++ b/protobuf/build.gradle.kts
@@ -87,13 +87,22 @@ codegenProject.tasks
         compileTasks.forEach { compileTask ->
             compileTask.dependsOn(this)
         }
+        // Always generate protobuf files. So we make sure they exist.
+        outputs.upToDateWhen {
+            false
+        }
         doLast {
-            outputSourceDirectorySet.srcDirs.forEach {
+            outputSourceDirectorySet.srcDirs.forEach { generatedDirectory ->
                 generatedFilesBaseDir.mkdirs()
-                val targetDirectory = File(generatedFilesBaseDir, it.name)
-                val movingSucceeded = it.renameTo(targetDirectory)
+                val targetDirectory = File(generatedFilesBaseDir, generatedDirectory.name)
+                // Delete already existing files
+                targetDirectory.deleteRecursively()
+
+                // Move generated files to target directory
+                val movingSucceeded = generatedDirectory.renameTo(targetDirectory)
+
                 require(movingSucceeded) {
-                    "Failed to move Generated protobuf files from '${it.absolutePath}' " +
+                    "Failed to move Generated protobuf files from '${generatedDirectory.absolutePath}' " +
                             "to destination directory '${targetDirectory.absolutePath}'"
                 }
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The IDE can't resolve the generated Protobuf code.

### Causes

We use a module called `protobuf-codegen` which is JVM only to generate the Protobuf files because the [protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin) doesn't support multiplatform.

Then, we add these generated files as a sourceset to the `protobuf` module, which is Multiplatform.

The problem is that protobuf-gradle-plugin [adds the generated sources](https://github.com/google/protobuf-gradle-plugin/blob/8dbac6395d23828cee5e298da61ab6c268987a9c/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L277) to the `protobuf-codegen` module too, and the IDE can't handle the fact that the same files are being used by multiple modules at the same time and doesn't consider these files as part of `protobuf` for all intents and purposes.

### Solutions

Take the outputs of the `generateProto` task and move them to another directory, that is not part of any `protobuf-codegen` source set.

Problems:
We lose sync between the generate task and the status of the generated source. I couldn't come up with a full fledged caching solution, to make sure that if something/someone edit the files inside `protobuf/generated` it would generate again when needed. So I just made it generate always.

This means that when compiling the `protobuf` module, we will literally ALWAYS generate the files again.
Fortunatelly, it seems to only take around 600ms on my machine, so I doubt anyone will notice 😄 

### Testing

Manually tested.

### How to test

Sync your IDE.
Run `generateProto` task or just try to run `ProtoContentMapperTest`.
References should be resolved.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
