### PR TITLE
fix: enable development api on testservice and fix fat jar creation [AR-2675]

### DIFF
--- a/testservice/Jenkinsfile
+++ b/testservice/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
             steps {
                 withMaven(jdk: 'AdoptiumJDK11', maven: 'M3', mavenLocalRepo: '.repository') {
                     withCredentials([usernamePassword(credentialsId: 'READ_PACKAGES_GITHUB_TOKEN', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
-                        sh './gradlew :testservice:jar'
+                        sh './gradlew :testservice:shadowJar'
                     }
                 }
             }

--- a/testservice/Jenkinsfile
+++ b/testservice/Jenkinsfile
@@ -49,7 +49,7 @@ LimitCORE=infinity
 TimeoutStartSec=8
 WorkingDirectory=${WORKSPACE}
 Environment="PATH=/usr/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
-ExecStart=java -Djava.library.path=${WORKSPACE}/native/libs/ -jar ${WORKSPACE}/testservice/build/libs/testservice-0.0.1-SNAPSHOT.jar server ${WORKSPACE}/testservice/config.yml
+ExecStart=java -Djava.library.path=${WORKSPACE}/native/libs/ -jar ${WORKSPACE}/testservice/build/libs/testservice-0.0.1-SNAPSHOT-all.jar server ${WORKSPACE}/testservice/config.yml
 Restart=always
 [Install]
 WantedBy=default.target

--- a/testservice/README.md
+++ b/testservice/README.md
@@ -19,7 +19,7 @@ Create fat jar for standalone execution:
 Run fat jar:
 
 ```shell
-java -jar testservice/build/libs/testservice-*.jar server testservice/config.yml
+java -jar testservice/build/libs/testservice-*-all.jar server testservice/config.yml
 ```
 
 ## Installation
@@ -49,7 +49,7 @@ LimitCORE=infinity
 TimeoutStartSec=8
 WorkingDirectory=${WORKSPACE}
 Environment="PATH=/usr/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
-ExecStart=java -Djava.library.path=${WORKSPACE}/native/libs/ -jar ${WORKSPACE}/testservice/build/libs/testservice-0.0.1-SNAPSHOT.jar server ${WORKSPACE}/testservice/config.yml
+ExecStart=java -Djava.library.path=${WORKSPACE}/native/libs/ -jar ${WORKSPACE}/testservice/build/libs/testservice-0.0.1-SNAPSHOT-all.jar server ${WORKSPACE}/testservice/config.yml
 Restart=always
 [Install]
 WantedBy=default.target

--- a/testservice/build.gradle.kts
+++ b/testservice/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm")
     java
     application
+    id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
 group = "com.wire.kalium.testservice"
@@ -26,14 +27,12 @@ tasks.named("run", JavaExec::class) {
     standardOutput = System.out
 }
 
-tasks.jar {
-    manifest.attributes["Main-Class"] = mainFunctionClassName
-    val dependencies = configurations
-        .runtimeClasspath
-        .get()
-        .map(::zipTree)
-    from(dependencies)
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+tasks.shadowJar {
+    archiveBaseName.set("testservice")
+    mergeServiceFiles()
+    manifest {
+        attributes(mapOf("Main-Class" to mainFunctionClassName))
+    }
 }
 
 repositories {

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -85,7 +85,8 @@ class InstanceService(val metricRegistry: MetricRegistry) : Managed {
         val before = System.currentTimeMillis()
         val instancePath = "${System.getProperty("user.home")}/.testservice/$instanceId"
         log.info("Instance $instanceId: Creating $instancePath")
-        val coreLogic = CoreLogic("Kalium Testservice", "$instancePath/accounts", kaliumConfigs = KaliumConfigs())
+        val kaliumConfigs = KaliumConfigs(developmentApiEnabled = true)
+        val coreLogic = CoreLogic("Kalium Testservice", "$instancePath/accounts", kaliumConfigs)
         CoreLogger.setLoggingLevel(KaliumLogLevel.VERBOSE)
 
         val serverConfig = if (instanceRequest.customBackend != null) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. The testservice did not upload prekeys after a certain change [AR-2675](https://wearezeta.atlassian.net/browse/AR-2675)
2. The testservice could not be started up via fat jar anymore

### Solutions

1. flag developmentApiEnabled in kaliumConfig is now set to true
2. Gradle Shadow Plugin is used to create a better fat jar than before

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
