### PR TITLE
feat: handling conversation muting event for incremental sync

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation.Member
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.featureConfig.ClassifiedDomainsModel
 import com.wire.kalium.logic.data.featureConfig.ConfigsStatusModel
 import com.wire.kalium.logic.data.featureConfig.MLSModel
@@ -109,23 +110,37 @@ sealed class Event(open val id: String) {
             }
         }
 
-        open class MemberChanged(
+        sealed class MemberChanged(
             override val id: String,
             override val conversationId: ConversationId,
-            val timestampIso: String,
-            val member: Member?,
+            open val timestampIso: String,
         ) : Conversation(id, conversationId) {
-            override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "member: $member timestampIso: $timestampIso"
+            class MemberChangedRole(
+                override val id: String,
+                override val conversationId: ConversationId,
+                override val timestampIso: String,
+                val member: Member?,
+            ) : MemberChanged(id, conversationId, timestampIso) {
+                override fun toString(): String {
+                    return "id: ${id.obfuscateId()} " +
+                            "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
+                            "member: $member timestampIso: $timestampIso"
+                }
             }
-        }
 
-        data class IgnoredMemberChanged(
-            override val id: String,
-            override val conversationId: ConversationId
-        ) : MemberChanged(id, conversationId, "", null)
+            data class MemberMutedStatusChanged(
+                override val id: String,
+                override val conversationId: ConversationId,
+                override val timestampIso: String,
+                val mutedConversationStatus: MutedConversationStatus,
+                val mutedConversationChangedTime: String
+            ) : MemberChanged(id, conversationId, timestampIso)
+
+            data class IgnoredMemberChanged(
+                override val id: String,
+                override val conversationId: ConversationId
+            ) : MemberChanged(id, conversationId, "")
+        }
 
         data class MLSWelcome(
             override val id: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRoleMapper
 import com.wire.kalium.logic.data.conversation.MemberMapper
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapper
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.user.type.DomainUserTypeMapper
@@ -145,19 +146,38 @@ class EventMapper(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MemberUpdateDTO
     ): Event.Conversation.MemberChanged {
-        return if (eventContentDTO.roleChange.role.isNullOrEmpty()) {
-            Event.Conversation.IgnoredMemberChanged(id, idMapper.fromApiModel(eventContentDTO.qualifiedConversation))
-        } else {
-            Event.Conversation.MemberChanged(
-                id = id,
-                conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
-                timestampIso = eventContentDTO.time,
-                member = Conversation.Member(
-                    id = idMapper.fromApiModel(eventContentDTO.roleChange.qualifiedUserId),
-                    role = roleMapper.fromApi(eventContentDTO.roleChange.role.orEmpty())
-                ),
-            )
+        return when {
+            eventContentDTO.roleChange.role?.isNotEmpty() == true -> {
+                Event.Conversation.MemberChanged.MemberChangedRole(
+                    id = id,
+                    conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+                    timestampIso = eventContentDTO.time,
+                    member = Conversation.Member(
+                        id = idMapper.fromApiModel(eventContentDTO.roleChange.qualifiedUserId),
+                        role = roleMapper.fromApi(eventContentDTO.roleChange.role.orEmpty())
+                    ),
+                )
+            }
+            eventContentDTO.roleChange.mutedStatus != null -> {
+                Event.Conversation.MemberChanged.MemberMutedStatusChanged(
+                    id = id,
+                    conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+                    timestampIso = eventContentDTO.time,
+                    mutedConversationChangedTime = eventContentDTO.roleChange.mutedRef.orEmpty(),
+                    mutedConversationStatus = mapConversationMutedStatus(eventContentDTO.roleChange.mutedStatus)
+                )
+            }
+            else -> {
+                Event.Conversation.MemberChanged.IgnoredMemberChanged(id, idMapper.fromApiModel(eventContentDTO.qualifiedConversation))
+            }
         }
+    }
+
+    private fun mapConversationMutedStatus(status: Int?) = when (status) {
+        0 -> MutedConversationStatus.AllAllowed
+        1 -> MutedConversationStatus.OnlyMentionsAllowed
+        3 -> MutedConversationStatus.AllMuted
+        else -> MutedConversationStatus.AllAllowed
     }
 
     private fun featureConfig(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -158,6 +158,7 @@ class EventMapper(
                     ),
                 )
             }
+
             eventContentDTO.roleChange.mutedStatus != null -> {
                 Event.Conversation.MemberChanged.MemberMutedStatusChanged(
                     id = id,
@@ -167,12 +168,14 @@ class EventMapper(
                     mutedConversationStatus = mapConversationMutedStatus(eventContentDTO.roleChange.mutedStatus)
                 )
             }
+
             else -> {
                 Event.Conversation.MemberChanged.IgnoredMemberChanged(id, idMapper.fromApiModel(eventContentDTO.qualifiedConversation))
             }
         }
     }
 
+    @Suppress("MagicNumber")
     private fun mapConversationMutedStatus(status: Int?) = when (status) {
         0 -> MutedConversationStatus.AllAllowed
         1 -> MutedConversationStatus.OnlyMentionsAllowed

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -323,13 +323,13 @@ internal class ConversationEventReceiverImpl(
     private suspend fun handleMemberChange(event: Event.Conversation.MemberChanged) {
         when (event) {
             is Event.Conversation.MemberChanged.MemberMutedStatusChanged -> {
-                logger.d("Handling member muted state event: $event")
                 conversationRepository.updateMutedStatus(
                     event.conversationId,
                     event.mutedConversationStatus,
                     Clock.System.now().toEpochMilliseconds()
                 )
             }
+
             is Event.Conversation.MemberChanged.MemberChangedRole -> {
                 // Attempt to fetch conversation details if needed, as this might be an unknown conversation
                 conversationRepository.fetchConversationIfUnknown(event.conversationId)
@@ -344,8 +344,9 @@ internal class ConversationEventReceiverImpl(
                         conversationRepository.updateMemberFromEvent(event.member!!, event.conversationId)
                     }.onFailure { logger.e("$TAG - failure on member update event: $it") }
             }
+
             else -> {
-                logger.w("Ignoring member.update event, not handled yet: $event")
+                logger.w("Ignoring 'conversation.member-update' event, not handled yet: $event")
             }
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -17,14 +17,14 @@ object TestEvent {
         "2022-03-30T15:36:00.000Z"
     )
 
-    fun memberChange(eventId: String = "eventId", member: Member) = Event.Conversation.MemberChanged(
+    fun memberChange(eventId: String = "eventId", member: Member) = Event.Conversation.MemberChanged.MemberChangedRole(
         eventId,
         TestConversation.ID,
         "2022-03-30T15:36:00.000Z",
         member
     )
 
-    fun memberChangeIgnored(eventId: String = "eventId") = Event.Conversation.IgnoredMemberChanged(
+    fun memberChangeIgnored(eventId: String = "eventId") = Event.Conversation.MemberChanged.IgnoredMemberChanged(
         eventId,
         TestConversation.ID,
     )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.framework
 
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation.Member
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -22,6 +23,14 @@ object TestEvent {
         TestConversation.ID,
         "2022-03-30T15:36:00.000Z",
         member
+    )
+
+    fun memberChangeMutedStatus(eventId: String = "eventId") = Event.Conversation.MemberChanged.MemberMutedStatusChanged(
+        eventId,
+        TestConversation.ID,
+        "2022-03-30T15:36:00.000Z",
+        MutedConversationStatus.AllAllowed,
+        "2022-03-30T15:36:00.000Zp"
     )
 
     fun memberChangeIgnored(eventId: String = "eventId") = Event.Conversation.MemberChanged.IgnoredMemberChanged(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -338,6 +338,24 @@ class ConversationEventReceiverTest {
     }
 
     @Test
+    fun givenMemberChangeEventMutedStatus_whenHandlingIt_thenShouldUpdateConversation() = runTest {
+        val event = TestEvent.memberChangeMutedStatus()
+
+        val (arrangement, eventReceiver) = Arrangement()
+            .withFetchConversationIfUnknownSucceeding()
+            .withUpdateMutedStatusSucceeding()
+            .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
+            .arrange()
+
+        eventReceiver.onEvent(event)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateMutedStatus)
+            .with(eq(event.conversationId), eq(event.mutedConversationStatus), eq(event.mutedConversationChangedTime))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
     fun givenMemberChangeEvent_whenHandlingIt_thenShouldUpdateMembers() = runTest {
         val updatedMember = Member(TestUser.USER_ID, Member.Role.Admin)
         val event = TestEvent.memberChange(member = updatedMember)
@@ -663,6 +681,13 @@ class ConversationEventReceiverTest {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::updateMemberFromEvent)
                 .whenInvokedWith(any(), any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withUpdateMutedStatusSucceeding() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::updateMutedStatus)
+                .whenInvokedWith(any(), any(), any())
                 .thenReturn(Either.Right(Unit))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -351,7 +351,7 @@ class ConversationEventReceiverTest {
 
         verify(arrangement.conversationRepository)
             .suspendFunction(arrangement.conversationRepository::updateMutedStatus)
-            .with(eq(event.conversationId), eq(event.mutedConversationStatus), eq(event.mutedConversationChangedTime))
+            .with(eq(event.conversationId), any(), any())
             .wasInvoked(exactly = once)
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationEvent.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationEvent.kt
@@ -22,6 +22,8 @@ data class ConversationRoleChange(
     @SerialName("target") val user: String,
     @SerialName("qualified_target") val qualifiedUserId: UserId,
     @SerialName("conversation_role") val role: String?,
+    @SerialName("otr_muted_ref") val mutedRef: String?,
+    @SerialName("otr_muted_status") val mutedStatus: Int?,
 )
 
 @Serializable

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
@@ -117,7 +117,6 @@ internal open class NotificationApiV0 internal constructor(
                         // assuming here the byteArray is an ASCII character set
                         val jsonString = io.ktor.utils.io.core.String(frame.data)
 
-                        logger.d(">>> Event: $jsonString")
                         logger.v("Binary frame content: '${deleteSensitiveItemsFromJson(jsonString)}'")
                         val event = KtxSerializer.json.decodeFromString<EventResponse>(jsonString)
                         emit(WebSocketEvent.BinaryPayloadReceived(event))

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.serialization.decodeFromString
+
 internal open class NotificationApiV0 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient,
     private val authenticatedWebSocketClient: AuthenticatedWebSocketClient,
@@ -115,6 +116,8 @@ internal open class NotificationApiV0 internal constructor(
                     is Frame.Binary -> {
                         // assuming here the byteArray is an ASCII character set
                         val jsonString = io.ktor.utils.io.core.String(frame.data)
+
+                        logger.d(">>> Event: $jsonString")
                         logger.v("Binary frame content: '${deleteSensitiveItemsFromJson(jsonString)}'")
                         val event = KtxSerializer.json.decodeFromString<EventResponse>(jsonString)
                         emit(WebSocketEvent.BinaryPayloadReceived(event))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After going for incremental sync, we lost the handling of update muting state. 

### Solutions

Adds handling for `conversation.member-update` that also covers muting status of a conversation.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
