### PR TITLE
fix: do not print out potentially sensitive data

### DIFF
--- a/buildSrc/src/main/kotlin/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/ProjectExtensions.kt
@@ -22,6 +22,8 @@ internal fun <T> getLocalProperty(propertyName: String, defaultValue: T, project
     }
 
     val localValue = localProperties.getOrDefault(propertyName, defaultValue) as? T ?: defaultValue
-    println("> Reading local prop '$propertyName' with value: $localValue")
+    if (localValue != null) {
+        println("> Reading local prop '$propertyName'")
+    }
     return localValue
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Data read from `local.properties` may contain sensitive data, this data should not end in stdout.

### Solutions

Remove `$localValue` from the logging and only log if the property contained data.


### Testing

#### How to Test

The CI should still continue to work, but the log does no longer show the values of `github.package.*`


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
