### PR TITLE
fix: remove @ prefix from the search query when looking for known contacts

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
@@ -41,7 +41,7 @@ internal class SearchKnownUsersUseCaseImpl(
     ): Flow<SearchUsersResult> {
         return if (isUserLookingForHandle(searchQuery)) {
             searchUserRepository.searchKnownUsersByHandle(
-                handle = searchQuery,
+                handle = searchQuery.removePrefix("@"),
                 searchUsersOptions = searchUsersOptions
             )
         } else {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -176,7 +176,6 @@ class SearchKnownUserUseCaseTest {
             .arrange()
 
         // when
-
         searchKnownUsersUseCase(
             searchQuery = searchQuery,
             searchUsersOptions = searchUsersOptions
@@ -274,7 +273,7 @@ class SearchKnownUserUseCaseTest {
             given(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchKnownUsersByHandle)
                 .whenInvokedWith(
-                    if (searchQuery == null) any() else eq(searchQuery),
+                    if (searchQuery == null) any() else eq(searchQuery.removePrefix("@")),
                     if (searchUsersOptions == null) any() else eq(searchUsersOptions)
                 )
                 .thenReturn(
@@ -342,7 +341,7 @@ class SearchKnownUserUseCaseTest {
             given(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchKnownUsersByNameOrHandleOrEmail)
                 .whenInvokedWith(
-                    if (searchQuery == null) any() else eq(searchQuery),
+                    if (searchQuery == null) any() else eq(searchQuery.removePrefix("@")),
                     if (searchUsersOptions == null) any() else eq(searchUsersOptions)
                 )
                 .thenReturn(flowOf(UserSearchResult(otherUsers)))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
- When user types a search query starting with '@' we search for the prefix into the handle table, but since we do not add it to the able we find no results.

Remove the prefix before passing it to search

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
