### PR TITLE
chore: improve logging by serializing to impromtu json

### DIFF
--- a/logger/src/commonMain/kotlin/com/wire/kalium/logger/Extensions.kt
+++ b/logger/src/commonMain/kotlin/com/wire/kalium/logger/Extensions.kt
@@ -2,12 +2,12 @@ package com.wire.kalium.logger
 
 private const val START_INDEX = 0
 private const val END_INDEX_ID = 7
-private const val END_INDEX_DOMAIN = 2
+private const val END_INDEX_DOMAIN = 3
 private const val END_INDEX_URL_PATH = 3
 
 fun String.obfuscateId(): String {
     return if (this.length >= END_INDEX_ID) {
-        this.substring(START_INDEX, END_INDEX_ID)
+        this.substring(START_INDEX, END_INDEX_ID) + "***"
     } else {
         this
     }
@@ -15,7 +15,7 @@ fun String.obfuscateId(): String {
 
 fun String.obfuscateDomain(): String {
     return if (this.length >= END_INDEX_DOMAIN) {
-        this.substring(START_INDEX, END_INDEX_DOMAIN)
+        this.substring(START_INDEX, END_INDEX_DOMAIN) + "***"
     } else {
         this
     }
@@ -23,7 +23,7 @@ fun String.obfuscateDomain(): String {
 
 fun String.obfuscateUrlPath(): String {
     return if (this.length >= END_INDEX_URL_PATH) {
-        "${this.substring(START_INDEX, END_INDEX_URL_PATH)}****"
+        this.substring(START_INDEX, END_INDEX_URL_PATH) + "***"
     } else {
         this
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -112,20 +112,19 @@ data class Conversation(
             object Admin : Role()
             data class Unknown(val name: String) : Role()
 
-            override fun toString(): String {
-                return when(this) {
+            override fun toString(): String =
+                when (this) {
                     is Member -> "member"
                     is Admin -> "admin"
                     is Unknown -> this.name
                 }
-            }
         }
 
         override fun toString(): String {
             return "${this.toMap().toJsonElement()}"
         }
 
-        fun toMap(): Map<String, String> =  mapOf(
+        fun toMap(): Map<String, String> = mapOf(
             "id" to "${id.value.obfuscateId()}@${id.domain.obfuscateDomain()}",
             "role" to "$role"
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -12,6 +12,7 @@ import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.util.EPOCH_FIRST_DAY
+import com.wire.kalium.network.utils.toJsonElement
 import kotlinx.datetime.Instant
 
 data class Conversation(
@@ -110,11 +111,24 @@ data class Conversation(
             object Member : Role()
             object Admin : Role()
             data class Unknown(val name: String) : Role()
+
+            override fun toString(): String {
+                return when(this) {
+                    is Member -> "member"
+                    is Admin -> "admin"
+                    is Unknown -> this.name
+                }
+            }
         }
 
         override fun toString(): String {
-            return "id: ${id.value.obfuscateId()}@${id.domain.obfuscateDomain()} role: $role"
+            return "${this.toMap().toJsonElement()}"
         }
+
+        fun toMap(): Map<String, String> =  mapOf(
+            "id" to "${id.value.obfuscateId()}@${id.domain.obfuscateDomain()}",
+            "role" to "$role"
+        )
     }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -14,7 +14,9 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
+import com.wire.kalium.network.utils.toJsonElement
 import kotlinx.datetime.Clock
+import kotlinx.serialization.json.JsonNull
 
 sealed class Event(open val id: String) {
 
@@ -29,9 +31,12 @@ sealed class Event(open val id: String) {
             val qualifiedFrom: UserId,
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "qualifiedFrom: ${qualifiedFrom.value.obfuscateId()}@${qualifiedFrom.domain.obfuscateDomain()} "
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "qualifiedFrom" to "${qualifiedFrom.value.obfuscateId()}@${qualifiedFrom.domain.obfuscateDomain()}"
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -45,11 +50,14 @@ sealed class Event(open val id: String) {
             val encryptedExternalContent: EncryptedData?
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "senderUserId: ${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()} " +
-                        "senderClientId:${senderClientId.value.obfuscateId()} " +
-                        "timestampIso: $timestampIso"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}",
+                    "senderClientId" to senderClientId.value.obfuscateId(),
+                    "timestampIso" to timestampIso
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -61,10 +69,13 @@ sealed class Event(open val id: String) {
             val content: String
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "senderUserId: ${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()} " +
-                        "timestampIso: $timestampIso"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}",
+                    "timestampIso" to timestampIso
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -75,9 +86,12 @@ sealed class Event(open val id: String) {
             val conversation: ConversationResponse
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "timestampIso: $timestampIso"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "timestampIso" to timestampIso
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -89,10 +103,14 @@ sealed class Event(open val id: String) {
             val timestampIso: String
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "addedBy: ${addedBy.value.obfuscateId()}@${addedBy.domain.obfuscateDomain()} members:$members " +
-                        "timestampIso: $timestampIso"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "addedBy" to "${addedBy.value.obfuscateId()}@${addedBy.domain.obfuscateDomain()}",
+                    "members" to members.map { it.toMap() },
+                    "timestampIso" to timestampIso
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -104,10 +122,13 @@ sealed class Event(open val id: String) {
             val timestampIso: String
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "removedBy: ${removedBy.value.obfuscateId()}@${removedBy.domain.obfuscateDomain()}" +
-                        "timestampIso: $timestampIso"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "removedBy" to "${removedBy.value.obfuscateId()}@${removedBy.domain.obfuscateDomain()}",
+                    "timestampIso" to timestampIso
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -123,9 +144,13 @@ sealed class Event(open val id: String) {
                 val member: Member?,
             ) : MemberChanged(id, conversationId, timestampIso) {
                 override fun toString(): String {
-                    return "id: ${id.obfuscateId()} " +
-                            "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                            "member: $member timestampIso: $timestampIso"
+                    val properties = mapOf(
+                        "id" to id.obfuscateId(),
+                        "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                        "member" to (member?.toMap() ?: JsonNull),
+                        "timestampIso" to timestampIso
+                    )
+                    return "${properties.toJsonElement()}"
                 }
             }
 
@@ -135,12 +160,31 @@ sealed class Event(open val id: String) {
                 override val timestampIso: String,
                 val mutedConversationStatus: MutedConversationStatus,
                 val mutedConversationChangedTime: String
-            ) : MemberChanged(id, conversationId, timestampIso)
+            ) : MemberChanged(id, conversationId, timestampIso) {
+                override fun toString(): String {
+                    val properties = mapOf(
+                        "id" to id.obfuscateId(),
+                        "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                        "timestampIso" to timestampIso,
+                        "mutedConversationStatus" to mutedConversationStatus.status,
+                        "mutedConversationChangedTime" to mutedConversationChangedTime
+                    )
+                    return "${properties.toJsonElement()}"
+                }
+            }
 
             data class IgnoredMemberChanged(
                 override val id: String,
                 override val conversationId: ConversationId
-            ) : MemberChanged(id, conversationId, "")
+            ) : MemberChanged(id, conversationId, "") {
+                override fun toString(): String {
+                    val properties = mapOf(
+                        "id" to id.obfuscateId(),
+                        "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    )
+                    return "${properties.toJsonElement()}"
+                }
+            }
         }
 
         data class MLSWelcome(
@@ -151,10 +195,13 @@ sealed class Event(open val id: String) {
             val timestampIso: String = Clock.System.now().toString()
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "timestampIso: $timestampIso " +
-                        "senderUserId:${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "timestampIso" to timestampIso,
+                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}"
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -165,10 +212,13 @@ sealed class Event(open val id: String) {
             val timestampIso: String,
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "timestampIso: $timestampIso " +
-                        "senderUserId:${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "timestampIso" to timestampIso,
+                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}"
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -180,11 +230,14 @@ sealed class Event(open val id: String) {
             val timestampIso: String,
         ) : Conversation(id, conversationId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "conversationId: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()} " +
-                        "senderUserId: ${senderUserId.toString().obfuscateId()} " +
-                        "timestampIso: $timestampIso " +
-                        "conversationName: $conversationName}"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}",
+                    "conversationName" to conversationName,
+                    "timestampIso" to timestampIso,
+                    )
+                return "${properties.toJsonElement()}"
             }
         }
     }
@@ -200,10 +253,13 @@ sealed class Event(open val id: String) {
             val name: String,
         ) : Team(id, teamId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "teamId: $teamId " +
-                        "icon: $icon " +
-                        "name: $name"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "teamId" to teamId,
+                    "icon" to icon,
+                    "name" to name,
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -213,9 +269,12 @@ sealed class Event(open val id: String) {
             val memberId: String,
         ) : Team(id, teamId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "teamId: $teamId " +
-                        "memberId: $memberId"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "teamId" to teamId.obfuscateId(),
+                    "memberId" to memberId.obfuscateId(),
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -226,10 +285,13 @@ sealed class Event(open val id: String) {
             val timestampIso: String,
         ) : Team(id, teamId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "teamId: $teamId " +
-                        "timestampIso: $timestampIso " +
-                        "memberId: $memberId"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "teamId" to teamId.obfuscateId(),
+                    "timestampIso" to timestampIso,
+                    "memberId" to memberId.obfuscateId(),
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -240,10 +302,13 @@ sealed class Event(open val id: String) {
             val permissionCode: Int?,
         ) : Team(id, teamId) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} " +
-                        "teamId: $teamId " +
-                        "permissionCode: $permissionCode " +
-                        "memberId: $memberId"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "teamId" to teamId.obfuscateId(),
+                    "permissionCode" to "$permissionCode",
+                    "memberId" to memberId.obfuscateId(),
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -255,26 +320,67 @@ sealed class Event(open val id: String) {
         data class FileSharingUpdated(
             override val id: String,
             val model: ConfigsStatusModel
-        ) : FeatureConfig(id)
+        ) : FeatureConfig(id) {
+            override fun toString(): String {
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "status" to model.status.name,
+                )
+                return "${properties.toJsonElement()}"
+            }
+        }
 
         data class MLSUpdated(
             override val id: String,
             val model: MLSModel
-        ) : FeatureConfig(id)
+        ) : FeatureConfig(id) {
+            override fun toString(): String {
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "status" to model.status.name,
+                    "allowedUsers" to model.allowedUsers.map { it.value.obfuscateId() }
+                )
+                return "${properties.toJsonElement()}"
+            }
+        }
 
         data class ClassifiedDomainsUpdated(
             override val id: String,
             val model: ClassifiedDomainsModel,
-        ) : FeatureConfig(id)
+        ) : FeatureConfig(id) {
+            override fun toString(): String {
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "status" to model.status.name,
+                    "domains" to model.config.domains.map { it.obfuscateDomain() }
+                )
+                return "${properties.toJsonElement()}"
+            }
+        }
 
         data class ConferenceCallingUpdated(
             override val id: String,
             val model: ConferenceCallingModel
-        ) : FeatureConfig(id)
+        ) : FeatureConfig(id) {
+            override fun toString(): String {
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "status" to model.status.name,
+                )
+                return "${properties.toJsonElement()}"
+            }
+        }
 
         data class UnknownFeatureUpdated(
             override val id: String
-        ) : FeatureConfig(id)
+        ) : FeatureConfig(id) {
+            override fun toString(): String {
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                )
+                return "${properties.toJsonElement()}"
+            }
+        }
     }
 
     sealed class User(
@@ -293,7 +399,11 @@ sealed class Event(open val id: String) {
             val completeAssetId: String?,
         ) : User(id) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} userId: ${userId.obfuscateId()}"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "userId" to userId.obfuscateId()
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
@@ -302,22 +412,41 @@ sealed class Event(open val id: String) {
             val connection: Connection
         ) : User(id) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()}"
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "connection" to connection.toMap()
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
         data class ClientRemove(override val id: String, val clientId: ClientId) : User(id) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} clientId: ${clientId.value.obfuscateId()} "
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "clientId" to clientId.value.obfuscateId()
+                )
+                return "${properties.toJsonElement()}"
             }
         }
 
         data class UserDelete(override val id: String, val userId: UserId) : User(id) {
             override fun toString(): String {
-                return "id: ${id.obfuscateId()} userId: ${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()} "
+                val properties = mapOf(
+                    "id" to id.obfuscateId(),
+                    "userId" to "${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()}"
+                )
+                return "${properties.toJsonElement()}"
             }
         }
     }
 
