### PR TITLE
fix(rc): ghost calls after restoring backup from other client [AR-2893]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -459,7 +459,8 @@ class UserSessionScope internal constructor(
         get() = RestoreBackupUseCaseImpl(
             userStorage.database.databaseImporter,
             kaliumFileSystem,
-            userId
+            userId,
+            clientIdProvider
         )
 
     val persistMessage: PersistMessageUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
@@ -204,7 +204,7 @@ internal class RestoreBackupUseCaseImpl(
         }
 
     private suspend fun isFromOtherClient(extractedBackupPath: Path): Boolean =
-        backupMetadata(extractedBackupPath)?.clientId != currentClientIdProvider().fold({""}, { it.value })
+        backupMetadata(extractedBackupPath)?.clientId != currentClientIdProvider().fold({ "" }, { it.value })
 }
 
 sealed class RestoreBackupResult {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/RestoreBackupTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/RestoreBackupTest.kt
@@ -69,7 +69,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
                 messageType = MessageType.Regular
             )
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
             // then
             val conversationsAfterBackup: List<ConversationViewEntity> =
@@ -105,7 +105,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
                 ).map(::mapFromDetailsToConversationEntity)
             )
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
             // then
             val conversationAfterRestore = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -138,7 +138,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
                 )
             )
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
             // then
             val conversationAfterRestore = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -157,7 +157,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         )
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val conversationAfterRestore = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -172,7 +172,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         backupDatabaseBuilder.conversationDAO.insertConversations(overLappingConversations)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         assertEquals(10, userDatabaseBuilder.conversationDAO.getAllConversations().first().size)
@@ -191,7 +191,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         backupDatabaseBuilder.conversationDAO.insertConversations(userConversations.map(::mapFromDetailsToConversationEntity))
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val conversationAfterRestore = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -209,7 +209,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             )
 
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
             // then
             backupConversations.forEach { conversationEntity ->
@@ -244,7 +244,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             )
 
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
             // then
             val restoredConversations = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -275,7 +275,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             backupDatabaseBuilder.teamDAO.insertTeam(teamEntity)
         }
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
         // then
         teams.forEach { teamEntity ->
             val restoredTeam = backupDatabaseBuilder.teamDAO.getTeamById(teamEntity.id).first()
@@ -291,7 +291,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             userDatabaseBuilder.teamDAO.insertTeam(teamEntity)
         }
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
         // then
         teams.forEach { teamEntity ->
             val restoredTeam = userDatabaseBuilder.teamDAO.getTeamById(teamEntity.id).first()
@@ -312,7 +312,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             conversationAmount = userConversationAmount,
         )
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val conversationsAfterBackup: List<ConversationViewEntity> = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -333,7 +333,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         )
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val calls = conversationsWithCallToBackup.map { it.second }
@@ -350,7 +350,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         )
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val calls = conversationsWithCallToBackup.map { it.second }
@@ -372,7 +372,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             conversationAmount = userConversationAmount
         )
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), true,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), true, null)
 
         // then
         val conversationsAfterBackup: List<ConversationViewEntity> = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -387,14 +387,13 @@ class RestoreBackupTest : BaseDatabaseTest() {
         assertEquals(allCalls.minus(backupCalls), allCalls)
     }
 
-
     @Test
     fun givenBackupHasUsersAndUserNot_whenRestoringBackup_thenThoseUsersAreRestored() = runTest {
         // given
         val userToBackup = backupDatabaseDataGenerator.generateAndInsertUsers(10)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val restoredUsers = userDatabaseBuilder.userDAO.getAllUsers().first()
@@ -407,7 +406,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         val usersPresent = userDatabaseDataGenerator.generateAndInsertUsers(10)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val restoredUsers = userDatabaseBuilder.userDAO.getAllUsers().first()
@@ -421,7 +420,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         val userToBackup = backupDatabaseDataGenerator.generateAndInsertUsers(50)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val restoredUsers = userDatabaseBuilder.userDAO.getAllUsers().first()
@@ -443,7 +442,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         }
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         val restoredUsers = userDatabaseBuilder.userDAO.getAllUsers().first()
@@ -457,7 +456,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         val assetsToRestore = backupDatabaseDataGenerator.generateAndInsertAssets(10)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         assetsToRestore.forEach { assetEntity ->
@@ -473,7 +472,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         val userAssets = userDatabaseDataGenerator.generateAndInsertAssets(10)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         assetsToRestore.forEach { assetEntity ->
@@ -497,7 +496,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         )
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
         // then
         test.forEach { conversationViewEntity ->
@@ -533,7 +532,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             )
 
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, null)
 
             // then
             backupConversationWithAssetContent.forEach { conversationViewEntity ->

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/RestoreBackupTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/RestoreBackupTest.kt
@@ -69,7 +69,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
                 messageType = MessageType.Regular
             )
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
             // then
             val conversationsAfterBackup: List<ConversationViewEntity> =
