### PR TITLE
chore: group network respose logs to one line

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
@@ -87,8 +87,7 @@ public class KaliumKtorCustomLogging private constructor(
 
     private suspend fun logRequest(request: HttpRequestBuilder): OutgoingContent? {
         if (level.info) {
-            kaliumLogger.v("REQUEST: ${obfuscatePath(Url(request.url))} ")
-            kaliumLogger.v("METHOD: ${request.method}")
+            kaliumLogger.v("REQUEST: ${obfuscatePath(Url(request.url))} - METHOD: ${request.method}")
         }
 
         val content = request.body as OutgoingContent
@@ -110,9 +109,9 @@ public class KaliumKtorCustomLogging private constructor(
 
     private fun logResponse(response: HttpResponse) {
         if (level.info) {
-            kaliumLogger.v("RESPONSE: ${response.status}")
-            kaliumLogger.v("METHOD: ${response.call.request.method}")
-            kaliumLogger.v("FROM: ${obfuscatePath(response.call.request.url)}")
+            kaliumLogger.v("RESPONSE: ${response.status} - " +
+                    "FROM: ${obfuscatePath(response.call.request.url)} - " +
+                    "METHOD: ${response.call.request.method}")
         }
 
         if (level.headers) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Network Réponse logs span across multiple lines making it hard to correlate response status to endpoint for automated analysis


### Solutions

Group several attributes in 1 line

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
