### PR TITLE
fix: MissingClientRegistration after reopening the app

### DIFF
--- a/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -20,10 +20,23 @@ actual class ProteusClientImpl actual constructor(rootDir: String) : ProteusClie
         return File(path).deleteRecursively()
     }
 
-    override suspend fun open() {
+    override suspend fun openOrCreate() {
+        val directory = File(path)
         box = wrapException {
-            File(path).mkdirs()
+            directory.mkdirs()
             CryptoBox.open(path)
+        }
+    }
+
+    override suspend fun openOrError() {
+        val directory = File(path)
+        if (directory.exists()) {
+            box = wrapException {
+                directory.mkdirs()
+                CryptoBox.open(path)
+            }
+        } else {
+            throw ProteusException("Local files were not found", ProteusException.Code.LOCAL_FILES_NOT_FOUND)
         }
     }
 

--- a/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -6,6 +6,7 @@ import com.wire.cryptobox.CryptoException
 import com.wire.kalium.cryptography.exceptions.ProteusException
 import java.io.File
 
+@Suppress("TooManyFunctions")
 actual class ProteusClientImpl actual constructor(rootDir: String) : ProteusClient {
 
     private val path: String

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -18,7 +18,10 @@ interface ProteusClient {
     fun clearLocalFiles(): Boolean
 
     @Throws(ProteusException::class, CancellationException::class)
-    suspend fun open()
+    suspend fun openOrCreate()
+
+    @Throws(ProteusException::class, CancellationException::class)
+    suspend fun openOrError()
 
     @Throws(ProteusException::class)
     fun getIdentity(): ByteArray

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/exceptions/ProteusException.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/exceptions/ProteusException.kt
@@ -122,7 +122,12 @@ class ProteusException(message: String?, val code: Code): Exception(message) {
         /**
          * An unspecified error occurred.
          */
-        UNKNOWN_ERROR
+        UNKNOWN_ERROR,
+
+        /**
+         * Local files were not found.
+         */
+        LOCAL_FILES_NOT_FOUND;
     }
 
     companion object {

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
@@ -1,12 +1,10 @@
 package com.wire.kalium.cryptography
 
-import com.wire.kalium.cryptography.exceptions.ProteusException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.js.ExperimentalJsExport
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 @IgnoreIOS
@@ -84,19 +82,4 @@ class ProteusClientTest : BaseProteusClientTest() {
         assertNotNull(bobClient.encrypt("Hello World".encodeToByteArray(), aliceSessionId))
     }
 
-    @Test
-    fun givenLocalFilesDoesNotExist_whenOpeningTheClient_thenThrowProteusException() = runTest {
-        val aliceClient = createProteusClient(alice.id)
-        val exception = assertFailsWith<ProteusException> {
-            aliceClient.openOrError() // at this point files hasn't been yet created
-        }
-        assertEquals(ProteusException.Code.LOCAL_FILES_NOT_FOUND, exception.code)
-    }
-
-    @Test
-    fun givenLocalFilesExist_whenOpeningTheClient_theDoNotThrowProteusException() = runTest {
-        val aliceClient = createProteusClient(alice.id)
-        aliceClient.openOrCreate() // files are being created
-        aliceClient.openOrError()
-    }
 }

--- a/cryptography/src/iosX64Main/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/iosX64Main/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -23,6 +23,7 @@ import platform.Foundation.create
 import platform.Foundation.valueForKey
 import platform.posix.memcpy
 
+@Suppress("TooManyFunctions")
 actual class ProteusClientImpl actual constructor(private val rootDir: String) : ProteusClient {
 
     private var box: EncryptionContext? = null
@@ -46,9 +47,6 @@ actual class ProteusClientImpl actual constructor(private val rootDir: String) :
         } else {
             throw ProteusException(message = "Local files were not found", code = ProteusException.Code.LOCAL_FILES_NOT_FOUND)
         }
-    }
-
-    override suspend fun open() {
     }
 
     override fun getIdentity(): ByteArray {

--- a/cryptography/src/iosX64Main/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/iosX64Main/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -35,9 +35,20 @@ actual class ProteusClientImpl actual constructor(private val rootDir: String) :
         // Delete the actual files
     }
 
-    override suspend fun open() {
+    override suspend fun openOrCreate() {
         NSFileManager.defaultManager.createDirectoryAtPath(rootDir, withIntermediateDirectories = true, null, null)
         box = EncryptionContext(NSURL.fileURLWithPath(rootDir))
+    }
+
+    override suspend fun openOrError() {
+        if (NSFileManager.defaultManager.fileExistsAtPath(rootDir)) {
+            box = EncryptionContext(NSURL.fileURLWithPath(rootDir))
+        } else {
+            throw ProteusException(message = "Local files were not found", code = ProteusException.Code.LOCAL_FILES_NOT_FOUND)
+        }
+    }
+
+    override suspend fun open() {
     }
 
     override fun getIdentity(): ByteArray {

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -31,11 +31,7 @@ actual class ProteusClientImpl actual constructor(rootDir: String) : ProteusClie
     }
 
     override suspend fun openOrError() {
-        val engine = MemoryEngine()
-        engine.init("in-memory").await()
-
-        box = Cryptobox(engine)
-        box.load().await() // TODO is the use of box.load() instead of box.create() ) correct for this method?
+        openOrCreate() // JS cryptobox is in-memory only
     }
 
     override fun getIdentity(): ByteArray {

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -13,6 +13,7 @@ import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
 
+@Suppress("TooManyFunctions")
 actual class ProteusClientImpl actual constructor(rootDir: String) : ProteusClient {
 
     private lateinit var box: Cryptobox

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -21,12 +21,20 @@ actual class ProteusClientImpl actual constructor(rootDir: String) : ProteusClie
         TODO("Not yet implemented")
     }
 
-    override suspend fun open() {
+    override suspend fun openOrCreate() {
         val engine = MemoryEngine()
         engine.init("in-memory").await()
 
         box = Cryptobox(engine)
         box.create().await()
+    }
+
+    override suspend fun openOrError() {
+        val engine = MemoryEngine()
+        engine.init("in-memory").await()
+
+        box = Cryptobox(engine)
+        box.load().await() // TODO is the use of box.load() instead of box.create() ) correct for this method?
     }
 
     override fun getIdentity(): ByteArray {

--- a/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.cryptography.exceptions.ProteusException
 import java.io.File
 import java.util.Base64
 
+@Suppress("TooManyFunctions")
 actual class ProteusClientImpl actual constructor(rootDir: String) : ProteusClient {
 
     private val path: String

--- a/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -20,11 +20,23 @@ actual class ProteusClientImpl actual constructor(rootDir: String) : ProteusClie
         return File(path).deleteRecursively()
     }
 
-    override suspend fun open() {
+    override suspend fun openOrCreate() {
         val directory = File(path)
         box = wrapException {
             directory.mkdirs()
             CryptoBox.open(path)
+        }
+    }
+
+    override suspend fun openOrError() {
+        val directory = File(path)
+        if (directory.exists()) {
+            box = wrapException {
+                directory.mkdirs()
+                CryptoBox.open(path)
+            }
+        } else {
+            throw ProteusException("Local files were not found", ProteusException.Code.LOCAL_FILES_NOT_FOUND)
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After closing and reopening the app, some actions like sending message result in `MissingClientRegistration`.

### Causes (Optional)

ProteusClient isn't retrieved from the local files after reopening the app.

### Solutions

Split `open` method into two: `openOrCreate` and `openOrError`. First one creates Proteus local files by opening the box even when not existing, the second one checks if files already exist and only then opens the box, otherwise returns failure.

### Testing

#### How to Test

Install the app, login, close the app, reopen again and try to send a message.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
