### PR TITLE
refactor: make UserSessionScope class final

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -15,7 +15,7 @@ import com.wire.kalium.logic.util.SecurityHelper
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 
 @Suppress("LongParameterList")
-fun UserSessionScope(
+internal fun UserSessionScope(
     applicationContext: Context,
     userId: UserId,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -14,13 +14,9 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.util.SecurityHelper
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 
-/**
- * This class is only for platform specific variables,
- * and it should only override functions/variables from UserSessionScopeCommon
- */
 @Suppress("LongParameterList")
-actual class UserSessionScope internal constructor(
-    private val applicationContext: Context,
+fun UserSessionScope(
+    applicationContext: Context,
     userId: UserId,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet,
     globalScope: GlobalKaliumScope,
@@ -31,24 +27,24 @@ actual class UserSessionScope internal constructor(
     featureSupport: FeatureSupport,
     userStorageProvider: UserStorageProvider,
     userSessionScopeProvider: UserSessionScopeProvider
-) : UserSessionScopeCommon(
-    userId,
-    authenticatedDataSourceSet,
-    globalScope,
-    globalCallManager,
-    globalPreferences,
-    dataStoragePaths,
-    kaliumConfigs,
-    featureSupport,
-    userSessionScopeProvider,
-    userStorageProvider
-) {
-    override val platformUserStorageProperties: PlatformUserStorageProperties
-        get() = PlatformUserStorageProperties(applicationContext, SecurityHelper(globalPreferences.passphraseStorage))
+): UserSessionScope {
+    val platformUserStorageProperties =
+        PlatformUserStorageProperties(applicationContext, SecurityHelper(globalPreferences.passphraseStorage))
 
-    override val clientConfig: ClientConfig get() = ClientConfigImpl(applicationContext)
+    val clientConfig: ClientConfig = ClientConfigImpl(applicationContext)
 
-    init {
-        onInit()
-    }
+    return UserSessionScope(
+        userId,
+        authenticatedDataSourceSet,
+        globalScope,
+        globalCallManager,
+        globalPreferences,
+        dataStoragePaths,
+        kaliumConfigs,
+        featureSupport,
+        userSessionScopeProvider,
+        userStorageProvider,
+        clientConfig,
+        platformUserStorageProperties
+    )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -67,9 +67,9 @@ import com.wire.kalium.logic.data.publicuser.SearchUserRepositoryImpl
 import com.wire.kalium.logic.data.publicuser.UserSearchApiWrapper
 import com.wire.kalium.logic.data.publicuser.UserSearchApiWrapperImpl
 import com.wire.kalium.logic.data.sync.InMemoryIncrementalSyncRepository
-import com.wire.kalium.logic.data.sync.SlowSyncRepositoryImpl
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepositoryImpl
 import com.wire.kalium.logic.data.team.TeamDataSource
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserDataSource
@@ -137,13 +137,8 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import com.wire.kalium.logic.sync.SetConnectionPolicyUseCase
-import com.wire.kalium.logic.sync.slow.SlowSyncCriteriaProvider
-import com.wire.kalium.logic.sync.slow.SlowSlowSyncCriteriaProviderImpl
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.sync.SyncManagerImpl
-import com.wire.kalium.logic.sync.slow.SlowSyncManager
-import com.wire.kalium.logic.sync.slow.SlowSyncWorker
-import com.wire.kalium.logic.sync.slow.SlowSyncWorkerImpl
 import com.wire.kalium.logic.sync.incremental.EventGatherer
 import com.wire.kalium.logic.sync.incremental.EventGathererImpl
 import com.wire.kalium.logic.sync.incremental.EventProcessor
@@ -178,6 +173,11 @@ import com.wire.kalium.logic.sync.receiver.message.ClearConversationContentHandl
 import com.wire.kalium.logic.sync.receiver.message.DeleteForMeHandler
 import com.wire.kalium.logic.sync.receiver.message.LastReadContentHandler
 import com.wire.kalium.logic.sync.receiver.message.MessageTextEditHandler
+import com.wire.kalium.logic.sync.slow.SlowSlowSyncCriteriaProviderImpl
+import com.wire.kalium.logic.sync.slow.SlowSyncCriteriaProvider
+import com.wire.kalium.logic.sync.slow.SlowSyncManager
+import com.wire.kalium.logic.sync.slow.SlowSyncWorker
+import com.wire.kalium.logic.sync.slow.SlowSyncWorkerImpl
 import com.wire.kalium.logic.util.TimeParser
 import com.wire.kalium.logic.util.TimeParserImpl
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
@@ -190,7 +190,6 @@ import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
 import kotlin.coroutines.CoroutineContext
 
-expect class UserSessionScope : UserSessionScopeCommon
 fun interface CurrentClientIdProvider {
     suspend operator fun invoke(): Either<CoreFailure, ClientId>
 }
@@ -200,19 +199,20 @@ fun interface SelfTeamIdProvider {
 }
 
 @Suppress("LongParameterList")
-abstract class UserSessionScopeCommon internal constructor(
+class UserSessionScope internal constructor(
     private val userId: UserId,
     private val authenticatedDataSourceSet: AuthenticatedDataSourceSet,
     private val globalScope: GlobalKaliumScope,
     private val globalCallManager: GlobalCallManager,
-    protected val globalPreferences: GlobalPrefProvider,
+    private val globalPreferences: GlobalPrefProvider,
     dataStoragePaths: DataStoragePaths,
     private val kaliumConfigs: KaliumConfigs,
     private val featureSupport: FeatureSupport,
     private val userSessionScopeProvider: UserSessionScopeProvider,
-    userStorageProvider: UserStorageProvider
+    userStorageProvider: UserStorageProvider,
+    private val clientConfig: ClientConfig,
+    platformUserStorageProperties: PlatformUserStorageProperties
 ) : CoroutineScope {
-    protected abstract val platformUserStorageProperties: PlatformUserStorageProperties
 
     private val userStorage = userStorageProvider.getOrCreate(
         userId,
@@ -243,7 +243,7 @@ abstract class UserSessionScopeCommon internal constructor(
     private val clientIdProvider = CurrentClientIdProvider { clientId() }
     private val selfConversationIdProvider: SelfConversationIdProvider by lazy { SelfConversationIdProviderImpl(conversationRepository) }
 
-    // TODO: make atomic
+    // TODO(refactor): Extract to Provider class and make atomic
     // val _teamId: Atomic<Either<CoreFailure, TeamId?>> = Atomic(Either.Left(CoreFailure.Unknown(Throwable("NotInitialized"))))
     private var _teamId: Either<CoreFailure, TeamId?> = Either.Left(CoreFailure.Unknown(Throwable("NotInitialized")))
 
@@ -393,10 +393,6 @@ abstract class UserSessionScopeCommon internal constructor(
             callMapper = callMapper
         )
     }
-
-    // TODO: Refactor. These should be passed in the constructor to
-    //       avoid depending on not-yet-initialized fields
-    protected abstract val clientConfig: ClientConfig
 
     private val clientRemoteRepository: ClientRemoteRepository
         get() = ClientRemoteDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.clientApi, clientConfig)
@@ -826,7 +822,7 @@ abstract class UserSessionScopeCommon internal constructor(
 
     override val coroutineContext: CoroutineContext = SupervisorJob()
 
-    fun onInit() {
+    init {
         launch {
             // TODO: Add a public start function to the Managers
             incrementalSyncManager

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -13,8 +13,8 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 
 @Suppress("LongParameterList")
-actual class UserSessionScope internal constructor(
-    override val platformUserStorageProperties: PlatformUserStorageProperties,
+fun UserSessionScope(
+    platformUserStorageProperties: PlatformUserStorageProperties,
     userId: UserId,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet,
     globalScope: GlobalKaliumScope,
@@ -25,22 +25,22 @@ actual class UserSessionScope internal constructor(
     featureSupport: FeatureSupport,
     userStorageProvider: UserStorageProvider,
     userSessionScopeProvider: UserSessionScopeProvider,
-) : UserSessionScopeCommon(
-    userId,
-    authenticatedDataSourceSet,
-    globalScope,
-    globalCallManager,
-    globalPreferences,
-    dataStoragePaths,
-    kaliumConfigs,
-    featureSupport,
-    userSessionScopeProvider,
-    userStorageProvider
-) {
+) : UserSessionScope {
 
-    override val clientConfig: ClientConfig get() = ClientConfigImpl()
+    val clientConfig: ClientConfig = ClientConfigImpl()
 
-    init {
-        onInit()
-    }
+    return UserSessionScope(
+        userId,
+        authenticatedDataSourceSet,
+        globalScope,
+        globalCallManager,
+        globalPreferences,
+        dataStoragePaths,
+        kaliumConfigs,
+        featureSupport,
+        userSessionScopeProvider,
+        userStorageProvider,
+        clientConfig,
+        platformUserStorageProperties
+    )
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -13,7 +13,7 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 
 @Suppress("LongParameterList")
-fun UserSessionScope(
+internal fun UserSessionScope(
     platformUserStorageProperties: PlatformUserStorageProperties,
     userId: UserId,
     authenticatedDataSourceSet: AuthenticatedDataSourceSet,
@@ -25,7 +25,7 @@ fun UserSessionScope(
     featureSupport: FeatureSupport,
     userStorageProvider: UserStorageProvider,
     userSessionScopeProvider: UserSessionScopeProvider,
-) : UserSessionScope {
+): UserSessionScope {
 
     val clientConfig: ClientConfig = ClientConfigImpl()
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`NullPointerException` when initializing `UserSessionScopeCommon`.

### Causes

- `platformUserStorageProperties` is not initialized yet, it will be initialized by the child class.

- `UserSessionScopeCommon` is abstract and it's easy to oversee the mistake of relying on abstract fields, leading to `NullPointerException`.

### Solutions

In order to prevent this from happening in the future:

- Rename `UserSessionScopeCommon` to `UserSessionScope` and make it a final class.

- Remove the platform-specific `UserSessionScope` by transforming them into a function. Platform-specific parameters now must be passed via the constructor of `UserSessionScope`, so it's up to each platform to figure out how to create the needed properties.

### Testing

Manually tested on JVM and Android.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
