### PR TITLE
test: use in-memory database for testing

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestKaliumDispatcher.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestKaliumDispatcher.kt
@@ -3,7 +3,6 @@ package com.wire.kalium.logic.test_util
 import com.wire.kalium.util.KaliumDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 object TestKaliumDispatcher : KaliumDispatcher {
 

--- a/persistence-test/src/androidMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/androidMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -5,13 +5,13 @@ import androidx.test.core.app.ApplicationProvider
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.GlobalDatabaseProvider
 import com.wire.kalium.persistence.db.GlobalDatabaseSecret
-import com.wire.kalium.persistence.db.InMemoryUserDatabaseProvider
+import com.wire.kalium.persistence.db.inMemoryDatabase
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.util.FileNameUtil
 import kotlinx.coroutines.test.TestDispatcher
 
 internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
-    return InMemoryUserDatabaseProvider(
+    return inMemoryDatabase(
         ApplicationProvider.getApplicationContext(),
         userId,
         dispatcher = dispatcher

--- a/persistence-test/src/androidMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/androidMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -5,16 +5,15 @@ import androidx.test.core.app.ApplicationProvider
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.GlobalDatabaseProvider
 import com.wire.kalium.persistence.db.GlobalDatabaseSecret
-import com.wire.kalium.persistence.db.UserDBSecret
+import com.wire.kalium.persistence.db.InMemoryUserDatabaseProvider
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import com.wire.kalium.persistence.util.FileNameUtil
 import kotlinx.coroutines.test.TestDispatcher
 
 internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
-    return UserDatabaseProvider(
+    return InMemoryUserDatabaseProvider(
         ApplicationProvider.getApplicationContext(),
         userId,
-        UserDBSecret("db_secret".toByteArray()),
         dispatcher = dispatcher
     )
 }

--- a/persistence-test/src/iosX64Main/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/iosX64Main/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -4,11 +4,12 @@ import co.touchlab.sqliter.DatabaseFileContext
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.GlobalDatabaseProvider
 import com.wire.kalium.persistence.db.UserDatabaseProvider
+import com.wire.kalium.persistence.db.InMemoryDatabaseProvider
 import com.wire.kalium.persistence.util.FileNameUtil
 import kotlinx.coroutines.test.TestDispatcher
 
 internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
-    return UserDatabaseProvider(userId, "123456789", dispatcher)
+    return InMemoryDatabaseProvider(userId, dispatcher)
 }
 
 internal actual fun deleteTestDatabase(userId: UserIDEntity) {

--- a/persistence-test/src/iosX64Main/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/iosX64Main/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -4,12 +4,12 @@ import co.touchlab.sqliter.DatabaseFileContext
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.GlobalDatabaseProvider
 import com.wire.kalium.persistence.db.UserDatabaseProvider
-import com.wire.kalium.persistence.db.InMemoryDatabaseProvider
+import com.wire.kalium.persistence.db.inMemoryDatabase
 import com.wire.kalium.persistence.util.FileNameUtil
 import kotlinx.coroutines.test.TestDispatcher
 
 internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
-    return InMemoryDatabaseProvider(userId, dispatcher)
+    return inMemoryDatabase(userId, dispatcher)
 }
 
 internal actual fun deleteTestDatabase(userId: UserIDEntity) {

--- a/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -2,13 +2,13 @@ package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.GlobalDatabaseProvider
-import com.wire.kalium.persistence.db.InMemoryUserDatabaseProvider
+import com.wire.kalium.persistence.db.inMemoryDatabase
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import kotlinx.coroutines.test.TestDispatcher
 import java.nio.file.Files
 
 internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
-    return InMemoryUserDatabaseProvider(userId, dispatcher)
+    return inMemoryDatabase(userId, dispatcher)
 }
 
 internal actual fun deleteTestDatabase(userId: UserIDEntity) {

--- a/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -2,13 +2,13 @@ package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.GlobalDatabaseProvider
+import com.wire.kalium.persistence.db.InMemoryUserDatabaseProvider
 import com.wire.kalium.persistence.db.UserDatabaseProvider
 import kotlinx.coroutines.test.TestDispatcher
 import java.nio.file.Files
 
 internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDispatcher): UserDatabaseProvider {
-    val dbFile = getTempDatabaseFile(getTempDatabaseFileNameForUser(userId))
-    return UserDatabaseProvider(userId, dbFile, dispatcher)
+    return InMemoryUserDatabaseProvider(userId, dispatcher)
 }
 
 internal actual fun deleteTestDatabase(userId: UserIDEntity) {

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -1,4 +1,5 @@
 @file:Suppress("MatchingDeclarationName")
+
 package com.wire.kalium.persistence.db
 
 import android.content.Context
@@ -9,6 +10,11 @@ import com.wire.kalium.persistence.util.FileNameUtil
 import kotlinx.coroutines.CoroutineDispatcher
 import net.sqlcipher.database.SupportFactory
 
+sealed interface DatabaseCredentials {
+    data class Passphrase(val value: UserDBSecret) : DatabaseCredentials
+    object NotSet : DatabaseCredentials
+}
+
 /**
  * Platform-specific data used to create the database
  * that might be necessary for future operations
@@ -16,8 +22,7 @@ import net.sqlcipher.database.SupportFactory
  */
 internal actual class PlatformDatabaseData(
     val context: Context,
-    val passphrase: UserDBSecret,
-    val isEncrypted: Boolean
+    val databaseCredentials: DatabaseCredentials
 )
 
 fun UserDatabaseProvider(
@@ -43,7 +48,25 @@ fun UserDatabaseProvider(
             name = dbName
         )
     }
-    return UserDatabaseProvider(userId, driver, dispatcher, PlatformDatabaseData(context, passphrase, encrypt))
+    val credentials = if (encrypt) {
+        DatabaseCredentials.Passphrase(passphrase)
+    } else {
+        DatabaseCredentials.NotSet
+    }
+    return UserDatabaseProvider(userId, driver, dispatcher, PlatformDatabaseData(context, credentials))
+}
+
+fun InMemoryUserDatabaseProvider(
+    context: Context,
+    userId: UserIDEntity,
+    dispatcher: CoroutineDispatcher
+): UserDatabaseProvider {
+    val driver = AndroidSqliteDriver(
+        schema = UserDatabase.Schema,
+        context = context,
+        name = null
+    )
+    return UserDatabaseProvider(userId, driver, dispatcher, PlatformDatabaseData(context, DatabaseCredentials.NotSet))
 }
 
 internal actual fun nuke(

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -56,7 +56,7 @@ fun UserDatabaseProvider(
     return UserDatabaseProvider(userId, driver, dispatcher, PlatformDatabaseData(context, credentials))
 }
 
-fun InMemoryUserDatabaseProvider(
+fun inMemoryDatabase(
     context: Context,
     userId: UserIDEntity,
     dispatcher: CoroutineDispatcher

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -61,12 +61,20 @@ fun inMemoryDatabase(
     userId: UserIDEntity,
     dispatcher: CoroutineDispatcher
 ): UserDatabaseProvider {
+    val passphrase = "testPass".toByteArray()
     val driver = AndroidSqliteDriver(
         schema = UserDatabase.Schema,
         context = context,
-        name = null
+        name = null,
+        factory = SupportFactory(passphrase)
     )
-    return UserDatabaseProvider(userId, driver, dispatcher, PlatformDatabaseData(context, DatabaseCredentials.NotSet))
+    return UserDatabaseProvider(
+        userId, driver, dispatcher, PlatformDatabaseData(
+            context, DatabaseCredentials.Passphrase(
+                UserDBSecret(passphrase)
+            )
+        )
+    )
 }
 
 internal actual fun nuke(

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -31,7 +31,7 @@ fun UserDatabaseProvider(
     )
 }
 
-fun InMemoryDatabaseProvider(
+fun inMemoryDatabase(
     userId: UserIDEntity,
     dispatcher: CoroutineDispatcher
 ): UserDatabaseProvider {

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -40,7 +40,7 @@ private fun sqlDriver(driverUri: String): SqlDriver = JdbcSqliteDriver(
     Properties(1).apply { put("foreign_keys", "true") }
 )
 
-fun InMemoryUserDatabaseProvider(userId: UserIDEntity, dispatcher: CoroutineDispatcher): UserDatabaseProvider {
+fun inMemoryDatabase(userId: UserIDEntity, dispatcher: CoroutineDispatcher): UserDatabaseProvider {
     val driver = sqlDriver(JdbcSqliteDriver.IN_MEMORY)
     UserDatabase.Schema.create(driver)
     return UserDatabaseProvider(userId, driver, dispatcher, PlatformDatabaseData(File("inMemory")))

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -13,7 +13,7 @@ import java.util.Properties
 private const val DATABASE_NAME = "main.db"
 
 internal actual class PlatformDatabaseData(
-    val storePath: File
+    val storePath: File?
 )
 
 fun UserDatabaseProvider(
@@ -27,10 +27,7 @@ fun UserDatabaseProvider(
     // Make sure all intermediate directories exist
     storePath.mkdirs()
 
-    val driver: SqlDriver = JdbcSqliteDriver(
-        "jdbc:sqlite:${databasePath.absolutePath}",
-        Properties(1).apply { put("foreign_keys", "true") }
-    )
+    val driver: SqlDriver = sqlDriver("jdbc:sqlite:${databasePath.absolutePath}")
 
     if (!databaseExists) {
         UserDatabase.Schema.create(driver)
@@ -38,8 +35,19 @@ fun UserDatabaseProvider(
     return UserDatabaseProvider(userId, driver, dispatcher, PlatformDatabaseData(storePath))
 }
 
+private fun sqlDriver(driverUri: String): SqlDriver = JdbcSqliteDriver(
+    driverUri,
+    Properties(1).apply { put("foreign_keys", "true") }
+)
+
+fun InMemoryUserDatabaseProvider(userId: UserIDEntity, dispatcher: CoroutineDispatcher): UserDatabaseProvider {
+    val driver = sqlDriver(JdbcSqliteDriver.IN_MEMORY)
+    UserDatabase.Schema.create(driver)
+    return UserDatabaseProvider(userId, driver, dispatcher, PlatformDatabaseData(File("inMemory")))
+}
+
 internal actual fun nuke(
     userId: UserIDEntity,
     database: UserDatabase,
     platformDatabaseData: PlatformDatabaseData
-): Boolean = platformDatabaseData.storePath.resolve(DATABASE_NAME).delete()
+): Boolean = platformDatabaseData.storePath?.resolve(DATABASE_NAME)?.delete() ?: false


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Using the new `TestUserDatabase` is waaay slower than using mocks.

For example, taking the changes from #1057, `SlowSyncRepository` is using an actual database instead of in-memory implementation.
With those changes, the `SlowSyncRepositoryTest` suite went went from 170~220ms to around 4.5 seconds.

With those changes, and this change to use in-memory database for testing, the test suite went down to 350~420ms on my machine.

Switching the file database to an in-memory version

### Causes

Disk operations are slow.

### Solutions

Use in-memory database for testing.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
