### PR TITLE
chore: enable SQL syntax highlighting on GitHub for sq and sqm files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sq linguist-language=SQL
+*.sqm linguist-language=SQL

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -219,7 +219,6 @@ LEFT JOIN MessageRestrictedAssetContent AS RestrictedAssetContent ON Message.id 
 LEFT JOIN MessageFailedToDecryptContent AS FailedToDecryptContent ON Message.id = FailedToDecryptContent.message_id AND Message.conversation_id = FailedToDecryptContent.conversation_id
 LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
 LEFT JOIN SelfUser;
-
 -- TODO: Remove IFNULL functions above if we can force SQLDelight to not unpack as notnull
 
 deleteAllMessages:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

GitHub doesn't add syntax highlighting for `.sq` and `.sqm` files.

### Solutions

Add `.gitattributes` instructions to add `SQL` syntax to these files.

### Testing

#### How to Test

* Check the diffs below, and/or
* Browse a `.sq` or `.sqm` file on this branch and compare it with browsing it on `develop`

### Attachments

#### Develop

![grafik](https://user-images.githubusercontent.com/9389043/198261353-9df114bb-d008-42c7-86fd-1089b90f76c0.png)

##### This branch

![grafik](https://user-images.githubusercontent.com/9389043/198261399-931e63a9-6d71-4fcb-b48a-7aa70313ee08.png)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
