### PR TITLE
test: add unit tests to AuthTokenStorage

### DIFF
--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/AuthTokenStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/AuthTokenStorage.kt
@@ -41,14 +41,10 @@ class AuthTokenStorage internal constructor(
         refreshToken: String?,
     ): AuthTokenEntity {
         val key = tokenKey(userId)
-        val newToken: AuthTokenEntity = (refreshToken?.let {
-            AuthTokenEntity(userId, accessToken, refreshToken, tokenType)
-        } ?: run {
-            kaliumPreferences.getSerializable(key, AuthTokenEntity.serializer())?.copy(
-                accessToken = accessToken,
-                tokenType = tokenType
-            )
-        }) ?: error("No token found for user")
+        val newToken = kaliumPreferences.getSerializable(key, AuthTokenEntity.serializer())
+            ?.let {
+                it.copy(accessToken = accessToken, refreshToken = refreshToken ?: it.refreshToken, tokenType = tokenType)
+            } ?: error("No token found for user")
 
         kaliumPreferences.putSerializable(
             key,
@@ -57,7 +53,6 @@ class AuthTokenStorage internal constructor(
         )
         return newToken
     }
-
     // TODO: make suspendable
     fun getToken(userId: UserIDEntity): AuthTokenEntity? =
         kaliumPreferences.getSerializable(

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/AuthTokenStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/AuthTokenStorageTest.kt
@@ -1,0 +1,86 @@
+package com.wire.kalium.persistence.client
+
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.Settings
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.kmmSettings.KaliumPreferencesSettings
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class AuthTokenStorageTest {
+    private val mockSettings: Settings = MapSettings()
+
+    private val kaliumPreferences = KaliumPreferencesSettings(mockSettings)
+
+    private lateinit var authTokenStorage: AuthTokenStorage
+
+    @BeforeTest
+    fun setup() {
+        mockSettings.clear()
+        authTokenStorage = AuthTokenStorage(kaliumPreferences)
+    }
+
+    @Test
+    fun givenAuthToken_whenInserting_thenAllDataIsStoredCorrectly() {
+        val authToken = TEST_AUTH_TOKENS
+        authTokenStorage.addOrReplace(authToken, null)
+        authTokenStorage.getToken(authToken.userId).also {
+            assertEquals(it, authToken)
+        }
+    }
+
+    @Test
+    fun givenAuthTokenAlreadyStored_whenReplacing_thenAllDataIsStoredCorrectly() {
+        val authToken = TEST_AUTH_TOKENS
+        val newToken = TEST_AUTH_TOKENS.copy(accessToken = "new_access_token")
+        authTokenStorage.addOrReplace(authToken, null)
+        authTokenStorage.addOrReplace(newToken, null)
+
+        authTokenStorage.getToken(authToken.userId).also {
+            assertEquals(it, newToken)
+        }
+    }
+
+    @Test
+    fun givenNoTokensStoredForUser_whenUpdating_thenThrowError() {
+        val expected =
+            TEST_AUTH_TOKENS.copy(accessToken = "new_access_token", tokenType = "new_token_type", refreshToken = "new_refresh_token")
+
+        assertFails {
+            authTokenStorage.updateToken(expected.userId, "access_token", "token_type", "refresh_token")
+        }
+    }
+
+    @Test
+    fun givenTokensStoredForUser_whenUpdatingWithNullRefreshToken_thenTokenIsUpdatedAndTheOldRefreshTokenIsUsed() {
+        val expected =
+            TEST_AUTH_TOKENS.copy(accessToken = "new_access_token", tokenType = "new_token_type")
+
+        authTokenStorage.addOrReplace(TEST_AUTH_TOKENS, null)
+        authTokenStorage.updateToken(expected.userId, expected.accessToken, expected.tokenType, null)
+
+        authTokenStorage.getToken(expected.userId).also {
+            assertEquals(it, expected)
+        }
+    }
+
+    @Test
+    fun givenTokensStoredForUser_whenUpdating_thenThrowError() {
+        val expected =
+            TEST_AUTH_TOKENS.copy(accessToken = "new_access_token", tokenType = "new_token_type", refreshToken = "new_refresh_token")
+
+        authTokenStorage.addOrReplace(TEST_AUTH_TOKENS, null)
+        authTokenStorage.updateToken(expected.userId, expected.accessToken, expected.tokenType, expected.refreshToken)
+
+        authTokenStorage.getToken(expected.userId).also {
+            assertEquals(it, expected)
+        }
+    }
+
+    private companion object {
+        val TEST_AUTH_TOKENS =
+            AuthTokenEntity(UserIDEntity("user_id", "user_domain"), "access_token", "refresh_token", "token_type")
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

AuthTokenStorage is not covered by unit tests 

### Solutions

add unit tests and fix any issues found, the same tests are added to dev in https://github.com/wireapp/kalium/pull/1268

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
