### PR TITLE
fix: only run affected tests fix and simplify shell exec functions

### DIFF
--- a/buildSrc/src/main/kotlin/OnlyAffectedTestTask.kt
+++ b/buildSrc/src/main/kotlin/OnlyAffectedTestTask.kt
@@ -84,7 +84,7 @@ open class OnlyAffectedTestTask : DefaultTask() {
      */
     private fun hasToRunAllTests(): Boolean {
         val globalBuildSettingsFiles = listOf(
-            "gradle/libs.version.toml",
+            "gradle/libs.versions.toml",
             "build.gradle.kts",
             "settings.gradle.kts",
         )

--- a/buildSrc/src/main/kotlin/OnlyAffectedTestTask.kt
+++ b/buildSrc/src/main/kotlin/OnlyAffectedTestTask.kt
@@ -90,8 +90,8 @@ open class OnlyAffectedTestTask : DefaultTask() {
         )
 
         val anySettingsFileChanged = globalBuildSettingsFiles.any { relativePath ->
-            val command = "bash -c 'git diff --quiet origin/develop -- ${project.rootDir}/$relativePath ; echo $'"
-            command.runCommandWithExitCode() != 0
+            val exitCode = "git diff --quiet origin/develop -- ${project.rootDir}/$relativePath".execute().exitValue()
+            exitCode != 0
         }
         if (anySettingsFileChanged) {
             println("\uD83D\uDD27 Running all tests because there are changes at the root level")

--- a/buildSrc/src/main/kotlin/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/ProjectExtensions.kt
@@ -29,10 +29,13 @@ internal fun <T> getLocalProperty(propertyName: String, defaultValue: T, project
 }
 
 /**
- * Run command and return the output
+ * Run command and return the [Process]
  */
 fun String.execute(): Process = ProcessGroovyMethods.execute(this).also {
     it.waitFor(30, TimeUnit.SECONDS)
 }
 
+/**
+ * Run command and return the output as text
+ */
 fun Process.text(): String = ProcessGroovyMethods.getText(this)

--- a/buildSrc/src/main/kotlin/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/ProjectExtensions.kt
@@ -1,5 +1,5 @@
+import org.codehaus.groovy.runtime.ProcessGroovyMethods
 import org.gradle.api.Project
-import java.io.File
 import java.util.Properties
 import java.util.concurrent.TimeUnit
 
@@ -31,36 +31,8 @@ internal fun <T> getLocalProperty(propertyName: String, defaultValue: T, project
 /**
  * Run command and return the output
  */
-fun String.runCommand(workingDir: File = File("./")): String? = try {
-    val proc = processCommand(workingDir)
-    proc!!.inputStream.bufferedReader().readText().trim()
-} catch (e: Exception) {
-    println("Error running command: $this")
-    e.printStackTrace()
-    null
+fun String.execute(): Process = ProcessGroovyMethods.execute(this).also {
+    it.waitFor(30, TimeUnit.SECONDS)
 }
 
-/**
- * Run command and return the exit code
- */
-fun String.runCommandWithExitCode(workingDir: File = File("./")): Int = try {
-    val proc = processCommand(workingDir)
-    proc!!.exitValue()
-} catch (e: Exception) {
-    println("Error running command: $this")
-    e.printStackTrace()
-    999
-}
-
-private fun String.processCommand(workingDir: File): Process? {
-    val parts = this.split("\\s".toRegex())
-    val proc = ProcessBuilder(*parts.toTypedArray())
-        .directory(workingDir)
-        .redirectOutput(ProcessBuilder.Redirect.PIPE)
-        .redirectError(ProcessBuilder.Redirect.PIPE)
-        .start()
-
-    proc.waitFor(1, TimeUnit.MINUTES)
-    proc.inputStream.bufferedReader().readText().trim()
-    return proc
-}
+fun Process.text(): String = ProcessGroovyMethods.getText(this)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The prev. PR #1262  tried to address the fact to detect changes on settings file, but there was an error, since the kotlin dsl processor was not working as expected, always returned error code.

Now this fixes and simplify the scripts command execution, also fixed a typo on `libs.versions.toml` file ref


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
