### PR TITLE
fix: introduce ImportClientUseCase for importing an existing client

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -33,6 +33,7 @@ interface ClientRepository {
     @Deprecated("this function is not cached use CurrentClientIdProvider")
     suspend fun currentClientId(): Either<CoreFailure, ClientId>
     suspend fun clearCurrentClientId(): Either<CoreFailure, Unit>
+    suspend fun persistRetainedClientId(clientId: ClientId): Either<CoreFailure, Unit>
     suspend fun retainedClientId(): Either<CoreFailure, ClientId>
     suspend fun clearRetainedClientId(): Either<CoreFailure, Unit>
     suspend fun clearHasRegisteredMLSClient(): Either<CoreFailure, Unit>
@@ -62,6 +63,9 @@ class ClientDataSource(
 
     override suspend fun persistClientId(clientId: ClientId): Either<CoreFailure, Unit> =
         wrapStorageRequest { clientRegistrationStorage.setRegisteredClientId(clientId.value) }
+
+    override suspend fun persistRetainedClientId(clientId: ClientId): Either<CoreFailure, Unit> =
+        wrapStorageRequest { clientRegistrationStorage.setRetainedClientId(clientId.value) }
 
     override suspend fun clearCurrentClientId(): Either<CoreFailure, Unit> =
         wrapStorageRequest { clientRegistrationStorage.clearRegisteredClientId() }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -76,8 +76,14 @@ class ClientScope(
     val clearClientData: ClearClientDataUseCase
         get() = ClearClientDataUseCaseImpl(mlsClientProvider, proteusClientProvider)
 
-    val verifyExistingClientUseCase: VerifyExistingClientUseCase
+    private val verifyExistingClientUseCase: VerifyExistingClientUseCase
         get() = VerifyExistingClientUseCaseImpl(clientRepository)
+
+    val importClient: ImportClientUseCase
+        get() = ImportClientUseCaseImpl(
+            clientRepository,
+            getOrRegister
+        )
 
     val getOrRegister: GetOrRegisterClientUseCase
         get() = GetOrRegisterClientUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ImportClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ImportClientUseCase.kt
@@ -1,0 +1,36 @@
+package com.wire.kalium.logic.feature.client
+
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.functional.fold
+
+interface ImportClientUseCase {
+
+    /**
+     * @param clientId client id of client
+     * @param registerClientParam: register client parameters for the case when client isn't already registered
+     * @return success if the client was successfully imported, failure otherwise
+     */
+    suspend operator fun invoke(clientId: ClientId, registerClientParam: RegisterClientUseCase.RegisterClientParam): RegisterClientResult
+}
+
+internal class ImportClientUseCaseImpl(
+    private val clientRepository: ClientRepository,
+    private val getOrRegisterClient: GetOrRegisterClientUseCase
+) : ImportClientUseCase {
+
+    override suspend fun invoke(
+        clientId: ClientId,
+        registerClientParam: RegisterClientUseCase.RegisterClientParam
+    ): RegisterClientResult {
+        return clientRepository.persistRetainedClientId(clientId)
+            .fold(
+                { coreFailure ->
+                    RegisterClientResult.Failure.Generic(coreFailure)
+                },
+                {
+                    getOrRegisterClient(registerClientParam)
+                }
+            )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -177,6 +177,17 @@ class ClientRepositoryTest {
         }
     }
 
+    @Test
+    fun givenAClientId_whenPersistingRetainedClientId_thenTheStorageShouldBeCalledWithRightParameter() = runTest {
+        val clientId = CLIENT_ID
+
+        clientRepository.persistRetainedClientId(clientId)
+
+        verify(clientRegistrationStorage)
+            .suspendFunction(clientRegistrationStorage::setRetainedClientId)
+            .with(eq(clientRepository))
+    }
+
     // clientInfo
     @Test
     fun givenClientId_whenGettingClientInformationSuccess_thenTheSuccessIsReturned() = runTest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ImportClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ImportClientUseCaseTest.kt
@@ -1,0 +1,88 @@
+package com.wire.kalium.logic.feature.client
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImportClientUseCaseTest {
+
+    @Test
+    fun givenClientId_whenInvoking_thenPersistClientIdAsRetainedAndCallGetOrRegisterClientUseCase() = runTest {
+        val (arrangement, importClientUse) = Arrangement()
+            .withPersistRetainedClientResult(Either.Right(Unit))
+            .withGetOrRegisterClientResult(RegisterClientResult.Success(TestClient.CLIENT))
+            .arrange()
+
+        val result = importClientUse.invoke(TestClient.CLIENT_ID, Arrangement.REGISTER_CLIENT_PARAM)
+
+        assertIs<RegisterClientResult.Success>(result)
+
+        verify(arrangement.clientRepository)
+            .suspendFunction(arrangement.clientRepository::persistRetainedClientId)
+            .with(eq(TestClient.CLIENT_ID))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.getOrRegisterClientUseCase)
+            .suspendFunction(arrangement.getOrRegisterClientUseCase::invoke)
+            .with(eq(Arrangement.REGISTER_CLIENT_PARAM))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenPersistClientIdFails_whenInvoking_thenFailureIsPropagated() = runTest {
+        val (_, importClientUse) = Arrangement()
+            .withPersistRetainedClientResult(Either.Left(StorageFailure.DataNotFound))
+            .arrange()
+
+        val result = importClientUse.invoke(TestClient.CLIENT_ID, Arrangement.REGISTER_CLIENT_PARAM)
+
+        assertIs<RegisterClientResult.Failure.Generic>(result)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val clientRepository = mock(classOf<ClientRepository>())
+
+        @Mock
+        val getOrRegisterClientUseCase = mock(classOf<GetOrRegisterClientUseCase>())
+
+        fun withGetOrRegisterClientResult(result: RegisterClientResult): Arrangement = apply {
+            given(getOrRegisterClientUseCase)
+                .suspendFunction(getOrRegisterClientUseCase::invoke)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withPersistRetainedClientResult(result: Either<CoreFailure, Unit>): Arrangement = apply {
+            given(clientRepository)
+                .suspendFunction(clientRepository::persistRetainedClientId)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun arrange() = this to ImportClientUseCaseImpl(clientRepository, getOrRegisterClientUseCase)
+
+        companion object {
+            val REGISTER_CLIENT_PARAM = RegisterClientUseCase.RegisterClientParam(
+                password = null,
+                capabilities = null
+            )
+        }
+    }
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
@@ -8,6 +8,7 @@ interface ClientRegistrationStorage {
     suspend fun getRegisteredClientId(): String?
     suspend fun setRegisteredClientId(registeredClientId: String)
     suspend fun observeRegisteredClientId(): Flow<String?>
+    suspend fun setRetainedClientId(retainedClientId: String)
     suspend fun getRetainedClientId(): String?
     suspend fun clearRegisteredClientId()
     suspend fun clearRetainedClientId()
@@ -26,6 +27,7 @@ class ClientRegistrationStorageImpl(private val metadataDAO: MetadataDAO) : Clie
     }
 
     override suspend fun observeRegisteredClientId(): Flow<String?> = metadataDAO.valueByKeyFlow(REGISTERED_CLIENT_ID_KEY)
+    override suspend fun setRetainedClientId(retainedClientId: String) = metadataDAO.insertValue(retainedClientId, RETAINED_CLIENT_ID_KEY)
     override suspend fun getRetainedClientId(): String? = metadataDAO.valueByKey(RETAINED_CLIENT_ID_KEY)
     override suspend fun clearRegisteredClientId() = metadataDAO.deleteValue(REGISTERED_CLIENT_ID_KEY)
     override suspend fun clearRetainedClientId() = metadataDAO.deleteValue(RETAINED_CLIENT_ID_KEY)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`PersistRegisteredClientUseCase` was deleted and it was use for Scala app migration

### Solutions

Introduce ImportClientUseCase which replaces the previously deleted `PersistRegisteredClientUseCase`.

### Testing

#### Test Coverage

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
