### PR TITLE
chore: bump AVS version to 9.0.2

### DIFF
--- a/calling/build.gradle.kts
+++ b/calling/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api(libs.avs)
+                api(files("libs/avs_9_0_2.aar")) // TODO temporary until avs9.0.2 is available on Maven-central
                 api(libs.jna.map {
                     project.dependencies.create(it, closureOf<ExternalModuleDependency> {
                         artifact {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Current version does not support MLS
- Black frame issue on video calls (AR-2582)

### Solutions

Upgrade AVS to 9.0.2

### Testing

#### How to Test

- Make a video call 
- Put the app on background
- Return into forground from recent apps
--> You should see others video and not a black frame.

### Notes (Optional)

AVS 9.0.2 is not yet available on Maven-central due to some issues on CI/CD and that could take some time.
I just included the aar directly, and temporary until we have it ready on Maven Central, so we have the time to test before releasing.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
