### PR TITLE
fix: access API was hardcoded to v0 when refreshing access token

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.network
 
+import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.serialization.mls
 import com.wire.kalium.network.serialization.xprotobuf
 import com.wire.kalium.network.session.SessionManager
@@ -27,11 +28,12 @@ import io.ktor.serialization.kotlinx.json.json
 internal class AuthenticatedNetworkClient(
     engine: HttpClientEngine,
     sessionManager: SessionManager,
+    accessTokenApi: (httpClient: HttpClient) -> AccessTokenApi,
     installCompression: Boolean = true
 ) {
     val httpClient: HttpClient = provideBaseHttpClient(engine, installCompression) {
         installWireDefaultRequest(sessionManager.session().second)
-        installAuth(sessionManager)
+        installAuth(sessionManager, accessTokenApi)
         install(ContentNegotiation) {
             mls()
             xprotobuf()
@@ -70,7 +72,8 @@ internal class UnboundNetworkClient(engine: HttpClientEngine) {
  */
 internal class AuthenticatedWebSocketClient(
     private val engine: HttpClientEngine,
-    private val sessionManager: SessionManager
+    private val sessionManager: SessionManager,
+    private val accessTokenApi: (httpClient: HttpClient) -> AccessTokenApi
 ) {
     /**
      * Creates a disposable [HttpClient] for a single use.
@@ -81,7 +84,7 @@ internal class AuthenticatedWebSocketClient(
     fun createDisposableHttpClient(): HttpClient =
         provideBaseHttpClient(engine) {
             installWireDefaultRequest(sessionManager.session().second)
-            installAuth(sessionManager)
+            installAuth(sessionManager, accessTokenApi)
             install(ContentNegotiation) {
                 mls()
                 xprotobuf()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
@@ -18,6 +18,7 @@ import com.wire.kalium.network.api.base.authenticated.search.UserSearchApi
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
 import com.wire.kalium.network.api.base.authenticated.serverpublickey.MLSPublicKeyApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
+import com.wire.kalium.network.api.v0.authenticated.AccessTokenApiV0
 import com.wire.kalium.network.api.v0.authenticated.AssetApiV0
 import com.wire.kalium.network.api.v0.authenticated.CallApiV0
 import com.wire.kalium.network.api.v0.authenticated.ClientApiV0
@@ -48,6 +49,7 @@ internal class AuthenticatedNetworkContainerV0 internal constructor(
 ) : AuthenticatedNetworkContainer,
     AuthenticatedHttpClientProvider by AuthenticatedHttpClientProviderImpl(
         sessionManager,
+        { httpClient -> AccessTokenApiV0(httpClient) },
         engine
     ) {
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
@@ -18,6 +18,7 @@ import com.wire.kalium.network.api.base.authenticated.search.UserSearchApi
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
 import com.wire.kalium.network.api.base.authenticated.serverpublickey.MLSPublicKeyApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
+import com.wire.kalium.network.api.v2.authenticated.AccessTokenApiV2
 import com.wire.kalium.network.api.v2.authenticated.AssetApiV2
 import com.wire.kalium.network.api.v2.authenticated.CallApiV2
 import com.wire.kalium.network.api.v2.authenticated.ClientApiV2
@@ -48,6 +49,7 @@ internal class AuthenticatedNetworkContainerV2 internal constructor(
 ) : AuthenticatedNetworkContainer,
     AuthenticatedHttpClientProvider by AuthenticatedHttpClientProviderImpl(
         sessionManager,
+        { httpClient -> AccessTokenApiV2(httpClient) },
         engine
     ) {
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
@@ -18,6 +18,7 @@ import com.wire.kalium.network.api.base.authenticated.search.UserSearchApi
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
 import com.wire.kalium.network.api.base.authenticated.serverpublickey.MLSPublicKeyApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
+import com.wire.kalium.network.api.v3.authenticated.AccessTokenApiV3
 import com.wire.kalium.network.api.v3.authenticated.AssetApiV3
 import com.wire.kalium.network.api.v3.authenticated.CallApiV3
 import com.wire.kalium.network.api.v3.authenticated.ClientApiV3
@@ -48,6 +49,7 @@ internal class AuthenticatedNetworkContainerV3 internal constructor(
 ) : AuthenticatedNetworkContainer,
     AuthenticatedHttpClientProvider by AuthenticatedHttpClientProviderImpl(
         sessionManager,
+        { httpClient -> AccessTokenApiV3(httpClient) },
         engine
     ) {
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
 import com.wire.kalium.network.api.base.model.RefreshTokenDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
-import com.wire.kalium.network.api.v0.authenticated.AccessTokenApiV0
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isInvalidCredentials
 import com.wire.kalium.network.exceptions.isUnknownClient

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.network.session
 
+import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
 import com.wire.kalium.network.api.base.model.RefreshTokenDTO
@@ -39,7 +40,7 @@ interface SessionManager {
     fun proxyCredentials(): ProxyCredentialsDTO?
 }
 
-fun HttpClientConfig<*>.installAuth(sessionManager: SessionManager) {
+fun HttpClientConfig<*>.installAuth(sessionManager: SessionManager, accessTokenApi: (httpClient: HttpClient) -> AccessTokenApi) {
     install("Add_WWW-Authenticate_Header") {
         addWWWAuthenticateHeaderIfNeeded()
     }
@@ -57,7 +58,7 @@ fun HttpClientConfig<*>.installAuth(sessionManager: SessionManager) {
                 BearerTokens(accessToken = access, refreshToken = refresh)
             }
             refreshTokens {
-                when (val response = AccessTokenApiV0(client).getToken(oldTokens!!.refreshToken)) {
+                when (val response = accessTokenApi(client).getToken(oldTokens!!.refreshToken)) {
                     is NetworkResponse.Success -> {
                         response.value.first.let { newAccessToken -> access = newAccessToken.value }
                         response.value.second?.let { newRefreshToken -> refresh = newRefreshToken.value }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.AuthenticatedWebSocketClient
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.UnboundNetworkClient
+import com.wire.kalium.network.api.v0.authenticated.AccessTokenApiV0
 import com.wire.kalium.network.api.v0.authenticated.networkContainer.AuthenticatedNetworkContainerV0
 import com.wire.kalium.network.api.v0.unauthenticated.networkContainer.UnauthenticatedNetworkContainerV0
 import com.wire.kalium.network.tools.KtxSerializer
@@ -84,7 +85,8 @@ internal interface ApiTest {
         val mockEngine = createMockEngine(responseBody, statusCode, assertion, headers)
         return AuthenticatedNetworkClient(
             engine = mockEngine,
-            sessionManager = TEST_SESSION_NAMAGER
+            sessionManager = TEST_SESSION_NAMAGER,
+            { httpClient -> AccessTokenApiV0(httpClient) }
         )
     }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
 import com.wire.kalium.network.api.base.model.RefreshTokenDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
+import com.wire.kalium.network.api.v0.authenticated.AccessTokenApiV0
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.session.installAuth
 import com.wire.kalium.network.tools.ServerConfigDTO
@@ -40,7 +41,7 @@ class SessionManagerTest {
         }
 
         val client = HttpClient(mockEngine) {
-            installAuth(sessionManager)
+            installAuth(sessionManager) { httpClient -> AccessTokenApiV0(httpClient) }
             expectSuccess = false
         }
 
@@ -58,7 +59,7 @@ class SessionManagerTest {
         }
 
         val client = HttpClient(mockEngine) {
-            installAuth(sessionManager)
+            installAuth(sessionManager) { httpClient -> AccessTokenApiV0(httpClient) }
             expectSuccess = false
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Code path for refreshing access token is hardcoded to use Api V0.

### Solutions

Inject `accessTokenApi` with the negotiate api version.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
