### PR TITLE
fix: member change messages are overwritten [AR-2667]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ConversationM
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.persistence.dao.ConversationEntity
+import com.wire.kalium.persistence.dao.message.LocalId
 import kotlinx.coroutines.flow.first
 
 interface ConversationGroupRepository {
@@ -132,7 +133,7 @@ internal class ConversationGroupRepositoryImpl(
             )
         }.onSuccess { response ->
             if (response is ConversationMemberAddedResponse.Changed) {
-                memberJoinEventHandler.handle(eventMapper.conversationMemberJoin("", response.event, true))
+                memberJoinEventHandler.handle(eventMapper.conversationMemberJoin(LocalId.generate(), response.event, true))
             }
         }.map {
             Either.Right(Unit)
@@ -168,7 +169,7 @@ internal class ConversationGroupRepositoryImpl(
             conversationApi.removeMember(idMapper.toApiModel(userId), idMapper.toApiModel(conversationId))
         }.onSuccess { response ->
             if (response is ConversationMemberRemovedResponse.Changed) {
-                memberLeaveEventHandler.handle(eventMapper.conversationMemberLeave("", response.event, false))
+                memberLeaveEventHandler.handle(eventMapper.conversationMemberLeave(LocalId.generate(), response.event, false))
             }
         }.map { }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/LocalId.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/LocalId.kt
@@ -1,0 +1,11 @@
+package com.wire.kalium.persistence.dao.message
+
+import kotlinx.datetime.Clock
+
+object LocalId {
+    private const val LOCAL_ID_PREFIX = "local_id_"
+
+    fun check(id: String): Boolean = id.startsWith(LOCAL_ID_PREFIX)
+
+    fun generate(): String = LOCAL_ID_PREFIX + Clock.System.now().toEpochMilliseconds()
+}


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Admin adds and removes user from group conversation messages is overwritten.

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Testing

#### How to Test

Add someone and then remove him/her right away - you should have two separate system messages.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
