### PR TITLE
fix: Use personal github token to be able to download core-crypto

### DIFF
--- a/testservice/Jenkinsfile
+++ b/testservice/Jenkinsfile
@@ -26,7 +26,9 @@ pipeline {
         stage('Build') {
             steps {
                 withMaven(jdk: 'AdoptiumJDK11', maven: 'M3', mavenLocalRepo: '.repository') {
-                    sh './gradlew :testservice:jar'
+                    withCredentials([usernamePassword(credentialsId: 'READ_PACKAGES_GITHUB_TOKEN', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+                        sh './gradlew :testservice:jar'
+                    }
                 }
             }
         }

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -97,7 +97,8 @@ class InstanceService(val metricRegistry: MetricRegistry) : Managed {
                 blackList = ServerConfig.STAGING.blackList,
                 teams = ServerConfig.STAGING.teams,
                 website = ServerConfig.STAGING.website,
-                isOnPremises = true
+                isOnPremises = true,
+                proxy = null
             )
         } else {
             if (instanceRequest.backend == "staging") {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fix to be able to get latest core-crypto library from restricted maven repository which was introduced with https://github.com/wireapp/kalium/commit/ab723db942d4c899c3d52378841aa3347b6d2888

Additional adjustment to an API change in the ServerConfig object (proxy variable without default value)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
