### PR TITLE
chore: revert compiling AVS from local aar

### DIFF
--- a/avs/build.gradle.kts
+++ b/avs/build.gradle.kts
@@ -1,0 +1,2 @@
+configurations.maybeCreate("default")
+artifacts.add("default", file("avs_9_0_2.aar"))

--- a/avs/build.gradle.kts
+++ b/avs/build.gradle.kts
@@ -1,2 +1,0 @@
-configurations.maybeCreate("default")
-artifacts.add("default", file("avs_9_0_2.aar"))

--- a/calling/build.gradle.kts
+++ b/calling/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api(files("libs/avs_9_0_2.aar")) // TODO temporary until avs9.0.2 is available on Maven-central
+                api(project(":avs")) // TODO temporary until avs9.0.2 is available on Maven-central
                 api(libs.jna.map {
                     project.dependencies.create(it, closureOf<ExternalModuleDependency> {
                         artifact {

--- a/calling/build.gradle.kts
+++ b/calling/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api(project(":avs")) // TODO temporary until avs9.0.2 is available on Maven-central
+                api(libs.avs)
                 api(libs.jna.map {
                     project.dependencies.create(it, closureOf<ExternalModuleDependency> {
                         artifact {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After upgrading AVS to 9.0.2 in #1308 using an aar file, instead of fetching it from Maven-Central(still not available there due some CI issues), our Android CI failed to run with this error
<img width="1255" alt="Wire 2023-01-06 at 5_36 PM" src="https://user-images.githubusercontent.com/18124919/211310598-dc1fe24e-4956-43cf-9be4-67ef70d0cb37.png">


### Causes (Optional)

Still investigating ..

### Solutions

To unblock everyone, I am reverting it to use old version from Maven central
### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
