### PR TITLE
chore: upgrade libsodium bindings to 0.8.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ detekt = "1.19.0"
 agp = "7.3.1"
 dokka = "1.7.20"
 carthage = "0.0.1"
-libsodiumBindings = "0.8.5"
+libsodiumBindings = "0.8.6"
 protobufCodegen = "0.9.1"
 
 [plugins]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Trying to run Reloaded with libsodium bindings 0.8.7 causes a failure:

```
15:12:49.497  E  FATAL EXCEPTION: main
                 Process: com.wire.android.internal.debug, PID: 11628
                 java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "__emutls_get_address" referenced by "/data/app/~~NrqjSvO5heT_q7r5OLpPcw==/com.wire.android.internal.debug-_okmA3v6m3Ks0qZU6KQG3Q==/base.apk!/lib/x86/libavs.so"...
                 	at java.lang.Runtime.loadLibrary0(Runtime.java:1087)
                 	at java.lang.Runtime.loadLibrary0(Runtime.java:1008)
                 	at java.lang.System.loadLibrary(System.java:1664)
                 	at com.waz.avs.AVSystem.load(AVSystem.java:29)
                 	at com.waz.call.FlowManager.<clinit>(FlowManager.java:66)
                 	at com.wire.kalium.logic.feature.call.FlowManagerServiceImpl.<init>(FlowManagerServiceImpl.kt:18)
                 	at com.wire.kalium.logic.feature.call.GlobalCallManager.<init>(GlobalCallManager.kt:79)
                 	at com.wire.kalium.logic.CoreLogic.<init>(CoreLogic.kt:49)
                 	at com.wire.android.di.CoreLogicModule.provideCoreLogic(CoreLogicModule.kt:111)
                 	at com.wire.android.di.CoreLogicModule_ProvideCoreLogicFactory.provideCoreLogic(CoreLogicModule_ProvideCoreLogicFactory.java:50)
                 	at com.wire.android.DaggerWireApplication_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get(DaggerWireApplication_HiltComponents_SingletonC.java:2359)
                 	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
                 	at com.wire.android.DaggerWireApplication_HiltComponents_SingletonC$SingletonCImpl.injectWireApplication2(DaggerWireApplication_HiltComponents_SingletonC.java:2304)
                 	at com.wire.android.DaggerWireApplication_HiltComponents_SingletonC$SingletonCImpl.injectWireApplication(DaggerWireApplication_HiltComponents_SingletonC.java:2262)
                 	at com.wire.android.Hilt_WireApplication.hiltInternalInject(Hilt_WireApplication.java:50)
                 	at com.wire.android.Hilt_WireApplication.onCreate(Hilt_WireApplication.java:41)
                 	at com.wire.android.WireApplication.onCreate(WireApplication.kt:58)
                 	at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1192)
                 	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6712)
                 	at android.app.ActivityThread.access$1300(ActivityThread.java:237)
                 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1913)
                 	at android.os.Handler.dispatchMessage(Handler.java:106)
                 	at android.os.Looper.loop(Looper.java:223)
                 	at android.app.ActivityThread.main(ActivityThread.java:7656)
                 	at java.lang.reflect.Method.invoke(Native Method)
                 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
                 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```

Using 0.8.5 we get tests failing:

```

com.wire.kalium.logic.feature.backup.CreateBackupUseCaseTest > givenSomeValidData_whenCreatingAnEncryptedBackup_thenTheFinalBackupFileIsCreatedCorrectly[test(AVD) - 11] FAILED 
	java.lang.RuntimeException: Unsupported platform
	at com.ionspin.kotlin.crypto.LibsodiumInitializer.loadLibrary(LibsodiumInitializer.kt:36)

com.wire.kalium.logic.feature.backup.RestoreBackupUseCaseTest > givenAValidEncryptedBackupFile_whenRestoring_thenTheBackupIsRestoredCorrectly[test(AVD) - 11] FAILED 
	java.lang.RuntimeException: Unsupported platform
	at com.ionspin.kotlin.crypto.LibsodiumInitializer.loadLibrary(LibsodiumInitializer.kt:36)

com.wire.kalium.logic.feature.backup.RestoreBackupUseCaseTest > givenACorrectlyEncryptedBackup_whenRestoringWithADBImportError_thenTheRightErrorIsThrown[test(AVD) - 11] FAILED 
	java.lang.RuntimeException: Unsupported platform
	at com.ionspin.kotlin.crypto.LibsodiumInitializer.loadLibrary(LibsodiumInitializer.kt:36)
```

### Causes

Yet to be defined, I'm looking deeper into it now.

### Solutions

So far, I've found the sweet spot: 0.8.6.

Tests run normally AND Reloaded doesn't crash.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
