### PR TITLE
fix: crash with random failed asset downloads

### DIFF
--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/asset/AssetApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/asset/AssetApiV0Test.kt
@@ -176,7 +176,8 @@ class AssetApiV0Test : ApiTest {
         // When
         val assetApi: AssetApi = AssetApiV0(networkClient)
         val response = assetApi.downloadAsset(assetId, ASSET_TOKEN, tempFileSink)
-        // todo: assert response
+        assertTrue(response is NetworkResponse.Error)
+        assertTrue(response.kException is KaliumException.GenericError)
     }
 
     companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some users reported some crashes when opening certain conversations. After reading the logs, it seems that there are some issues regarding actions on the `KaliumFileSystem` when downloading assets. So since I can't reproduce these crashes, nor deduct what may be causing them, I added a preventive mechanism with a `try/catch` clause to at least prevent the app from crashing.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
