### PR TITLE
fix: clear reactions when receiving message edits (AR-2881) (AR-2849)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -55,7 +55,6 @@ interface MessageRepository {
 
     suspend fun deleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun markMessageAsDeleted(messageUuid: String, conversationId: ConversationId): Either<StorageFailure, Unit>
-    suspend fun markMessageAsEdited(messageUuid: String, conversationId: ConversationId, timeStamp: String): Either<StorageFailure, Unit>
     suspend fun updateMessageStatus(
         messageStatus: MessageEntity.Status,
         conversationId: ConversationId,
@@ -114,15 +113,11 @@ interface MessageRepository {
         visibility: List<Message.Visibility> = Message.Visibility.values().toList()
     ): Either<CoreFailure, List<Message>>
 
-    suspend fun updateTextMessageContent(
+    suspend fun updateTextMessage(
         conversationId: ConversationId,
-        messageContent: MessageContent.TextEdited
-    ): Either<CoreFailure, Unit>
-
-    suspend fun updateMessageId(
-        conversationId: ConversationId,
-        oldMessageId: String,
-        newMessageId: String
+        messageContent: MessageContent.TextEdited,
+        newMessageId: String,
+        editTimeStamp: String
     ): Either<CoreFailure, Unit>
 
     suspend fun resetAssetProgressStatus()
@@ -220,14 +215,6 @@ class MessageDataSource(
         wrapStorageRequest {
             messageDAO.markMessageAsDeleted(id = messageUuid, conversationsId = idMapper.toDaoModel(conversationId))
         }
-
-    override suspend fun markMessageAsEdited(
-        messageUuid: String,
-        conversationId: ConversationId,
-        timeStamp: String
-    ) = wrapStorageRequest {
-        messageDAO.markAsEdited(timeStamp, idMapper.toDaoModel(conversationId), messageUuid)
-    }
 
     override suspend fun getMessageById(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Message> =
         wrapStorageRequest {
@@ -352,40 +339,27 @@ class MessageDataSource(
         messageDAO.getPendingToConfirmMessagesByConversationAndVisibilityAfterDate(
             idMapper.toDaoModel(conversationId),
             date,
-            visibility.map { it.toEntityVisibility() })
-            .map(messageMapper::fromEntityToMessage)
+            visibility.map { it.toEntityVisibility() }
+        ).map(messageMapper::fromEntityToMessage)
     }
 
-    override suspend fun updateMessageId(
+    override suspend fun updateTextMessage(
         conversationId: ConversationId,
-        oldMessageId: String,
-        newMessageId: String
-    ): Either<CoreFailure, Unit> =
-        wrapStorageRequest {
-            messageDAO.updateMessageId(idMapper.toDaoModel(conversationId), oldMessageId, newMessageId)
-        }
-
-    override suspend fun updateTextMessageContent(
-        conversationId: ConversationId,
-        messageContent: MessageContent.TextEdited
+        messageContent: MessageContent.TextEdited,
+        newMessageId: String,
+        editTimeStamp: String
     ): Either<CoreFailure, Unit> {
-        val messageToUpdate = getMessageById(conversationId, messageContent.editMessageId)
-
-        return messageToUpdate.flatMap { message ->
-            wrapStorageRequest {
-                if (message.content is MessageContent.Text) {
-                    messageDAO.updateTextMessageContent(
-                        idMapper.toDaoModel(conversationId),
-                        messageContent.editMessageId,
-                        MessageEntityContent.Text(
-                            messageContent.newContent,
-                            messageContent.newMentions.map { messageMentionMapper.fromModelToDao(it) }
-                        )
-                    )
-                } else {
-                    throw IllegalStateException("Text message can only be updated on message having TextMessageContent set as content")
-                }
-            }
+        return wrapStorageRequest {
+            messageDAO.updateTextMessageContent(
+                editTimeStamp = editTimeStamp,
+                conversationId = idMapper.toDaoModel(conversationId),
+                currentMessageId = messageContent.editMessageId,
+                newTextContent = MessageEntityContent.Text(
+                    messageContent.newContent,
+                    messageContent.newMentions.map { messageMentionMapper.fromModelToDao(it) }
+                ),
+                newMessageId = newMessageId
+            )
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.sync.receiver.conversation.message
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.asset.AssetRepository
@@ -176,7 +177,11 @@ internal class ApplicationMessageHandlerImpl(
                 persistMessage(message)
             }
 
-            is MessageContent.Reaction -> persistReaction(content, signaling.conversationId, signaling.senderUserId, signaling.date)
+            is MessageContent.Reaction -> {
+                kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.MESSAGES)
+                    .w("EDITING MESSAGE (REACTION): ORIGINAL ID: ${content.messageId}, EMOJI: ${content.emojiSet}")
+                persistReaction(content, signaling.conversationId, signaling.senderUserId, signaling.date)
+            }
             is MessageContent.DeleteMessage -> handleDeleteMessage(content, signaling.conversationId, signaling.senderUserId)
             is MessageContent.DeleteForMe -> deleteForMeHandler.handle(signaling, content)
             is MessageContent.Calling -> {
@@ -187,7 +192,11 @@ internal class ApplicationMessageHandlerImpl(
                 )
             }
 
-            is MessageContent.TextEdited -> editTextHandler.handle(signaling, content)
+            is MessageContent.TextEdited -> {
+                kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.MESSAGES)
+                    .w("EDITING MESSAGE: ORIGINAL ID: ${content.editMessageId}, NEW ID: ${signaling.id}")
+                editTextHandler.handle(signaling, content)
+            }
             is MessageContent.LastRead -> lastReadContentHandler.handle(signaling, content)
             is MessageContent.Cleared -> clearConversationContentHandler.handle(signaling, content)
             is MessageContent.Receipt -> receiptMessageHandler.handle(signaling, content)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -1,6 +1,5 @@
 package com.wire.kalium.logic.sync.receiver.conversation.message
 
-import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.asset.AssetRepository
@@ -177,11 +176,7 @@ internal class ApplicationMessageHandlerImpl(
                 persistMessage(message)
             }
 
-            is MessageContent.Reaction -> {
-                kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.MESSAGES)
-                    .w("EDITING MESSAGE (REACTION): ORIGINAL ID: ${content.messageId}, EMOJI: ${content.emojiSet}")
-                persistReaction(content, signaling.conversationId, signaling.senderUserId, signaling.date)
-            }
+            is MessageContent.Reaction -> persistReaction(content, signaling.conversationId, signaling.senderUserId, signaling.date)
             is MessageContent.DeleteMessage -> handleDeleteMessage(content, signaling.conversationId, signaling.senderUserId)
             is MessageContent.DeleteForMe -> deleteForMeHandler.handle(signaling, content)
             is MessageContent.Calling -> {
@@ -192,11 +187,7 @@ internal class ApplicationMessageHandlerImpl(
                 )
             }
 
-            is MessageContent.TextEdited -> {
-                kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.MESSAGES)
-                    .w("EDITING MESSAGE: ORIGINAL ID: ${content.editMessageId}, NEW ID: ${signaling.id}")
-                editTextHandler.handle(signaling, content)
-            }
+            is MessageContent.TextEdited -> editTextHandler.handle(signaling, content)
             is MessageContent.LastRead -> lastReadContentHandler.handle(signaling, content)
             is MessageContent.Cleared -> clearConversationContentHandler.handle(signaling, content)
             is MessageContent.Receipt -> receiptMessageHandler.handle(signaling, content)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/MessageTextEditHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/MessageTextEditHandler.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.sync.receiver.message
 
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.message.Message
@@ -26,8 +27,9 @@ class MessageTextEditHandlerImpl(
     ) = messageRepository.getMessageById(message.conversationId, messageContent.editMessageId).flatMap { currentMessage ->
 
         if (currentMessage.senderUserId != message.senderUserId) {
+            val obfuscatedId = message.senderUserId.toString().obfuscateId()
             kaliumLogger.w(
-                message = "User '${message.senderUserId}' attempted to edit a message from another user. Ignoring the edit completely"
+                message = "User '$obfuscatedId' attempted to edit a message from another user. Ignoring the edit completely"
             )
             // Same as message not found. _i.e._ not found for the original sender at least
             return@flatMap Either.Left(StorageFailure.DataNotFound)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
@@ -73,4 +73,16 @@ object TestMessage {
         editStatus = MessageEntity.EditStatus.NotEdited,
         senderName = "senderName"
     )
+
+    fun signalingMessage(
+        content: MessageContent.Signaling
+    ) = Message.Signaling(
+        id = TEST_MESSAGE_ID,
+        content = content,
+        conversationId = TestConversation.ID,
+        date = "currentDate",
+        senderUserId = TEST_SENDER_USER_ID,
+        senderClientId = TEST_SENDER_CLIENT_ID,
+        status = Message.Status.SENT
+    )
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -487,8 +487,8 @@ WHERE message_id = ? AND conversation_id = ?;
 
 updateMessageId:
 UPDATE Message
-SET id = ?
-WHERE id = ? AND conversation_id = ?;
+SET id = :newId
+WHERE id = :oldId AND conversation_id = :conversationId;
 
 selectAllMessages:
 SELECT * FROM Message ORDER BY strftime('%Y-%m-%d %H:%M:%f', date) DESC LIMIT ? OFFSET ?;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Reactions.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Reactions.sq
@@ -21,6 +21,9 @@ insertReaction:
 INSERT OR REPLACE INTO Reaction(message_id, conversation_id, sender_id, emoji, date)
 VALUES(?, ?, ?, ?, ?);
 
+deleteAllReactionsForMessage:
+DELETE FROM Reaction WHERE message_id = ? AND conversation_id = ?;
+
 selectByMessageIdAndConversationIdAndSenderId:
 SELECT * FROM Reaction WHERE message_id = ? AND conversation_id = ? AND sender_id = ?;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -11,7 +11,6 @@ interface MessageDAO {
     suspend fun updateAssetUploadStatus(uploadStatus: MessageEntity.UploadStatus, id: String, conversationId: QualifiedIDEntity)
     suspend fun updateAssetDownloadStatus(downloadStatus: MessageEntity.DownloadStatus, id: String, conversationId: QualifiedIDEntity)
     suspend fun markMessageAsDeleted(id: String, conversationsId: QualifiedIDEntity)
-    suspend fun markAsEdited(editTimeStamp: String, conversationId: QualifiedIDEntity, id: String)
     suspend fun deleteAllMessages()
 
     /**
@@ -40,7 +39,6 @@ interface MessageDAO {
     suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>)
     fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
     suspend fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity)
-    suspend fun updateMessageId(conversationId: QualifiedIDEntity, oldMessageId: String, newMessageId: String)
     suspend fun updateMessageDate(date: String, id: String, conversationId: QualifiedIDEntity)
     suspend fun updateMessagesAddMillisToDate(millis: Long, conversationId: QualifiedIDEntity, status: MessageEntity.Status)
     suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?>
@@ -63,9 +61,11 @@ interface MessageDAO {
 
     suspend fun getAllPendingMessagesFromUser(userId: UserIDEntity): List<MessageEntity>
     suspend fun updateTextMessageContent(
+        editTimeStamp: String,
         conversationId: QualifiedIDEntity,
-        messageId: String,
-        newTextContent: MessageEntityContent.Text
+        currentMessageId: String,
+        newTextContent: MessageEntityContent.Text,
+        newMessageId: String
     )
 
     suspend fun getConversationMessagesByContentType(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.persistence.dao.message
 import app.cash.sqldelight.coroutines.asFlow
 import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MessagesQueries
+import com.wire.kalium.persistence.ReactionsQueries
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -26,7 +27,8 @@ import kotlinx.coroutines.flow.Flow
 class MessageDAOImpl(
     private val queries: MessagesQueries,
     private val conversationsQueries: ConversationsQueries,
-    private val selfUserId: UserIDEntity
+    private val selfUserId: UserIDEntity,
+    private val reactionsQueries: ReactionsQueries
 ) : MessageDAO {
     private val mapper = MessageMapper
 
@@ -34,10 +36,6 @@ class MessageDAOImpl(
 
     override suspend fun markMessageAsDeleted(id: String, conversationsId: QualifiedIDEntity) =
         queries.markMessageAsDeleted(id, conversationsId)
-
-    override suspend fun markAsEdited(editTimeStamp: String, conversationId: QualifiedIDEntity, id: String) {
-        queries.markMessageAsEdited(editTimeStamp, id, conversationId)
-    }
 
     override suspend fun deleteAllMessages() = queries.deleteAllMessages()
 
@@ -286,10 +284,6 @@ class MessageDAOImpl(
     override suspend fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity) =
         queries.updateMessageStatus(status, id, conversationId)
 
-    override suspend fun updateMessageId(conversationId: QualifiedIDEntity, oldMessageId: String, newMessageId: String) {
-        queries.updateMessageId(newMessageId, oldMessageId, conversationId)
-    }
-
     override suspend fun updateMessageDate(date: String, id: String, conversationId: QualifiedIDEntity) =
         queries.updateMessageDate(date, id, conversationId)
 
@@ -343,23 +337,26 @@ class MessageDAOImpl(
             .executeAsList()
 
     override suspend fun updateTextMessageContent(
+        editTimeStamp: String,
         conversationId: QualifiedIDEntity,
-        messageId: String,
-        newTextContent: MessageEntityContent.Text
-    ) {
-        queries.transaction {
-            queries.updateMessageTextContent(newTextContent.messageBody, messageId, conversationId)
-            queries.deleteMessageMentions(messageId, conversationId)
-            newTextContent.mentions.forEach {
-                queries.insertMessageMention(
-                    message_id = messageId,
-                    conversation_id = conversationId,
-                    start = it.start,
-                    length = it.length,
-                    user_id = it.userId
-                )
-            }
+        currentMessageId: String,
+        newTextContent: MessageEntityContent.Text,
+        newMessageId: String
+    ): Unit = queries.transaction {
+        queries.markMessageAsEdited(editTimeStamp, currentMessageId, conversationId)
+        reactionsQueries.deleteAllReactionsForMessage(currentMessageId, conversationId)
+        queries.deleteMessageMentions(currentMessageId, conversationId)
+        queries.updateMessageTextContent(newTextContent.messageBody, currentMessageId, conversationId)
+        newTextContent.mentions.forEach {
+            queries.insertMessageMention(
+                message_id = currentMessageId,
+                conversation_id = conversationId,
+                start = it.start,
+                length = it.length,
+                user_id = it.userId
+            )
         }
+        queries.updateMessageId(newMessageId, currentMessageId, conversationId)
     }
 
     override suspend fun getConversationMessagesByContentType(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -113,7 +113,7 @@ class UserDatabaseBuilder internal constructor(
         get() = CallDAOImpl(database.callsQueries)
 
     val messageDAO: MessageDAO
-        get() = MessageDAOImpl(database.messagesQueries, database.conversationsQueries, userId)
+        get() = MessageDAOImpl(database.messagesQueries, database.conversationsQueries, userId, database.reactionsQueries)
 
     val assetDAO: AssetDAO
         get() = AssetDAOImpl(database.assetsQueries)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageTextEditTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageTextEditTest.kt
@@ -1,0 +1,138 @@
+package com.wire.kalium.persistence.dao.message
+
+import app.cash.turbine.test
+import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MessageTextEditTest : BaseMessageTest() {
+
+    @Test
+    fun givenTextWasInserted_whenUpdatingContent_thenShouldUpdateTheId() = runTest {
+        insertInitialData()
+
+        messageDAO.updateTextMessageContent(
+            editTimeStamp = "newDate",
+            conversationId = CONVERSATION_ID,
+            currentMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = ORIGINAL_CONTENT.copy(messageBody = "Howdy"),
+            newMessageId = NEW_MESSAGE_ID
+        )
+
+        assertNull(messageDAO.getMessageById(ORIGINAL_MESSAGE_ID, CONVERSATION_ID).first())
+        assertNotNull(messageDAO.getMessageById(NEW_MESSAGE_ID, CONVERSATION_ID).first())
+    }
+
+    @Test
+    fun givenTextWasInserted_whenUpdatingMessageBody_thenContentShouldHaveNewMessageBody() = runTest {
+        insertInitialData()
+        reactionDAO.insertReaction(ORIGINAL_MESSAGE_ID, CONVERSATION_ID, SELF_USER_ID, "Date", "💁‍♂️")
+        reactionDAO.insertReaction(ORIGINAL_MESSAGE_ID, CONVERSATION_ID, OTHER_USER_2.id, "Date", "🤌️")
+
+        val newMessageBody = "newBody"
+
+        messageDAO.updateTextMessageContent(
+            editTimeStamp = "newDate",
+            conversationId = CONVERSATION_ID,
+            currentMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = ORIGINAL_CONTENT.copy(messageBody = newMessageBody),
+            newMessageId = NEW_MESSAGE_ID
+        )
+
+        val result = messageDAO.getMessageById(NEW_MESSAGE_ID, CONVERSATION_ID).first()!!
+
+        val content = result.content
+        assertIs<MessageEntityContent.Text>(content)
+
+        assertEquals(newMessageBody, content.messageBody)
+    }
+
+    @Test
+    fun givenTextWasInserted_whenUpdatingContentWithMentions_thenShouldAddMentions() = runTest {
+        insertInitialData()
+
+        val mentions = listOf(MessageEntity.Mention(0, 1, OTHER_USER_2.id))
+        messageDAO.updateTextMessageContent(
+            editTimeStamp = "newDate",
+            conversationId = CONVERSATION_ID,
+            currentMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = ORIGINAL_CONTENT.copy(
+                messageBody = "Howdy",
+                mentions = mentions
+            ),
+            newMessageId = NEW_MESSAGE_ID
+        )
+
+        val result = messageDAO.getMessageById(NEW_MESSAGE_ID, CONVERSATION_ID).first()!!
+
+        val content = result.content
+        assertIs<MessageEntityContent.Text>(content)
+
+        assertContentEquals(mentions, content.mentions)
+    }
+
+    @Test
+    fun givenTextWasInsertedAndReacted_whenUpdatingContent_thenShouldClearReactions() = runTest {
+        insertInitialData()
+
+        messageDAO.updateTextMessageContent(
+            editTimeStamp = "newDate",
+            conversationId = CONVERSATION_ID,
+            currentMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = ORIGINAL_CONTENT.copy(messageBody = "Howdy"),
+            newMessageId = NEW_MESSAGE_ID
+        )
+
+        reactionDAO.observeMessageReactions(CONVERSATION_ID, NEW_MESSAGE_ID).test {
+            val reactions = awaitItem()
+            assertTrue(reactions.isEmpty())
+        }
+    }
+
+    @Test
+    fun givenTextWasInserted_whenUpdatingContent_thenShouldMarkAsEditedWithNewDate() = runTest {
+        insertInitialData()
+
+        val editDate = "newDate"
+        messageDAO.updateTextMessageContent(
+            editTimeStamp = editDate,
+            conversationId = CONVERSATION_ID,
+            currentMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = ORIGINAL_CONTENT.copy(messageBody = "Howdy"),
+            newMessageId = NEW_MESSAGE_ID
+        )
+
+        val result = messageDAO.getMessageById(NEW_MESSAGE_ID, CONVERSATION_ID).first()!!
+
+        assertIs<MessageEntity.Regular>(result)
+        val editStatus = result.editStatus
+        assertIs<MessageEntity.EditStatus.Edited>(editStatus)
+        assertEquals(editDate, editStatus.lastTimeStamp)
+    }
+
+    override suspend fun insertInitialData() {
+        super.insertInitialData()
+        messageDAO.insertOrIgnoreMessage(ORIGINAL_MESSAGE)
+    }
+
+    private companion object {
+        const val ORIGINAL_MESSAGE_ID = "originalMessageId"
+        const val NEW_MESSAGE_ID = "newMessageId"
+        val ORIGINAL_SENDER_ID = OTHER_USER.id
+        val CONVERSATION_ID = TEST_CONVERSATION_1.id
+        val ORIGINAL_CONTENT = MessageEntityContent.Text(messageBody = "Hello")
+        val ORIGINAL_MESSAGE = newRegularMessageEntity(
+            id = ORIGINAL_MESSAGE_ID,
+            content = ORIGINAL_CONTENT,
+            conversationId = CONVERSATION_ID,
+            senderUserId = ORIGINAL_SENDER_ID
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. When a message is edited, we should clear the current reactions it has. At the moment we’re not clearing it.
2. When a message with reactions is edited, further edits and reactions will not be handled. 

### Causes (Optional)

1. Was not implemented before.
2. The Reactions table will cause a Foreign Key Constraint Failure when we attempt to update the ID of a message during and `UPDATE`, and it was a silent error because we don't have this whole operation inside a transaction.


### Solutions

- Move the whole edit a text message to a single DB transaction
This had the bonus that we were exposing 3 DB operations just to edit a single text message, and these operations were not being used elsewhere (update ID and mark as edited). So these functions are now removed.

- Make sure we clear reactions before editing the message ID

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

### Attachments

In the video below, I'm sending messages, reacting and editing from the Web wrapper, everything seems to be alright:

https://user-images.githubusercontent.com/9389043/209229742-1b11aa3b-bf86-4ded-a1ec-610edda0d952.mp4

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
