### PR TITLE
fix: update conversation mute status end point is called multiple times in row

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -93,13 +93,6 @@ interface ConversationRepository {
     suspend fun deleteMembersFromEvent(userIDList: List<UserId>, conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun getOneToOneConversationWithOtherUser(otherUserId: UserId): Either<CoreFailure, Conversation>
 
-    @Deprecated("sdsd")
-    suspend fun updateMutedStatus(
-        conversationId: ConversationId,
-        mutedStatus: MutedConversationStatus,
-        mutedStatusTimestamp: Long
-    ): Either<CoreFailure, Unit>
-
     suspend fun updateMutedStatusLocally(
         conversationId: ConversationId,
         mutedStatus: MutedConversationStatus,
@@ -479,28 +472,6 @@ internal class ConversationDataSource internal constructor(
         return wrapStorageRequest {
             val conversationEntity = conversationDAO.getConversationWithOtherUser(idMapper.toDaoModel(otherUserId))
             conversationEntity?.let { conversationMapper.fromDaoModel(it) }
-        }
-    }
-
-    /**
-     * Updates the conversation muting options status and the timestamp of the applied change, both remotely and local
-     */
-    override suspend fun updateMutedStatus(
-        conversationId: ConversationId,
-        mutedStatus: MutedConversationStatus,
-        mutedStatusTimestamp: Long
-    ): Either<CoreFailure, Unit> = wrapApiRequest {
-        conversationApi.updateConversationMemberState(
-            memberUpdateRequest = conversationStatusMapper.toMutedStatusApiModel(mutedStatus, mutedStatusTimestamp),
-            conversationId = idMapper.toApiModel(conversationId)
-        )
-    }.flatMap {
-        wrapStorageRequest {
-            conversationDAO.updateConversationMutedStatus(
-                conversationId = idMapper.toDaoModel(conversationId),
-                mutedStatus = conversationStatusMapper.toMutedStatusDaoModel(mutedStatus),
-                mutedStatusTimestamp = mutedStatusTimestamp
-            )
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
@@ -33,8 +33,6 @@ internal class UpdateConversationMutedStatusUseCaseImpl(
         mutedConversationStatus: MutedConversationStatus,
         mutedStatusTimestamp: Long
     ): ConversationUpdateStatusResult =
-
-        //conversationRepository.updateMutedStatus(conversationId, mutedConversationStatus, mutedStatusTimestamp)
         conversationRepository.updateMutedStatusRemotely(conversationId, mutedConversationStatus, mutedStatusTimestamp)
             .flatMap {
                 conversationRepository.updateMutedStatusLocally(conversationId, mutedConversationStatus, mutedStatusTimestamp)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger
 import kotlinx.datetime.Clock
@@ -32,8 +33,12 @@ internal class UpdateConversationMutedStatusUseCaseImpl(
         mutedConversationStatus: MutedConversationStatus,
         mutedStatusTimestamp: Long
     ): ConversationUpdateStatusResult =
-        conversationRepository.updateMutedStatus(conversationId, mutedConversationStatus, mutedStatusTimestamp)
-            .fold({
+
+        //conversationRepository.updateMutedStatus(conversationId, mutedConversationStatus, mutedStatusTimestamp)
+        conversationRepository.updateMutedStatusRemotely(conversationId, mutedConversationStatus, mutedStatusTimestamp)
+            .flatMap {
+                conversationRepository.updateMutedStatusLocally(conversationId, mutedConversationStatus, mutedStatusTimestamp)
+            }.fold({
                 kaliumLogger.e("Something went wrong when updating the convId ($conversationId) to (${mutedConversationStatus.status}")
                 ConversationUpdateStatusResult.Failure
             }, {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
@@ -20,7 +20,7 @@ internal class MemberChangeEventHandlerImpl(
     override suspend fun handle(event: Event.Conversation.MemberChanged) {
         when (event) {
             is Event.Conversation.MemberChanged.MemberMutedStatusChanged -> {
-                conversationRepository.updateMutedStatus(
+                conversationRepository.updateMutedStatusLocally(
                     event.conversationId,
                     event.mutedConversationStatus,
                     Clock.System.now().toEpochMilliseconds()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCaseTest.kt
@@ -45,7 +45,6 @@ class UpdateConversationMutedStatusUseCaseTest {
         val result = updateConversationMutedStatus(conversationId, MutedConversationStatus.AllMuted)
         assertEquals(ConversationUpdateStatusResult.Success::class, result::class)
 
-
         verify(conversationRepository)
             .suspendFunction(conversationRepository::updateMutedStatusRemotely)
             .with(any(), eq(MutedConversationStatus.AllMuted), any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.wire.kalium.logic.feature.conversation
 
-import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.framework.TestConversation
@@ -33,35 +33,51 @@ class UpdateConversationMutedStatusUseCaseTest {
     fun givenAConversationId_whenInvokingAMutedStatusChange_thenShouldDelegateTheCallAndReturnASuccessResult() = runTest {
         val conversationId = TestConversation.ID
         given(conversationRepository)
-            .suspendFunction(conversationRepository::updateMutedStatus)
+            .suspendFunction(conversationRepository::updateMutedStatusRemotely)
+            .whenInvokedWith(any(), eq(MutedConversationStatus.AllMuted), any())
+            .thenReturn(Either.Right(Unit))
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::updateMutedStatusLocally)
             .whenInvokedWith(any(), eq(MutedConversationStatus.AllMuted), any())
             .thenReturn(Either.Right(Unit))
 
         val result = updateConversationMutedStatus(conversationId, MutedConversationStatus.AllMuted)
         assertEquals(ConversationUpdateStatusResult.Success::class, result::class)
 
+
         verify(conversationRepository)
-            .suspendFunction(conversationRepository::updateMutedStatus)
+            .suspendFunction(conversationRepository::updateMutedStatusRemotely)
             .with(any(), eq(MutedConversationStatus.AllMuted), any())
             .wasInvoked(exactly = once)
 
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::updateMutedStatusLocally)
+            .with(any(), eq(MutedConversationStatus.AllMuted), any())
+            .wasInvoked(exactly = once)
     }
 
     @Test
     fun givenAConversationId_whenInvokingAMutedStatusChangeAndFails_thenShouldDelegateTheCallAndReturnAFailureResult() = runTest {
         val conversationId = TestConversation.ID
+
         given(conversationRepository)
-            .suspendFunction(conversationRepository::updateMutedStatus)
+            .suspendFunction(conversationRepository::updateMutedStatusRemotely)
             .whenInvokedWith(any(), eq(MutedConversationStatus.AllMuted), any())
-            .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
+            .thenReturn(Either.Left(NetworkFailure.ServerMiscommunication(RuntimeException("some error"))))
 
         val result = updateConversationMutedStatus(conversationId, MutedConversationStatus.AllMuted)
         assertEquals(ConversationUpdateStatusResult.Failure::class, result::class)
 
         verify(conversationRepository)
-            .suspendFunction(conversationRepository::updateMutedStatus)
+            .suspendFunction(conversationRepository::updateMutedStatusRemotely)
             .with(any(), eq(MutedConversationStatus.AllMuted), any())
             .wasInvoked(exactly = once)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::updateMutedStatusLocally)
+            .with(any(), eq(MutedConversationStatus.AllMuted), any())
+            .wasNotInvoked()
 
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
@@ -49,14 +49,14 @@ class MemberChangeEventHandlerTest {
 
         val (arrangement, eventHandler) = Arrangement()
             .withFetchConversationIfUnknownSucceeding()
-            .withUpdateMutedStatusSucceeding()
+            .withUpdateMutedStatusLocally(Either.Right(Unit))
             .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
             .arrange()
 
         eventHandler.handle(event)
 
         verify(arrangement.conversationRepository)
-            .suspendFunction(arrangement.conversationRepository::updateMutedStatus)
+            .suspendFunction(arrangement.conversationRepository::updateMutedStatusLocally)
             .with(eq(event.conversationId), any(), any())
             .wasInvoked(exactly = once)
     }
@@ -156,6 +156,13 @@ class MemberChangeEventHandlerTest {
                 .suspendFunction(conversationRepository::updateMutedStatus)
                 .whenInvokedWith(any(), any(), any())
                 .thenReturn(Either.Right(Unit))
+        }
+
+        fun withUpdateMutedStatusLocally(result: Either<StorageFailure, Unit>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::updateMutedStatusLocally)
+                .whenInvokedWith(any(), any(), any())
+                .thenReturn(result)
         }
 
         fun withFetchUsersIfUnknownByIdsReturning(result: Either<StorageFailure, Unit>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
@@ -151,13 +151,6 @@ class MemberChangeEventHandlerTest {
                 .thenReturn(Either.Right(Unit))
         }
 
-        fun withUpdateMutedStatusSucceeding() = apply {
-            given(conversationRepository)
-                .suspendFunction(conversationRepository::updateMutedStatus)
-                .whenInvokedWith(any(), any(), any())
-                .thenReturn(Either.Right(Unit))
-        }
-
         fun withUpdateMutedStatusLocally(result: Either<StorageFailure, Unit>) = apply {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::updateMutedStatusLocally)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. after conversation delete endpoint is called, the app is calling updates mute status as well.
2. update conversation mute status end point is called multiple times in row.

### Solutions

1. is out of the scope of this PR
2. when receiving an update mute status event from BE the app is updating the mute status remotely and locally which trigger another conversation mute status update event. 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
