### PR TITLE
fix(notification): ignore OneOnOne conversations in busy mode

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -314,11 +314,11 @@ LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.messa
 LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id;
 
 needsToBeNotified:
-WITH targetMessage(isSelfMessage, isMentioningSelfUser, isQuotingSelfUser, isOneOnOne, mutedStatus) AS (
+WITH targetMessage(isSelfMessage, isMentioningSelfUser, isQuotingSelfUser, mutedStatus) AS (
 SELECT isSelfMessage,
  IFNULL( isMentioningSelfUser, 0 ) == 1 AS  isMentioningSelfUser,
 	IFNULL( isQuotingSelfUser, 0 ) == 1 AS isQuotingSelfUser,
-	 (conversationType == 'ONE_ON_ONE') AS isOneOnOne, mutedStatus  FROM MessagePreview WHERE id = ? AND conversationId = ?)
+	mutedStatus  FROM MessagePreview WHERE id = ? AND conversationId = ?)
 SELECT (
     CASE mutedStatus
     WHEN 'ALL_MUTED' THEN 0
@@ -328,7 +328,7 @@ SELECT (
                 isSelfMessage == 0
                 AND isMentioningSelfUser == 1
                 OR  isQuotingSelfUser == 1
-                OR isOneOnOne == 1 FROM targetMessage)
+                FROM targetMessage)
             WHEN 'AWAY' THEN 0
             WHEN 'NONE' THEN  (SELECT isSelfMessage == 0 FROM targetMessage)
             WHEN 'AVAILABLE' THEN (SELECT isSelfMessage == 0 FROM targetMessage)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a user is in busy mode, only mentions and replies must be notified!

### Causes (Optional)

Added another case that isn't necessary. 

### Solutions

Exclude OneOnOne conversations from the logic.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
