### PR TITLE
feat: rename group conversations flow (AR-1112)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Clock
 
 interface ConversationRepository {
     @DelicateKaliumApi("this function does not get values from cache")
@@ -146,7 +147,7 @@ interface ConversationRepository {
 
     suspend fun getConversationIdsByUserId(userId: UserId): Either<CoreFailure, List<ConversationId>>
     suspend fun insertConversations(conversations: List<Conversation>): Either<CoreFailure, Unit>
-
+    suspend fun changeConversationName(conversationId: ConversationId, conversationName: String): Either<CoreFailure, Unit>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -565,6 +566,14 @@ internal class ConversationDataSource internal constructor(
                 conversationMapper.toDaoModel(conversation)
             }
             conversationDAO.insertConversations(conversationEntities)
+        }
+    }
+
+    override suspend fun changeConversationName(conversationId: ConversationId, conversationName: String): Either<CoreFailure, Unit> {
+        return wrapApiRequest {
+            conversationApi.updateConversationName(idMapper.toApiModel(conversationId), conversationName)
+        }.flatMap {
+            updateConversationName(conversationId, conversationName, Clock.System.now().toString())
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -123,6 +123,9 @@ class ConversationScope internal constructor(
     val leaveConversation: LeaveConversationUseCase
         get() = LeaveConversationUseCaseImpl(conversationGroupRepository, selfUserId)
 
+    val renameConversation: RenameConversationUseCase
+        get() = RenameConversationUseCaseImpl(conversationRepository, persistMessage, selfUserId)
+
     val updateMLSGroupsKeyingMaterials: UpdateKeyingMaterialsUseCase
         get() = UpdateKeyingMaterialsUseCaseImpl(mlsConversationRepository, updateKeyingMaterialThresholdProvider)
 
@@ -134,5 +137,4 @@ class ConversationScope internal constructor(
             selfUserId,
             selfConversationIdProvider
         )
-
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCase.kt
@@ -1,19 +1,14 @@
 package com.wire.kalium.logic.feature.conversation
 
-import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
-import kotlinx.datetime.Clock
 
 /**
- * Renames a conversation by it's ID.
+ * Renames a conversation by its ID.
  */
 interface RenameConversationUseCase {
     /**
@@ -33,22 +28,8 @@ internal class RenameConversationUseCaseImpl(
             .fold({
                 RenamingResult.Failure(it)
             }, {
-                generateSystemMessage(conversationId, conversationName)
                 RenamingResult.Success
             })
-    }
-
-    private suspend fun generateSystemMessage(conversationId: ConversationId, conversationName: String): Either<CoreFailure, Unit> {
-        val message = Message.System(
-            id = uuid4().toString(),
-            conversationId = conversationId,
-            content = MessageContent.ConversationRenamed(conversationName),
-            date = Clock.System.now().toString(),
-            senderUserId = selfUserId,
-            status = Message.Status.SENT,
-            visibility = Message.Visibility.VISIBLE
-        )
-        return persistMessage(message)
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCase.kt
@@ -1,0 +1,58 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.fold
+import kotlinx.datetime.Clock
+
+/**
+ * Renames a conversation by it's ID.
+ */
+interface RenameConversationUseCase {
+    /**
+     * @param conversationId the conversation id to rename
+     * @param conversationName the new conversation name
+     */
+    suspend operator fun invoke(conversationId: ConversationId, conversationName: String): RenamingResult
+}
+
+internal class RenameConversationUseCaseImpl(
+    val conversationRepository: ConversationRepository,
+    val persistMessage: PersistMessageUseCase,
+    val selfUserId: UserId
+) : RenameConversationUseCase {
+    override suspend fun invoke(conversationId: ConversationId, conversationName: String): RenamingResult {
+        return conversationRepository.changeConversationName(conversationId, conversationName)
+            .fold({
+                RenamingResult.Failure(it)
+            }, {
+                generateSystemMessage(conversationId, conversationName)
+                RenamingResult.Success
+            })
+    }
+
+    private suspend fun generateSystemMessage(conversationId: ConversationId, conversationName: String): Either<CoreFailure, Unit> {
+        val message = Message.System(
+            id = uuid4().toString(),
+            conversationId = conversationId,
+            content = MessageContent.ConversationRenamed(conversationName),
+            date = Clock.System.now().toString(),
+            senderUserId = selfUserId,
+            status = Message.Status.SENT,
+            visibility = Message.Visibility.VISIBLE
+        )
+        return persistMessage(message)
+    }
+}
+
+sealed class RenamingResult {
+    object Success : RenamingResult()
+    data class Failure(val coreFailure: CoreFailure) : RenamingResult()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -708,6 +708,24 @@ class ConversationRepositoryTest {
         }
     }
 
+    @Test
+    fun givenAConversation_WhenChangingNameConversation_ShouldReturnSuccess() = runTest {
+        val newConversationName = "new_name"
+        val (arrange, conversationRepository) = Arrangement()
+            .withConversationRenameApiCall(newConversationName)
+            .withConversationRenameCall(newConversationName)
+            .arrange()
+
+        val result = conversationRepository.changeConversationName(CONVERSATION_ID, newConversationName)
+        with(result) {
+            shouldSucceed()
+            verify(arrange.conversationDAO)
+                .suspendFunction(arrange.conversationDAO::updateConversationName)
+                .with(any(), eq(newConversationName), any())
+                .wasInvoked(exactly = once)
+        }
+    }
+
     private class Arrangement {
         @Mock
         val userRepository: UserRepository = mock(UserRepository::class)
@@ -769,10 +787,10 @@ class ConversationRepositoryTest {
                 .whenInvokedWith(anything())
                 .thenReturn(Either.Right(mlsClient))
 
-                given(selfTeamIdProvider)
-                    .suspendFunction(selfTeamIdProvider::invoke)
-                    .whenInvoked()
-                    .then { Either.Right(TestTeam.TEAM_ID) }
+            given(selfTeamIdProvider)
+                .suspendFunction(selfTeamIdProvider::invoke)
+                .whenInvoked()
+                .then { Either.Right(TestTeam.TEAM_ID) }
         }
 
         fun withHasEstablishedMLSGroup(isClient: Boolean) = apply {
@@ -943,6 +961,20 @@ class ConversationRepositoryTest {
                 .suspendFunction(conversationDAO::getConversationIdsByUserId)
                 .whenInvokedWith(any())
                 .thenReturn(conversationIdEntities)
+        }
+
+        fun withConversationRenameCall(newName: String = "newName") = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::updateConversationName)
+                .whenInvokedWith(any(), eq(newName), any())
+                .thenReturn(Unit)
+        }
+
+        fun withConversationRenameApiCall(newName: String = "newName") = apply {
+            given(conversationApi)
+                .suspendFunction(conversationApi::updateConversationName)
+                .whenInvokedWith(any(), eq(newName))
+                .thenReturn(NetworkResponse.Success(Unit, emptyMap(), HttpStatusCode.OK.value))
         }
 
         fun arrange() = this to conversationRepository

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCaseTest.kt
@@ -1,0 +1,77 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser.USER_ID
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RenameConversationUseCaseTest {
+
+    @Test
+    fun givenAConversation_WhenChangingNameIsSuccessful_ThenReturnSuccess() = runTest {
+        val (arrangement, renameConversation) = Arrangement()
+            .withRenameConversationIs(Either.Right(Unit))
+            .arrange()
+
+        val result = renameConversation(TestConversation.ID, "new_name")
+
+        assertIs<RenamingResult.Success>(result)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::changeConversationName)
+            .with(eq(TestConversation.ID), eq("new_name"))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAConversation_WhenChangingNameFails_ThenReturnFailure() = runTest {
+        val (arrangement, renameConversation) = Arrangement()
+            .withRenameConversationIs(Either.Left(CoreFailure.Unknown(RuntimeException("Error!"))))
+            .arrange()
+
+        val result = renameConversation(TestConversation.ID, "new_name")
+
+        assertIs<RenamingResult.Failure>(result)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::changeConversationName)
+            .with(eq(TestConversation.ID), eq("new_name"))
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement {
+        @Mock
+        val conversationRepository = mock(classOf<ConversationRepository>())
+
+        @Mock
+        val persistMessage = mock(classOf<PersistMessageUseCase>())
+
+        val selfUserId = USER_ID
+
+        private val renameConversation = RenameConversationUseCaseImpl(conversationRepository, persistMessage, selfUserId)
+
+        fun withRenameConversationIs(either: Either<CoreFailure, Unit>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::changeConversationName)
+                .whenInvokedWith(any(), any())
+                .thenReturn(either)
+        }
+
+        fun arrange() = this to renameConversation
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
@@ -1,10 +1,11 @@
 package com.wire.kalium.network.api.base.authenticated.conversation
 
-import com.wire.kalium.network.api.base.model.ConversationId
-import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationAccessInfoDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationMemberRoleDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.UpdateConversationAccessResponse
+import com.wire.kalium.network.api.base.model.ConversationId
+import com.wire.kalium.network.api.base.model.QualifiedID
+import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface ConversationApi {
@@ -50,4 +51,6 @@ interface ConversationApi {
         userId: UserId,
         conversationMemberRoleDTO: ConversationMemberRoleDTO
     ): NetworkResponse<Unit>
+
+    suspend fun updateConversationName(conversationId: QualifiedID, conversationName: String): NetworkResponse<Unit>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationRenameRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationRenameRequest.kt
@@ -1,0 +1,7 @@
+package com.wire.kalium.network.api.base.authenticated.conversation
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConversationRenameRequest(@SerialName("name") val name: String)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ConversationA
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberAddedResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberRemovedResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationPagingResponse
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationRenameRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponseDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationsDetailsRequest
@@ -17,6 +18,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.model.UpdateC
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.PaginationRequest
+import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
@@ -166,6 +168,15 @@ internal open class ConversationApiV0 internal constructor(
         }
     }
 
+    override suspend fun updateConversationName(conversationId: QualifiedID, conversationName: String): NetworkResponse<Unit> =
+        wrapKaliumResponse {
+            httpClient.put(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_NAME"
+            ) {
+                setBody(ConversationRenameRequest(conversationName))
+            }
+        }
+
     protected companion object {
         const val PATH_CONVERSATIONS = "conversations"
         const val PATH_SELF = "self"
@@ -175,6 +186,7 @@ internal open class ConversationApiV0 internal constructor(
         const val PATH_CONVERSATIONS_LIST = "list"
         const val PATH_LIST_IDS = "list-ids"
         const val PATH_ACCESS = "access"
+        const val PATH_NAME = "name"
 
         const val QUERY_KEY_START = "start"
         const val QUERY_KEY_SIZE = "size"

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
@@ -228,6 +228,23 @@ class ConversationApiV0Test : ApiTest {
         assertTrue(response.isSuccessful())
     }
 
+    @Test
+    fun whenUpdatingConversationName_thenTheRequestShouldBeConfiguredCorrectly() = runTest {
+        val conversationId = ConversationId("conversationId", "conversationDomain")
+        val networkClient = mockAuthenticatedNetworkClient(
+            "", statusCode = HttpStatusCode.NoContent,
+            assertion = {
+                assertPut()
+                assertPathEqual("/conversations/conversationDomain/conversationId/name")
+            }
+        )
+
+        val conversationApi = ConversationApiV0(networkClient)
+        val response = conversationApi.updateConversationName(conversationId, "new_name")
+
+        assertTrue(response.isSuccessful())
+    }
+
     private companion object {
         const val PATH_CONVERSATIONS = "/conversations"
         const val PATH_CONVERSATIONS_LIST_V2 = "/conversations/list/v2"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Kalium side logic, to update/rename a conversation, this includes:
- Usecase to operate
- Creation of system message triggered by action
- API calls to update endpoint

### Causes (Optional)

Enables renaming usecase for usage of reloaded app flow.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
