### PR TITLE
fix: app refreshing auth tokens more that it needs to

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -40,7 +40,7 @@ internal actual class UserSessionScopeProviderImpl(
             globalPreferences.proxyCredentialsStorage
         )
         val networkContainer: AuthenticatedNetworkContainer = AuthenticatedNetworkContainer.create(sessionManager)
-        val featureSupport = FeatureSupportImpl(kaliumConfigs, sessionManager.session().second.metaData.commonApiVersion.version)
+        val featureSupport = FeatureSupportImpl(kaliumConfigs, sessionManager.serverConfig().metaData.commonApiVersion.version)
         val proteusClientProvider = ProteusClientProviderImpl(rootProteusPath, userId, globalPreferences.passphraseStorage, kaliumConfigs)
 
         val userSessionWorkScheduler = UserSessionWorkSchedulerImpl(appContext, userId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -60,10 +60,14 @@ class SessionManagerImpl internal constructor(
                 tokenType = newAccessTokeDTO.tokenType,
                 refreshToken = newRefreshTokenDTO?.value
             )
+        }.map {
+            sessionMapper.fromEntityToSessionDTO(it)
+        }.onSuccess {
+            session.set(it)
         }.fold({
             TODO("IMPORTANT! Not yet implemented")
         }, {
-            sessionMapper.fromEntityToSessionDTO(it)
+            it
         })
 
     override suspend fun onSessionExpired() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -47,7 +47,7 @@ class SessionManagerImpl internal constructor(
     override fun serverConfig(): ServerConfigDTO = serverConfig.get() ?: run {
         serverConfig.set(sessionRepository.fullAccountInfo(userId)
             .map { serverConfigMapper.toDTO(it.serverConfig) }
-            .fold({ TODO() }, { it })
+            .fold({ throw error("use serverConfig is missing or an error while reading local storage") }, { it })
         )
         serverConfig.get()!!
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.network
 
+import app.cash.sqldelight.internal.Atomic
 import com.wire.kalium.logic.configuration.server.ServerConfigMapper
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -10,6 +11,7 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.nullableFold
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.wrapStorageNullableRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.model.AccessTokenDTO
@@ -22,7 +24,7 @@ import com.wire.kalium.persistence.client.AuthTokenStorage
 import com.wire.kalium.persistence.client.ProxyCredentialsStorage
 
 @Suppress("LongParameterList")
-class SessionManagerImpl(
+class SessionManagerImpl internal constructor(
     private val sessionRepository: SessionRepository,
     private val userId: QualifiedID,
     private val tokenStorage: AuthTokenStorage,
@@ -31,19 +33,24 @@ class SessionManagerImpl(
     private val serverConfigMapper: ServerConfigMapper = MapperProvider.serverConfigMapper(),
     private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : SessionManager {
-    override fun session(): Pair<SessionDTO, ServerConfigDTO> = sessionRepository.fullAccountInfo(userId).fold({
-        TODO("IMPORTANT! Not yet implemented")
-    }, { account ->
-        val session: SessionDTO = wrapStorageRequest { tokenStorage.getToken(idMapper.toDaoModel(account.info.userId)) }
+
+    private val session: Atomic<SessionDTO?> = Atomic(null)
+    private var serverConfig: Atomic<ServerConfigDTO?> = Atomic(null)
+
+    override fun session(): SessionDTO = session.get() ?: run {
+        wrapStorageRequest { tokenStorage.getToken(idMapper.toDaoModel(userId)) }
             .map { sessionMapper.fromEntityToSessionDTO(it) }
-            .fold({
-                throw IllegalStateException("No token found for user")
-            }, {
-                it
-            })
-        val serverConfig = serverConfigMapper.toDTO(account.serverConfig)
-        session to serverConfig
-    })
+            .onSuccess { session.set(it) }
+        session.get()!!
+    }
+
+    override fun serverConfig(): ServerConfigDTO = serverConfig.get() ?: run {
+        serverConfig.set(sessionRepository.fullAccountInfo(userId)
+            .map { serverConfigMapper.toDTO(it.serverConfig) }
+            .fold({ TODO() }, { it })
+        )
+        serverConfig.get()!!
+    }
 
     override fun updateLoginSession(newAccessTokeDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO =
         wrapStorageRequest {

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -39,7 +39,7 @@ internal actual class UserSessionScopeProviderImpl(
             proxyCredentialsStorage = globalPreferences.proxyCredentialsStorage
         )
         val networkContainer: AuthenticatedNetworkContainer = AuthenticatedNetworkContainer.create(sessionManager)
-        val featureSupport = FeatureSupportImpl(kaliumConfigs, sessionManager.session().second.metaData.commonApiVersion.version)
+        val featureSupport = FeatureSupportImpl(kaliumConfigs, sessionManager.serverConfig().metaData.commonApiVersion.version)
         val proteusClientProvider = ProteusClientProviderImpl(rootProteusPath, userId, globalPreferences.passphraseStorage, kaliumConfigs)
 
         val userSessionWorkScheduler = UserSessionWorkSchedulerImpl(userId)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
@@ -30,7 +30,7 @@ internal class AuthenticatedNetworkClient(
     installCompression: Boolean = true
 ) {
     val httpClient: HttpClient = provideBaseHttpClient(engine, installCompression) {
-        installWireDefaultRequest(sessionManager.session().second)
+        installWireDefaultRequest(sessionManager.serverConfig())
         installAuth(sessionManager)
         install(ContentNegotiation) {
             mls()
@@ -80,7 +80,7 @@ internal class AuthenticatedWebSocketClient(
      */
     fun createDisposableHttpClient(): HttpClient =
         provideBaseHttpClient(engine) {
-            installWireDefaultRequest(sessionManager.session().second)
+            installWireDefaultRequest(sessionManager.serverConfig())
             installAuth(sessionManager)
             install(ContentNegotiation) {
                 mls()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/LogoutApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/LogoutApiV0.kt
@@ -22,7 +22,7 @@ internal open class LogoutApiV0 internal constructor(
 
     override suspend fun logout(): NetworkResponse<Unit> = wrapKaliumResponse {
         httpClient.post("$PATH_ACCESS/$PATH_LOGOUT") {
-            header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=${sessionManager.session().first.refreshToken}")
+            header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=${sessionManager.session().refreshToken}")
         }
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
@@ -44,7 +44,7 @@ import io.ktor.client.engine.HttpClientEngine
 
 internal class AuthenticatedNetworkContainerV0 internal constructor(
     private val sessionManager: SessionManager,
-    engine: HttpClientEngine = defaultHttpEngine(sessionManager.session().second.links.proxy, sessionManager.proxyCredentials())
+    engine: HttpClientEngine = defaultHttpEngine(sessionManager.serverConfig().links.proxy, sessionManager.proxyCredentials())
 ) : AuthenticatedNetworkContainer,
     AuthenticatedHttpClientProvider by AuthenticatedHttpClientProviderImpl(
         sessionManager,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
@@ -44,7 +44,7 @@ import io.ktor.client.engine.HttpClientEngine
 
 internal class AuthenticatedNetworkContainerV2 internal constructor(
     private val sessionManager: SessionManager,
-    engine: HttpClientEngine = defaultHttpEngine(sessionManager.session().second.links.proxy, sessionManager.proxyCredentials())
+    engine: HttpClientEngine = defaultHttpEngine(sessionManager.serverConfig().links.proxy, sessionManager.proxyCredentials())
 ) : AuthenticatedNetworkContainer,
     AuthenticatedHttpClientProvider by AuthenticatedHttpClientProviderImpl(
         sessionManager,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
@@ -44,7 +44,7 @@ import io.ktor.client.engine.HttpClientEngine
 
 internal class AuthenticatedNetworkContainerV3 internal constructor(
     private val sessionManager: SessionManager,
-    engine: HttpClientEngine = defaultHttpEngine(sessionManager.session().second.links.proxy, sessionManager.proxyCredentials())
+    engine: HttpClientEngine = defaultHttpEngine(sessionManager.serverConfig().links.proxy, sessionManager.proxyCredentials())
 ) : AuthenticatedNetworkContainer,
     AuthenticatedHttpClientProvider by AuthenticatedHttpClientProviderImpl(
         sessionManager,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -68,8 +68,7 @@ interface AuthenticatedNetworkContainer {
         fun create(
             sessionManager: SessionManager
         ): AuthenticatedNetworkContainer {
-            val version = sessionManager.session().second.metaData.commonApiVersion.version
-            return when (version) {
+            return when (val version = sessionManager.serverConfig().metaData.commonApiVersion.version) {
                 0 -> AuthenticatedNetworkContainerV0(
                     sessionManager
                 )
@@ -101,9 +100,9 @@ internal interface AuthenticatedHttpClientProvider {
 
 internal class AuthenticatedHttpClientProviderImpl(
     private val sessionManager: SessionManager,
-    private val engine: HttpClientEngine = defaultHttpEngine(sessionManager.session().second.links.proxy),
+    private val engine: HttpClientEngine = defaultHttpEngine(sessionManager.serverConfig().links.proxy),
 ) : AuthenticatedHttpClientProvider {
-    override val backendConfig = sessionManager.session().second.links
+    override val backendConfig = sessionManager.serverConfig().links
 
     override val networkClient by lazy {
         AuthenticatedNetworkClient(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -49,7 +49,7 @@ fun HttpClientConfig<*>.installAuth(sessionManager: SessionManager, accessTokenA
         bearer {
 
             loadTokens {
-                val session  = sessionManager.session()
+                val session = sessionManager.session()
                 BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
             }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -28,7 +28,9 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlin.coroutines.CoroutineContext
 
 interface SessionManager {
-    fun session(): Pair<SessionDTO, ServerConfigDTO>
+    fun session(): SessionDTO
+
+    fun serverConfig(): ServerConfigDTO
     fun updateLoginSession(
         newAccessTokenDTO: AccessTokenDTO,
         newRefreshTokenDTO: RefreshTokenDTO?
@@ -45,24 +47,17 @@ fun HttpClientConfig<*>.installAuth(sessionManager: SessionManager) {
     }
     install(Auth) {
         bearer {
-            // memory cache the tokens
-            var access: String
-            var refresh: String
-            sessionManager.session().first.also { storedSession ->
-                access = storedSession.accessToken
-                refresh = storedSession.refreshToken
-            }
 
             loadTokens {
-                BearerTokens(accessToken = access, refreshToken = refresh)
+                val session  = sessionManager.session()
+                BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
             }
+
             refreshTokens {
                 when (val response = AccessTokenApiV0(client).getToken(oldTokens!!.refreshToken)) {
                     is NetworkResponse.Success -> {
-                        response.value.first.let { newAccessToken -> access = newAccessToken.value }
-                        response.value.second?.let { newRefreshToken -> refresh = newRefreshToken.value }
-                        sessionManager.updateLoginSession(response.value.first, response.value.second)
-                        BearerTokens(access, refresh)
+                        val newSession = sessionManager.updateLoginSession(response.value.first, response.value.second)
+                        BearerTokens(newSession.accessToken, newSession.refreshToken)
                     }
 
                     is NetworkResponse.Error -> {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/TestSessionManagerV0.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/TestSessionManagerV0.kt
@@ -12,7 +12,8 @@ class TestSessionManagerV0 : SessionManager {
     private val serverConfig = TEST_BACKEND_CONFIG
     private var session = testCredentials
 
-    override fun session(): Pair<SessionDTO, ServerConfigDTO> = Pair(session, serverConfig)
+    override fun session(): SessionDTO = session
+    override fun serverConfig(): ServerConfigDTO = serverConfig
     override fun updateLoginSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?) =
         SessionDTO(
             session.userId,

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerTest.kt
@@ -68,7 +68,8 @@ class SessionManagerTest {
     }
 
     private fun createFakeSessionManager() = object : SessionManager {
-        override fun session(): Pair<SessionDTO, ServerConfigDTO> = testCredentials to TEST_BACKEND_CONFIG
+        override fun session(): SessionDTO = testCredentials
+        override fun serverConfig(): ServerConfigDTO = TEST_BACKEND_CONFIG
 
         override fun updateLoginSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO =
             testCredentials

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/logout/LogoutApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/logout/LogoutApiV0Test.kt
@@ -28,7 +28,7 @@ class LogoutApiV0Test : ApiTest {
                     assertPost()
                     assertNoQueryParams()
                     assertPathEqual(PATH_LOGOUT)
-                    assertHeaderEqual(HttpHeaders.Cookie, "zuid=${sessionManager.session().first.refreshToken}")
+                    assertHeaderEqual(HttpHeaders.Cookie, "zuid=${sessionManager.session().refreshToken}")
                 }
             )
             val logout: LogoutApi = LogoutApiV0(networkClient, sessionManager)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the access token has a lifetime of 15 min but it was noticed that in some cases the refresh is executed more often that it need to.

### Causes (Optional)

each user has 2 HTTP clients at a time and each have its own AuthTokens cache. 
when one of the HTTP clients update the token, the second one is still had the old token cached, which lead to the token being updated twice in a row,

### Solutions

move the caching of tokens to the `SessionManager`

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
