### PR TITLE
fix: messages randomly not triggering notifications (AR-2867)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -31,7 +31,6 @@ import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.DelicateKaliumApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
@@ -3,22 +3,32 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 
 interface MarkMessagesAsNotifiedUseCase {
-    suspend operator fun invoke(conversationId: ConversationId?, date: String = DateTimeUtil.currentIsoDateTimeString()): Result
+    suspend operator fun invoke(conversationId: ConversationId?): Result
 }
 
-class MarkMessagesAsNotifiedUseCaseImpl(private val conversationRepository: ConversationRepository) : MarkMessagesAsNotifiedUseCase {
+class MarkMessagesAsNotifiedUseCaseImpl(
+    private val conversationRepository: ConversationRepository,
+    private val messageRepository: MessageRepository
+) : MarkMessagesAsNotifiedUseCase {
 
-    override suspend operator fun invoke(conversationId: ConversationId?, date: String): Result {
-        return if (conversationId == null) {
-            conversationRepository.updateAllConversationsNotificationDate(date)
-        } else {
-            conversationRepository.updateConversationNotificationDate(conversationId, date)
+    override suspend operator fun invoke(conversationId: ConversationId?): Result =
+        messageRepository.getInstantOfLatestMessageFromOtherUsers().map {
+            it.toIsoDateTimeString()
+        }.flatMap { date ->
+            if (conversationId == null) {
+                conversationRepository.updateAllConversationsNotificationDate(date)
+            } else {
+                conversationRepository.updateConversationNotificationDate(conversationId, date)
+            }
         }.fold({ Result.Failure(it) }) { Result.Success }
-    }
+
 }
 
 sealed class Result {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
@@ -9,26 +9,55 @@ import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 
-interface MarkMessagesAsNotifiedUseCase {
-    suspend operator fun invoke(conversationId: ConversationId?): Result
-}
-
-class MarkMessagesAsNotifiedUseCaseImpl(
+/**
+ * Marks conversations in one or all conversations as notified, so the notifications for these messages won't show up again.
+ * @see GetNotificationsUseCase
+ */
+class MarkMessagesAsNotifiedUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
     private val messageRepository: MessageRepository
-) : MarkMessagesAsNotifiedUseCase {
+) {
 
-    override suspend operator fun invoke(conversationId: ConversationId?): Result =
+    /**
+     * @param conversationId the specific conversation that needs to be marked as notified,
+     * or null for marking all notifications as notified.
+     */
+    @Deprecated("This will be removed in order to use a more explicit input", ReplaceWith("invoke(UpdateTarget)"))
+    suspend operator fun invoke(conversationId: ConversationId?): Result = if (conversationId == null) {
+        invoke(UpdateTarget.AllConversations)
+    } else {
+        invoke(UpdateTarget.SingleConversation(conversationId))
+    }
+
+    /**
+     * @param conversationsToUpdate which conversation(s) to be marked as notified.
+     */
+    suspend operator fun invoke(conversationsToUpdate: UpdateTarget): Result =
         messageRepository.getInstantOfLatestMessageFromOtherUsers().map {
             it.toIsoDateTimeString()
         }.flatMap { date ->
-            if (conversationId == null) {
-                conversationRepository.updateAllConversationsNotificationDate(date)
-            } else {
-                conversationRepository.updateConversationNotificationDate(conversationId, date)
+            when (conversationsToUpdate) {
+                UpdateTarget.AllConversations -> conversationRepository.updateAllConversationsNotificationDate(date)
+
+                is UpdateTarget.SingleConversation ->
+                    conversationRepository.updateConversationNotificationDate(conversationsToUpdate.conversationId, date)
             }
         }.fold({ Result.Failure(it) }) { Result.Success }
 
+    /**
+     * Specifies which conversations should be marked as notified
+     */
+    sealed interface UpdateTarget {
+        /**
+         * All conversations should be marked as notified.
+         */
+        object AllConversations : UpdateTarget
+
+        /**
+         * A specific conversation, represented by its [conversationId], should be marked as notified
+         */
+        data class SingleConversation(val conversationId: ConversationId) : UpdateTarget
+    }
 }
 
 sealed class Result {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -198,7 +198,7 @@ class MessageScope internal constructor(
         )
 
     val markMessagesAsNotified: MarkMessagesAsNotifiedUseCase
-        get() = MarkMessagesAsNotifiedUseCaseImpl(conversationRepository, messageRepository)
+        get() = MarkMessagesAsNotifiedUseCase(conversationRepository, messageRepository)
 
     val updateAssetMessageUploadStatus: UpdateAssetMessageUploadStatusUseCase
         get() = UpdateAssetMessageUploadStatusUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -197,7 +197,8 @@ class MessageScope internal constructor(
             messageSender
         )
 
-    val markMessagesAsNotified: MarkMessagesAsNotifiedUseCase get() = MarkMessagesAsNotifiedUseCaseImpl(conversationRepository)
+    val markMessagesAsNotified: MarkMessagesAsNotifiedUseCase
+        get() = MarkMessagesAsNotifiedUseCaseImpl(conversationRepository, messageRepository)
 
     val updateAssetMessageUploadStatus: UpdateAssetMessageUploadStatusUseCase
         get() = UpdateAssetMessageUploadStatusUseCaseImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCaseTest.kt
@@ -3,8 +3,12 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.feature.message.MarkMessagesAsNotifiedUseCase.UpdateTarget
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import io.mockative.Mock
+import io.mockative.any
 import io.mockative.anything
 import io.mockative.classOf
 import io.mockative.eq
@@ -14,35 +18,28 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MarkMessagesAsNotifiedUseCaseTest {
 
-    @Mock
-    val conversationRepository: ConversationRepository = mock(classOf<ConversationRepository>())
-
-    private lateinit var markMessagesAsNotifiedUseCase: MarkMessagesAsNotifiedUseCase
-
-    @BeforeTest
-    fun setUp() {
-        markMessagesAsNotifiedUseCase = MarkMessagesAsNotifiedUseCaseImpl(conversationRepository)
-    }
-
     @Test
-    fun givenMarkIsCalledWithConversationIdNull_whenInvokingTheUseCase_thenAllConversationsAreMarkedAsNotified() = runTest {
-        given(conversationRepository).coroutine { updateAllConversationsNotificationDate(DATE) }.then { Either.Right(Unit) }
+    fun givenMarkIsCalledForAllConversations_whenInvokingTheUseCase_thenAllConversationsAreMarkedAsNotified() = runTest {
+        val (arrangement, markMessagesAsNotified) = Arrangement()
+            .withUpdatingAllConversationsReturning(Either.Right(Unit))
+            .withLastInstantFromOthersReturning(Either.Right(TEST_INSTANT))
+            .arrange()
 
-        val result = markMessagesAsNotifiedUseCase(null, DATE)
+        val result = markMessagesAsNotified(UpdateTarget.AllConversations)
 
-        verify(conversationRepository)
+        verify(arrangement.conversationRepository)
             .coroutine { updateAllConversationsNotificationDate(DATE) }
             .wasInvoked(exactly = once)
 
-        verify(conversationRepository)
-            .suspendFunction(conversationRepository::updateConversationNotificationDate)
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateConversationNotificationDate)
             .with(anything(), anything())
             .wasNotInvoked()
 
@@ -50,22 +47,21 @@ class MarkMessagesAsNotifiedUseCaseTest {
     }
 
     @Test
-    fun givenMarkIsCalledWithSomeConversationId_whenInvokingTheUseCase_thenSpecificConversationIsMarkedAsNotified() = runTest {
-        given(conversationRepository).coroutine { updateAllConversationsNotificationDate(DATE) }.then { Either.Right(Unit) }
-        given(conversationRepository)
-            .suspendFunction(conversationRepository::updateConversationNotificationDate)
-            .whenInvokedWith(eq(CONVERSATION_ID), anything())
-            .then { _, _ -> Either.Right(Unit) }
+    fun givenMarkIsCalledWithSpecificConversationId_whenInvokingTheUseCase_thenSpecificConversationIsMarkedAsNotified() = runTest {
+        val (arrangement, markMessagesAsNotified) = Arrangement()
+            .withUpdatingOneConversationReturning(Either.Right(Unit))
+            .withLastInstantFromOthersReturning(Either.Right(TEST_INSTANT))
+            .arrange()
 
-        val result = markMessagesAsNotifiedUseCase(CONVERSATION_ID, DATE)
+        val result = markMessagesAsNotified(UpdateTarget.SingleConversation(CONVERSATION_ID))
 
-        verify(conversationRepository)
-            .suspendFunction(conversationRepository::updateConversationNotificationDate)
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateConversationNotificationDate)
             .with(eq(CONVERSATION_ID), anything())
             .wasInvoked(exactly = once)
 
-        verify(conversationRepository)
-            .suspendFunction(conversationRepository::updateAllConversationsNotificationDate)
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateAllConversationsNotificationDate)
             .with(anything())
             .wasNotInvoked()
 
@@ -73,35 +69,71 @@ class MarkMessagesAsNotifiedUseCaseTest {
     }
 
     @Test
-    fun givenMarkingPropagateError_whenInvokingTheUseCase_thenFailureIsReturned() = runTest {
+    fun givenUpdatingOneConversationFails_whenInvokingTheUseCase_thenFailureIsPropagated() = runTest {
         val failure = StorageFailure.DataNotFound
-        given(conversationRepository).coroutine { updateAllConversationsNotificationDate(DATE) }.then { Either.Right(Unit) }
-        given(conversationRepository)
-            .suspendFunction(conversationRepository::updateConversationNotificationDate)
-            .whenInvokedWith(eq(CONVERSATION_ID), anything())
-            .then { _, _ -> Either.Left(failure) }
 
-        val result = markMessagesAsNotifiedUseCase(CONVERSATION_ID, DATE)
+        val (_, markMessagesAsNotified) = Arrangement()
+            .withUpdatingOneConversationReturning(Either.Left(failure))
+            .withLastInstantFromOthersReturning(Either.Right(TEST_INSTANT))
+            .arrange()
+
+        val result = markMessagesAsNotified(UpdateTarget.SingleConversation(CONVERSATION_ID))
 
         assertEquals(result, Result.Failure(failure))
     }
 
     @Test
-    fun givenMarkingPropagateError_whenInvokingTheUseCase_thenFailureIsReturned2() = runTest {
+    fun givenUpdatingAllConversationsFails_whenInvokingTheUseCase_thenFailureIsPropagated() = runTest {
         val failure = StorageFailure.DataNotFound
-        given(conversationRepository).coroutine { updateAllConversationsNotificationDate(DATE) }.then { Either.Left(failure) }
-        given(conversationRepository)
-            .suspendFunction(conversationRepository::updateConversationNotificationDate)
-            .whenInvokedWith(eq(CONVERSATION_ID), anything())
-            .then { _, _ -> Either.Right(Unit) }
 
-        val result = markMessagesAsNotifiedUseCase(null, DATE)
+        val (_, markMessagesAsNotified) = Arrangement()
+            .withUpdatingAllConversationsReturning(Either.Left(failure))
+            .withLastInstantFromOthersReturning(Either.Right(TEST_INSTANT))
+            .arrange()
+
+        val result = markMessagesAsNotified(UpdateTarget.AllConversations)
 
         assertEquals(result, Result.Failure(failure))
     }
 
+    private class Arrangement {
+
+        @Mock
+        val conversationRepository: ConversationRepository = mock(classOf<ConversationRepository>())
+
+        @Mock
+        val messageRepository: MessageRepository = mock(classOf<MessageRepository>())
+
+        fun withUpdatingAllConversationsReturning(result: Either<StorageFailure, Unit>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::updateAllConversationsNotificationDate)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withUpdatingOneConversationReturning(result: Either<StorageFailure, Unit>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::updateConversationNotificationDate)
+                .whenInvokedWith(any(), any())
+                .thenReturn(result)
+        }
+
+        fun withLastInstantFromOthersReturning(result: Either<StorageFailure, Instant>) = apply {
+            given(messageRepository)
+                .suspendFunction(messageRepository::getInstantOfLatestMessageFromOtherUsers)
+                .whenInvoked()
+                .thenReturn(result)
+        }
+
+        fun arrange() = this to MarkMessagesAsNotifiedUseCase(
+            conversationRepository, messageRepository
+        )
+
+    }
+
     companion object {
-        private const val DATE = "some_date"
+        private val TEST_INSTANT = Instant.fromEpochMilliseconds(123_456_789L)
+        private val DATE = TEST_INSTANT.toIsoDateTimeString()
         private val CONVERSATION_ID = QualifiedID("some_id", "some_domain")
     }
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -470,6 +470,11 @@ updateAssetKeys {
     WHERE id = :messageId AND conversation_id = : conversationId;
 }
 
+getLatestMessageFromOtherUsers:
+SELECT * FROM MessageDetailsView
+WHERE MessageDetailsView.isSelfMessage = FALSE
+ORDER BY strftime('%Y-%m-%d %H:%M:%f', MessageDetailsView.date) DESC LIMIT 1;
+
 updateMessageDate:
 UPDATE Message
 SET date = ?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -38,7 +38,11 @@ interface MessageDAO {
      * @see insertOrIgnoreMessage
      */
     suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>)
-    fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
+
+    /**
+     * Returns the most recent message sent from other users, _i.e._ not self user
+     */
+    suspend fun getLatestMessageFromOtherUsers(): MessageEntity?
     suspend fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity)
     suspend fun updateMessageId(conversationId: QualifiedIDEntity, oldMessageId: String, newMessageId: String)
     suspend fun updateMessageDate(date: String, id: String, conversationId: QualifiedIDEntity)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -38,6 +38,7 @@ interface MessageDAO {
      * @see insertOrIgnoreMessage
      */
     suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>)
+    fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
 
     /**
      * Returns the most recent message sent from other users, _i.e._ not self user

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -63,7 +63,10 @@ class MessageDAOImpl(
         }
     }
 
-    override fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
+    override suspend fun getLatestMessageFromOtherUsers(): MessageEntity? =
+        queries.getLatestMessageFromOtherUsers(mapper::toEntityMessageFromView).executeAsOneOrNull()
+
+    private fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
         queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
 
     @Deprecated("For test only!")

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -66,7 +66,7 @@ class MessageDAOImpl(
     override suspend fun getLatestMessageFromOtherUsers(): MessageEntity? =
         queries.getLatestMessageFromOtherUsers(mapper::toEntityMessageFromView).executeAsOneOrNull()
 
-    private fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
+    override fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
         queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
 
     @Deprecated("For test only!")

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageLatestTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageLatestTest.kt
@@ -1,0 +1,61 @@
+package com.wire.kalium.persistence.dao.message
+
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
+
+class MessageLatestTest : BaseMessageTest() {
+
+    @Test
+    fun givenMultipleMessagesFromOtherUsers_whenGettingLatestMessageFromOtherUsers_thenLatestIsReturned() = runTest {
+        insertInitialData()
+        val initialInstant = Clock.System.now()
+
+        val mostRecentMessage = insertTestMessage(initialInstant + 30.days, OTHER_USER_2.id, TEST_CONVERSATION_2.id)
+
+        insertTestMessage(initialInstant, OTHER_USER.id, TEST_CONVERSATION_1.id)
+        insertTestMessage(initialInstant + 5.seconds, OTHER_USER_2.id, TEST_CONVERSATION_2.id)
+        insertTestMessage(initialInstant + 15.seconds, OTHER_USER.id, TEST_CONVERSATION_1.id)
+
+        val result = messageDAO.getLatestMessageFromOtherUsers()
+
+        assertEquals(mostRecentMessage.id, result!!.id)
+    }
+
+    @Test
+    fun givenMostRecentMessageIsFromSelfUser_whenGettingLatestMessageFromOtherUsers_thenLatestFromOthersIsReturned() = runTest {
+        insertInitialData()
+        val initialInstant = Clock.System.now()
+
+        // Actual most recent
+        insertTestMessage(initialInstant + 30.days, SELF_USER.id, TEST_CONVERSATION_2.id)
+
+        insertTestMessage(initialInstant, OTHER_USER.id, TEST_CONVERSATION_1.id)
+        insertTestMessage(initialInstant + 5.seconds, OTHER_USER_2.id, TEST_CONVERSATION_2.id)
+
+        val mostRecentFromOthers = insertTestMessage(initialInstant + 15.seconds, OTHER_USER.id, TEST_CONVERSATION_1.id)
+
+        val result = messageDAO.getLatestMessageFromOtherUsers()
+
+        assertEquals(mostRecentFromOthers.id, result!!.id)
+    }
+
+    private suspend fun insertTestMessage(
+        instant: Instant,
+        senderUserId: QualifiedIDEntity,
+        conversationId: QualifiedIDEntity
+    ) = newRegularMessageEntity(
+        id = Random.nextBytes(10).decodeToString(),
+        conversationId = conversationId,
+        senderUserId = senderUserId,
+        date = instant.toString()
+    ).also { messageDAO.insertOrIgnoreMessage(it) }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When receiving messages with little interval between them, not all messages trigger a notification.

### Causes

When we display a notification for a conversation, we call `markMessagesAsNotified(conversationId, DateTimeUtil.currentIsoDateTimeString())`.

What if the `currentIsoDate` is off by a few seconds in the future compared to the backend's clock? The messages that come from the server within this timespan in the next seconds will NOT trigger a notification.

### Solutions

Don't allow passing some arbitrary datetime, use the datetime of the last received message instead.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

### How To Test

I've tried the following experiments:

#### Change the phone's clock to a few minutes in the future

If you advance the device's clock on purpose, so it is 1min in "the future" compared to the server's time. After a notification is received, you should be able to receive another one quickly after. _i.e._ the device's clock should NOT interfere with notifications.

Before the fix, when doing this experiment with 5 minutes, I wasn't able to receive more notifications in the same conversation for 5 minutes.


#### Send messages in quick succession

I attempted to send around 1 message per second, with the contents: `1, 2, 3, 4, 5, 6, 7, 8, 9, 0`.

I was almost always receiving only 1 and 8 before the fix. Sometimes 1 and a 7.

Makes me believe that my emulator and the server are off by around 7 seconds.

Videos documenting it:

https://user-images.githubusercontent.com/9389043/209250161-63a0b425-38c9-4e69-aad4-38281b8be8bc.mp4

https://user-images.githubusercontent.com/9389043/209250194-e1ec1f9f-0dde-4a5c-baa1-136096329829.mp4 

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
