### PR TITLE
chore(api-v3): support changed conversation.access-update event AR-2743

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationAccessInfoDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationAccessInfoDTO.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.network.api.base.authenticated.conversation.model
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
@@ -14,9 +15,12 @@ import kotlinx.serialization.json.JsonNames
  * Further info: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/672006169/API+changes+v2+v3
  */
 @Serializable
-data class ConversationAccessInfoDTO(
-    @SerialName("access") val access: Set<ConversationAccessDTO>,
-    @SerialName("access_role_v2") @JsonNames("access_role") val accessRole: Set<ConversationAccessRoleDTO> = ConversationAccessRoleDTO.DEFAULT_VALUE_WHEN_NULL
+@OptIn(ExperimentalSerializationApi::class)
+data class ConversationAccessInfoDTO constructor(
+    @SerialName("access")
+    val access: Set<ConversationAccessDTO>,
+    @SerialName("access_role_v2") @JsonNames("access_role")
+    val accessRole: Set<ConversationAccessRoleDTO> = ConversationAccessRoleDTO.DEFAULT_VALUE_WHEN_NULL
 )
 
 sealed class UpdateConversationAccessResponse {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationAccessInfoDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationAccessInfoDTO.kt
@@ -5,11 +5,18 @@ import com.wire.kalium.network.api.base.model.ConversationAccessDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
+/**
+ * **Deprecation info**: Since API v3 `access_role_v2` is deprecated and will be replaced by `access_role`, but until all servers have
+ * been upgraded to have API v3 has its minimum supported version and all previously stored events have expired we need support both cases.
+ *
+ * Further info: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/672006169/API+changes+v2+v3
+ */
 @Serializable
 data class ConversationAccessInfoDTO(
     @SerialName("access") val access: Set<ConversationAccessDTO>,
-    @SerialName("access_role_v2") val accessRole: Set<ConversationAccessRoleDTO> = ConversationAccessRoleDTO.DEFAULT_VALUE_WHEN_NULL
+    @SerialName("access_role_v2") @JsonNames("access_role") val accessRole: Set<ConversationAccessRoleDTO> = ConversationAccessRoleDTO.DEFAULT_VALUE_WHEN_NULL
 )
 
 sealed class UpdateConversationAccessResponse {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/base/authenticated/notification/AccessUpdateTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/base/authenticated/notification/AccessUpdateTest.kt
@@ -1,0 +1,51 @@
+package com.wire.kalium.api.base.authenticated.notification
+
+import com.wire.kalium.model.EventContentDTOJson
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationAccessInfoDTO
+import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
+import com.wire.kalium.network.tools.KtxSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AccessUpdateTest {
+
+    private val json get() = KtxSerializer.json
+
+    @Test
+    fun givenPayload_whenDecoding_thenSuccess() {
+        val result = json.decodeFromString(
+            EventContentDTO.Conversation.AccessUpdate.serializer(),
+            EventContentDTOJson.validAccessUpdate.rawJson
+        )
+
+        assertEquals(result, EventContentDTOJson.validAccessUpdate.serializableData)
+    }
+
+    @Test
+    fun givenPayloadWithDeprecatedAccessRoleField_whenDecoding_thenSuccess() {
+        val result = json.decodeFromString(
+            EventContentDTO.Conversation.AccessUpdate.serializer(),
+            EventContentDTOJson.validAccessUpdateWithDeprecatedAccessRoleField.rawJson
+        )
+
+        assertEquals(result, EventContentDTOJson.validAccessUpdate.serializableData)
+    }
+
+    @Test
+    fun givenPayloadWithAccessRoleAndDeprecatedAccessRoleField_whenDecoding_thenDeprecatedFieldIsPreferred() {
+        val result = json.decodeFromString(
+            ConversationAccessInfoDTO.serializer(),
+            """
+                {
+                    "access": ["invite"]
+                    "access_role": ["team_member"]
+                    "access_role_v2": ["guest"]
+                }
+            """.trimIndent()
+        )
+
+        assertEquals(result.accessRole, setOf(ConversationAccessRoleDTO.GUEST))
+    }
+
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
@@ -12,7 +12,26 @@ import com.wire.kalium.network.api.base.model.UserId
 
 object EventContentDTOJson {
 
-    private val jsonProvider = { serializable: EventContentDTO.Conversation.AccessUpdate ->
+    private val jsonProviderAccessUpdate = { serializable: EventContentDTO.Conversation.AccessUpdate ->
+        """
+        |{
+        |  "qualified_conversation" : {
+        |    "id" : "${serializable.qualifiedConversation.value}",
+        |    "domain" : "${serializable.qualifiedConversation.domain}"
+        |  },
+        |  "qualified_from" : {
+        |     "id" : "${serializable.qualifiedFrom.value}",
+        |     "domain" : "${serializable.qualifiedFrom.domain}"
+        |  }, 
+        |  "data" : {
+        |       "access": [code],
+        |       "access_role": [team_member]
+        |  }
+        |}
+        """.trimMargin()
+    }
+
+    private val jsonProviderAccessUpdateWithDeprecatedAccessRoleField = { serializable: EventContentDTO.Conversation.AccessUpdate ->
         """
         |{
         |  "qualified_conversation" : {
@@ -82,7 +101,19 @@ object EventContentDTOJson {
                 setOf(ConversationAccessRoleDTO.TEAM_MEMBER)
             )
         ),
-        jsonProvider
+        jsonProviderAccessUpdate
+    )
+
+    val validAccessUpdateWithDeprecatedAccessRoleField = ValidJsonProvider(
+        EventContentDTO.Conversation.AccessUpdate(
+            qualifiedConversation = ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            qualifiedFrom = UserId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            data = ConversationAccessInfoDTO(
+                setOf(ConversationAccessDTO.CODE),
+                setOf(ConversationAccessRoleDTO.TEAM_MEMBER)
+            )
+        ),
+        jsonProviderAccessUpdateWithDeprecatedAccessRoleField
     )
 
     val validMemberJoin = ValidJsonProvider(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

The `access_role_v2` will be renamed to `access_role` in a future version of the backend so during a transition period we will need to support both cases.

For more details see: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/672006169/API+changes+v2+v3?focusedCommentId=684916909#comment-684916909

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