@@ -105,7 +105,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
                 ).map(::mapFromDetailsToConversationEntity)
             )
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
             // then
             val conversationAfterRestore = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -138,7 +138,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
                 )
             )
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
             // then
             val conversationAfterRestore = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -157,7 +157,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         )
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val conversationAfterRestore = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -172,7 +172,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         backupDatabaseBuilder.conversationDAO.insertConversations(overLappingConversations)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         assertEquals(10, userDatabaseBuilder.conversationDAO.getAllConversations().first().size)
@@ -191,7 +191,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         backupDatabaseBuilder.conversationDAO.insertConversations(userConversations.map(::mapFromDetailsToConversationEntity))
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val conversationAfterRestore = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -209,7 +209,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             )
 
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
             // then
             backupConversations.forEach { conversationEntity ->
@@ -244,7 +244,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             )
 
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
             // then
             val restoredConversations = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -275,7 +275,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             backupDatabaseBuilder.teamDAO.insertTeam(teamEntity)
         }
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
         // then
         teams.forEach { teamEntity ->
             val restoredTeam = backupDatabaseBuilder.teamDAO.getTeamById(teamEntity.id).first()
@@ -291,7 +291,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             userDatabaseBuilder.teamDAO.insertTeam(teamEntity)
         }
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
         // then
         teams.forEach { teamEntity ->
             val restoredTeam = userDatabaseBuilder.teamDAO.getTeamById(teamEntity.id).first()
@@ -312,7 +312,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             conversationAmount = userConversationAmount,
         )
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val conversationsAfterBackup: List<ConversationViewEntity> = userDatabaseBuilder.conversationDAO.getAllConversations().first()
@@ -333,7 +333,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         )
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val calls = conversationsWithCallToBackup.map { it.second }
@@ -350,7 +350,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         )
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val calls = conversationsWithCallToBackup.map { it.second }
@@ -360,12 +360,41 @@ class RestoreBackupTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenBackupHasUniqueConversationWithCallsButFromOtherClient_whenRestoringBackup_thenNoCallsAreInserted() = runTest {
+        // given
+        val backupConversationAmount = 3
+        val backupConversationsWithCalls = backupDatabaseDataGenerator.generateAndInsertConversationsWithCall(
+            conversationAmount = backupConversationAmount
+        )
+
+        val userConversationAmount = 2
+        val userConversationsWithCalls = userDatabaseDataGenerator.generateAndInsertConversationsWithCall(
+            conversationAmount = userConversationAmount
+        )
+        // when
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), true,  null)
+
+        // then
+        val conversationsAfterBackup: List<ConversationViewEntity> = userDatabaseBuilder.conversationDAO.getAllConversations().first()
+
+        val backupCalls = backupConversationsWithCalls.map { it.second }
+        val userCalls = userConversationsWithCalls.map { it.second }
+
+        assertEquals(backupConversationAmount + userConversationAmount, conversationsAfterBackup.size)
+
+        val allCalls = userDatabaseBuilder.callDAO.observeCalls().first()
+        assertEquals(allCalls, userCalls)
+        assertEquals(allCalls.minus(backupCalls), allCalls)
+    }
+
+
+    @Test
     fun givenBackupHasUsersAndUserNot_whenRestoringBackup_thenThoseUsersAreRestored() = runTest {
         // given
         val userToBackup = backupDatabaseDataGenerator.generateAndInsertUsers(10)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val restoredUsers = userDatabaseBuilder.userDAO.getAllUsers().first()
@@ -378,7 +407,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         val usersPresent = userDatabaseDataGenerator.generateAndInsertUsers(10)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val restoredUsers = userDatabaseBuilder.userDAO.getAllUsers().first()
@@ -392,7 +421,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         val userToBackup = backupDatabaseDataGenerator.generateAndInsertUsers(50)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val restoredUsers = userDatabaseBuilder.userDAO.getAllUsers().first()
@@ -414,7 +443,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         }
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         val restoredUsers = userDatabaseBuilder.userDAO.getAllUsers().first()
@@ -428,7 +457,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         val assetsToRestore = backupDatabaseDataGenerator.generateAndInsertAssets(10)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         assetsToRestore.forEach { assetEntity ->
@@ -444,7 +473,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         val userAssets = userDatabaseDataGenerator.generateAndInsertAssets(10)
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         assetsToRestore.forEach { assetEntity ->
@@ -468,7 +497,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
         )
 
         // when
-        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+        userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
         // then
         test.forEach { conversationViewEntity ->
@@ -504,7 +533,7 @@ class RestoreBackupTest : BaseDatabaseTest() {
             )
 
             // when
-            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), null)
+            userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false,  null)
 
             // then
             backupConversationWithAssetContent.forEach { conversationViewEntity ->


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we create a backup while being in a call, log out, clear data, log in and restore it, while the call is still ongoing, we end up alone in a call which can’t be hanged up, just continues forever.

### Causes (Optional)

When we clear data and log in again, the app has to register a new client so calls intended for a previous client won't work anymore.

### Solutions

Check if the backup we want to restore is from another client, if so then do not restore calls table because all calls there are not meant for the client that we currently try to do it on.

Needs releases with:

- https://github.com/wireapp/kalium/pull/1302

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

STR:
- be in an active call
- create a backup while being in the call without password
- logout of the app, clear data
- login again
- restore the backup
- original call shouldn't be ongoing anymore

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[SQPIT-764]: https://wearezeta.atlassian.net/browse/SQPIT-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SQPIT-764]: https://wearezeta.atlassian.net/browse/SQPIT-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