### PR TITLE
docs: tiny docs generation fix

### DIFF
--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -35,5 +35,5 @@ jobs:
               with:
                   branch: gh-pages
                   clean: false
-                  folder: build/dokka/
+                  folder: build/dokka/htmlMultiModule
                   target-folder: docs

--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -35,5 +35,5 @@ jobs:
               with:
                   branch: gh-pages
                   clean: false
-                  folder: build/dokka/htmlMultiModule
+                  folder: build/dokka/
                   target-folder: docs

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,8 +88,6 @@ rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJ
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "17.6.0"
 }
 
-tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory.set(buildDir.resolve("dokka"))
-}
+tasks.dokkaHtmlMultiModule.configure {}
 
 apply(from = "$rootDir/gradle/detekt.gradle")

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonDokkaConfig.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonDokkaConfig.kt
@@ -27,8 +27,6 @@ fun Project.commonDokkaConfig() {
     plugins.apply("org.jetbrains.dokka")
     val rootProject = rootProject
     tasks.withType(AbstractDokkaLeafTask::class.java).configureEach {
-        outputDirectory.set(file("build/dokka"))
-
         dokkaSourceSets.configureEach {
             file("module.md").takeIf { it.exists() }?.let {
                 includes.from(it)

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonDokkaConfig.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonDokkaConfig.kt
@@ -2,7 +2,7 @@ package com.wire.kalium.plugins
 
 import org.gradle.api.Project
 import org.jetbrains.dokka.DokkaConfiguration.Visibility
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
 
 val documentedSubprojects = listOf(
     "calling",
@@ -26,7 +26,7 @@ fun Project.commonDokkaConfig() {
 
     plugins.apply("org.jetbrains.dokka")
     val rootProject = rootProject
-    tasks.withType(DokkaTaskPartial::class.java).configureEach {
+    tasks.withType(AbstractDokkaLeafTask::class.java).configureEach {
         outputDirectory.set(file("build/dokka"))
 
         dokkaSourceSets.configureEach {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. Dokka is failing to generate
2. When running `./gradlew :module:dokkaHtml` to test out a single module, it doesn't include samples and the other settings present when running through `./gradlew dokkaHtmlMultiModule`.

### Causes

1. I broke it in https://github.com/wireapp/kalium/pull/1243
2. `dokkaHtmlMultiModule` will invoke `DokkaTaskPartial` for the modules, when running `dokkaHtml` on a specific module, only a `DokkaTask` will be called, and these two types are are not directly related by inheritance.

### Solutions

1. Revert back to let Dokka solve the default output, and configure the publishing action to correctly solve it
2. Instead of configuring `DokkaTaskPartial`, configure all `AbstractDokkaLeafTask`, which both types of Dokka tasks inherit from.

### Testing

I've tested it manually here.

#### How to Test

- `./gradlew dokkaHtmlMultiModule` to generate the documentation for all modules. The output will be in `./build/dokka/htmlMultiModule`
- `./gradlew :$MODULE$:dokkaHtml` to generate docs for a specific `$MODULE$`. The output will be in `$MODULE$/build/dokkaHtml`.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
