### PR TITLE
fix: add member not working against API v2

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/ConversationApiV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/ConversationApiV2.kt
@@ -5,10 +5,12 @@ import com.wire.kalium.network.api.base.authenticated.conversation.AddConversati
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberAddedResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponseDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationsDetailsRequest
+import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.v0.authenticated.ConversationApiV0
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -35,7 +37,8 @@ internal open class ConversationApiV2 internal constructor(
             setBody(request)
         }.let { response ->
             when (response.status) {
-                HttpStatusCode.OK -> wrapKaliumResponse<ConversationMemberAddedResponse.Changed> { response }
+                HttpStatusCode.OK -> wrapKaliumResponse<EventContentDTO.Conversation.MemberJoinDTO> { response }
+                    .mapSuccess { ConversationMemberAddedResponse.Changed(it) }
                 HttpStatusCode.NoContent -> NetworkResponse.Success(ConversationMemberAddedResponse.Unchanged, response)
                 else -> wrapKaliumResponse { response }
             }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
@@ -147,7 +147,7 @@ class ConversationApiV0Test : ApiTest {
             setOf(ConversationAccessDTO.PRIVATE, ConversationAccessDTO.INVITE), setOf()
         )
         val networkClient = mockAuthenticatedNetworkClient(
-            EventContentDTOJson.valid.rawJson, statusCode = HttpStatusCode.OK
+            EventContentDTOJson.validAccessUpdate.rawJson, statusCode = HttpStatusCode.OK
         )
 
         val conversationApi = ConversationApiV0(networkClient)
@@ -196,14 +196,36 @@ class ConversationApiV0Test : ApiTest {
         val request = AddConversationMembersRequest(listOf(userId), "Member")
 
         val networkClient = mockAuthenticatedNetworkClient(
-            "", statusCode = HttpStatusCode.OK,
+            EventContentDTOJson.validMemberJoin.rawJson, statusCode = HttpStatusCode.OK,
             assertion = {
                 assertPost()
                 assertPathEqual("$PATH_CONVERSATIONS/${conversationId.value}/$PATH_MEMBERS/$PATH_V2")
             }
         )
         val conversationApi = ConversationApiV0(networkClient)
-        conversationApi.addMember(request, conversationId)
+        val response = conversationApi.addMember(request, conversationId)
+
+        assertTrue(response.isSuccessful())
+    }
+
+    @Test
+    fun whenRemovingMemberFromGroup_thenTheMemberShouldBeRemovedCorrectly() = runTest {
+        val conversationId = ConversationId("conversationId", "conversationDomain")
+        val userId = UserId("userId", "userDomain")
+
+        val networkClient = mockAuthenticatedNetworkClient(
+            EventContentDTOJson.validMemberLeave.rawJson, statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertDelete()
+                assertPathEqual(
+                    "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_MEMBERS/${userId.domain}/${userId.value}"
+                )
+            }
+        )
+        val conversationApi = ConversationApiV0(networkClient)
+        val response = conversationApi.removeMember(userId, conversationId)
+
+        assertTrue(response.isSuccessful())
     }
 
     private companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v2/ConversationApiV2Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v2/ConversationApiV2Test.kt
@@ -1,15 +1,18 @@
 package com.wire.kalium.api.v2
 
 import com.wire.kalium.api.ApiTest
+import com.wire.kalium.model.EventContentDTOJson
 import com.wire.kalium.model.conversation.ConversationDetailsResponse
 import com.wire.kalium.model.conversation.ConversationListIdsResponseJson
 import com.wire.kalium.network.api.base.authenticated.conversation.AddConversationMembersRequest
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v2.authenticated.ConversationApiV2
+import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class ConversationApiV2Test : ApiTest {
     @Test
@@ -41,14 +44,16 @@ class ConversationApiV2Test : ApiTest {
         val request = AddConversationMembersRequest(listOf(userId), "Member")
 
         val networkClient = mockAuthenticatedNetworkClient(
-            "", statusCode = HttpStatusCode.OK,
+            EventContentDTOJson.validMemberJoin.rawJson, statusCode = HttpStatusCode.OK,
             assertion = {
                 assertPost()
                 assertPathEqual("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_MEMBERS")
             }
         )
         val conversationApi = ConversationApiV2(networkClient)
-        conversationApi.addMember(request, conversationId)
+        val response = conversationApi.addMember(request, conversationId)
+
+        assertTrue(response.isSuccessful())
     }
 
     private companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
@@ -1,6 +1,8 @@
 package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMembers
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationUsers
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationAccessInfoDTO
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
@@ -29,7 +31,49 @@ object EventContentDTOJson {
         """.trimMargin()
     }
 
-    val valid = ValidJsonProvider(
+    private val jsonProviderMemberJoin = { serializable: EventContentDTO.Conversation.MemberJoinDTO ->
+        """
+        |{
+        |  "qualified_conversation" : {
+        |    "id" : "${serializable.qualifiedConversation.value}",
+        |    "domain" : "${serializable.qualifiedConversation.domain}"
+        |  },
+        |  "qualified_from" : {
+        |     "id" : "${serializable.qualifiedFrom.value}",
+        |     "domain" : "${serializable.qualifiedFrom.domain}"
+        |  }, 
+        |  "from" : "${serializable.from}",
+        |  "time" : "${serializable.time}",
+        |  "data" : {
+        |       "user_ids" : [],
+        |       "users" : []
+        |  }
+        |}
+        """.trimMargin()
+    }
+
+    private val jsonProviderMemberLeave = { serializable: EventContentDTO.Conversation.MemberLeaveDTO ->
+        """
+        |{
+        |  "qualified_conversation" : {
+        |    "id" : "${serializable.qualifiedConversation.value}",
+        |    "domain" : "${serializable.qualifiedConversation.domain}"
+        |  },
+        |  "qualified_from" : {
+        |     "id" : "${serializable.qualifiedFrom.value}",
+        |     "domain" : "${serializable.qualifiedFrom.domain}"
+        |  }, 
+        |  "from" : "${serializable.from}",
+        |  "time" : "${serializable.time}",
+        |  "data" : {
+        |       "user_ids" : [],
+        |       qualified_user_ids : [] 
+        |  }
+        |}
+        """.trimMargin()
+    }
+
+    val validAccessUpdate = ValidJsonProvider(
         EventContentDTO.Conversation.AccessUpdate(
             qualifiedConversation = ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             qualifiedFrom = UserId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
@@ -39,6 +83,28 @@ object EventContentDTOJson {
             )
         ),
         jsonProvider
+    )
+
+    val validMemberJoin = ValidJsonProvider(
+        EventContentDTO.Conversation.MemberJoinDTO(
+            qualifiedConversation = ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            qualifiedFrom = UserId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            from = "ebafd3d4-1548-49f2-ac4e-b2757e6ca44b",
+            time = "2021-05-31T10:52:02.671Z",
+            members = ConversationMembers(emptyList(), emptyList())
+        ),
+        jsonProviderMemberJoin
+    )
+
+    val validMemberLeave = ValidJsonProvider(
+        EventContentDTO.Conversation.MemberLeaveDTO(
+            qualifiedConversation = ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            qualifiedFrom = UserId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            from = "ebafd3d4-1548-49f2-ac4e-b2757e6ca44b",
+            time = "2021-05-31T10:52:02.671Z",
+            members = ConversationUsers(emptyList(), emptyList())
+        ),
+        jsonProviderMemberLeave
     )
 
     val validNullAccessRole = """


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Add member response parsing fails when using API v2

### Causes

Response parsing changed but was only updated in API v0

### Solutions

Apply changes to v2

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
