### PR TITLE
fix: execute db queries on io CoroutineContext

### DIFF
--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensionsTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensionsTest.kt
@@ -18,9 +18,12 @@ import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MessageRepositoryExtensionsTest {
 
     private val fakePagingSource = object : PagingSource<Int, MessageEntity>() {
@@ -35,7 +38,7 @@ class MessageRepositoryExtensionsTest {
         val pagingConfig = PagingConfig(20)
         val pager = Pager(pagingConfig) { fakePagingSource }
 
-        val kaliumPager = KaliumPager(pager, fakePagingSource)
+        val kaliumPager = KaliumPager(pager, fakePagingSource, StandardTestDispatcher())
         val (arrangement, messageRepositoryExtensions) = Arrangement()
             .withMessageExtensionsReturningPager(kaliumPager)
             .arrange()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
@@ -38,7 +38,7 @@ internal interface ServerConfigRepository {
     /**
      * @return list of all locally stored server configurations
      */
-    fun configList(): Either<StorageFailure, List<ServerConfig>>
+    suspend fun configList(): Either<StorageFailure, List<ServerConfig>>
 
     /**
      * @return observable list of all locally stored server configurations
@@ -110,7 +110,7 @@ internal class ServerConfigDataSource(
         wrapApiRequest { api.fetchServerConfig(serverConfigUrl) }
             .map { serverConfigMapper.fromDTO(it) }
 
-    override fun configList(): Either<StorageFailure, List<ServerConfig>> =
+    override suspend fun configList(): Either<StorageFailure, List<ServerConfig>> =
         wrapStorageRequest { dao.allConfig() }.map { it.map(serverConfigMapper::fromEntity) }
 
     override fun configFlow(): Either<StorageFailure, Flow<List<ServerConfig>>> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepository.kt
@@ -43,16 +43,16 @@ internal interface ServerConfigRepository {
     /**
      * @return observable list of all locally stored server configurations
      */
-    fun configFlow(): Either<StorageFailure, Flow<List<ServerConfig>>>
+    suspend fun configFlow(): Either<StorageFailure, Flow<List<ServerConfig>>>
 
     /**
      * delete a locally stored server configuration
      */
-    fun deleteById(id: String): Either<StorageFailure, Unit>
-    fun delete(serverConfig: ServerConfig): Either<StorageFailure, Unit>
+    suspend fun deleteById(id: String): Either<StorageFailure, Unit>
+    suspend fun delete(serverConfig: ServerConfig): Either<StorageFailure, Unit>
     suspend fun getOrFetchMetadata(serverLinks: ServerConfig.Links): Either<CoreFailure, ServerConfig>
-    fun storeConfig(links: ServerConfig.Links, metadata: ServerConfig.MetaData): Either<StorageFailure, ServerConfig>
-    fun storeConfig(links: ServerConfig.Links, versionInfo: ServerConfig.VersionInfo): Either<StorageFailure, ServerConfig>
+    suspend fun storeConfig(links: ServerConfig.Links, metadata: ServerConfig.MetaData): Either<StorageFailure, ServerConfig>
+    suspend fun storeConfig(links: ServerConfig.Links, versionInfo: ServerConfig.VersionInfo): Either<StorageFailure, ServerConfig>
 
     /**
      * calculate the app/server common api version for a new non stored config and store it locally if the version is valid
@@ -72,7 +72,7 @@ internal interface ServerConfigRepository {
     /**
      * retrieve a config from the local DB by Links
      */
-    fun configByLinks(links: ServerConfig.Links): Either<StorageFailure, ServerConfig>
+    suspend fun configByLinks(links: ServerConfig.Links): Either<StorageFailure, ServerConfig>
 
     /**
      * update the api version of a locally stored config
@@ -113,12 +113,12 @@ internal class ServerConfigDataSource(
     override suspend fun configList(): Either<StorageFailure, List<ServerConfig>> =
         wrapStorageRequest { dao.allConfig() }.map { it.map(serverConfigMapper::fromEntity) }
 
-    override fun configFlow(): Either<StorageFailure, Flow<List<ServerConfig>>> =
+    override suspend fun configFlow(): Either<StorageFailure, Flow<List<ServerConfig>>> =
         wrapStorageRequest { dao.allConfigFlow().map { it.map(serverConfigMapper::fromEntity) } }
 
-    override fun deleteById(id: String) = wrapStorageRequest { dao.deleteById(id) }
+    override suspend fun deleteById(id: String) = wrapStorageRequest { dao.deleteById(id) }
 
-    override fun delete(serverConfig: ServerConfig) = deleteById(serverConfig.id)
+    override suspend fun delete(serverConfig: ServerConfig) = deleteById(serverConfig.id)
     override suspend fun getOrFetchMetadata(serverLinks: ServerConfig.Links): Either<CoreFailure, ServerConfig> =
         wrapStorageRequest { dao.configByLinks(serverConfigMapper.toEntity(serverLinks)) }.fold({
             fetchApiVersionAndStore(serverLinks)
@@ -126,7 +126,7 @@ internal class ServerConfigDataSource(
             Either.Right(serverConfigMapper.fromEntity(it))
         })
 
-    override fun storeConfig(links: ServerConfig.Links, metadata: ServerConfig.MetaData): Either<StorageFailure, ServerConfig> =
+    override suspend fun storeConfig(links: ServerConfig.Links, metadata: ServerConfig.MetaData): Either<StorageFailure, ServerConfig> =
         wrapStorageRequest {
             // check if such config is already inserted
             val storedConfigId = dao.configByLinks(serverConfigMapper.toEntity(links))?.id
@@ -165,7 +165,10 @@ internal class ServerConfigDataSource(
             serverConfigMapper.fromEntity(it)
         }
 
-    override fun storeConfig(links: ServerConfig.Links, versionInfo: ServerConfig.VersionInfo): Either<StorageFailure, ServerConfig> {
+    override suspend fun storeConfig(
+        links: ServerConfig.Links,
+        versionInfo: ServerConfig.VersionInfo
+    ): Either<StorageFailure, ServerConfig> {
         val metaDataDTO = backendMetaDataUtil.calculateApiVersion(
             versionInfoDTO = VersionInfoDTO(
                 developmentSupported = versionInfo.developmentSupported,
@@ -188,7 +191,7 @@ internal class ServerConfigDataSource(
         dao.configById(id)
     }.map { serverConfigMapper.fromEntity(it) }
 
-    override fun configByLinks(links: ServerConfig.Links): Either<StorageFailure, ServerConfig> =
+    override suspend fun configByLinks(links: ServerConfig.Links): Either<StorageFailure, ServerConfig> =
         wrapStorageRequest { dao.configByLinks(serverConfigMapper.toEntity(links)) }.map { serverConfigMapper.fromEntity(it) }
 
     override suspend fun updateConfigApiVersion(id: String): Either<CoreFailure, Unit> = configById(id)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigRepositoryTest.kt
@@ -54,13 +54,13 @@ class ServerConfigRepositoryTest {
     }
 
     @Test
-    fun givenStoredConfig_thenItCanBeRetrievedAsList() {
+    fun givenStoredConfig_thenItCanBeRetrievedAsList() = runTest {
         val (arrangement, repository) = Arrangement().withDaoEntityResponse().arrange()
         val expected = listOf(newServerConfig(1), newServerConfig(2), newServerConfig(3))
 
         repository.configList().shouldSucceed { assertEquals(it, expected) }
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::allConfig)
+            .suspendFunction(arrangement.serverConfigDAO::allConfig)
             .wasInvoked(exactly = once)
     }
 
@@ -75,12 +75,12 @@ class ServerConfigRepositoryTest {
         assertEquals(expected.first(), actual.value.first()[0])
 
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::allConfigFlow)
+            .suspendFunction(arrangement.serverConfigDAO::allConfigFlow)
             .wasInvoked(exactly = once)
     }
 
     @Test
-    fun givenStoredConfig_thenItCanBeRetrievedById() {
+    fun givenStoredConfig_thenItCanBeRetrievedById() = runTest {
         val (arrangement, repository) = Arrangement()
             .withConfigById(newServerConfigEntity(1))
             .arrange()
@@ -97,7 +97,7 @@ class ServerConfigRepositoryTest {
     }
 
     @Test
-    fun givenStoredConfig_thenItCanBeDeleted() {
+    fun givenStoredConfig_thenItCanBeDeleted() = runTest {
         val serverConfigId = "1"
         val (arrangement, repository) = Arrangement()
             .withConfigById(newServerConfigEntity(1))
@@ -107,13 +107,13 @@ class ServerConfigRepositoryTest {
 
         actual.shouldSucceed()
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::deleteById)
+            .suspendFunction(arrangement.serverConfigDAO::deleteById)
             .with(any())
             .wasInvoked(exactly = once)
     }
 
     @Test
-    fun givenStoredConfig_whenDeleting_thenItCanBeDeleted() {
+    fun givenStoredConfig_whenDeleting_thenItCanBeDeleted() = runTest {
         val serverConfig = newServerConfig(1)
         val (arrangement, repository) = Arrangement()
             .withConfigById(newServerConfigEntity(1))
@@ -123,7 +123,7 @@ class ServerConfigRepositoryTest {
 
         actual.shouldSucceed()
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::deleteById)
+            .suspendFunction(arrangement.serverConfigDAO::deleteById)
             .with(any())
             .wasInvoked(exactly = once)
     }
@@ -155,7 +155,7 @@ class ServerConfigRepositoryTest {
             .wasInvoked(exactly = once)
 
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::insert)
+            .suspendFunction(arrangement.serverConfigDAO::insert)
             .with(any())
             .wasInvoked(exactly = once)
     }
@@ -186,18 +186,18 @@ class ServerConfigRepositoryTest {
             .wasNotInvoked()
 
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::configByLinks)
+            .suspendFunction(arrangement.serverConfigDAO::configByLinks)
             .with(any())
             .wasNotInvoked()
 
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::insert)
+            .suspendFunction(arrangement.serverConfigDAO::insert)
             .with(any())
             .wasNotInvoked()
     }
 
     @Test
-    fun givenStoredConfig_whenAddingTheSameOneWithNewApiVersionParams_thenStoredOneShouldBeUpdatedAndReturned() {
+    fun givenStoredConfig_whenAddingTheSameOneWithNewApiVersionParams_thenStoredOneShouldBeUpdatedAndReturned() = runTest {
         val (arrangement, repository) = Arrangement()
             .withUpdatedServerConfig()
             .arrange()
@@ -207,19 +207,19 @@ class ServerConfigRepositoryTest {
             .shouldSucceed { assertEquals(arrangement.expectedServerConfig, it) }
 
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::configByLinks)
+            .suspendFunction(arrangement.serverConfigDAO::configByLinks)
             .with(any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::insert)
+            .suspendFunction(arrangement.serverConfigDAO::insert)
             .with(any())
             .wasNotInvoked()
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::updateApiVersion)
+            .suspendFunction(arrangement.serverConfigDAO::updateApiVersion)
             .with(any(), any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::setFederationToTrue)
+            .suspendFunction(arrangement.serverConfigDAO::setFederationToTrue)
             .with(any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
@@ -229,7 +229,7 @@ class ServerConfigRepositoryTest {
     }
 
     @Test
-    fun givenStoredConfig_whenAddingNewOne_thenNewOneShouldBeInsertedAndReturned() {
+    fun givenStoredConfig_whenAddingNewOne_thenNewOneShouldBeInsertedAndReturned() = runTest {
         val expected = newServerConfig(1)
         val (arrangement, repository) = Arrangement()
             .withConfigForNewRequest(newServerConfigEntity(1))
@@ -240,19 +240,19 @@ class ServerConfigRepositoryTest {
             .shouldSucceed { assertEquals(it, expected) }
 
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::configByLinks)
+            .suspendFunction(arrangement.serverConfigDAO::configByLinks)
             .with(any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::insert)
+            .suspendFunction(arrangement.serverConfigDAO::insert)
             .with(any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::updateApiVersion)
+            .suspendFunction(arrangement.serverConfigDAO::updateApiVersion)
             .with(any(), any())
             .wasNotInvoked()
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::setFederationToTrue)
+            .suspendFunction(arrangement.serverConfigDAO::setFederationToTrue)
             .with(any())
             .wasNotInvoked()
         verify(arrangement.serverConfigDAO)
@@ -262,7 +262,7 @@ class ServerConfigRepositoryTest {
     }
 
     @Test
-    fun givenStoredConfigLinksAndVersionInfoData_whenAddingNewOne_thenCommonApiShouldBeCalculatedAndConfigShouldBeStored() {
+    fun givenStoredConfigLinksAndVersionInfoData_whenAddingNewOne_thenCommonApiShouldBeCalculatedAndConfigShouldBeStored() = runTest {
         val expectedServerConfig = newServerConfig(1)
         val expectedServerConfigDTO = newServerConfigDTO(1)
         val expectedVersionInfo = ServerConfig.VersionInfo(
@@ -285,19 +285,19 @@ class ServerConfigRepositoryTest {
             .with(any(), any(), any(), any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::configByLinks)
+            .suspendFunction(arrangement.serverConfigDAO::configByLinks)
             .with(any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::insert)
+            .suspendFunction(arrangement.serverConfigDAO::insert)
             .with(any())
             .wasInvoked(exactly = once)
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::updateApiVersion)
+            .suspendFunction(arrangement.serverConfigDAO::updateApiVersion)
             .with(any(), any())
             .wasNotInvoked()
         verify(arrangement.serverConfigDAO)
-            .function(arrangement.serverConfigDAO::setFederationToTrue)
+            .suspendFunction(arrangement.serverConfigDAO::setFederationToTrue)
             .with(any())
             .wasNotInvoked()
         verify(arrangement.serverConfigDAO)
@@ -337,9 +337,9 @@ class ServerConfigRepositoryTest {
             )
         )
 
-        fun withConfigForNewRequest(serverConfigEntity: ServerConfigEntity): Arrangement {
+        suspend fun withConfigForNewRequest(serverConfigEntity: ServerConfigEntity): Arrangement {
             given(serverConfigDAO)
-                .invocation { configByLinks(serverConfigEntity.links) }
+                .coroutine { configByLinks(serverConfigEntity.links) }
                 .then { null }
             given(serverConfigDAO)
                 .function(serverConfigDAO::configById)
@@ -355,8 +355,8 @@ class ServerConfigRepositoryTest {
             return this
         }
 
-        fun withDaoEntityResponse(): Arrangement {
-            given(serverConfigDAO).invocation { allConfig() }
+        suspend fun withDaoEntityResponse(): Arrangement {
+            given(serverConfigDAO).coroutine { allConfig() }
                 .then { listOf(newServerConfigEntity(1), newServerConfigEntity(2), newServerConfigEntity(3)) }
             return this
         }
@@ -371,14 +371,14 @@ class ServerConfigRepositoryTest {
 
         fun withConfigByLinks(serverConfigEntity: ServerConfigEntity?): Arrangement {
             given(serverConfigDAO)
-                .function(serverConfigDAO::configByLinks)
+                .suspendFunction(serverConfigDAO::configByLinks)
                 .whenInvokedWith(any())
                 .thenReturn(serverConfigEntity)
             return this
         }
 
-        fun withDaoEntityFlowResponse(): Arrangement {
-            given(serverConfigDAO).invocation { allConfigFlow() }
+        suspend fun withDaoEntityFlowResponse(): Arrangement {
+            given(serverConfigDAO).coroutine { allConfigFlow() }
                 .then { flowOf(listOf(newServerConfigEntity(1), newServerConfigEntity(2), newServerConfigEntity(3))) }
             return this
         }
@@ -392,7 +392,7 @@ class ServerConfigRepositoryTest {
             return this
         }
 
-        fun withUpdatedServerConfig(): Arrangement {
+        suspend fun withUpdatedServerConfig(): Arrangement {
             val newServerConfigEntity = serverConfigEntity.copy(
                 metaData = serverConfigEntity.metaData.copy(
                     apiVersion = 5,
@@ -401,7 +401,7 @@ class ServerConfigRepositoryTest {
             )
 
             given(serverConfigDAO)
-                .invocation { configByLinks(serverConfigEntity.links) }
+                .coroutine { configByLinks(serverConfigEntity.links) }
                 .then { serverConfigEntity }
             given(serverConfigDAO)
                 .function(serverConfigDAO::configById)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCaseTest.kt
@@ -72,7 +72,7 @@ class StoreServerConfigUseCaseTest {
             result: Either<StorageFailure, ServerConfig>
         ) = apply {
             given(configRepository)
-                .function(
+                .suspendFunction(
                     configRepository::storeConfig,
                     fun2<ServerConfig.Links, ServerConfig.VersionInfo>())
                 .whenInvokedWith(eq(links), eq(versionInfo))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/UpdateApiVersionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/server/UpdateApiVersionUseCaseTest.kt
@@ -34,7 +34,7 @@ class UpdateApiVersionUseCaseTest {
         val configList = listOf(newServerConfig(1), newServerConfig(2), newServerConfig(3), newServerConfig(4))
 
         given(configRepository)
-            .function(configRepository::configList)
+            .suspendFunction(configRepository::configList)
             .whenInvoked()
             .thenReturn(
                 Either.Right(configList)

--- a/persistence/src/androidAndroidTest/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensionsTest.kt
+++ b/persistence/src/androidAndroidTest/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensionsTest.kt
@@ -10,6 +10,8 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.utils.stubs.newConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -17,6 +19,7 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MessageExtensionsTest : BaseDatabaseTest() {
 
     private lateinit var messageExtensions: MessageExtensions
@@ -33,7 +36,7 @@ class MessageExtensionsTest : BaseDatabaseTest() {
         messageDAO = db.messageDAO
         conversationDAO = db.conversationDAO
         userDAO = db.userDAO
-        messageExtensions = MessageExtensionsImpl(messagesQueries, MessageMapper)
+        messageExtensions = MessageExtensionsImpl(messagesQueries, MessageMapper, StandardTestDispatcher())
     }
 
     @After

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumPager.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumPager.kt
@@ -4,14 +4,17 @@ import androidx.paging.Pager
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Exposes a [pagingDataFlow] that can be used in Android UI components to display paginated data.
  */
 class KaliumPager<EntityType : Any>(
     private val pager: Pager<Int, EntityType>,
-    internal val pagingSource: PagingSource<Int, EntityType>
+    internal val pagingSource: PagingSource<Int, EntityType>,
+    private val coroutineContext: CoroutineContext
 ) {
     val pagingDataFlow: Flow<PagingData<EntityType>>
-        get() = pager.flow
+        get() = pager.flow.flowOn(coroutineContext)
 }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -5,18 +5,21 @@ import androidx.paging.PagingConfig
 import app.cash.sqldelight.paging3.QueryPagingSource
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.dao.ConversationIDEntity
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 actual interface MessageExtensions {
     fun getPagerForConversation(
         conversationId: ConversationIDEntity,
         visibilities: Collection<MessageEntity.Visibility>,
-        pagingConfig: PagingConfig
+        pagingConfig: PagingConfig,
     ): KaliumPager<MessageEntity>
 }
 
 actual class MessageExtensionsImpl actual constructor(
     private val messagesQueries: MessagesQueries,
-    private val messageMapper: MessageMapper
+    private val messageMapper: MessageMapper,
+    private val coroutineContext: CoroutineContext
 ) : MessageExtensions {
 
     override fun getPagerForConversation(
@@ -27,24 +30,27 @@ actual class MessageExtensionsImpl actual constructor(
         // We could return a Flow directly, but having the PagingSource is the only way to test this
         return KaliumPager(
             Pager(pagingConfig) { getPagingSource(conversationId, visibilities) },
-            getPagingSource(conversationId, visibilities)
+            getPagingSource(conversationId, visibilities),
+            coroutineContext
         )
     }
 
-    private fun getPagingSource(
+    private suspend fun getPagingSource(
         conversationId: ConversationIDEntity,
         visibilities: Collection<MessageEntity.Visibility>
-    ) = QueryPagingSource(
-        countQuery = messagesQueries.countByConversationIdAndVisibility(conversationId, visibilities),
-        transacter = messagesQueries,
-        queryProvider = { limit, offset ->
-            messagesQueries.selectByConversationIdAndVisibility(
-                conversationId,
-                visibilities,
-                limit,
-                offset,
-                messageMapper::toEntityMessageFromView
-            )
-        }
-    )
+    ) = withContext(coroutineContext) {
+        QueryPagingSource(
+            countQuery = messagesQueries.countByConversationIdAndVisibility(conversationId, visibilities),
+            transacter = messagesQueries,
+            queryProvider = { limit, offset ->
+                messagesQueries.selectByConversationIdAndVisibility(
+                    conversationId,
+                    visibilities,
+                    limit,
+                    offset,
+                    messageMapper::toEntityMessageFromView
+                )
+            }
+        )
+    }
 }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -5,7 +5,6 @@ import androidx.paging.PagingConfig
 import app.cash.sqldelight.paging3.QueryPagingSource
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.dao.ConversationIDEntity
-import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 actual interface MessageExtensions {
@@ -35,10 +34,10 @@ actual class MessageExtensionsImpl actual constructor(
         )
     }
 
-    private suspend fun getPagingSource(
+    private fun getPagingSource(
         conversationId: ConversationIDEntity,
         visibilities: Collection<MessageEntity.Visibility>
-    ) = withContext(coroutineContext) {
+    ) =
         QueryPagingSource(
             countQuery = messagesQueries.countByConversationIdAndVisibility(conversationId, visibilities),
             transacter = messagesQueries,
@@ -52,5 +51,4 @@ actual class MessageExtensionsImpl actual constructor(
                 )
             }
         )
-    }
 }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -15,9 +15,15 @@ import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
 import net.sqlcipher.database.SupportFactory
+import kotlin.coroutines.CoroutineContext
 
 // TODO(refactor): Unify creation just like it's done for UserDataBase
-actual class GlobalDatabaseProvider(private val context: Context, passphrase: GlobalDatabaseSecret, encrypt: Boolean = true) {
+actual class GlobalDatabaseProvider(
+    private val context: Context,
+    private val queriesContext: CoroutineContext,
+    passphrase: GlobalDatabaseSecret,
+    encrypt: Boolean = true
+) {
     private val dbName = FileNameUtil.globalDBName()
     private val driver: AndroidSqliteDriver
     private val database: GlobalDatabase
@@ -52,10 +58,10 @@ actual class GlobalDatabaseProvider(private val context: Context, passphrase: Gl
     }
 
     actual val serverConfigurationDAO: ServerConfigurationDAO
-        get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries)
+        get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries, queriesContext)
 
     actual val accountsDAO: AccountsDAO
-        get() = AccountsDAOImpl(database.accountsQueries, database.currentAccountQueries)
+        get() = AccountsDAOImpl(database.accountsQueries, database.currentAccountQueries, queriesContext)
 
     actual fun nuke(): Boolean {
         driver.close()

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -14,15 +14,16 @@ import com.wire.kalium.persistence.daokaliumdb.LogoutReasonAdapter
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
+import com.wire.kalium.util.KaliumDispatcherImpl
 import net.sqlcipher.database.SupportFactory
 import kotlin.coroutines.CoroutineContext
 
 // TODO(refactor): Unify creation just like it's done for UserDataBase
 actual class GlobalDatabaseProvider(
     private val context: Context,
-    private val queriesContext: CoroutineContext,
     passphrase: GlobalDatabaseSecret,
-    encrypt: Boolean = true
+    encrypt: Boolean = true,
+    private val queriesContext: CoroutineContext = KaliumDispatcherImpl.io
 ) {
     private val dbName = FileNameUtil.globalDBName()
     private val driver: AndroidSqliteDriver

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
@@ -80,14 +80,14 @@ private class ConnectionMapper {
 class ConnectionDAOImpl(
     private val connectionsQueries: ConnectionsQueries,
     private val conversationsQueries: ConversationsQueries,
-    private val coroutineContext: CoroutineContext
+    private val queriesContext: CoroutineContext
 ) : ConnectionDAO {
 
     private val connectionMapper = ConnectionMapper()
     override suspend fun getConnections(): Flow<List<ConnectionEntity>> {
         return connectionsQueries.getConnections()
             .asFlow()
-            .flowOn(coroutineContext)
+            .flowOn(queriesContext)
             .mapToList()
             .map { it.map(connectionMapper::toModel) }
     }
@@ -95,11 +95,11 @@ class ConnectionDAOImpl(
     override suspend fun getConnectionRequests(): Flow<List<ConnectionEntity>> {
         return connectionsQueries.selectConnectionRequests(connectionMapper::toModel)
             .asFlow()
-            .flowOn(coroutineContext)
+            .flowOn(queriesContext)
             .mapToList()
     }
 
-    override suspend fun insertConnection(connectionEntity: ConnectionEntity) = withContext(coroutineContext) {
+    override suspend fun insertConnection(connectionEntity: ConnectionEntity) = withContext(queriesContext) {
         connectionsQueries.insertConnection(
             from_id = connectionEntity.from,
             conversation_id = connectionEntity.conversationId,
@@ -111,7 +111,7 @@ class ConnectionDAOImpl(
         )
     }
 
-    override suspend fun insertConnections(conversationList: List<ConnectionEntity>) = withContext(coroutineContext) {
+    override suspend fun insertConnections(conversationList: List<ConnectionEntity>) = withContext(queriesContext) {
         connectionsQueries.transaction {
             for (connectionEntity: ConnectionEntity in conversationList) {
                 connectionsQueries.insertConnection(
@@ -127,11 +127,11 @@ class ConnectionDAOImpl(
         }
     }
 
-    override suspend fun updateConnectionLastUpdatedTime(lastUpdate: String, id: String) = withContext(coroutineContext) {
+    override suspend fun updateConnectionLastUpdatedTime(lastUpdate: String, id: String) = withContext(queriesContext) {
         connectionsQueries.updateConnectionLastUpdated(lastUpdate, id)
     }
 
-    override suspend fun deleteConnectionDataAndConversation(conversationId: QualifiedIDEntity) = withContext(coroutineContext) {
+    override suspend fun deleteConnectionDataAndConversation(conversationId: QualifiedIDEntity) = withContext(queriesContext) {
         connectionsQueries.transaction {
             connectionsQueries.deleteConnection(conversationId)
             conversationsQueries.deleteConversation(conversationId)
@@ -141,15 +141,15 @@ class ConnectionDAOImpl(
     override suspend fun getConnectionRequestsForNotification(): Flow<List<ConnectionEntity>> {
         return connectionsQueries.selectConnectionsForNotification(connectionMapper::toModel)
             .asFlow()
-            .flowOn(coroutineContext)
+            .flowOn(queriesContext)
             .mapToList()
     }
 
-    override suspend fun updateNotificationFlag(flag: Boolean, userId: QualifiedIDEntity) = withContext(coroutineContext) {
+    override suspend fun updateNotificationFlag(flag: Boolean, userId: QualifiedIDEntity) = withContext(queriesContext) {
         connectionsQueries.updateNotificationFlag(flag, userId)
     }
 
-    override suspend fun updateAllNotificationFlags(flag: Boolean) = withContext(coroutineContext) {
+    override suspend fun updateAllNotificationFlags(flag: Boolean) = withContext(queriesContext) {
         connectionsQueries.transaction {
             connectionsQueries.selectConnectionRequests()
                 .executeAsList()
@@ -157,7 +157,7 @@ class ConnectionDAOImpl(
         }
     }
 
-    override suspend fun setAllConnectionsAsNotified() = withContext(coroutineContext) {
+    override suspend fun setAllConnectionsAsNotified() = withContext(queriesContext) {
         connectionsQueries.setAllConnectionsAsNotified()
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -304,17 +304,21 @@ class ConversationDAOImpl(
 
     override suspend fun insertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity) =
         withContext(coroutineContext) {
+            nonSuspendInsertMembersWithQualifiedId(memberList, conversationID)
+        }
+
+    private fun nonSuspendInsertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity) =
             memberQueries.transaction {
                 for (member: Member in memberList) {
                     userQueries.insertOrIgnoreUserId(member.user)
                     memberQueries.insertMember(member.user, conversationID, member.role)
                 }
             }
-        }
-
-    override suspend fun insertMembers(memberList: List<Member>, groupId: String) = withContext(coroutineContext) {
-        getConversationByGroupID(groupId).firstOrNull()?.let {
-            insertMembersWithQualifiedId(memberList, it.id)
+    override suspend fun insertMembers(memberList: List<Member>, groupId: String) {
+        withContext(coroutineContext) {
+            getConversationByGroupID(groupId).firstOrNull()?.let {
+                nonSuspendInsertMembersWithQualifiedId(memberList, it.id)
+            }
         }
     }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -10,9 +10,12 @@ import com.wire.kalium.persistence.util.mapToOneOrNull
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
+import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import com.wire.kalium.persistence.ConversationDetails as SQLDelightConversationView
 import com.wire.kalium.persistence.Member as SQLDelightMember
@@ -146,19 +149,21 @@ internal val MLS_DEFAULT_CIPHER_SUITE = ConversationEntity.CipherSuite.MLS_128_D
 class ConversationDAOImpl(
     private val conversationQueries: ConversationsQueries,
     private val userQueries: UsersQueries,
-    private val memberQueries: MembersQueries
+    private val memberQueries: MembersQueries,
+    private val coroutineContext: CoroutineContext
 ) : ConversationDAO {
 
     private val memberMapper = MemberMapper()
     private val conversationMapper = ConversationMapper()
-    override suspend fun getSelfConversationId(protocol: ConversationEntity.Protocol) =
+    override suspend fun getSelfConversationId(protocol: ConversationEntity.Protocol) = withContext(coroutineContext) {
         conversationQueries.selfConversationId(protocol).executeAsOneOrNull()
+    }
 
-    override suspend fun insertConversation(conversationEntity: ConversationEntity) {
+    override suspend fun insertConversation(conversationEntity: ConversationEntity) = withContext(coroutineContext) {
         nonSuspendingInsertConversation(conversationEntity)
     }
 
-    override suspend fun insertConversations(conversationEntities: List<ConversationEntity>) {
+    override suspend fun insertConversations(conversationEntities: List<ConversationEntity>) = withContext(coroutineContext) {
         conversationQueries.transaction {
             for (conversationEntity: ConversationEntity in conversationEntities) {
                 nonSuspendingInsertConversation(conversationEntity)
@@ -198,7 +203,7 @@ class ConversationDAOImpl(
         }
     }
 
-    override suspend fun updateConversation(conversationEntity: ConversationEntity) {
+    override suspend fun updateConversation(conversationEntity: ConversationEntity) = withContext(coroutineContext) {
         conversationQueries.updateConversation(
             conversationEntity.name,
             conversationEntity.type,
@@ -207,19 +212,20 @@ class ConversationDAOImpl(
         )
     }
 
-    override suspend fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String) {
-        conversationQueries.updateConversationGroupState(groupState, groupId)
-    }
+    override suspend fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String) =
+        withContext(coroutineContext) {
+            conversationQueries.updateConversationGroupState(groupState, groupId)
+        }
 
-    override suspend fun updateConversationModifiedDate(qualifiedID: QualifiedIDEntity, date: String) {
+    override suspend fun updateConversationModifiedDate(qualifiedID: QualifiedIDEntity, date: String) = withContext(coroutineContext) {
         conversationQueries.updateConversationModifiedDate(date, qualifiedID)
     }
 
-    override suspend fun updateConversationNotificationDate(qualifiedID: QualifiedIDEntity, date: String) {
+    override suspend fun updateConversationNotificationDate(qualifiedID: QualifiedIDEntity, date: String) = withContext(coroutineContext) {
         conversationQueries.updateConversationNotificationsDate(date, qualifiedID)
     }
 
-    override suspend fun updateAllConversationsNotificationDate(date: String) {
+    override suspend fun updateAllConversationsNotificationDate(date: String) = withContext(coroutineContext) {
         conversationQueries.updateAllUnNotifiedConversationsNotificationsDate(date)
     }
 
@@ -227,6 +233,7 @@ class ConversationDAOImpl(
         return conversationQueries.selectAllConversations()
             .asFlow()
             .mapToList()
+            .flowOn(coroutineContext)
             .map { it.map(conversationMapper::toModel) }
     }
 
@@ -234,6 +241,7 @@ class ConversationDAOImpl(
         return conversationQueries.selectAllConversationDetails()
             .asFlow()
             .mapToList()
+            .flowOn(coroutineContext)
             .map { list -> list.map { it.let { conversationMapper.toModel(it) } } }
     }
 
@@ -241,62 +249,70 @@ class ConversationDAOImpl(
         return conversationQueries.selectByQualifiedId(qualifiedID)
             .asFlow()
             .mapToOneOrNull()
+            .flowOn(coroutineContext)
             .map { it?.let { conversationMapper.toModel(it) } }
     }
 
-    override suspend fun getConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationViewEntity {
-        return conversationQueries.selectByQualifiedId(qualifiedID).executeAsOne().let {
-            conversationMapper.toModel(it)
+    override suspend fun getConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationViewEntity =
+        withContext(coroutineContext) {
+            conversationQueries.selectByQualifiedId(qualifiedID).executeAsOne().let {
+                conversationMapper.toModel(it)
+            }
         }
-    }
 
     override suspend fun observeConversationWithOtherUser(userId: UserIDEntity): Flow<ConversationViewEntity?> {
         return memberQueries.selectConversationByMember(userId)
             .asFlow()
             .mapToOneOrNull()
+            .flowOn(coroutineContext)
             .map { it?.let { conversationMapper.fromOneToOneToModel(it) } }
     }
 
     override suspend fun getConversationByGroupID(groupID: String): Flow<ConversationViewEntity?> {
         return conversationQueries.selectByGroupId(groupID)
             .asFlow()
+            .flowOn(coroutineContext)
             .mapToOneOrNull()
             .map { it?.let { conversationMapper.toModel(it) } }
     }
 
-    override suspend fun getConversationIdByGroupID(groupID: String) =
+    override suspend fun getConversationIdByGroupID(groupID: String) = withContext(coroutineContext) {
         conversationQueries.getConversationIdByGroupId(groupID).executeAsOne()
+    }
 
     override suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationViewEntity> =
-        conversationQueries.selectByGroupState(groupState, ConversationEntity.Protocol.MLS)
-            .executeAsList()
-            .map(conversationMapper::toModel)
+        withContext(coroutineContext) {
+            conversationQueries.selectByGroupState(groupState, ConversationEntity.Protocol.MLS)
+                .executeAsList()
+                .map(conversationMapper::toModel)
+        }
 
-    override suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity) {
+    override suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity) = withContext(coroutineContext) {
         conversationQueries.deleteConversation(qualifiedID)
     }
 
-    override suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity) {
+    override suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity) = withContext(coroutineContext) {
         memberQueries.transaction {
             userQueries.insertOrIgnoreUserId(member.user)
             memberQueries.insertMember(member.user, conversationID, member.role)
         }
     }
 
-    override suspend fun updateMember(member: Member, conversationID: QualifiedIDEntity) {
+    override suspend fun updateMember(member: Member, conversationID: QualifiedIDEntity) = withContext(coroutineContext) {
         memberQueries.updateMemberRole(member.role, member.user, conversationID)
     }
 
-    override suspend fun insertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity) {
-        memberQueries.transaction {
-            for (member: Member in memberList) {
-                userQueries.insertOrIgnoreUserId(member.user)
-                memberQueries.insertMember(member.user, conversationID, member.role)
+    override suspend fun insertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity) =
+        withContext(coroutineContext) {
+            memberQueries.transaction {
+                for (member: Member in memberList) {
+                    userQueries.insertOrIgnoreUserId(member.user)
+                    memberQueries.insertMember(member.user, conversationID, member.role)
+                }
             }
         }
-    }
 
-    override suspend fun insertMembers(memberList: List<Member>, groupId: String) {
+    override suspend fun insertMembers(memberList: List<Member>, groupId: String) = withContext(coroutineContext) {
         getConversationByGroupID(groupId).firstOrNull()?.let {
             insertMembersWithQualifiedId(memberList, it.id)
         }
@@ -306,7 +322,7 @@ class ConversationDAOImpl(
         member: Member,
         status: ConnectionEntity.State,
         conversationID: QualifiedIDEntity
-    ) {
+    ) = withContext(coroutineContext) {
         memberQueries.transaction {
             userQueries.updateUserConnectionStatus(status, member.user)
             val recordDidNotExist = userQueries.selectChanges().executeAsOne() == 0L
@@ -318,19 +334,21 @@ class ConversationDAOImpl(
         }
     }
 
-    override suspend fun deleteMemberByQualifiedID(userID: QualifiedIDEntity, conversationID: QualifiedIDEntity) {
-        memberQueries.deleteMember(conversationID, userID)
-    }
+    override suspend fun deleteMemberByQualifiedID(userID: QualifiedIDEntity, conversationID: QualifiedIDEntity) =
+        withContext(coroutineContext) {
+            memberQueries.deleteMember(conversationID, userID)
+        }
 
-    override suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, conversationID: QualifiedIDEntity) {
-        memberQueries.transaction {
-            userIDList.forEach {
-                memberQueries.deleteMember(conversationID, it)
+    override suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, conversationID: QualifiedIDEntity) =
+        withContext(coroutineContext) {
+            memberQueries.transaction {
+                userIDList.forEach {
+                    memberQueries.deleteMember(conversationID, it)
+                }
             }
         }
-    }
 
-    override suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, groupId: String) {
+    override suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, groupId: String) = withContext(coroutineContext) {
         getConversationByGroupID(groupId).firstOrNull()?.let {
             deleteMembersByQualifiedID(userIDList, it.id)
         }
@@ -339,6 +357,7 @@ class ConversationDAOImpl(
     override suspend fun getAllMembers(qualifiedID: QualifiedIDEntity): Flow<List<Member>> {
         return memberQueries.selectAllMembersByConversation(qualifiedID.value)
             .asFlow()
+            .flowOn(coroutineContext)
             .mapToList()
             .map { it.map(memberMapper::toModel) }
     }
@@ -347,13 +366,14 @@ class ConversationDAOImpl(
         conversationId: QualifiedIDEntity,
         mutedStatus: ConversationEntity.MutedStatus,
         mutedStatusTimestamp: Long
-    ) {
+    ) = withContext(coroutineContext) {
         conversationQueries.updateConversationMutingStatus(mutedStatus, mutedStatusTimestamp, conversationId)
     }
 
     override suspend fun getConversationsForNotifications(): Flow<List<ConversationViewEntity>> {
         return conversationQueries.selectConversationsWithUnnotifiedMessages()
             .asFlow()
+            .flowOn(coroutineContext)
             .mapToList()
             .map { it.map(conversationMapper::toModel) }
     }
@@ -362,67 +382,80 @@ class ConversationDAOImpl(
         conversationID: QualifiedIDEntity,
         accessList: List<ConversationEntity.Access>,
         accessRoleList: List<ConversationEntity.AccessRole>
-    ) {
+    ) = withContext(coroutineContext) {
         conversationQueries.updateAccess(accessList, accessRoleList, conversationID)
     }
 
-    override suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: String) {
+    override suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: String) = withContext(coroutineContext) {
         conversationQueries.updateConversationReadDate(date, conversationID)
     }
 
     override suspend fun updateConversationMemberRole(conversationId: QualifiedIDEntity, userId: UserIDEntity, role: Member.Role) =
-        memberQueries.updateMemberRole(role, userId, conversationId)
+        withContext(coroutineContext) {
+            memberQueries.updateMemberRole(role, userId, conversationId)
+        }
 
-    override suspend fun updateKeyingMaterial(groupId: String, timestamp: Instant) {
+    override suspend fun updateKeyingMaterial(groupId: String, timestamp: Instant) = withContext(coroutineContext) {
         conversationQueries.updateKeyingMaterialDate(timestamp.epochSeconds, groupId)
     }
 
-    override suspend fun getConversationsByKeyingMaterialUpdate(threshold: Duration): List<String> =
+    override suspend fun getConversationsByKeyingMaterialUpdate(threshold: Duration): List<String> = withContext(coroutineContext) {
         conversationQueries.selectByKeyingMaterialUpdate(
             ConversationEntity.GroupState.ESTABLISHED,
             ConversationEntity.Protocol.MLS,
             DateTimeUtil.currentInstant().epochSeconds.minus(threshold.inWholeSeconds)
         ).executeAsList()
+    }
 
-    override suspend fun setProposalTimer(proposalTimer: ProposalTimerEntity) {
+    override suspend fun setProposalTimer(proposalTimer: ProposalTimerEntity) = withContext(coroutineContext) {
         conversationQueries.updateProposalTimer(proposalTimer.firingDate.toString(), proposalTimer.groupID)
     }
 
-    override suspend fun clearProposalTimer(groupID: String) {
+    override suspend fun clearProposalTimer(groupID: String) = withContext(coroutineContext) {
         conversationQueries.clearProposalTimer(groupID)
     }
 
     override suspend fun getProposalTimers(): Flow<List<ProposalTimerEntity>> {
         return conversationQueries.selectProposalTimers(ConversationEntity.Protocol.MLS)
             .asFlow()
+            .flowOn(coroutineContext)
             .mapToList()
             .map { list -> list.map { ProposalTimerEntity(it.mls_group_id, it.mls_proposal_timer.toInstant()) } }
     }
 
     override suspend fun observeIsUserMember(conversationId: QualifiedIDEntity, userId: UserIDEntity): Flow<Boolean> =
-        conversationQueries.isUserMember(conversationId, userId).asFlow().mapToOneOrNull().map { it != null }
+        conversationQueries.isUserMember(conversationId, userId)
+            .asFlow()
+            .flowOn(coroutineContext)
+            .mapToOneOrNull()
+            .map { it != null }
 
     override suspend fun whoDeletedMeInConversation(conversationId: QualifiedIDEntity, selfUserIdString: String): UserIDEntity? =
-        conversationQueries.whoDeletedMeInConversation(conversationId, selfUserIdString).executeAsOneOrNull()
+        withContext(coroutineContext) {
+            conversationQueries.whoDeletedMeInConversation(conversationId, selfUserIdString).executeAsOneOrNull()
+        }
 
-    override suspend fun updateConversationName(conversationId: QualifiedIDEntity, conversationName: String, timestamp: String) {
-        conversationQueries.updateConversationName(conversationName, timestamp, conversationId)
-    }
+    override suspend fun updateConversationName(conversationId: QualifiedIDEntity, conversationName: String, timestamp: String) =
+        withContext(coroutineContext) {
+            conversationQueries.updateConversationName(conversationName, timestamp, conversationId)
+        }
 
-    override suspend fun updateConversationType(conversationID: QualifiedIDEntity, type: ConversationEntity.Type) {
-        conversationQueries.updateConversationType(type, conversationID)
-    }
+    override suspend fun updateConversationType(conversationID: QualifiedIDEntity, type: ConversationEntity.Type) =
+        withContext(coroutineContext) {
+            conversationQueries.updateConversationType(type, conversationID)
+        }
 
-    override suspend fun revokeOneOnOneConversationsWithDeletedUser(userId: UserIDEntity) {
+    override suspend fun revokeOneOnOneConversationsWithDeletedUser(userId: UserIDEntity) = withContext(coroutineContext) {
         memberQueries.deleteUserFromGroupConversations(userId, userId)
     }
 
-    override suspend fun getConversationIdsByUserId(userId: UserIDEntity): List<QualifiedIDEntity> {
-        return memberQueries.selectConversationsByMember(userId).executeAsList().map { it.conversation }
+    override suspend fun getConversationIdsByUserId(userId: UserIDEntity): List<QualifiedIDEntity> = withContext(coroutineContext) {
+        memberQueries.selectConversationsByMember(userId).executeAsList().map { it.conversation }
     }
 
-    override suspend fun updateConversationReceiptMode(conversationID: QualifiedIDEntity, receiptMode: ConversationEntity.ReceiptMode) {
-        conversationQueries.updateConversationReceiptMode(receiptMode, conversationID)
-    }
+    override suspend fun updateConversationReceiptMode(conversationID: QualifiedIDEntity, receiptMode: ConversationEntity.ReceiptMode) =
+        withContext(coroutineContext) {
+            conversationQueries.updateConversationReceiptMode(receiptMode, conversationID)
+        }
 
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -341,16 +341,21 @@ class ConversationDAOImpl(
 
     override suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, conversationID: QualifiedIDEntity) =
         withContext(coroutineContext) {
-            memberQueries.transaction {
-                userIDList.forEach {
-                    memberQueries.deleteMember(conversationID, it)
-                }
+            nonSuspendDeleteMembersByQualifiedID(userIDList, conversationID)
+        }
+
+    private fun nonSuspendDeleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, conversationID: QualifiedIDEntity) =
+        memberQueries.transaction {
+            userIDList.forEach {
+                memberQueries.deleteMember(conversationID, it)
             }
         }
 
-    override suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, groupId: String) = withContext(coroutineContext) {
-        getConversationByGroupID(groupId).firstOrNull()?.let {
-            deleteMembersByQualifiedID(userIDList, it.id)
+    override suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, groupId: String) {
+        withContext(coroutineContext) {
+            getConversationByGroupID(groupId).firstOrNull()?.let {
+                nonSuspendDeleteMembersByQualifiedID(userIDList, it.id)
+            }
         }
     }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/PrekeyDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/PrekeyDAO.kt
@@ -1,6 +1,8 @@
 package com.wire.kalium.persistence.dao
 
 import com.wire.kalium.persistence.MetadataQueries
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 interface PrekeyDAO {
     suspend fun updateOTRLastPrekeyId(newKeyId: Int)
@@ -9,9 +11,10 @@ interface PrekeyDAO {
 }
 
 internal class PrekeyDAOImpl internal constructor(
-    private val metadataQueries: MetadataQueries
+    private val metadataQueries: MetadataQueries,
+    private val queriesContext: CoroutineContext
 ) : PrekeyDAO {
-    override suspend fun updateOTRLastPrekeyId(newKeyId: Int) {
+    override suspend fun updateOTRLastPrekeyId(newKeyId: Int) = withContext(queriesContext) {
         metadataQueries.transaction {
             val currentId = metadataQueries.selectValueByKey(OTR_LAST_PRE_KEY_ID).executeAsOneOrNull()?.toInt()
             if (currentId == null || newKeyId > currentId) {
@@ -20,12 +23,13 @@ internal class PrekeyDAOImpl internal constructor(
         }
     }
 
-    override suspend fun forceInsertOTRLastPrekeyId(newKeyId: Int) {
+    override suspend fun forceInsertOTRLastPrekeyId(newKeyId: Int) = withContext(queriesContext) {
         metadataQueries.insertValue(OTR_LAST_PRE_KEY_ID, newKeyId.toString())
     }
 
-    override suspend fun lastOTRPrekeyId(): Int? =
+    override suspend fun lastOTRPrekeyId(): Int? = withContext(queriesContext) {
         metadataQueries.selectValueByKey(OTR_LAST_PRE_KEY_ID).executeAsOneOrNull()?.toInt()
+    }
 
     private companion object {
         const val OTR_LAST_PRE_KEY_ID = "otr_last_pre_key_id"

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/TeamDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/TeamDAOImpl.kt
@@ -3,7 +3,10 @@ package com.wire.kalium.persistence.dao
 import app.cash.sqldelight.coroutines.asFlow
 import com.wire.kalium.persistence.TeamsQueries
 import com.wire.kalium.persistence.util.mapToOneOrNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 import com.wire.kalium.persistence.Team as SQLDelightTeam
 
 class TeamMapper {
@@ -16,34 +19,44 @@ class TeamMapper {
     }
 }
 
-class TeamDAOImpl(private val queries: TeamsQueries) : TeamDAO {
+class TeamDAOImpl(
+    private val queries: TeamsQueries,
+    private val coroutineContext: CoroutineContext
+) : TeamDAO {
 
     val mapper = TeamMapper()
 
-    override suspend fun insertTeam(team: TeamEntity) = queries.insertTeam(
-        id = team.id,
-        name = team.name,
-        icon = team.icon
-    )
+    override suspend fun insertTeam(team: TeamEntity) = withContext(coroutineContext) {
+        queries.insertTeam(
+            id = team.id,
+            name = team.name,
+            icon = team.icon
+        )
+    }
 
-    override suspend fun insertTeams(teams: List<TeamEntity>) = queries.transaction {
-        for (team: TeamEntity in teams) {
-            queries.insertTeam(
-                id = team.id,
-                name = team.name,
-                icon = team.icon
-            )
+    override suspend fun insertTeams(teams: List<TeamEntity>) = withContext(coroutineContext) {
+        queries.transaction {
+            for (team: TeamEntity in teams) {
+                queries.insertTeam(
+                    id = team.id,
+                    name = team.name,
+                    icon = team.icon
+                )
+            }
         }
     }
 
     override suspend fun getTeamById(teamId: String) = queries.selectTeamById(id = teamId)
         .asFlow()
+        .flowOn(coroutineContext)
         .mapToOneOrNull()
         .map { it?.let { mapper.toModel(team = it) } }
 
-    override suspend fun updateTeam(team: TeamEntity) = queries.updateTeam(
-        id = team.id,
-        name = team.name,
-        icon = team.icon
-    )
+    override suspend fun updateTeam(team: TeamEntity) = withContext(coroutineContext) {
+        queries.updateTeam(
+            id = team.id,
+            name = team.name,
+            icon = team.icon
+        )
+    }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -138,7 +138,7 @@ interface UserDAO {
     suspend fun getAllUsers(): Flow<List<UserEntity>>
     fun observeAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): Flow<List<UserEntity>>
     suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?>
-    fun getUserMinimizedByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntityMinimized?
+    suspend fun getUserMinimizedByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntityMinimized?
     suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): List<UserEntity>
     suspend fun getUserByNameOrHandleOrEmailAndConnectionStates(
         searchQuery: String,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -225,7 +225,7 @@ class UserDAOImpl internal constructor(
             .shareIn(databaseScope, Lazily, 1)
     }
 
-    override fun getUserMinimizedByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntityMinimized? = withContext(queriesContext) {
+    override suspend fun getUserMinimizedByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntityMinimized? = withContext(queriesContext) {
         userQueries.selectMinimizedByQualifiedId(listOf(qualifiedID)) { qualifiedId, name, completeAssetId, userType ->
             mapper.toModelMinimized(qualifiedId, name, completeAssetId, userType)
         }.executeAsOneOrNull()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -8,8 +8,11 @@ import com.wire.kalium.persistence.util.mapToOneOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted.Companion.Lazily
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 import com.wire.kalium.persistence.User as SQLDelightUser
 
 class UserMapper {
@@ -49,12 +52,13 @@ class UserMapper {
 class UserDAOImpl internal constructor(
     private val userQueries: UsersQueries,
     private val userCache: Cache<UserIDEntity, Flow<UserEntity?>>,
-    private val databaseScope: CoroutineScope
+    private val databaseScope: CoroutineScope,
+    private val queriesContext: CoroutineContext
 ) : UserDAO {
 
     val mapper = UserMapper()
 
-    override suspend fun insertUser(user: UserEntity) {
+    override suspend fun insertUser(user: UserEntity) = withContext(queriesContext) {
         userQueries.insertUser(
             user.id,
             user.name,
@@ -72,7 +76,7 @@ class UserDAOImpl internal constructor(
         )
     }
 
-    override suspend fun insertOrIgnoreUsers(users: List<UserEntity>) {
+    override suspend fun insertOrIgnoreUsers(users: List<UserEntity>) = withContext(queriesContext) {
         userQueries.transaction {
             for (user: UserEntity in users) {
                 userQueries.insertOrIgnoreUser(
@@ -94,7 +98,7 @@ class UserDAOImpl internal constructor(
         }
     }
 
-    override suspend fun upsertTeamMembers(users: List<UserEntity>) {
+    override suspend fun upsertTeamMembers(users: List<UserEntity>) = withContext(queriesContext) {
         userQueries.transaction {
             for (user: UserEntity in users) {
                 userQueries.updateTeamMemberUser(
@@ -131,7 +135,7 @@ class UserDAOImpl internal constructor(
         }
     }
 
-    override suspend fun upsertUsers(users: List<UserEntity>) {
+    override suspend fun upsertUsers(users: List<UserEntity>) = withContext(queriesContext) {
         userQueries.transaction {
             for (user: UserEntity in users) {
                 userQueries.updateUser(
@@ -195,7 +199,7 @@ class UserDAOImpl internal constructor(
         }
     }
 
-    override suspend fun updateUser(user: UserEntity) {
+    override suspend fun updateUser(user: UserEntity) = withContext(queriesContext) {
         userQueries.updateSelfUser(
             user.name,
             user.handle,
@@ -209,6 +213,7 @@ class UserDAOImpl internal constructor(
 
     override suspend fun getAllUsers(): Flow<List<UserEntity>> = userQueries.selectAllUsers()
         .asFlow()
+        .flowOn(queriesContext)
         .mapToList()
         .map { entryList -> entryList.map(mapper::toModel) }
 
@@ -220,22 +225,25 @@ class UserDAOImpl internal constructor(
             .shareIn(databaseScope, Lazily, 1)
     }
 
-    override fun getUserMinimizedByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntityMinimized? =
+    override fun getUserMinimizedByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntityMinimized? = withContext(queriesContext) {
         userQueries.selectMinimizedByQualifiedId(listOf(qualifiedID)) { qualifiedId, name, completeAssetId, userType ->
             mapper.toModelMinimized(qualifiedId, name, completeAssetId, userType)
         }.executeAsOneOrNull()
-
-    override suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): List<UserEntity> {
-        return userQueries.selectByQualifiedId(qualifiedIDList)
-            .executeAsList()
-            .map { mapper.toModel(it) }
     }
+
+    override suspend fun getUsersByQualifiedIDList(qualifiedIDList: List<QualifiedIDEntity>): List<UserEntity> =
+        withContext(queriesContext) {
+            userQueries.selectByQualifiedId(qualifiedIDList)
+                .executeAsList()
+                .map { mapper.toModel(it) }
+        }
 
     override suspend fun getUserByNameOrHandleOrEmailAndConnectionStates(
         searchQuery: String,
         connectionStates: List<ConnectionEntity.State>
     ): Flow<List<UserEntity>> = userQueries.selectByNameOrHandleOrEmailAndConnectionState(searchQuery, connectionStates)
         .asFlow()
+        .flowOn(queriesContext)
         .mapToList()
         .map { it.map(mapper::toModel) }
 
@@ -244,28 +252,31 @@ class UserDAOImpl internal constructor(
         connectionStates: List<ConnectionEntity.State>
     ) = userQueries.selectByHandleAndConnectionState(handle, connectionStates)
         .asFlow()
+        .flowOn(queriesContext)
         .mapToList()
         .map { it.map(mapper::toModel) }
 
-    override suspend fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity) {
+    override suspend fun deleteUserByQualifiedID(qualifiedID: QualifiedIDEntity) = withContext(queriesContext) {
         userQueries.deleteUser(qualifiedID)
     }
 
-    override suspend fun markUserAsDeleted(qualifiedID: QualifiedIDEntity) {
+    override suspend fun markUserAsDeleted(qualifiedID: QualifiedIDEntity) = withContext(queriesContext) {
         userQueries.markUserAsDeleted(user_type = UserTypeEntity.NONE, qualified_id = qualifiedID)
     }
 
-    override suspend fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String) {
+    override suspend fun updateUserHandle(qualifiedID: QualifiedIDEntity, handle: String) = withContext(queriesContext) {
         userQueries.updateUserhandle(handle, qualifiedID)
     }
 
-    override suspend fun updateUserAvailabilityStatus(qualifiedID: QualifiedIDEntity, status: UserAvailabilityStatusEntity) {
-        userQueries.updateUserAvailabilityStatus(status, qualifiedID)
-    }
+    override suspend fun updateUserAvailabilityStatus(qualifiedID: QualifiedIDEntity, status: UserAvailabilityStatusEntity) =
+        withContext(queriesContext) {
+            userQueries.updateUserAvailabilityStatus(status, qualifiedID)
+        }
 
     override fun observeUsersNotInConversation(conversationId: QualifiedIDEntity): Flow<List<UserEntity>> =
         userQueries.getUsersNotPartOfTheConversation(conversationId)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
             .map { it.map(mapper::toModel) }
 
@@ -275,27 +286,32 @@ class UserDAOImpl internal constructor(
     ): Flow<List<UserEntity>> =
         userQueries.getUsersNotInConversationByNameOrHandleOrEmail(conversationId, searchQuery)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
             .map { it.map(mapper::toModel) }
 
     override suspend fun getUsersNotInConversationByHandle(conversationId: QualifiedIDEntity, handle: String): Flow<List<UserEntity>> =
         userQueries.getUsersNotInConversationByHandle(conversationId, handle)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
             .map { it.map(mapper::toModel) }
 
-    override suspend fun insertOrIgnoreUserWithConnectionStatus(qualifiedID: QualifiedIDEntity, connectionStatus: ConnectionEntity.State) {
-        userQueries.insertOrIgnoreUserIdWithConnectionStatus(qualifiedID, connectionStatus)
-    }
+    override suspend fun insertOrIgnoreUserWithConnectionStatus(qualifiedID: QualifiedIDEntity, connectionStatus: ConnectionEntity.State) =
+        withContext(queriesContext) {
+            userQueries.insertOrIgnoreUserIdWithConnectionStatus(qualifiedID, connectionStatus)
+        }
 
     override fun observeAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): Flow<List<UserEntity>> =
         userQueries.selectAllUsersWithConnectionStatus(connectionState)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
             .map { it.map(mapper::toModel) }
 
-    override suspend fun getAllUsersByTeam(teamId: String): List<UserEntity> =
+    override suspend fun getAllUsersByTeam(teamId: String): List<UserEntity> = withContext(queriesContext) {
         userQueries.selectUsersByTeam(teamId)
             .executeAsList()
             .map(mapper::toModel)
+    }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
@@ -8,6 +8,9 @@ import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 import com.wire.kalium.persistence.Call as SQLDelightCall
 
 internal object CallMapper {
@@ -38,10 +41,11 @@ internal object CallMapper {
 
 internal class CallDAOImpl(
     private val callsQueries: CallsQueries,
+    private val queriesContext: CoroutineContext,
     private val mapper: CallMapper = CallMapper
 ) : CallDAO {
 
-    override suspend fun insertCall(call: CallEntity) {
+    override suspend fun insertCall(call: CallEntity) = withContext(queriesContext) {
         val createdTime: Long = DateTimeUtil.currentInstant().toEpochMilliseconds()
 
         callsQueries.insertCall(
@@ -57,48 +61,58 @@ internal class CallDAOImpl(
     override suspend fun observeCalls(): Flow<List<CallEntity>> =
         callsQueries.selectAllCalls(mapper = mapper::fromCalls)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
 
     override suspend fun observeIncomingCalls(): Flow<List<CallEntity>> =
         callsQueries.selectIncomingCalls(mapper = mapper::fromCalls)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
 
     override suspend fun observeEstablishedCalls(): Flow<List<CallEntity>> =
         callsQueries.selectEstablishedCalls(mapper = mapper::fromCalls)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
 
     override suspend fun observeOngoingCalls(): Flow<List<CallEntity>> =
         callsQueries.selectOngoingCalls(mapper = mapper::fromCalls)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
 
-    override suspend fun updateLastCallStatusByConversationId(status: CallEntity.Status, conversationId: QualifiedIDEntity) {
-        callsQueries.updateLastCallStatusByConversationId(
-            status,
-            conversationId
-        )
+    override suspend fun updateLastCallStatusByConversationId(status: CallEntity.Status, conversationId: QualifiedIDEntity) =
+        withContext(queriesContext) {
+            callsQueries.updateLastCallStatusByConversationId(
+                status,
+                conversationId
+            )
+        }
+
+    override suspend fun getCallerIdByConversationId(conversationId: QualifiedIDEntity): String = withContext(queriesContext) {
+        callsQueries.lastCallCallerIdByConversationId(conversationId).executeAsOne()
     }
 
-    override suspend fun getCallerIdByConversationId(conversationId: QualifiedIDEntity): String =
-        callsQueries.lastCallCallerIdByConversationId(conversationId).executeAsOne()
-
     override suspend fun getCallStatusByConversationId(conversationId: QualifiedIDEntity): CallEntity.Status? =
-        callsQueries.lastCallStatusByConversationId(conversationId).executeAsOneOrNull()
+        withContext(queriesContext) {
+            callsQueries.lastCallStatusByConversationId(conversationId).executeAsOneOrNull()
+        }
 
     override suspend fun getLastClosedCallByConversationId(conversationId: QualifiedIDEntity): Flow<String?> =
         callsQueries.selectLastClosedCallCreationTimeConversationId(conversationId)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToOneOrNull()
 
     override suspend fun getLastCallConversationTypeByConversationId(
         conversationId: QualifiedIDEntity
-    ): ConversationEntity.Type? =
+    ): ConversationEntity.Type? = withContext(queriesContext) {
         callsQueries.selectLastCallConversionTypeByConversationId(conversationId)
             .executeAsOneOrNull()
+    }
 
-    override suspend fun updateOpenCallsToClosedStatus() {
+    override suspend fun updateOpenCallsToClosedStatus() = withContext(queriesContext) {
         callsQueries.updateOpenCallsToClosedStatus()
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -21,7 +21,7 @@ internal object ClientMapper {
 
 internal class ClientDAOImpl internal constructor(
     private val clientsQueries: ClientsQueries,
-    private val queriesContext: CoroutineContext
+    private val queriesContext: CoroutineContext,
     private val mapper: ClientMapper = ClientMapper
 ) : ClientDAO {
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -5,6 +5,9 @@ import com.wire.kalium.persistence.ClientsQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.util.mapToList
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 internal object ClientMapper {
     @Suppress("FunctionParameterNaming")
@@ -18,19 +21,24 @@ internal object ClientMapper {
 
 internal class ClientDAOImpl internal constructor(
     private val clientsQueries: ClientsQueries,
+    private val queriesContext: CoroutineContext
     private val mapper: ClientMapper = ClientMapper
 ) : ClientDAO {
 
-    override suspend fun insertClient(client: InsertClientParam): Unit =
+    override suspend fun insertClient(client: InsertClientParam): Unit = withContext(queriesContext) {
         clientsQueries.insertClient(client.userId, client.id, client.deviceType, true)
 
-    override suspend fun insertClients(clients: List<InsertClientParam>) = clientsQueries.transaction {
-        clients.forEach { client ->
-            clientsQueries.insertClient(client.userId, client.id, client.deviceType, true)
+    }
+
+    override suspend fun insertClients(clients: List<InsertClientParam>) = withContext(queriesContext) {
+        clientsQueries.transaction {
+            clients.forEach { client ->
+                clientsQueries.insertClient(client.userId, client.id, client.deviceType, true)
+            }
         }
     }
 
-    override suspend fun insertClientsAndRemoveRedundant(clients: List<InsertClientParam>) =
+    override suspend fun insertClientsAndRemoveRedundant(clients: List<InsertClientParam>) = withContext(queriesContext) {
         clientsQueries.transaction {
             clients.forEach { client ->
                 clientsQueries.insertClient(client.userId, client.id, client.deviceType, true)
@@ -39,44 +47,57 @@ internal class ClientDAOImpl internal constructor(
                 clientsQueries.deleteClientsOfUserExcept(userId, clientsList.map { it.id })
             }
         }
+    }
 
-    override suspend fun tryMarkInvalid(invalidClientsList: List<Pair<QualifiedIDEntity, List<String>>>) = clientsQueries.transaction {
-        invalidClientsList.forEach { (userId, clientIdList) ->
-            clientsQueries.tryMarkAsInvalid(userId, clientIdList)
+    override suspend fun tryMarkInvalid(invalidClientsList: List<Pair<QualifiedIDEntity, List<String>>>) = withContext(queriesContext) {
+        clientsQueries.transaction {
+            invalidClientsList.forEach { (userId, clientIdList) ->
+                clientsQueries.tryMarkAsInvalid(userId, clientIdList)
+            }
         }
     }
 
     override suspend fun getClientsOfUserByQualifiedIDFlow(qualifiedID: QualifiedIDEntity): Flow<List<Client>> =
         clientsQueries.selectAllClientsByUserId(qualifiedID, mapper::fromClient)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
 
-    override suspend fun getClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): List<Client> =
+    override suspend fun getClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): List<Client> = withContext(queriesContext) {
         clientsQueries.selectAllClientsByUserId(qualifiedID, mapper = mapper::fromClient)
             .executeAsList()
+    }
 
     override suspend fun getClientsOfUsersByQualifiedIDs(
         ids: List<QualifiedIDEntity>
-    ): Map<QualifiedIDEntity, List<Client>> =
+    ): Map<QualifiedIDEntity, List<Client>> = withContext(queriesContext) {
         clientsQueries.selectAllClientsByUserIdList(ids, mapper = mapper::fromClient)
             .executeAsList()
             .groupBy { it.userId }
+    }
 
-    override suspend fun deleteClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): Unit =
+    override suspend fun deleteClientsOfUserByQualifiedID(qualifiedID: QualifiedIDEntity): Unit = withContext(queriesContext) {
         clientsQueries.deleteClientsOfUser(qualifiedID)
+    }
 
     override suspend fun deleteClient(
         userId: QualifiedIDEntity,
         clientId: String
-    ) = clientsQueries.deleteClient(userId, clientId)
+    ) = withContext(queriesContext) {
+        clientsQueries.deleteClient(userId, clientId)
+    }
 
     override suspend fun getClientsOfConversation(id: QualifiedIDEntity): Map<QualifiedIDEntity, List<Client>> =
-        clientsQueries.selectAllClientsByConversation(id, mapper = mapper::fromClient)
+        withContext(queriesContext) {
+            clientsQueries.selectAllClientsByConversation(id, mapper = mapper::fromClient)
+                .executeAsList()
+                .groupBy { it.userId }
+        }
+
+    override suspend fun conversationRecipient(ids: QualifiedIDEntity): Map<QualifiedIDEntity, List<Client>> = withContext(queriesContext) {
+        clientsQueries.conversationRecipets(ids, mapper = mapper::fromClient)
             .executeAsList()
             .groupBy { it.userId }
-
-    override suspend fun conversationRecipient(ids: QualifiedIDEntity): Map<QualifiedIDEntity, List<Client>> =
-        clientsQueries.conversationRecipets(ids, mapper = mapper::fromClient)
-            .executeAsList().groupBy { it.userId }
+    }
 
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -37,7 +37,7 @@ interface MessageDAO {
      * @see insertOrIgnoreMessage
      */
     suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>)
-
+    suspend fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
     /**
      * Returns the most recent message sent from other users, _i.e._ not self user
      */

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -37,7 +37,6 @@ interface MessageDAO {
      * @see insertOrIgnoreMessage
      */
     suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>)
-    fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
 
     /**
      * Returns the most recent message sent from other users, _i.e._ not self user

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -77,8 +77,7 @@ class MessageDAOImpl(
         queries.getLatestMessageFromOtherUsers(mapper::toEntityMessageFromView).executeAsOneOrNull()
     }
 
-    private fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) = withContext(coroutineContext) {
-        queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
+    private fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) = queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
 
     @Deprecated("For test only!")
     override suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>) = withContext(coroutineContext) {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -53,22 +53,20 @@ class MessageDAOImpl(
         message: MessageEntity,
         updateConversationReadDate: Boolean,
         updateConversationModifiedDate: Boolean
-    ) {
-        withContext(coroutineContext) {
-            queries.transaction {
-                if (updateConversationReadDate) {
-                    conversationsQueries.updateConversationReadDate(message.date, message.conversationId)
-                }
+    ) = withContext(coroutineContext) {
+        queries.transaction {
+            if (updateConversationReadDate) {
+                conversationsQueries.updateConversationReadDate(message.date, message.conversationId)
+            }
 
-                insertInDB(message)
+            insertInDB(message)
 
-                if (!needsToBeNotified(message.id, message.conversationId)) {
-                    conversationsQueries.updateConversationNotificationsDate(message.date, message.conversationId)
-                }
+            if (!needsToBeNotified(message.id, message.conversationId)) {
+                conversationsQueries.updateConversationNotificationsDate(message.date, message.conversationId)
+            }
 
-                if (updateConversationModifiedDate) {
-                    conversationsQueries.updateConversationModifiedDate(message.date, message.conversationId)
-                }
+            if (updateConversationModifiedDate) {
+                conversationsQueries.updateConversationModifiedDate(message.date, message.conversationId)
             }
         }
     }
@@ -77,7 +75,8 @@ class MessageDAOImpl(
         queries.getLatestMessageFromOtherUsers(mapper::toEntityMessageFromView).executeAsOneOrNull()
     }
 
-    private fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) = queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
+    private fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
+        queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
 
     @Deprecated("For test only!")
     override suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>) = withContext(coroutineContext) {
@@ -483,13 +482,11 @@ class MessageDAOImpl(
             .executeAsList()
     }
 
-
     override suspend fun getReceiptModeFromGroupConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity.ReceiptMode? =
         withContext(coroutineContext) {
             conversationsQueries.selectReceiptModeFromGroupConversationByQualifiedId(qualifiedID)
                 .executeAsOneOrNull()
         }
-
 
     override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, mapper, coroutineContext)
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -79,10 +79,8 @@ class MessageDAOImpl(
         nonSuspendNeedsToBeNotified(id, conversationId)
     }
 
-
     private fun nonSuspendNeedsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
         queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
-
 
     @Deprecated("For test only!")
     override suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>) = withContext(coroutineContext) {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -77,9 +77,8 @@ class MessageDAOImpl(
         queries.getLatestMessageFromOtherUsers(mapper::toEntityMessageFromView).executeAsOneOrNull()
     }
 
-    override fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) = withContext(coroutineContext) {
+    private fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) = withContext(coroutineContext) {
         queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
-    }
 
     @Deprecated("For test only!")
     override suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>) = withContext(coroutineContext) {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -61,7 +61,7 @@ class MessageDAOImpl(
 
             insertInDB(message)
 
-            if (!needsToBeNotified(message.id, message.conversationId)) {
+            if (!nonSuspendNeedsToBeNotified(message.id, message.conversationId)) {
                 conversationsQueries.updateConversationNotificationsDate(message.date, message.conversationId)
             }
 
@@ -75,8 +75,14 @@ class MessageDAOImpl(
         queries.getLatestMessageFromOtherUsers(mapper::toEntityMessageFromView).executeAsOneOrNull()
     }
 
-    private fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
+    override suspend fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) = withContext(coroutineContext) {
+        nonSuspendNeedsToBeNotified(id, conversationId)
+    }
+
+
+    private fun nonSuspendNeedsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
         queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
+
 
     @Deprecated("For test only!")
     override suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>) = withContext(coroutineContext) {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -22,61 +22,77 @@ import com.wire.kalium.persistence.kaliumLogger
 import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 @Suppress("TooManyFunctions")
 class MessageDAOImpl(
     private val queries: MessagesQueries,
     private val conversationsQueries: ConversationsQueries,
     private val selfUserId: UserIDEntity,
-    private val reactionsQueries: ReactionsQueries
+    private val reactionsQueries: ReactionsQueries,
+    private val coroutineContext: CoroutineContext
 ) : MessageDAO {
     private val mapper = MessageMapper
 
-    override suspend fun deleteMessage(id: String, conversationsId: QualifiedIDEntity) = queries.deleteMessage(id, conversationsId)
+    override suspend fun deleteMessage(id: String, conversationsId: QualifiedIDEntity) = withContext(coroutineContext) {
+        queries.deleteMessage(id, conversationsId)
+    }
 
     override suspend fun markMessageAsDeleted(id: String, conversationsId: QualifiedIDEntity) =
-        queries.markMessageAsDeleted(id, conversationsId)
+        withContext(coroutineContext) {
+            queries.markMessageAsDeleted(id, conversationsId)
+        }
 
-    override suspend fun deleteAllMessages() = queries.deleteAllMessages()
+    override suspend fun deleteAllMessages() = withContext(coroutineContext) {
+        queries.deleteAllMessages()
+    }
 
     override suspend fun insertOrIgnoreMessage(
         message: MessageEntity,
         updateConversationReadDate: Boolean,
         updateConversationModifiedDate: Boolean
     ) {
-        queries.transaction {
-            if (updateConversationReadDate) {
-                conversationsQueries.updateConversationReadDate(message.date, message.conversationId)
-            }
+        withContext(coroutineContext) {
+            queries.transaction {
+                if (updateConversationReadDate) {
+                    conversationsQueries.updateConversationReadDate(message.date, message.conversationId)
+                }
 
-            insertInDB(message)
+                insertInDB(message)
 
-            if (!needsToBeNotified(message.id, message.conversationId)) {
-                conversationsQueries.updateConversationNotificationsDate(message.date, message.conversationId)
-            }
+                if (!needsToBeNotified(message.id, message.conversationId)) {
+                    conversationsQueries.updateConversationNotificationsDate(message.date, message.conversationId)
+                }
 
-            if (updateConversationModifiedDate) {
-                conversationsQueries.updateConversationModifiedDate(message.date, message.conversationId)
+                if (updateConversationModifiedDate) {
+                    conversationsQueries.updateConversationModifiedDate(message.date, message.conversationId)
+                }
             }
         }
     }
 
-    override suspend fun getLatestMessageFromOtherUsers(): MessageEntity? =
+    override suspend fun getLatestMessageFromOtherUsers(): MessageEntity? = withContext(coroutineContext) {
         queries.getLatestMessageFromOtherUsers(mapper::toEntityMessageFromView).executeAsOneOrNull()
+    }
 
-    override fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) =
+    override fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity) = withContext(coroutineContext) {
         queries.needsToBeNotified(id, conversationId).executeAsOne() == 1L
+    }
 
     @Deprecated("For test only!")
-    override suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>) =
+    override suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>) = withContext(coroutineContext) {
         queries.transaction {
             messages.forEach { insertInDB(it) }
         }
+    }
 
     /**
      * Be careful and run this operation in ONE wrapping transaction.
      */
     private fun insertInDB(message: MessageEntity) {
+        // do not add withContext
         if (!updateIdIfAlreadyExists(message)) {
             if (isValidAssetMessageUpdate(message)) {
                 updateAssetMessage(message)
@@ -89,6 +105,7 @@ class MessageDAOImpl(
     }
 
     private fun insertBaseMessage(message: MessageEntity) {
+        // do not add withContext
         queries.insertOrIgnoreMessage(
             id = message.id,
             conversation_id = message.conversationId,
@@ -291,26 +308,38 @@ class MessageDAOImpl(
         uploadStatus: MessageEntity.UploadStatus,
         id: String,
         conversationId: QualifiedIDEntity
-    ) = queries.updateAssetUploadStatus(uploadStatus, id, conversationId)
+    ) = withContext(coroutineContext) {
+        queries.updateAssetUploadStatus(uploadStatus, id, conversationId)
+    }
 
     override suspend fun updateAssetDownloadStatus(
         downloadStatus: MessageEntity.DownloadStatus,
         id: String,
         conversationId: QualifiedIDEntity
-    ) = queries.updateAssetDownloadStatus(downloadStatus, id, conversationId)
+    ) = withContext(coroutineContext) {
+        queries.updateAssetDownloadStatus(downloadStatus, id, conversationId)
+    }
 
     override suspend fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity) =
-        queries.updateMessageStatus(status, id, conversationId)
+        withContext(coroutineContext) {
+            queries.updateMessageStatus(status, id, conversationId)
+        }
 
     override suspend fun updateMessageDate(date: String, id: String, conversationId: QualifiedIDEntity) =
-        queries.updateMessageDate(date, id, conversationId)
+        withContext(coroutineContext) {
+            queries.updateMessageDate(date, id, conversationId)
+        }
 
     override suspend fun updateMessagesAddMillisToDate(millis: Long, conversationId: QualifiedIDEntity, status: MessageEntity.Status) =
-        queries.updateMessagesAddMillisToDate(millis, conversationId, status)
+        withContext(coroutineContext) {
+            queries.updateMessagesAddMillisToDate(millis, conversationId, status)
+        }
 
+    // TODO: mark internal since it is used for tests only
     override suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?> =
         queries.selectById(id, conversationId, mapper::toEntityMessageFromView)
             .asFlow()
+            .flowOn(coroutineContext)
             .mapToOneOrNull()
 
     override suspend fun getMessagesByConversationAndVisibility(
@@ -325,7 +354,10 @@ class MessageDAOImpl(
             limit.toLong(),
             offset.toLong(),
             mapper::toEntityMessageFromView
-        ).asFlow().mapToList()
+        )
+            .asFlow()
+            .flowOn(coroutineContext)
+            .mapToList()
 
     override suspend fun getNotificationMessage(
         filteredContent: List<MessageEntity.ContentType>
@@ -333,7 +365,9 @@ class MessageDAOImpl(
         queries.getNotificationsMessages(
             filteredContent,
             mapper::toNotificationEntity
-        ).asFlow().mapToList()
+        ).asFlow()
+            .flowOn(coroutineContext)
+            .mapToList()
 
     override suspend fun observeMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,
@@ -345,14 +379,17 @@ class MessageDAOImpl(
             mapper::toEntityMessageFromView
         )
             .asFlow()
+            .flowOn(coroutineContext)
             .mapToList()
 
     override suspend fun getAllPendingMessagesFromUser(userId: UserIDEntity): List<MessageEntity> =
-        queries.selectMessagesFromUserByStatus(
-            userId, MessageEntity.Status.PENDING,
-            mapper::toEntityMessageFromView
-        )
-            .executeAsList()
+        withContext(coroutineContext) {
+            queries.selectMessagesFromUserByStatus(
+                userId, MessageEntity.Status.PENDING,
+                mapper::toEntityMessageFromView
+            )
+                .executeAsList()
+        }
 
     override suspend fun updateTextMessageContent(
         editTimeStamp: String,
@@ -360,40 +397,48 @@ class MessageDAOImpl(
         currentMessageId: String,
         newTextContent: MessageEntityContent.Text,
         newMessageId: String
-    ): Unit = queries.transaction {
-        queries.markMessageAsEdited(editTimeStamp, currentMessageId, conversationId)
-        reactionsQueries.deleteAllReactionsForMessage(currentMessageId, conversationId)
-        queries.deleteMessageMentions(currentMessageId, conversationId)
-        queries.updateMessageTextContent(newTextContent.messageBody, currentMessageId, conversationId)
-        newTextContent.mentions.forEach {
-            queries.insertMessageMention(
-                message_id = currentMessageId,
-                conversation_id = conversationId,
-                start = it.start,
-                length = it.length,
-                user_id = it.userId
-            )
+    ): Unit = withContext(coroutineContext) {
+        queries.transaction {
+            queries.markMessageAsEdited(editTimeStamp, currentMessageId, conversationId)
+            reactionsQueries.deleteAllReactionsForMessage(currentMessageId, conversationId)
+            queries.deleteMessageMentions(currentMessageId, conversationId)
+            queries.updateMessageTextContent(newTextContent.messageBody, currentMessageId, conversationId)
+            newTextContent.mentions.forEach {
+                queries.insertMessageMention(
+                    message_id = currentMessageId,
+                    conversation_id = conversationId,
+                    start = it.start,
+                    length = it.length,
+                    user_id = it.userId
+                )
+            }
+            queries.updateMessageId(newMessageId, currentMessageId, conversationId)
+            queries.updateQuotedMessageId(newMessageId, currentMessageId, conversationId)
         }
-        queries.updateMessageId(newMessageId, currentMessageId, conversationId)
-        queries.updateQuotedMessageId(newMessageId, currentMessageId, conversationId)
     }
 
     override suspend fun getConversationMessagesByContentType(
         conversationId: QualifiedIDEntity,
         contentType: MessageEntity.ContentType
-    ): List<MessageEntity> =
+    ): List<MessageEntity> = withContext(coroutineContext) {
         queries.getConversationMessagesByContentType(conversationId, contentType, mapper::toEntityMessageFromView)
             .executeAsList()
+    }
 
     override suspend fun deleteAllConversationMessages(conversationId: QualifiedIDEntity) {
-        queries.deleteAllConversationMessages(conversationId)
+        withContext(coroutineContext) {
+            queries.deleteAllConversationMessages(conversationId)
+        }
     }
 
     override suspend fun observeLastMessages(): Flow<List<MessagePreviewEntity>> =
-        queries.getLastMessages(mapper::toPreviewEntity).asFlow().mapToList()
+        withContext(coroutineContext) {
+            queries.getLastMessages(mapper::toPreviewEntity).asFlow().mapToList()
+        }
 
-    override suspend fun observeUnreadMessages(): Flow<List<MessagePreviewEntity>> =
+    override suspend fun observeUnreadMessages(): Flow<List<MessagePreviewEntity>> = withContext(coroutineContext) {
         queries.getUnreadMessages(mapper::toPreviewEntity).asFlow().mapToList()
+    }
 
     private fun contentTypeOf(content: MessageEntityContent): MessageEntity.ContentType = when (content) {
         is MessageEntityContent.Text -> TEXT
@@ -409,34 +454,46 @@ class MessageDAOImpl(
         is MessageEntityContent.CryptoSessionReset -> CRYPTO_SESSION_RESET
     }
 
-    override suspend fun resetAssetDownloadStatus() = queries.resetAssetDownloadStatus()
+    override suspend fun resetAssetDownloadStatus() = withContext(coroutineContext) {
+        queries.resetAssetDownloadStatus()
+    }
+
     override suspend fun markMessagesAsDecryptionResolved(
         conversationId: QualifiedIDEntity,
         userId: QualifiedIDEntity,
         clientId: String,
-    ) = queries.transaction {
-        val messages = queries.selectFailedDecryptedByConversationIdAndSenderIdAndClientId(conversationId, userId, clientId).executeAsList()
-        queries.markMessagesAsDecryptionResolved(messages)
+    ) = withContext(coroutineContext) {
+        // TODO: mark all messages form the user client as resolved regardless of the conversation
+        queries.transaction {
+            val messages =
+                queries.selectFailedDecryptedByConversationIdAndSenderIdAndClientId(conversationId, userId, clientId).executeAsList()
+            queries.markMessagesAsDecryptionResolved(messages)
+        }
     }
 
-    override suspend fun resetAssetUploadStatus() = queries.resetAssetUploadStatus()
+    override suspend fun resetAssetUploadStatus() = withContext(coroutineContext) {
+        queries.resetAssetUploadStatus()
+    }
 
     override suspend fun getPendingToConfirmMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,
         date: String,
         visibility: List<MessageEntity.Visibility>
-    ): List<MessageEntity> {
-        return queries
+    ): List<MessageEntity> = withContext(coroutineContext) {
+        queries
             .selectPendingMessagesByConversationIdAndVisibilityAfterDate(conversationId, visibility, date, mapper::toEntityMessageFromView)
             .executeAsList()
     }
 
-    override suspend fun getReceiptModeFromGroupConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity.ReceiptMode? {
-        return conversationsQueries.selectReceiptModeFromGroupConversationByQualifiedId(qualifiedID)
-            .executeAsOneOrNull()
-    }
 
-    override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, mapper)
+    override suspend fun getReceiptModeFromGroupConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity.ReceiptMode? =
+        withContext(coroutineContext) {
+            conversationsQueries.selectReceiptModeFromGroupConversationByQualifiedId(qualifiedID)
+                .executeAsOneOrNull()
+        }
+
+
+    override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, mapper, coroutineContext)
 
     private fun MessageEntityContent.Asset.hasValidRemoteData() =
         assetId.isNotEmpty() && assetOtrKey.isNotEmpty() && assetSha256Key.isNotEmpty()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.MessagesQueries
+import kotlin.coroutines.CoroutineContext
 
 expect interface MessageExtensions
-expect class MessageExtensionsImpl(messagesQueries: MessagesQueries, messageMapper: MessageMapper) : MessageExtensions
+expect class MessageExtensionsImpl(messagesQueries: MessagesQueries, messageMapper: MessageMapper, coroutineContext: CoroutineContext) : MessageExtensions

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -4,4 +4,8 @@ import com.wire.kalium.persistence.MessagesQueries
 import kotlin.coroutines.CoroutineContext
 
 expect interface MessageExtensions
-expect class MessageExtensionsImpl(messagesQueries: MessagesQueries, messageMapper: MessageMapper, coroutineContext: CoroutineContext) : MessageExtensions
+expect class MessageExtensionsImpl(
+    messagesQueries: MessagesQueries,
+    messageMapper: MessageMapper,
+    coroutineContext: CoroutineContext
+) : MessageExtensions

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/AccountsDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/AccountsDAO.kt
@@ -1,8 +1,6 @@
 package com.wire.kalium.persistence.daokaliumdb
 
 import app.cash.sqldelight.coroutines.asFlow
-import app.cash.sqldelight.coroutines.mapToList
-import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.wire.kalium.persistence.AccountsQueries
 import com.wire.kalium.persistence.CurrentAccountQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -12,6 +10,9 @@ import com.wire.kalium.persistence.model.SsoIdEntity
 import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 data class AccountInfoEntity(
     val userIDEntity: UserIDEntity,
@@ -108,18 +109,20 @@ interface AccountsDAO {
 internal class AccountsDAOImpl internal constructor(
     private val queries: AccountsQueries,
     private val currentAccountQueries: CurrentAccountQueries,
+    private val queriesContext: CoroutineContext,
     private val mapper: AccountMapper = AccountMapper
 ) : AccountsDAO {
-    override suspend fun ssoId(userIDEntity: UserIDEntity): SsoIdEntity? =
+    override suspend fun ssoId(userIDEntity: UserIDEntity): SsoIdEntity? = withContext(queriesContext) {
         queries.ssoId(userIDEntity).executeAsOneOrNull()
             ?.let { mapper.toSsoIdEntity(scim_external_id = it.scim_external_id, subject = it.subject, tenant = it.tenant) }
+    }
 
     override suspend fun insertOrReplace(
         userIDEntity: UserIDEntity,
         ssoIdEntity: SsoIdEntity?,
         serverConfigId: String,
         isPersistentWebSocketEnabled: Boolean
-    ) {
+    ) = withContext(queriesContext) {
         queries.insertOrReplace(
             scimExternalId = ssoIdEntity?.scimExternalId,
             subject = ssoIdEntity?.subject,
@@ -134,43 +137,49 @@ internal class AccountsDAOImpl internal constructor(
     override suspend fun observeAccount(userIDEntity: UserIDEntity): Flow<AccountInfoEntity?> =
         queries.accountInfo(userIDEntity, mapper = mapper::fromAccount)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToOneOrNull()
 
-    override suspend fun allAccountList(): List<AccountInfoEntity> =
+    override suspend fun allAccountList(): List<AccountInfoEntity> = withContext(queriesContext) {
         queries.allAccounts(mapper = mapper::fromAccount).executeAsList()
+    }
 
-    override suspend fun allValidAccountList(): List<AccountInfoEntity> =
+    override suspend fun allValidAccountList(): List<AccountInfoEntity> = withContext(queriesContext) {
         queries.allValidAccounts(mapper = mapper::fromAccount).executeAsList()
+    }
 
     override suspend fun observerValidAccountList(): Flow<List<AccountInfoEntity>> =
         queries.allValidAccounts(mapper = mapper::fromAccount)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
 
     override suspend fun observeAllAccountList(): Flow<List<AccountInfoEntity>> =
         queries.allAccounts(mapper = mapper::fromAccount)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToList()
 
     override fun isFederated(userIDEntity: UserIDEntity): Boolean? =
         queries.isFederationEnabled(userIDEntity).executeAsOneOrNull()
 
-    override suspend fun doesValidAccountExists(userIDEntity: UserIDEntity): Boolean =
+    override suspend fun doesValidAccountExists(userIDEntity: UserIDEntity): Boolean = withContext(queriesContext) {
         queries.doesValidAccountExist(userIDEntity).executeAsOne()
-
+    }
     override fun currentAccount(): AccountInfoEntity? =
         currentAccountQueries.currentAccountInfo(mapper = mapper::fromAccount).executeAsOneOrNull()
 
     override fun observerCurrentAccount(): Flow<AccountInfoEntity?> =
         currentAccountQueries.currentAccountInfo(mapper = mapper::fromAccount)
             .asFlow()
+            .flowOn(queriesContext)
             .mapToOneOrNull()
 
-    override suspend fun setCurrentAccount(userIDEntity: UserIDEntity?) {
+    override suspend fun setCurrentAccount(userIDEntity: UserIDEntity?) = withContext(queriesContext) {
         currentAccountQueries.update(userIDEntity)
     }
 
-    override suspend fun updateSsoId(userIDEntity: UserIDEntity, ssoIdEntity: SsoIdEntity?) {
+    override suspend fun updateSsoId(userIDEntity: UserIDEntity, ssoIdEntity: SsoIdEntity?) = withContext(queriesContext){
         queries.updateSsoId(
             scimExternalId = ssoIdEntity?.scimExternalId,
             subject = ssoIdEntity?.subject,
@@ -179,26 +188,28 @@ internal class AccountsDAOImpl internal constructor(
         )
     }
 
-    override suspend fun deleteAccount(userIDEntity: UserIDEntity) {
+    override suspend fun deleteAccount(userIDEntity: UserIDEntity) = withContext(queriesContext) {
         queries.delete(userIDEntity)
     }
 
-    override suspend fun markAccountAsInvalid(userIDEntity: UserIDEntity, logoutReason: LogoutReason) {
+    override suspend fun markAccountAsInvalid(userIDEntity: UserIDEntity, logoutReason: LogoutReason) = withContext(queriesContext) {
         queries.markAccountAsLoggedOut(logoutReason, userIDEntity)
     }
 
-    override suspend fun updatePersistentWebSocketStatus(userIDEntity: UserIDEntity, isPersistentWebSocketEnabled: Boolean) {
+    override suspend fun updatePersistentWebSocketStatus(userIDEntity: UserIDEntity, isPersistentWebSocketEnabled: Boolean) = withContext(queriesContext) {
         queries.updatePersistentWebSocketStatus(isPersistentWebSocketEnabled, userIDEntity)
     }
 
-    override suspend fun persistentWebSocketStatus(userIDEntity: UserIDEntity): Boolean =
+    override suspend fun persistentWebSocketStatus(userIDEntity: UserIDEntity): Boolean = withContext(queriesContext) {
         queries.persistentWebSocketStatus(userIDEntity).executeAsOne()
+    }
 
     override suspend fun getAllValidAccountPersistentWebSocketStatus(): Flow<List<PersistentWebSocketStatusEntity>> =
-        queries.allValidAccountsPersistentWebSocketStatus(mapper = mapper::fromPersistentWebSocketStatus).asFlow().mapToList()
+        queries.allValidAccountsPersistentWebSocketStatus(mapper = mapper::fromPersistentWebSocketStatus).asFlow().flowOn(queriesContext).mapToList()
 
-    override suspend fun accountInfo(userIDEntity: UserIDEntity): AccountInfoEntity? =
+    override suspend fun accountInfo(userIDEntity: UserIDEntity): AccountInfoEntity? = withContext(queriesContext) {
         queries.accountInfo(userIDEntity, mapper = mapper::fromAccount).executeAsOneOrNull()
+    }
 
     override fun fullAccountInfo(userIDEntity: UserIDEntity): FullAccountEntity? =
         queries.fullAccountInfo(userIDEntity, mapper = mapper::fromFullAccountInfo).executeAsOneOrNull()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/AccountsDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/AccountsDAO.kt
@@ -166,6 +166,7 @@ internal class AccountsDAOImpl internal constructor(
     override suspend fun doesValidAccountExists(userIDEntity: UserIDEntity): Boolean = withContext(queriesContext) {
         queries.doesValidAccountExist(userIDEntity).executeAsOne()
     }
+
     override fun currentAccount(): AccountInfoEntity? =
         currentAccountQueries.currentAccountInfo(mapper = mapper::fromAccount).executeAsOneOrNull()
 
@@ -179,7 +180,7 @@ internal class AccountsDAOImpl internal constructor(
         currentAccountQueries.update(userIDEntity)
     }
 
-    override suspend fun updateSsoId(userIDEntity: UserIDEntity, ssoIdEntity: SsoIdEntity?) = withContext(queriesContext){
+    override suspend fun updateSsoId(userIDEntity: UserIDEntity, ssoIdEntity: SsoIdEntity?) = withContext(queriesContext) {
         queries.updateSsoId(
             scimExternalId = ssoIdEntity?.scimExternalId,
             subject = ssoIdEntity?.subject,
@@ -188,24 +189,28 @@ internal class AccountsDAOImpl internal constructor(
         )
     }
 
-    override suspend fun deleteAccount(userIDEntity: UserIDEntity) = withContext(queriesContext) {
-        queries.delete(userIDEntity)
-    }
+    override suspend fun deleteAccount(userIDEntity: UserIDEntity) =
+        withContext(queriesContext) {
+            queries.delete(userIDEntity)
+        }
 
-    override suspend fun markAccountAsInvalid(userIDEntity: UserIDEntity, logoutReason: LogoutReason) = withContext(queriesContext) {
-        queries.markAccountAsLoggedOut(logoutReason, userIDEntity)
-    }
+    override suspend fun markAccountAsInvalid(userIDEntity: UserIDEntity, logoutReason: LogoutReason) =
+        withContext(queriesContext) {
+            queries.markAccountAsLoggedOut(logoutReason, userIDEntity)
+        }
 
-    override suspend fun updatePersistentWebSocketStatus(userIDEntity: UserIDEntity, isPersistentWebSocketEnabled: Boolean) = withContext(queriesContext) {
-        queries.updatePersistentWebSocketStatus(isPersistentWebSocketEnabled, userIDEntity)
-    }
+    override suspend fun updatePersistentWebSocketStatus(userIDEntity: UserIDEntity, isPersistentWebSocketEnabled: Boolean) =
+        withContext(queriesContext) {
+            queries.updatePersistentWebSocketStatus(isPersistentWebSocketEnabled, userIDEntity)
+        }
 
     override suspend fun persistentWebSocketStatus(userIDEntity: UserIDEntity): Boolean = withContext(queriesContext) {
         queries.persistentWebSocketStatus(userIDEntity).executeAsOne()
     }
 
     override suspend fun getAllValidAccountPersistentWebSocketStatus(): Flow<List<PersistentWebSocketStatusEntity>> =
-        queries.allValidAccountsPersistentWebSocketStatus(mapper = mapper::fromPersistentWebSocketStatus).asFlow().flowOn(queriesContext).mapToList()
+        queries.allValidAccountsPersistentWebSocketStatus(mapper = mapper::fromPersistentWebSocketStatus).asFlow().flowOn(queriesContext)
+            .mapToList()
 
     override suspend fun accountInfo(userIDEntity: UserIDEntity): AccountInfoEntity? = withContext(queriesContext) {
         queries.accountInfo(userIDEntity, mapper = mapper::fromAccount).executeAsOneOrNull()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/ServerConfigurationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/ServerConfigurationDAO.kt
@@ -178,7 +178,6 @@ internal class ServerConfigurationDAOImpl internal constructor(
     override fun configById(id: String): ServerConfigEntity? =
         queries.getById(id, mapper = mapper::fromServerConfiguration).executeAsOneOrNull()
 
-
     override suspend fun configByLinks(links: ServerConfigEntity.Links): ServerConfigEntity? = withContext(queriesContext) {
         with(links) {
             queries.getByLinks(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/ServerConfigurationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/ServerConfigurationDAO.kt
@@ -105,7 +105,7 @@ interface ServerConfigurationDAO {
     suspend fun insert(insertData: InsertData)
     suspend fun allConfigFlow(): Flow<List<ServerConfigEntity>>
     suspend fun allConfig(): List<ServerConfigEntity>
-    suspend fun configById(id: String): ServerConfigEntity?
+    fun configById(id: String): ServerConfigEntity?
     suspend fun configByLinks(links: ServerConfigEntity.Links): ServerConfigEntity?
     suspend fun updateApiVersion(id: String, commonApiVersion: Int)
     suspend fun updateApiVersionAndDomain(id: String, domain: String, commonApiVersion: Int)
@@ -175,9 +175,9 @@ internal class ServerConfigurationDAOImpl internal constructor(
         queries.storedConfig(mapper = mapper::fromServerConfiguration).executeAsList()
     }
 
-    override suspend fun configById(id: String): ServerConfigEntity? = withContext(queriesContext) {
+    override fun configById(id: String): ServerConfigEntity? =
         queries.getById(id, mapper = mapper::fromServerConfiguration).executeAsOneOrNull()
-    }
+
 
     override suspend fun configByLinks(links: ServerConfigEntity.Links): ServerConfigEntity? = withContext(queriesContext) {
         with(links) {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -33,11 +33,14 @@ import com.wire.kalium.persistence.dao.reaction.ReactionDAO
 import com.wire.kalium.persistence.dao.reaction.ReactionDAOImpl
 import com.wire.kalium.persistence.dao.receipt.ReceiptDAO
 import com.wire.kalium.persistence.dao.receipt.ReceiptDAOImpl
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
+import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.JvmInline
 
 internal const val USER_CACHE_SIZE = 125
@@ -59,6 +62,9 @@ class UserDatabaseBuilder internal constructor(
     dispatcher: CoroutineDispatcher,
     private val platformDatabaseData: PlatformDatabaseData
 ) {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val queriesContext: CoroutineContext = KaliumDispatcherImpl.io.limitedParallelism(4)
 
     internal val database: UserDatabase = UserDatabase(
         driver = sqlDriver,
@@ -91,44 +97,44 @@ class UserDatabaseBuilder internal constructor(
     private val databaseScope = CoroutineScope(SupervisorJob() + dispatcher)
     private val userCache = LRUCache<UserIDEntity, Flow<UserEntity?>>(USER_CACHE_SIZE)
     val userDAO: UserDAO
-        get() = UserDAOImpl(database.usersQueries, userCache, databaseScope)
+        get() = UserDAOImpl(database.usersQueries, userCache, databaseScope, queriesContext)
 
     val connectionDAO: ConnectionDAO
-        get() = ConnectionDAOImpl(database.connectionsQueries, database.conversationsQueries)
+        get() = ConnectionDAOImpl(database.connectionsQueries, database.conversationsQueries, queriesContext)
 
     val conversationDAO: ConversationDAO
-        get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries)
+        get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries, queriesContext)
 
     private val metadataCache = LRUCache<String, Flow<String?>>(METADATA_CACHE_SIZE)
     val metadataDAO: MetadataDAO
-        get() = MetadataDAOImpl(database.metadataQueries, metadataCache, databaseScope)
+        get() = MetadataDAOImpl(database.metadataQueries, metadataCache, databaseScope, queriesContext)
 
     val clientDAO: ClientDAO
-        get() = ClientDAOImpl(database.clientsQueries)
+        get() = ClientDAOImpl(database.clientsQueries, queriesContext)
 
     val databaseImporter: DatabaseImporter
         get() = DatabaseImporterImpl(sqlDriver)
 
     val callDAO: CallDAO
-        get() = CallDAOImpl(database.callsQueries)
+        get() = CallDAOImpl(database.callsQueries, queriesContext)
 
     val messageDAO: MessageDAO
-        get() = MessageDAOImpl(database.messagesQueries, database.conversationsQueries, userId, database.reactionsQueries)
+        get() = MessageDAOImpl(database.messagesQueries, database.conversationsQueries, userId, database.reactionsQueries, queriesContext)
 
     val assetDAO: AssetDAO
-        get() = AssetDAOImpl(database.assetsQueries)
+        get() = AssetDAOImpl(database.assetsQueries, queriesContext)
 
     val teamDAO: TeamDAO
-        get() = TeamDAOImpl(database.teamsQueries)
+        get() = TeamDAOImpl(database.teamsQueries, queriesContext)
 
     val reactionDAO: ReactionDAO
-        get() = ReactionDAOImpl(database.reactionsQueries)
+        get() = ReactionDAOImpl(database.reactionsQueries, queriesContext)
 
     val receiptDAO: ReceiptDAO
-        get() = ReceiptDAOImpl(database.receiptsQueries, TableMapper.receiptAdapter)
+        get() = ReceiptDAOImpl(database.receiptsQueries, TableMapper.receiptAdapter, queriesContext)
 
     val prekeyDAO: PrekeyDAO
-        get() = PrekeyDAOImpl(database.metadataQueries)
+        get() = PrekeyDAOImpl(database.metadataQueries, queriesContext)
 
     val migrationDAO: MigrationDAO get() = MigrationDAOImpl(database.conversationsQueries)
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -36,7 +36,6 @@ import com.wire.kalium.persistence.dao.receipt.ReceiptDAOImpl
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -60,11 +59,9 @@ class UserDatabaseBuilder internal constructor(
     private val userId: UserIDEntity,
     private val sqlDriver: SqlDriver,
     dispatcher: CoroutineDispatcher,
-    private val platformDatabaseData: PlatformDatabaseData
+    private val platformDatabaseData: PlatformDatabaseData,
+    private val queriesContext: CoroutineContext = KaliumDispatcherImpl.io
 ) {
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private val queriesContext: CoroutineContext = KaliumDispatcherImpl.io.limitedParallelism(4)
 
     internal val database: UserDatabase = UserDatabase(
         driver = sqlDriver,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/daokaliumdb/ServerConfigurationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/daokaliumdb/ServerConfigurationDAOTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package com.wire.kalium.persistence.daokaliumdb
 
 import com.wire.kalium.persistence.GlobalDBBaseTest
@@ -34,7 +36,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenServerConfig_ThenItCanBeInsertedAndRetrieved() {
+    fun givenServerConfig_ThenItCanBeInsertedAndRetrieved() = runTest {
         val expect = config1
         insertConfig(expect)
         val actual = db.serverConfigurationDAO.configById(expect.id)
@@ -43,7 +45,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenAlreadyStoredServerConfig_whenInsertingNewOneWithTheSameApiBaseUrl_thenNothingChanges() {
+    fun givenAlreadyStoredServerConfig_whenInsertingNewOneWithTheSameApiBaseUrl_thenNothingChanges() = runTest {
         val newLinks = config1.links.copy(api = "new_base_url.com")
         val duplicatedConfig = config1.copy(links = newLinks)
         insertConfig(config1)
@@ -57,7 +59,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenAlreadyStoredServerConfig_whenInsertingNewOneWithTheSameTitle_thenNothingChanges() {
+    fun givenAlreadyStoredServerConfig_whenInsertingNewOneWithTheSameTitle_thenNothingChanges() = runTest {
         val newLinks = config1.links.copy(title = "title")
         val duplicatedConfig = config1.copy(links = newLinks)
         insertConfig(config1)
@@ -72,7 +74,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenAlreadyStoredServerConfig_whenInsertingNewOneWithTheSameWSUrl_thenNothingChanges() {
+    fun givenAlreadyStoredServerConfig_whenInsertingNewOneWithTheSameWSUrl_thenNothingChanges() = runTest {
         val newLinks = config1.links.copy(website = "ws_de.berlin.com")
         val duplicatedConfig = config1.copy(links = newLinks)
         insertConfig(config1)
@@ -87,7 +89,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenAlreadyStoredServerConfig_whenInsertingNewOneWithTheSameDomain_thenNothingChanges() {
+    fun givenAlreadyStoredServerConfig_whenInsertingNewOneWithTheSameDomain_thenNothingChanges() = runTest {
         val newMetaData = config1.metaData.copy(domain = "new_domain")
         val duplicatedConfig = config1.copy(metaData = newMetaData)
         insertConfig(config1)
@@ -102,7 +104,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenExistingConfig_thenItCanBeDeleted() {
+    fun givenExistingConfig_thenItCanBeDeleted() = runTest {
         insertConfig(config1)
         db.serverConfigurationDAO.deleteById(config1.id)
 
@@ -121,7 +123,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenNewApiVersion_thenItCanBeUpdated() {
+    fun givenNewApiVersion_thenItCanBeUpdated() = runTest {
         insertConfig(config1)
         val newVersion = config1.metaData.copy(apiVersion = 2)
         val expected = config1.copy(metaData = newVersion)
@@ -132,7 +134,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenNewApiVersionAndDomain_thenItCanBeUpdated() {
+    fun givenNewApiVersionAndDomain_thenItCanBeUpdated() = runTest {
         insertConfig(config1)
         val newVersion = 2
         val newDomain = "new.domain.de"
@@ -144,7 +146,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
     }
 
     @Test
-    fun givenFederationEnabled_thenItCanBeUpdated() {
+    fun givenFederationEnabled_thenItCanBeUpdated() = runTest {
         insertConfig(
             config1.copy(metaData = config1.metaData.copy(federation = true))
         )
@@ -155,7 +157,7 @@ class ServerConfigurationDAOTest : GlobalDBBaseTest() {
         assertEquals(expected, actual)
     }
 
-    private fun insertConfig(serverConfigEntity: ServerConfigEntity) {
+    private suspend fun insertConfig(serverConfigEntity: ServerConfigEntity) {
         with(serverConfigEntity) {
             db.serverConfigurationDAO.insert(
                 ServerConfigurationDAO.InsertData(

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/globalDB/AccountsDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/globalDB/AccountsDAOTest.kt
@@ -23,7 +23,7 @@ class AccountsDAOTest : GlobalDBBaseTest() {
     lateinit var db: GlobalDatabaseProvider
 
     @BeforeTest
-    fun setUp() {
+    fun setUp() = runTest {
         deleteDatabase()
         db = createDatabase()
 

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -1,9 +1,11 @@
 package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.MessagesQueries
+import kotlin.coroutines.CoroutineContext
 
 actual interface MessageExtensions
 actual class MessageExtensionsImpl actual constructor(
     messagesQueries: MessagesQueries,
-    messageMapper: MessageMapper
+    messageMapper: MessageMapper,
+    coroutineContext: CoroutineContext
 ) : MessageExtensions

--- a/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/iosX64Main/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -13,9 +13,14 @@ import com.wire.kalium.persistence.daokaliumdb.LogoutReasonAdapter
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlin.coroutines.CoroutineContext
 
 // TODO(refactor): Unify creation just like it's done for UserDataBase
-actual class GlobalDatabaseProvider(passphrase: String) {
+actual class GlobalDatabaseProvider(
+    passphrase: String,
+    private val queriesContext: CoroutineContext = KaliumDispatcherImpl.io
+) {
 
     val database: GlobalDatabase
 
@@ -35,10 +40,10 @@ actual class GlobalDatabaseProvider(passphrase: String) {
     }
 
     actual val serverConfigurationDAO: ServerConfigurationDAO
-        get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries)
+        get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries, queriesContext)
 
     actual val accountsDAO: AccountsDAO
-        get() = AccountsDAOImpl(database.accountsQueries, database.currentAccountQueries)
+        get() = AccountsDAOImpl(database.accountsQueries, database.currentAccountQueries, queriesContext)
 
     actual fun nuke(): Boolean {
         TODO("Not yet implemented")

--- a/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -1,9 +1,11 @@
 package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.MessagesQueries
+import kotlin.coroutines.CoroutineContext
 
 actual interface MessageExtensions
 actual class MessageExtensionsImpl actual constructor(
     messagesQueries: MessagesQueries,
-    messageMapper: MessageMapper
+    messageMapper: MessageMapper,
+    coroutineContext: CoroutineContext
 ) : MessageExtensions

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -1,9 +1,11 @@
 package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.MessagesQueries
+import kotlin.coroutines.CoroutineContext
 
 actual interface MessageExtensions
 actual class MessageExtensionsImpl actual constructor(
     messagesQueries: MessagesQueries,
-    messageMapper: MessageMapper
+    messageMapper: MessageMapper,
+    coroutineContext: CoroutineContext
 ) : MessageExtensions

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -14,10 +14,15 @@ import com.wire.kalium.persistence.daokaliumdb.LogoutReasonAdapter
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
+import com.wire.kalium.util.KaliumDispatcherImpl
 import java.io.File
+import kotlin.coroutines.CoroutineContext
 
 // TODO(refactor): Unify creation just like it's done for UserDataBase
-actual class GlobalDatabaseProvider(private val storePath: File) {
+actual class GlobalDatabaseProvider(
+    private val storePath: File,
+    private val queriesContext: CoroutineContext = KaliumDispatcherImpl.io
+) {
 
     private val dbName = FileNameUtil.globalDBName()
     private val database: GlobalDatabase
@@ -54,10 +59,10 @@ actual class GlobalDatabaseProvider(private val storePath: File) {
     }
 
     actual val serverConfigurationDAO: ServerConfigurationDAO
-        get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries)
+        get() = ServerConfigurationDAOImpl(database.serverConfigurationQueries, queriesContext)
 
     actual val accountsDAO: AccountsDAO
-        get() = AccountsDAOImpl(database.accountsQueries, database.currentAccountQueries)
+        get() = AccountsDAOImpl(database.accountsQueries, database.currentAccountQueries, queriesContext)
 
     actual fun nuke(): Boolean {
         return storePath.resolve(dbName).delete()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

data base queries are executed on the main thread (most of the times)

### Causes (Optional)

not paying attention to the fact that sqlDelight does not switch context when executing queries

### Solutions

Switch context when executing DB queries to the IO context

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
