### PR TITLE
ci: run tests on all modules if there build logic change

### DIFF
--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -33,7 +33,20 @@ jobs:
             - name: Validate Gradle wrapper
               uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
 
+            # Checks for changes in the top-level gradle settings or buildSrc
+            - name: Identify build configuration changes
+              id: identify-build-configuration-changes
+              uses: tj-actions/changed-files@v35
+              with:
+                  files: |
+                      /*.gradle.*
+                      /gradle/*.gradle.*
+                      buildSrc/src/**
+                      *.versions.toml
+
+            # TODO: RE-ENABLE AFTER TESTING CI SETUP
             - name: Build the samples
+              if: ${{ false }}
               env:
                   GITHUB_USER: ${{ github.actor }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,7 +73,22 @@ jobs:
                   disable-animations: false
                   script: echo "Generated AVD snapshot for caching."
 
-            - name: Android Instrumentation Tests
+            # If any Gradle file was modified, run tests on ALL modules
+            - name: Android Tests (All Modules)
+              id: test-all-modules
+              if: steps.identify-build-configuration-changes.outputs.any_modified == 'true'
+              uses: reactivecircus/android-emulator-runner@v2
+              with:
+                  api-level: ${{ matrix.api-level }}
+                  target: google_apis
+                  script: ./gradlew connectedDebugAndroidTest
+              env:
+                  GITHUB_USER: ${{ github.actor }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            # Only run this if the previous step was skipped
+            - name: Android Tests (Affected Modules)
+              if: steps.test-all-modules.outcome == 'skipped'
               uses: reactivecircus/android-emulator-runner@v2
               with:
                   api-level: ${{ matrix.api-level }}

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -32,14 +32,38 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
 
+      # Checks for changes in the top-level gradle settings or buildSrc
+      - name: Identify build configuration changes
+        id: identify-build-configuration-changes
+        uses: tj-actions/changed-files@v35
+        with:
+            files: |
+                /*.gradle.*
+                /gradle/*.gradle.*
+                buildSrc/src/**
+                *.versions.toml
+
+      # TODO: RE-ENABLE AFTER TESTING CI SETUP
       - name: Build the samples
+        if: ${{ false }}
         env:
             GITHUB_USER: ${{ github.actor }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
             ./gradlew :samples:compileKotlinIosX64
 
-      - name: iOS Tests
+      # If any Gradle file was modified, run tests on ALL modules
+      - name: iOS Tests (All Modules)
+        id: test-all-modules
+        if: steps.identify-build-configuration-changes.outputs.any_modified == 'true'
+        run: ./gradlew iosX64Test
+        env:
+            GITHUB_USER: ${{ github.actor }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Only run this if the previous step was skipped
+      - name: iOS Tests (Affected Modules)
+        if: steps.test-all-modules.outcome == 'skipped'
         run: ./gradlew iOSOnlyAffectedTest
         env:
             GITHUB_USER: ${{ github.actor }}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we try to optimise Android and iOS tests by only testing affected modules.
For example, if there's a change in `cryptography`, only `cryptography` and the modules that depend on it will be tested. `network`, for example, won't be tested because it has no relationship with it.

However, we don't check if there were changes in gradle files or version catalogs. When we bump a dependency, it can go through without running tests on Android and iOS, as "no modules were affected".

### Solutions

Use [changed-files](https://github.com/tj-actions/changed-files) action to identify when relevant top-level build settings were changed, and force tests on all modules.

### Testing

I'm testing on this PR by adding some blank lines in files and see how the workflows react.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