-    data class Unknown(override val id: String) : Event(id)
+    data class Unknown(override val id: String) : Event(id) {
+        override fun toString(): String {
+            val properties = mapOf(
+                "id" to id.obfuscateId(),
+            )
+            return "${properties.toJsonElement()}"
+        }
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -31,25 +31,26 @@ sealed class Message(
         val editStatus: EditStatus,
         val reactions: Reactions = Reactions.EMPTY
     ) : Message(id, content, conversationId, date, senderUserId, status, visibility) {
+        @Suppress("LongMethod")
         override fun toString(): String {
-            var properties: MutableMap<String, String>
+            val properties: MutableMap<String, String>
             val typeKey = "type"
             when (content) {
                 is MessageContent.Text -> {
                     properties = mutableMapOf(
-                        typeKey  to "text"
+                        typeKey to "text"
                     )
                 }
 
                 is MessageContent.TextEdited -> {
                     properties = mutableMapOf(
-                        typeKey  to "textEdit"
+                        typeKey to "textEdit"
                     )
                 }
 
                 is MessageContent.Calling -> {
                     properties = mutableMapOf(
-                        typeKey  to "calling"
+                        typeKey to "calling"
                     )
                 }
 
@@ -63,7 +64,7 @@ sealed class Message(
                     properties = mutableMapOf(
                         typeKey to "asset",
                         "sizeInBytes" to "${content.value.sizeInBytes}",
-                        "mimeType" to "${content.value.mimeType}",
+                        "mimeType" to content.value.mimeType,
                         "metaData" to "${content.value.metadata}",
                         "downloadStatus" to "${content.value.downloadStatus}",
                         "uploadStatus" to "${content.value.uploadStatus}",
@@ -75,14 +76,14 @@ sealed class Message(
                      properties = mutableMapOf(
                          typeKey to "restrictedAsset",
                         "sizeInBytes" to "${content.sizeInBytes}",
-                        "mimeType" to "${content.mimeType}",
+                        "mimeType" to content.mimeType,
                     )
                 }
 
                 is MessageContent.DeleteForMe -> {
                     properties = mutableMapOf(
                         typeKey to "deleteForMe",
-                        "messageId" to "${content.messageId.obfuscateId()}",
+                        "messageId" to content.messageId.obfuscateId(),
                     )
                 }
 
@@ -121,7 +122,7 @@ sealed class Message(
                 }
             }
 
-            val standardProperties = mapOf<String, String>(
+            val standardProperties = mapOf(
                 "id" to id.obfuscateId(),
                 "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
                 "date" to date,
@@ -169,7 +170,7 @@ sealed class Message(
                 }
             }
 
-            val standardProperties = mapOf<String, String>(
+            val standardProperties = mapOf(
                 "id" to id.obfuscateId(),
                 "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
                 "date" to date,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.network.utils.toJsonElement
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -36,13 +37,21 @@ data class Connection(
     val fromUser: OtherUser? = null
 ) {
     override fun toString(): String {
-        return "Connection( conversationId: ${conversationId.obfuscateId()}, from:${from.obfuscateId()}," +
-                " lastUpdate:$lastUpdate," +
-                " qualifiedConversationId:${qualifiedConversationId.value.obfuscateId()}" +
-                "@${qualifiedConversationId.domain.obfuscateDomain()}, " +
-                "qualifiedToId:${qualifiedToId.value.obfuscateId()}@${qualifiedToId.domain.obfuscateDomain()}, " +
-                "status:$status, toId:${toId.obfuscateId()} " +
-                "fromUser:${fromUser?.id?.value?.obfuscateId()}@ ${fromUser?.id?.domain?.obfuscateDomain()} "
+        return "${this.toMap().toJsonElement()}"
+    }
+
+    fun toMap(): Map<String, String> {
+        val qId = qualifiedConversationId
+        return mapOf(
+            "conversationId" to conversationId.obfuscateId(),
+            "from" to from.obfuscateId(),
+            "lastUpdate" to lastUpdate,
+            "qualifiedConversationId" to "${qId.value.obfuscateId()}@${qId.domain.obfuscateDomain()}",
+            "qualifiedToId" to "${qualifiedToId.value.obfuscateId()}@${qualifiedToId.domain.obfuscateDomain()}",
+            "status" to status.name,
+            "toId" to toId.obfuscateId(),
+            "fromUser" to "${fromUser?.id?.value?.obfuscateId() ?: "null"}@${fromUser?.id?.domain?.obfuscateDomain() ?: "null"}"
+        )
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -153,7 +153,7 @@ internal class ApplicationMessageHandlerImpl(
     // TODO(qol): split this function so it's easier to maintain
     @Suppress("ComplexMethod", "LongMethod")
     private suspend fun processMessage(message: Message) {
-        logger.i(message = "Message received: $message")
+        logger.i(message = "Message received: { \"message\" : $message }")
 
         when (message) {
             is Message.Regular -> when (val content = message.content) {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumKtorCustomLogging.kt
@@ -21,6 +21,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.HttpResponsePipeline
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.charset
 import io.ktor.http.content.OutgoingContent
@@ -141,13 +142,11 @@ public class KaliumKtorCustomLogging private constructor(
         val jsonElement = properties.toJsonElement()
         val logString = "RESPONSE: $jsonElement"
 
-        if (response.status.value < 400) {
+        if (response.status.value < HttpStatusCode.BadRequest.value) {
             kaliumLogger.v(logString)
-        }
-        else if (response.status.value < 500) {
+        } else if (response.status.value < HttpStatusCode.InternalServerError.value) {
             kaliumLogger.w(logString)
-        }
-        else {
+        } else {
             kaliumLogger.e(logString)
         }
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
@@ -28,7 +28,7 @@ fun obfuscatedJsonMessage(text: String): String {
 }
 
 fun obfuscatedJsonElement(element: JsonElement): JsonElement =
-    when(element) {
+    when (element) {
         is JsonPrimitive, JsonNull -> element
         is JsonArray -> {
             if (element.jsonArray.size > 0) {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/SerializationUtils.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/SerializationUtils.kt
@@ -1,0 +1,45 @@
+package com.wire.kalium.network.utils
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+
+// See: https://github.com/Kotlin/kotlinx.serialization/issues/746#issuecomment-737000705
+
+fun Any?.toJsonElement(): JsonElement {
+    return when (this) {
+        is Number -> JsonPrimitive(this)
+        is Boolean -> JsonPrimitive(this)
+        is String -> JsonPrimitive(this)
+        is Array<*> -> this.toJsonArray()
+        is List<*> -> this.toJsonArray()
+        is Map<*, *> -> this.toJsonObject()
+        is JsonElement -> this
+        else -> JsonNull
+    }
+}
+
+fun Array<*>.toJsonArray(): JsonArray {
+    val array = mutableListOf<JsonElement>()
+    this.forEach { array.add(it.toJsonElement()) }
+    return JsonArray(array)
+}
+
+fun List<*>.toJsonArray(): JsonArray {
+    val array = mutableListOf<JsonElement>()
+    this.forEach { array.add(it.toJsonElement()) }
+    return JsonArray(array)
+}
+
+fun Map<*, *>.toJsonObject(): JsonObject {
+    val map = mutableMapOf<String, JsonElement>()
+    this.forEach {
+        if (it.key is String) {
+            map[it.key as String] = it.value.toJsonElement()
+        }
+    }
+    return JsonObject(map)
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/SerializationUtils.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/SerializationUtils.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
-
 // See: https://github.com/Kotlin/kotlinx.serialization/issues/746#issuecomment-737000705
 
 fun Any?.toJsonElement(): JsonElement {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -46,6 +46,13 @@ sealed class MessageEntity(
     sealed class EditStatus {
         object NotEdited : EditStatus()
         data class Edited(val lastTimeStamp: String) : EditStatus()
+
+        override fun toString(): String {
+            return when (this){
+                is NotEdited -> "NOT_EDITED"
+                is Edited -> "EDITED_AT: ${this.lastTimeStamp}"
+            }
+        }
     }
 
     enum class UploadStatus {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -48,7 +48,7 @@ sealed class MessageEntity(
         data class Edited(val lastTimeStamp: String) : EditStatus()
 
         override fun toString(): String {
-            return when (this){
+            return when (this) {
                 is NotEdited -> "NOT_EDITED"
                 is Edited -> "EDITED_AT: ${this.lastTimeStamp}"
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logging is a bit all over the place. This is an attempt to try and standardise a few representations. When fed to the appropriate tools, not only the logs are searchable but the log lines containing json can be used to perform more complex queries.


### Solutions

Change the `toString()` representation of some objects to actually be JSON, without the object itself declaring it can be serialised to JSON

1. have a way to create `JsonElement` from any `Map<String, Any>`
2. for every object create a `Map<String, Any>`
3. produce string `"${map.toJsonElement()}"`
4. ...
5. Profit


### Attachments (Optional)

```
2022-11-04 12:16:07.914 7133-12629/com.wire.android.dev.debug V/DataDogLogger: Message received: { "message" : {"type":"calling","id":"90d6673***","conversationId":"870d00d***@wir***","date":"2022-11-04T11:16:04.635Z","senderUserId":"fc69492***","status":"SENT","visibility":"VISIBLE","senderClientId":"3f3d0b1***","editStatus":"com.wire.kalium.logic.data.message.Message$EditStatus$NotEdited@cc77dfc"} }	| at .log(DataDogLogger.kt:18)

2022-11-04 12:32:42.149 7133-16434/com.wire.android.dev.debug V/featureId:event_receiver: RESPONSE: {"method":"GET","endpoint":"prod-nginz-https.wire.com/v3/not***?size=100***&client=e6d***&since=154***","status":200}

2022-11-04 12:33:14.622 7133-16074/com.wire.android.dev.debug V/featureId:event_receiver: REQUEST: {"method":"GET","endpoint":"prod-nginz-https.wire.com/v3/not***?size=100***&client=f6d***&since=631***"}

2022-11-04 12:32:42.154 7133-7812/com.wire.android.dev.debug V/featureId:event_receiver: RESPONSE BODY: {"Content-Type":"application/json", "Content":"response body omitted"}


```
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
