### PR TITLE
fix(mls): show member join/leave system message [AR-2877]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -1,5 +1,6 @@
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.benasher44.uuid.uuid4
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -39,7 +40,7 @@ internal class MemberJoinEventHandlerImpl(
                 conversationRepository.persistMembers(event.members, event.conversationId)
             }.onSuccess {
                 val message = Message.System(
-                    id = event.id,
+                    id = event.id.ifEmpty { uuid4().toString() },
                     content = MessageContent.MemberChange.Added(members = event.members.map { it.id }),
                     conversationId = event.conversationId,
                     date = event.timestampIso,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
@@ -95,7 +95,7 @@ class MemberJoinEventHandlerTest {
 
         val (arrangement, eventHandler) = Arrangement()
             .withPersistingMessageReturning(Either.Right(Unit))
-            .withFetchConversationIfUnknownFailing(NetworkFailure.NoNetworkConnection(null))
+            .withFetchConversationIfUnknownSucceeding()
             .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
             .withPersistMembersSucceeding()
             .arrange()
@@ -119,7 +119,7 @@ class MemberJoinEventHandlerTest {
 
         val (arrangement, eventHandler) = Arrangement()
             .withPersistingMessageReturning(Either.Right(Unit))
-            .withFetchConversationIfUnknownFailing(NetworkFailure.NoNetworkConnection(null))
+            .withFetchConversationIfUnknownSucceeding()
             .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
             .withPersistMembersSucceeding()
             .arrange()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
@@ -112,6 +112,30 @@ class MemberJoinEventHandlerTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenMemberJoinEventWithEmptyId_whenHandlingIt_thenShouldPersistSystemMessage() = runTest {
+        val newMembers = listOf(Member(TestUser.USER_ID, Member.Role.Admin))
+        val event = TestEvent.memberJoin(members = newMembers).copy(id = "")
+
+        val (arrangement, eventHandler) = Arrangement()
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .withFetchConversationIfUnknownFailing(NetworkFailure.NoNetworkConnection(null))
+            .withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit))
+            .withPersistMembersSucceeding()
+            .arrange()
+
+        eventHandler.handle(event)
+
+        verify(arrangement.persistMessage)
+            .suspendFunction(arrangement.persistMessage::invoke)
+            .with(
+                matching {
+                    it is Message.System && it.content is MessageContent.MemberChange && it.id.isNotEmpty()
+                }
+            )
+            .wasInvoked(exactly = once)
+    }
+
     private class Arrangement {
         @Mock
         val persistMessage = mock(classOf<PersistMessageUseCase>())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Fixing add/leave member system message for MLS conversations.

### Issues
After add/leave member happens and the system message shows in the MLS conversation, the next actions will not have the system message. This PR will fix that and it shows the system message for member changes always.

### Causes (Optional)
The system message for member-changes doesn't have event-id [or message id], the first message was surviving the insert into db because it's not against the primary key rules in the db. But the second message and after that, since they don't have the event-id as well, start to seeing duplicate messages error in the db [ the first one had no id as well!]

### Solutions

The system message for member change doesn't have event-id [ message id ] for proteus we were generating it manually, for MLS we needed to do that as well.
Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

-Create an MLS group
- add or remove members more that once
- system messages must be appear as many as the above action was done

### Attachments (Optional)
![After the Fix](https://user-images.githubusercontent.com/9512842/209826771-81158463-3702-4e6d-91b2-6f6ea7306a26.jpeg)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
