### PR TITLE
chore: fetch core-crypto from Github Packages

### DIFF
--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -54,12 +54,18 @@ jobs:
 
       - name: Android Unit Test
         run: ./gradlew testDebugUnitTest
+        env:
+            GITHUB_USER: ${{ github.actor }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Android Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedAndroidOnlyAffectedTest
+        env:
+            GITHUB_USER: ${{ github.actor }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive Test Reports
         if: always()

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: iOS Tests
         run: ./gradlew iOSOnlyAffectedTest
+        env:
+            GITHUB_USER: ${{ github.actor }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive Test Reports
         if: always()

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -22,6 +22,9 @@ jobs:
           fetch-depth: 0
 
       - name: Build the CLI App
+        env:
+            GITHUB_USER: ${{ github.actor }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./gradlew :cli:build -Djava.library.path=$LD_LIBRARY_PATH
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@
 
 ## How to build
 
+### GitHub Packages authentication
+
+In `local.properties` add:
+```
+github.package_registry.user=<github_username>
+github.package_registry.token=<github_token>
+```
+The github token need include the `packages:read` scope. See [GitHub packages docs](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages) for more details and [Creating a personal access token ](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+
+alternatively the credentials are also read from your environment if `GITHUB_USER` and `GITHUB_TOKEN` exists.
+
 ### Dependencies
 
 - JDK 11 (ex: openjdk-11-jdk on Ubuntu)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,13 @@ allprojects {
         google()
         mavenCentral()
         mavenLocal()
-        maven(url = "https://raw.githubusercontent.com/wireapp/wire-maven/main/releases")
+        maven {
+            url = uri("https://maven.pkg.github.com/wireapp/core-crypto")
+            credentials {
+                username = getLocalProperty("github.package_registry.user", System.getenv("GITHUB_USER"))
+                password = getLocalProperty("github.package_registry.token", System.getenv("GITHUB_TOKEN"))
+            }
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -34,7 +34,7 @@ object Versions {
     const val turbine = "0.7.0"
     const val avs = "8.2.16"
     const val jna = "5.6.0"
-    const val coreCrypto = "0.6.0-pre1"
+    const val coreCrypto = "0.6.0-pre.2"
     const val desugarJdk = "1.1.5"
     const val kermit = "1.0.0"
     const val detekt = "1.19.0"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fetch core-crypto from Github Packages by replacing the `wire-maven` repository.

❗ GitHub Packages currently requires authentication so I added a new section to the  README on how configure Github Packages credentials. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
