### PR TITLE
fix: crash when inserting receipts of unknown messages

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Receipts.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Receipts.sq
@@ -12,9 +12,25 @@ CREATE TABLE Receipt (
     PRIMARY KEY (message_id, conversation_id, user_id, type)
 );
 
+-- TODO: Cast to proper types when/if SQLDelight supports it:
 insertReceipt:
+WITH insertion(message_id, conversation_id, user_id, type, date) AS(
+    VALUES (CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT))
+)
 INSERT OR IGNORE INTO Receipt(message_id, conversation_id, user_id, type, date)
-VALUES(?, ?, ?, ?, ?);
+SELECT
+    insertion.message_id,
+    insertion.conversation_id,
+    insertion.user_id,
+    insertion.type,
+    insertion.date
+FROM insertion
+WHERE EXISTS (
+    SELECT 1 FROM Message
+    WHERE
+        Message.conversation_id = insertion.conversation_id AND
+        Message.id = insertion.message_id
+);
 
 CREATE VIEW IF NOT EXISTS ReceiptDetails
 AS SELECT

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/receipt/ReceiptDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/receipt/ReceiptDAO.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.persistence.dao.receipt
 
 import com.squareup.sqldelight.runtime.coroutines.asFlow
+import com.wire.kalium.persistence.Receipt
 import com.wire.kalium.persistence.ReceiptsQueries
 import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -25,7 +26,8 @@ interface ReceiptDAO {
 }
 
 class ReceiptDAOImpl(
-    private val receiptsQueries: ReceiptsQueries
+    private val receiptsQueries: ReceiptsQueries,
+    private val receiptAdapter: Receipt.Adapter
 ) : ReceiptDAO {
 
     override suspend fun insertReceipts(
@@ -38,7 +40,11 @@ class ReceiptDAOImpl(
         receiptsQueries.transaction {
             messageIds.forEach { messageId ->
                 receiptsQueries.insertReceipt(
-                    messageId, conversationId, userId, type, date.toString()
+                    messageId,
+                    receiptAdapter.conversation_idAdapter.encode(conversationId),
+                    receiptAdapter.user_idAdapter.encode(userId),
+                    receiptAdapter.typeAdapter.encode(type),
+                    date.toString()
                 )
             }
         }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -118,7 +118,7 @@ class UserDatabaseBuilder internal constructor(
         get() = ReactionDAOImpl(database.reactionsQueries)
 
     val receiptDAO: ReceiptDAO
-        get() = ReceiptDAOImpl(database.receiptsQueries)
+        get() = ReceiptDAOImpl(database.receiptsQueries, TableMapper.receiptAdapter)
 
     val prekeyDAO: PrekeyDAO
         get() = PrekeyDAOImpl(database.metadataQueries)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/receipt/ReceiptDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/receipt/ReceiptDAOTest.kt
@@ -139,6 +139,15 @@ class ReceiptDAOTest : BaseDatabaseTest() {
         assertEquals(ReceiptTypeEntity.DELIVERY, result.first().type)
     }
 
+    @Test
+    fun givenReceiptsOfAnUnknownMessage_whenGettingDetails_shouldNotThrow() = runTest {
+        insertTestData()
+
+        receiptDAO.insertReceipts(
+            OTHER_USER.id, TEST_CONVERSATION.id, Clock.System.now(), ReceiptTypeEntity.DELIVERY, listOf("SomeUnknownMessage")
+        )
+    }
+
     private suspend fun insertTestData() {
         userDAO.insertUser(SELF_USER)
         userDAO.insertUser(OTHER_USER)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Crash when inserting some read receipts.

### Causes

Other clients may send read receipts of messages unknown to us, as maybe they were batching and sending all at once, including messages that existed before we logged in on this new device.

`INSERT OR IGNORE` serves for checking when `PRIMARY KEY` or `UNIQUE` constraints fail, **it does not** ignore `FOREIGN KEY` constraints, which is this case.


### Solutions

A bit of a complicated insert with `WHERE EXISTS`.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Send messages from device A in a conversation.
Login with device B.
Read the messages from another account.
Device B should receive receipts from older messages unknown to it

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
