### PR TITLE
chore: add AVS lib in a separate module (develop)

### DIFF
--- a/avs/build.gradle.kts
+++ b/avs/build.gradle.kts
@@ -1,0 +1,2 @@
+configurations.maybeCreate("default")
+artifacts.add("default", file("avs_9_0_2.aar"))

--- a/avs/build.gradle.kts
+++ b/avs/build.gradle.kts
@@ -1,2 +1,2 @@
 configurations.maybeCreate("default")
-artifacts.add("default", file("avs_9_0_2.aar"))
+artifacts.add("default", file("avs-9-0-2.aar"))

--- a/calling/build.gradle.kts
+++ b/calling/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api(files("libs/avs_9_0_2.aar")) // TODO temporary until avs9.0.2 is available on Maven-central
+                api(project(":avs")) // TODO temporary until avs9.0.2 is available on Maven-central
                 api(libs.jna.map {
                     project.dependencies.create(it, closureOf<ExternalModuleDependency> {
                         artifact {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

THIS A TEMPORARY SOLUTION UNTIL WE HAVE AN AVAILABLE VERSION ON MAVEN-CENTRAL

 After [bumping AVS version to 9.0.2](https://github.com/wireapp/kalium/pull/1308) by adding the aar locally, our CI failed to build the android app :
 

```
Direct local .aar file dependencies are not supported when building an AAR. 
The resulting AAR would be broken because the classes and Android resources from any local .aar 
file dependencies would not be packaged in the resulting AAR. Previous versions of the Android 
Gradle Plugin produce broken AARs in this case too (despite not throwing this error). The 
following direct local .aar file dependencies of the :library_module project caused this error: 
______.aar

```
We reverted in [chore: revert compiling AVS from local aar](https://github.com/wireapp/kalium/pull/1313)

### Solutions

In this PR I am trying this [workaround](https://github.com/brim-borium/spotify_sdk/issues/99#issuecomment-878910598) : Adding AVS in a separate temporary module and compile it in calling module

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
