### PR TITLE
fix: asset messages content can be overwritten by id

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -406,25 +406,8 @@ INSERT OR IGNORE INTO MessageRestrictedAssetContent(message_id, conversation_id,
 VALUES(?, ?, ?,?,?);
 
 insertMessageAssetContent:
-INSERT INTO MessageAssetContent(message_id, conversation_id, asset_size, asset_name, asset_mime_type, asset_upload_status, asset_download_status, asset_otr_key, asset_sha256, asset_id, asset_token, asset_domain, asset_encryption_algorithm, asset_width, asset_height, asset_duration_ms, asset_normalized_loudness)
-VALUES(?, ?, ?, ?, ?, ? ,?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(message_id, conversation_id) DO UPDATE SET
-message_id = excluded.message_id,
-asset_size = excluded.asset_size,
-asset_name = excluded.asset_name,
-asset_mime_type = excluded.asset_mime_type,
-asset_upload_status = excluded.asset_upload_status,
-asset_download_status = excluded.asset_download_status,
-asset_otr_key = excluded.asset_otr_key,
-asset_sha256 = excluded.asset_sha256,
-asset_id = excluded.asset_id,
-asset_token = excluded.asset_token,
-asset_domain = excluded.asset_domain,
-asset_encryption_algorithm = excluded.asset_encryption_algorithm,
-asset_width = excluded.asset_width,
-asset_height = excluded.asset_height,
-asset_duration_ms = excluded.asset_duration_ms,
-asset_normalized_loudness = excluded.asset_normalized_loudness;
+INSERT OR IGNORE INTO MessageAssetContent(message_id, conversation_id, asset_size, asset_name, asset_mime_type, asset_upload_status, asset_download_status, asset_otr_key, asset_sha256, asset_id, asset_token, asset_domain, asset_encryption_algorithm, asset_width, asset_height, asset_duration_ms, asset_normalized_loudness)
+VALUES(?, ?, ?, ?, ?, ? ,?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 insertMemberChangeMessage:
 INSERT OR IGNORE INTO MessageMemberChangeContent(message_id, conversation_id, member_change_list, member_change_type)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -930,7 +930,7 @@ class MessageDAOTest : BaseDatabaseTest() {
         val updatedMessage = messageDAO.getMessageById(messageId, conversationId).firstOrNull()
         val updatedMessageContent = updatedMessage?.content
 
-        // assert values that should not be updated
+        // asset values that should not be updated
         assertTrue((updatedMessage?.visibility == MessageEntity.Visibility.VISIBLE))
         assertTrue(updatedMessageContent is MessageEntityContent.Asset)
         assertEquals(initialAssetSize, updatedMessageContent.assetSizeInBytes)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -849,7 +849,7 @@ class MessageDAOTest : BaseDatabaseTest() {
     @Suppress("LongMethod")
     @Test
     @IgnoreIOS
-    fun givenAnAssetMessageInDB_WhenTryingAnAssetUpdate_ThenTheFinalMessageShouldIncludeTheChanges() = runTest {
+    fun givenAnAssetMessageInDB_WhenTryingAnAssetUpdate_thenIgnore() = runTest {
         // given
         val conversationId = QualifiedIDEntity("1", "someDomain")
         val messageId = "assetMessageId"
@@ -930,25 +930,22 @@ class MessageDAOTest : BaseDatabaseTest() {
         val updatedMessage = messageDAO.getMessageById(messageId, conversationId).firstOrNull()
         val updatedMessageContent = updatedMessage?.content
 
-        // assert values are updated
+        // assert values that should not be updated
         assertTrue((updatedMessage?.visibility == MessageEntity.Visibility.VISIBLE))
         assertTrue(updatedMessageContent is MessageEntityContent.Asset)
-        assertEquals(updatedDownloadStatus, updatedMessageContent.assetDownloadStatus)
-        assertEquals(updatedAssetSize, updatedMessageContent.assetSizeInBytes)
-        assertEquals(updatedAssetName, updatedMessageContent.assetName)
-        assertEquals(updatedMimeType, updatedMessageContent.assetMimeType)
-        assertEquals(updatedAssetEncryption, updatedMessageContent.assetEncryptionAlgorithm)
-        assertEquals(updatedAssetToken, updatedMessageContent.assetToken)
-        assertEquals(updatedAssetId, updatedMessageContent.assetId)
-        assertEquals(updatedAssetDomain, updatedMessageContent.assetDomain)
+        assertEquals(initialAssetSize, updatedMessageContent.assetSizeInBytes)
+        assertEquals(initialAssetName, updatedMessageContent.assetName)
+        assertEquals(initialMimeType, updatedMessageContent.assetMimeType)
+        assertEquals(initialAssetEncryption, updatedMessageContent.assetEncryptionAlgorithm)
+        assertEquals(initialAssetToken, updatedMessageContent.assetToken)
+        assertEquals(initialAssetId, updatedMessageContent.assetId)
+        assertEquals(initialDomain, updatedMessageContent.assetDomain)
         assertTrue(updatedMessageContent.assetOtrKey.contentEquals(dummyOtrKey))
         assertTrue(updatedMessageContent.assetSha256Key.contentEquals(dummySha256Key))
-
-        // assert values that should not be updated
+        assertEquals(initialDownloadStatus, updatedMessageContent.assetDownloadStatus)
         assertEquals(initialMetadataWidth, updatedMessageContent.assetWidth)
         assertEquals(initialMetadataHeight, updatedMessageContent.assetHeight)
         assertEquals(initialUploadStatus, updatedMessageContent.assetUploadStatus)
-
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -875,9 +875,7 @@ class MessageDAOTest : BaseDatabaseTest() {
         val initialAssetToken = "Some-token"
         val updatedAssetToken = "updated-token"
         val initialMetadataWidth = 100
-        val updatedMetadataWidth = null
         val initialMetadataHeight = 300
-        val updatedMetadataHeight = null
         val initialAssetMessage = newRegularMessageEntity(
             id = messageId,
             date = "2000-01-01T13:00:00.000Z",
@@ -889,7 +887,7 @@ class MessageDAOTest : BaseDatabaseTest() {
                 assetSizeInBytes = initialAssetSize,
                 assetName = initialAssetName,
                 assetMimeType = initialMimeType,
-                assetOtrKey = dummyOtrKey,
+                assetOtrKey = byteArrayOf(),
                 assetSha256Key = dummySha256Key,
                 assetId = initialAssetId,
                 assetDomain = initialDomain,
@@ -913,9 +911,7 @@ class MessageDAOTest : BaseDatabaseTest() {
                 assetEncryptionAlgorithm = updatedAssetEncryption,
                 assetUploadStatus = updatedUploadStatus,
                 assetDownloadStatus = updatedDownloadStatus,
-                assetToken = updatedAssetToken,
-                assetWidth = updatedMetadataWidth,
-                assetHeight = updatedMetadataHeight
+                assetToken = updatedAssetToken
             )
         )
         conversationDAO.insertConversation(newConversationEntity(id = conversationId, lastReadDate = "2000-01-01T12:00:00.000Z"))
@@ -930,17 +926,17 @@ class MessageDAOTest : BaseDatabaseTest() {
         val updatedMessageContent = updatedMessage?.content
         assertTrue((updatedMessage?.visibility == MessageEntity.Visibility.VISIBLE))
         assertTrue(updatedMessageContent is MessageEntityContent.Asset)
-        assertEquals(updatedMessageContent.assetUploadStatus, updatedUploadStatus)
-        assertEquals(updatedMessageContent.assetDownloadStatus, updatedDownloadStatus)
-        assertEquals(updatedMessageContent.assetSizeInBytes, updatedAssetSize)
-        assertEquals(updatedMessageContent.assetName, updatedAssetName)
-        assertEquals(updatedMessageContent.assetMimeType, updatedMimeType)
-        assertEquals(updatedMessageContent.assetEncryptionAlgorithm, updatedAssetEncryption)
-        assertEquals(updatedMessageContent.assetToken, updatedAssetToken)
-        assertEquals(updatedMessageContent.assetId, updatedAssetId)
-        assertEquals(updatedMessageContent.assetDomain, updatedAssetDomain)
-        assertEquals(updatedMessageContent.assetWidth, updatedMetadataWidth)
-        assertEquals(updatedMessageContent.assetHeight, updatedMetadataHeight)
+        assertEquals(updatedUploadStatus, updatedMessageContent.assetUploadStatus)
+        assertEquals(updatedDownloadStatus, updatedMessageContent.assetDownloadStatus)
+        assertEquals(updatedAssetSize, updatedMessageContent.assetSizeInBytes)
+        assertEquals(updatedAssetName, updatedMessageContent.assetName)
+        assertEquals(updatedMimeType, updatedMessageContent.assetMimeType)
+        assertEquals(updatedAssetEncryption, updatedMessageContent.assetEncryptionAlgorithm)
+        assertEquals(updatedAssetToken, updatedMessageContent.assetToken)
+        assertEquals(updatedAssetId, updatedMessageContent.assetId)
+        assertEquals(updatedAssetDomain, updatedMessageContent.assetDomain)
+        assertEquals(initialMetadataWidth, updatedMessageContent.assetWidth)
+        assertEquals(initialMetadataHeight, updatedMessageContent.assetHeight)
         assertTrue(updatedMessageContent.assetOtrKey.contentEquals(dummyOtrKey))
         assertTrue(updatedMessageContent.assetSha256Key.contentEquals(dummySha256Key))
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -876,6 +876,9 @@ class MessageDAOTest : BaseDatabaseTest() {
         val updatedAssetToken = "updated-token"
         val initialMetadataWidth = 100
         val initialMetadataHeight = 300
+        val updatedMetadataHeight = null
+        val updatedMetadataWidth = null
+
         val initialAssetMessage = newRegularMessageEntity(
             id = messageId,
             date = "2000-01-01T13:00:00.000Z",
@@ -887,7 +890,7 @@ class MessageDAOTest : BaseDatabaseTest() {
                 assetSizeInBytes = initialAssetSize,
                 assetName = initialAssetName,
                 assetMimeType = initialMimeType,
-                assetOtrKey = byteArrayOf(),
+                assetOtrKey = dummyOtrKey,
                 assetSha256Key = dummySha256Key,
                 assetId = initialAssetId,
                 assetDomain = initialDomain,
@@ -911,7 +914,9 @@ class MessageDAOTest : BaseDatabaseTest() {
                 assetEncryptionAlgorithm = updatedAssetEncryption,
                 assetUploadStatus = updatedUploadStatus,
                 assetDownloadStatus = updatedDownloadStatus,
-                assetToken = updatedAssetToken
+                assetToken = updatedAssetToken,
+                assetWidth = updatedMetadataWidth,
+                assetHeight = updatedMetadataHeight
             )
         )
         conversationDAO.insertConversation(newConversationEntity(id = conversationId, lastReadDate = "2000-01-01T12:00:00.000Z"))
@@ -924,9 +929,10 @@ class MessageDAOTest : BaseDatabaseTest() {
         // then
         val updatedMessage = messageDAO.getMessageById(messageId, conversationId).firstOrNull()
         val updatedMessageContent = updatedMessage?.content
+
+        // assert values are updated
         assertTrue((updatedMessage?.visibility == MessageEntity.Visibility.VISIBLE))
         assertTrue(updatedMessageContent is MessageEntityContent.Asset)
-        assertEquals(updatedUploadStatus, updatedMessageContent.assetUploadStatus)
         assertEquals(updatedDownloadStatus, updatedMessageContent.assetDownloadStatus)
         assertEquals(updatedAssetSize, updatedMessageContent.assetSizeInBytes)
         assertEquals(updatedAssetName, updatedMessageContent.assetName)
@@ -935,10 +941,14 @@ class MessageDAOTest : BaseDatabaseTest() {
         assertEquals(updatedAssetToken, updatedMessageContent.assetToken)
         assertEquals(updatedAssetId, updatedMessageContent.assetId)
         assertEquals(updatedAssetDomain, updatedMessageContent.assetDomain)
-        assertEquals(initialMetadataWidth, updatedMessageContent.assetWidth)
-        assertEquals(initialMetadataHeight, updatedMessageContent.assetHeight)
         assertTrue(updatedMessageContent.assetOtrKey.contentEquals(dummyOtrKey))
         assertTrue(updatedMessageContent.assetSha256Key.contentEquals(dummySha256Key))
+
+        // assert values that should not be updated
+        assertEquals(initialMetadataWidth, updatedMessageContent.assetWidth)
+        assertEquals(initialMetadataHeight, updatedMessageContent.assetHeight)
+        assertEquals(initialUploadStatus, updatedMessageContent.assetUploadStatus)
+
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

asset messages content can be overwritten by id

### Solutions

after investigation, this has no impact on send/receive asset messages.
so i reverted the changes and ignored the insert when the message id matches

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
