### PR TITLE
fix: Update all assets fields when updating

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -460,9 +460,9 @@ UPDATE MessageAssetContent
 SET asset_download_status = ?
 WHERE message_id = ? AND conversation_id = ?;
 
-updateAssetKeys {
+updateAssetContent {
     UPDATE MessageAssetContent
-    SET asset_id = :assetId, asset_otr_key = :assetOtrKey, asset_sha256 = :assetSha256
+    SET asset_id = :assetId, asset_domain = :assetDomain, asset_otr_key = :assetOtrKey, asset_sha256 = :assetSha256, asset_name = :assetName, asset_download_status = :assetDownloadStatus, asset_upload_status = :assetUploadStatus, asset_size = :assetSize, asset_mime_type = :assetMimeType, asset_token = :assetToken, asset_encryption_algorithm = :assetEncryptionAlgorithm
     WHERE message_id = :messageId AND conversation_id = :conversationId;
 
     UPDATE Message

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -227,6 +227,7 @@ class MessageDAOImpl(
         }
         val assetMessageContent = message.content as MessageEntityContent.Asset
         with(assetMessageContent) {
+            // This will ONLY update the VISIBILITY of the original base message and all the asset content related fields
             queries.updateAssetContent(
                 messageId = message.id,
                 conversationId = message.conversationId,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -220,15 +220,29 @@ class MessageDAOImpl(
     }
 
     private fun updateAssetMessage(message: MessageEntity) {
+        if (message.content !is MessageEntityContent.Asset) {
+            kaliumLogger.e("The message can't be updated because it is not an asset")
+            return
+        }
         val assetMessageContent = message.content as MessageEntityContent.Asset
-        queries.updateAssetKeys(
-            messageId = message.id,
-            conversationId = message.conversationId,
-            assetId = assetMessageContent.assetId,
-            assetOtrKey = assetMessageContent.assetOtrKey,
-            assetSha256 = assetMessageContent.assetSha256Key,
-            visibility = message.visibility
-        )
+        with(assetMessageContent) {
+            queries.updateAssetContent(
+                messageId = message.id,
+                conversationId = message.conversationId,
+                visibility = message.visibility,
+                assetId = assetId,
+                assetDomain = assetDomain,
+                assetToken = assetToken,
+                assetSize = assetSizeInBytes,
+                assetMimeType = assetMimeType,
+                assetName = assetName,
+                assetOtrKey = assetOtrKey,
+                assetSha256 = assetSha256Key,
+                assetUploadStatus = assetUploadStatus,
+                assetDownloadStatus = assetDownloadStatus,
+                assetEncryptionAlgorithm = assetEncryptionAlgorithm
+            )
+        }
     }
 
     /*

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -846,6 +846,7 @@ class MessageDAOTest : BaseDatabaseTest() {
             assertTrue((updatedMessage?.visibility == MessageEntity.Visibility.HIDDEN))
         }
 
+    @Suppress("LongMethod")
     @Test
     @IgnoreIOS
     fun givenAnAssetMessageInDB_WhenTryingAnAssetUpdate_ThenTheFinalMessageShouldIncludeTheChanges() = runTest {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -859,6 +859,24 @@ class MessageDAOTest : BaseDatabaseTest() {
         val updatedUploadStatus = MessageEntity.UploadStatus.UPLOADED
         val initialDownloadStatus = MessageEntity.DownloadStatus.IN_PROGRESS
         val updatedDownloadStatus = MessageEntity.DownloadStatus.SAVED_INTERNALLY
+        val initialAssetSize = 1000L
+        val updatedAssetSize = 2000L
+        val initialAssetName = "Some asset name.zip"
+        val updatedAssetName = "updated asset name.svg"
+        val initialAssetId = "some-id-124567"
+        val updatedAssetId = "some-updated-id-0000"
+        val initialDomain = "some@domain.com"
+        val updatedAssetDomain = "some@future-domain.com"
+        val initialMimeType = "application/zip"
+        val updatedMimeType = "image/svg"
+        val initialAssetEncryption = "AES/GCM"
+        val updatedAssetEncryption = "AES/CBC"
+        val initialAssetToken = "Some-token"
+        val updatedAssetToken = "updated-token"
+        val initialMetadataWidth = 100
+        val updatedMetadataWidth = null
+        val initialMetadataHeight = 300
+        val updatedMetadataHeight = null
         val initialAssetMessage = newRegularMessageEntity(
             id = messageId,
             date = "2000-01-01T13:00:00.000Z",
@@ -867,21 +885,36 @@ class MessageDAOTest : BaseDatabaseTest() {
             senderClientId = senderClientId,
             visibility = MessageEntity.Visibility.VISIBLE,
             content = MessageEntityContent.Asset(
-                assetSizeInBytes = 1000,
-                assetName = "some-asset.zip",
-                assetMimeType = "application/zip",
+                assetSizeInBytes = initialAssetSize,
+                assetName = initialAssetName,
+                assetMimeType = initialMimeType,
                 assetOtrKey = dummyOtrKey,
                 assetSha256Key = dummySha256Key,
-                assetId = "some-asset-id",
-                assetEncryptionAlgorithm = "AES/GCM",
+                assetId = initialAssetId,
+                assetDomain = initialDomain,
+                assetEncryptionAlgorithm = initialAssetEncryption,
                 assetUploadStatus = initialUploadStatus,
-                assetDownloadStatus = initialDownloadStatus
+                assetDownloadStatus = initialDownloadStatus,
+                assetToken = initialAssetToken,
+                assetWidth = initialMetadataWidth,
+                assetHeight = initialMetadataHeight
             )
         )
         val updatedAssetMessage = initialAssetMessage.copy(
             content = (initialAssetMessage.content as MessageEntityContent.Asset).copy(
+                assetSizeInBytes = updatedAssetSize,
+                assetName = updatedAssetName,
+                assetMimeType = updatedMimeType,
+                assetOtrKey = dummyOtrKey,
+                assetSha256Key = dummySha256Key,
+                assetId = updatedAssetId,
+                assetDomain = updatedAssetDomain,
+                assetEncryptionAlgorithm = updatedAssetEncryption,
                 assetUploadStatus = updatedUploadStatus,
                 assetDownloadStatus = updatedDownloadStatus,
+                assetToken = updatedAssetToken,
+                assetWidth = updatedMetadataWidth,
+                assetHeight = updatedMetadataHeight
             )
         )
         conversationDAO.insertConversation(newConversationEntity(id = conversationId, lastReadDate = "2000-01-01T12:00:00.000Z"))
@@ -898,6 +931,17 @@ class MessageDAOTest : BaseDatabaseTest() {
         assertTrue(updatedMessageContent is MessageEntityContent.Asset)
         assertEquals(updatedMessageContent.assetUploadStatus, updatedUploadStatus)
         assertEquals(updatedMessageContent.assetDownloadStatus, updatedDownloadStatus)
+        assertEquals(updatedMessageContent.assetSizeInBytes, updatedAssetSize)
+        assertEquals(updatedMessageContent.assetName, updatedAssetName)
+        assertEquals(updatedMessageContent.assetMimeType, updatedMimeType)
+        assertEquals(updatedMessageContent.assetEncryptionAlgorithm, updatedAssetEncryption)
+        assertEquals(updatedMessageContent.assetToken, updatedAssetToken)
+        assertEquals(updatedMessageContent.assetId, updatedAssetId)
+        assertEquals(updatedMessageContent.assetDomain, updatedAssetDomain)
+        assertEquals(updatedMessageContent.assetWidth, updatedMetadataWidth)
+        assertEquals(updatedMessageContent.assetHeight, updatedMetadataHeight)
+        assertTrue(updatedMessageContent.assetOtrKey.contentEquals(dummyOtrKey))
+        assertTrue(updatedMessageContent.assetSha256Key.contentEquals(dummySha256Key))
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Asset content fields were not being updating properly, so they were treated as a normal message insert and hence being ignored. 

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution (WIP)
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
