### PR TITLE
fix: make quoted username nullable [AR-2871]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -92,7 +92,7 @@ sealed class MessageContent {
 
     data class QuotedMessageDetails(
         val senderId: UserId,
-        val senderName: String,
+        val senderName: String?,
         val isQuotingSelfUser: Boolean,
         /**
          * Indicates that the hash of the quote

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -175,7 +175,7 @@ sealed class MessageEntityContent {
              * matches the hash of the original message
              */
             val isVerified: Boolean,
-            val senderName: String,
+            val senderName: String?,
             val dateTime: String,
             val editTimestamp: String?,
             val visibility: MessageEntity.Visibility,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -310,7 +310,7 @@ object MessageMapper {
                         senderId = quotedSenderId.requireField("quotedSenderId"),
                         isQuotingSelfUser = isQuotingSelfUser.requireField("isQuotingSelfUser"),
                         isVerified = isQuoteVerified ?: false,
-                        senderName = quotedSenderName.requireField("quotedSenderName"),
+                        senderName = quotedSenderName,
                         dateTime = quotedMessageDateTime.requireField("quotedMessageDateTime"),
                         editTimestamp = quotedMessageEditTimestamp,
                         visibility = quotedMessageVisibility.requireField("quotedMessageVisibility"),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
In some edge case's for example when user was deleted we should make quoted sender name field nullable and show it as unavailable username


### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
