### PR TITLE
feat: change user display name (AR-1068)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -211,8 +211,7 @@ internal class UserDataSource internal constructor(
                 .map(userMapper::fromDaoModelToSelfUser)
         }
     }
-
-
+    
     @Deprecated(
         message = "Create a dedicated function to update the corresponding user property, instead of updating the whole user",
         replaceWith = ReplaceWith("eg: updateSelfDisplayName(displayName: String)")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.self.ChangeHandleRequest
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
+import com.wire.kalium.network.api.base.authenticated.self.UserUpdateRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
@@ -60,6 +61,7 @@ internal interface UserRepository {
     suspend fun updateSelfUser(newName: String? = null, newAccent: Int? = null, newAssetId: String? = null): Either<CoreFailure, SelfUser>
     suspend fun getSelfUser(): SelfUser?
     suspend fun updateSelfHandle(handle: String): Either<NetworkFailure, Unit>
+    suspend fun updateSelfDisplayName(displayName: String): Either<CoreFailure, Unit>
     suspend fun updateLocalSelfUserHandle(handle: String)
     fun observeAllKnownUsers(): Flow<Either<StorageFailure, List<OtherUser>>>
     suspend fun getKnownUser(userId: UserId): Flow<OtherUser?>
@@ -212,7 +214,7 @@ internal class UserDataSource internal constructor(
 
     // FIXME(refactor): user info can be updated with null, null and null
     override suspend fun updateSelfUser(newName: String?, newAccent: Int?, newAssetId: String?): Either<CoreFailure, SelfUser> {
-        val user = observeSelfUser().firstOrNull() ?: return Either.Left(CoreFailure.Unknown(NullPointerException()))
+        val user = getSelfUser() ?: return Either.Left(CoreFailure.Unknown(NullPointerException()))
         val updateRequest = userMapper.fromModelToUpdateApiModel(user, newName, newAccent, newAssetId)
         return wrapApiRequest { selfApi.updateSelf(updateRequest) }
             .map { userMapper.fromUpdateRequestToDaoModel(user, updateRequest) }
@@ -230,6 +232,15 @@ internal class UserDataSource internal constructor(
     override suspend fun updateSelfHandle(handle: String): Either<NetworkFailure, Unit> = wrapApiRequest {
         selfApi.changeHandle(ChangeHandleRequest(handle))
     }
+
+    override suspend fun updateSelfDisplayName(displayName: String): Either<CoreFailure, Unit> =
+        wrapApiRequest { selfApi.updateSelf(UserUpdateRequest(displayName, null, null)) }
+            .flatMap {
+                wrapStorageRequest {
+                    // userDAO.updateUserHandle(selfUserId.toDao(), displayName)
+                    kaliumLogger.d("local.db updateSelfDisplayName: $displayName")
+                }
+            }
 
     override suspend fun updateLocalSelfUserHandle(handle: String) =
         userDAO.updateUserHandle(selfUserId.toDao(), handle)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -233,14 +233,13 @@ internal class UserDataSource internal constructor(
         selfApi.changeHandle(ChangeHandleRequest(handle))
     }
 
-    override suspend fun updateSelfDisplayName(displayName: String): Either<CoreFailure, Unit> =
-        wrapApiRequest { selfApi.updateSelf(UserUpdateRequest(displayName, null, null)) }
-            .flatMap {
-                wrapStorageRequest {
-                    // userDAO.updateUserHandle(selfUserId.toDao(), displayName)
-                    kaliumLogger.d("local.db updateSelfDisplayName: $displayName")
-                }
-            }
+    override suspend fun updateSelfDisplayName(displayName: String): Either<CoreFailure, Unit> = wrapApiRequest {
+        selfApi.updateSelf(UserUpdateRequest(displayName, null, null))
+    }.flatMap {
+        wrapStorageRequest {
+            userDAO.updateUserDisplayName(selfUserId.toDao(), displayName)
+        }
+    }
 
     override suspend fun updateLocalSelfUserHandle(handle: String) =
         userDAO.updateUserHandle(selfUserId.toDao(), handle)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -211,7 +211,7 @@ internal class UserDataSource internal constructor(
                 .map(userMapper::fromDaoModelToSelfUser)
         }
     }
-    
+
     @Deprecated(
         message = "Create a dedicated function to update the corresponding user property, instead of updating the whole user",
         replaceWith = ReplaceWith("eg: updateSelfDisplayName(displayName: String)")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -212,7 +212,12 @@ internal class UserDataSource internal constructor(
         }
     }
 
-    // FIXME(refactor): user info can be updated with null, null and null
+
+    @Deprecated(
+        message = "Create a dedicated function to update the corresponding user property, instead of updating the whole user",
+        replaceWith = ReplaceWith("eg: updateSelfDisplayName(displayName: String)")
+    )
+    // FIXME(refactor): create a dedicated function to update avatar, as this is the only usage of this function.
     override suspend fun updateSelfUser(newName: String?, newAccent: Int?, newAssetId: String?): Either<CoreFailure, SelfUser> {
         val user = getSelfUser() ?: return Either.Left(CoreFailure.Unknown(NullPointerException()))
         val updateRequest = userMapper.fromModelToUpdateApiModel(user, newName, newAccent, newAssetId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateDisplayNameUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateDisplayNameUseCase.kt
@@ -1,0 +1,30 @@
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
+
+fun interface UpdateDisplayNameUseCase {
+    suspend operator fun invoke(displayName: String): DisplayNameUpdateResult
+}
+
+internal class UpdateDisplayNameUseCaseImpl(
+    private val userRepository: UserRepository,
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
+) : UpdateDisplayNameUseCase {
+    override suspend fun invoke(displayName: String): DisplayNameUpdateResult = withContext(dispatchers.io) {
+        userRepository.updateSelfDisplayName(displayName)
+            .fold(
+                { DisplayNameUpdateResult.Failure(it) },
+                { DisplayNameUpdateResult.Success }
+            )
+    }
+}
+
+sealed class DisplayNameUpdateResult {
+    object Success : DisplayNameUpdateResult()
+    data class Failure(val coreFailure: CoreFailure) : DisplayNameUpdateResult()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateDisplayNameUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateDisplayNameUseCase.kt
@@ -7,7 +7,14 @@ import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
 
+/**
+ * Updates the display name of the current user.
+ */
 fun interface UpdateDisplayNameUseCase {
+    /**
+     * @param displayName The new display name.
+     * @return The result of the operation [DisplayNameUpdateResult.Success] or a mapped [CoreFailure].
+     */
     suspend operator fun invoke(displayName: String): DisplayNameUpdateResult
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -91,4 +91,6 @@ class UserScope internal constructor(
     val timestampKeyRepository get() = TimestampKeyRepositoryImpl(metadataDAO)
 
     val persistMigratedUsers: PersistMigratedUsersUseCase get() = PersistMigratedUsersUseCaseImpl(userRepository)
+
+    val updateDisplayName: UpdateDisplayNameUseCase get() = UpdateDisplayNameUseCaseImpl(userRepository)
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -196,6 +196,28 @@ class UserRepositoryTest {
         }
     }
 
+    @Test
+    fun givenANewDisplayName_whenUpdatingOk_thenShouldSucceed() = runTest {
+        val (arrangement, userRepository) = Arrangement()
+            .withGetSelfUserId()
+            .withUpdateDisplayNameApiRequestResponse(NetworkResponse.Success(Unit, mapOf(), HttpStatusCode.OK.value))
+            .arrange()
+
+        val result = userRepository.updateSelfDisplayName("newDisplayName")
+
+        with(result) {
+            shouldSucceed()
+            verify(arrangement.selfApi)
+                .suspendFunction(arrangement.selfApi::updateSelf)
+                .with(any())
+                .wasInvoked(exactly = once)
+            verify(arrangement.userDAO)
+                .suspendFunction(arrangement.userDAO::updateUserDisplayName)
+                .with(any(), any())
+                .wasInvoked(exactly = once)
+        }
+    }
+
 // TODO other UserRepository tests
 
     private class Arrangement {
@@ -297,6 +319,14 @@ class UserRepositoryTest {
                 .suspendFunction(userDetailsApi::getMultipleUsers)
                 .whenInvokedWith(any())
                 .thenReturn(NetworkResponse.Success(result, mapOf(), HttpStatusCode.OK.value))
+            return this
+        }
+
+        fun withUpdateDisplayNameApiRequestResponse(response: NetworkResponse<Unit>) = apply {
+            given(selfApi)
+                .suspendFunction(selfApi::updateSelf)
+                .whenInvokedWith(any())
+                .thenReturn(response)
             return this
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.receiver.UserEventReceiverTest
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.logic.test_util.TestNetworkResponseError
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
@@ -197,7 +198,7 @@ class UserRepositoryTest {
     }
 
     @Test
-    fun givenANewDisplayName_whenUpdatingOk_thenShouldSucceed() = runTest {
+    fun givenANewDisplayName_whenUpdatingOk_thenShouldSucceedAndPersistTheNameLocally() = runTest {
         val (arrangement, userRepository) = Arrangement()
             .withGetSelfUserId()
             .withUpdateDisplayNameApiRequestResponse(NetworkResponse.Success(Unit, mapOf(), HttpStatusCode.OK.value))
@@ -215,6 +216,28 @@ class UserRepositoryTest {
                 .suspendFunction(arrangement.userDAO::updateUserDisplayName)
                 .with(any(), any())
                 .wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenANewDisplayName_whenUpdatingFails_thenShouldNotPersistLocallyTheName() = runTest {
+        val (arrangement, userRepository) = Arrangement()
+            .withGetSelfUserId()
+            .withUpdateDisplayNameApiRequestResponse(TestNetworkResponseError.genericResponseError())
+            .arrange()
+
+        val result = userRepository.updateSelfDisplayName("newDisplayName")
+
+        with(result) {
+            shouldFail()
+            verify(arrangement.selfApi)
+                .suspendFunction(arrangement.selfApi::updateSelf)
+                .with(any())
+                .wasInvoked(exactly = once)
+            verify(arrangement.userDAO)
+                .suspendFunction(arrangement.userDAO::updateUserDisplayName)
+                .with(any(), any())
+                .wasNotInvoked()
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateDisplayNameUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateDisplayNameUseCaseTest.kt
@@ -1,0 +1,76 @@
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateDisplayNameUseCaseTest {
+
+    @Test
+    fun givenValidParams_whenUpdatingDisplayName_thenShouldReturnASuccessResult() = runTest {
+        val (arrangement, updateDisplayName) = Arrangement()
+            .withSuccessfulUploadResponse()
+            .arrange()
+
+        val result = updateDisplayName(NEW_DISPLAY_NAME)
+
+        assertTrue(result is DisplayNameUpdateResult.Success)
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSelfDisplayName)
+            .with(any())
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenAnError_whenUpdatingDisplayName_thenShouldReturnAMappedCoreFailure() = runTest {
+        val (arrangement, updateDisplayName) = Arrangement()
+            .withErrorResponse()
+            .arrange()
+
+        val result = updateDisplayName(NEW_DISPLAY_NAME)
+
+        assertTrue(result is DisplayNameUpdateResult.Failure)
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSelfDisplayName)
+            .with(any())
+            .wasInvoked(once)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val userRepository = mock(classOf<UserRepository>())
+
+        fun withSuccessfulUploadResponse() = apply {
+            given(userRepository)
+                .suspendFunction(userRepository::updateSelfDisplayName)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withErrorResponse() = apply {
+            given(userRepository)
+                .suspendFunction(userRepository::updateSelfDisplayName)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Left(CoreFailure.Unknown(Throwable("an error"))))
+        }
+
+        fun arrange() = this to UpdateDisplayNameUseCaseImpl(userRepository)
+    }
+
+    companion object {
+        const val NEW_DISPLAY_NAME = "new display name"
+    }
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -140,3 +140,6 @@ getUsersNotPartOfTheConversation:
 SELECT * FROM User AS user
  WHERE NOT EXISTS (SELECT user FROM Member AS member WHERE member.conversation == :converastion_id AND user.qualified_id == member.user)
  AND connection_status = "ACCEPTED";
+
+updateUserDisplayName:
+UPDATE User SET name = ? WHERE qualified_id = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -163,4 +163,5 @@ interface UserDAO {
 
     suspend fun getUsersNotInConversationByHandle(conversationId: QualifiedIDEntity, handle: String): Flow<List<UserEntity>>
     suspend fun getAllUsersByTeam(teamId: String): List<UserEntity>
+    suspend fun updateUserDisplayName(selfUserId: QualifiedIDEntity, displayName: String)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -298,4 +298,8 @@ class UserDAOImpl internal constructor(
         userQueries.selectUsersByTeam(teamId)
             .executeAsList()
             .map(mapper::toModel)
+
+    override suspend fun updateUserDisplayName(selfUserId: QualifiedIDEntity, displayName: String) {
+        userQueries.updateUserDisplayName(displayName, selfUserId)
+    }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -577,6 +577,20 @@ class UserDAOTest : BaseDatabaseTest() {
         assertEquals(expected, persistedUsers)
     }
 
+    @Test
+    fun givenAnExistingUser_whenUpdatingTheDisplayName_thenTheValueShouldBeUpdated() = runTest(dispatcher) {
+        // given
+        val expectedNewDisplayName = "new user display name"
+        db.userDAO.insertUser(user1)
+
+        // when
+        db.userDAO.updateUserDisplayName(user1.id, expectedNewDisplayName)
+
+        // then
+        val persistedUser = db.userDAO.getUserByQualifiedID(user1.id).first()
+        assertEquals(expectedNewDisplayName, persistedUser?.name)
+    }
+
     private companion object {
         val USER_ENTITY_1 = newUserEntity(QualifiedIDEntity("1", "wire.com"))
         val USER_ENTITY_2 = newUserEntity(QualifiedIDEntity("2", "wire.com"))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Creates and enables a use case to update the self user, `"display name" eg. John Doe`.

### Solutions

Reuse the API implementation that we have for updating the user's avatar, but on the repo layer, we better separate for granularity.

### Testing

WIP.

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Later will be provided the AR counterpart, so you can test changing the user display name if you like to do so.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
