### PR TITLE
fix(notification): notification in busy mode

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -49,7 +49,6 @@ interface MessageRepository {
         message: Message.Standalone,
         updateConversationReadDate: Boolean = false,
         updateConversationModifiedDate: Boolean = false,
-        updateConversationNotificationsDate: Boolean = false
     ): Either<CoreFailure, Unit>
 
     suspend fun deleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
@@ -197,13 +196,11 @@ class MessageDataSource(
         message: Message.Standalone,
         updateConversationReadDate: Boolean,
         updateConversationModifiedDate: Boolean,
-        updateConversationNotificationsDate: Boolean
     ): Either<CoreFailure, Unit> = wrapStorageRequest {
         messageDAO.insertOrIgnoreMessage(
             messageMapper.fromMessageToEntity(message),
             updateConversationReadDate,
-            updateConversationModifiedDate,
-            updateConversationNotificationsDate
+            updateConversationModifiedDate
         )
     }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -23,16 +23,6 @@ CREATE TABLE Message (
       PRIMARY KEY (id, conversation_id)
 );
 
--- update the lastMessageNotified date for a conversation that is
--- ALL_MUTED after inserting a new message related to that conversation
-CREATE TRIGGER updateMutedConversationNotificationDateAfterNewMessage
-AFTER INSERT
-ON Message
-BEGIN
- UPDATE Conversation SET last_notified_message_date = new.date
- WHERE qualified_id = new.conversation_id AND muted_status = 'ALL_MUTED';
-END;
-
 -- Allows optimized querying of messages sorting by date.
 CREATE INDEX message_date_index ON Message(date);
 
@@ -309,7 +299,7 @@ QuotedMessage.isQuotingSelfUser AS isQuotingSelfUser,
 TextContent.text_body AS text,
 AssetContent.asset_mime_type AS assetMimeType,
 (strftime('%Y-%m-%dT%H:%M:%fZ', Message.date) > strftime('%Y-%m-%dT%H:%M:%fZ', Conversation.last_read_date)) AS isUnread,
-IFNULL((strftime('%Y-%m-%dT%H:%M:%fZ', Message.date) > strftime('%Y-%m-%dT%H:%M:%fZ', Conversation.last_notified_message_date)), FALSE) AS shouldNotify,
+IFNULL((strftime('%Y-%m-%dT%H:%M:%fZ', Message.date) > strftime('%Y-%m-%dT%H:%M:%fZ',IFNULL(  Conversation.last_notified_message_date, '1970-01-01T00:00:00.000Z' ))), FALSE) AS shouldNotify,
 Conversation.muted_status AS mutedStatus,
 Conversation.type AS conversationType
 FROM Message
@@ -322,6 +312,39 @@ LEFT JOIN MessageMention AS Mention ON Message.id == Mention.message_id AND Self
 LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
 LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
 LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id;
+
+needsToBeNotified:
+WITH targetMessage(isSelfMessage, isMentioningSelfUser, isQuotingSelfUser, isOneOnOne, mutedStatus) AS (
+SELECT isSelfMessage,
+ IFNULL( isMentioningSelfUser, 0 ) == 1 AS  isMentioningSelfUser,
+	IFNULL( isQuotingSelfUser, 0 ) == 1 AS isQuotingSelfUser,
+	 (conversationType == 'ONE_ON_ONE') AS isOneOnOne, mutedStatus  FROM MessagePreview WHERE id = ?)
+SELECT (
+    CASE mutedStatus
+    WHEN 'ALL_MUTED' THEN 0
+    WHEN 'ALL_ALLOWED' THEN (
+        SELECT CASE (SELECT User.user_availability_status FROM SelfUser LEFT JOIN User ON SelfUser.id = User.qualified_id)
+            WHEN 'BUSY' THEN (SELECT
+                isSelfMessage == 0
+                AND isMentioningSelfUser == 1
+                OR  isQuotingSelfUser == 1
+                OR isOneOnOne == 1 FROM targetMessage)
+            WHEN 'AWAY' THEN 0
+            WHEN 'NONE' THEN  (SELECT isSelfMessage == 0 FROM targetMessage)
+            WHEN 'AVAILABLE' THEN (SELECT isSelfMessage == 0 FROM targetMessage)
+            ELSE (SELECT isSelfMessage == 0 FROM targetMessage)  END
+        )
+    WHEN 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' THEN (
+        SELECT CASE (SELECT User.user_availability_status FROM SelfUser LEFT JOIN User ON SelfUser.id = User.qualified_id)
+            WHEN 'AWAY' THEN 0
+            ELSE  (SELECT isSelfMessage == 0
+                  AND isMentioningSelfUser == 1
+                  OR isQuotingSelfUser== 1
+									FROM targetMessage)
+            END
+        )
+    ELSE (SELECT isSelfMessage == 0 FROM targetMessage) END)
+     AS needsToBeNotified FROM targetMessage;
 
 getLastMessages:
 SELECT * FROM MessagePreview AS message
