### PR TITLE
refactor: use clientIdProvider to get cached value

### DIFF
--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -5,7 +5,6 @@ import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -15,6 +14,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import io.mockative.Mock
@@ -44,7 +44,7 @@ class CallManagerTest {
     private val messageSender = mock(classOf<MessageSender>())
 
     @Mock
-    private val clientRepository = mock(classOf<ClientRepository>())
+    private val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
     @Mock
     private val conversationRepository = mock(classOf<ConversationRepository>())
@@ -70,7 +70,7 @@ class CallManagerTest {
             calling = calling,
             callRepository = callRepository,
             userRepository = userRepository,
-            clientRepository = clientRepository,
+            currentClientIdProvider = currentClientIdProvider,
             conversationRepository = conversationRepository,
             messageSender = messageSender,
             kaliumDispatchers = dispatcher,

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -16,7 +16,6 @@ import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.ParticipantMapperImpl
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -57,13 +56,14 @@ import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallClientList
 import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 
 @Suppress("LongParameterList", "TooManyFunctions")
 class CallManagerImpl internal constructor(
     private val calling: Calling,
     private val callRepository: CallRepository,
     private val userRepository: UserRepository,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val conversationRepository: ConversationRepository,
     private val messageSender: MessageSender,
     kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl,
@@ -84,7 +84,7 @@ class CallManagerImpl internal constructor(
     }
 
     private val clientId: Deferred<ClientId> = scope.async(start = CoroutineStart.LAZY) {
-        clientRepository.currentClientId().fold({
+        currentClientIdProvider().fold({
             TODO("adjust correct variable calling")
         }, {
             callingLogger.d("$TAG - clientId $it")

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -9,13 +9,13 @@ import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapper
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 import io.ktor.util.collections.ConcurrentMap
 import kotlinx.coroutines.Dispatchers
@@ -47,7 +47,7 @@ actual class GlobalCallManager(
         userId: QualifiedID,
         callRepository: CallRepository,
         userRepository: UserRepository,
-        clientRepository: ClientRepository,
+        currentClientIdProvider: CurrentClientIdProvider,
         conversationRepository: ConversationRepository,
         messageSender: MessageSender,
         callMapper: CallMapper,
@@ -59,7 +59,7 @@ actual class GlobalCallManager(
             calling = calling,
             callRepository = callRepository,
             userRepository = userRepository,
-            clientRepository = clientRepository,
+            currentClientIdProvider = currentClientIdProvider,
             callMapper = callMapper,
             messageSender = messageSender,
             conversationRepository = conversationRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProvider.kt
@@ -8,6 +8,7 @@ import com.wire.kalium.cryptography.MlsDBSecret
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.util.SecurityHelper
@@ -21,14 +22,14 @@ interface MLSClientProvider {
 class MLSClientProviderImpl(
     private val rootKeyStorePath: String,
     private val userId: UserId,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val passphraseStorage: PassphraseStorage
 ) : MLSClientProvider {
 
     private var mlsClient: MLSClient? = null
 
     override suspend fun getMLSClient(clientId: ClientId?): Either<CoreFailure, MLSClient> {
-        val currentClientId = clientId ?: clientRepository.currentClientId().fold({ return Either.Left(it) }, { it })
+        val currentClientId = clientId ?: currentClientIdProvider().fold({ return Either.Left(it) }, { it })
         val cryptoUserId = CryptoUserID(value = userId.value, domain = userId.domain)
 
         val location = "$rootKeyStorePath/${currentClientId.value}".also {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -2,12 +2,12 @@ package com.wire.kalium.logic.data.keypackage
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
@@ -31,7 +31,7 @@ interface KeyPackageRepository {
 }
 
 class KeyPackageDataSource(
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val keyPackageApi: KeyPackageApi,
     private val mlsClientProvider: MLSClientProvider,
     private val selfUserId: UserId,
@@ -39,7 +39,7 @@ class KeyPackageDataSource(
 ) : KeyPackageRepository {
 
     override suspend fun claimKeyPackages(userIds: List<UserId>): Either<CoreFailure, List<KeyPackageDTO>> =
-        clientRepository.currentClientId().flatMap { selfClientId ->
+        currentClientIdProvider().flatMap { selfClientId ->
             userIds.map { userId ->
                 wrapApiRequest {
                     keyPackageApi.claimKeyPackages(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -294,7 +294,7 @@ class UserSessionScope internal constructor(
 
     private val mlsClientProvider: MLSClientProvider by lazy {
         MLSClientProviderImpl(
-            "${authenticatedDataSourceSet.authenticatedRootDir}/mls", userId, clientRepository, globalPreferences.passphraseStorage
+            "${authenticatedDataSourceSet.authenticatedRootDir}/mls", userId, clientIdProvider, globalPreferences.passphraseStorage
         )
     }
 
@@ -593,7 +593,7 @@ class UserSessionScope internal constructor(
             userId = userId,
             callRepository = callRepository,
             userRepository = userRepository,
-            clientRepository = clientRepository,
+            currentClientIdProvider = clientIdProvider,
             conversationRepository = conversationRepository,
             messageSender = messages.messageSender,
             federatedIdMapper = federatedIdMapper,
@@ -728,7 +728,7 @@ class UserSessionScope internal constructor(
 
     private val keyPackageRepository: KeyPackageRepository
         get() = KeyPackageDataSource(
-            clientRepository, authenticatedDataSourceSet.authenticatedNetworkContainer.keyPackageApi, mlsClientProvider, userId
+            clientIdProvider, authenticatedDataSourceSet.authenticatedNetworkContainer.keyPackageApi, mlsClientProvider, userId
         )
 
     private val logoutRepository: LogoutRepository = LogoutDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.logoutApi)
@@ -763,7 +763,7 @@ class UserSessionScope internal constructor(
             userRepository,
             syncManager,
             mlsConversationRepository,
-            clientRepository,
+            clientIdProvider,
             assetRepository,
             messages.messageSender,
             teamRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -3,13 +3,13 @@ package com.wire.kalium.logic.feature.call
 import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 
 expect class GlobalCallManager {
@@ -19,7 +19,7 @@ expect class GlobalCallManager {
         userId: QualifiedID,
         callRepository: CallRepository,
         userRepository: UserRepository,
-        clientRepository: ClientRepository,
+        currentClientIdProvider: CurrentClientIdProvider,
         conversationRepository: ConversationRepository,
         messageSender: MessageSender,
         callMapper: CallMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -49,16 +49,16 @@ class ClientScope(
     val selfClients: SelfClientsUseCase get() = SelfClientsUseCaseImpl(clientRepository, clientIdProvider)
     val deleteClient: DeleteClientUseCase get() = DeleteClientUseCaseImpl(clientRepository)
     val needsToRegisterClient: NeedsToRegisterClientUseCase
-        get() = NeedsToRegisterClientUseCaseImpl(clientRepository, sessionRepository, selfUserId)
+        get() = NeedsToRegisterClientUseCaseImpl(clientIdProvider, sessionRepository, selfUserId)
     val deregisterNativePushToken: DeregisterTokenUseCase
         get() = DeregisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
     val mlsKeyPackageCountUseCase: MLSKeyPackageCountUseCase
-        get() = MLSKeyPackageCountUseCaseImpl(keyPackageRepository, clientRepository, keyPackageLimitsProvider)
+        get() = MLSKeyPackageCountUseCaseImpl(keyPackageRepository, clientIdProvider, keyPackageLimitsProvider)
     val refillKeyPackages: RefillKeyPackagesUseCase
         get() = RefillKeyPackagesUseCaseImpl(
             keyPackageRepository,
             keyPackageLimitsProvider,
-            clientRepository
+            clientIdProvider
         )
     val persistOtherUserClients: PersistOtherUserClientsUseCase
         get() = PersistOtherUserClientsUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCase.kt
@@ -1,8 +1,8 @@
 package com.wire.kalium.logic.feature.client
 
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.auth.AccountInfo
 import com.wire.kalium.logic.functional.fold
 
@@ -11,7 +11,7 @@ interface NeedsToRegisterClientUseCase {
 }
 
 class NeedsToRegisterClientUseCaseImpl(
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val sessionRepository: SessionRepository,
     private val selfUserId: UserId
 ) : NeedsToRegisterClientUseCase {
@@ -21,7 +21,7 @@ class NeedsToRegisterClientUseCaseImpl(
             {
                 when (it) {
                     is AccountInfo.Invalid -> false
-                    is AccountInfo.Valid -> clientRepository.currentClientId().fold({ true }, { false })
+                    is AccountInfo.Valid -> currentClientIdProvider().fold({ true }, { false })
                 }
             }
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContent.kt
@@ -4,13 +4,13 @@ import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
@@ -59,7 +59,7 @@ interface ClearConversationContentUseCase {
 
 internal class ClearConversationContentUseCaseImpl(
     private val clearConversationContent: ClearConversationContent,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val messageSender: MessageSender,
     private val selfUserId: UserId,
     private val selfConversationIdProvider: SelfConversationIdProvider
@@ -67,7 +67,7 @@ internal class ClearConversationContentUseCaseImpl(
 
     override suspend fun invoke(conversationId: ConversationId): ClearConversationContentUseCase.Result =
         clearConversationContent(conversationId).flatMap {
-            clientRepository.currentClientId().flatMap { currentClientId ->
+            currentClientIdProvider().flatMap { currentClientId ->
                 selfConversationIdProvider().flatMap { selfConversationId ->
                     val regularMessage = Message.Signaling(
                         id = uuid4().toString(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -12,6 +11,7 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.SelfTeamIdProvider
 import com.wire.kalium.logic.feature.connection.MarkConnectionRequestAsNotifiedUseCase
 import com.wire.kalium.logic.feature.connection.MarkConnectionRequestAsNotifiedUseCaseImpl
@@ -34,7 +34,7 @@ class ConversationScope internal constructor(
     private val userRepository: UserRepository,
     private val syncManager: SyncManager,
     private val mlsConversationRepository: MLSConversationRepository,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val assetRepository: AssetRepository,
     private val messageSender: MessageSender,
     private val teamRepository: TeamRepository,
@@ -87,7 +87,7 @@ class ConversationScope internal constructor(
         get() = DeleteTeamConversationUseCaseImpl(selfTeamIdProvider, teamRepository, conversationRepository)
 
     val createGroupConversation: CreateGroupConversationUseCase
-        get() = CreateGroupConversationUseCase(conversationRepository, conversationGroupRepository, syncManager, clientRepository)
+        get() = CreateGroupConversationUseCase(conversationRepository, conversationGroupRepository, syncManager, currentClientIdProvider)
 
     val addMemberToConversationUseCase: AddMemberToConversationUseCase
         get() = AddMemberToConversationUseCaseImpl(conversationGroupRepository)
@@ -108,7 +108,7 @@ class ConversationScope internal constructor(
         get() = UpdateConversationReadDateUseCase(
             conversationRepository,
             messageSender,
-            clientRepository,
+            currentClientIdProvider,
             selfUserId,
             selfConversationIdProvider,
         )
@@ -134,7 +134,7 @@ class ConversationScope internal constructor(
     val clearConversationContent: ClearConversationContentUseCase
         get() = ClearConversationContentUseCaseImpl(
             clearConversationContent = ClearConversationContentImpl(conversationRepository, assetRepository),
-            clientRepository,
+            currentClientIdProvider,
             messageSender,
             selfUserId,
             selfConversationIdProvider

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
@@ -2,12 +2,12 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase.Result
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
@@ -24,7 +24,7 @@ class CreateGroupConversationUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
     private val conversationGroupRepository: ConversationGroupRepository,
     private val syncManager: SyncManager,
-    private val clientRepository: ClientRepository
+    private val currentClientIdProvider: CurrentClientIdProvider
 ) {
 
     /**
@@ -34,7 +34,7 @@ class CreateGroupConversationUseCase internal constructor(
      */
     suspend operator fun invoke(name: String, userIdList: List<UserId>, options: ConversationOptions): Result =
         syncManager.waitUntilLiveOrFailure().flatMap {
-            clientRepository.currentClientId()
+            currentClientIdProvider()
         }.flatMap { clientId ->
             conversationGroupRepository.createGroupConversation(name, userIdList, options.copy(creatorClientId = clientId.value))
         }.flatMap { conversation ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -2,12 +2,12 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onSuccess
@@ -17,7 +17,7 @@ import kotlinx.datetime.Instant
 class UpdateConversationReadDateUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
     private val messageSender: MessageSender,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val selfUserId: UserId,
     private val selfConversationIdProvider: SelfConversationIdProvider
 ) {
@@ -32,7 +32,7 @@ class UpdateConversationReadDateUseCase internal constructor(
     private suspend fun sendLastReadMessageToOtherClients(conversationId: QualifiedID, selfConversationId: QualifiedID, time: Instant) {
         val generatedMessageUuid = uuid4().toString()
 
-        clientRepository.currentClientId().flatMap { currentClientId ->
+        currentClientIdProvider().flatMap { currentClientId ->
             val regularMessage = Message.Signaling(
                 id = generatedMessageUuid,
                 content = MessageContent.LastRead(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
@@ -2,10 +2,10 @@ package com.wire.kalium.logic.feature.keypackage
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.fold
 
 interface MLSKeyPackageCountUseCase {
@@ -14,7 +14,7 @@ interface MLSKeyPackageCountUseCase {
 
 class MLSKeyPackageCountUseCaseImpl(
     private val keyPackageRepository: KeyPackageRepository,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider,
 ) : MLSKeyPackageCountUseCase {
     override suspend operator fun invoke(fromAPI: Boolean): MLSKeyPackageCountResult =
@@ -23,7 +23,7 @@ class MLSKeyPackageCountUseCaseImpl(
             false -> validKeyPackagesCountFromMLSClient()
         }
 
-    private suspend fun validKeyPackagesCountFromAPI() = clientRepository.currentClientId().fold({
+    private suspend fun validKeyPackagesCountFromAPI() = currentClientIdProvider().fold({
         MLSKeyPackageCountResult.Failure.FetchClientIdFailure(it)
     }, { selfClient ->
         keyPackageRepository.getAvailableKeyPackageCount(selfClient).fold(
@@ -33,7 +33,7 @@ class MLSKeyPackageCountUseCaseImpl(
     })
 
     private suspend fun validKeyPackagesCountFromMLSClient() =
-        clientRepository.currentClientId().fold({
+        currentClientIdProvider().fold({
             MLSKeyPackageCountResult.Failure.FetchClientIdFailure(it)
         }, { selfClient ->
             keyPackageRepository.validKeyPackageCount(selfClient).fold(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
@@ -1,9 +1,9 @@
 package com.wire.kalium.logic.feature.keypackage
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
@@ -25,10 +25,10 @@ interface RefillKeyPackagesUseCase {
 class RefillKeyPackagesUseCaseImpl(
     private val keyPackageRepository: KeyPackageRepository,
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
 ) : RefillKeyPackagesUseCase {
     override suspend operator fun invoke(): RefillKeyPackagesResult =
-        clientRepository.currentClientId().flatMap { selfClientId ->
+        currentClientIdProvider().flatMap { selfClientId ->
             keyPackageRepository.getAvailableKeyPackageCount(selfClientId)
                 .flatMap {
                     if (keyPackageLimitsProvider.needsRefill(it.count)) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -1,11 +1,10 @@
 package com.wire.kalium.logic.feature.message
 
 import com.benasher44.uuid.uuid4
-import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.MESSAGES
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.ASSETS
+import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.MESSAGES
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -14,6 +13,7 @@ import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.map
@@ -27,7 +27,7 @@ import kotlinx.datetime.Clock
 class DeleteMessageUseCase internal constructor(
     private val messageRepository: MessageRepository,
     private val userRepository: UserRepository,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val assetRepository: AssetRepository,
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSender: MessageSender
@@ -45,7 +45,7 @@ class DeleteMessageUseCase internal constructor(
                     val selfUser = userRepository.observeSelfUser().first()
                     val generatedMessageUuid = uuid4().toString()
 
-                    return clientRepository.currentClientId().flatMap { currentClientId ->
+                    return currentClientIdProvider().flatMap { currentClientId ->
                         val regularMessage = Message.Signaling(
                             id = generatedMessageUuid,
                             content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else MessageContent.DeleteForMe(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -157,7 +157,7 @@ class MessageScope internal constructor(
         get() = DeleteMessageUseCase(
             messageRepository,
             userRepository,
-            clientRepository,
+            currentClientIdProvider,
             assetRepository,
             slowSyncRepository,
             messageSender
@@ -186,7 +186,7 @@ class MessageScope internal constructor(
         get() = SendKnockUseCase(
             persistMessage,
             userRepository,
-            clientRepository,
+            currentClientIdProvider,
             slowSyncRepository,
             messageSender
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.logic.feature.message
 
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -10,6 +9,7 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
@@ -20,7 +20,7 @@ import kotlinx.datetime.Clock
 class SendKnockUseCase internal constructor(
     private val persistMessage: PersistMessageUseCase,
     private val userRepository: UserRepository,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSender: MessageSender
 ) {
@@ -34,7 +34,7 @@ class SendKnockUseCase internal constructor(
 
         val generatedMessageUuid = uuid4().toString()
 
-        return clientRepository.currentClientId().flatMap { currentClientId ->
+        return currentClientIdProvider().flatMap { currentClientId ->
             val message = Message.Regular(
                 id = generatedMessageUuid,
                 content = MessageContent.Knock(hotKnock),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -2,12 +2,12 @@ package com.wire.kalium.logic.data.keypackage
 
 import com.wire.kalium.cryptography.MLSClient
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
@@ -117,7 +117,7 @@ class KeyPackageRepositoryTest {
         val keyPackageApi = mock(classOf<KeyPackageApi>())
 
         @Mock
-        val clientRepository = mock(classOf<ClientRepository>())
+        val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
         @Mock
         val mlsClientProvider = mock(classOf<MLSClientProvider>())
@@ -128,7 +128,7 @@ class KeyPackageRepositoryTest {
         }
 
         fun withCurrentClientId() = apply {
-            given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked().then { Either.Right(SELF_CLIENT_ID) }
+            given(currentClientIdProvider).suspendFunction(currentClientIdProvider::invoke).whenInvoked().then { Either.Right(SELF_CLIENT_ID) }
         }
 
         fun withGeneratingKeyPackagesSuccessful() = apply {
@@ -157,7 +157,7 @@ class KeyPackageRepositoryTest {
                 .thenReturn(NetworkResponse.Success(EMPTY_CLAIMED_KEY_PACKAGES, mapOf(), 200))
         }
 
-        fun arrange() = this to KeyPackageDataSource(clientRepository, keyPackageApi, mlsClientProvider, SELF_USER_ID)
+        fun arrange() = this to KeyPackageDataSource(currentClientIdProvider, keyPackageApi, mlsClientProvider, SELF_USER_ID)
 
         internal companion object {
             const val KEY_PACKAGE_COUNT = 100

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -128,7 +128,10 @@ class KeyPackageRepositoryTest {
         }
 
         fun withCurrentClientId() = apply {
-            given(currentClientIdProvider).suspendFunction(currentClientIdProvider::invoke).whenInvoked().then { Either.Right(SELF_CLIENT_ID) }
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
+                .whenInvoked()
+                .then { Either.Right(SELF_CLIENT_ID) }
         }
 
         fun withGeneratingKeyPackagesSuccessful() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
@@ -1,11 +1,11 @@
 package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.logic.StorageFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.auth.AccountInfo
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -39,8 +39,8 @@ class NeedsToRegisterClientUseCaseTest {
             .with(any())
             .wasInvoked(exactly = once)
 
-        verify(arrangement.clientRepository)
-            .suspendFunction(arrangement.clientRepository::currentClientId)
+        verify(arrangement.currentClientIdProvider)
+            .suspendFunction(arrangement.currentClientIdProvider::invoke)
             .wasNotInvoked()
     }
 
@@ -60,8 +60,8 @@ class NeedsToRegisterClientUseCaseTest {
             .with(any())
             .wasInvoked(exactly = once)
 
-        verify(arrangement.clientRepository)
-            .suspendFunction(arrangement.clientRepository::currentClientId)
+        verify(arrangement.currentClientIdProvider)
+            .suspendFunction(arrangement.currentClientIdProvider::invoke)
             .wasInvoked(exactly = once)
     }
 
@@ -81,8 +81,8 @@ class NeedsToRegisterClientUseCaseTest {
             .with(any())
             .wasInvoked(exactly = once)
 
-        verify(arrangement.clientRepository)
-            .suspendFunction(arrangement.clientRepository::currentClientId)
+        verify(arrangement.currentClientIdProvider)
+            .suspendFunction(arrangement.currentClientIdProvider::invoke)
             .wasInvoked(exactly = once)
     }
 
@@ -92,7 +92,7 @@ class NeedsToRegisterClientUseCaseTest {
 
     private class Arrangement {
         @Mock
-        val clientRepository = configure(mock(classOf<ClientRepository>())) {
+        val currentClientIdProvider = configure(mock(classOf<CurrentClientIdProvider>())) {
             stubsUnitByDefault = true
         }
 
@@ -100,11 +100,11 @@ class NeedsToRegisterClientUseCaseTest {
         val sessionRepository = mock(SessionRepository::class)
 
         private var needsToRegisterClientUseCase: NeedsToRegisterClientUseCase =
-            NeedsToRegisterClientUseCaseImpl(clientRepository, sessionRepository, selfUserId)
+            NeedsToRegisterClientUseCaseImpl(currentClientIdProvider, sessionRepository, selfUserId)
 
         fun withCurrentClientId(result: Either<StorageFailure, ClientId>) = apply {
-            given(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .whenInvoked()
                 .then { result }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCaseTest.kt
@@ -2,11 +2,11 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -44,8 +44,8 @@ class ClearConversationContentUseCaseTest {
                 .with(anything())
                 .wasInvoked(Times(1))
 
-            verify(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            verify(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .wasNotInvoked()
 
             verify(messageSender)
@@ -76,8 +76,8 @@ class ClearConversationContentUseCaseTest {
                 .with(anything())
                 .wasInvoked(Times(1))
 
-            verify(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            verify(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .wasInvoked(Times(1))
 
             verify(messageSender)
@@ -109,8 +109,8 @@ class ClearConversationContentUseCaseTest {
                 .with(anything())
                 .wasInvoked(Times(1))
 
-            verify(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            verify(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .wasInvoked(Times(1))
 
             verify(messageSender)
@@ -142,8 +142,8 @@ class ClearConversationContentUseCaseTest {
                 .with(anything())
                 .wasInvoked(Times(1))
 
-            verify(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            verify(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .wasInvoked(Times(1))
 
             verify(messageSender)
@@ -163,16 +163,16 @@ class ClearConversationContentUseCaseTest {
         val conversationRepository: ConversationRepository = mock(classOf<ConversationRepository>())
 
         @Mock
-        val clearConversationContent: ClearConversationContent = mock(classOf<ClearConversationContent>())
+        val clearConversationContent = mock(classOf<ClearConversationContent>())
 
         @Mock
-        val clientRepository: ClientRepository = mock(classOf<ClientRepository>())
+        val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
         @Mock
         val selfConversationIdProvider: SelfConversationIdProvider = mock(SelfConversationIdProvider::class)
 
         @Mock
-        val messageSender: MessageSender = mock(classOf<MessageSender>())
+        val messageSender = mock(classOf<MessageSender>())
 
         fun withClearConversationContent(isSuccessFull: Boolean): Arrangement {
             given(clearConversationContent)
@@ -184,8 +184,8 @@ class ClearConversationContentUseCaseTest {
         }
 
         fun withCurrentClientId(isSuccessFull: Boolean): Arrangement {
-            given(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .whenInvoked()
                 .thenReturn(
                     if (isSuccessFull) Either.Right(ClientId("someValue"))
@@ -210,7 +210,7 @@ class ClearConversationContentUseCaseTest {
 
         fun arrange() = this to ClearConversationContentUseCaseImpl(
             clearConversationContent,
-            clientRepository,
+            currentClientIdProvider,
             messageSender,
             UserId("someValue", "someDomain"),
             selfConversationIdProvider

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCaseTest.kt
@@ -3,12 +3,12 @@ package com.wire.kalium.logic.feature.conversation
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
@@ -16,6 +16,7 @@ import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.test_util.wasInTheLastSecond
 import io.mockative.Mock
 import io.mockative.any
+import io.mockative.classOf
 import io.mockative.configure
 import io.mockative.eq
 import io.mockative.given
@@ -145,7 +146,7 @@ class CreateGroupConversationUseCaseTest {
         val conversationGroupRepository = mock(ConversationGroupRepository::class)
 
         @Mock
-        val clientRepository = mock(ClientRepository::class)
+        val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
         @Mock
         val syncManager = configure(mock(SyncManager::class)) {
@@ -153,7 +154,7 @@ class CreateGroupConversationUseCaseTest {
         }
 
         private val createGroupConversation = CreateGroupConversationUseCase(
-            conversationRepository, conversationGroupRepository, syncManager, clientRepository
+            conversationRepository, conversationGroupRepository, syncManager, currentClientIdProvider
         )
 
         fun withWaitingForSyncSucceeding() = withSyncReturning(Either.Right(Unit))
@@ -181,8 +182,8 @@ class CreateGroupConversationUseCaseTest {
         }
 
         fun withCurrentClientIdReturning(clientId: String) = apply {
-            given(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .whenInvoked()
                 .thenReturn(Either.Right(ClientId(clientId)))
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCaseTest.kt
@@ -2,10 +2,10 @@ package com.wire.kalium.logic.feature.keypackage
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCaseTest.Arrangement.Companion.CLIENT_FETCH_ERROR
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCaseTest.Arrangement.Companion.KEY_PACKAGE_COUNT
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCaseTest.Arrangement.Companion.KEY_PACKAGE_COUNT_DTO
@@ -87,13 +87,13 @@ class MLSKeyPackageCountUseCaseTest {
         val keyPackageRepository = mock(classOf<KeyPackageRepository>())
 
         @Mock
-        val clientRepository: ClientRepository = mock(classOf<ClientRepository>())
+        val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
         @Mock
         val keyPackageLimitsProvider = mock(classOf<KeyPackageLimitsProvider>())
 
         fun withClientId(result: Either<CoreFailure, ClientId>) = apply {
-            given(clientRepository).suspendFunction(clientRepository::currentClientId).whenInvoked()
+            given(currentClientIdProvider).suspendFunction(currentClientIdProvider::invoke).whenInvoked()
                 .then { result }
         }
 
@@ -112,7 +112,7 @@ class MLSKeyPackageCountUseCaseTest {
         }
 
         fun arrange() = this to MLSKeyPackageCountUseCaseImpl(
-            keyPackageRepository, clientRepository, keyPackageLimitsProvider
+            keyPackageRepository, currentClientIdProvider, keyPackageLimitsProvider
         )
 
         companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCaseTest.kt
@@ -1,9 +1,9 @@
 package com.wire.kalium.logic.feature.keypackage
 
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageCountDTO
@@ -83,16 +83,16 @@ class RefillKeyPackageUseCaseTest {
         val keyPackageLimitsProvider = mock(classOf<KeyPackageLimitsProvider>())
 
         @Mock
-        val clientRepository: ClientRepository = mock(classOf<ClientRepository>())
+        val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
         private var refillKeyPackageUseCase = RefillKeyPackagesUseCaseImpl(
             keyPackageRepository,
             keyPackageLimitsProvider,
-            clientRepository
+            currentClientIdProvider
         )
 
         fun withExistingSelfClientId() = apply {
-            given(clientRepository).suspendFunction(clientRepository::currentClientId)
+            given(currentClientIdProvider).suspendFunction(currentClientIdProvider::invoke)
                 .whenInvoked()
                 .then { Either.Right(TestClient.CLIENT_ID) }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCaseTest.kt
@@ -1,7 +1,6 @@
 package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.data.asset.AssetRepository
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
@@ -16,6 +15,7 @@ import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.framework.TestUser
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.anything
+import io.mockative.classOf
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.matching
@@ -191,7 +192,7 @@ class DeleteMessageUseCaseTest {
         val userRepository: UserRepository = mock(UserRepository::class)
 
         @Mock
-        val clientRepository: ClientRepository = mock(ClientRepository::class)
+        val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
         @Mock
         private val slowSyncRepository = mock(SlowSyncRepository::class)
@@ -209,7 +210,7 @@ class DeleteMessageUseCaseTest {
         fun arrange() = this to DeleteMessageUseCase(
             messageRepository,
             userRepository,
-            clientRepository,
+            currentClientIdProvider,
             assetRepository,
             slowSyncRepository,
             messageSender
@@ -230,8 +231,8 @@ class DeleteMessageUseCaseTest {
         }
 
         fun withCurrentClientIdIs(clientId: ClientId) = apply {
-            given(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .whenInvoked()
                 .then { Either.Right(clientId) }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.feature.message
 
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
@@ -12,6 +11,7 @@ import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
 import io.mockative.any
@@ -54,7 +54,7 @@ class SendKnockUserCaseTest {
         private val userRepository = mock(classOf<UserRepository>())
 
         @Mock
-        private val clientRepository = mock(classOf<ClientRepository>())
+        val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
         @Mock
         private val slowSyncRepository = mock(classOf<SlowSyncRepository>())
@@ -85,8 +85,8 @@ class SendKnockUserCaseTest {
                 .suspendFunction(userRepository::observeSelfUser)
                 .whenInvoked()
                 .thenReturn(flowOf(fakeSelfUser()))
-            given(clientRepository)
-                .suspendFunction(clientRepository::currentClientId)
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
                 .whenInvoked()
                 .thenReturn(Either.Right(someClientId))
             given(persistMessage)
@@ -107,7 +107,7 @@ class SendKnockUserCaseTest {
         fun arrange() = this to SendKnockUseCase(
             persistMessage,
             userRepository,
-            clientRepository,
+            currentClientIdProvider,
             slowSyncRepository,
             messageSender
         )

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -20,7 +20,6 @@ import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.call.mapper.ParticipantMapperImpl
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -57,13 +56,14 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 
 @Suppress("LongParameterList", "TooManyFunctions")
 class CallManagerImpl internal constructor(
     private val calling: Calling,
     private val callRepository: CallRepository,
     private val userRepository: UserRepository,
-    private val clientRepository: ClientRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
     private val conversationRepository: ConversationRepository,
     private val messageSender: MessageSender,
     kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl,
@@ -84,7 +84,7 @@ class CallManagerImpl internal constructor(
     }
 
     private val clientId: Deferred<ClientId> = scope.async(start = CoroutineStart.LAZY) {
-        clientRepository.currentClientId().fold({
+        currentClientIdProvider().fold({
             TODO("adjust correct variable calling")
         }, {
             callingLogger.d("$TAG - clientId $it")

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -7,13 +7,13 @@ import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapper
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 import io.ktor.util.collections.ConcurrentMap
 
@@ -26,7 +26,7 @@ actual class GlobalCallManager {
     private val calling by lazy {
         Calling.INSTANCE.apply {
             wcall_setup()
-	    wcall_run()
+            wcall_run()
             wcall_set_log_handler(
                 logHandler = LogHandlerImpl,
                 arg = null
@@ -43,7 +43,7 @@ actual class GlobalCallManager {
         userId: QualifiedID,
         callRepository: CallRepository,
         userRepository: UserRepository,
-        clientRepository: ClientRepository,
+        currentClientIdProvider: CurrentClientIdProvider,
         conversationRepository: ConversationRepository,
         messageSender: MessageSender,
         callMapper: CallMapper,
@@ -55,7 +55,7 @@ actual class GlobalCallManager {
             calling = calling,
             callRepository = callRepository,
             userRepository = userRepository,
-            clientRepository = clientRepository,
+            currentClientIdProvider = currentClientIdProvider,
             callMapper = callMapper,
             messageSender = messageSender,
             conversationRepository = conversationRepository,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We use clientRepository to get the current clientId

### Solutions

Use clientProvider to get cached value

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
