### PR TITLE
fix: app stuck at loading screen after migration

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
@@ -33,13 +33,13 @@ internal class StoreServerConfigUseCaseImpl(
         return configRepository.storeConfig(cleanLinks, versionInfo)
             .fold({ StoreServerConfigResult.Failure.Generic(it) }, { StoreServerConfigResult.Success(it) })
     }
+}
 
+sealed class StoreServerConfigResult {
+    // TODO: change to return the id only so we are now passing the whole config object around in the app
+    class Success(val serverConfig: ServerConfig) : StoreServerConfigResult()
 
-    sealed class StoreServerConfigResult {
-        // TODO: change to return the id only so we are now passing the whole config object around in the app
-        class Success(val serverConfig: ServerConfig) : StoreServerConfigResult()
-
-        sealed class Failure : StoreServerConfigResult() {
-            class Generic(val genericFailure: CoreFailure) : Failure()
-        }
+    sealed class Failure : StoreServerConfigResult() {
+        class Generic(val genericFailure: CoreFailure) : Failure()
     }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
@@ -25,7 +25,7 @@ internal class StoreServerConfigUseCaseImpl(
     override suspend fun invoke(links: ServerConfig.Links, versionInfo: ServerConfig.VersionInfo): StoreServerConfigResult {
         val cleanWsLink = URLBuilder(links.webSocket).apply {
             pathSegments = pathSegments.toMutableList().apply {
-                remove("await")
+                if (last() == "await") removeLast()
             }
         }.buildString()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
@@ -25,7 +25,7 @@ internal class StoreServerConfigUseCaseImpl(
     override suspend fun invoke(links: ServerConfig.Links, versionInfo: ServerConfig.VersionInfo): StoreServerConfigResult {
         val cleanWsLink = URLBuilder(links.webSocket).apply {
             pathSegments = pathSegments.toMutableList().apply {
-                if (last() == "await") removeLast()
+                if (lastOrNull() == "await") removeLast()
             }
         }.buildString()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCaseTest.kt
@@ -1,0 +1,87 @@
+package com.wire.kalium.logic.feature.server
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.configuration.server.ServerConfigRepository
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.stubs.newServerConfig
+import io.mockative.Mock
+import io.mockative.eq
+import io.mockative.fun2
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreServerConfigUseCaseTest {
+
+    @Test
+    fun givenServerConfigRepository_whenStoreConfig_thenSuccess() = runTest {
+        val links = newServerConfig(1).links
+        val versionInfo = ServerConfig.VersionInfo(false, listOf(1), null, listOf(2))
+        val expected = newServerConfig(1)
+
+        val (arrangement, useCase) = Arrangement()
+            .withStoreConfig(expected.links, versionInfo, Either.Right(expected))
+            .arrange()
+
+        useCase(links, versionInfo).also {
+            assertIs<StoreServerConfigResult.Success>(it)
+            assertEquals(expected, it.serverConfig)
+        }
+
+        verify(arrangement.configRepository)
+            .coroutine { arrangement.configRepository.storeConfig(links, versionInfo) }
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenServerlinkswithAwaitAtTheEndOfWebSocketLink_whenStoreConfig_thenStoreWithAwaitRemoved() = runTest {
+        val links = newServerConfig(1).links.copy(webSocket = "wss://example.com/await")
+        val versionInfo = ServerConfig.VersionInfo(false, listOf(1), null, listOf(2))
+        val expected = newServerConfig(1).copy(links = links.copy(webSocket = "wss://example.com/"))
+
+        val (arrangement, useCase) = Arrangement()
+            .withStoreConfig(expected.links, versionInfo, Either.Right(expected))
+            .arrange()
+
+        useCase(links, versionInfo).also {
+            assertIs<StoreServerConfigResult.Success>(it)
+            assertEquals(expected, it.serverConfig)
+        }
+
+        verify(arrangement.configRepository)
+            .coroutine { arrangement.configRepository.storeConfig(expected.links, versionInfo) }
+            .wasInvoked(exactly = once)
+    }
+
+
+    private class Arrangement {
+        @Mock
+        val configRepository = mock(ServerConfigRepository::class)
+        private val useCase = StoreServerConfigUseCaseImpl(configRepository)
+
+        suspend fun withStoreConfig(
+            links: ServerConfig.Links,
+            versionInfo: ServerConfig.VersionInfo,
+            result: Either<StorageFailure, ServerConfig>
+        ) = apply {
+            given(configRepository)
+                .function(
+                    configRepository::storeConfig,
+                    fun2<ServerConfig.Links, ServerConfig.VersionInfo>())
+                .whenInvokedWith(eq(links), eq(versionInfo))
+                .thenReturn(result)
+        }
+
+        fun arrange() = this to useCase
+    }
+
+}
+

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCaseTest.kt
@@ -61,7 +61,6 @@ class StoreServerConfigUseCaseTest {
             .wasInvoked(exactly = once)
     }
 
-
     private class Arrangement {
         @Mock
         val configRepository = mock(ServerConfigRepository::class)
@@ -84,4 +83,3 @@ class StoreServerConfigUseCaseTest {
     }
 
 }
-

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCaseTest.kt
@@ -42,7 +42,7 @@ class StoreServerConfigUseCaseTest {
     }
 
     @Test
-    fun givenServerlinkswithAwaitAtTheEndOfWebSocketLink_whenStoreConfig_thenStoreWithAwaitRemoved() = runTest {
+    fun givenServerLinksWithAwaitAtTheEndOfWebSocketLink_whenStoreConfig_thenStoreWithAwaitRemoved() = runTest {
         val links = newServerConfig(1).links.copy(webSocket = "wss://example.com/await")
         val versionInfo = ServerConfig.VersionInfo(false, listOf(1), null, listOf(2))
         val expected = newServerConfig(1).copy(links = links.copy(webSocket = "wss://example.com/"))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

 app stuck at loading screen after migration

### Causes (Optional)

when reading the server config in staging from the old it can happen that the app adds "/await" to the end of the link path

### Solutions

clean the server config links when migrating

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
