### PR TITLE
fix: downgrade to older official release version b/c jitpack.io is unreachable

### DIFF
--- a/testservice/build.gradle.kts
+++ b/testservice/build.gradle.kts
@@ -42,7 +42,9 @@ repositories {
 
 dependencies {
     add("implementation", "io.dropwizard:dropwizard-core:${Versions.dropwizard}")
-    add("implementation", "com.github.smoketurner:dropwizard-swagger:72e8441e4a")
+    // TODO: The next line was replaced by the following because jitpack.io repo was unreachable
+    // add("implementation", "com.github.smoketurner:dropwizard-swagger:72e8441e4a")
+    add("implementation", "com.smoketurner:dropwizard-swagger:2.0.12-1")
     add("implementation", "org.slf4j:slf4j-api:1.7.22")
 
     // prometheus metrics


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The needed version of our dependency **dropwizard-swagger** for kalium-testservice is currently not downloadable because https://jitpack.io/com/github/smoketurner/dropwizard-swagger/72e8441e4a/dropwizard-swagger-72e8441e4a.pom produces an error.

We have to use jitpack in order to get a specific commit (72e8441e4a) because our security team asked for it. Unfortunately the project was a bit unmaintained and did not make a release with this commit yet. I asked in their bug tracker to make a release and they are on it.

### Solutions

In the meantime we downgrade to an older version available from mvn public repos.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
