### PR TITLE
fix(notifications): set connections and conversations notif flag in single query (AR-2771)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -167,7 +167,7 @@ internal class ConnectionDataSource(
     }
 
     override suspend fun setAllConnectionsAsNotified() {
-        connectionDAO.updateAllNotificationFlags(false)
+        connectionDAO.setAllConnectionsAsNotified()
     }
 
     override suspend fun insertConnectionFromEvent(event: Event.User.NewConnection): Either<CoreFailure, Unit> =

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
@@ -33,6 +33,11 @@ UPDATE Connection SET last_update = ? WHERE to_id = ?;
 updateNotificationFlag:
 UPDATE Connection SET should_notify = ? WHERE qualified_to = ?;
 
+setAllConnectionsAsNotified:
+UPDATE Connection SET should_notify = 0
+WHERE qualified_to IN
+(SELECT qualified_conversation FROM Connection WHERE status = 'PENDING' AND should_notify = 1);
+
 getConnections:
 SELECT * FROM Connection;
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
@@ -35,8 +35,7 @@ UPDATE Connection SET should_notify = ? WHERE qualified_to = ?;
 
 setAllConnectionsAsNotified:
 UPDATE Connection SET should_notify = 0
-WHERE qualified_to IN
-(SELECT qualified_conversation FROM Connection WHERE status = 'PENDING' AND should_notify = 1);
+WHERE status = 'PENDING' AND should_notify = 1;
 
 getConnections:
 SELECT * FROM Connection;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -69,12 +69,9 @@ WHERE qualified_id = ?;
 updateAllUnNotifiedConversationsNotificationsDate:
 UPDATE Conversation
 SET last_notified_message_date = ?
-WHERE qualified_id IN
-(SELECT qualified_id FROM ConversationDetails
- WHERE mutedStatus != 'ALL_MUTED'
- AND (lastNotifiedMessageDate ISNULL
- OR DateTime(last_modified_date) > DateTime(lastNotifiedMessageDate))
-);
+WHERE muted_status != 'ALL_MUTED'
+AND (last_notified_message_date ISNULL
+OR DateTime(last_modified_date) > DateTime(last_notified_message_date));
 
 updateConversationModifiedDate:
 UPDATE Conversation

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -66,6 +66,16 @@ UPDATE Conversation
 SET last_notified_message_date = ?
 WHERE qualified_id = ?;
 
+updateAllUnNotifiedConversationsNotificationsDate:
+UPDATE Conversation
+SET last_notified_message_date = ?
+WHERE qualified_id IN
+(SELECT qualified_id FROM ConversationDetails
+ WHERE mutedStatus != 'ALL_MUTED'
+ AND (lastNotifiedMessageDate ISNULL
+ OR DateTime(last_modified_date) > DateTime(lastNotifiedMessageDate))
+);
+
 updateConversationModifiedDate:
 UPDATE Conversation
 SET last_modified_date = ?

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -443,7 +443,7 @@ countByConversationIdAndVisibility:
 SELECT count(*) FROM Message WHERE conversation_id = ? AND visibility IN ? ORDER BY Datetime(date) DESC;
 
 selectByConversationIdAndVisibility:
-SELECT * FROM MessageDetailsView WHERE MessageDetailsView.conversationId = ? AND visibility IN ? ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;
+SELECT * FROM MessageDetailsView WHERE MessageDetailsView.conversationId = ? AND visibility IN ?  ORDER BY Datetime(date) DESC LIMIT ? OFFSET ?;
 
 selectMessagesByConversationIdAndVisibilityAfterDate:
 SELECT * FROM MessageDetailsView WHERE MessageDetailsView.conversationId = ? AND visibility IN ? AND Datetime(date) > Datetime(?) ORDER BY Datetime(date) DESC;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
@@ -51,4 +51,5 @@ interface ConnectionDAO {
     suspend fun getConnectionRequestsForNotification(): Flow<List<ConnectionEntity>>
     suspend fun updateNotificationFlag(flag: Boolean, userId: QualifiedIDEntity)
     suspend fun updateAllNotificationFlags(flag: Boolean)
+    suspend fun setAllConnectionsAsNotified()
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
@@ -2,12 +2,12 @@ package com.wire.kalium.persistence.dao
 
 import com.squareup.sqldelight.runtime.coroutines.asFlow
 import com.squareup.sqldelight.runtime.coroutines.mapToList
-import com.wire.kalium.persistence.Connection as SQLDelightConnection
 import com.wire.kalium.persistence.ConnectionsQueries
 import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.util.requireField
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import com.wire.kalium.persistence.Connection as SQLDelightConnection
 
 private class ConnectionMapper {
     fun toModel(state: SQLDelightConnection): ConnectionEntity = ConnectionEntity(
@@ -147,5 +147,9 @@ class ConnectionDAOImpl(
                 .executeAsList()
                 .forEach { connectionsQueries.updateNotificationFlag(flag, it.qualified_to) }
         }
+    }
+
+    override suspend fun setAllConnectionsAsNotified() {
+        connectionsQueries.setAllConnectionsAsNotified()
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -224,11 +224,7 @@ class ConversationDAOImpl(
     }
 
     override suspend fun updateAllConversationsNotificationDate(date: String) {
-        conversationQueries.transaction {
-            conversationQueries.selectConversationsWithUnnotifiedMessages()
-                .executeAsList()
-                .forEach { conversationQueries.updateConversationNotificationsDate(date, it.qualifiedId) }
-        }
+        conversationQueries.updateAllUnNotifiedConversationsNotificationsDate(date)
     }
 
     override suspend fun getAllConversations(): Flow<List<ConversationViewEntity>> {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConnectionDaoTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConnectionDaoTest.kt
@@ -68,7 +68,7 @@ class ConnectionDaoTest : BaseDatabaseTest() {
             lastUpdate = "2022-03-30T15:36:00.000Z",
             qualifiedConversationId = QualifiedIDEntity(id, "wire.com"),
             qualifiedToId = QualifiedIDEntity("me", "wire.com"),
-            status = ConnectionEntity.State.SENT,
+            status = ConnectionEntity.State.PENDING,
             toId = "me@wire.com",
             shouldNotify = true
         )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConnectionDaoTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConnectionDaoTest.kt
@@ -55,7 +55,7 @@ class ConnectionDaoTest : BaseDatabaseTest() {
     fun givenFewConnections_WhenUpdateNotifyFlagForAll_ThenItIsUpdated() = runTest {
         db.connectionDAO.insertConnection(connection1)
         db.connectionDAO.insertConnection(connection2)
-        db.connectionDAO.updateAllNotificationFlags(false)
+        db.connectionDAO.setAllConnectionsAsNotified()
         val result = db.connectionDAO.getConnectionRequests().first()
         assertEquals(false, result[0].shouldNotify)
         assertEquals(false, result[1].shouldNotify)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
To reset the notification flag for conversations and connections, we can perform the update 1 single query.

### Issues
It was implemented with nested loops instead of single query.

### Causes (Optional)
Performance!

### Solutions

Replaced with single query.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
