### PR TITLE
fix: last processed event id is updated for transient event

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -145,7 +145,7 @@ internal class ConversationGroupRepositoryImpl(
             )
         }.onSuccess { response ->
             if (response is ConversationMemberAddedResponse.Changed) {
-                memberJoinEventHandler.handle(eventMapper.conversationMemberJoin("", response.event))
+                memberJoinEventHandler.handle(eventMapper.conversationMemberJoin("", response.event, true))
             }
         }.map {
             Either.Right(Unit)
@@ -181,7 +181,7 @@ internal class ConversationGroupRepositoryImpl(
             conversationApi.removeMember(idMapper.toApiModel(userId), idMapper.toApiModel(conversationId))
         }.onSuccess { response ->
             if (response is ConversationMemberRemovedResponse.Changed) {
-                memberLeaveEventHandler.handle(eventMapper.conversationMemberLeave("", response.event))
+                memberLeaveEventHandler.handle(eventMapper.conversationMemberLeave("", response.event, false))
             }
         }.map { }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -228,7 +228,7 @@ class MLSConversationDataSource(
 
     private suspend fun processCommitBundleEvents(events: List<EventContentDTO>) {
         events.forEach { eventContentDTO ->
-            val event = MapperProvider.eventMapper().fromEventContentDTO("", eventContentDTO)
+            val event = MapperProvider.eventMapper().fromEventContentDTO("", eventContentDTO, true)
             if (event is Event.Conversation) {
                 commitBundleEventReceiver.onEvent(event)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -18,18 +18,18 @@ import com.wire.kalium.network.utils.toJsonElement
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.JsonNull
 
-sealed class Event(open val id: String) {
+sealed class Event(open val id: String, open val transient: Boolean) {
 
     sealed class Conversation(
-        id: String,
-        open val conversationId: ConversationId
-    ) : Event(id) {
+        id: String, override val transient: Boolean, open val conversationId: ConversationId
+    ) : Event(id, transient) {
         data class AccessUpdate(
             override val id: String,
             override val conversationId: ConversationId,
             val data: ConversationResponse,
             val qualifiedFrom: UserId,
-        ) : Conversation(id, conversationId) {
+            override val transient: Boolean
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -43,12 +43,13 @@ sealed class Event(open val id: String) {
         data class NewMessage(
             override val id: String,
             override val conversationId: ConversationId,
+            override val transient: Boolean,
             val senderUserId: UserId,
             val senderClientId: ClientId,
             val timestampIso: String,
             val content: String,
             val encryptedExternalContent: EncryptedData?
-        ) : Conversation(id, conversationId) {
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -64,10 +65,11 @@ sealed class Event(open val id: String) {
         data class NewMLSMessage(
             override val id: String,
             override val conversationId: ConversationId,
+            override val transient: Boolean,
             val senderUserId: UserId,
             val timestampIso: String,
             val content: String
-        ) : Conversation(id, conversationId) {
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -82,9 +84,10 @@ sealed class Event(open val id: String) {
         data class NewConversation(
             override val id: String,
             override val conversationId: ConversationId,
+            override val transient: Boolean,
             val timestampIso: String,
             val conversation: ConversationResponse
-        ) : Conversation(id, conversationId) {
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -98,10 +101,11 @@ sealed class Event(open val id: String) {
         data class MemberJoin(
             override val id: String,
             override val conversationId: ConversationId,
+            override val transient: Boolean,
             val addedBy: UserId,
             val members: List<Member>,
             val timestampIso: String
-        ) : Conversation(id, conversationId) {
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -117,10 +121,11 @@ sealed class Event(open val id: String) {
         data class MemberLeave(
             override val id: String,
             override val conversationId: ConversationId,
+            override val transient: Boolean,
             val removedBy: UserId,
             val removedList: List<UserId>,
             val timestampIso: String
-        ) : Conversation(id, conversationId) {
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -136,13 +141,15 @@ sealed class Event(open val id: String) {
             override val id: String,
             override val conversationId: ConversationId,
             open val timestampIso: String,
-        ) : Conversation(id, conversationId) {
+            transient: Boolean,
+        ) : Conversation(id, transient, conversationId) {
             class MemberChangedRole(
                 override val id: String,
                 override val conversationId: ConversationId,
                 override val timestampIso: String,
+                override val transient: Boolean,
                 val member: Member?,
-            ) : MemberChanged(id, conversationId, timestampIso) {
+            ) : MemberChanged(id, conversationId, timestampIso, transient) {
                 override fun toString(): String {
                     val properties = mapOf(
                         "id" to id.obfuscateId(),
@@ -158,9 +165,10 @@ sealed class Event(open val id: String) {
                 override val id: String,
                 override val conversationId: ConversationId,
                 override val timestampIso: String,
+                override val transient: Boolean,
                 val mutedConversationStatus: MutedConversationStatus,
                 val mutedConversationChangedTime: String
-            ) : MemberChanged(id, conversationId, timestampIso) {
+            ) : MemberChanged(id, conversationId, timestampIso, transient) {
                 override fun toString(): String {
                     val properties = mapOf(
                         "id" to id.obfuscateId(),
@@ -175,8 +183,9 @@ sealed class Event(open val id: String) {
 
             data class IgnoredMemberChanged(
                 override val id: String,
-                override val conversationId: ConversationId
-            ) : MemberChanged(id, conversationId, "") {
+                override val conversationId: ConversationId,
+                override val transient: Boolean
+            ) : MemberChanged(id, conversationId, "", transient) {
                 override fun toString(): String {
                     val properties = mapOf(
                         "id" to id.obfuscateId(),
@@ -190,10 +199,11 @@ sealed class Event(open val id: String) {
         data class MLSWelcome(
             override val id: String,
             override val conversationId: ConversationId,
+            override val transient: Boolean,
             val senderUserId: UserId,
             val message: String,
             val timestampIso: String = Clock.System.now().toString()
-        ) : Conversation(id, conversationId) {
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -208,9 +218,10 @@ sealed class Event(open val id: String) {
         data class DeletedConversation(
             override val id: String,
             override val conversationId: ConversationId,
+            override val transient: Boolean,
             val senderUserId: UserId,
             val timestampIso: String,
-        ) : Conversation(id, conversationId) {
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -225,10 +236,11 @@ sealed class Event(open val id: String) {
         data class RenamedConversation(
             override val id: String,
             override val conversationId: ConversationId,
+            override val transient: Boolean,
             val conversationName: String,
             val senderUserId: UserId,
             val timestampIso: String,
-        ) : Conversation(id, conversationId) {
+        ) : Conversation(id, transient, conversationId) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -244,14 +256,16 @@ sealed class Event(open val id: String) {
 
     sealed class Team(
         id: String,
-        open val teamId: String
-    ) : Event(id) {
+        open val teamId: String,
+        transient: Boolean,
+    ) : Event(id, transient) {
         data class Update(
             override val id: String,
+            override val transient: Boolean,
             override val teamId: String,
             val icon: String,
             val name: String,
-        ) : Team(id, teamId) {
+        ) : Team(id, teamId, transient) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -266,8 +280,9 @@ sealed class Event(open val id: String) {
         data class MemberJoin(
             override val id: String,
             override val teamId: String,
+            override val transient: Boolean,
             val memberId: String,
-        ) : Team(id, teamId) {
+        ) : Team(id, teamId, transient) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -280,10 +295,11 @@ sealed class Event(open val id: String) {
 
         data class MemberLeave(
             override val id: String,
+            override val transient: Boolean,
             override val teamId: String,
             val memberId: String,
             val timestampIso: String,
-        ) : Team(id, teamId) {
+        ) : Team(id, teamId, transient) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -298,9 +314,10 @@ sealed class Event(open val id: String) {
         data class MemberUpdate(
             override val id: String,
             override val teamId: String,
+            override val transient: Boolean,
             val memberId: String,
             val permissionCode: Int?,
-        ) : Team(id, teamId) {
+        ) : Team(id, teamId, transient) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -316,11 +333,11 @@ sealed class Event(open val id: String) {
 
     sealed class FeatureConfig(
         id: String,
-    ) : Event(id) {
+        transient: Boolean,
+    ) : Event(id, transient) {
         data class FileSharingUpdated(
-            override val id: String,
-            val model: ConfigsStatusModel
-        ) : FeatureConfig(id) {
+            override val id: String, override val transient: Boolean, val model: ConfigsStatusModel
+        ) : FeatureConfig(id, transient) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -331,37 +348,34 @@ sealed class Event(open val id: String) {
         }
 
         data class MLSUpdated(
-            override val id: String,
-            val model: MLSModel
-        ) : FeatureConfig(id) {
+            override val id: String, override val transient: Boolean, val model: MLSModel
+        ) : FeatureConfig(id, transient) {
             override fun toString(): String {
-                val properties = mapOf(
-                    "id" to id.obfuscateId(),
+                val properties = mapOf("id" to id.obfuscateId(),
                     "status" to model.status.name,
-                    "allowedUsers" to model.allowedUsers.map { it.value.obfuscateId() }
-                )
+                    "allowedUsers" to model.allowedUsers.map { it.value.obfuscateId() })
                 return "${properties.toJsonElement()}"
             }
         }
 
         data class ClassifiedDomainsUpdated(
             override val id: String,
+            override val transient: Boolean,
             val model: ClassifiedDomainsModel,
-        ) : FeatureConfig(id) {
+        ) : FeatureConfig(id, transient) {
             override fun toString(): String {
-                val properties = mapOf(
-                    "id" to id.obfuscateId(),
+                val properties = mapOf("id" to id.obfuscateId(),
                     "status" to model.status.name,
-                    "domains" to model.config.domains.map { it.obfuscateDomain() }
-                )
+                    "domains" to model.config.domains.map { it.obfuscateDomain() })
                 return "${properties.toJsonElement()}"
             }
         }
 
         data class ConferenceCallingUpdated(
             override val id: String,
-            val model: ConferenceCallingModel
-        ) : FeatureConfig(id) {
+            override val transient: Boolean,
+            val model: ConferenceCallingModel,
+        ) : FeatureConfig(id, transient) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -372,8 +386,9 @@ sealed class Event(open val id: String) {
         }
 
         data class UnknownFeatureUpdated(
-            override val id: String
-        ) : FeatureConfig(id) {
+            override val id: String,
+            override val transient: Boolean,
+        ) : FeatureConfig(id, transient) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -384,11 +399,12 @@ sealed class Event(open val id: String) {
     }
 
     sealed class User(
-        id: String,
-    ) : Event(id) {
+        id: String, transient: Boolean
+    ) : Event(id, transient) {
 
         data class Update(
             override val id: String,
+            override val transient: Boolean,
             val userId: String,
             val accentId: Int?,
             val ssoIdDeleted: Boolean?,
@@ -397,45 +413,43 @@ sealed class Event(open val id: String) {
             val email: String?,
             val previewAssetId: String?,
             val completeAssetId: String?,
-        ) : User(id) {
+        ) : User(id, transient) {
             override fun toString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "userId" to userId.obfuscateId()
+                    "id" to id.obfuscateId(), "userId" to userId.obfuscateId()
                 )
                 return "${properties.toJsonElement()}"
             }
         }
 
         data class NewConnection(
-            override val id: String,
-            val connection: Connection
-        ) : User(id) {
+            override val transient: Boolean, override val id: String, val connection: Connection
+        ) : User(id, transient) {
             override fun toString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "connection" to connection.toMap()
+                    "id" to id.obfuscateId(), "connection" to connection.toMap()
                 )
                 return "${properties.toJsonElement()}"
             }
         }
 
-        data class ClientRemove(override val id: String, val clientId: ClientId) : User(id) {
+        data class ClientRemove(
+            override val transient: Boolean, override val id: String, val clientId: ClientId
+        ) : User(id, transient) {
             override fun toString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "clientId" to clientId.value.obfuscateId()
+                    "id" to id.obfuscateId(), "clientId" to clientId.value.obfuscateId()
                 )
                 return "${properties.toJsonElement()}"
             }
         }
 
         data class UserDelete(
+            override val transient: Boolean,
             override val id: String,
             val userId: UserId,
             val timestampIso: String = Clock.System.now().toString() // TODO we are not receiving it from API
-        ) :
-            User(id) {
+        ) : User(id, transient) {
             override fun toString(): String {
                 val properties = mapOf(
                     "id" to id.obfuscateId(),
@@ -447,7 +461,10 @@ sealed class Event(open val id: String) {
         }
     }
 
-    data class Unknown(override val id: String) : Event(id) {
+    data class Unknown(
+        override val id: String,
+        override val transient: Boolean,
+    ) : Event(id, transient) {
         override fun toString(): String {
             val properties = mapOf(
                 "id" to id.obfuscateId(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -32,51 +32,55 @@ class EventMapper(
         // TODO(edge-case): Multiple payloads in the same event have the same ID, is this an issue when marking lastProcessedEventId?
         val id = eventResponse.id
         return eventResponse.payload?.map { eventContentDTO ->
-            fromEventContentDTO(id, eventContentDTO)
+            fromEventContentDTO(id, eventContentDTO, eventResponse.transient)
         } ?: listOf()
     }
 
     @Suppress("ComplexMethod")
-    fun fromEventContentDTO(id: String, eventContentDTO: EventContentDTO): Event =
+    fun fromEventContentDTO(id: String, eventContentDTO: EventContentDTO, transient: Boolean): Event =
         when (eventContentDTO) {
-            is EventContentDTO.Conversation.NewMessageDTO -> newMessage(id, eventContentDTO)
-            is EventContentDTO.Conversation.NewConversationDTO -> newConversation(id, eventContentDTO)
-            is EventContentDTO.Conversation.MemberJoinDTO -> conversationMemberJoin(id, eventContentDTO)
-            is EventContentDTO.Conversation.MemberLeaveDTO -> conversationMemberLeave(id, eventContentDTO)
-            is EventContentDTO.Conversation.MemberUpdateDTO -> memberUpdate(id, eventContentDTO)
-            is EventContentDTO.Conversation.MLSWelcomeDTO -> welcomeMessage(id, eventContentDTO)
-            is EventContentDTO.Conversation.NewMLSMessageDTO -> newMLSMessage(id, eventContentDTO)
-            is EventContentDTO.User.NewConnectionDTO -> connectionUpdate(id, eventContentDTO)
-            is EventContentDTO.User.ClientRemoveDTO -> clientRemove(id, eventContentDTO)
-            is EventContentDTO.User.UserDeleteDTO -> userDelete(id, eventContentDTO)
-            is EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO -> featureConfig(id, eventContentDTO)
-            is EventContentDTO.User.NewClientDTO, EventContentDTO.Unknown -> Event.Unknown(id)
-            is EventContentDTO.Conversation.AccessUpdate -> Event.Unknown(id) // TODO: update it after logic code is merged
-            is EventContentDTO.Conversation.DeletedConversationDTO -> conversationDeleted(id, eventContentDTO)
-            is EventContentDTO.Conversation.ConversationRenameDTO -> conversationRenamed(id, eventContentDTO)
-            is EventContentDTO.Team.MemberJoin -> teamMemberJoined(id, eventContentDTO)
-            is EventContentDTO.Team.MemberLeave -> teamMemberLeft(id, eventContentDTO)
-            is EventContentDTO.Team.MemberUpdate -> teamMemberUpdate(id, eventContentDTO)
-            is EventContentDTO.Team.Update -> teamUpdate(id, eventContentDTO)
-            is EventContentDTO.User.UpdateDTO -> userUpdate(id, eventContentDTO)
+            is EventContentDTO.Conversation.NewMessageDTO -> newMessage(id, eventContentDTO, transient)
+            is EventContentDTO.Conversation.NewConversationDTO -> newConversation(id, eventContentDTO, transient)
+            is EventContentDTO.Conversation.MemberJoinDTO -> conversationMemberJoin(id, eventContentDTO, transient)
+            is EventContentDTO.Conversation.MemberLeaveDTO -> conversationMemberLeave(id, eventContentDTO, transient)
+            is EventContentDTO.Conversation.MemberUpdateDTO -> memberUpdate(id, eventContentDTO, transient)
+            is EventContentDTO.Conversation.MLSWelcomeDTO -> welcomeMessage(id, eventContentDTO, transient)
+            is EventContentDTO.Conversation.NewMLSMessageDTO -> newMLSMessage(id, eventContentDTO, transient)
+            is EventContentDTO.User.NewConnectionDTO -> connectionUpdate(id, eventContentDTO, transient)
+            is EventContentDTO.User.ClientRemoveDTO -> clientRemove(id, eventContentDTO, transient)
+            is EventContentDTO.User.UserDeleteDTO -> userDelete(id, eventContentDTO, transient)
+            is EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO -> featureConfig(id, eventContentDTO, transient)
+            is EventContentDTO.User.NewClientDTO, EventContentDTO.Unknown -> Event.Unknown(id, transient)
+            is EventContentDTO.Conversation.AccessUpdate -> Event.Unknown(id, transient) // TODO: update it after logic code is merged
+            is EventContentDTO.Conversation.DeletedConversationDTO -> conversationDeleted(id, eventContentDTO, transient)
+            is EventContentDTO.Conversation.ConversationRenameDTO -> conversationRenamed(id, eventContentDTO, transient)
+            is EventContentDTO.Team.MemberJoin -> teamMemberJoined(id, eventContentDTO, transient)
+            is EventContentDTO.Team.MemberLeave -> teamMemberLeft(id, eventContentDTO, transient)
+            is EventContentDTO.Team.MemberUpdate -> teamMemberUpdate(id, eventContentDTO, transient)
+            is EventContentDTO.Team.Update -> teamUpdate(id, eventContentDTO, transient)
+            is EventContentDTO.User.UpdateDTO -> userUpdate(id, eventContentDTO, transient)
         }
 
     private fun welcomeMessage(
         id: String,
-        eventContentDTO: EventContentDTO.Conversation.MLSWelcomeDTO
+        eventContentDTO: EventContentDTO.Conversation.MLSWelcomeDTO,
+        transient: Boolean
     ) = Event.Conversation.MLSWelcome(
         id,
         idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+        transient,
         idMapper.fromApiModel(eventContentDTO.qualifiedFrom),
-        eventContentDTO.message
+        eventContentDTO.message,
     )
 
     private fun newMessage(
         id: String,
-        eventContentDTO: EventContentDTO.Conversation.NewMessageDTO
+        eventContentDTO: EventContentDTO.Conversation.NewMessageDTO,
+        transient: Boolean
     ) = Event.Conversation.NewMessage(
         id,
         idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+        transient,
         idMapper.fromApiModel(eventContentDTO.qualifiedFrom),
         ClientId(eventContentDTO.data.sender),
         eventContentDTO.time,
@@ -88,10 +92,12 @@ class EventMapper(
 
     private fun newMLSMessage(
         id: String,
-        eventContentDTO: EventContentDTO.Conversation.NewMLSMessageDTO
+        eventContentDTO: EventContentDTO.Conversation.NewMLSMessageDTO,
+        transient: Boolean
     ) = Event.Conversation.NewMLSMessage(
         id,
         idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+        transient,
         idMapper.fromApiModel(eventContentDTO.qualifiedFrom),
         eventContentDTO.time,
         eventContentDTO.message
@@ -99,55 +105,64 @@ class EventMapper(
 
     private fun connectionUpdate(
         id: String,
-        eventConnectionDTO: EventContentDTO.User.NewConnectionDTO
+        eventConnectionDTO: EventContentDTO.User.NewConnectionDTO,
+        transient: Boolean
     ) = Event.User.NewConnection(
+        transient,
         id,
         connectionMapper.fromApiToModel(eventConnectionDTO.connection)
     )
 
-    private fun userDelete(id: String, eventUserDelete: EventContentDTO.User.UserDeleteDTO): Event.User.UserDelete {
-        return Event.User.UserDelete(id, idMapper.fromApiModel(eventUserDelete.userId))
+    private fun userDelete(id: String, eventUserDelete: EventContentDTO.User.UserDeleteDTO, transient: Boolean): Event.User.UserDelete {
+        return Event.User.UserDelete(transient, id, idMapper.fromApiModel(eventUserDelete.userId))
     }
 
-    private fun clientRemove(id: String, eventClientRemove: EventContentDTO.User.ClientRemoveDTO): Event.User.ClientRemove {
-        return Event.User.ClientRemove(id, ClientId(eventClientRemove.client.clientId))
+    private fun clientRemove(id: String, eventClientRemove: EventContentDTO.User.ClientRemoveDTO, transient: Boolean): Event.User.ClientRemove {
+        return Event.User.ClientRemove(transient, id, ClientId(eventClientRemove.client.clientId))
     }
 
     private fun newConversation(
         id: String,
-        eventContentDTO: EventContentDTO.Conversation.NewConversationDTO
+        eventContentDTO: EventContentDTO.Conversation.NewConversationDTO,
+        transient: Boolean
     ) = Event.Conversation.NewConversation(
         id,
         idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
+        transient,
         eventContentDTO.time,
         eventContentDTO.data
     )
 
     fun conversationMemberJoin(
         id: String,
-        eventContentDTO: EventContentDTO.Conversation.MemberJoinDTO
+        eventContentDTO: EventContentDTO.Conversation.MemberJoinDTO,
+        transient: Boolean
     ) = Event.Conversation.MemberJoin(
         id = id,
         conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
         addedBy = idMapper.fromApiModel(eventContentDTO.qualifiedFrom),
         members = eventContentDTO.members.users.map { memberMapper.fromApiModel(it) },
-        timestampIso = eventContentDTO.time
+        timestampIso = eventContentDTO.time,
+        transient = transient
     )
 
     fun conversationMemberLeave(
         id: String,
-        eventContentDTO: EventContentDTO.Conversation.MemberLeaveDTO
+        eventContentDTO: EventContentDTO.Conversation.MemberLeaveDTO,
+        transient: Boolean
     ) = Event.Conversation.MemberLeave(
         id = id,
         conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
         removedBy = idMapper.fromApiModel(eventContentDTO.qualifiedFrom),
         removedList = eventContentDTO.members.qualifiedUserIds.map { idMapper.fromApiModel(it) },
-        timestampIso = eventContentDTO.time
+        timestampIso = eventContentDTO.time,
+        transient = transient
     )
 
     private fun memberUpdate(
         id: String,
-        eventContentDTO: EventContentDTO.Conversation.MemberUpdateDTO
+        eventContentDTO: EventContentDTO.Conversation.MemberUpdateDTO,
+        transient: Boolean
     ): Event.Conversation.MemberChanged {
         return when {
             eventContentDTO.roleChange.role?.isNotEmpty() == true -> {
@@ -155,6 +170,7 @@ class EventMapper(
                     id = id,
                     conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
                     timestampIso = eventContentDTO.time,
+                    transient = transient,
                     member = Conversation.Member(
                         id = idMapper.fromApiModel(eventContentDTO.roleChange.qualifiedUserId),
                         role = roleMapper.fromApi(eventContentDTO.roleChange.role.orEmpty())
@@ -168,12 +184,13 @@ class EventMapper(
                     conversationId = idMapper.fromApiModel(eventContentDTO.qualifiedConversation),
                     timestampIso = eventContentDTO.time,
                     mutedConversationChangedTime = eventContentDTO.roleChange.mutedRef.orEmpty(),
+                    transient = transient,
                     mutedConversationStatus = mapConversationMutedStatus(eventContentDTO.roleChange.mutedStatus)
                 )
             }
 
             else -> {
-                Event.Conversation.MemberChanged.IgnoredMemberChanged(id, idMapper.fromApiModel(eventContentDTO.qualifiedConversation))
+                Event.Conversation.MemberChanged.IgnoredMemberChanged(id, idMapper.fromApiModel(eventContentDTO.qualifiedConversation), transient)
             }
         }
     }
@@ -188,94 +205,112 @@ class EventMapper(
 
     private fun featureConfig(
         id: String,
-        featureConfigUpdatedDTO: EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO
+        featureConfigUpdatedDTO: EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO,
+        transient: Boolean
     ) = when (featureConfigUpdatedDTO.data) {
         is FeatureConfigData.FileSharing -> Event.FeatureConfig.FileSharingUpdated(
             id,
+            transient,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.FileSharing)
         )
 
         is FeatureConfigData.MLS -> Event.FeatureConfig.MLSUpdated(
             id,
+            transient,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.MLS)
         )
 
         is FeatureConfigData.ClassifiedDomains -> Event.FeatureConfig.ClassifiedDomainsUpdated(
             id,
+            transient,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.ClassifiedDomains)
         )
 
         is FeatureConfigData.ConferenceCalling -> Event.FeatureConfig.ConferenceCallingUpdated(
             id,
+            transient,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.ConferenceCalling)
         )
 
-        else -> Event.FeatureConfig.UnknownFeatureUpdated(id)
+        else -> Event.FeatureConfig.UnknownFeatureUpdated(id, transient)
     }
 
     private fun conversationDeleted(
         id: String,
-        deletedConversationDTO: EventContentDTO.Conversation.DeletedConversationDTO
+        deletedConversationDTO: EventContentDTO.Conversation.DeletedConversationDTO,
+        transient: Boolean
     ) = Event.Conversation.DeletedConversation(
         id = id,
         conversationId = idMapper.fromApiModel(deletedConversationDTO.qualifiedConversation),
         senderUserId = idMapper.fromApiModel(deletedConversationDTO.qualifiedFrom),
+        transient = transient,
         timestampIso = deletedConversationDTO.time
     )
 
     private fun conversationRenamed(
         id: String,
-        event: EventContentDTO.Conversation.ConversationRenameDTO
+        event: EventContentDTO.Conversation.ConversationRenameDTO,
+        transient: Boolean
     ) = Event.Conversation.RenamedConversation(
         id = id,
         conversationId = idMapper.fromApiModel(event.qualifiedConversation),
         senderUserId = idMapper.fromApiModel(event.qualifiedFrom),
         conversationName = event.updateNameData.conversationName,
+        transient = transient,
         timestampIso = event.time,
     )
 
     private fun teamMemberJoined(
         id: String,
-        event: EventContentDTO.Team.MemberJoin
+        event: EventContentDTO.Team.MemberJoin,
+        transient: Boolean
     ) = Event.Team.MemberJoin(
         id = id,
         teamId = event.teamId,
+        transient = transient,
         memberId = event.teamMember.nonQualifiedUserId
     )
 
     private fun teamMemberLeft(
         id: String,
-        event: EventContentDTO.Team.MemberLeave
+        event: EventContentDTO.Team.MemberLeave,
+        transient: Boolean
     ) = Event.Team.MemberLeave(
         id = id,
         teamId = event.teamId,
         memberId = event.teamMember.nonQualifiedUserId,
+        transient = transient,
         timestampIso = event.time
     )
 
     private fun teamMemberUpdate(
         id: String,
-        event: EventContentDTO.Team.MemberUpdate
+        event: EventContentDTO.Team.MemberUpdate,
+        transient: Boolean
     ) = Event.Team.MemberUpdate(
         id = id,
         teamId = event.teamId,
         memberId = event.permissionsResponse.nonQualifiedUserId,
+        transient = transient,
         permissionCode = event.permissionsResponse.permissions.own
     )
 
     private fun teamUpdate(
         id: String,
-        event: EventContentDTO.Team.Update
+        event: EventContentDTO.Team.Update,
+        transient: Boolean
     ) = Event.Team.Update(
         id = id,
         teamId = event.teamId,
         icon = event.teamUpdate.icon,
+        transient = transient,
         name = event.teamUpdate.name
     )
 
     private fun userUpdate(
         id: String,
-        event: EventContentDTO.User.UpdateDTO
+        event: EventContentDTO.User.UpdateDTO,
+        transient: Boolean
     ) = Event.User.Update(
         id = id,
         userId = event.userData.nonQualifiedUserId,
@@ -285,6 +320,7 @@ class EventMapper(
         handle = event.userData.handle,
         email = event.userData.email,
         previewAssetId = event.userData.assets?.getPreviewAssetOrNull()?.key,
+        transient = transient,
         completeAssetId = event.userData.assets?.getCompleteAssetOrNull()?.key
     )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -41,6 +41,8 @@ internal class EventProcessorImpl(
             is Event.Team -> teamEventReceiver.onEvent(event)
         }
         kaliumLogger.withFeatureId(EVENT_RECEIVER).i("Updating lastProcessedEventId ${event.id.obfuscateId()}")
-        eventRepository.updateLastProcessedEventId(event.id)
+        if (!event.transient) {
+            eventRepository.updateLastProcessedEventId(event.id)
+        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -79,7 +79,7 @@ class ConversationRepositoryTest {
 
     @Test
     fun givenNewConversationEvent_whenCallingPersistConversation_thenConversationShouldBePersisted() = runTest {
-        val event = Event.Conversation.NewConversation("id", TestConversation.ID, "time", CONVERSATION_RESPONSE)
+        val event = Event.Conversation.NewConversation("id", TestConversation.ID,  false, "time", CONVERSATION_RESPONSE)
         val selfUserFlow = flowOf(TestUser.SELF)
         val (arrangement, conversationRepository) = Arrangement()
             .withSelfUserFlow(selfUserFlow)
@@ -104,6 +104,7 @@ class ConversationRepositoryTest {
         val event = Event.Conversation.NewConversation(
             "id",
             TestConversation.ID,
+            false,
             "time",
             CONVERSATION_RESPONSE.copy(
                 groupId = RAW_GROUP_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -842,6 +842,7 @@ class MLSConversationRepositoryTest {
             val WELCOME_EVENT = Event.Conversation.MLSWelcome(
                 "eventId",
                 TestConversation.ID,
+                false,
                 TestUser.USER_ID,
                 WELCOME.encodeBase64(),
                 timestampIso = "2022-03-30T15:36:00.000Z"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -15,6 +15,7 @@ object TestEvent {
     fun memberJoin(eventId: String = "eventId", members: List<Member> = listOf()) = Event.Conversation.MemberJoin(
         eventId,
         TestConversation.ID,
+        false,
         TestUser.USER_ID,
         members,
         "2022-03-30T15:36:00.000Z"
@@ -24,6 +25,7 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         "2022-03-30T15:36:00.000Z",
+        false,
         member
     )
 
@@ -31,6 +33,7 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         "2022-03-30T15:36:00.000Z",
+        false,
         MutedConversationStatus.AllAllowed,
         "2022-03-30T15:36:00.000Zp"
     )
@@ -38,15 +41,18 @@ object TestEvent {
     fun memberChangeIgnored(eventId: String = "eventId") = Event.Conversation.MemberChanged.IgnoredMemberChanged(
         eventId,
         TestConversation.ID,
+        false,
     )
 
-    fun clientRemove(eventId: String = "eventId", clientId: ClientId) = Event.User.ClientRemove(eventId, clientId)
-    fun userDelete(eventId: String = "eventId", userId: UserId) = Event.User.UserDelete(eventId, userId)
+    fun clientRemove(eventId: String = "eventId", clientId: ClientId) = Event.User.ClientRemove(false, eventId, clientId)
+    fun userDelete(eventId: String = "eventId", userId: UserId) = Event.User.UserDelete(false, eventId, userId)
     fun updateUser(eventId: String = "eventId", userId: UserId) = Event.User.Update(
-        eventId, userId.toString(), null, false, "newName", null, null, null, null
+        eventId,
+        false, userId.toString(), null, false, "newName", null, null, null, null
     )
 
     fun newConnection(eventId: String = "eventId") = Event.User.NewConnection(
+        false,
         eventId,
         Connection(
             conversationId = "conversationId",
@@ -62,6 +68,7 @@ object TestEvent {
     fun deletedConversation(eventId: String = "eventId") = Event.Conversation.DeletedConversation(
         eventId,
         TestConversation.ID,
+        false,
         TestUser.USER_ID,
         "2022-03-30T15:36:00.000Z"
     )
@@ -69,6 +76,7 @@ object TestEvent {
     fun renamedConversation(eventId: String = "eventId") = Event.Conversation.RenamedConversation(
         eventId,
         TestConversation.ID,
+        false,
         "newName",
         TestUser.USER_ID,
         "2022-03-30T15:36:00.000Z"
@@ -78,12 +86,14 @@ object TestEvent {
         eventId,
         teamId = "teamId",
         name = "teamName",
+        transient = false,
         icon = "icon",
     )
 
     fun teamMemberJoin(eventId: String = "eventId") = Event.Team.MemberJoin(
         eventId,
         teamId = "teamId",
+        false,
         memberId = "memberId"
     )
 
@@ -91,14 +101,16 @@ object TestEvent {
         eventId,
         teamId = "teamId",
         memberId = "memberId",
-        timestampIso = "2022-03-30T15:36:00.000Z"
+        timestampIso = "2022-03-30T15:36:00.000Z",
+        transient = false
     )
 
     fun teamMemberUpdate(eventId: String = "eventId", permissionCode: Int) = Event.Team.MemberUpdate(
         eventId,
         teamId = "teamId",
         memberId = "memberId",
-        permissionCode = permissionCode
+        permissionCode = permissionCode,
+        transient = false
     )
 
     fun newMessageEvent(
@@ -108,6 +120,7 @@ object TestEvent {
     ) = Event.Conversation.NewMessage(
         "eventId",
         TestConversation.ID,
+        false,
         senderUserId,
         TestClient.CLIENT_ID,
         "time",
@@ -120,6 +133,7 @@ object TestEvent {
     ) = Event.Conversation.NewMLSMessage(
         "eventId",
         TestConversation.ID,
+        false,
         TestUser.USER_ID,
         timestamp.toString(),
         "content"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -172,15 +172,15 @@ class FeatureConfigEventReceiverTest {
 
         fun newMLSUpdatedEvent(
             model: MLSModel
-        ) = Event.FeatureConfig.MLSUpdated("eventId", model)
+        ) = Event.FeatureConfig.MLSUpdated("eventId", false, model)
 
         fun newFileSharingUpdatedEvent(
             model: ConfigsStatusModel
-        ) = Event.FeatureConfig.FileSharingUpdated("eventId", model)
+        ) = Event.FeatureConfig.FileSharingUpdated("eventId", false, model)
 
         fun newConferenceCallingUpdatedEvent(
             model: ConferenceCallingModel
-        ) = Event.FeatureConfig.ConferenceCallingUpdated("eventId", model)
+        ) = Event.FeatureConfig.ConferenceCallingUpdated("eventId", false, model)
 
         fun arrange() = this to featureConfigEventReceiver
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -35,6 +35,7 @@ class NewConversationEventHandlerTest {
         val event = Event.Conversation.NewConversation(
             id = "eventId",
             conversationId = TestConversation.ID,
+            transient = false,
             timestampIso = "timestamp",
             conversation = TestConversation.CONVERSATION_RESPONSE,
         )
@@ -67,6 +68,7 @@ class NewConversationEventHandlerTest {
         val event = Event.Conversation.NewConversation(
             id = "eventId",
             conversationId = TestConversation.ID,
+            false,
             timestampIso = "timestamp",
             conversation = TestConversation.CONVERSATION_RESPONSE
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

for event received, there is a flag `transit` that dictates if this event is received when the user is online only (e.g. User x is typing). These events should not update the last processed event ID.

### Solutions

update the last processed event id if and only if transit == false

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
