### PR TITLE
fix: updating access role is failing

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -238,7 +238,7 @@ internal class ConversationMapperImpl(
         } else emptyList(),
         name = name,
         access = options.access?.toList()?.map { toApiModel(it) },
-        accessRole = options.accessRole?.toList()?.map { toApiModel(it) },
+        accessRole = options.accessRole?.map { toApiModel(it) },
         convTeamInfo = teamId?.let { ConvTeamInfo(false, it) },
         messageTimer = null,
         receiptMode = if (options.readReceiptsEnabled) ReceiptMode.ENABLED else ReceiptMode.DISABLED,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationAccessInfoDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationAccessInfoDTO.kt
@@ -3,10 +3,8 @@ package com.wire.kalium.network.api.base.authenticated.conversation.model
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonNames
 
 /**
  * **Deprecation info**: Since API v3 `access_role_v2` is deprecated and will be replaced by `access_role`, but until all servers have
@@ -15,11 +13,10 @@ import kotlinx.serialization.json.JsonNames
  * Further info: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/672006169/API+changes+v2+v3
  */
 @Serializable
-@OptIn(ExperimentalSerializationApi::class)
 data class ConversationAccessInfoDTO constructor(
     @SerialName("access")
     val access: Set<ConversationAccessDTO>,
-    @SerialName("access_role_v2") @JsonNames("access_role")
+    @SerialName("access_role_v2")
     val accessRole: Set<ConversationAccessRoleDTO> = ConversationAccessRoleDTO.DEFAULT_VALUE_WHEN_NULL
 )
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
@@ -44,7 +44,8 @@ object EventContentDTOJson {
         |  }, 
         |  "data" : {
         |       "access": [code],
-        |       "access_role_v2": [team_member]
+        |       "access_role_v2": [team_member],
+        |       "access_role": "activated"
         |  }
         |}
         """.trimMargin()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/PrekeyDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/PrekeyDAO.kt
@@ -13,8 +13,8 @@ internal class PrekeyDAOImpl internal constructor(
 ) : PrekeyDAO {
     override suspend fun updateOTRLastPrekeyId(newKeyId: Int) {
         metadataQueries.transaction {
-            val currentId = metadataQueries.selectValueByKey(OTR_LAST_PRE_KEY_ID).executeAsOne().toInt()
-            if (newKeyId > currentId) {
+            val currentId = metadataQueries.selectValueByKey(OTR_LAST_PRE_KEY_ID).executeAsOneOrNull()?.toInt()
+            if (currentId == null || newKeyId > currentId) {
                 metadataQueries.insertValue(OTR_LAST_PRE_KEY_ID, newKeyId.toString())
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

updating conversation access role is failing with Serialization exception

### Causes (Optional)

to support API [V3](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/672006169/API+changes+v2+v3) the annotation @JsonName was added to the access role field, but when deserializing response from API v0-2 this annotation is clashing with the legacy field also named access_role

### Solutions

remove the JsonName annotation it for now and fix tests 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
