### PR TITLE
fix: missed calls notifications (AR-2825)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
@@ -51,9 +51,11 @@ class OnCloseCall(
     }
 
     private fun shouldPersistMissedCall(conversationId: String, callStatus: CallStatus): Boolean {
+        if(callStatus == CallStatus.MISSED)
+            return true
         return callRepository.getCallMetadataProfile().data[conversationId]?.let {
             val isGroupCall = it.conversationType == Conversation.Type.GROUP
-            (callStatus == CallStatus.CLOSED && isGroupCall && it.establishedTime.isNullOrEmpty()) || callStatus == CallStatus.MISSED
+            (callStatus == CallStatus.CLOSED && isGroupCall && it.establishedTime.isNullOrEmpty())
         } ?: false
     }
 

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
@@ -51,7 +51,7 @@ class OnCloseCall(
     }
 
     private fun shouldPersistMissedCall(conversationId: String, callStatus: CallStatus): Boolean {
-        if(callStatus == CallStatus.MISSED)
+        if (callStatus == CallStatus.MISSED)
             return true
         return callRepository.getCallMetadataProfile().data[conversationId]?.let {
             val isGroupCall = it.conversationType == Conversation.Type.GROUP

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -758,11 +758,6 @@ class CallRepositoryTest {
             .whenInvokedWith(any())
             .thenReturn("callerId@domain")
 
-        given(persistMessage)
-            .suspendFunction(persistMessage::invoke)
-            .whenInvokedWith(any())
-            .thenReturn(Either.Right(Unit))
-
         // when
         callRepository.createCall(
             conversationId = conversationId,
@@ -778,11 +773,6 @@ class CallRepositoryTest {
             .wasInvoked(exactly = once)
 
         verify(callDAO).suspendFunction(callDAO::insertCall)
-            .with(any())
-            .wasInvoked(exactly = once)
-
-        verify(persistMessage)
-            .suspendFunction(persistMessage::invoke)
             .with(any())
             .wasInvoked(exactly = once)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -1331,7 +1331,7 @@ class CallRepositoryTest {
         private val groupConversation = TestConversation.GROUP().copy(id = conversationId)
         private val oneOnOneConversation = TestConversation.one_on_one(conversationId)
         private val callerId = UserId(value = "callerId", domain = "domain")
-        private val callerIdString = "callerId@domain")
+        private const val callerIdString = "callerId@domain"
 
         private val oneOnOneConversationDetails = ConversationDetails.OneOne(
             conversation = oneOnOneConversation,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -1261,6 +1261,33 @@ class CallRepositoryTest {
         )
     }
 
+    @Test
+    fun givenAMissedCall_whenPersistMissedCallInvoked_thenStoreTheMissedCallInDatabase() = runTest {
+
+        val qualifiedIdEntity = QualifiedIDEntity(conversationId.value, conversationId.domain)
+        given(callDAO)
+            .suspendFunction(callDAO::getCallerIdByConversationId)
+            .whenInvokedWith(eq(qualifiedIdEntity))
+            .thenReturn(callerIdString)
+
+        given(persistMessage)
+            .suspendFunction(persistMessage::invoke)
+            .whenInvokedWith(eq(any()))
+            .thenReturn(Either.Right(Unit))
+
+        callRepository.persistMissedCall(conversationId)
+
+        verify(callDAO)
+            .suspendFunction(callDAO::getCallerIdByConversationId)
+            .with(eq(qualifiedIdEntity))
+            .wasInvoked(exactly = once)
+
+        verify(persistMessage)
+            .suspendFunction(persistMessage::invoke)
+            .with(eq(any()))
+            .wasInvoked(exactly = once)
+    }
+
     private fun provideCall(id: ConversationId, status: CallStatus) = Call(
         conversationId = id,
         status = status,
@@ -1304,6 +1331,7 @@ class CallRepositoryTest {
         private val groupConversation = TestConversation.GROUP().copy(id = conversationId)
         private val oneOnOneConversation = TestConversation.one_on_one(conversationId)
         private val callerId = UserId(value = "callerId", domain = "domain")
+        private val callerIdString = "callerId@domain")
 
         private val oneOnOneConversationDetails = ConversationDetails.OneOne(
             conversation = oneOnOneConversation,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -1272,7 +1272,7 @@ class CallRepositoryTest {
 
         given(persistMessage)
             .suspendFunction(persistMessage::invoke)
-            .whenInvokedWith(eq(any()))
+            .whenInvokedWith(any())
             .thenReturn(Either.Right(Unit))
 
         callRepository.persistMissedCall(conversationId)
@@ -1284,7 +1284,7 @@ class CallRepositoryTest {
 
         verify(persistMessage)
             .suspendFunction(persistMessage::invoke)
-            .with(eq(any()))
+            .with(any())
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
@@ -51,9 +51,11 @@ class OnCloseCall(
     }
 
     private fun shouldPersistMissedCall(conversationId: String, callStatus: CallStatus): Boolean {
+        if (callStatus == CallStatus.MISSED)
+            return true
         return callRepository.getCallMetadataProfile().data[conversationId]?.let {
             val isGroupCall = it.conversationType == Conversation.Type.GROUP
-            (callStatus == CallStatus.CLOSED && isGroupCall && it.establishedTime.isNullOrEmpty()) || callStatus == CallStatus.MISSED
+            (callStatus == CallStatus.CLOSED && isGroupCall && it.establishedTime.isNullOrEmpty())
         } ?: false
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Missed call notification displayed when we accept a call on a different client.
- Called system message displayed during a call

### Causes (Optional)

We were checking if the call is closed and is not answered in the current device

### Solutions

Now we are checking missed calls for 1:1 calls using a value returned in OnCloseCall callback
For group calls we still check if the call got answered or not since AVS did report missed calls for group calls

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Start a call from desktop to AR and different client
- Answer that call from the other client
- On AR you should not see missed call notification or "someone called" as a system message

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
