### PR TITLE
feat: migrate other users data [AR-2689]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -36,6 +36,7 @@ interface UserMapper {
 
     fun fromApiSelfModelToDaoModel(userDTO: UserDTO): UserEntity
     fun fromDaoModelToSelfUser(userEntity: UserEntity): SelfUser
+    fun fromSelfUserToDaoModel(selfUser: SelfUser): UserEntity
 
     /**
      * Maps the user data to be updated. if the parameters [newName] [newAccent] [newAssetId] are nulls,
@@ -133,6 +134,25 @@ internal class UserMapperImpl(
             previewAssetId?.let { idMapper.fromDaoModel(it) },
             completeAssetId?.let { idMapper.fromDaoModel(it) },
             availabilityStatusMapper.fromDaoAvailabilityStatusToModel(availabilityStatus)
+        )
+    }
+
+    override fun fromSelfUserToDaoModel(selfUser: SelfUser): UserEntity = with(selfUser) {
+        UserEntity(
+            id = idMapper.toDaoModel(id),
+            name = name,
+            handle = handle,
+            email = email,
+            phone = phone,
+            accentId = accentId,
+            team = teamId?.value,
+            connectionStatus = connectionStateMapper.fromUserConnectionStateToDao(connectionStatus),
+            previewAssetId = previewPicture?.let { idMapper.toDaoModel(it) },
+            completeAssetId = completePicture?.let { idMapper.toDaoModel(it) },
+            availabilityStatus = availabilityStatusMapper.fromModelAvailabilityStatusToDao(availabilityStatus),
+            userType = UserTypeEntity.STANDARD,
+            botService = null,
+            deleted = false
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -66,7 +66,7 @@ internal interface UserRepository {
     suspend fun getUsersFromTeam(teamId: TeamId): Either<StorageFailure, List<OtherUser>>
     suspend fun getTeamRecipients(teamId: TeamId): Either<CoreFailure, List<Recipient>>
     suspend fun updateUserFromEvent(event: Event.User.Update): Either<CoreFailure, Unit>
-    suspend fun removeUser(userId: UserId): Either<CoreFailure, Unit>
+    suspend fun insertUsersIfUnknown(users: List<User>): Either<StorageFailure, Unit>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -312,11 +312,17 @@ internal class UserDataSource internal constructor(
         userDAO.updateUser(userMapper.toUpdateDaoFromEvent(event, user))
     }
 
-    override suspend fun removeUser(userId: UserId): Either<CoreFailure, Unit> {
-        return wrapStorageRequest {
-            userDAO.markUserAsDeleted(idMapper.toDaoModel(userId))
+    override suspend fun insertUsersIfUnknown(users: List<User>): Either<StorageFailure, Unit> =
+        wrapStorageRequest {
+            userDAO.insertOrIgnoreUsers(
+                users.map { user ->
+                    when (user) {
+                        is OtherUser -> publicUserMapper.fromPublicUserToDaoModel(user)
+                        is SelfUser -> userMapper.fromSelfUserToDaoModel(user)
+                    }
+                }
+            )
         }
-    }
 
     companion object {
         const val SELF_USER_ID_KEY = "selfUserID"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -66,6 +66,7 @@ internal interface UserRepository {
     suspend fun getUsersFromTeam(teamId: TeamId): Either<StorageFailure, List<OtherUser>>
     suspend fun getTeamRecipients(teamId: TeamId): Either<CoreFailure, List<Recipient>>
     suspend fun updateUserFromEvent(event: Event.User.Update): Either<CoreFailure, Unit>
+    suspend fun removeUser(userId: UserId): Either<CoreFailure, Unit>
     suspend fun insertUsersIfUnknown(users: List<User>): Either<StorageFailure, Unit>
 }
 
@@ -310,6 +311,12 @@ internal class UserDataSource internal constructor(
         val user =
             userDAO.getUserByQualifiedID(idMapper.toDaoModel(userId)).firstOrNull() ?: return Either.Left(StorageFailure.DataNotFound)
         userDAO.updateUser(userMapper.toUpdateDaoFromEvent(event, user))
+    }
+
+    override suspend fun removeUser(userId: UserId): Either<CoreFailure, Unit> {
+        return wrapStorageRequest {
+            userDAO.markUserAsDeleted(idMapper.toDaoModel(userId))
+        }
     }
 
     override suspend fun insertUsersIfUnknown(users: List<User>): Either<StorageFailure, Unit> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/type/UserTypeMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/type/UserTypeMapper.kt
@@ -23,6 +23,16 @@ class UserEntityTypeMapperImpl : UserEntityTypeMapper {
     override val none: UserTypeEntity
         get() = UserTypeEntity.NONE
 
+    override fun fromUserType(userType: UserType): UserTypeEntity = when(userType) {
+        UserType.INTERNAL -> standard
+        UserType.ADMIN -> admin
+        UserType.OWNER -> owner
+        UserType.EXTERNAL -> external
+        UserType.FEDERATED -> federated
+        UserType.GUEST -> guest
+        UserType.SERVICE -> service
+        UserType.NONE -> none
+    }
 }
 
 class DomainUserTypeMapperImpl : DomainUserTypeMapper {
@@ -60,7 +70,9 @@ class DomainUserTypeMapperImpl : DomainUserTypeMapper {
 
 }
 
-interface UserEntityTypeMapper : UserTypeMapper<UserTypeEntity>
+interface UserEntityTypeMapper : UserTypeMapper<UserTypeEntity> {
+    fun fromUserType(userType: UserType): UserTypeEntity
+}
 
 interface DomainUserTypeMapper : UserTypeMapper<UserType> {
     fun fromUserTypeEntity(userTypeEntity: UserTypeEntity?): UserType

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/PersistMigratedUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/PersistMigratedUsersUseCase.kt
@@ -1,0 +1,21 @@
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.data.user.User
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.functional.isRight
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.kaliumLogger
+
+fun interface PersistMigratedUsersUseCase {
+    suspend operator fun invoke(users: List<User>): Boolean
+}
+
+internal class PersistMigratedUsersUseCaseImpl(
+    private val userRepository: UserRepository
+) : PersistMigratedUsersUseCase {
+
+    override suspend fun invoke(users: List<User>): Boolean =
+        userRepository.insertUsersIfUnknown(users)
+            .onFailure { kaliumLogger.e("Error while persisting migrated users $it") }
+            .isRight()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -75,4 +75,6 @@ class UserScope internal constructor(
     val serverLinks get() = SelfServerConfigUseCase(selfUserId, serverConfigRepository)
 
     val timestampKeyRepository get() = TimestampKeyRepositoryImpl(metadataDAO)
+
+    val persistMigratedUsers: PersistMigratedUsersUseCase get() = PersistMigratedUsersUseCaseImpl(userRepository)
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -46,6 +46,10 @@ user_type = excluded.user_type,
 bot_service = excluded.bot_service,
 deleted = excluded.deleted;
 
+insertOrIgnoreUser:
+INSERT OR IGNORE INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service, deleted)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
 updateUser:
 UPDATE User
 SET name = ?, handle = ?, email = ?, phone = ?, accent_id = ?, team = ?, preview_asset_id = ?, complete_asset_id = ?, user_type = ?, bot_service = ?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -96,6 +96,12 @@ interface UserDAO {
      */
     suspend fun insertUser(user: UserEntity)
 
+
+    /**
+     * Inserts each user into the local storage or ignores if already exists
+     */
+    suspend fun insertOrIgnoreUsers(users: List<UserEntity>)
+
     /**
      * This will update all columns, except [ConnectionEntity.State] or insert a new record with default value
      * [ConnectionEntity.State.NOT_CONNECTED]

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -72,6 +72,28 @@ class UserDAOImpl internal constructor(
         )
     }
 
+    override suspend fun insertOrIgnoreUsers(users: List<UserEntity>) {
+        userQueries.transaction {
+            for (user: UserEntity in users) {
+                userQueries.insertOrIgnoreUser(
+                    user.id,
+                    user.name,
+                    user.handle,
+                    user.email,
+                    user.phone,
+                    user.accentId,
+                    user.team,
+                    user.connectionStatus,
+                    user.previewAssetId,
+                    user.completeAssetId,
+                    user.userType,
+                    user.botService,
+                    user.deleted
+                )
+            }
+        }
+    }
+
     override suspend fun upsertTeamMembers(users: List<UserEntity>) {
         userQueries.transaction {
             for (user: UserEntity in users) {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -575,6 +575,32 @@ class UserDAOTest : BaseDatabaseTest() {
 
     }
 
+    @Test
+    fun givenNonExistingUser_whenInsertingOrIgnoringUsers_thenInsertThisUser() = runTest(dispatcher) {
+        // given
+        val usersToInsert = listOf(user1, user2)
+        val expected = listOf(user1, user2)
+        // when
+        db.userDAO.insertOrIgnoreUsers(usersToInsert)
+        // then
+        val persistedUsers = db.userDAO.getAllUsers().first()
+        assertEquals(expected, persistedUsers)
+    }
+
+    @Test
+    fun givenNonExistingAndExistingUsers_whenInsertingOrIgnoringUsers_thenInsertOnlyNonExistingUsers() = runTest(dispatcher) {
+        // given
+        val existingUser = user1
+        val usersToInsert = listOf(user1.copy(name = "other name to make sure this one wasn't inserted nor edited"), user2)
+        val expected = listOf(user1, user2)
+        db.userDAO.insertUser(existingUser)
+        // when
+        db.userDAO.insertOrIgnoreUsers(usersToInsert)
+        // then
+        val persistedUsers = db.userDAO.getAllUsers().first()
+        assertEquals(expected, persistedUsers)
+    }
+
     private companion object {
         val USER_ENTITY_1 = newUserEntity(QualifiedIDEntity("1", "wire.com"))
         val USER_ENTITY_2 = newUserEntity(QualifiedIDEntity("2", "wire.com"))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When migrating from old app version, we get all conversations and messages but not info about members of these conversations and creators of messages, sometimes the old app can still have some useful information about for instance removed members and we won't get info about them during sync anymore.

### Solutions

Implement `PersistMigratedUsersUseCase` which adds missing users data, if such user has been fetched during the sync then just ignore.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
