### PR TITLE
refactor: narrow down the subtype of Messages when querying locally

### DIFF
--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensionsTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensionsTest.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.logic.data.message
 
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
-import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.wire.kalium.logic.data.id.IdMapper
@@ -20,7 +19,6 @@ import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -38,7 +36,7 @@ class MessageRepositoryExtensionsTest {
         val pagingConfig = PagingConfig(20)
         val pager = Pager(pagingConfig) { fakePagingSource }
 
-        val kaliumPager = KaliumPager<MessageEntity>(pager, fakePagingSource)
+        val kaliumPager = KaliumPager(pager, fakePagingSource)
         val (arrangement, messageRepositoryExtensions) = Arrangement()
             .withMessageExtensionsReturningPager(kaliumPager)
             .arrange()
@@ -112,6 +110,5 @@ class MessageRepositoryExtensionsTest {
     private companion object {
         val CONVERSATION_ID_ENTITY = TestConversation.ENTITY_ID
         val MESSAGE = TestMessage.TEXT_MESSAGE
-        val MESSAGE_ENTITY = TestMessage.ENTITY
     }
 }

--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensionsTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensionsTest.kt
@@ -42,9 +42,9 @@ class MessageRepositoryExtensionsTest {
         val (arrangement, messageRepositoryExtensions) = Arrangement()
             .withMessageExtensionsReturningPager(kaliumPager)
             .arrange()
-
+        MessageRepositoryExtensionsTest
         val visibilities = listOf(Message.Visibility.VISIBLE)
-        val result: Flow<PagingData<Message>> = messageRepositoryExtensions.getPaginatedMessagesByConversationIdAndVisibility(
+        messageRepositoryExtensions.getPaginatedMessagesByConversationIdAndVisibility(
             TestConversation.ID,
             visibilities,
             pagingConfig

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensions.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensions.kt
@@ -16,7 +16,7 @@ actual interface MessageRepositoryExtensions {
         conversationId: ConversationId,
         visibility: List<Message.Visibility>,
         pagingConfig: PagingConfig,
-    ): Flow<PagingData<Message>>
+    ): Flow<PagingData<Message.Standalone>>
 }
 
 actual class MessageRepositoryExtensionsImpl actual constructor(
@@ -29,7 +29,7 @@ actual class MessageRepositoryExtensionsImpl actual constructor(
         conversationId: ConversationId,
         visibility: List<Message.Visibility>,
         pagingConfig: PagingConfig,
-    ): Flow<PagingData<Message>> {
+    ): Flow<PagingData<Message.Standalone>> {
         val pager: KaliumPager<MessageEntity> = messageDAO.platformExtensions.getPagerForConversation(
             idMapper.toDaoModel(conversationId),
             visibility.map { it.toEntityVisibility() },

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesByConversationUseCase.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesByConversationUseCase.kt
@@ -18,7 +18,7 @@ class GetPaginatedFlowOfMessagesByConversationUseCase internal constructor(
         conversationId: ConversationId,
         visibility: List<Message.Visibility> = Message.Visibility.values().toList(),
         pagingConfig: PagingConfig
-    ): Flow<PagingData<Message>> = messageRepository.extensions.getPaginatedMessagesByConversationIdAndVisibility(
+    ): Flow<PagingData<Message.Standalone>> = messageRepository.extensions.getPaginatedMessagesByConversationIdAndVisibility(
         conversationId, visibility, pagingConfig
     ).flowOn(dispatcher.io)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -149,7 +149,7 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         val unreadMessagesCount: Int = 0,
         val unreadMentionsCount: Long = 0L,
         val unreadEventCount: UnreadEventCount,
-        val lastMessage: Message?
+        val lastMessage: Message.Standalone?
     ) : ConversationDetails(conversation)
 
     data class Group(
@@ -159,7 +159,7 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         val unreadMessagesCount: Int = 0,
         val unreadMentionsCount: Long = 0L,
         val unreadEventCount: UnreadEventCount,
-        val lastMessage: Message?,
+        val lastMessage: Message.Standalone?,
         val isSelfUserMember: Boolean,
         val isSelfUserCreator: Boolean
     ) : ConversationDetails(conversation)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -35,7 +35,7 @@ interface ConversationMapper {
     fun fromApiModelToDaoModel(apiModel: ConversationResponse, mlsGroupState: GroupState?, selfUserTeamId: TeamId?): ConversationEntity
     fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol
     fun fromDaoModel(daoModel: ConversationViewEntity): Conversation
-    fun fromDaoModelToDetails(daoModel: ConversationViewEntity, lastMessage: Message?): ConversationDetails
+    fun fromDaoModelToDetails(daoModel: ConversationViewEntity, lastMessage: Message.Standalone?): ConversationDetails
     fun fromDaoModel(daoModel: ProposalTimerEntity): ProposalTimer
     fun toDAOAccess(accessList: Set<ConversationAccessDTO>): List<ConversationEntity.Access>
     fun toDAOAccessRole(accessRoleList: Set<ConversationAccessRoleDTO>): List<ConversationEntity.AccessRole>
@@ -105,7 +105,7 @@ internal class ConversationMapperImpl(
     }
 
     @Suppress("ComplexMethod", "LongMethod")
-    override fun fromDaoModelToDetails(daoModel: ConversationViewEntity, lastMessage: Message?): ConversationDetails =
+    override fun fromDaoModelToDetails(daoModel: ConversationViewEntity, lastMessage: Message.Standalone?): ConversationDetails =
         with(daoModel) {
             when (type) {
                 ConversationEntity.Type.SELF -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -19,7 +19,7 @@ import kotlinx.datetime.Instant
 
 interface MessageMapper {
     fun fromMessageToEntity(message: Message.Standalone): MessageEntity
-    fun fromEntityToMessage(message: MessageEntity): Message
+    fun fromEntityToMessage(message: MessageEntity): Message.Standalone
     fun fromMessageToLocalNotificationMessage(message: Message, author: LocalNotificationMessageAuthor): LocalNotificationMessage
 }
 
@@ -70,7 +70,7 @@ class MessageMapperImpl(
         }
     }
 
-    override fun fromEntityToMessage(message: MessageEntity): Message {
+    override fun fromEntityToMessage(message: MessageEntity): Message.Standalone {
         val status = when (message.status) {
             MessageEntity.Status.PENDING -> Message.Status.PENDING
             MessageEntity.Status.SENT -> Message.Status.SENT


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When fetching a list of messages, we're only returning the `standalone` messages: The ones that can be visible.

However, I forgot to make it clear when doing #1171 

### Solutions

Specify the `Standalone` subtype.

> **Note**: What about renaming `Standalone` to `Displayable` or something like that?
> Any name suggestion is welcome.

### Testing

Compiler does it ;) 

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
