### PR TITLE
fix: update receipts when editing a text message

### DIFF
--- a/persistence/src/commonMain/db_user/migrations/23.sqm
+++ b/persistence/src/commonMain/db_user/migrations/23.sqm
@@ -1,7 +1,11 @@
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
 import com.wire.kalium.persistence.dao.receipt.ReceiptTypeEntity;
 
-CREATE TABLE Receipt (
+-- Delete the ReceiptDetails View
+DROP VIEW ReceiptDetails;
+
+-- Create new table with ON UPDATE CASCADE
+CREATE TABLE ReceiptTemp (
     message_id TEXT NOT NULL,
     conversation_id TEXT AS QualifiedIDEntity NOT NULL,
     user_id TEXT AS QualifiedIDEntity NOT NULL,
@@ -12,26 +16,16 @@ CREATE TABLE Receipt (
     PRIMARY KEY (message_id, conversation_id, user_id, type)
 );
 
--- TODO: Cast to proper types when/if SQLDelight supports it:
-insertReceipt:
-WITH insertion(message_id, conversation_id, user_id, type, date) AS(
-    VALUES (CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT))
-)
-INSERT OR IGNORE INTO Receipt(message_id, conversation_id, user_id, type, date)
-SELECT
-    insertion.message_id,
-    insertion.conversation_id,
-    insertion.user_id,
-    insertion.type,
-    insertion.date
-FROM insertion
-WHERE EXISTS (
-    SELECT 1 FROM Message
-    WHERE
-        Message.conversation_id = insertion.conversation_id AND
-        Message.id = insertion.message_id
-);
+-- Migrate data to new table
+INSERT INTO ReceiptTemp(message_id, conversation_id, user_id, type, date) SELECT * FROM Receipt;
 
+-- Drop old table
+DROP TABLE IF EXISTS Receipt;
+
+-- Rename new temp table to Receipt
+ALTER TABLE ReceiptTemp RENAME TO Receipt;
+
+-- Create the View again
 CREATE VIEW IF NOT EXISTS ReceiptDetails
 AS SELECT
 	Receipt.type,
@@ -50,10 +44,3 @@ FROM
 	Receipt
 INNER JOIN User ON User.qualified_id = Receipt.user_id
 ORDER BY User.name;
-
-selectReceiptsByConversationIdAndMessageId:
-SELECT *
-FROM ReceiptDetails
-    WHERE messageId = ?
-	AND conversationId = ?
-	AND type = ?;

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/BaseMessageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/BaseMessageTest.kt
@@ -4,6 +4,7 @@ import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.reaction.ReactionDAO
+import com.wire.kalium.persistence.dao.receipt.ReceiptDAO
 import com.wire.kalium.persistence.utils.stubs.newConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
 import kotlin.test.BeforeTest
@@ -14,6 +15,7 @@ open class BaseMessageTest : BaseDatabaseTest() {
     protected lateinit var conversationDAO: ConversationDAO
     protected lateinit var userDAO: UserDAO
     protected lateinit var reactionDAO: ReactionDAO
+    protected lateinit var receiptDAO: ReceiptDAO
 
     @BeforeTest
     fun setUp() {
@@ -24,6 +26,7 @@ open class BaseMessageTest : BaseDatabaseTest() {
         messageDAO = db.messageDAO
         conversationDAO = db.conversationDAO
         userDAO = db.userDAO
+        receiptDAO = db.receiptDAO
     }
 
     /**

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageTextEditTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageTextEditTest.kt
@@ -1,9 +1,11 @@
 package com.wire.kalium.persistence.dao.message
 
 import app.cash.turbine.test
+import com.wire.kalium.persistence.dao.receipt.ReceiptTypeEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -31,10 +33,33 @@ class MessageTextEditTest : BaseMessageTest() {
     }
 
     @Test
-    fun givenTextWasInserted_whenUpdatingMessageBody_thenContentShouldHaveNewMessageBody() = runTest {
+    fun givenTextWasInsertedAndReacted_whenUpdatingMessageBody_thenContentShouldHaveNewMessageBody() = runTest {
         insertInitialData()
         reactionDAO.insertReaction(ORIGINAL_MESSAGE_ID, CONVERSATION_ID, SELF_USER_ID, "Date", "💁‍♂️")
         reactionDAO.insertReaction(ORIGINAL_MESSAGE_ID, CONVERSATION_ID, OTHER_USER_2.id, "Date", "🤌️")
+
+        val newMessageBody = "newBody"
+
+        messageDAO.updateTextMessageContent(
+            editTimeStamp = "newDate",
+            conversationId = CONVERSATION_ID,
+            currentMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = ORIGINAL_CONTENT.copy(messageBody = newMessageBody),
+            newMessageId = NEW_MESSAGE_ID
+        )
+
+        val result = messageDAO.getMessageById(NEW_MESSAGE_ID, CONVERSATION_ID).first()!!
+
+        val content = result.content
+        assertIs<MessageEntityContent.Text>(content)
+
+        assertEquals(newMessageBody, content.messageBody)
+    }
+
+    @Test
+    fun givenTextWasInsertedAndWithReceipts_whenUpdatingMessageBody_thenContentShouldHaveNewMessageBody() = runTest {
+        insertInitialData()
+        receiptDAO.insertReceipts(OTHER_USER.id, CONVERSATION_ID, Clock.System.now(), ReceiptTypeEntity.READ, listOf(ORIGINAL_MESSAGE_ID))
 
         val newMessageBody = "newBody"
 
@@ -93,6 +118,29 @@ class MessageTextEditTest : BaseMessageTest() {
         reactionDAO.observeMessageReactions(CONVERSATION_ID, NEW_MESSAGE_ID).test {
             val reactions = awaitItem()
             assertTrue(reactions.isEmpty())
+        }
+    }
+
+    @Test
+    fun givenTextWasInsertedAndReceiptsAttached_whenUpdatingContent_thenReceiptsRemainAfterBeingEdited() = runTest {
+        insertInitialData()
+        val instant = Clock.System.now()
+        receiptDAO.insertReceipts(OTHER_USER.id, CONVERSATION_ID, instant, ReceiptTypeEntity.READ, listOf(ORIGINAL_MESSAGE_ID))
+
+        messageDAO.updateTextMessageContent(
+            editTimeStamp = "newDate",
+            conversationId = CONVERSATION_ID,
+            currentMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = ORIGINAL_CONTENT.copy(messageBody = "Howdy"),
+            newMessageId = NEW_MESSAGE_ID
+        )
+
+        receiptDAO.observeDetailedReceiptsForMessage(CONVERSATION_ID, NEW_MESSAGE_ID, ReceiptTypeEntity.READ).test {
+            val receipts = awaitItem()
+            assertEquals(1, receipts.size)
+
+            assertEquals(OTHER_USER.id, receipts.first().userId)
+            assertEquals(instant, receipts.first().date)
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When there are read/delivery receipts attached to a message, edits won't work.

### Causes

Foreign Key constraint violation when we update the ID of the message.

### Solutions

Add `ON UPDATE CASCADE` to make sure the receipts continue pointing to the new message.
This is the expected behaviour according to [the docs](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/150933773/Use+case+Receive+and+store+read+receipts#Deleting).

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
