### PR TITLE
fix: Make SendTextUseCase accept mentions

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -50,7 +50,12 @@ class ProtoContentMapperImpl(
 
     private fun mapReadableContentToProtobuf(protoContent: ProtoContent.Readable) =
         when (val readableContent = protoContent.messageContent) {
-            is MessageContent.Text -> GenericMessage.Content.Text(Text(content = readableContent.value))
+            is MessageContent.Text -> GenericMessage.Content.Text(
+                Text(
+                    content = readableContent.value,
+                    mentions = readableContent.mentions.map { messageMentionMapper.fromModelToProto(it) })
+            )
+
             is MessageContent.Calling -> GenericMessage.Content.Calling(Calling(content = readableContent.value))
             is MessageContent.Asset -> GenericMessage.Content.Asset(assetMapper.fromAssetContentToProtoAssetMessage(readableContent.value))
             is MessageContent.Knock -> GenericMessage.Content.Knock(Knock(hotKnock = readableContent.hotKnock))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
@@ -51,7 +51,6 @@ class MessageEnvelopeCreatorImpl(
         message: Message.Regular
     ): Either<CoreFailure, MessageEnvelope> {
         val senderClientId = message.senderClientId
-        ProtoContent.Readable(message.id, message.content)
 
         val actualMessageContent = ProtoContent.Readable(message.id, message.content)
         val (encodedContent, externalDataBlob) = getContentAndExternalData(actualMessageContent, recipients)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -30,7 +30,11 @@ class SendTextMessageUseCase internal constructor(
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
-    suspend operator fun invoke(conversationId: ConversationId, text: String, mentions: List<MessageMention> = listOf()): Either<CoreFailure, Unit> = withContext(dispatchers.io) {
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        text: String,
+        mentions: List<MessageMention> = listOf()
+    ): Either<CoreFailure, Unit> = withContext(dispatchers.io) {
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.message.mention.MessageMention
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
@@ -29,7 +30,7 @@ class SendTextMessageUseCase internal constructor(
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
-    suspend operator fun invoke(conversationId: ConversationId, text: String): Either<CoreFailure, Unit> = withContext(dispatchers.io) {
+    suspend operator fun invoke(conversationId: ConversationId, text: String, mentions: List<MessageMention> = listOf()): Either<CoreFailure, Unit> = withContext(dispatchers.io) {
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }
@@ -38,7 +39,7 @@ class SendTextMessageUseCase internal constructor(
         provideClientId().flatMap { clientId ->
             val message = Message.Regular(
                 id = generatedMessageUuid,
-                content = MessageContent.Text(text),
+                content = MessageContent.Text(text, mentions),
                 conversationId = conversationId,
                 date = Clock.System.now().toString(),
                 senderUserId = selfUserId,


### PR DESCRIPTION
# What's new in this PR?

### Issues

sending mentions was not possible

### Causes (Optional)

- `SendTextMessageUseCase` was not accepting Mentions as a parameter 
- `ProtoContentMapper` was not mapping mentions correctly for sending messages

### Solutions

- add mentions as a parameter into `SendTextMessageUseCase`
- fix mapping in `ProtoContentMapper`

