### PR TITLE
fix: allow receiving of null receipt modes

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -257,7 +257,7 @@ internal class ConversationMapperImpl(
         accessRole = options.accessRole?.map { toApiModel(it) },
         convTeamInfo = teamId?.let { ConvTeamInfo(false, it) },
         messageTimer = null,
-        receiptMode = options.readReceiptsEnabled?.let { if (it) ReceiptMode.ENABLED else ReceiptMode.DISABLED },
+        receiptMode = if (options.readReceiptsEnabled) ReceiptMode.ENABLED else ReceiptMode.DISABLED,
         conversationRole = ConversationDataSource.DEFAULT_MEMBER_ROLE,
         protocol = toApiModel(options.protocol),
         creatorClient = options.creatorClientId?.value

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationOptions.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationOptions.kt
@@ -4,7 +4,7 @@ package com.wire.kalium.logic.data.conversation
 data class ConversationOptions(
     val access: Set<Conversation.Access>? = null,
     val accessRole: Set<Conversation.AccessRole>? = null,
-    val readReceiptsEnabled: Boolean? = false,
+    val readReceiptsEnabled: Boolean = false,
     val protocol: Protocol = Protocol.PROTEUS,
     // TODO(qol): use ClientId class
     val creatorClientId: ClientId? = null

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ReceiptModeMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ReceiptModeMapper.kt
@@ -6,36 +6,32 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ReceiptMode
 import com.wire.kalium.persistence.dao.ConversationEntity
 
 interface ReceiptModeMapper {
-    fun toDaoModel(receiptMode: Conversation.ReceiptMode?): ConversationEntity.ReceiptMode
-    fun fromApiToModel(receiptMode: ReceiptMode?): Conversation.ReceiptMode
-    fun fromApiToDaoModel(receiptMode: ReceiptMode?): ConversationEntity.ReceiptMode
-    fun fromEntityToModel(receiptMode: ConversationEntity.ReceiptMode?): Conversation.ReceiptMode
+    fun toDaoModel(receiptMode: Conversation.ReceiptMode): ConversationEntity.ReceiptMode
+    fun fromApiToModel(receiptMode: ReceiptMode): Conversation.ReceiptMode
+    fun fromApiToDaoModel(receiptMode: ReceiptMode): ConversationEntity.ReceiptMode
+    fun fromEntityToModel(receiptMode: ConversationEntity.ReceiptMode): Conversation.ReceiptMode
 }
 
 class ReceiptModeMapperImpl(
     val idMapper: IdMapper = MapperProvider.idMapper()
 ) : ReceiptModeMapper {
-    override fun fromApiToDaoModel(receiptMode: ReceiptMode?): ConversationEntity.ReceiptMode = when (receiptMode) {
+    override fun fromApiToDaoModel(receiptMode: ReceiptMode): ConversationEntity.ReceiptMode = when (receiptMode) {
         ReceiptMode.DISABLED -> ConversationEntity.ReceiptMode.DISABLED
         ReceiptMode.ENABLED -> ConversationEntity.ReceiptMode.ENABLED
-        null -> ConversationEntity.ReceiptMode.DISABLED
     }
 
-    override fun toDaoModel(receiptMode: Conversation.ReceiptMode?): ConversationEntity.ReceiptMode = when (receiptMode) {
+    override fun toDaoModel(receiptMode: Conversation.ReceiptMode): ConversationEntity.ReceiptMode = when (receiptMode) {
         Conversation.ReceiptMode.DISABLED -> ConversationEntity.ReceiptMode.DISABLED
         Conversation.ReceiptMode.ENABLED -> ConversationEntity.ReceiptMode.ENABLED
-        null -> ConversationEntity.ReceiptMode.DISABLED
     }
 
-    override fun fromApiToModel(receiptMode: ReceiptMode?): Conversation.ReceiptMode = when (receiptMode) {
+    override fun fromApiToModel(receiptMode: ReceiptMode): Conversation.ReceiptMode = when (receiptMode) {
         ReceiptMode.DISABLED -> Conversation.ReceiptMode.DISABLED
         ReceiptMode.ENABLED -> Conversation.ReceiptMode.ENABLED
-        null -> Conversation.ReceiptMode.DISABLED
     }
 
-    override fun fromEntityToModel(receiptMode: ConversationEntity.ReceiptMode?): Conversation.ReceiptMode = when (receiptMode) {
+    override fun fromEntityToModel(receiptMode: ConversationEntity.ReceiptMode): Conversation.ReceiptMode = when (receiptMode) {
         ConversationEntity.ReceiptMode.DISABLED -> Conversation.ReceiptMode.DISABLED
         ConversationEntity.ReceiptMode.ENABLED -> Conversation.ReceiptMode.ENABLED
-        null -> Conversation.ReceiptMode.DISABLED
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -396,8 +396,6 @@ class MessageDataSource(
         conversationId: ConversationId
     ): Either<CoreFailure, Conversation.ReceiptMode?> = wrapStorageRequest {
         messageDAO.getReceiptModeFromGroupConversationByQualifiedID(conversationId.toDao())
-            .let {
-                receiptModeMapper.fromEntityToModel(it)
-            }
+            ?.let { receiptModeMapper.fromEntityToModel(it) }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ReceiptModeMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ReceiptModeMapperTest.kt
@@ -51,20 +51,6 @@ class ReceiptModeMapperTest {
     }
 
     @Test
-    fun givenAConversationReceiptModeNull_whenMappingToDaoModel_thenReturnConversationEntityReceiptModeDisabled() {
-        // given
-        val conversationReceiptMode = null
-
-        val expectedResult = ConversationEntity.ReceiptMode.DISABLED
-
-        // when
-        val result = receiptModeMapper.toDaoModel(conversationReceiptMode)
-
-        // then
-        assertEquals(expectedResult, result)
-    }
-
-    @Test
     fun givenAnApiReceiptModeEnabled_whenMappingFromApiToDaoModel_thenReturnConversationEntityReceiptModeEnabled() {
         // given
         val conversationReceiptMode = ReceiptMode.ENABLED
@@ -82,20 +68,6 @@ class ReceiptModeMapperTest {
     fun givenAnApiReceiptModeDisabled_whenMappingFromApiToDaoModel_thenReturnConversationEntityReceiptModeDisabled() {
         // given
         val conversationReceiptMode = ReceiptMode.DISABLED
-
-        val expectedResult = ConversationEntity.ReceiptMode.DISABLED
-
-        // when
-        val result = receiptModeMapper.fromApiToDaoModel(conversationReceiptMode)
-
-        // then
-        assertEquals(expectedResult, result)
-    }
-
-    @Test
-    fun givenAnApiReceiptModeNull_whenMappingFromApiToDaoModel_thenReturnConversationEntityReceiptModeDisabled() {
-        // given
-        val conversationReceiptMode = null
 
         val expectedResult = ConversationEntity.ReceiptMode.DISABLED
 
@@ -135,20 +107,6 @@ class ReceiptModeMapperTest {
     }
 
     @Test
-    fun givenAnApiReceiptModeNull_whenMappingFromApiToModel_thenReturnConversationReceiptModeDisabled() {
-        // given
-        val conversationReceiptMode = null
-
-        val expectedResult = Conversation.ReceiptMode.DISABLED
-
-        // when
-        val result = receiptModeMapper.fromApiToModel(conversationReceiptMode)
-
-        // then
-        assertEquals(expectedResult, result)
-    }
-
-    @Test
     fun givenAConversationEntityReceiptModeEnabled_whenMappingFromEntityToModel_thenReturnConversationReceiptModeEnabled() {
         // given
         val conversationReceiptMode = ConversationEntity.ReceiptMode.ENABLED
@@ -166,20 +124,6 @@ class ReceiptModeMapperTest {
     fun givenAConversationEntityReceiptModeDisabled_whenMappingFromEntityToModel_thenReturnConversationReceiptModeDisabled() {
         // given
         val conversationReceiptMode = ConversationEntity.ReceiptMode.DISABLED
-
-        val expectedResult = Conversation.ReceiptMode.DISABLED
-
-        // when
-        val result = receiptModeMapper.fromEntityToModel(conversationReceiptMode)
-
-        // then
-        assertEquals(expectedResult, result)
-    }
-
-    @Test
-    fun givenAConversationEntityReceiptModeNull_whenMappingFromEntityToModel_thenReturnConversationReceiptModeDisabled() {
-        // given
-        val conversationReceiptMode = null
 
         val expectedResult = Conversation.ReceiptMode.DISABLED
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationResponse.kt
@@ -32,7 +32,7 @@ data class GlobalTeamConversationResponse(
     val mlsCipherSuiteTag: Int?,
 
     @SerialName("receipt_mode")
-    val receiptMode: ReceiptMode?,
+    val receiptMode: ReceiptMode,
 
     @SerialName("access")
     val access: Set<ConversationAccessDTO>
@@ -83,7 +83,7 @@ data class ConversationResponse(
     val accessRole: Set<ConversationAccessRoleDTO> = ConversationAccessRoleDTO.DEFAULT_VALUE_WHEN_NULL,
 
     @SerialName("receipt_mode")
-    val receiptMode: ReceiptMode?,
+    val receiptMode: ReceiptMode,
 ) {
 
     val isOneOnOneConversation: Boolean
@@ -147,7 +147,7 @@ data class ConversationResponseV3(
     val accessRole: Set<ConversationAccessRoleDTO> = ConversationAccessRoleDTO.DEFAULT_VALUE_WHEN_NULL,
 
     @SerialName("receipt_mode")
-    val receiptMode: ReceiptMode?,
+    val receiptMode: ReceiptMode,
 )
 
 @Serializable

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/CreateConversationRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/CreateConversationRequest.kt
@@ -24,7 +24,7 @@ data class CreateConversationRequest(
     // Receipt mode, controls if read receipts are enabled for the conversation.
     // Any positive value is interpreted as enabled.
     @SerialName("receipt_mode")
-    val receiptMode: ReceiptMode?,
+    val receiptMode: ReceiptMode,
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles
     // designed by Wire (i.e., no custom roles can have the same prefix)
     @SerialName("conversation_role")
@@ -53,7 +53,7 @@ internal data class CreateConversationRequestV3(
     // Receipt mode, controls if read receipts are enabled for the conversation.
     // Any positive value is interpreted as enabled.
     @SerialName("receipt_mode")
-    val receiptMode: ReceiptMode?,
+    val receiptMode: ReceiptMode,
     // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles
     // designed by Wire (i.e., no custom roles can have the same prefix)
     @SerialName("conversation_role")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ReceiptMode.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ReceiptMode.kt
@@ -1,10 +1,12 @@
 package com.wire.kalium.network.api.base.authenticated.conversation
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.nullable
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
@@ -14,13 +16,15 @@ enum class ReceiptMode(val value: Int) {
     ENABLED(1);
 
     object ReceiptModeAsIntSerializer : KSerializer<ReceiptMode> {
-        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ReceiptMode", PrimitiveKind.INT)
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ReceiptMode", PrimitiveKind.INT).nullable
+
         override fun serialize(encoder: Encoder, value: ReceiptMode) {
             encoder.encodeInt(value.value)
         }
 
+        @OptIn(ExperimentalSerializationApi::class)
         override fun deserialize(decoder: Decoder): ReceiptMode {
-            val value = decoder.decodeInt()
+            val value = if (decoder.decodeNotNullMark()) decoder.decodeInt() else 0
             return if (value > 0) ENABLED else DISABLED
         }
     }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v2/ConversationApiV2Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v2/ConversationApiV2Test.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.model.EventContentDTOJson
 import com.wire.kalium.model.conversation.ConversationDetailsResponse
 import com.wire.kalium.model.conversation.ConversationListIdsResponseJson
 import com.wire.kalium.network.api.base.authenticated.conversation.AddConversationMembersRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.ReceiptMode
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v2.authenticated.ConversationApiV2
@@ -12,6 +13,7 @@ import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ConversationApiV2Test : ApiTest {
@@ -54,6 +56,20 @@ class ConversationApiV2Test : ApiTest {
         val response = conversationApi.addMember(request, conversationId)
 
         assertTrue(response.isSuccessful())
+    }
+
+    @Test
+    fun givenNullReceiptMode_whenFetchingConversationDetails_thenShouldReturnDisabled() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            ConversationDetailsResponse.withNullReceiptMode.rawJson, statusCode = HttpStatusCode.OK
+        )
+
+        val conversationApi = ConversationApiV2(networkClient)
+
+        val response = conversationApi.fetchConversationsListDetails(listOf())
+
+        assertTrue(response.isSuccessful())
+        assertEquals(ReceiptMode.DISABLED, response.value.conversationsFound.first().receiptMode)
     }
 
     private companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v3/ConversationApiV3Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v3/ConversationApiV3Test.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertTrue
 class ConversationApiV3Test : ApiTest {
 
     @Test
-    fun givenACreateNewConversationRequest_whenCallingCreateNewConversation_thenTheRequestShouldBeConfiguredOK() = runTest {
+    fun givenACreateNewConversationRequest_wheniCallingCreateNewConversaton_thenTheRequestShouldBeConfiguredOK() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
             CREATE_CONVERSATION_RESPONSE,
             statusCode = HttpStatusCode.Created,

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/ConversationDetailsResponse.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/ConversationDetailsResponse.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.model.conversation
 
 import com.wire.kalium.api.json.AnyResponseProvider
+import com.wire.kalium.api.json.ValidJsonProvider
 
 object ConversationDetailsResponse {
 
@@ -114,4 +115,71 @@ object ConversationDetailsResponse {
     }
 
     val validGetDetailsForIds = AnyResponseProvider(data = "", jsonProvider)
+
+    val withNullReceiptMode = AnyResponseProvider(data = "") {
+        """
+        |{
+        |    "failed": [],
+        |    "found": [
+        |        {
+        |            "access": [
+        |                "invite"
+        |            ],
+        |            "access_role": "activated",
+        |            "access_role_v2": [
+        |                "team_member",
+        |                "non_team_member",
+        |                "service"
+        |            ],
+        |            "creator": "f4680835-2cfe-4d4d-8491-cbb201bd5c2b",
+        |            "id": "ebafd3d4-1548-49f2-ac4e-b2757e6ca44b",
+        |            "last_event": "0.0",
+        |            "last_event_time": "1970-01-01T00:00:00.000Z",
+        |            "members": {
+        |                "others": [
+        |                    {
+        |                        "conversation_role": "wire_member",
+        |                        "id": "22dfd5cc-11ae-4a9d-9046-ba27585f4613",
+        |                        "qualified_id": {
+        |                            "domain": "bella.wire.link",
+        |                            "id": "22dfd5cc-11ae-4a9d-9046-ba27585f4613"
+        |                        },
+        |                        "status": 0
+        |                    }
+        |                ],
+        |                "self": {
+        |                    "conversation_role": "wire_admin",
+        |                    "hidden": false,
+        |                    "hidden_ref": null,
+        |                    "id": "f4680835-2cfe-4d4d-8491-cbb201bd5c2b",
+        |                    "otr_archived": false,
+        |                    "otr_archived_ref": null,
+        |                    "otr_muted_ref": null,
+        |                    "otr_muted_status": null,
+        |                    "qualified_id": {
+        |                        "domain": "anta.wire.link",
+        |                        "id": "f4680835-2cfe-4d4d-8491-cbb201bd5c2b"
+        |                    },
+        |                    "service": null,
+        |                    "status": 0,
+        |                    "status_ref": "0.0",
+        |                    "status_time": "1970-01-01T00:00:00.000Z"
+        |                }
+        |            },
+        |            "message_timer": null,
+        |            "name": "test-anta-grp",
+        |            "protocol": "proteus",
+        |            "qualified_id": {
+        |                "domain": "anta.wire.link",
+        |                "id": "ebafd3d4-1548-49f2-ac4e-b2757e6ca44b"
+        |            },
+        |            "receipt_mode": null,
+        |            "team": null,
+        |            "type": 0
+        |        }
+        |    ],
+        |    "not_found": []
+        |}
+        """.trimMargin()
+    }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/CreateConversationRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/CreateConversationRequestJson.kt
@@ -45,7 +45,7 @@ object CreateConversationRequestJson {
         |           "id": "${it.qualifiedUsers?.get(0)?.value}"
         |       }
         |   ],
-        |   "receipt_mode": ${it.receiptMode?.value},
+        |   "receipt_mode": ${it.receiptMode.value},
         |   "team": {
         |       "managed": false,
         |       "teamid": "${it.convTeamInfo?.teamId}"
@@ -75,7 +75,7 @@ object CreateConversationRequestJson {
         |           "id": "${it.qualifiedUsers?.get(0)?.value}"
         |       }
         |   ],
-        |   "receipt_mode": ${it.receiptMode?.value},
+        |   "receipt_mode": ${it.receiptMode.value},
         |   "team": {
         |       "managed": false,
         |       "teamid": "${it.convTeamInfo?.teamId}"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we allow creation of DTOs with null read receipts. Whilst it makes sense because we can receive that from the backend, it also allows us sending `null` to the backend.

We should reduce this permissiveness so it only works when coming in without allowing the creation of nullable stuff internally within Kalium.

### Solutions

Remove the nullables and make it so the custom Serializer accepts nullable integers, but we convert that to `Disabled` inside of it.

### Testing

Some tests for handling of nullability can actually be removed now.

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
