### PR TITLE
refactor: move column adapters to a dedicated package

### DIFF
--- a/detekt/baseline.xml
+++ b/detekt/baseline.xml
@@ -159,7 +159,6 @@
     <ID>NoMultipleSpaces:com.wire.kalium.logic.feature.auth.ValidatePasswordUseCaseTest.kt:43</ID>
     <ID>NoMultipleSpaces:com.wire.kalium.persistence.GlobalDBBaseTest.kt:7</ID>
     <ID>NoSemicolons:com.wire.kalium.logic.data.user.type.UserType.kt:1</ID>
-    <ID>NoTrailingSpaces:com.wire.kalium.persistence.dao.ContentTypeAdapter.kt:13</ID>
     <ID>NoUnusedImports:com.wire.kalium.logic.data.user.ConnectionStateMapper.kt:4</ID>
     <ID>NoUnusedImports:com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCaseTest.kt:4</ID>
     <ID>NoUnusedImports:com.wire.kalium.logic.feature.call.MediaManagerServiceImpl.kt:6</ID>
@@ -177,9 +176,7 @@
     <ID>SpacingAroundColon:com.wire.kalium.cryptography.exceptions.ProteusException.kt:3</ID>
     <ID>SpacingAroundColon:com.wire.kalium.logic.feature.session.SessionResult.kt:7</ID>
     <ID>SpacingAroundColon:com.wire.kalium.persistence.client.LastRetrievedNotificationEventStorage.kt:19</ID>
-    <ID>SpacingAroundColon:com.wire.kalium.persistence.dao.QualifiedIDAdapter.kt:5</ID>
     <ID>SpacingAroundCurly:com.wire.kalium.logic.feature.call.RejectCallUseCaseTest.kt:27</ID>
-    <ID>SpacingAroundKeyword:com.wire.kalium.persistence.dao.MemberRoleAdapter.kt:12</ID>
     <ID>StringTemplate:com.wire.kalium.cryptography.IDs.kt:26</ID>
     <ID>StringTemplate:com.wire.kalium.logic.data.sso.SSOUtil.kt:5</ID>
     <ID>TooGenericExceptionCaught:CoreFailure.kt$e: Exception</ID>

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -7,10 +7,10 @@ import com.wire.kalium.persistence.Accounts
 import com.wire.kalium.persistence.CurrentAccount
 import com.wire.kalium.persistence.GlobalDatabase
 import com.wire.kalium.persistence.ServerConfiguration
-import com.wire.kalium.persistence.dao.QualifiedIDAdapter
+import com.wire.kalium.persistence.adapter.QualifiedIDAdapter
 import com.wire.kalium.persistence.daokaliumdb.AccountsDAO
 import com.wire.kalium.persistence.daokaliumdb.AccountsDAOImpl
-import com.wire.kalium.persistence.daokaliumdb.LogoutReasonAdapter
+import com.wire.kalium.persistence.adapter.LogoutReasonAdapter
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/BotServiceAdapter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/BotServiceAdapter.kt
@@ -1,8 +1,9 @@
-package com.wire.kalium.persistence.dao
+package com.wire.kalium.persistence.adapter
 
 import app.cash.sqldelight.ColumnAdapter
+import com.wire.kalium.persistence.dao.BotEntity
 