@@ -512,9 +535,7 @@ WHERE conversation_id IS :conversation_id;
 getNotificationsMessages:
 SELECT * FROM MessagePreview AS message
 WHERE shouldNotify == 1
-AND isSelfMessage == 0
 AND visibility = 'VISIBLE'
-AND (mutedStatus == 'ALL_ALLOWED' OR (mutedStatus == 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' AND (isQuotingSelfUser OR isMentioningSelfUser)))
 AND contentType IN ?;
 
 selectByConversationIdAndSenderIdAndTimeAndType:

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -22,8 +22,7 @@ interface MessageDAO {
     suspend fun insertOrIgnoreMessage(
         message: MessageEntity,
         updateConversationReadDate: Boolean = false,
-        updateConversationModifiedDate: Boolean = false,
-        updateConversationNotificationsDate: Boolean = false
+        updateConversationModifiedDate: Boolean = false
     )
 
     /**

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -1,14 +1,13 @@
 package com.wire.kalium.persistence.dao.message
 
 import app.cash.sqldelight.coroutines.asFlow
-import app.cash.sqldelight.coroutines.mapToList
-import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.ASSET
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.CONVERSATION_RENAMED
+import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.CRYPTO_SESSION_RESET
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.FAILED_DECRYPTION
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.KNOCK
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.MEMBER_CHANGE
@@ -21,7 +20,6 @@ import com.wire.kalium.persistence.kaliumLogger
 import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import kotlinx.coroutines.flow.Flow
-import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.CRYPTO_SESSION_RESET
 
 @Suppress("TooManyFunctions")
 class MessageDAOImpl(
@@ -45,8 +43,7 @@ class MessageDAOImpl(
     override suspend fun insertOrIgnoreMessage(
         message: MessageEntity,
         updateConversationReadDate: Boolean,
-        updateConversationModifiedDate: Boolean,
-        updateConversationNotificationsDate: Boolean
+        updateConversationModifiedDate: Boolean
     ) {
         queries.transaction {
             if (updateConversationReadDate) {
@@ -55,11 +52,12 @@ class MessageDAOImpl(
 
             insertInDB(message)
 
+            if (queries.needsToBeNotified(message.id).executeAsOne() == 0L) {
+                conversationsQueries.updateConversationNotificationsDate(message.date, message.conversationId)
+            }
+
             if (updateConversationModifiedDate) {
                 conversationsQueries.updateConversationModifiedDate(message.date, message.conversationId)
-            }
-            if (updateConversationNotificationsDate) {
-                conversationsQueries.updateConversationNotificationsDate(message.date, message.conversationId)
             }
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Moved all the logic to decide whether we a message needs to be notified or not in the Message queries.
This query respect user status and the conversation status.
### Issues

We had distributed logic everywhere! put it in one place and respect all the required states.


### Solutions


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)
In another PR.

- [ ] I have added automated test to this contribution

#### How to Test
Notifications should work as normal!

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
