### PR TITLE
fix: join group call un-muted by default (AR-2870)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCase.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.call.usecase
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
+import kotlinx.coroutines.flow.first
 
 /**
  * This use case is responsible for muting a call.
@@ -20,8 +21,9 @@ class MuteCallUseCase internal constructor(
             conversationId = conversationId.toString(),
             isMuted = true
         )
-        callRepository.getCallMetadataProfile()[conversationId.toString()]?.establishedTime?.let {
-            callManager.value.muteCall(true)
+        val activeCall = callRepository.establishedCallsFlow().first().find {
+            it.conversationId == conversationId
         }
+        activeCall?.let { callManager.value.muteCall(true) }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.call.usecase
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
+import kotlinx.coroutines.flow.first
 
 /**
  * This use case is responsible for un-mute a call.
@@ -20,9 +21,11 @@ class UnMuteCallUseCase(
             conversationId = conversationId.toString(),
             isMuted = false
         )
-        // We should call AVS muting method only for established call, otherwise incoming call could mute the current call
-        callRepository.getCallMetadataProfile()[conversationId.toString()]?.establishedTime?.let {
-            callManager.value.muteCall(false)
+        val activeCall = callRepository.establishedCallsFlow().first().find {
+            it.conversationId == conversationId
         }
+
+        // We should call AVS muting method only for established call, otherwise incoming call could mute the current call
+        activeCall?.let { callManager.value.muteCall(false) }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/UnMuteCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/UnMuteCallUseCaseTest.kt
@@ -1,7 +1,5 @@
 package com.wire.kalium.logic.feature.call
 
-import com.wire.kalium.logic.data.call.CallMetadata
-import com.wire.kalium.logic.data.call.CallMetadataProfile
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
@@ -14,10 +12,13 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.thenDoNothing
 import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class UnMuteCallUseCaseTest {
 
     @Mock
@@ -44,24 +45,18 @@ class UnMuteCallUseCaseTest {
     }
 
     @Test
-    fun `givenAEstablishedCallWhenUnMuteUseCaseCalledThenUpdateMuteStateAndMuteCall`() = runTest {
-        val updateCallMetadata = callMetadata.copy(establishedTime = "time")
+    fun givenAnEstablishedCallWhenUnMuteUseCaseCalledThenUpdateMuteStateAndMuteCall() = runTest {
         given(callRepository)
-            .function(callRepository::getCallMetadataProfile)
-            .whenInvoked()
-            .thenReturn(
-                CallMetadataProfile(mapOf(conversationId.toString() to updateCallMetadata))
-            )
+            .suspendFunction(callRepository::establishedCallsFlow)
+            .whenInvoked().then {
+                flowOf(listOf(call))
+            }
 
         unMuteCall(conversationId)
 
         verify(callRepository)
             .function(callRepository::updateIsMutedById)
             .with(eq(conversationId.toString()), eq(isMuted))
-            .wasInvoked(once)
-
-        verify(callRepository)
-            .function(callRepository::getCallMetadataProfile)
             .wasInvoked(once)
 
         verify(callManager)
@@ -71,23 +66,18 @@ class UnMuteCallUseCaseTest {
     }
 
     @Test
-    fun `givenNonEstablishedCallWhenUnMuteUseCaseCalledThenUpdateMuteStateOnly`() = runTest {
+    fun givenNonEstablishedCallWhenUnMuteUseCaseCalledThenUpdateMuteStateOnly() = runTest {
         given(callRepository)
-            .function(callRepository::getCallMetadataProfile)
-            .whenInvoked()
-            .thenReturn(
-                CallMetadataProfile(mapOf(conversationId.toString() to callMetadata))
-            )
+            .suspendFunction(callRepository::establishedCallsFlow)
+            .whenInvoked().then {
+                flowOf(listOf())
+            }
 
         unMuteCall(conversationId)
 
         verify(callRepository)
             .function(callRepository::updateIsMutedById)
             .with(eq(conversationId.toString()), eq(isMuted))
-            .wasInvoked(once)
-
-        verify(callRepository)
-            .function(callRepository::getCallMetadataProfile)
             .wasInvoked(once)
 
         verify(callManager)
@@ -99,7 +89,10 @@ class UnMuteCallUseCaseTest {
     companion object {
         const val isMuted = false
         private val conversationId = ConversationId("value", "domain")
-        val callMetadata = CallMetadata(
+        val call = Call(
+            conversationId = conversationId,
+            status = CallStatus.ESTABLISHED,
+            callerId = "called-id",
             isMuted = false,
             isCameraOn = false,
             conversationName = null,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Microphone is not set to muted when joining an ongoing group call.

### Causes (Optional)

The issue is not reproducible and it's rarely happening. My theory is the cached value is not available when joining the call leading the app to skip the muting action

### Solutions

Get value from database to check if there is an active call instead of cache

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
