### PR TITLE
feat(mls): recover mls conversations from 404 sync (AR-2694)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -65,6 +65,7 @@ interface MLSConversationRepository {
     suspend fun leaveGroup(groupID: GroupID): Either<CoreFailure, Unit>
     suspend fun requestToJoinGroup(groupID: GroupID, epoch: ULong): Either<CoreFailure, Unit>
     suspend fun joinGroupByExternalCommit(groupID: GroupID, groupInfo: ByteArray): Either<CoreFailure, Unit>
+    suspend fun isGroupOutOfSync(groupID: GroupID, currentEpoch: ULong): Either<CoreFailure, Boolean>
     suspend fun clearJoinViaExternalCommit(groupID: GroupID)
     suspend fun getMLSGroupsRequiringKeyingMaterialUpdate(threshold: Duration): Either<CoreFailure, List<GroupID>>
     suspend fun updateKeyingMaterial(groupID: GroupID): Either<CoreFailure, Unit>
@@ -208,6 +209,13 @@ class MLSConversationDataSource(
             }
         }
     }
+
+    override suspend fun isGroupOutOfSync(groupID: GroupID, currentEpoch: ULong): Either<CoreFailure, Boolean> =
+        mlsClientProvider.getMLSClient().flatMap { mlsClient ->
+            wrapMLSRequest {
+                mlsClient.conversationEpoch(idMapper.toCryptoModel(groupID)) < currentEpoch
+            }
+        }
 
     override suspend fun clearJoinViaExternalCommit(groupID: GroupID) {
         mlsClientProvider.getMLSClient().flatMap { mlsClient ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -1,0 +1,116 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.flatMapLeft
+import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isMlsMissingGroupInfo
+import com.wire.kalium.network.exceptions.isMlsStaleMessage
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
+
+/**
+ * Send an external commit to join all MLS conversations for which the user is a member,
+ * but has not yet joined the corresponding MLS group.
+ */
+interface JoinExistingMLSConversationUseCase {
+    suspend operator fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit>
+}
+
+@Suppress("LongParameterList")
+class JoinExistingMLSConversationUseCaseImpl(
+    private val featureSupport: FeatureSupport,
+    private val conversationApi: ConversationApi,
+    private val clientRepository: ClientRepository,
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
+) : JoinExistingMLSConversationUseCase {
+    private val dispatcher = kaliumDispatcher.io
+
+    override suspend operator fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit> =
+        if (!featureSupport.isMLSSupported ||
+            !clientRepository.hasRegisteredMLSClient().getOrElse(false)
+        ) {
+            kaliumLogger.d("Skip re-join existing MLS conversation(s), since MLS is not supported.")
+            Either.Right(Unit)
+        } else {
+            conversationRepository.getConversationById(conversationId)?.let { conversation ->
+                withContext(dispatcher) {
+                    joinOrEstablishMLSGroupAndRetry(conversation)
+                }
+            } ?: Either.Left(StorageFailure.DataNotFound)
+        }
+
+    private suspend fun joinOrEstablishMLSGroup(conversation: Conversation): Either<CoreFailure, Unit> {
+        return if (conversation.protocol is Conversation.ProtocolInfo.MLS) {
+            if (conversation.protocol.epoch == 0UL) {
+                if (
+                    conversation.type == Conversation.Type.GLOBAL_TEAM ||
+                    conversation.type == Conversation.Type.SELF
+                ) {
+                    kaliumLogger.i("Establish group for ${conversation.type}")
+                    mlsConversationRepository.establishMLSGroup(
+                        conversation.protocol.groupId,
+                        emptyList()
+                    )
+                } else {
+                    Either.Right(Unit)
+                }
+            } else {
+                wrapApiRequest {
+                    conversationApi.fetchGroupInfo(idMapper.toApiModel(conversation.id))
+                }.flatMap { groupInfo ->
+                    mlsConversationRepository.joinGroupByExternalCommit(
+                        conversation.protocol.groupId,
+                        groupInfo
+                    )
+                }
+            }
+        } else {
+            Either.Right(Unit)
+        }
+    }
+
+    private suspend fun joinOrEstablishMLSGroupAndRetry(
+        conversation: Conversation
+    ): Either<CoreFailure, Unit> =
+        joinOrEstablishMLSGroup(conversation)
+            .flatMapLeft { failure ->
+                if (failure is NetworkFailure.ServerMiscommunication && failure.kaliumException is KaliumException.InvalidRequestError) {
+                    if (failure.kaliumException.isMlsStaleMessage()) {
+                        kaliumLogger.w("Epoch out of date for conversation ${conversation.id}, re-fetching and re-trying")
+                        // Re-fetch current epoch and try again
+                        conversationRepository.fetchConversation(conversation.id).flatMap {
+                            conversationRepository.detailsById(conversation.id).flatMap { conversation ->
+                                joinOrEstablishMLSGroup(conversation)
+                            }
+                        }
+                    } else if (failure.kaliumException.isMlsMissingGroupInfo()) {
+                        kaliumLogger.w("conversation has no group info, ignoring...")
+                        Either.Right(Unit)
+                    } else {
+                        Either.Left(failure)
+                    }
+                } else {
+                    Either.Left(failure)
+                }
+            }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -1,55 +1,36 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLS.GroupState
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.MLSConversationRepository
-import com.wire.kalium.logic.data.id.IdMapper
-import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
-import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.getOrElse
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.logic.wrapApiRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
-import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.network.exceptions.isMlsMissingGroupInfo
-import com.wire.kalium.network.exceptions.isMlsStaleMessage
-import com.wire.kalium.util.KaliumDispatcher
-import com.wire.kalium.util.KaliumDispatcherImpl
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
 
 /**
  * Send an external commit to join all MLS conversations for which the user is a member,
  * but has not yet joined the corresponding MLS group.
  */
 interface JoinExistingMLSConversationsUseCase {
-    suspend operator fun invoke(): Either<CoreFailure, Unit>
+    suspend operator fun invoke(keepRetryingOnFailure: Boolean = true): Either<CoreFailure, Unit>
 }
 
 @Suppress("LongParameterList")
 class JoinExistingMLSConversationsUseCaseImpl(
     private val featureSupport: FeatureSupport,
-    private val conversationApi: ConversationApi,
     private val clientRepository: ClientRepository,
     private val conversationRepository: ConversationRepository,
-    private val mlsConversationRepository: MLSConversationRepository,
-    private val idMapper: IdMapper = MapperProvider.idMapper(),
-    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
+    private val joinExistingMLSConversationUseCase: JoinExistingMLSConversationUseCase
 ) : JoinExistingMLSConversationsUseCase {
-    private val dispatcher = kaliumDispatcher.io
-    private val scope = CoroutineScope(dispatcher)
 
-    override suspend operator fun invoke(): Either<CoreFailure, Unit> =
+    override suspend operator fun invoke(keepRetryingOnFailure: Boolean): Either<CoreFailure, Unit> =
         if (!featureSupport.isMLSSupported ||
-            !clientRepository.hasRegisteredMLSClient().getOrElse(false)) {
+            !clientRepository.hasRegisteredMLSClient().getOrElse(false)
+        ) {
             kaliumLogger.d("Skip re-join existing MLS conversation(s), since MLS is not supported.")
             Either.Right(Unit)
         } else {
@@ -57,67 +38,10 @@ class JoinExistingMLSConversationsUseCaseImpl(
                 kaliumLogger.d("Requesting to re-join ${pendingConversations.size} existing MLS conversation(s)")
 
                 return pendingConversations.map { conversation ->
-                    scope.async {
-                        joinOrEstablishMLSGroupAndRetry(conversation)
-                    }
-                }.map {
-                    it.await()
+                    joinExistingMLSConversationUseCase(conversation.id)
                 }.foldToEitherWhileRight(Unit) { value, _ ->
                     value
                 }
             }
         }
-
-    private suspend fun joinOrEstablishMLSGroup(conversation: Conversation): Either<CoreFailure, Unit> {
-        return if (conversation.protocol is Conversation.ProtocolInfo.MLS) {
-            if (conversation.protocol.epoch == 0UL) {
-                if (
-                    conversation.type == Conversation.Type.GLOBAL_TEAM ||
-                    conversation.type == Conversation.Type.SELF
-                ) {
-                    kaliumLogger.i("Establish group for ${conversation.type}")
-                    mlsConversationRepository.establishMLSGroup(
-                        conversation.protocol.groupId,
-                        emptyList()
-                    )
-                 } else {
-                    Either.Right(Unit)
-                }
-            } else {
-                wrapApiRequest {
-                    conversationApi.fetchGroupInfo(idMapper.toApiModel(conversation.id))
-                }.flatMap { groupInfo ->
-                    mlsConversationRepository.joinGroupByExternalCommit(
-                        conversation.protocol.groupId,
-                        groupInfo
-                    )
-                }
-            }
-        } else {
-            Either.Right(Unit)
-        }
-    }
-
-    private suspend fun joinOrEstablishMLSGroupAndRetry(conversation: Conversation): Either<CoreFailure, Unit> =
-        joinOrEstablishMLSGroup(conversation)
-            .flatMapLeft { failure ->
-                if (failure is NetworkFailure.ServerMiscommunication && failure.kaliumException is KaliumException.InvalidRequestError) {
-                    if (failure.kaliumException.isMlsStaleMessage()) {
-                        kaliumLogger.w("Epoch out of date for conversation ${conversation.id}, re-fetching and re-trying")
-                        // Re-fetch current epoch and try again
-                        conversationRepository.fetchConversation(conversation.id).flatMap {
-                            conversationRepository.detailsById(conversation.id).flatMap { conversation ->
-                                joinOrEstablishMLSGroup(conversation)
-                            }
-                        }
-                    } else if (failure.kaliumException.isMlsMissingGroupInfo()) {
-                        kaliumLogger.w("conversation has no group info, ignoring...")
-                        Either.Right(Unit)
-                    } else {
-                        Either.Left(failure)
-                    }
-                } else {
-                    Either.Left(failure)
-                }
-            }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManager.kt
@@ -1,0 +1,46 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+internal interface MLSConversationsRecoveryManager {
+    suspend fun invoke()
+}
+
+internal class MLSConversationsRecoveryManagerImpl(
+    private val featureSupport: FeatureSupport,
+    private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val clientRepository: ClientRepository,
+    private val recoverMLSConversationsUseCase: RecoverMLSConversationsUseCase,
+    private val slowSyncRepository: SlowSyncRepository,
+) : MLSConversationsRecoveryManager {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun invoke() {
+        incrementalSyncRepository.incrementalSyncState.collect { syncState ->
+            if (syncState is IncrementalSyncStatus.Live &&
+                featureSupport.isMLSSupported &&
+                clientRepository.hasRegisteredMLSClient().getOrElse(false)
+                && slowSyncRepository.isMLSNeedsRecovery()
+            ) {
+                recoverMLSConversations()
+            }
+        }
+    }
+
+    private suspend fun recoverMLSConversations() =
+        recoverMLSConversationsUseCase.invoke().let { result ->
+            when (result) {
+                is RecoverMLSConversationsResult.Failure ->
+                    kaliumLogger.w("Error while recovering MLS conversations: ${result.failure}")
+                is RecoverMLSConversationsResult.Success ->
+                    slowSyncRepository.updateMLSNeedsRecovery(false)
+            }
+        }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt
@@ -1,0 +1,75 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLS.GroupState
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.foldToEitherWhileRight
+import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.kaliumLogger
+
+
+sealed class RecoverMLSConversationsResult {
+    object Success : RecoverMLSConversationsResult()
+    class Failure(val failure: CoreFailure) : RecoverMLSConversationsResult()
+}
+
+/**
+ * Iterate all MLS Established conversation after 404 sync error to
+ * check for outOfSync epochs, if find anything then tries to rejoin!
+ */
+interface RecoverMLSConversationsUseCase {
+    suspend operator fun invoke(): RecoverMLSConversationsResult
+}
+
+@Suppress("LongParameterList")
+class RecoverMLSConversationsUseCaseImpl(
+    private val featureSupport: FeatureSupport,
+    private val clientRepository: ClientRepository,
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val joinExistingMLSConversationUseCase: JoinExistingMLSConversationUseCase,
+) : RecoverMLSConversationsUseCase {
+    override suspend operator fun invoke(): RecoverMLSConversationsResult =
+        if (!featureSupport.isMLSSupported ||
+            !clientRepository.hasRegisteredMLSClient().getOrElse(false)
+        ) {
+            kaliumLogger.d("Skip re-join existing MLS conversation(s), since MLS is not supported.")
+            RecoverMLSConversationsResult.Success
+        } else {
+            conversationRepository.getConversationsByGroupState(GroupState.ESTABLISHED)
+                .flatMap { groups ->
+                    groups.map { recoverMLSGroup(it) }
+                        .foldToEitherWhileRight(Unit) { value, _ -> value }
+                }.fold(
+                    { RecoverMLSConversationsResult.Failure(it) },
+                    { RecoverMLSConversationsResult.Success }
+                )
+        }
+
+    private suspend fun recoverMLSGroup(conversation: Conversation): Either<CoreFailure, Unit> {
+        return if (conversation.protocol is Conversation.ProtocolInfo.MLS) {
+            mlsConversationRepository.isGroupOutOfSync(conversation.protocol.groupId, conversation.protocol.epoch)
+                .fold({ checkEpochFailure ->
+                    Either.Left(checkEpochFailure)
+                }, { isGroupOutOfSync ->
+                    if (isGroupOutOfSync) {
+                        joinExistingMLSConversationUseCase(conversation.id).onFailure { joinFailure ->
+                            Either.Left(joinFailure)
+                        }
+                    } else {
+                        Either.Right(Unit)
+                    }
+                })
+        } else {
+            Either.Right(Unit)
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandler.kt
@@ -23,6 +23,7 @@ internal class IncrementalSyncRecoveryHandlerImpl(
         kaliumLogger.i("$TAG Checking if we can recover from the failure: $failure")
         if (shouldRestartSlowSyncProcess(failure)) {
             slowSyncRepository.clearLastSlowSyncCompletionInstant()
+            slowSyncRepository.updateMLSNeedsRecovery(true)
         } else {
             kaliumLogger.i("$TAG Retrying to recover form the failure $failure, perform the incremental sync again")
             onIncrementalSyncRetryCallback.retry()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -701,6 +701,25 @@ class MLSConversationRepositoryTest {
             .wasInvoked(once)
     }
 
+    @Test
+    fun givenConversationWithOutdatedEpoch_whenCallingIsGroupOutOfSync_returnsTrue() = runTest {
+        val returnEpoch = 10UL
+        val conversationEpoch = 5UL
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withGetMLSClientSuccessful()
+            .withGetGroupEpochReturn(returnEpoch)
+            .arrange()
+
+        val result = mlsConversationRepository.isGroupOutOfSync(Arrangement.GROUP_ID, conversationEpoch)
+        result.shouldSucceed()
+
+        verify(arrangement.mlsClient)
+            .function(arrangement.mlsClient::conversationEpoch)
+            .with(any())
+            .wasInvoked(once)
+
+    }
+
     class Arrangement {
         val idMapper: IdMapper = IdMapperImpl()
 
@@ -781,6 +800,13 @@ class MLSConversationRepositoryTest {
                 .function(mlsClient::addMember)
                 .whenInvokedWith(anything(), anything())
                 .thenReturn(COMMIT_BUNDLE)
+        }
+
+        fun withGetGroupEpochReturn(epoch: ULong) = apply {
+            given(mlsClient)
+                .function(mlsClient::conversationEpoch)
+                .whenInvokedWith(anything())
+                .thenReturn(epoch)
         }
 
         fun withJoinConversationSuccessful() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
@@ -94,4 +94,14 @@ class SlowSyncRepositoryTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun givenMLSRecoveryStatusIsUpdated_whenGettingStatus_thenTheStateMatches() = runTest {
+        val newStatus = true
+        slowSyncRepository.updateMLSNeedsRecovery(newStatus)
+
+        val currentState = slowSyncRepository.isMLSNeedsRecovery()
+
+        assertEquals(newStatus, currentState)
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -1,0 +1,337 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.model.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.NetworkResponse
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.twice
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class JoinExistingMLSConversationUseCaseTest {
+
+    @Test
+    fun givenMLSSupportIsDisabled_whenInvokingUseCase_ThenRequestToJoinConversationIsNotCalled() =
+        runTest {
+            val (arrangement, joinExistingMLSConversationUseCase) = Arrangement()
+                .withIsMLSSupported(false)
+                .withGetConversationsByIdSuccessful()
+                .withJoinByExternalCommitSuccessful()
+                .arrange()
+
+            joinExistingMLSConversationUseCase(Arrangement.MLS_CONVERSATION1.id).shouldSucceed()
+
+            verify(arrangement.mlsConversationRepository)
+                .suspendFunction(arrangement.mlsConversationRepository::joinGroupByExternalCommit)
+                .with(eq(Arrangement.MLS_CONVERSATION1), anything())
+                .wasNotInvoked()
+        }
+
+    @Test
+    fun givenNoMLSClientIsRegistered_whenInvokingUseCase_ThenRequestToJoinConversationIsNotCalled() =
+        runTest {
+            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(false)
+                .withGetConversationsByIdSuccessful()
+                .withJoinByExternalCommitSuccessful()
+                .arrange()
+
+            joinExistingMLSConversationsUseCase(Arrangement.MLS_CONVERSATION1.id).shouldSucceed()
+
+            verify(arrangement.mlsConversationRepository)
+                .suspendFunction(arrangement.mlsConversationRepository::joinGroupByExternalCommit)
+                .with(eq(Arrangement.MLS_CONVERSATION1), anything())
+                .wasNotInvoked()
+        }
+
+    @Test
+    fun givenGroupConversationWithZeroEpoch_whenInvokingUseCase_ThenDoNotEstablishGroup() =
+        runTest {
+            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION)
+                .withEstablishMLSGroupSuccessful()
+                .arrange()
+
+            joinExistingMLSConversationsUseCase(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION.id).shouldSucceed()
+
+            verify(arrangement.mlsConversationRepository)
+                .suspendFunction(arrangement.mlsConversationRepository::establishMLSGroup)
+                .with(eq(Arrangement.GROUP_ID3), eq(emptyList()))
+                .wasNotInvoked()
+        }
+
+    @Test
+    fun givenSelfConversationWithZeroEpoch_whenInvokingUseCase_ThenEstablishGroup() =
+        runTest {
+            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_SELF_CONVERSATION)
+                .withEstablishMLSGroupSuccessful()
+                .arrange()
+
+            joinExistingMLSConversationsUseCase(Arrangement.MLS_UNESTABLISHED_SELF_CONVERSATION.id).shouldSucceed()
+
+            verify(arrangement.mlsConversationRepository)
+                .suspendFunction(arrangement.mlsConversationRepository::establishMLSGroup)
+                .with(eq(Arrangement.GROUP_ID_SELF), eq(emptyList()))
+                .wasInvoked(once)
+        }
+
+    @Test
+    fun givenGlobalTeamConversationWithZeroEpoch_whenInvokingUseCase_ThenEstablishGroup() =
+        runTest {
+            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_GLOBAL_TEAM_CONVERSATION)
+                .withEstablishMLSGroupSuccessful()
+                .arrange()
+
+            joinExistingMLSConversationsUseCase(Arrangement.MLS_UNESTABLISHED_GLOBAL_TEAM_CONVERSATION.id).shouldSucceed()
+
+            verify(arrangement.mlsConversationRepository)
+                .suspendFunction(arrangement.mlsConversationRepository::establishMLSGroup)
+                .with(eq(Arrangement.GROUP_ID_TEAM), eq(emptyList()))
+                .wasInvoked(once)
+        }
+
+    @Test
+    fun givenOutOfDateEpochFailure_whenInvokingUseCase_ThenRetryWithNewEpoch() = runTest {
+        val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByIdSuccessful(Arrangement.MLS_CONVERSATION1)
+            .withJoinByExternalCommitSuccessful()
+            .withJoinByExternalCommitGroupFailing(Arrangement.MLS_STALE_MESSAGE_FAILURE, times = 1)
+            .withFetchConversationSuccessful()
+            .withFetchingGroupInfoSuccessful()
+            .withGetConversationByIdSuccessful()
+            .arrange()
+
+        joinExistingMLSConversationsUseCase(Arrangement.MLS_CONVERSATION1.id).shouldSucceed()
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::fetchConversation)
+            .with(eq(Arrangement.MLS_CONVERSATION1.id))
+            .wasInvoked(once)
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::joinGroupByExternalCommit)
+            .with(eq(Arrangement.GROUP_ID1), anything())
+            .wasInvoked(twice)
+
+    }
+
+    @Test
+    fun givenNonRecoverableFailure_whenInvokingUseCase_ThenFailureIsReported() = runTest {
+        val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByIdSuccessful()
+            .withFetchingGroupInfoSuccessful()
+            .withJoinByExternalCommitGroupFailing(Arrangement.MLS_UNSUPPORTED_PROPOSAL_FAILURE)
+            .arrange()
+
+        joinExistingMLSConversationsUseCase(Arrangement.MLS_CONVERSATION1.id).shouldFail()
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val featureSupport = mock(classOf<FeatureSupport>())
+
+        @Mock
+        val conversationApi = mock(classOf<ConversationApi>())
+
+        @Mock
+        val clientRepository = mock(classOf<ClientRepository>())
+
+        @Mock
+        val conversationRepository = mock(classOf<ConversationRepository>())
+
+        @Mock
+        val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
+
+        fun arrange() = this to JoinExistingMLSConversationUseCaseImpl(
+            featureSupport,
+            conversationApi,
+            clientRepository,
+            conversationRepository,
+            mlsConversationRepository
+        )
+
+        @Suppress("MaxLineLength")
+        fun withGetConversationsByIdSuccessful(conversation: Conversation = MLS_CONVERSATION1) =
+            apply {
+                given(conversationRepository)
+                    .suspendFunction(conversationRepository::getConversationById)
+                    .whenInvokedWith(anything())
+                    .then { conversation }
+            }
+
+        fun withFetchConversationSuccessful() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::fetchConversation)
+                .whenInvokedWith(anything())
+                .then { Either.Right(Unit) }
+        }
+
+        fun withGetConversationByIdSuccessful() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::detailsById)
+                .whenInvokedWith(anything())
+                .then { Either.Right(MLS_CONVERSATION1) }
+        }
+
+        fun withEstablishMLSGroupSuccessful() = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::establishMLSGroup)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withJoinByExternalCommitSuccessful() = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::joinGroupByExternalCommit)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withJoinByExternalCommitGroupFailing(failure: CoreFailure, times: Int = Int.MAX_VALUE) = apply {
+            var invocationCounter = 0
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::joinGroupByExternalCommit)
+                .whenInvokedWith(matching { invocationCounter += 1; invocationCounter <= times }, anything())
+                .thenReturn(Either.Left(failure))
+        }
+
+        fun withFetchingGroupInfoSuccessful() = apply {
+            given(conversationApi)
+                .suspendFunction(conversationApi::fetchGroupInfo)
+                .whenInvokedWith(anything())
+                .thenReturn(NetworkResponse.Success(PUBLIC_GROUP_STATE, mapOf(), 200))
+        }
+
+        fun withIsMLSSupported(supported: Boolean) = apply {
+            given(featureSupport)
+                .invocation { featureSupport.isMLSSupported }
+                .thenReturn(supported)
+        }
+
+        fun withHasRegisteredMLSClient(result: Boolean) = apply {
+            given(clientRepository)
+                .suspendFunction(clientRepository::hasRegisteredMLSClient)
+                .whenInvoked()
+                .thenReturn(Either.Right(result))
+        }
+
+        companion object {
+            val PUBLIC_GROUP_STATE = "public_group_state".encodeToByteArray()
+
+            val MLS_UNSUPPORTED_PROPOSAL_FAILURE = NetworkFailure.ServerMiscommunication(
+                KaliumException.InvalidRequestError(
+                    ErrorResponse(
+                        422,
+                        "Unsupported proposal type",
+                        "mls-unsupported-proposal"
+                    )
+                )
+            )
+
+            val MLS_STALE_MESSAGE_FAILURE = NetworkFailure.ServerMiscommunication(
+                KaliumException.InvalidRequestError(
+                    ErrorResponse(
+                        403,
+                        "The conversation epoch in a message is too old",
+                        "mls-stale-message"
+                    )
+                )
+            )
+
+            val GROUP_ID1 = GroupID("group1")
+            val GROUP_ID2 = GroupID("group2")
+            val GROUP_ID3 = GroupID("group3")
+            val GROUP_ID_SELF = GroupID("group-self")
+            val GROUP_ID_TEAM = GroupID("group-team")
+
+            val MLS_CONVERSATION1 = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID1,
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 1UL,
+                    keyingMaterialLastUpdate = Clock.System.now(),
+                    cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("id1", "domain"))
+
+            val MLS_CONVERSATION2 = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID2,
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 1UL,
+                    keyingMaterialLastUpdate = Clock.System.now(),
+                    cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("id2", "domain"))
+
+            val MLS_UNESTABLISHED_GROUP_CONVERSATION = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID3,
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 0UL,
+                    keyingMaterialLastUpdate = Clock.System.now(),
+                    cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("id3", "domain"))
+
+            val MLS_UNESTABLISHED_SELF_CONVERSATION = TestConversation.SELF(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID_SELF,
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 0UL,
+                    keyingMaterialLastUpdate = Clock.System.now(),
+                    cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("self", "domain"))
+
+            val MLS_UNESTABLISHED_GLOBAL_TEAM_CONVERSATION = TestConversation.GLOBAL_TEAM(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID_TEAM,
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 0UL,
+                    keyingMaterialLastUpdate = Clock.System.now(),
+                    cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("team", "domain"))
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManagerTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManagerTests.kt
@@ -1,0 +1,181 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MLSConversationsRecoveryManagerTests {
+    @Test
+    fun givenMLSNeedsRecoveryTrue_whenObservingAndSyncFinishes_MLSNeedRecoveryKeyGetsUpdated() =
+        runTest {
+            val (arrangement, mlsConversationsRecoveryManager) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withRecoverMLSConversationsResult(RecoverMLSConversationsResult.Success)
+                .withMLSNeedsRecoveryReturn(true)
+                .withIncrementalSyncState(IncrementalSyncStatus.Live)
+                .arrange()
+            mlsConversationsRecoveryManager.invoke()
+            verify(arrangement.recoverMLSConversationsUseCase)
+                .suspendFunction(arrangement.recoverMLSConversationsUseCase::invoke)
+                .wasInvoked(once)
+            verify(arrangement.slowSyncRepository)
+                .suspendFunction(arrangement.slowSyncRepository::updateMLSNeedsRecovery)
+                .with(eq(false))
+                .wasInvoked(once)
+        }
+
+    @Test
+    fun givenMLSNeedsRecoveryFalse_whenObservingAndSyncFinishes_RecoverMLSConversationNotPerformed() =
+        runTest {
+            val (arrangement, mlsConversationsRecoveryManager) = Arrangement()
+                .withIsMLSSupported(true)
+                .withRecoverMLSConversationsResult(RecoverMLSConversationsResult.Success)
+                .withMLSNeedsRecoveryReturn(false)
+                .withHasRegisteredMLSClient(true)
+                .withIncrementalSyncState(IncrementalSyncStatus.Live)
+                .arrange()
+
+            mlsConversationsRecoveryManager.invoke()
+
+            verify(arrangement.recoverMLSConversationsUseCase)
+                .suspendFunction(arrangement.recoverMLSConversationsUseCase::invoke)
+                .wasNotInvoked()
+            verify(arrangement.slowSyncRepository)
+                .suspendFunction(arrangement.slowSyncRepository::updateMLSNeedsRecovery)
+                .with(anything())
+                .wasNotInvoked()
+        }
+
+    @Test
+    fun givenMLSSupportIsDisabled_whenObservingAndSyncFinishes_recoverMLSConversationsUseCaseNotPerformed() =
+        runTest {
+            val (arrangement, _) = Arrangement()
+                .withIsMLSSupported(false)
+                .withIncrementalSyncState(IncrementalSyncStatus.Live)
+                .arrange()
+
+            verify(arrangement.recoverMLSConversationsUseCase)
+                .suspendFunction(arrangement.recoverMLSConversationsUseCase::invoke)
+                .wasNotInvoked()
+            verify(arrangement.slowSyncRepository)
+                .suspendFunction(arrangement.slowSyncRepository::updateMLSNeedsRecovery)
+                .with(anything())
+                .wasNotInvoked()
+        }
+
+    @Test
+    fun givenMLSClientHasNotBeenRegistered_whenObservingAndSyncFinishes_recoverMLSConversationsUseCaseNotPerformed() =
+        runTest {
+
+            val (arrangement, _) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(false)
+                .withIsMLSSupported(false)
+                .withIncrementalSyncState(IncrementalSyncStatus.Live)
+                .arrange()
+
+            verify(arrangement.recoverMLSConversationsUseCase)
+                .suspendFunction(arrangement.recoverMLSConversationsUseCase::invoke)
+                .wasNotInvoked()
+        }
+
+    @Test
+    fun givenwithRecoverMLSConversationsResult_whenObservingAndSyncFinishes_updateMLSNeedsRecoveryNotCalled() =
+        runTest {
+            val (arrangement, mlsConversationsRecoveryManager) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withRecoverMLSConversationsResult(RecoverMLSConversationsResult.Failure(StorageFailure.DataNotFound))
+                .withMLSNeedsRecoveryReturn(true)
+                .withIncrementalSyncState(IncrementalSyncStatus.Live)
+                .arrange()
+
+            mlsConversationsRecoveryManager.invoke()
+
+            verify(arrangement.recoverMLSConversationsUseCase)
+                .suspendFunction(arrangement.recoverMLSConversationsUseCase::invoke)
+                .wasInvoked(once)
+            verify(arrangement.slowSyncRepository)
+                .suspendFunction(arrangement.slowSyncRepository::updateMLSNeedsRecovery)
+                .with(anything())
+                .wasNotInvoked()
+        }
+
+    private class Arrangement {
+        @Mock
+        val incrementalSyncRepository: IncrementalSyncRepository = mock(classOf<IncrementalSyncRepository>())
+
+        @Mock
+        val clientRepository = mock(classOf<ClientRepository>())
+
+        @Mock
+        val featureSupport = mock(classOf<FeatureSupport>())
+
+        @Mock
+        val recoverMLSConversationsUseCase = mock(classOf<RecoverMLSConversationsUseCase>())
+
+        @Mock
+        val slowSyncRepository = mock(classOf<SlowSyncRepository>())
+
+
+        fun withMLSNeedsRecoveryReturn(state: Boolean) = apply {
+            given(slowSyncRepository)
+                .suspendFunction(slowSyncRepository::isMLSNeedsRecovery)
+                .whenInvoked()
+                .thenReturn(state)
+        }
+
+        fun withRecoverMLSConversationsResult(result: RecoverMLSConversationsResult) = apply {
+            given(recoverMLSConversationsUseCase)
+                .suspendFunction(recoverMLSConversationsUseCase::invoke)
+                .whenInvoked()
+                .thenReturn(result)
+        }
+
+        fun withIsMLSSupported(supported: Boolean) = apply {
+            given(featureSupport)
+                .invocation { featureSupport.isMLSSupported }
+                .thenReturn(supported)
+        }
+
+        fun withHasRegisteredMLSClient(result: Boolean) = apply {
+            given(clientRepository)
+                .suspendFunction(clientRepository::hasRegisteredMLSClient)
+                .whenInvoked()
+                .thenReturn(Either.Right(result))
+        }
+
+        fun withIncrementalSyncState(state: IncrementalSyncStatus) = apply {
+            given(incrementalSyncRepository)
+                .getter(incrementalSyncRepository::incrementalSyncState)
+                .whenInvoked()
+                .thenReturn(flowOf(state))
+        }
+
+        fun arrange() = this to MLSConversationsRecoveryManagerImpl(
+            featureSupport,
+            incrementalSyncRepository,
+            clientRepository,
+            recoverMLSConversationsUseCase,
+            slowSyncRepository
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCaseTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCaseTests.kt
@@ -1,0 +1,267 @@
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.Times
+import io.mockative.any
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.twice
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecoverMLSConversationsUseCaseTests {
+    @Test
+    fun givenOutdatedListGroups_ThenRequestToJoinThemPerformed() = runTest {
+        val conversations = listOf(Arrangement.MLS_CONVERSATION1, Arrangement.MLS_CONVERSATION2)
+        val (arrangement, recoverMLSConversationsUseCase) = Arrangement()
+            .withConversationsByGroupStateReturns(Either.Right(conversations))
+            .withJoinExistingMLSConversationUseCaseSuccessful()
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withConversationIsOutOfSyncReturnsTrueFor(listOf(Arrangement.GROUP_ID1, Arrangement.GROUP_ID2))
+            .arrange()
+
+        val actual = recoverMLSConversationsUseCase()
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::isGroupOutOfSync)
+            .with(any(), any())
+            .wasInvoked(Times(conversations.size))
+
+        verify(arrangement.joinExistingMLSConversationUseCase)
+            .suspendFunction(arrangement.joinExistingMLSConversationUseCase::invoke)
+            .with(any())
+            .wasInvoked(Times(conversations.size))
+
+        assertIs<RecoverMLSConversationsResult.Success>(actual)
+    }
+
+    @Test
+    fun givenOutdatedListGroups_ThenRequestToUpdateSucceededPartially_ThenReturnFailed() = runTest {
+        val conversations = listOf(Arrangement.MLS_CONVERSATION1, Arrangement.MLS_CONVERSATION2)
+        val (arrangement, recoverMLSConversationsUseCase) = Arrangement()
+            .withConversationsByGroupStateReturns(Either.Right(conversations))
+            .withJoinExistingMLSConversationUseCaseFailsFor(Arrangement.MLS_CONVERSATION1.id)
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withConversationIsOutOfSyncReturnsTrueFor(listOf(Arrangement.GROUP_ID1, Arrangement.GROUP_ID2))
+            .arrange()
+
+        val actual = recoverMLSConversationsUseCase()
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::isGroupOutOfSync)
+            .with(any(), any())
+            .wasInvoked(Times(conversations.size))
+
+
+        verify(arrangement.joinExistingMLSConversationUseCase)
+            .suspendFunction(arrangement.joinExistingMLSConversationUseCase::invoke)
+            .with(any())
+            .wasInvoked(Times(conversations.size))
+
+
+        assertIs<RecoverMLSConversationsResult.Failure>(actual)
+    }
+
+    @Test
+    fun givenEmptyListOfOutdatedGroups_ThenUpdateShouldNotCalled() = runTest {
+        val conversations = emptyList<Conversation>()
+        val (arrangement, recoverMLSConversationsUseCase) = Arrangement()
+            .withConversationsByGroupStateReturns(Either.Right(conversations))
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withJoinExistingMLSConversationUseCaseSuccessful()
+            .withConversationIsOutOfSyncReturnsFalseFor(Arrangement.GROUP_ID1)
+            .arrange()
+
+        val actual = recoverMLSConversationsUseCase()
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::isGroupOutOfSync)
+            .with(any(), any())
+            .wasNotInvoked()
+
+
+        verify(arrangement.joinExistingMLSConversationUseCase)
+            .suspendFunction(arrangement.joinExistingMLSConversationUseCase::invoke)
+            .with(any())
+            .wasNotInvoked()
+
+        assertIs<RecoverMLSConversationsResult.Success>(actual)
+    }
+
+    @Test
+    fun givenPartiallyOutdatedConversationsList_ThenJoinShouldBeInvokedCorrectly() = runTest {
+        val conversations = listOf(Arrangement.MLS_CONVERSATION1, Arrangement.MLS_CONVERSATION2)
+        val (arrangement, recoverMLSConversationsUseCase) = Arrangement()
+            .withConversationsByGroupStateReturns(Either.Right(conversations))
+            .withJoinExistingMLSConversationUseCaseSuccessful()
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withConversationIsOutOfSyncReturnsFalseFor(Arrangement.GROUP_ID2)
+            .arrange()
+
+        val actual = recoverMLSConversationsUseCase()
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::isGroupOutOfSync)
+            .with(any(), any())
+            .wasInvoked(twice)
+
+        verify(arrangement.joinExistingMLSConversationUseCase)
+            .suspendFunction(arrangement.joinExistingMLSConversationUseCase::invoke)
+            .with(any())
+            .wasInvoked(once)
+
+        assertIs<RecoverMLSConversationsResult.Success>(actual)
+    }
+
+
+    @Test
+    fun whenFetchingListOfConversationsFails_ThenShouldReturnFailure() = runTest {
+        val (arrangement, recoverMLSConversationsUseCase) = Arrangement()
+            .withConversationsByGroupStateReturns(Either.Left(StorageFailure.DataNotFound))
+            .withJoinExistingMLSConversationUseCaseSuccessful()
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withConversationIsOutOfSyncReturnsTrueFor(listOf())
+            .arrange()
+
+        val actual = recoverMLSConversationsUseCase()
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::isGroupOutOfSync)
+            .with(any(), any())
+            .wasNotInvoked()
+
+        assertIs<RecoverMLSConversationsResult.Failure>(actual)
+    }
+
+    private class Arrangement {
+        @Mock
+        val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
+
+        @Mock
+        val featureSupport = mock(classOf<FeatureSupport>())
+
+        @Mock
+        val joinExistingMLSConversationUseCase = mock(classOf<JoinExistingMLSConversationUseCase>())
+
+        @Mock
+        val clientRepository = mock(classOf<ClientRepository>())
+
+        @Mock
+        val conversationRepository = mock(classOf<ConversationRepository>())
+
+        private var recoverMLSConversationsUseCase = RecoverMLSConversationsUseCaseImpl(
+            featureSupport,
+            clientRepository,
+            conversationRepository,
+            mlsConversationRepository,
+            joinExistingMLSConversationUseCase
+        )
+
+        fun withIsMLSSupported(supported: Boolean) = apply {
+            given(featureSupport)
+                .invocation { featureSupport.isMLSSupported }
+                .thenReturn(supported)
+        }
+
+        fun withHasRegisteredMLSClient(result: Boolean) = apply {
+            given(clientRepository)
+                .suspendFunction(clientRepository::hasRegisteredMLSClient)
+                .whenInvoked()
+                .thenReturn(Either.Right(result))
+        }
+
+        fun withConversationsByGroupStateReturns(either: Either<StorageFailure, List<Conversation>>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::getConversationsByGroupState)
+                .whenInvokedWith(anything())
+                .thenReturn(either)
+        }
+
+        fun withJoinExistingMLSConversationUseCaseSuccessful() = apply {
+            given(joinExistingMLSConversationUseCase)
+                .suspendFunction(joinExistingMLSConversationUseCase::invoke)
+                .whenInvokedWith(anything())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withConversationIsOutOfSyncReturnsTrueFor(groupIds: List<GroupID>) = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::isGroupOutOfSync)
+                .whenInvokedWith(matching { it in groupIds }, any())
+                .thenReturn(Either.Right(true))
+        }
+
+        fun withConversationIsOutOfSyncReturnsFalseFor(groupID: GroupID) = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::isGroupOutOfSync)
+                .whenInvokedWith(eq(groupID), anything())
+                .thenReturn(Either.Right(false))
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::isGroupOutOfSync)
+                .whenInvokedWith(matching { it != groupID }, anything())
+                .thenReturn(Either.Right(true))
+        }
+
+        fun withJoinExistingMLSConversationUseCaseFailsFor(failedGroupId: ConversationId) = apply {
+            given(joinExistingMLSConversationUseCase)
+                .suspendFunction(joinExistingMLSConversationUseCase::invoke)
+                .whenInvokedWith(eq(failedGroupId))
+                .thenReturn(Either.Left(StorageFailure.DataNotFound))
+            given(joinExistingMLSConversationUseCase)
+                .suspendFunction(joinExistingMLSConversationUseCase::invoke)
+                .whenInvokedWith(matching { it != failedGroupId })
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun arrange() = this to recoverMLSConversationsUseCase
+
+        companion object {
+            val GROUP_ID1 = GroupID("group1")
+            val GROUP_ID2 = GroupID("group2")
+            val MLS_CONVERSATION1 = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID1,
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 1UL,
+                    keyingMaterialLastUpdate = Clock.System.now(),
+                    cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("id1", "domain"))
+
+            val MLS_CONVERSATION2 = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID2,
+                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    epoch = 1UL,
+                    keyingMaterialLastUpdate = Clock.System.now(),
+                    cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("id2", "domain"))
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandlerTest.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.sync.incremental
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import io.mockative.Mock
+import io.mockative.any
 import io.mockative.classOf
 import io.mockative.mock
 import io.mockative.verify
@@ -23,6 +24,11 @@ class IncrementalSyncRecoveryHandlerTest {
         with(arrangement) {
             verify(slowSyncRepository)
                 .suspendFunction(slowSyncRepository::clearLastSlowSyncCompletionInstant)
+                .wasNotInvoked()
+
+            verify(slowSyncRepository)
+                .suspendFunction(slowSyncRepository::updateMLSNeedsRecovery)
+                .with(any())
                 .wasNotInvoked()
 
             verify(onIncrementalSyncRetryCallback)
@@ -46,6 +52,11 @@ class IncrementalSyncRecoveryHandlerTest {
         with(arrangement) {
             verify(slowSyncRepository)
                 .suspendFunction(slowSyncRepository::clearLastSlowSyncCompletionInstant)
+                .wasNotInvoked()
+
+            verify(slowSyncRepository)
+                .suspendFunction(slowSyncRepository::updateMLSNeedsRecovery)
+                .with(any())
                 .wasNotInvoked()
 
             verify(onIncrementalSyncRetryCallback)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Recovery manager for MLS conversations after the user hit 404 sync error/state!

### Issues
Conversation will be out of sync in this case and won't be useful!

### Causes (Optional)
Long time out of sync!

### Solutions
We need to recover/check all the MLS Groups after 404 state (Long period out of sync) by checking all local epochs vs remote epochs.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
