### PR TITLE
feat: restricted conference calling part2

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -84,6 +84,15 @@ class FeatureConfigMapperTest {
         assertEquals(Status.ENABLED, model.status)
     }
 
+    @Test
+    fun givenApiModelResponse_whenMappingConferenceCallingToModel_thenShouldBeMappedCorrectly() {
+        val (arrangement, mapper) = Arrangement().arrange()
+
+        val model = mapper.fromDTO(arrangement.featureConfigResponse.conferenceCalling)
+
+        assertEquals(Status.ENABLED, model.status)
+    }
+
     private class Arrangement {
         val featureConfigResponse = FeatureConfigResponse(
             FeatureConfigData.AppLock(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveIsConferenceCallingEnabledUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveIsConferenceCallingEnabledUseCaseTest.kt
@@ -1,0 +1,75 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObserveIsConferenceCallingEnabledUseCaseTest {
+
+    @Mock
+    val userConfigRepository = mock(classOf<UserConfigRepository>())
+
+    private lateinit var observeIsConferenceCallingEnabled: ObserveIsConferenceCallingEnabledUseCase
+
+    @BeforeTest
+    fun setUp() {
+        observeIsConferenceCallingEnabled = ObserveIsConferenceCallingEnabledUseCaseImpl(
+            userConfigRepository = userConfigRepository
+        )
+    }
+
+    @Test
+    fun givenAnStorageErrorOccurred_whenInvokingObserveIsConferenceCallingEnabled_thenReturnFalse() = runTest {
+        given(userConfigRepository)
+            .function(userConfigRepository::isConferenceCallingEnabledFlow)
+            .whenInvoked()
+            .thenReturn(flowOf(Either.Left(StorageFailure.Generic(Throwable("error")))))
+
+        val result = observeIsConferenceCallingEnabled()
+
+        result.test {
+            assertEquals(false, awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenUserTeamDoesntHaveConferenceCallingEnabled_whenInvokingObserveIsConferenceCallingEnabled_thenReturnFalse() = runTest {
+        given(userConfigRepository)
+            .function(userConfigRepository::isConferenceCallingEnabledFlow)
+            .whenInvoked()
+            .thenReturn(flowOf(Either.Right(false)))
+
+        val result = observeIsConferenceCallingEnabled()
+
+        result.test {
+            assertEquals(false, awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenUserTeamHaveConferenceCallingEnabled_whenInvokingObserveIsConferenceCallingEnabled_thenReturnTrue() = runTest {
+        given(userConfigRepository)
+            .function(userConfigRepository::isConferenceCallingEnabledFlow)
+            .whenInvoked()
+            .thenReturn(flowOf(Either.Right(true)))
+
+        val result = observeIsConferenceCallingEnabled()
+
+        result.test {
+            assertEquals(true, awaitItem())
+            awaitComplete()
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/GetFeatureConfigsStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/GetFeatureConfigsStatusUseCaseTest.kt
@@ -88,6 +88,11 @@ class GetFeatureConfigsStatusUseCaseTest {
             .function(arrangement.userConfigRepository::setMLSEnabled)
             .with(eq(false))
             .wasInvoked(exactly = once)
+
+        verify(arrangement.userConfigRepository)
+            .function(arrangement.userConfigRepository::setConferenceCallingEnabled)
+            .with(eq(true))
+            .wasInvoked(exactly = once)
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/config/UserConfigStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/config/UserConfigStorageTest.kt
@@ -44,4 +44,13 @@ class UserConfigStorageTest {
             userConfigStorage.isClassifiedDomainsEnabledFlow().first()
         )
     }
+
+    @Test
+    fun givenAConferenceCallingStatusValue_whenPersistingIt_saveAndThenRestoreTheValueLocally() = runTest {
+        userConfigStorage.persistConferenceCalling(true)
+        assertEquals(
+            true,
+            userConfigStorage.isConferenceCallingEnabledFlow().first()
+        )
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2535 - Calls restriction on non paying members](https://wearezeta.atlassian.net/browse/AR-2535)

This is the PR for tests only.

### Issues

Users that aren't in a paying team were able to start a conference/group call.

### Causes (Optional)

We weren't checking for this feature flag.

### Solutions

Correctly listen and verify the feature flag value when starting a conference/group call.

### Dependencies (Optional)

This is the PR with tests

Needs releases with:

- [X] #1062 

### Testing

#### How to Test

It is not possible to test it yet, tests will be possible when Kalium side is merged and will be used in AR.