-class BotServiceAdapter : ColumnAdapter<BotEntity, String> {
+internal class BotServiceAdapter : ColumnAdapter<BotEntity, String> {
 
     override fun decode(databaseValue: String): BotEntity {
         val components = databaseValue.split("@")

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/ContentTypeAdapter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/ContentTypeAdapter.kt
@@ -1,14 +1,14 @@
-package com.wire.kalium.persistence.dao
+package com.wire.kalium.persistence.adapter
 
 import app.cash.sqldelight.ColumnAdapter
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.TEXT
 
-class ContentTypeAdapter : ColumnAdapter<ContentType, String> {
+internal class ContentTypeAdapter : ColumnAdapter<ContentType, String> {
 
     override fun decode(databaseValue: String): ContentType =
         ContentType.values().firstOrNull { it.name == databaseValue } ?: TEXT
 
     override fun encode(value: ContentType) = value.name
-    
+
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/ConversationAdapter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/ConversationAdapter.kt
@@ -1,8 +1,9 @@
-package com.wire.kalium.persistence.dao
+package com.wire.kalium.persistence.adapter
 
 import app.cash.sqldelight.ColumnAdapter
+import com.wire.kalium.persistence.dao.ConversationEntity
 
-class ConversationAccessRoleListAdapter : ColumnAdapter<List<ConversationEntity.AccessRole>, String> {
+internal class ConversationAccessRoleListAdapter : ColumnAdapter<List<ConversationEntity.AccessRole>, String> {
     override fun decode(databaseValue: String): List<ConversationEntity.AccessRole> =
         if (databaseValue.isEmpty()) {
             listOf()
@@ -17,7 +18,7 @@ class ConversationAccessRoleListAdapter : ColumnAdapter<List<ConversationEntity.
     }
 }
 
-class ConversationAccessListAdapter : ColumnAdapter<List<ConversationEntity.Access>, String> {
+internal class ConversationAccessListAdapter : ColumnAdapter<List<ConversationEntity.Access>, String> {
     override fun decode(databaseValue: String): List<ConversationEntity.Access> =
         if (databaseValue.isEmpty()) {
             listOf()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/LogoutReasonAdapter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/LogoutReasonAdapter.kt
@@ -1,9 +1,9 @@
-package com.wire.kalium.persistence.daokaliumdb
+package com.wire.kalium.persistence.adapter
 
 import app.cash.sqldelight.ColumnAdapter
 import com.wire.kalium.persistence.model.LogoutReason
 
-object LogoutReasonAdapter : ColumnAdapter<LogoutReason, String> {
+internal object LogoutReasonAdapter : ColumnAdapter<LogoutReason, String> {
     override fun decode(databaseValue: String): LogoutReason = LogoutReason.valueOf(databaseValue)
 
     override fun encode(value: LogoutReason): String = value.name

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/MemberRoleAdapter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/MemberRoleAdapter.kt
@@ -1,15 +1,16 @@
-package com.wire.kalium.persistence.dao
+package com.wire.kalium.persistence.adapter
 
 import app.cash.sqldelight.ColumnAdapter
+import com.wire.kalium.persistence.dao.Member
 
-class MemberRoleAdapter : ColumnAdapter<Member.Role, String> {
+internal class MemberRoleAdapter : ColumnAdapter<Member.Role, String> {
     override fun decode(databaseValue: String): Member.Role = when (databaseValue) {
         ADMIN -> Member.Role.Admin
         MEMBER -> Member.Role.Member
         else -> Member.Role.Unknown(databaseValue)
     }
 
-    override fun encode(value: Member.Role): String = when(value) {
+    override fun encode(value: Member.Role): String = when (value) {
         Member.Role.Admin -> ADMIN
         Member.Role.Member -> MEMBER
         is Member.Role.Unknown -> value.name

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/QualifiedIDAdapter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/QualifiedIDAdapter.kt
@@ -1,8 +1,9 @@
-package com.wire.kalium.persistence.dao
+package com.wire.kalium.persistence.adapter
 
 import app.cash.sqldelight.ColumnAdapter
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
 
-object QualifiedIDAdapter: ColumnAdapter<QualifiedIDEntity, String> {
+internal object QualifiedIDAdapter : ColumnAdapter<QualifiedIDEntity, String> {
 
     override fun decode(databaseValue: String): QualifiedIDEntity {
         val components = databaseValue.split("@")
@@ -15,7 +16,7 @@ object QualifiedIDAdapter: ColumnAdapter<QualifiedIDEntity, String> {
 
 }
 
-class QualifiedIDListAdapter : ColumnAdapter<List<QualifiedIDEntity>, String> {
+internal class QualifiedIDListAdapter : ColumnAdapter<List<QualifiedIDEntity>, String> {
 
     override fun decode(databaseValue: String): List<QualifiedIDEntity> =
         if (databaseValue.isEmpty()) listOf()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
@@ -23,13 +23,13 @@ import com.wire.kalium.persistence.Reaction
 import com.wire.kalium.persistence.Receipt
 import com.wire.kalium.persistence.SelfUser
 import com.wire.kalium.persistence.User
-import com.wire.kalium.persistence.dao.BotServiceAdapter
-import com.wire.kalium.persistence.dao.ContentTypeAdapter
-import com.wire.kalium.persistence.dao.ConversationAccessListAdapter
-import com.wire.kalium.persistence.dao.ConversationAccessRoleListAdapter
-import com.wire.kalium.persistence.dao.MemberRoleAdapter
-import com.wire.kalium.persistence.dao.QualifiedIDAdapter
-import com.wire.kalium.persistence.dao.QualifiedIDListAdapter
+import com.wire.kalium.persistence.adapter.BotServiceAdapter
+import com.wire.kalium.persistence.adapter.ContentTypeAdapter
+import com.wire.kalium.persistence.adapter.ConversationAccessListAdapter
+import com.wire.kalium.persistence.adapter.ConversationAccessRoleListAdapter
+import com.wire.kalium.persistence.adapter.MemberRoleAdapter
+import com.wire.kalium.persistence.adapter.QualifiedIDAdapter
+import com.wire.kalium.persistence.adapter.QualifiedIDListAdapter
 
 internal object TableMapper {
     val callAdapter = Call.Adapter(

--- a/persistence/src/darwinMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/darwinMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -8,10 +8,10 @@ import com.wire.kalium.persistence.Accounts
 import com.wire.kalium.persistence.CurrentAccount
 import com.wire.kalium.persistence.GlobalDatabase
 import com.wire.kalium.persistence.ServerConfiguration
-import com.wire.kalium.persistence.dao.QualifiedIDAdapter
+import com.wire.kalium.persistence.adapter.QualifiedIDAdapter
 import com.wire.kalium.persistence.daokaliumdb.AccountsDAO
 import com.wire.kalium.persistence.daokaliumdb.AccountsDAOImpl
-import com.wire.kalium.persistence.daokaliumdb.LogoutReasonAdapter
+import com.wire.kalium.persistence.adapter.LogoutReasonAdapter
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -7,10 +7,10 @@ import com.wire.kalium.persistence.Accounts
 import com.wire.kalium.persistence.CurrentAccount
 import com.wire.kalium.persistence.GlobalDatabase
 import com.wire.kalium.persistence.ServerConfiguration
-import com.wire.kalium.persistence.dao.QualifiedIDAdapter
+import com.wire.kalium.persistence.adapter.QualifiedIDAdapter
 import com.wire.kalium.persistence.daokaliumdb.AccountsDAO
 import com.wire.kalium.persistence.daokaliumdb.AccountsDAOImpl
-import com.wire.kalium.persistence.daokaliumdb.LogoutReasonAdapter
+import com.wire.kalium.persistence.adapter.LogoutReasonAdapter
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Adapters are mixed up with DAOs in the Project view.

### Solutions

Move to their own dedicated package. Also, make them `internal` as it's not useful to make them `public`

### Testing

#### Test Coverage

- [ ] I have added automated test to this contribution

Not Applicable

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
