### PR TITLE
fix: handle 404 notification errors in all API versions

### DIFF
--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/notification/NotificationApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/notification/NotificationApiV0Test.kt
@@ -7,12 +7,14 @@ import com.wire.kalium.network.AuthenticatedWebSocketClient
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.v0.authenticated.NotificationApiV0
+import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -102,7 +104,7 @@ class NotificationApiV0Test : ApiTest {
     }
 
     @Test
-    fun given404Response_whenGettingAllNotifications_thenTheErrorIsBeingForwarded() = runTest {
+    fun given404Response_whenGettingAllNotifications_thenTheHardcodedV0ErrorIsBeingForwarded() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
             NotificationEventsResponseJson.notificationsWithUnknownEventAtFirstPosition,
             statusCode = HttpStatusCode.NotFound
@@ -112,6 +114,10 @@ class NotificationApiV0Test : ApiTest {
         val result = notificationsApi.getAllNotifications(1, "")
 
         assertFalse(result.isSuccessful())
+
+        val exception = result.kException
+        assertIs<KaliumException.InvalidRequestError>(exception)
+        assertEquals(NotificationApiV0.Hardcoded.NOTIFICATIONS_4O4_ERROR, exception.errorResponse)
     }
 
     @Test

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v3/notification/NotificationApiV3Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v3/notification/NotificationApiV3Test.kt
@@ -1,0 +1,44 @@
+package com.wire.kalium.api.v3.notification
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.api.TEST_BACKEND_CONFIG
+import com.wire.kalium.api.json.model.ErrorResponseJson
+import com.wire.kalium.network.AuthenticatedWebSocketClient
+import com.wire.kalium.network.api.v3.authenticated.NotificationApiV3
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.isSuccessful
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NotificationApiV3Test : ApiTest {
+
+    /**
+     * Doesn't do anything.
+     * TODO: Actually mock WS with data
+     */
+    private fun fakeWebsocketClient(): AuthenticatedWebSocketClient = mockWebsocketClient()
+
+    @Test
+    fun given404Response_whenGettingAllNotifications_thenTheErrorResponseIsBeingForwarded() = runTest {
+        val errorResponseJson = ErrorResponseJson.valid
+        val networkClient = mockAuthenticatedNetworkClient(
+            errorResponseJson.rawJson,
+            statusCode = HttpStatusCode.NotFound
+        )
+        val notificationsApi = NotificationApiV3(networkClient, fakeWebsocketClient(), TEST_BACKEND_CONFIG.links)
+
+        val result = notificationsApi.getAllNotifications(1, "")
+
+        assertFalse(result.isSuccessful())
+        val exception = result.kException
+        assertIs<KaliumException.InvalidRequestError>(exception)
+
+        assertEquals(errorResponseJson.serializableData, exception.errorResponse)
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On API V0~V2, we get a Serialization Error when receiving a 404 on `/notifications`

### Causes

V3 changed the response, so there aren't events anymore.
We addressed it by removing the failure override, that would retrieve the events even in case of failure.

The problem is that it was done for ALL versions.

And we end up trying to read `ErrorResponse` from a 404 in V0~V2.


### Solutions

Create a hardcoded 404 overwrite for Notifications on V0~V2.

On V3, don't override, just perform the request normally and handle the `ErrorResponse` if it comes.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
