### PR TITLE
fix: Dependency issue with logger frameworks in testservice

### DIFF
--- a/testservice/build.gradle.kts
+++ b/testservice/build.gradle.kts
@@ -43,14 +43,19 @@ repositories {
 dependencies {
     add("implementation", "io.dropwizard:dropwizard-core:${Versions.dropwizard}")
     add("implementation", "com.github.smoketurner:dropwizard-swagger:72e8441e4a")
+    add("implementation", "org.slf4j:slf4j-api:1.7.22")
 
     // prometheus metrics
     add("implementation", "io.prometheus:simpleclient_dropwizard:${Versions.prometheus_simpleclient}")
     add("implementation", "io.prometheus:simpleclient_servlet:${Versions.prometheus_simpleclient}")
 
     add("implementation", project(":network"))
-    add("implementation", project(":cryptography"))
-    add("implementation", project(":logic"))
+    add("implementation", project(":cryptography")) {
+        exclude("org.slf4j", "slf4j-api")
+    }
+    add("implementation", project(":logic")) {
+        exclude("org.slf4j", "slf4j-api")
+    }
 
     // Okio
     implementation(libs.okio.core)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

testservice was able to compile but not to run due to errors with the logging:
```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions prior to 1.8.
SLF4J: Ignoring binding found at [jar:file:/Users/sven/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.2.11/4741689214e9d1e8408b206506cbe76d1c6a7d60/logback-classic-1.2.11.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#ignoredBindings for an explanation.
Exception in thread "main" java.lang.IllegalStateException: Unable to acquire the logger context
        at io.dropwizard.logging.LoggingUtil.getLoggerContext(LoggingUtil.java:46)
        at io.dropwizard.logging.BootstrapLogging.bootstrap(BootstrapLogging.java:51)
        at io.dropwizard.logging.BootstrapLogging.bootstrap(BootstrapLogging.java:40)
        at io.dropwizard.Application.bootstrapLogging(Application.java:38)
        at io.dropwizard.Application.<init>(Application.java:26)
        at com.wire.kalium.testservice.TestserviceApplication.<init>(TestserviceApplication.kt:21)
        at com.wire.kalium.testservice.TestserviceApplication$Companion.main(TestserviceApplication.kt:26)
        at com.wire.kalium.testservice.TestserviceApplication.main(TestserviceApplication.kt)
```

### Solutions

Pinned sfl4j to version 1.7.22 by implicitly adding it as dependency and excluding it from cryptographic and logic dependencies.



----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
