### PR TITLE
test: fix flaky tests using UnconfinedTestDispatcher

### DIFF
--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -13,7 +13,6 @@ import com.wire.kalium.persistence.utils.stubs.newUserEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -386,7 +385,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             val expectedConversationSeenDate = "2022-03-30T15:36:00.000Z"
             teamDAO.insertTeam(team)
 
-            launch(UnconfinedTestDispatcher(testScheduler)) {
+            launch {
                 // when
                 conversationDAO.observeGetConversationByQualifiedID(conversationEntity1.id).test {
                     // then
@@ -409,7 +408,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
                     cancelAndIgnoreRemainingEvents()
                 }
-            }
+            }.join()
         }
 
     @Test
@@ -528,7 +527,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 //
 //         messageDAO.insertMessages(message)
 //
-//         launch(UnconfinedTestDispatcher(testScheduler)) {
+//         launch {
 //             // when
 //             conversationDAO.observeGetConversationByQualifiedID(conversationId).test {
 //                 val conversation = awaitItem()
@@ -536,7 +535,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 //                 // then
 //                 assertEquals(unreadMessagesCount, conversation.unreadContentCountEntity.values.sum())
 //             }
-//         }
+//         }.join()
 //     }
 
     @Test
@@ -581,7 +580,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         messageDAO.insertMessages(message)
 
-        launch(UnconfinedTestDispatcher(testScheduler)) {
+        launch {
             // when
             conversationDAO.observeGetConversationByQualifiedID(conversationId).test {
                 val conversation = awaitItem()
@@ -589,7 +588,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
                 // then
                 assertEquals(unreadMessagesCount, conversation.unreadContentCountEntity.values.sum())
             }
-        }
+        }.join()
     }
 
     // TODO kubaz enable after unread counter performance fix
@@ -618,7 +617,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 //             )
 //         )
 //
-//         launch(UnconfinedTestDispatcher(testScheduler)) {
+//         launch {
 //             // when
 //             conversationDAO.observeGetConversationByQualifiedID(conversationId).test {
 //                 val conversation = awaitItem()
@@ -626,7 +625,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 //                 // then
 //                 assertContains(conversation.unreadContentCountEntity.keys, MessageEntity.ContentType.TEXT)
 //             }
-//         }
+//         }.join
 //     }
 
     @Test
@@ -669,7 +668,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             )
         )
 
-        launch(UnconfinedTestDispatcher(testScheduler)) {
+        launch {
             // when
             conversationDAO.observeGetConversationByQualifiedID(conversationId).test {
                 val conversation = awaitItem()
@@ -677,7 +676,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
                 // then
                 assertContains(conversation.unreadContentCountEntity.keys, MessageEntity.ContentType.ASSET)
             }
-        }
+        }.join()
     }
 
     // TODO kubaz fix after implementing unread indicator
@@ -706,7 +705,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 //             )
 //         )
 //
-//         launch(UnconfinedTestDispatcher(testScheduler)) {
+//         launch {
 //             // when
 //             conversationDAO.observeGetConversationByQualifiedID(conversationId).test {
 //                 val conversation = awaitItem()
@@ -714,7 +713,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 //                 // then
 //                 assertContains(conversation.unreadContentCountEntity.keys, MessageEntity.ContentType.MISSED_CALL)
 //             }
-//         }
+//         }.join()
 //     }
 
     @Test
@@ -746,7 +745,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         messageDAO.insertMessages(message)
 
-        launch(UnconfinedTestDispatcher(testScheduler)) {
+        launch {
             // when
             conversationDAO.observeGetConversationByQualifiedID(conversationId).test {
                 val conversation = awaitItem()
@@ -754,7 +753,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
                 // then
                 assertEquals(0, conversation.unreadContentCountEntity.values.sum())
             }
-        }
+        }.join()
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some flaky tests were introduced recently and they're making a lot of PR checks fail.

### Causes

Usage of `launch(UnconfinedTestDispatcher)` without waiting for the job to end, causing `UncompletedCoroutinesError`

### Solutions

Remove unnecessary `UnconfinedTestDispatcher`, add `join` to wait completion.

> **Note**: We should be able to upgrade `turbine` soon as we upgrade Kotlin, removing the need to use the `launch` completely.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
