### PR TITLE
feat: migration of messages (AR-2626)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MigratedMessage.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MigratedMessage.kt
@@ -1,0 +1,4 @@
+package com.wire.kalium.logic.data.message
+
+class MigratedMessage {
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MigratedMessage.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MigratedMessage.kt
@@ -1,4 +1,43 @@
 package com.wire.kalium.logic.data.message
 
-class MigratedMessage {
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+
+data class MigratedMessage(
+    val conversationId: ConversationId,
+    val senderUserId: UserId,
+    val senderClientId: ClientId,
+    val timestampIso: String,
+    val content: String,
+    val encryptedProto: ByteArray?
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MigratedMessage
+
+        if (conversationId != other.conversationId) return false
+        if (senderUserId != other.senderUserId) return false
+        if (senderClientId != other.senderClientId) return false
+        if (timestampIso != other.timestampIso) return false
+        if (content != other.content) return false
+        if (encryptedProto != null) {
+            if (other.encryptedProto == null) return false
+            if (!encryptedProto.contentEquals(other.encryptedProto)) return false
+        } else if (other.encryptedProto != null) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = conversationId.hashCode()
+        result = 31 * result + senderUserId.hashCode()
+        result = 31 * result + senderClientId.hashCode()
+        result = 31 * result + timestampIso.hashCode()
+        result = 31 * result + content.hashCode()
+        result = 31 * result + (encryptedProto?.contentHashCode() ?: 0)
+        return result
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -766,7 +766,6 @@ class UserSessionScope internal constructor(
             slowSyncRepository,
             messageSendingScheduler,
             timeParser,
-            proteusUnpacker,
             applicationMessageHandler,
             this
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -166,13 +166,13 @@ import com.wire.kalium.logic.sync.receiver.conversation.MemberLeaveEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MemberLeaveEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.NewConversationEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.NewConversationEventHandlerImpl
-import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.RenamedConversationEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.RenamedConversationEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpackerImpl
+import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpacker
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpackerImpl
 import com.wire.kalium.logic.sync.receiver.message.ClearConversationContentHandler
@@ -766,6 +766,8 @@ class UserSessionScope internal constructor(
             slowSyncRepository,
             messageSendingScheduler,
             timeParser,
+            proteusUnpacker,
+            applicationMessageHandler,
             this
         )
     val users: UserScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageUploadStatusUseCase
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageUploadStatusUseCaseImpl
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandler
-import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpacker
 import com.wire.kalium.logic.util.TimeParser
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
@@ -55,7 +54,6 @@ class MessageScope internal constructor(
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
     private val timeParser: TimeParser,
-    private val proteusMessageUnpacker: ProteusMessageUnpacker,
     private val applicationMessageHandler: ApplicationMessageHandler,
     private val scope: CoroutineScope,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
@@ -188,6 +186,6 @@ class MessageScope internal constructor(
         )
 
     val persistMigratedMessage: PersistMigratedMessagesUseCase
-        get() = PersistMigratedMessagesUseCaseImpl(applicationMessageHandler, proteusMessageUnpacker, protoContentMapper)
+        get() = PersistMigratedMessagesUseCaseImpl(applicationMessageHandler, protoContentMapper)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -188,6 +188,6 @@ class MessageScope internal constructor(
         )
 
     val persistMigratedMessage: PersistMigratedMessagesUseCase
-        get() = PersistMigratedMessagesUseCaseImpl(applicationMessageHandler, proteusMessageUnpacker)
+        get() = PersistMigratedMessagesUseCaseImpl(applicationMessageHandler, proteusMessageUnpacker, protoContentMapper)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -29,6 +29,8 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCa
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageUploadStatusUseCase
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageUploadStatusUseCaseImpl
 import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandler
+import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpacker
 import com.wire.kalium.logic.util.TimeParser
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
@@ -53,6 +55,8 @@ class MessageScope internal constructor(
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
     private val timeParser: TimeParser,
+    private val proteusMessageUnpacker: ProteusMessageUnpacker,
+    private val applicationMessageHandler: ApplicationMessageHandler,
     private val scope: CoroutineScope,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
@@ -184,6 +188,6 @@ class MessageScope internal constructor(
         )
 
     val persistMigratedMessage: PersistMigratedMessagesUseCase
-        get() = PersistMigratedMessagesUseCaseImpl(persistMessage)
+        get() = PersistMigratedMessagesUseCaseImpl(applicationMessageHandler, proteusMessageUnpacker)
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -182,4 +182,8 @@ class MessageScope internal constructor(
             timeParser,
             EphemeralNotificationsManager
         )
+
+    val persistMigratedMessage: PersistMigratedMessagesUseCase
+        get() = PersistMigratedMessagesUseCaseImpl(persistMessage)
+
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
@@ -19,7 +19,6 @@ fun interface PersistMigratedMessagesUseCase {
 
 internal class PersistMigratedMessagesUseCaseImpl(
     private val applicationMessageHandler: ApplicationMessageHandler,
-    private val proteusMessageUnpacker: ProteusMessageUnpacker,
     private val protoContentMapper: ProtoContentMapper,
 ) : PersistMigratedMessagesUseCase {
     override suspend fun invoke(messages: List<MigratedMessage>): Either<CoreFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
@@ -1,0 +1,20 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.message.MigratedMessage
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.functional.Either
+
+/**
+ * Persist migrated messages from old datasource
+ */
+fun interface PersistMigratedMessagesUseCase {
+    suspend operator fun invoke(messages: List<MigratedMessage>): Either<CoreFailure, Unit>
+}
+
+internal class PersistMigratedMessagesUseCaseImpl(val persistMessage: PersistMessageUseCase) : PersistMigratedMessagesUseCase {
+    override suspend fun invoke(messages: List<MigratedMessage>): Either<CoreFailure, Unit> {
+       // todo: map to message class and let the current usecase do the work
+        return Either.Right(Unit)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
@@ -8,7 +8,6 @@ import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandler
-import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpacker
 
 /**
  * Persist migrated messages from old datasource

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
@@ -2,11 +2,12 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.message.MigratedMessage
+import com.wire.kalium.logic.data.message.PlainMessageBlob
+import com.wire.kalium.logic.data.message.ProtoContent
+import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandler
-import com.wire.kalium.logic.sync.receiver.conversation.message.MessageUnpackResult
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpacker
 
 /**
@@ -19,26 +20,26 @@ fun interface PersistMigratedMessagesUseCase {
 internal class PersistMigratedMessagesUseCaseImpl(
     private val applicationMessageHandler: ApplicationMessageHandler,
     private val proteusMessageUnpacker: ProteusMessageUnpacker,
+    private val protoContentMapper: ProtoContentMapper,
 ) : PersistMigratedMessagesUseCase {
     override suspend fun invoke(messages: List<MigratedMessage>): Either<CoreFailure, Unit> {
-        messages.map { migratedMessage ->
-            proteusMessageUnpacker.unpackMigratedProteusMessage(migratedMessage)
-                .fold({
-                    kaliumLogger.d("Ignoring signal message")
-                }, { unpackResult ->
-                    when (unpackResult) {
-                        is MessageUnpackResult.ApplicationMessage -> applicationMessageHandler.handleContent(
-                            migratedMessage.conversationId,
-                            migratedMessage.timestampIso,
-                            migratedMessage.senderUserId,
-                            migratedMessage.senderClientId,
-                            unpackResult.content
+        messages.filter { it.encryptedProto != null }
+            .map { migratedMessage ->
+                migratedMessage to protoContentMapper.decodeFromProtobuf(PlainMessageBlob(migratedMessage.encryptedProto!!))
+            }.forEach { (message, proto) ->
+                when (proto) {
+                    is ProtoContent.ExternalMessageInstructions -> kaliumLogger.w("Ignoring external message")
+                    is ProtoContent.Readable -> {
+                        applicationMessageHandler.handleContent(
+                            message.conversationId,
+                            message.timestampIso,
+                            message.senderUserId,
+                            message.senderClientId,
+                            proto
                         )
-
-                        MessageUnpackResult.HandshakeMessage -> kaliumLogger.d("Ignoring signal message")
                     }
-                })
-        }
+                }
+            }
         return Either.Right(Unit)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
@@ -8,7 +8,9 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandler
-import io.ktor.utils.io.core.toByteArray
+import com.wire.kalium.protobuf.encodeToByteArray
+import com.wire.kalium.protobuf.messages.GenericMessage
+import com.wire.kalium.protobuf.messages.Text
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -23,7 +25,7 @@ import kotlin.test.assertTrue
 class PersistMigratedMessagesUseCaseTest {
 
     @Test
-    fun givenAValidSendKnockRequest_whenSendingKnock_thenShouldReturnASuccessResult() = runTest {
+    fun givenAValidProtoMessage_whenMigratingMessage_thenShouldReturnASuccessResult() = runTest {
         // Given
         val (arrangement, persistMigratedMessages) = Arrangement()
             .withSuccessfulHandling()
@@ -44,6 +46,7 @@ class PersistMigratedMessagesUseCaseTest {
         @Mock
         private val applicationMessageHandler = mock(classOf<ApplicationMessageHandler>())
 
+        val genericMessage = GenericMessage("uuid", GenericMessage.Content.Text(Text("some_text")))
 
         fun fakeMigratedMessage() = MigratedMessage(
             conversationId = TestConversation.ID,
@@ -51,7 +54,7 @@ class PersistMigratedMessagesUseCaseTest {
             senderClientId = TestClient.CLIENT_ID,
             "",
             "some_content",
-            "some_content".toByteArray()
+            genericMessage.encodeToByteArray()
         )
 
         fun withSuccessfulHandling(): Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
@@ -1,0 +1,71 @@
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.data.message.MigratedMessage
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandler
+import io.ktor.utils.io.core.toByteArray
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PersistMigratedMessagesUseCaseTest {
+
+    @Test
+    fun givenAValidSendKnockRequest_whenSendingKnock_thenShouldReturnASuccessResult() = runTest {
+        // Given
+        val (arrangement, persistMigratedMessages) = Arrangement()
+            .withSuccessfulHandling()
+            .arrange()
+
+        // When
+        val result = persistMigratedMessages(listOf(arrangement.fakeMigratedMessage()))
+
+        // Then
+        assertTrue(result is Either.Right)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        private val persistMessage = mock(classOf<PersistMessageUseCase>())
+
+        @Mock
+        private val applicationMessageHandler = mock(classOf<ApplicationMessageHandler>())
+
+
+        fun fakeMigratedMessage() = MigratedMessage(
+            conversationId = TestConversation.ID,
+            senderUserId = TestUser.USER_ID,
+            senderClientId = TestClient.CLIENT_ID,
+            "",
+            "some_content",
+            "some_content".toByteArray()
+        )
+
+        fun withSuccessfulHandling(): Arrangement {
+            given(applicationMessageHandler)
+                .suspendFunction(applicationMessageHandler::handleContent)
+                .whenInvokedWith(any(), any(), any(), any(), any())
+                .thenReturn(Unit)
+            return this
+        }
+
+        fun arrange() = this to PersistMigratedMessagesUseCaseImpl(
+            applicationMessageHandler,
+            MapperProvider.protoContentMapper()
+        )
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Migration of messages logic on Kalium side:

- Creation of UseCase to persist migrated messages
- Reusage of existing `ApplicationMessageHandler` to allow proper parsing and transformation of ProtoMessages

### Causes (Optional)

Enables the migration of messages.

### Testing

* WIP

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
