### PR TITLE
chore: add ide support for cross-platform development

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.5.1" // TODO(upgrade): Breaking changes in 0.6.0
     id("scripts.testing")
     id("scripts.detekt")
+    alias(libs.plugins.completeKotlin)
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ turbine = "0.12.1"
 avs = "9.0.2-rc1"
 jna = "5.6.0"
 core-crypto = "0.6.0-rc.3"
+completeKotlin = "1.1.0"
 desugar-jdk = "1.1.5"
 kermit = "1.2.2"
 detekt = "1.19.0"
@@ -47,9 +48,9 @@ annotation = "1.2.0"
 [plugins]
 # Home-made convention plugins
 kalium-library = { id = "kalium.library" }
-
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-application = { id = "com.android.application", version.ref = "agp" }
+completeKotlin = { id = "com.louiscad.complete-kotlin", version.ref = "completeKotlin"}
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When attempting to write `darwin` code from a Windows or Linux machine, there's absolutely no IDE support.

The IDE says that "Kotlin is not configured" for such files, and says there're Unresolved References in every platform-specific code.

### Causes

As Kotlin won't really build `darwin` on Linux and Windows machines, it doesn't bother downloading the platorm-specific dependencies.

### Solutions

Rely on [CompleteKotlin](https://github.com/LouisCAD/CompleteKotlin).

It pretty much downloads all platform-specific `klibs` that we might require.

Some interesting notes:

#### Will it slowdown CI, with more dependencies needed?

Nope. The plugin checks [the CI environment variable](https://github.com/LouisCAD/CompleteKotlin/blob/af2a6f6e01bf27acbaf5b7f4e234dfd0948c640e/plugin/src/main/kotlin/com/louiscad/complete_kotlin/CompleteKotlinPlugin.kt#L20) before proceeding. If it's `true` it will not perform any action.

Both systems we use ([GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) and [Jenkins](https://github.com/jenkinsci/jenkins/pull/5370)) have this flag as `true` by default.

#### Will it slowdown fellow developers on Linux or Windows?

_Maybe_, a bit. It took around a minute to perform a Gradle Sync on my machine, which spent most of the time downloading and indexing all the `darwin` stuff. 
This is on a 600MBit/s wired connection, a Radeon 7950X processor and PCIE 4.0 SSD. So I can imagine it taking some extra 5~10 minutes depending on these three components (connection speed, processor and storage read/write speed).

But it should be a one-time thing and then it's all fun.

To be more hardware-inclusive in the future with the open source community we could hide this behind a flag by default. I struggled a bit reading properties inside the root `build.gradle.kts` `plugins` block and applying plugins from the version catalog.

As this project is still flying under the radar and there are only two or three developers using Linux or Windows at the moment on nice connections and powerful machines, I don't feel guilty for now :) 

### Testing

#### Test Coverage

Not Applicable

#### How to Test

On a Windows or Linux machine, open the project and navigate to some `darwinMain` source set, type `NS` and watch the IDE actually be useful.

### Attachments

![image](https://user-images.githubusercontent.com/9389043/212195546-01ff6ab7-2328-4047-bd01-edf51b5fcc51.png)

Checkout my taskbar, I'm on Windows!!!!!!! Thanks a lot @LouisCAD. If you're reading this, I own you some coffee, beer, tea, or all of the above when we meet :)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
