### PR TITLE
refactpr: update last processed event with the correct value

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -2,13 +2,17 @@ package com.wire.kalium.logic.data.event
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.notification.NotificationApi
@@ -29,7 +33,7 @@ import kotlin.coroutines.coroutineContext
 interface EventRepository {
     suspend fun pendingEvents(): Flow<Either<CoreFailure, Event>>
     suspend fun liveEvents(): Either<CoreFailure, Flow<WebSocketEvent<Event>>>
-    suspend fun updateLastProcessedEventId(eventId: String)
+    suspend fun updateLastProcessedEventId(eventId: String): Either<StorageFailure, Unit>
 
     /**
      * Gets the last processed event ID, if it exists.
@@ -42,17 +46,17 @@ interface EventRepository {
 class EventDataSource(
     private val notificationApi: NotificationApi,
     private val metadataDAO: MetadataDAO,
-    private val clientRepository: ClientRepository,
+    private val currentClientId: CurrentClientIdProvider,
     private val eventMapper: EventMapper = MapperProvider.eventMapper()
 ) : EventRepository {
 
     // TODO(edge-case): handle Missing notification response (notify user that some messages are missing)
 
     override suspend fun pendingEvents(): Flow<Either<CoreFailure, Event>> =
-        clientRepository.currentClientId().fold({ flowOf(Either.Left(it)) }, { clientId -> pendingEventsFlow(clientId) })
+        currentClientId().fold({ flowOf(Either.Left(it)) }, { clientId -> pendingEventsFlow(clientId) })
 
     override suspend fun liveEvents(): Either<CoreFailure, Flow<WebSocketEvent<Event>>> =
-        clientRepository.currentClientId().map { clientId -> liveEventsFlow(clientId) }
+        currentClientId().map { clientId -> liveEventsFlow(clientId) }
 
     private suspend fun liveEventsFlow(clientId: ClientId): Flow<WebSocketEvent<Event>> =
         notificationApi.listenToLiveEvents(clientId.value).map { webSocketEvent ->
@@ -102,17 +106,22 @@ class EventDataSource(
         }
     }
 
-    override suspend fun lastEventId(): Either<CoreFailure, String> = metadataDAO.valueByKey(LAST_PROCESSED_EVENT_ID_KEY)?.let {
+    override suspend fun lastEventId(): Either<CoreFailure, String> = wrapStorageRequest {
+        metadataDAO.valueByKey(LAST_PROCESSED_EVENT_ID_KEY)
+    }.fold({
+        currentClientId()
+            .flatMap { currentClientId ->
+                wrapApiRequest { notificationApi.lastNotification(currentClientId.value) }
+                    .flatMap { lastEvent ->
+                        updateLastProcessedEventId(lastEvent.id).map { lastEvent.id }
+                    }
+            }
+    }, {
         Either.Right(it)
-    } ?: run {
-        clientRepository.currentClientId().flatMap { clientId ->
-            wrapApiRequest { notificationApi.lastNotification(clientId.value) }.map { it.id }
-        }
-    }
+    })
 
-    override suspend fun updateLastProcessedEventId(eventId: String) {
+    override suspend fun updateLastProcessedEventId(eventId: String) =
         wrapStorageRequest { metadataDAO.insertValue(eventId, LAST_PROCESSED_EVENT_ID_KEY) }
-    }
 
     private suspend fun getNextPendingEventsPage(
         lastFetchedNotificationId: String?,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -538,7 +538,7 @@ class UserSessionScope internal constructor(
         get() = EventDataSource(
             authenticatedDataSourceSet.authenticatedNetworkContainer.notificationApi,
             userStorage.database.metadataDAO,
-            clientRepository
+            clientIdProvider
         )
 
     internal val keyPackageManager: KeyPackageManager =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -66,9 +66,7 @@ internal class EventGathererImpl(
     override suspend fun gatherEvents(): Flow<Event> = flow {
         offlineEventBuffer.clear()
         _currentSource.value = EventSource.PENDING
-        eventRepository.lastEventId().map { eventId ->
-            eventRepository.updateLastProcessedEventId(eventId)
-        }.flatMap {
+        eventRepository.lastEventId().flatMap {
             eventRepository.liveEvents()
         }.onSuccess { webSocketEventFlow ->
             handleWebSocketEventsWhilePolicyAllows(webSocketEventFlow)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -1,17 +1,7 @@
 package com.wire.kalium.logic.data.event
 
 import app.cash.turbine.test
-import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.connection.ConnectionMapperImpl
-import com.wire.kalium.logic.data.connection.ConnectionStatusMapperImpl
-import com.wire.kalium.logic.data.conversation.ConversationRoleMapperImpl
-import com.wire.kalium.logic.data.conversation.MemberMapperImpl
-import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapperImpl
-import com.wire.kalium.logic.data.id.IdMapperImpl
-import com.wire.kalium.logic.data.publicuser.PublicUserMapperImpl
-import com.wire.kalium.logic.data.user.AvailabilityStatusMapperImpl
-import com.wire.kalium.logic.data.user.ConnectionStateMapperImpl
-import com.wire.kalium.logic.data.user.type.DomainUserTypeMapperImpl
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
@@ -27,49 +17,18 @@ import com.wire.kalium.persistence.dao.MetadataDAO
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
+import io.mockative.configure
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EventRepositoryTest {
-
-    @Mock
-    private val notificationApi: NotificationApi = mock(classOf<NotificationApi>())
-
-    @Mock
-    val metaDAO = mock(classOf<MetadataDAO>())
-
-    @Mock
-    private val clientRepository: ClientRepository = mock(classOf<ClientRepository>())
-
-    @Mock
-    private val eventMapper: EventMapper =
-        EventMapper(
-            IdMapperImpl(),
-            MemberMapperImpl(IdMapperImpl(), ConversationRoleMapperImpl()),
-            ConnectionMapperImpl(
-                IdMapperImpl(),
-                ConnectionStatusMapperImpl(),
-                PublicUserMapperImpl(IdMapperImpl(), AvailabilityStatusMapperImpl(), ConnectionStateMapperImpl())
-            ),
-            FeatureConfigMapperImpl(),
-            ConversationRoleMapperImpl(),
-            DomainUserTypeMapperImpl()
-        )
-
-    private lateinit var eventRepository: EventRepository
-
-    @BeforeTest
-    fun setup() {
-        eventRepository = EventDataSource(notificationApi, metaDAO, clientRepository, eventMapper)
-    }
 
     @Test
     fun givenPendingEvents_whenGettingPendingEvents_thenReturnPendingFirstFollowedByComplete() = runTest {
@@ -82,20 +41,10 @@ class EventRepositoryTest {
         val pendingEvent = EventResponse("pendingEventId", listOf(pendingEventPayload))
         val notificationsPageResponse = NotificationResponse("time", false, listOf(pendingEvent))
 
-        given(metaDAO)
-            .suspendFunction(metaDAO::valueByKey).whenInvokedWith(any())
-            .thenReturn("someNotificationId")
-
-        given(notificationApi)
-            .suspendFunction(notificationApi::notificationsByBatch)
-            .whenInvokedWith(any(), any(), any())
-            .thenReturn(NetworkResponse.Success(notificationsPageResponse, mapOf(), 200))
-
-        val clientId = TestClient.CLIENT_ID
-        given(clientRepository)
-            .suspendFunction(clientRepository::currentClientId)
-            .whenInvoked()
-            .thenReturn(Either.Right(clientId))
+        val (arrangement, eventRepository) = Arrangement()
+            .withLastStoredEventId("someNotificationId")
+            .withNotificationsByBatch(NetworkResponse.Success(notificationsPageResponse, mapOf(), 200))
+            .arrangement()
 
         eventRepository.pendingEvents().test {
             awaitItem().shouldSucceed {
@@ -107,9 +56,43 @@ class EventRepositoryTest {
 
     @Test
     fun givenNoSavedLastProcessedId_whenGettingLastProcessedEventId_thenShouldAskFromAPI() = runTest {
-        given(metaDAO)
-            .suspendFunction(metaDAO::valueByKey).whenInvokedWith(any())
-            .thenReturn(null)
+        val pendingEventPayload = EventContentDTO.Conversation.NewMessageDTO(
+            TestConversation.NETWORK_ID,
+            UserId("value", "domain"),
+            "eventTime",
+            MessageEventData("text", "senderId", "recipient")
+        )
+        val pendingEvent = EventResponse("pendingEventId", listOf(pendingEventPayload))
+
+        val (arrangement, eventRepository) = Arrangement()
+            .withLastStoredEventId(null)
+            .withLastNotificationRemote(NetworkResponse.Success(pendingEvent, mapOf(), 200))
+            .arrangement()
+
+
+        val result = eventRepository.lastEventId()
+        result.shouldSucceed { assertEquals(pendingEvent.id, it) }
+
+        verify(arrangement.notificationApi)
+            .suspendFunction(arrangement.notificationApi::lastNotification)
+            .with(any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenASavedLastProcessedId_whenGettingLastEventId_thenShouldReturnIt() = runTest {
+        val eventId = "dh817h2e"
+
+        val (arrangement, eventRepository) = Arrangement()
+            .withLastStoredEventId(eventId)
+            .arrangement()
+
+        val result = eventRepository.lastEventId()
+        result.shouldSucceed { assertEquals(eventId, it) }
+    }
+
+    @Test
+    fun givenNoLastProcessedEventIdIsStored_thenLastEventIsFetchedFromRemoteAndStored() = runTest {
 
         val pendingEventPayload = EventContentDTO.Conversation.NewMessageDTO(
             TestConversation.NETWORK_ID,
@@ -119,34 +102,70 @@ class EventRepositoryTest {
         )
         val pendingEvent = EventResponse("pendingEventId", listOf(pendingEventPayload))
 
-        val clientId = TestClient.CLIENT_ID
-        given(clientRepository)
-            .suspendFunction(clientRepository::currentClientId)
-            .whenInvoked()
-            .thenReturn(Either.Right(clientId))
+        val expected = pendingEvent.id
+        val (arrangement, eventRepository) = Arrangement()
+            .withLastStoredEventId(null)
+            .withLastNotificationRemote(NetworkResponse.Success(pendingEvent, mapOf(), 200))
+            .withUpdateLastProcessedEventId()
+            .arrangement()
 
-        given(notificationApi)
-            .suspendFunction(notificationApi::lastNotification)
-            .whenInvokedWith(any())
-            .thenReturn(NetworkResponse.Success(pendingEvent, mapOf(), 200))
+        eventRepository.lastEventId().shouldSucceed {
+            assertEquals(expected, it)
+        }
 
-        val result = eventRepository.lastEventId()
-        result.shouldSucceed { assertEquals(pendingEvent.id, it) }
-
-        verify(notificationApi)
-            .suspendFunction(notificationApi::lastNotification)
-            .with(any())
+        verify(arrangement.metaDAO)
+            .coroutine { arrangement.metaDAO.insertValue(key = LAST_PROCESSED_EVENT_ID_KEY, value = expected) }
             .wasInvoked(exactly = once)
     }
 
-    @Test
-    fun givenASavedLastProcessedId_whenGettingLastEventId_thenShouldReturnIt() = runTest {
-        val eventId = "dh817h2e"
-        given(metaDAO)
-            .suspendFunction(metaDAO::valueByKey).whenInvokedWith(any())
-            .thenReturn(eventId)
+    private companion object {
+        const val LAST_PROCESSED_EVENT_ID_KEY = "last_processed_event_id"
+    }
 
-        val result = eventRepository.lastEventId()
-        result.shouldSucceed { assertEquals(eventId, it) }
+    private class Arrangement {
+        @Mock
+        val notificationApi: NotificationApi = mock(classOf<NotificationApi>())
+
+        @Mock
+        val metaDAO = configure(mock(classOf<MetadataDAO>())) {stubsUnitByDefault = true}
+
+        @Mock
+        val clientIdProvider = mock(CurrentClientIdProvider::class)
+
+        private val eventRepository: EventRepository = EventDataSource(notificationApi, metaDAO, clientIdProvider)
+
+        suspend fun withLastStoredEventId(value: String?) = apply {
+            given(metaDAO)
+                .coroutine { metaDAO.valueByKey(LAST_PROCESSED_EVENT_ID_KEY) }
+                .thenReturn(value)
+        }
+
+        fun withNotificationsByBatch(result: NetworkResponse<NotificationResponse>) = apply {
+            given(notificationApi)
+                .suspendFunction(notificationApi::notificationsByBatch)
+                .whenInvokedWith(any(), any(), any())
+                .thenReturn(result)
+        }
+
+        fun withLastNotificationRemote(result: NetworkResponse<EventResponse>) = apply {
+            given(notificationApi)
+                .suspendFunction(notificationApi::lastNotification)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withUpdateLastProcessedEventId() = apply {
+            given(metaDAO)
+                .suspendFunction(metaDAO::insertValue)
+                .whenInvokedWith(any(), any())
+        }
+
+        fun arrangement(): Pair<Arrangement, EventRepository> {
+            given(clientIdProvider)
+                .suspendFunction(clientIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(Either.Right(TestClient.CLIENT_ID))
+            return this to eventRepository
+        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
@@ -1,7 +1,10 @@
 package com.wire.kalium.logic.sync.incremental
 
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.framework.TestEvent
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.receiver.ConversationEventReceiver
 import com.wire.kalium.logic.sync.receiver.FeatureConfigEventReceiver
 import com.wire.kalium.logic.sync.receiver.TeamEventReceiver
@@ -10,6 +13,7 @@ import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import io.mockative.Mock
 import io.mockative.configure
 import io.mockative.eq
+import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
@@ -23,7 +27,9 @@ class EventProcessorTest {
         // Given
         val event = TestEvent.memberJoin()
 
-        val (arrangement, eventProcessor) = Arrangement().arrange()
+        val (arrangement, eventProcessor) = Arrangement()
+            .withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
+            .arrange()
 
         // When
         eventProcessor.processEvent(event)
@@ -40,7 +46,9 @@ class EventProcessorTest {
         // Given
         val event = TestEvent.memberJoin()
 
-        val (arrangement, eventProcessor) = Arrangement().arrange()
+        val (arrangement, eventProcessor) = Arrangement()
+            .withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
+            .arrange()
 
         // When
         eventProcessor.processEvent(event)
@@ -57,7 +65,10 @@ class EventProcessorTest {
         // Given
         val event = TestEvent.newConnection()
 
-        val (arrangement, eventProcessor) = Arrangement().arrange()
+        val (arrangement, eventProcessor) = Arrangement()
+//             .withLastProcessedEventId(Either.Right(LAST_EVENT_ID))
+            .withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
+            .arrange()
 
         // When
         eventProcessor.processEvent(event)
@@ -67,6 +78,10 @@ class EventProcessorTest {
             .suspendFunction(arrangement.userEventReceiver::onEvent)
             .with(eq(event))
             .wasInvoked(exactly = once)
+    }
+
+    private companion object {
+        const val LAST_EVENT_ID = "last_event_id"
     }
 
     private class Arrangement {
@@ -95,6 +110,12 @@ class EventProcessorTest {
                 teamEventReceiver,
                 featureConfigEventReceiver
             )
+
+        suspend fun withUpdateLastProcessedEventId(eventId: String, result: Either<StorageFailure, Unit>) = apply {
+            given(eventRepository)
+                .coroutine { eventRepository.updateLastProcessedEventId(eventId) }
+                .then { result }
+        }
 
         fun arrange() = this to eventProcessor
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when querying the last processed event id the app is updating the value with the same old one  

### Solutions

fix it and use currentClientId provider instead of querying the current client id every time form the DB

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
