### PR TITLE
fix: multiple /push/tokens requests [AR-2691]

### DIFF
--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.persistence.cache.Cache
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.shareIn
 
@@ -28,6 +29,7 @@ class MetadataDAOImpl internal constructor(
         metadataQueries.selectValueByKey(key)
             .asFlow()
             .mapToOneOrNull()
+            .distinctUntilChanged()
             .shareIn(databaseScope, SharingStarted.Lazily, 1)
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MetadataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MetadataDAOTest.kt
@@ -1,13 +1,17 @@
 package com.wire.kalium.persistence.dao
 
+import app.cash.turbine.test
 import com.wire.kalium.persistence.BaseDatabaseTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MetadataDAOTest : BaseDatabaseTest() {
 
     private val value1 = "value1"
@@ -48,5 +52,29 @@ class MetadataDAOTest : BaseDatabaseTest() {
     fun giveNonExistingKey_thenNullValueWillBeReturned() = runTest(dispatcher) {
         metadataDAO.insertValue(value1, key1)
         assertNull(metadataDAO.valueByKeyFlow(key2).first())
+    }
+
+    @Test
+    fun giveExistingKey_whenValueHasBeenModified_thenEmitNewValue() = runTest(dispatcher) {
+        launch(dispatcher) {
+            metadataDAO.insertValue(value1, key1)
+            metadataDAO.valueByKeyFlow(key1).test {
+                assertEquals(value1, this.awaitItem())
+                metadataDAO.insertValue(value2, key1)
+                assertEquals(value2, this.awaitItem())
+            }
+        }
+    }
+
+    @Test
+    fun giveExistingKey_whenOtherValueHasBeenModified_thenDoNotReEmitTheSameValue() = runTest(dispatcher) {
+        launch(dispatcher) {
+            metadataDAO.insertValue(value1, key1)
+            metadataDAO.valueByKeyFlow(key1).test {
+                assertEquals(value1, this.awaitItem())
+                metadataDAO.insertValue(value2, key2)
+                this.expectNoEvents()
+            }
+        }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We receive multiple 404 responses for the `/push/tokens` requests when we have multiple accounts logged in.

### Causes (Optional)

Because of the way our metadata storage is created - it's a key-value DB and to observe changes, we have `valueByKeyFlow` method which transforms `Query` into a `Flow`. The problem is that every update/insert into this table, makes the `Query` dirty and results in re-emission of the same item even if it's another row that has been changed. I was able to make an infinite loop by just adding a random, not related key-value to metadata table after each `/push/tokens` request to prove it. 

### Solutions

Add `distinctUntilChanged` to `valueByKeyFlow` to prevent emitting the same item if another row has been changed.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have multiple accounts logged in, open the app and see how many `/push/tokens` requests are made.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
