### PR TITLE
fix(notification): limit notifications to 10 messages when fetching messages from repo

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -188,8 +188,7 @@ class MessageDataSource(
                     // todo: needs some clean up!
                     id = conversationId.toModel(),
                     conversationName = messages.first().conversationName ?: "",
-                    messages = messages.sortedBy { message -> message.date }
-                        .take(messageSizePerConversation)
+                    messages = messages.take(messageSizePerConversation)
                         .map { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
                     isOneToOneConversation = messages.first().conversationType?.let { type ->
                         type == ConversationEntity.Type.ONE_ON_ONE

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -77,6 +77,7 @@ interface MessageRepository {
         conversationId: ConversationId,
         messageUuid: String
     ): Either<CoreFailure, Unit>
+
     suspend fun getInstantOfLatestMessageFromOtherUsers(): Either<StorageFailure, Instant>
     suspend fun updateMessageDate(conversationId: ConversationId, messageUuid: String, date: String): Either<CoreFailure, Unit>
     suspend fun updatePendingMessagesAddMillisToDate(conversationId: ConversationId, millis: Long): Either<CoreFailure, Unit>
@@ -88,7 +89,7 @@ interface MessageRepository {
         visibility: List<Message.Visibility> = Message.Visibility.values().toList()
     ): Flow<List<Message>>
 
-    suspend fun getNotificationMessage(): Flow<List<LocalNotificationConversation>>
+    suspend fun getNotificationMessage(messageSizePerConversation: Int = 10): Flow<List<LocalNotificationConversation>>
 
     suspend fun getMessagesByConversationIdAndVisibilityAfterDate(
         conversationId: ConversationId,
@@ -170,7 +171,7 @@ class MessageDataSource(
         ).map { messagelist -> messagelist.map(messageMapper::fromEntityToMessage) }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override suspend fun getNotificationMessage(): Flow<List<LocalNotificationConversation>> =
+    override suspend fun getNotificationMessage(messageSizePerConversation: Int): Flow<List<LocalNotificationConversation>> =
         messageDAO.getNotificationMessage(
             listOf(
                 MessageEntity.ContentType.TEXT,
@@ -187,7 +188,9 @@ class MessageDataSource(
                     // todo: needs some clean up!
                     id = conversationId.toModel(),
                     conversationName = messages.first().conversationName ?: "",
-                    messages = messages.map { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
+                    messages = messages.sortedBy { message -> message.date }
+                        .take(messageSizePerConversation)
+                        .map { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
                     isOneToOneConversation = messages.first().conversationType?.let { type ->
                         type == ConversationEntity.Type.ONE_ON_ONE
                     } ?: false

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -245,7 +245,7 @@ class GetNotificationsUseCaseTest {
         fun withConversationsForNotifications(list: List<LocalNotificationConversation>?): Arrangement {
             given(messageRepository)
                 .suspendFunction(messageRepository::getNotificationMessage)
-                .whenInvoked(any())
+                .whenInvokedWith(any())
                 .thenReturn(list?.let { flowOf(it) } ?: flowOf())
 
             return this

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -245,7 +245,7 @@ class GetNotificationsUseCaseTest {
         fun withConversationsForNotifications(list: List<LocalNotificationConversation>?): Arrangement {
             given(messageRepository)
                 .suspendFunction(messageRepository::getNotificationMessage)
-                .whenInvoked()
+                .whenInvoked(any())
                 .thenReturn(list?.let { flowOf(it) } ?: flowOf())
 
             return this

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -515,7 +515,7 @@ SELECT * FROM MessagePreview AS message
 WHERE shouldNotify == 1
 AND visibility = 'VISIBLE'
 AND isSelfMessage == 0
-AND contentType IN ?;
+AND contentType IN ? ORDER BY strftime('%Y-%m-%d %H:%M:%f', message.date) DESC;
 
 selectByConversationIdAndSenderIdAndTimeAndType:
 SELECT * FROM MessageDetailsView WHERE conversationId = ? AND senderUserId = ? AND date = ? AND contentType = ?;


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
### Issues
One ques if you have lot of unread and not notified messages experience slowness and ANR in the app.

### Causes (Optional)
When we querying the not notified messages for the user, there is no size limit how many messages should be fetched.
### Solutions

Final and best Solution[not implemented here - blocked by sqldelight]
We can use window functions in sql to filter the messages based on conversations id in the query; but at the moment sqldelight has an issue with `OVER` and `PARTITION` keywords
See: https://github.com/cashapp/sqldelight/issues/2799

Solution in this PR:
Filtering the messages after fetching them from the db in the Repo.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
