### PR TITLE
feat(sync): insert history-lost systemMessage after 404 sync recovery (AR-2897)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -29,9 +29,16 @@ sealed class CoreFailure {
      */
     object DevelopmentAPINotAllowedOnProduction : CoreFailure()
 
+
     data class Unknown(val rootCause: Throwable?) : CoreFailure()
 
     abstract class FeatureFailure : CoreFailure()
+
+    /**
+     * It's only allowed to insert system messages as bulk for all conversations.
+     */
+    object OnlySystemMessageAllowed: FeatureFailure()
+
 }
 
 sealed class NetworkFailure : CoreFailure() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -29,7 +29,6 @@ sealed class CoreFailure {
      */
     object DevelopmentAPINotAllowedOnProduction : CoreFailure()
 
-
     data class Unknown(val rootCause: Throwable?) : CoreFailure()
 
     abstract class FeatureFailure : CoreFailure()
@@ -37,8 +36,7 @@ sealed class CoreFailure {
     /**
      * It's only allowed to insert system messages as bulk for all conversations.
      */
-    object OnlySystemMessageAllowed: FeatureFailure()
-
+    object OnlySystemMessageAllowed : FeatureFailure()
 }
 
 sealed class NetworkFailure : CoreFailure() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -240,6 +240,10 @@ sealed interface Message {
                 is MessageContent.ConversationReceiptModeChanged -> mutableMapOf(
                     typeKey to "conversationReceiptModeChanged"
                 )
+
+                MessageContent.HistoryLost -> mutableMapOf(
+                    typeKey to "conversationMightLostHistory"
+                )
             }
 
             val standardProperties = mapOf(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -204,6 +204,8 @@ sealed class MessageContent {
     object ClientAction : Signaling()
 
     object CryptoSessionReset : System()
+
+    object HistoryLost: System()
 }
 
 sealed class MessagePreviewContent {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -205,7 +205,7 @@ sealed class MessageContent {
 
     object CryptoSessionReset : System()
 
-    object HistoryLost: System()
+    object HistoryLost : System()
 }
 
 sealed class MessagePreviewContent {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -277,6 +277,7 @@ class MessageMapperImpl(
         is MessageContent.TeamMemberRemoved -> MessageEntityContent.TeamMemberRemoved(userName)
         is MessageContent.NewConversationReceiptMode -> MessageEntityContent.NewConversationReceiptMode(receiptMode)
         is MessageContent.ConversationReceiptModeChanged -> MessageEntityContent.ConversationReceiptModeChanged(receiptMode)
+        is MessageContent.HistoryLost -> MessageEntityContent.HistoryLost
     }
 
     private fun MessageEntityContent.Regular.toMessageContent(hidden: Boolean): MessageContent.Regular = when (this) {
@@ -357,6 +358,7 @@ class MessageMapperImpl(
         is MessageEntityContent.CryptoSessionReset -> MessageContent.CryptoSessionReset
         is MessageEntityContent.NewConversationReceiptMode -> MessageContent.NewConversationReceiptMode(receiptMode)
         is MessageEntityContent.ConversationReceiptModeChanged -> MessageContent.ConversationReceiptModeChanged(receiptMode)
+        is MessageEntityContent.HistoryLost -> MessageContent.HistoryLost
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -217,9 +217,13 @@ class MessageDataSource(
 
     override suspend fun persistSystemMessageToAllConversations(
         message: Message.System
-    ): Either<CoreFailure, Unit> = wrapStorageRequest {
+    ): Either<CoreFailure, Unit> {
         messageMapper.fromMessageToEntity(message).let {
-            if (it is MessageEntity.System) messageDAO.persistSystemMessageToAllConversations(it)
+            return if (it is MessageEntity.System) {
+                wrapStorageRequest {
+                    messageDAO.persistSystemMessageToAllConversations(it)
+                }
+            } else Either.Left(CoreFailure.OnlySystemMessageAllowed)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -57,6 +57,10 @@ interface MessageRepository {
         updateConversationModifiedDate: Boolean = false,
     ): Either<CoreFailure, Unit>
 
+    suspend fun persistSystemMessageToAllConversations(
+        message: Message.System
+    ): Either<CoreFailure, Unit>
+
     suspend fun deleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun markMessageAsDeleted(messageUuid: String, conversationId: ConversationId): Either<StorageFailure, Unit>
     suspend fun updateMessageStatus(
@@ -209,6 +213,14 @@ class MessageDataSource(
             updateConversationReadDate,
             updateConversationModifiedDate
         )
+    }
+
+    override suspend fun persistSystemMessageToAllConversations(
+        message: Message.System
+    ): Either<CoreFailure, Unit> = wrapStorageRequest {
+        messageMapper.fromMessageToEntity(message).let {
+            if (it is MessageEntity.System) messageDAO.persistSystemMessageToAllConversations(it)
+        }
     }
 
     override suspend fun deleteMessage(messageUuid: String, conversationId: ConversationId): Either<CoreFailure, Unit> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -73,5 +73,6 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.CryptoSessionReset -> false
             is MessageContent.NewConversationReceiptMode -> false
             is MessageContent.ConversationReceiptModeChanged -> false
+            is MessageContent.HistoryLost -> false
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -130,6 +130,7 @@ import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCaseImpl
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManager
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManagerImpl
 import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCase
+import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCaseImpl
 import com.wire.kalium.logic.feature.message.EphemeralNotificationsManager
 import com.wire.kalium.logic.feature.message.MLSMessageCreator
 import com.wire.kalium.logic.feature.message.MLSMessageCreatorImpl
@@ -468,7 +469,7 @@ class UserSessionScope internal constructor(
         get() = PersistMessageUseCaseImpl(messageRepository, userId)
 
     private val addSystemMessageToAllConversationsUseCase: AddSystemMessageToAllConversationsUseCase
-        get() = AddSystemMessageToAllConversationsUseCase(messageRepository, slowSyncRepository, userId)
+        get() = AddSystemMessageToAllConversationsUseCaseImpl(messageRepository, slowSyncRepository, userId)
 
     private val callRepository: CallRepository by lazy {
         CallDataSource(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -129,6 +129,7 @@ import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
 import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCaseImpl
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManager
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManagerImpl
+import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCase
 import com.wire.kalium.logic.feature.message.EphemeralNotificationsManager
 import com.wire.kalium.logic.feature.message.MLSMessageCreator
 import com.wire.kalium.logic.feature.message.MLSMessageCreatorImpl
@@ -466,6 +467,9 @@ class UserSessionScope internal constructor(
     val persistMessage: PersistMessageUseCase
         get() = PersistMessageUseCaseImpl(messageRepository, userId)
 
+    private val addSystemMessageToAllConversationsUseCase: AddSystemMessageToAllConversationsUseCase
+        get() = AddSystemMessageToAllConversationsUseCase(messageRepository, slowSyncRepository, userId)
+
     private val callRepository: CallRepository by lazy {
         CallDataSource(
             callApi = authenticatedDataSourceSet.authenticatedNetworkContainer.callApi,
@@ -629,7 +633,8 @@ class UserSessionScope internal constructor(
     private val incrementalSyncRecoveryHandler: IncrementalSyncRecoveryHandlerImpl
         get() =
             IncrementalSyncRecoveryHandlerImpl(
-                slowSyncRepository
+                slowSyncRepository,
+                addSystemMessageToAllConversationsUseCase
             )
 
     private val incrementalSyncManager by lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -1,0 +1,38 @@
+package com.wire.kalium.logic.feature.message
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.data.user.UserId
+
+import com.wire.kalium.util.DateTimeUtil
+import kotlinx.coroutines.flow.first
+
+/**
+ * persist a local system message to all conversations
+ */
+class AddSystemMessageToAllConversationsUseCase internal constructor(
+    private val messageRepository: MessageRepository,
+    private val slowSyncRepository: SlowSyncRepository,
+    private val selfUserId: UserId
+) {
+    suspend operator fun invoke() {
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
+        val generatedMessageUuid = uuid4().toString()
+        val message = Message.System(
+            id = generatedMessageUuid,
+            content = MessageContent.HistoryLost,
+            conversationId = ConversationId("", ""),// the conversation id will be ignored in the repo level!
+            date = DateTimeUtil.currentIsoDateTimeString(),
+            senderUserId = selfUserId,
+            status = Message.Status.SENT,
+        )
+        messageRepository.persistSystemMessageToAllConversations(message)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -28,7 +28,7 @@ class AddSystemMessageToAllConversationsUseCase internal constructor(
         val message = Message.System(
             id = generatedMessageUuid,
             content = MessageContent.HistoryLost,
-            //the conversation id will be ignored in the repo level!
+            // the conversation id will be ignored in the repo level!
             conversationId = ConversationId("", ""),
             date = DateTimeUtil.currentIsoDateTimeString(),
             senderUserId = selfUserId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -12,15 +12,19 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.first
 
+interface AddSystemMessageToAllConversationsUseCase {
+    suspend operator fun invoke()
+}
+
 /**
  * persist a local system message to all conversations
  */
-class AddSystemMessageToAllConversationsUseCase internal constructor(
+class AddSystemMessageToAllConversationsUseCaseImpl internal constructor(
     private val messageRepository: MessageRepository,
     private val slowSyncRepository: SlowSyncRepository,
     private val selfUserId: UserId
-) {
-    suspend operator fun invoke() {
+) : AddSystemMessageToAllConversationsUseCase {
+    override suspend operator fun invoke() {
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -12,13 +12,13 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.first
 
+/**
+ * persist a local system message to all conversations
+ */
 interface AddSystemMessageToAllConversationsUseCase {
     suspend operator fun invoke()
 }
 
-/**
- * persist a local system message to all conversations
- */
 class AddSystemMessageToAllConversationsUseCaseImpl internal constructor(
     private val messageRepository: MessageRepository,
     private val slowSyncRepository: SlowSyncRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -28,7 +28,8 @@ class AddSystemMessageToAllConversationsUseCase internal constructor(
         val message = Message.System(
             id = generatedMessageUuid,
             content = MessageContent.HistoryLost,
-            conversationId = ConversationId("", ""),// the conversation id will be ignored in the repo level!
+            //the conversation id will be ignored in the repo level!
+            conversationId = ConversationId("", ""),
             date = DateTimeUtil.currentIsoDateTimeString(),
             senderUserId = selfUserId,
             status = Message.Status.SENT,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandler.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.sync.incremental
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCase
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.HttpErrorCodes
@@ -16,7 +17,8 @@ internal fun interface OnIncrementalSyncRetryCallback {
 }
 
 internal class IncrementalSyncRecoveryHandlerImpl(
-    private val slowSyncRepository: SlowSyncRepository
+    private val slowSyncRepository: SlowSyncRepository,
+    private val addSystemMessageToAllConversationsUseCase: AddSystemMessageToAllConversationsUseCase
 ) : IncrementalSyncRecoveryHandler {
 
     override suspend fun recover(failure: CoreFailure, onIncrementalSyncRetryCallback: OnIncrementalSyncRetryCallback) {
@@ -24,6 +26,7 @@ internal class IncrementalSyncRecoveryHandlerImpl(
         if (shouldRestartSlowSyncProcess(failure)) {
             slowSyncRepository.clearLastSlowSyncCompletionInstant()
             slowSyncRepository.setNeedsToRecoverMLSGroups(true)
+            addSystemMessageToAllConversationsUseCase()
         } else {
             kaliumLogger.i("$TAG Retrying to recover form the failure $failure, perform the incremental sync again")
             onIncrementalSyncRetryCallback.retry()

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -418,6 +418,10 @@ insertOrIgnoreMessage:
 INSERT OR IGNORE INTO Message(id, content_type, conversation_id, date, sender_user_id, sender_client_id, status, visibility, expects_read_confirmation)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?);
 
+insertOrIgnoreBullkSystemMessage:
+INSERT OR IGNORE INTO Message(id, content_type, conversation_id, date, sender_user_id, sender_client_id, status, visibility, expects_read_confirmation)
+SELECT ?, ?, conversation_id, ?, ?, ?, ?, ?, ? FROM Conversation;
+
 insertMessageMention:
 INSERT OR IGNORE INTO MessageMention(message_id, conversation_id, start, length, user_id)
 VALUES (?, ?, ?, ?, ?);

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -418,9 +418,9 @@ insertOrIgnoreMessage:
 INSERT OR IGNORE INTO Message(id, content_type, conversation_id, date, sender_user_id, sender_client_id, status, visibility, expects_read_confirmation)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?);
 
-insertOrIgnoreBullkSystemMessage:
+insertOrIgnoreBulkSystemMessage:
 INSERT OR IGNORE INTO Message(id, content_type, conversation_id, date, sender_user_id, sender_client_id, status, visibility, expects_read_confirmation)
-SELECT ?, ?, conversation_id, ?, ?, ?, ?, ?, ? FROM Conversation;
+SELECT ?, ?, qualified_id, ?, ?, ?, ?, ?, ? FROM Conversation WHERE type IN ('ONE_ON_ONE', 'GROUP') ;
 
 insertMessageMention:
 INSERT OR IGNORE INTO MessageMention(message_id, conversation_id, start, length, user_id)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -37,6 +37,8 @@ interface MessageDAO {
      * @see insertOrIgnoreMessage
      */
     suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>)
+
+    suspend fun persistSystemMessageToAllConversations(message: MessageEntity.System)
     suspend fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
     /**
      * Returns the most recent message sent from other users, _i.e._ not self user

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -473,6 +473,7 @@ class MessageDAOImpl(
         queries.getUnreadMessages(mapper::toPreviewEntity).asFlow().mapToList()
     }
 
+    @Suppress("ComplexMethod")
     private fun contentTypeOf(content: MessageEntityContent): MessageEntity.ContentType = when (content) {
         is MessageEntityContent.Text -> TEXT
         is MessageEntityContent.Asset -> ASSET

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -93,7 +93,7 @@ class MessageDAOImpl(
     }
 
     override suspend fun persistSystemMessageToAllConversations(message: MessageEntity.System) {
-        queries.insertOrIgnoreBullkSystemMessage(
+        queries.insertOrIgnoreBulkSystemMessage(
             id = message.id,
             date = message.date,
             sender_user_id = message.senderUserId,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -121,7 +121,7 @@ sealed class MessageEntity(
     enum class ContentType {
         TEXT, ASSET, KNOCK, MEMBER_CHANGE, MISSED_CALL, RESTRICTED_ASSET,
         CONVERSATION_RENAMED, UNKNOWN, FAILED_DECRYPTION, REMOVED_FROM_TEAM, CRYPTO_SESSION_RESET,
-        NEW_CONVERSATION_RECEIPT_MODE, CONVERSATION_RECEIPT_MODE_CHANGED
+        NEW_CONVERSATION_RECEIPT_MODE, CONVERSATION_RECEIPT_MODE_CHANGED, HISTORY_LOST
     }
 
     enum class MemberChangeType {
@@ -242,6 +242,7 @@ sealed class MessageEntityContent {
     data class TeamMemberRemoved(val userName: String) : System()
     data class NewConversationReceiptMode(val receiptMode: Boolean) : System()
     data class ConversationReceiptModeChanged(val receiptMode: Boolean) : System()
+    object HistoryLost : System()
 }
 
 /**

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -106,6 +106,7 @@ object MessageMapper {
         MessageEntity.ContentType.CRYPTO_SESSION_RESET -> MessagePreviewEntityContent.CryptoSessionReset
         MessageEntity.ContentType.NEW_CONVERSATION_RECEIPT_MODE -> MessagePreviewEntityContent.Unknown
         MessageEntity.ContentType.CONVERSATION_RECEIPT_MODE_CHANGED -> MessagePreviewEntityContent.Unknown
+        MessageEntity.ContentType.HISTORY_LOST -> MessagePreviewEntityContent.Unknown
     }
 
     @Suppress("ComplexMethod", "UNUSED_PARAMETER")
@@ -412,6 +413,7 @@ object MessageMapper {
             MessageEntity.ContentType.CONVERSATION_RECEIPT_MODE_CHANGED -> MessageEntityContent.ConversationReceiptModeChanged(
                 receiptMode = conversationReceiptModeChanged ?: false
             )
+            MessageEntity.ContentType.HISTORY_LOST -> MessageEntityContent.HistoryLost
         }
 
         return createMessageEntity(

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.ConversationDAO
+import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.utils.IgnoreIOS
@@ -1051,6 +1052,105 @@ class MessageDAOTest : BaseDatabaseTest() {
         )
         assertTrue {
             result.first()?.content == MessageEntityContent.ConversationReceiptModeChanged(receiptMode = true)
+        }
+    }
+
+    @Test
+    fun givenOneOnOneConversations_WhenPersistSystemMessageInBulk_ThenPersistedForAllConversations() = runTest {
+        // given
+        val conversationId1 = QualifiedIDEntity("1", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = conversationId1))
+        val conversationId2 = QualifiedIDEntity("2", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = conversationId2))
+
+        val messageId = "systemMessage"
+        userDAO.insertUser(userEntity1)
+
+        // when
+        messageDAO.persistSystemMessageToAllConversations(
+            newSystemMessageEntity(
+                id = messageId,
+                date = "2000-01-01T13:00:00.000Z",
+                conversationId = conversationId1,
+                senderUserId = userEntity1.id,
+                content = MessageEntityContent.HistoryLost
+            )
+        )
+
+        // then
+        val result1 = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = conversationId1)
+        val result2 = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = conversationId2)
+        assertTrue {
+            result1.first()?.content == MessageEntityContent.HistoryLost &&
+            result2.first()?.content == MessageEntityContent.HistoryLost
+        }
+    }
+
+    @Test
+    fun givenMixedTypeOfConversations_WhenPersistSystemMessageInBulk_ThenMessageShouldPersistedOnlyForOneOnOneAndGroups() = runTest {
+        // given
+        val selfConversation = QualifiedIDEntity("selfConversation", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = selfConversation).copy(
+            type = ConversationEntity.Type.SELF
+        ))
+        val oneOnOneConversation = QualifiedIDEntity("oneOnOneConversation", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = oneOnOneConversation).copy(
+            type = ConversationEntity.Type.ONE_ON_ONE
+        ))
+        val groupConversation = QualifiedIDEntity("groupConversation", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = groupConversation).copy(
+            type = ConversationEntity.Type.GROUP
+        ))
+        val connectionPendingConversation = QualifiedIDEntity("connectionPendingConversation", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = connectionPendingConversation).copy(
+            type = ConversationEntity.Type.CONNECTION_PENDING
+        ))
+        val globalTeamConversation = QualifiedIDEntity("globalTeamConversation", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = globalTeamConversation).copy(
+            type = ConversationEntity.Type.GLOBAL_TEAM
+        ))
+
+        val messageId = "systemMessage"
+        userDAO.insertUser(userEntity1)
+
+        // when
+        messageDAO.persistSystemMessageToAllConversations(
+            newSystemMessageEntity(
+                id = messageId,
+                date = "2000-01-01T13:00:00.000Z",
+                conversationId = selfConversation,
+                senderUserId = userEntity1.id,
+                content = MessageEntityContent.HistoryLost
+            )
+        )
+
+        // then
+        val resultForSelfConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = selfConversation)
+        val resultForOneOnOneConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = oneOnOneConversation)
+        val resultForGroupConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = groupConversation)
+        val resultForConnectionPendingConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = connectionPendingConversation)
+        val resultForGlobalTeamConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = globalTeamConversation)
+
+        assertTrue {
+            resultForSelfConversation.firstOrNull() == null &&
+                    resultForOneOnOneConversation.first()?.content == MessageEntityContent.HistoryLost &&
+                    resultForGroupConversation.first()?.content == MessageEntityContent.HistoryLost &&
+                    resultForConnectionPendingConversation.firstOrNull() == null &&
+                    resultForGlobalTeamConversation.firstOrNull() == null
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
After the 404 error in sync, since the would happen if the user stays offline for long time, there is a chance of missing messages and losing history!
We need to inform the user about that by inserting a local system message for all conversations that indicates the history lost probability. 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
