### PR TITLE
feat: receive receipts (AR-2678)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.logic.data.message
 
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.mention.MessageMention
+import com.wire.kalium.logic.data.message.receipt.ReceiptType
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.datetime.Instant
@@ -185,9 +186,7 @@ sealed class MessageContent {
 
     data class Availability(val status: UserAvailabilityStatus) : Signaling()
 
-    data class Receipt(val type: Type, val messageIds: List<String>) : Signaling() {
-        enum class Type { READ, DELIVERY }
-    }
+    data class Receipt(val type: ReceiptType, val messageIds: List<String>) : Signaling()
 
     // we can add other types to be processed, but signaling ones shouldn't be persisted
     object Ignored : Signaling() // messages that aren't processed in any way

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/receipt/ReceiptRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/receipt/ReceiptRepository.kt
@@ -15,7 +15,7 @@ interface ReceiptRepository {
         conversationId: ConversationId,
         date: Instant,
         type: ReceiptType,
-        vararg messageIds: String
+        messageIds: List<String>
     )
 
     suspend fun observeMessageReceipts(
@@ -36,7 +36,7 @@ class ReceiptRepositoryImpl(
         conversationId: ConversationId,
         date: Instant,
         type: ReceiptType,
-        vararg messageIds: String
+        messageIds: List<String>
     ) {
         receiptDAO.insertReceipts(
             userId = idMapper.toDaoModel(userId),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -618,7 +618,7 @@ class UserSessionScope internal constructor(
 
     private val messageEncoder get() = MessageContentEncoder()
 
-    private val receiptMessageHandler = ReceiptMessageHandler(
+    private val receiptMessageHandler get() = ReceiptMessageHandler(
         selfUserId = this.userId,
         receiptRepository = receiptRepository
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -191,6 +191,7 @@ import com.wire.kalium.logic.sync.receiver.message.ClearConversationContentHandl
 import com.wire.kalium.logic.sync.receiver.message.DeleteForMeHandler
 import com.wire.kalium.logic.sync.receiver.message.LastReadContentHandler
 import com.wire.kalium.logic.sync.receiver.message.MessageTextEditHandler
+import com.wire.kalium.logic.sync.receiver.message.ReceiptMessageHandler
 import com.wire.kalium.logic.sync.slow.SlowSlowSyncCriteriaProviderImpl
 import com.wire.kalium.logic.sync.slow.SlowSyncCriteriaProvider
 import com.wire.kalium.logic.sync.slow.SlowSyncManager
@@ -617,6 +618,11 @@ class UserSessionScope internal constructor(
 
     private val messageEncoder get() = MessageContentEncoder()
 
+    private val receiptMessageHandler = ReceiptMessageHandler(
+        selfUserId = this.userId,
+        receiptRepository = receiptRepository
+    )
+
     private val applicationMessageHandler: ApplicationMessageHandler
         get() = ApplicationMessageHandlerImpl(
             userRepository,
@@ -634,7 +640,8 @@ class UserSessionScope internal constructor(
                 selfConversationIdProvider,
             ),
             DeleteForMeHandler(conversationRepository, messageRepository, userId, selfConversationIdProvider),
-            messageEncoder
+            messageEncoder,
+            receiptMessageHandler
         )
 
     private val newMessageHandler: NewMessageEventHandlerImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.sync.receiver.message.ClearConversationContentHandl
 import com.wire.kalium.logic.sync.receiver.message.DeleteForMeHandler
 import com.wire.kalium.logic.sync.receiver.message.LastReadContentHandler
 import com.wire.kalium.logic.sync.receiver.message.MessageTextEditHandler
+import com.wire.kalium.logic.sync.receiver.message.ReceiptMessageHandler
 import com.wire.kalium.logic.util.MessageContentEncoder
 import com.wire.kalium.util.string.toHexString
 
@@ -62,7 +63,8 @@ internal class ApplicationMessageHandlerImpl(
     private val lastReadContentHandler: LastReadContentHandler,
     private val clearConversationContentHandler: ClearConversationContentHandler,
     private val deleteForMeHandler: DeleteForMeHandler,
-    private val messageEncoder: MessageContentEncoder
+    private val messageEncoder: MessageContentEncoder,
+    private val receiptMessageHandler: ReceiptMessageHandler
 ) : ApplicationMessageHandler {
 
     private val logger by lazy { kaliumLogger.withFeatureId(ApplicationFlow.EVENT_RECEIVER) }
@@ -173,7 +175,7 @@ internal class ApplicationMessageHandlerImpl(
             is MessageContent.TextEdited -> editTextHandler.handle(signaling, content)
             is MessageContent.LastRead -> lastReadContentHandler.handle(signaling, content)
             is MessageContent.Cleared -> clearConversationContentHandler.handle(signaling, content)
-            is MessageContent.Receipt -> TODO("Receiving of read receipts not yet implemented")
+            is MessageContent.Receipt -> receiptMessageHandler.handle(signaling, content)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/ReceiptMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/ReceiptMessageHandler.kt
@@ -1,0 +1,31 @@
+package com.wire.kalium.logic.sync.receiver.message
+
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.receipt.ReceiptRepository
+import com.wire.kalium.logic.data.user.UserId
+import kotlinx.datetime.Instant
+
+internal class ReceiptMessageHandler(
+    private val selfUserId: UserId,
+    private val receiptRepository: ReceiptRepository
+) {
+
+    suspend fun handle(
+        message: Message.Signaling,
+        messageContent: MessageContent.Receipt
+    ) {
+        // Receipts from self user shouldn't happen,
+        // If it happens, it's unnecessary,
+        // and we can squish some performance by skipping it completely
+        if (message.senderUserId == selfUserId) return
+
+        receiptRepository.persistReceipts(
+            userId = message.senderUserId,
+            conversationId = message.conversationId,
+            date = Instant.parse(message.date),
+            type = messageContent.type,
+            messageIds = messageContent.messageIds
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/receipt/ReceiptRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/receipt/ReceiptRepositoryTest.kt
@@ -42,7 +42,7 @@ class ReceiptRepositoryTest {
             conversationId = TEST_CONVERSATION_ID,
             date = date,
             type = ReceiptType.READ,
-            messageIds = arrayOf(TEST_MESSAGE_ID)
+            messageIds = listOf(TEST_MESSAGE_ID)
         )
 
         launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -70,7 +70,7 @@ class ReceiptRepositoryTest {
                 conversationId = TEST_CONVERSATION_ID,
                 date = date,
                 type = ReceiptType.READ,
-                messageIds = arrayOf(TEST_MESSAGE_ID)
+                messageIds = listOf(TEST_MESSAGE_ID)
             )
 
             receiptRepository.persistReceipts(
@@ -78,7 +78,7 @@ class ReceiptRepositoryTest {
                 conversationId = TEST_CONVERSATION_ID,
                 date = date,
                 type = ReceiptType.READ,
-                messageIds = arrayOf(TEST_MESSAGE_ID)
+                messageIds = listOf(TEST_MESSAGE_ID)
             )
 
             launch(UnconfinedTestDispatcher(testScheduler)) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/ObserveMessageReceiptsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/ObserveMessageReceiptsUseCaseTest.kt
@@ -8,6 +8,7 @@ import com.wire.kalium.logic.data.message.receipt.DetailedReceipt
 import com.wire.kalium.logic.data.message.receipt.ReceiptType
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestMessage
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -30,6 +32,14 @@ class ObserveMessageReceiptsUseCaseTest {
         var usedReceiptType: ReceiptType? = null
 
         val receiptRepository = object : ReceiptRepositoryStub() {
+            override suspend fun persistReceipts(
+                userId: UserId,
+                conversationId: ConversationId,
+                date: Instant,
+                type: ReceiptType,
+                messageIds: List<String>
+            ) = Unit
+
             override suspend fun observeMessageReceipts(
                 conversationId: ConversationId,
                 messageId: String,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/stub/ReceiptRepositoryStub.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/stub/ReceiptRepositoryStub.kt
@@ -16,7 +16,7 @@ open class ReceiptRepositoryStub : ReceiptRepository {
         conversationId: ConversationId,
         date: Instant,
         type: ReceiptType,
-        vararg messageIds: String
+        messageIds: List<String>
     ): Unit = Unit
 
     override suspend fun observeMessageReceipts(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
@@ -15,6 +15,7 @@ import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.message.PersistReactionUseCase
 import com.wire.kalium.logic.data.message.ProtoContent
+import com.wire.kalium.logic.data.message.receipt.ReceiptRepository
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentImpl
@@ -26,6 +27,7 @@ import com.wire.kalium.logic.sync.receiver.message.ClearConversationContentHandl
 import com.wire.kalium.logic.sync.receiver.message.DeleteForMeHandler
 import com.wire.kalium.logic.sync.receiver.message.LastReadContentHandler
 import com.wire.kalium.logic.sync.receiver.message.MessageTextEditHandler
+import com.wire.kalium.logic.sync.receiver.message.ReceiptMessageHandler
 import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.logic.util.MessageContentEncoder
 import io.mockative.Mock
@@ -101,6 +103,9 @@ class ApplicationMessageHandlerTest {
         private val userRepository = mock(classOf<UserRepository>())
 
         @Mock
+        private val receiptRepository = mock(classOf<ReceiptRepository>())
+
+        @Mock
         val userConfigRepository = mock(classOf<UserConfigRepository>())
 
         @Mock
@@ -135,7 +140,11 @@ class ApplicationMessageHandlerTest {
                 selfUserId = TestUser.USER_ID,
                 selfConversationIdProvider = selfConversationIdProvider
             ),
-            MessageContentEncoder()
+            MessageContentEncoder(),
+            ReceiptMessageHandler(
+                selfUserId = TestUser.USER_ID,
+                receiptRepository = receiptRepository
+            )
         )
 
         fun withPersistingMessageReturning(result: Either<CoreFailure, Unit>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
@@ -1,0 +1,145 @@
+package com.wire.kalium.logic.sync.receiver.conversation.message
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.receipt.ReceiptRepository
+import com.wire.kalium.logic.data.message.receipt.ReceiptRepositoryImpl
+import com.wire.kalium.logic.data.message.receipt.ReceiptType
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.sync.receiver.message.ReceiptMessageHandler
+import com.wire.kalium.persistence.TestUserDatabase
+import com.wire.kalium.persistence.dao.ConversationIDEntity
+import com.wire.kalium.persistence.dao.UserIDEntity
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ReceiptMessageHandlerTest {
+
+    private val userDatabase = TestUserDatabase(SELF_USER_ID_ENTITY)
+    private val receiptRepository: ReceiptRepository = ReceiptRepositoryImpl(userDatabase.builder.receiptDAO)
+    private val receiptMessageHandler = ReceiptMessageHandler(SELF_USER_ID, receiptRepository)
+
+    private suspend fun insertTestData() {
+        userDatabase.builder.userDAO.insertUser(TestUser.ENTITY.copy(id = SELF_USER_ID_ENTITY))
+        userDatabase.builder.userDAO.insertUser(TestUser.ENTITY.copy(id = OTHER_USER_ID_ENTITY))
+        userDatabase.builder.conversationDAO.insertConversation(CONVERSATION_ENTITY)
+        userDatabase.builder.messageDAO.insertMessage(MESSAGE_ENTITY)
+    }
+
+    @Test
+    fun givenAReceiptIsHandled_whenFetchingReceiptsOfThatType_thenTheResultShouldContainTheNewReceipt() = runTest {
+        insertTestData()
+
+        val date = Clock.System.now()
+        val senderUserId = OTHER_USER_ID
+        val type = ReceiptType.READ
+
+        handleNewReceipt(type, date, senderUserId)
+
+        receiptRepository.observeMessageReceipts(CONVERSATION_ID, MESSAGE_ID, ReceiptType.READ).test {
+            assertEquals(1, awaitItem().size)
+        }
+    }
+
+    @Test
+    fun givenAReceiptIsHandled_whenFetchingReceiptsOfThatType_thenTheResultShouldMatchTheDateAndUser() = runTest {
+        insertTestData()
+
+        val date = Clock.System.now()
+        val senderUserId = OTHER_USER_ID
+        val type = ReceiptType.READ
+
+        handleNewReceipt(type, date, senderUserId)
+
+        receiptRepository.observeMessageReceipts(CONVERSATION_ID, MESSAGE_ID, ReceiptType.READ).test {
+            val batch = awaitItem()
+            assertEquals(1, batch.size)
+            val receipt = batch.first()
+            assertEquals(date, receipt.date)
+            assertEquals(senderUserId, receipt.userSummary.userId)
+        }
+    }
+
+    @Test
+    fun givenAReceiptOfSelfUserIsHandled_whenFetchingReceiptsOfThatType_thenTheResultShouldContainNoReceipts() = runTest {
+        insertTestData()
+
+        val date = Clock.System.now()
+        // Using Self User ID for the receipt
+        val senderUserId = SELF_USER_ID
+        val type = ReceiptType.READ
+
+        handleNewReceipt(type, date, senderUserId)
+
+        receiptRepository.observeMessageReceipts(CONVERSATION_ID, MESSAGE_ID, ReceiptType.READ).test {
+            assertTrue { awaitItem().isEmpty() }
+        }
+    }
+
+    @Test
+    fun givenAReceiptIsHandled_whenFetchingReceiptsOfAnotherType_thenTheResultShouldContainNoReceipts() = runTest {
+        insertTestData()
+
+        val date = Clock.System.now()
+        val senderUserId = OTHER_USER_ID
+        // Delivery != Read
+        val type = ReceiptType.DELIVERY
+
+        handleNewReceipt(type, date, senderUserId)
+
+        receiptRepository.observeMessageReceipts(CONVERSATION_ID, MESSAGE_ID, ReceiptType.READ).test {
+            assertTrue { awaitItem().isEmpty() }
+        }
+    }
+
+    private suspend fun handleNewReceipt(
+        type: ReceiptType,
+        date: Instant,
+        senderUserId: QualifiedID
+    ) {
+        val content = MessageContent.Receipt(
+            type = type,
+            messageIds = listOf(MESSAGE_ID)
+        )
+        receiptMessageHandler.handle(
+            message = Message.Signaling(
+                id = "signalingId",
+                content = content,
+                conversationId = CONVERSATION_ID,
+                date = date.toString(),
+                senderUserId = senderUserId,
+                senderClientId = ClientId("SomeClientId"),
+                status = Message.Status.SENT,
+            ),
+            messageContent = content
+        )
+    }
+
+    private companion object {
+        val CONVERSATION_ID = TestConversation.CONVERSATION.id
+        val CONVERSATION_ENTITY_ID = ConversationIDEntity(CONVERSATION_ID.value, CONVERSATION_ID.domain)
+        val CONVERSATION_ENTITY = TestConversation.ENTITY.copy(id = CONVERSATION_ENTITY_ID)
+
+        val SELF_USER_ID = TestUser.SELF.id
+        val SELF_USER_ID_ENTITY = UserIDEntity(SELF_USER_ID.value, SELF_USER_ID.domain)
+
+        val OTHER_USER_ID = TestUser.OTHER_USER_ID
+        val OTHER_USER_ID_ENTITY = UserIDEntity(OTHER_USER_ID.value, OTHER_USER_ID.domain)
+
+        val MESSAGE_ID = "messageId"
+        val MESSAGE_ENTITY = TestMessage.ENTITY.copy(
+            id = MESSAGE_ID,
+            conversationId = CONVERSATION_ENTITY_ID,
+            senderUserId = SELF_USER_ID_ENTITY,
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
@@ -135,7 +135,7 @@ class ReceiptMessageHandlerTest {
         val OTHER_USER_ID = TestUser.OTHER_USER_ID
         val OTHER_USER_ID_ENTITY = UserIDEntity(OTHER_USER_ID.value, OTHER_USER_ID.domain)
 
-        val MESSAGE_ID = "messageId"
+        const val MESSAGE_ID = "messageId"
         val MESSAGE_ENTITY = TestMessage.ENTITY.copy(
             id = MESSAGE_ID,
             conversationId = CONVERSATION_ENTITY_ID,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/receipt/ReceiptDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/receipt/ReceiptDAO.kt
@@ -14,7 +14,7 @@ interface ReceiptDAO {
         conversationId: ConversationIDEntity,
         date: Instant,
         type: ReceiptTypeEntity,
-        vararg messageIds: String
+        messageIds: List<String>
     )
 
     suspend fun observeDetailedReceiptsForMessage(
@@ -33,7 +33,7 @@ class ReceiptDAOImpl(
         conversationId: ConversationIDEntity,
         date: Instant,
         type: ReceiptTypeEntity,
-        vararg messageIds: String
+        messageIds: List<String>
     ) {
         receiptsQueries.transaction {
             messageIds.forEach { messageId ->

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/receipt/ReceiptDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/receipt/ReceiptDAOTest.kt
@@ -50,7 +50,7 @@ class ReceiptDAOTest : BaseDatabaseTest() {
 
         val insertedInstant = Clock.System.now()
         receiptDAO.insertReceipts(
-            OTHER_USER.id, TEST_CONVERSATION.id, insertedInstant, ReceiptTypeEntity.DELIVERY, TEST_MESSAGE.id
+            OTHER_USER.id, TEST_CONVERSATION.id, insertedInstant, ReceiptTypeEntity.DELIVERY, listOf(TEST_MESSAGE.id)
         )
 
         val result = receiptDAO
@@ -78,10 +78,10 @@ class ReceiptDAOTest : BaseDatabaseTest() {
         insertTestData()
 
         receiptDAO.insertReceipts(
-            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, TEST_MESSAGE.id
+            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, listOf(TEST_MESSAGE.id)
         )
         receiptDAO.insertReceipts(
-            SELF_USER_ID, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, TEST_MESSAGE.id
+            SELF_USER_ID, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, listOf(TEST_MESSAGE.id)
         )
 
         val result = receiptDAO
@@ -98,10 +98,10 @@ class ReceiptDAOTest : BaseDatabaseTest() {
         insertTestData()
 
         receiptDAO.insertReceipts(
-            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, TEST_MESSAGE.id
+            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, listOf(TEST_MESSAGE.id)
         )
         receiptDAO.insertReceipts(
-            SELF_USER_ID, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.READ, TEST_MESSAGE.id
+            SELF_USER_ID, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.READ, listOf(TEST_MESSAGE.id)
         )
 
         val result = receiptDAO
@@ -125,10 +125,10 @@ class ReceiptDAOTest : BaseDatabaseTest() {
         )
 
         receiptDAO.insertReceipts(
-            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, TEST_MESSAGE.id
+            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, listOf(TEST_MESSAGE.id)
         )
         receiptDAO.insertReceipts(
-            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, otherMessageId
+            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, listOf(otherMessageId)
         )
 
         val result = receiptDAO


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We're not receiving read/delivery receipts.

### Solutions

Implement it.
Although the model was already there and we were able to read from storage, there was no protobuf parsing and insertion into the DB.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
