### PR TITLE
feat: perform SlowSync only once a week (AR-2597)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -79,11 +79,12 @@ internal class SlowSyncManager(
             if (isSlowSyncNeeded(lastTimeSlowSyncWasPerformed)) {
                 logger.i("Starting SlowSync as all criteria are met and it wasn't performed recently")
                 performSlowSync()
+                logger.i("SlowSync completed. Updating last completion instant")
+                slowSyncRepository.setLastSlowSyncCompletionInstant(Clock.System.now())
             } else {
                 logger.i("No need to perform SlowSync. Marking as Complete")
             }
             slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
-            slowSyncRepository.setLastSlowSyncCompletionInstant(Clock.System.now())
         } else {
             // STOP SYNC
             logger.i("SlowSync Stopped as criteria are not met: $syncCriteriaResolution")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.functional.combine
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncExceptionHandler
 import com.wire.kalium.logic.sync.incremental.IncrementalSyncManager
@@ -16,6 +17,9 @@ import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -50,35 +54,61 @@ internal class SlowSyncManager(
         }
     })
 
-    init { startMonitoring() }
+    init {
+        startMonitoring()
+    }
 
     private fun startMonitoring() {
         scope.launch(coroutineExceptionHandler) {
             slowSyncCriteriaProvider
                 .syncCriteriaFlow()
                 .distinctUntilChanged()
+                .combine(slowSyncRepository.observeLastSlowSyncCompletionInstant())
                 // Collect latest will cancel whatever is running inside the collector when a new value is emitted
-                .collectLatest { handleCriteriaResolution(it) }
+                .collectLatest { (syncCriteriaResolution, lastTimeSlowSyncWasPerformed) ->
+                    handleCriteriaResolution(syncCriteriaResolution, lastTimeSlowSyncWasPerformed)
+                }
         }
     }
 
-    private suspend fun handleCriteriaResolution(it: SyncCriteriaResolution) {
-        if (it is SyncCriteriaResolution.Ready) {
-            // START SYNC
-            logger.i("Starting SlowSync as all criteria are met")
-            slowSyncWorker.performSlowSyncSteps().cancellable().collect { step ->
-                logger.i("Performing SlowSyncStep $step")
-                slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Ongoing(step))
+    private suspend fun handleCriteriaResolution(syncCriteriaResolution: SyncCriteriaResolution, lastTimeSlowSyncWasPerformed: Instant?) {
+        if (syncCriteriaResolution is SyncCriteriaResolution.Ready) {
+            // START SYNC IF NEEDED
+            logger.i("SlowSync criteria ready, checking if SlowSync is needed or already performed")
+            logger.i("Last SlowSync was performed on '$lastTimeSlowSyncWasPerformed'")
+            if (isSlowSyncNeeded(lastTimeSlowSyncWasPerformed)) {
+                logger.i("Starting SlowSync as all criteria are met and it wasn't performed recently")
+                performSlowSync()
+            } else {
+                logger.i("No need to perform SlowSync. Marking as Complete")
             }
             slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+            slowSyncRepository.setLastSlowSyncCompletionInstant(Clock.System.now())
         } else {
             // STOP SYNC
-            logger.i("SlowSync Stopped as criteria are not met: $it")
+            logger.i("SlowSync Stopped as criteria are not met: $syncCriteriaResolution")
             slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Pending)
+        }
+    }
+
+    private fun isSlowSyncNeeded(lastTimeSlowSyncWasPerformed: Instant?): Boolean {
+        return lastTimeSlowSyncWasPerformed?.let {
+            val currentTime = Clock.System.now()
+            val nextSlowSyncDateTime = lastTimeSlowSyncWasPerformed + MIN_TIME_BETWEEN_SLOW_SYNCS
+            logger.i("Next SlowSync should be performed on '$nextSlowSyncDateTime'")
+            currentTime > nextSlowSyncDateTime
+        } ?: true
+    }
+
+    private suspend fun performSlowSync() {
+        slowSyncWorker.performSlowSyncSteps().cancellable().collect { step ->
+            logger.i("Performing SlowSyncStep $step")
+            slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Ongoing(step))
         }
     }
 
     private companion object {
         val RETRY_DELAY = 10.seconds
+        val MIN_TIME_BETWEEN_SLOW_SYNCS = 1.days
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -109,6 +109,6 @@ internal class SlowSyncManager(
 
     private companion object {
         val RETRY_DELAY = 10.seconds
-        val MIN_TIME_BETWEEN_SLOW_SYNCS = 1.days
+        val MIN_TIME_BETWEEN_SLOW_SYNCS = 7.days
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.sync.SlowSyncStep
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.flowThatFailsOnFirstTime
 import io.mockative.Mock
+import io.mockative.any
 import io.mockative.anyInstanceOf
 import io.mockative.classOf
 import io.mockative.configure
@@ -117,6 +118,23 @@ class SlowSyncManagerTest {
                 }
             )
             .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenItWasCompletedRecently_whenCriteriaAreMet_thenShouldNotUpdateLastCompletedDate() = runTest(TestKaliumDispatcher.default) {
+        val initialTime = Clock.System.now()
+
+        val (arrangement, _) = Arrangement()
+            .withSatisfiedCriteria()
+            .withLastSlowSyncPerformedAt(flowOf(initialTime))
+            .arrange()
+
+        advanceUntilIdle()
+
+        verify(arrangement.slowSyncRepository)
+            .function(arrangement.slowSyncRepository::setLastSlowSyncCompletionInstant)
+            .with(any<Instant?>())
+            .wasNotInvoked()
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.sync.SlowSyncStep
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.flowThatFailsOnFirstTime
 import io.mockative.Mock
+import io.mockative.anyInstanceOf
 import io.mockative.classOf
 import io.mockative.configure
 import io.mockative.eq
@@ -21,13 +22,17 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
 
 class SlowSyncManagerTest {
 
@@ -138,6 +143,93 @@ class SlowSyncManagerTest {
     }
 
     @Test
+    fun givenItWasPerformedRecently_whenCriteriaAreMet_thenShouldNotStartSlowSync() = runTest(TestKaliumDispatcher.default) {
+        val criteriaChannel = Channel<SyncCriteriaResolution>(Channel.UNLIMITED)
+        val stepSharedFlow = MutableSharedFlow<SlowSyncStep>(extraBufferCapacity = 1)
+        stepSharedFlow.emit(SlowSyncStep.CONVERSATIONS)
+        val (arrangement, _) = Arrangement()
+            .withSatisfiedCriteria()
+            .withSlowSyncWorkerReturning(stepSharedFlow)
+            .withLastSlowSyncPerformedAt(flowOf(Clock.System.now()))
+            .arrange()
+
+        criteriaChannel.send(SyncCriteriaResolution.Ready)
+        advanceUntilIdle()
+
+        // Never updated to Ongoing
+        verify(arrangement.slowSyncRepository)
+            .suspendFunction(arrangement.slowSyncRepository::updateSlowSyncStatus)
+            .with(anyInstanceOf(SlowSyncStatus.Ongoing::class))
+            .wasNotInvoked()
+
+        // No collectors
+        assertEquals(0, stepSharedFlow.subscriptionCount.value)
+    }
+
+    @Test
+    fun givenItWasPerformedRecently_whenLastPerformedIsCleared_thenShouldStartSlowSyncAgain() = runTest(TestKaliumDispatcher.default) {
+        val criteriaChannel = Channel<SyncCriteriaResolution>(Channel.UNLIMITED)
+        criteriaChannel.send(SyncCriteriaResolution.Ready)
+
+        val lastPerformedInstant = Channel<Instant?>(Channel.UNLIMITED)
+        lastPerformedInstant.send(Clock.System.now())
+
+        val stepSharedFlow = Channel<SlowSyncStep>(Channel.UNLIMITED)
+        val step = SlowSyncStep.CONVERSATIONS
+        stepSharedFlow.send(step)
+
+        val (arrangement, _) = Arrangement()
+            .withSatisfiedCriteria()
+            .withSlowSyncWorkerReturning(stepSharedFlow.receiveAsFlow())
+            .withLastSlowSyncPerformedAt(lastPerformedInstant.receiveAsFlow())
+            .arrange()
+
+        advanceUntilIdle()
+
+        // Not updated to Ongoing
+        verify(arrangement.slowSyncRepository)
+            .suspendFunction(arrangement.slowSyncRepository::updateSlowSyncStatus)
+            .with(anyInstanceOf(SlowSyncStatus.Ongoing::class))
+            .wasNotInvoked()
+
+        lastPerformedInstant.send(null)
+        advanceUntilIdle()
+
+        // Updated to Ongoing after clearing lastPerformed
+        verify(arrangement.slowSyncRepository)
+            .suspendFunction(arrangement.slowSyncRepository::updateSlowSyncStatus)
+            .with(eq(SlowSyncStatus.Ongoing(step)))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenItWasPerformedLongAgoAndCriteriaAreMet_whenWorkerEmitsAStep_thenShouldUpdateStateInRepository() =
+        runTest(TestKaliumDispatcher.default) {
+            val stepChannel = Channel<SlowSyncStep>(Channel.UNLIMITED)
+            val (arrangement, _) = Arrangement()
+                .withSatisfiedCriteria()
+                .withSlowSyncWorkerReturning(stepChannel.consumeAsFlow())
+                .withLastSlowSyncPerformedAt(flowOf(Clock.System.now() - 30.days))
+                .arrange()
+
+            val step = SlowSyncStep.CONTACTS
+            advanceUntilIdle()
+
+            verify(arrangement.slowSyncRepository)
+                .function(arrangement.slowSyncRepository::updateSlowSyncStatus)
+                .with(eq(SlowSyncStatus.Ongoing(step)))
+                .wasNotInvoked()
+
+            stepChannel.send(step)
+            advanceUntilIdle()
+
+            verify(arrangement.slowSyncRepository)
+                .function(arrangement.slowSyncRepository::updateSlowSyncStatus)
+                .with(eq(SlowSyncStatus.Ongoing(step)))
+                .wasInvoked(exactly = once)
+        }
+
+    @Test
     fun givenCriteriaAreNotMet_whenManagerIsCreated_thenShouldNotStartSlowSync() = runTest(TestKaliumDispatcher.default) {
         var isCollected = false
         val stepFlow = flow<SlowSyncStep> { isCollected = true }
@@ -162,11 +254,22 @@ class SlowSyncManagerTest {
         @Mock
         val slowSyncWorker: SlowSyncWorker = mock(classOf<SlowSyncWorker>())
 
+        init {
+            withLastSlowSyncPerformedAt(flowOf(null))
+        }
+
         fun withCriteriaProviderReturning(criteriaFlow: Flow<SyncCriteriaResolution>) = apply {
             given(slowSyncCriteriaProvider)
                 .suspendFunction(slowSyncCriteriaProvider::syncCriteriaFlow)
                 .whenInvoked()
                 .thenReturn(criteriaFlow)
+        }
+
+        fun withLastSlowSyncPerformedAt(lasSyncFlow: Flow<Instant?>) = apply {
+            given(slowSyncRepository)
+                .suspendFunction(slowSyncRepository::observeLastSlowSyncCompletionInstant)
+                .whenInvoked()
+                .thenReturn(lasSyncFlow)
         }
 
         fun withSatisfiedCriteria() = withCriteriaProviderReturning(flowOf(SyncCriteriaResolution.Ready))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We're performing SlowSync every time Kalium launches

### Causes

We didn't handle all necessary events when receiving them through the REST API or Websockets. We still don't, but we are handling the necessary ones for Kalium to work properly at the moment.

### Solutions

Perform it once a week.
Why once a week?
Cause it's a time long enough that may expose important events we could be ignoring, and not too short that would prevent us from seeing the benefits of this change.

Inside `SlowSyncManager`, when the time comes to perform it, we check the last time it was performed. If it the time since the last slow sync is longer than a treshold (7 days), we perform it again.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Sync! And try to Sync again :)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
