### PR TITLE
ci: speed up CI builds

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'zulu'
           cache: gradle
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -17,8 +17,8 @@ jobs:
             - name: Set up JDK 11
               uses: actions/setup-java@v3
               with:
-                java-version: '11'
-                distribution: 'adopt'
+                java-version: '17'
+                distribution: 'zulu'
                 cache: gradle
 
             - name: Validate Gradle wrapper

--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -24,8 +24,9 @@ jobs:
             - name: Set up JDK 11
               uses: actions/setup-java@v3
               with:
-                  java-version: '11'
-                  distribution: 'adopt'
+                  java-version: '17'
+                  distribution: 'zulu'
+                  cache: gradle
 
             - name: Gradle Setup
               uses: gradle/gradle-build-action@v2

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -21,8 +21,9 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'zulu'
+          cache: gradle
 
       - name: Gradle Setup
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   gradle-run-tests:
     runs-on: ubuntu-22.04
+    # TODO: When migrating away from Cryptobox, use a regular Ubuntu machine with JDK 17 and caching
     container: wirebot/cryptobox:1.1.1
     steps:
       - name: Checkout

--- a/buildSrc/src/main/kotlin/OnlyAffectedTestTask.kt
+++ b/buildSrc/src/main/kotlin/OnlyAffectedTestTask.kt
@@ -86,6 +86,7 @@ open class OnlyAffectedTestTask : DefaultTask() {
         val globalBuildSettingsFiles = listOf(
             "gradle/libs.versions.toml",
             "build.gradle.kts",
+            "gradle.properties",
             "settings.gradle.kts",
         )
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx2g -XX:+UseParallelGC
 android.useAndroidX=true
 kotlin.native.binary.memoryModel=experimental
 kotlin.js.generate.executable.default=false


### PR DESCRIPTION
By upgrading the JDK version to 17, enabling the parallel GC and caching dependencies between builds.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Our CI is sloooooow.

### Causes

- We do _not_ cache gradle dependencies between builds for all workflows.
- We're using JDK 11
- We're not using parallel garbage collector

### Solutions

#### Caching
The [setup-java](https://github.com/actions/setup-java#caching-packages-dependencies) action is able to cache dependencies between builds. And the cache is smart enough to consider the hash of all important gradle files, so if the hash changes, the cache won't be used.

We can easily enable it by adding `cache: 'gradle'` to all missing workflows.

We had issues in the past and disabled the cache, mostly because this smart hashing thing wasn't in place and we were using transient dependencies early in development.

Also, it's easier to clear caches now, just going to [Actions/Cache](https://github.com/wireapp/kalium/actions/caches).

#### JDK upgrade

Since Gradle 7.3, JDK 17 is supported. It's not something we had in the beginning of the project, but it's a quick win now.

Adopt JDK is not a thing anymore, so I just opted for Azul's Zulu. We could maybe benchmark it and see if there's a significant difference between Zulu and Temurin and maybe be more scientific about it, but not today :)

#### Bonus

[Parallel Garbage Collector](https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html) is now enabled.

According to [Bitrise's analysis](https://bitrise.io/blog/post/switch-to-jdk-17-parallel-gc-and-speed-up-your-android-builds-by-9-20), the combo of upgrading to JDK 17 + enabling the Parallel GC resulted in improvements from 9% to 20% in their benchmarks using three different projects.

### Testing

As this build changed the `gradle.properties` file, all tests should run.

### Notes

The JDK switch + dependency caching should only affect CI.

The parallel GC affects our local builds, but it's compatible with JDK 11 that some developers are using on their local machines.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
