### PR TITLE
test: add tools to create databases for testing

### DIFF
--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -24,6 +24,9 @@ android {
     packagingOptions {
         resources.pickFirsts.add("google/protobuf/*.proto")
     }
+    // Run only Instrumented tests. No need to run Unit AND Instrumented
+    // We have JVM tests if we want to run quickly on our machines
+    sourceSets.remove(sourceSets["test"])
 }
 
 kotlin {
@@ -87,7 +90,7 @@ kotlin {
                 implementation(Dependencies.Android.work)
             }
         }
-        val androidTest by getting {
+        val androidAndroidTest by getting {
             dependencies {
                 implementation(Dependencies.AndroidInstruments.androidTestRunner)
                 implementation(Dependencies.AndroidInstruments.androidTestRules)

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -68,6 +68,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(project(":persistence-test"))
                 // coroutines
                 implementation(Dependencies.Coroutines.test)
                 implementation(Dependencies.Test.turbine)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/reaction/ReactionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/reaction/ReactionRepositoryTest.kt
@@ -1,0 +1,74 @@
+package com.wire.kalium.logic.data.reaction
+
+import com.wire.kalium.logic.data.message.reaction.ReactionRepositoryImpl
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.persistence.TestUserDatabase
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ReactionRepositoryTest {
+
+    private val userDatabase = TestUserDatabase(TestUser.ENTITY_ID)
+    private val reactionsDao = userDatabase.provider.reactionDAO
+    private val conversationDao = userDatabase.provider.conversationDAO
+    private val userDao = userDatabase.provider.userDAO
+    private val messageDao = userDatabase.provider.messageDAO
+
+    private val reactionRepository = ReactionRepositoryImpl(SELF_USER_ID, reactionsDao)
+
+    @AfterTest
+    fun tearDown() {
+        userDatabase.delete()
+    }
+
+    @Test
+    fun givenSelfUserReactionWasPersisted_whenGettingSelfUserReactions_thenShouldReturnPreviouslyStored() = runTest {
+        insertInitialData()
+        val emoji = "🫡"
+        reactionRepository.persistReaction(TEST_MESSAGE_ID, TEST_CONVERSATION_ID, SELF_USER_ID, "Date", emoji)
+
+        val result = reactionRepository.getSelfUserReactionsForMessage(TEST_MESSAGE_ID, TEST_CONVERSATION_ID)
+
+        result.shouldSucceed {
+            assertTrue(it.size == 1)
+            assertEquals(emoji, it.first())
+        }
+    }
+
+    suspend fun insertInitialData() {
+        userDao.insertUser(TEST_SELF_USER_ENTITY)
+        conversationDao.insertConversation(TEST_CONVERSATION_ENTITY)
+        messageDao.insertMessage(TEST_MESSAGE_ENTITY)
+    }
+
+    private companion object {
+        private val SELF_USER_ID = TestUser.USER_ID
+        private val TEST_SELF_USER_ENTITY = TestUser.ENTITY.copy(
+            id = QualifiedIDEntity(
+                SELF_USER_ID.value,
+                SELF_USER_ID.domain
+            )
+        )
+        private val TEST_CONVERSATION_ID = TestConversation.ID
+        private val TEST_CONVERSATION_ENTITY =
+            TestConversation.ENTITY.copy(
+                id = QualifiedIDEntity(
+                    TEST_CONVERSATION_ID.value,
+                    TEST_CONVERSATION_ID.domain
+                )
+            )
+        private val TEST_MESSAGE_ID = TestMessage.TEST_MESSAGE_ID
+        private val TEST_MESSAGE_ENTITY = TestMessage.ENTITY.copy(
+            id = TEST_MESSAGE_ID,
+            senderUserId = TEST_SELF_USER_ENTITY.id,
+            conversationId = TEST_CONVERSATION_ENTITY.id
+        )
+    }
+}

--- a/persistence-test/build.gradle.kts
+++ b/persistence-test/build.gradle.kts
@@ -1,0 +1,70 @@
+plugins {
+    Plugins.androidLibrary(this)
+    Plugins.multiplatform(this)
+}
+
+group = "com.wire.kalium"
+version = "0.0.1-SNAPSHOT"
+
+android {
+    compileSdk = Android.Sdk.compile
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    defaultConfig {
+        minSdk = Android.Sdk.min
+        targetSdk = Android.Sdk.target
+        consumerProguardFiles("consumer-proguard-rules.pro")
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+kotlin {
+    jvm {
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        }
+        testRuns["test"].executionTask.configure {
+            useJUnit()
+        }
+    }
+    android()
+    iosX64()
+    js(IR) {
+        browser {
+            testTask {
+                useMocha {
+                    timeout = "5s"
+                }
+            }
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(project(":persistence"))
+                // coroutines
+                implementation(Dependencies.Coroutines.core) {
+                    version {
+                        // strictly using the native-mt version on coroutines
+                        strictly(Versions.coroutines)
+                    }
+                }
+                implementation(Dependencies.Coroutines.test)
+
+                implementation(kotlin("test"))
+                implementation(Dependencies.MultiplatformSettings.test)
+            }
+        }
+        val androidMain by getting {
+            dependencies {
+                implementation(Dependencies.AndroidInstruments.androidTestRunner)
+                implementation(Dependencies.AndroidInstruments.androidTestRules)
+                implementation(Dependencies.AndroidInstruments.androidTestCore)
+            }
+        }
+    }
+}

--- a/persistence-test/src/androidMain/AndroidManifest.xml
+++ b/persistence-test/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.wire.kalium.persistence-test" />

--- a/persistence-test/src/androidMain/AndroidManifest.xml
+++ b/persistence-test/src/androidMain/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.wire.kalium.persistence-test" />
+          package="com.wire.kalium.persistence.test" />

--- a/persistence-test/src/androidMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/androidMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -1,0 +1,34 @@
+package com.wire.kalium.persistence
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.db.GlobalDatabaseProvider
+import com.wire.kalium.persistence.db.GlobalDatabaseSecret
+import com.wire.kalium.persistence.db.UserDBSecret
+import com.wire.kalium.persistence.db.UserDatabaseProvider
+import com.wire.kalium.persistence.util.FileNameUtil
+import kotlinx.coroutines.test.TestDispatcher
+
+internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
+    return UserDatabaseProvider(
+        ApplicationProvider.getApplicationContext(),
+        userId,
+        UserDBSecret("db_secret".toByteArray()),
+        dispatcher = dispatcher
+    )
+}
+
+internal actual fun deleteTestDatabase(userId: UserIDEntity) {
+    val context: Context = ApplicationProvider.getApplicationContext()
+    context.deleteDatabase(getTempDatabaseFileNameForUser(userId))
+}
+
+internal actual fun createTestGlobalDatabase(): GlobalDatabaseProvider {
+    return GlobalDatabaseProvider(ApplicationProvider.getApplicationContext(), GlobalDatabaseSecret("test_db_secret".toByteArray()))
+}
+
+internal actual fun deleteTestGlobalDatabase() {
+    val context: Context = ApplicationProvider.getApplicationContext()
+    context.deleteDatabase(FileNameUtil.globalDBName())
+}

--- a/persistence-test/src/commonMain/kotlin/com/wire/kalium/persistence/TestGlobalDatabase.kt
+++ b/persistence-test/src/commonMain/kotlin/com/wire/kalium/persistence/TestGlobalDatabase.kt
@@ -1,0 +1,25 @@
+package com.wire.kalium.persistence
+
+import com.wire.kalium.persistence.db.GlobalDatabaseProvider
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+
+class TestGlobalDatabase(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+) {
+
+    val provider: GlobalDatabaseProvider
+
+    init {
+        deleteTestGlobalDatabase()
+        provider = createTestGlobalDatabase()
+    }
+
+    fun delete() {
+        deleteTestGlobalDatabase()
+    }
+}
+
+internal expect fun deleteTestGlobalDatabase()
+
+internal expect fun createTestGlobalDatabase(): GlobalDatabaseProvider

--- a/persistence-test/src/commonMain/kotlin/com/wire/kalium/persistence/TestUserDatabase.kt
+++ b/persistence-test/src/commonMain/kotlin/com/wire/kalium/persistence/TestUserDatabase.kt
@@ -1,0 +1,29 @@
+package com.wire.kalium.persistence
+
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.db.UserDatabaseProvider
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+
+class TestUserDatabase(
+    val userId: UserIDEntity,
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+) {
+
+    val provider: UserDatabaseProvider
+
+    init {
+        deleteTestDatabase(userId)
+        provider = createTestDatabase(userId, dispatcher)
+    }
+
+    fun delete() {
+        deleteTestDatabase(userId)
+    }
+}
+
+internal fun getTempDatabaseFileNameForUser(userId: UserIDEntity) = "TEMP-TEST-DB-${userId.value}.${userId.domain}.db"
+
+internal expect fun deleteTestDatabase(userId: UserIDEntity)
+
+internal expect fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider

--- a/persistence-test/src/iosX64Main/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/iosX64Main/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -1,0 +1,24 @@
+package com.wire.kalium.persistence
+
+import co.touchlab.sqliter.DatabaseFileContext
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.db.GlobalDatabaseProvider
+import com.wire.kalium.persistence.db.UserDatabaseProvider
+import com.wire.kalium.persistence.util.FileNameUtil
+import kotlinx.coroutines.test.TestDispatcher
+
+internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
+    return UserDatabaseProvider(userId, "123456789", dispatcher)
+}
+
+internal actual fun deleteTestDatabase(userId: UserIDEntity) {
+    DatabaseFileContext.deleteDatabase(FileNameUtil.userDBName(userId))
+}
+
+internal actual fun createTestGlobalDatabase(): GlobalDatabaseProvider {
+    return GlobalDatabaseProvider("123456789")
+}
+
+internal actual fun deleteTestGlobalDatabase() {
+    DatabaseFileContext.deleteDatabase(FileNameUtil.globalDBName())
+}

--- a/persistence-test/src/jsMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/jsMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -1,0 +1,19 @@
+package com.wire.kalium.persistence
+
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.db.GlobalDatabaseProvider
+import com.wire.kalium.persistence.db.UserDatabaseProvider
+import kotlinx.coroutines.test.TestDispatcher
+
+internal actual fun createTestDatabase(
+    userId: UserIDEntity,
+    dispatcher: TestDispatcher
+): UserDatabaseProvider = TODO("JavaScript Database not yet supported")
+
+internal actual fun deleteTestDatabase(userId: UserIDEntity) { TODO("JavaScript Database not yet supported") }
+
+internal actual fun createTestGlobalDatabase(): GlobalDatabaseProvider = TODO("JavaScript Database not yet supported")
+
+internal actual fun deleteTestGlobalDatabase() { TODO("JavaScript Database not yet supported") }
+
+

--- a/persistence-test/src/jsMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/jsMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -15,5 +15,3 @@ internal actual fun deleteTestDatabase(userId: UserIDEntity) { TODO("JavaScript 
 internal actual fun createTestGlobalDatabase(): GlobalDatabaseProvider = TODO("JavaScript Database not yet supported")
 
 internal actual fun deleteTestGlobalDatabase() { TODO("JavaScript Database not yet supported") }
-
-

--- a/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -26,4 +26,3 @@ internal actual fun deleteTestGlobalDatabase() {
 private fun getGlobalDatabaseFile() = getTempDatabaseFile("TEST_GLOBAL_DATABASE.db")
 
 private fun getTempDatabaseFile(fileName: String) = Files.createTempDirectory("test-storage").toFile().resolve(fileName)
-

--- a/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -1,0 +1,29 @@
+package com.wire.kalium.persistence
+
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.db.GlobalDatabaseProvider
+import com.wire.kalium.persistence.db.UserDatabaseProvider
+import kotlinx.coroutines.test.TestDispatcher
+import java.nio.file.Files
+
+internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
+    val dbFile = getTempDatabaseFile(getTempDatabaseFileNameForUser(userId))
+    return UserDatabaseProvider(userId, dbFile, dispatcher)
+}
+
+internal actual fun deleteTestDatabase(userId: UserIDEntity) {
+    getTempDatabaseFile(getTempDatabaseFileNameForUser(userId)).delete()
+}
+
+internal actual fun createTestGlobalDatabase(): GlobalDatabaseProvider {
+    return GlobalDatabaseProvider(getGlobalDatabaseFile())
+}
+
+internal actual fun deleteTestGlobalDatabase() {
+    getGlobalDatabaseFile().delete()
+}
+
+private fun getGlobalDatabaseFile() = getTempDatabaseFile("TEST_GLOBAL_DATABASE.db")
+
+private fun getTempDatabaseFile(fileName: String) = Files.createTempDirectory("test-storage").toFile().resolve(fileName)
+

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/util/FileNameUtil.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/util/FileNameUtil.kt
@@ -2,7 +2,7 @@ package com.wire.kalium.persistence.util
 
 import com.wire.kalium.persistence.dao.UserIDEntity
 
-internal object FileNameUtil {
+object FileNameUtil {
     fun appPrefFile() = SHARED_PREFERENCE_FILE_NAME
     fun globalDBName() = GLOBAL_DB_NAME
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are always mocking the Database.
For some complex high-level tests it's way easier (and faithful to actual prod code) to use a real Database.

For example, if we want to test a scenario where we receive a Sync event, like new message, and then call a UseCase to get messages from a conversation.

Mocking all the different mechanisms would be a huge pain.

### Solutions

Create a `persistence-test` module, which can be used by consumers of `persistence`.
This module contains simple `TestUserDatabase` and `TestGlobalDatabase` classes that can be used to grab DAOs and use actual DAOs instead of mocks.

#### Example of usage

In this example (added in this PR to the `logic` module), we test the `ReactionRepository` using an actual Dao:

```kt

class ReactionRepositoryTest {

    private val userDatabase = TestUserDatabase(TestUser.ENTITY_ID)
    private val reactionRepository = ReactionRepositoryImpl(SELF_USER_ID, reactionsDao)

    @Test
    fun givenSelfUserReactionWasPersisted_whenGettingSelfUserReactions_thenShouldReturnPreviouslyStored() = runTest {
        insertInitialData()
        val emoji = "🫡"
        reactionRepository.persistReaction(TEST_MESSAGE_ID, TEST_CONVERSATION_ID, SELF_USER_ID, "Date", emoji)

        val result = reactionRepository.getSelfUserReactionsForMessage(TEST_MESSAGE_ID, TEST_CONVERSATION_ID)

        result.shouldSucceed {
            assertTrue(it.size == 1)
            assertEquals(emoji, it.first())
        }
    }

}

```

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
