### PR TITLE
fix: migrate asset names and sizes [AR-2939]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MigratedMessage.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MigratedMessage.kt
@@ -10,7 +10,9 @@ data class MigratedMessage(
     val senderClientId: ClientId,
     val timestampIso: String,
     val content: String,
-    val encryptedProto: ByteArray?
+    val encryptedProto: ByteArray?,
+    val assetName: String?,
+    val assetSize: Int?,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MigratedMessage
 import com.wire.kalium.logic.data.message.PlainMessageBlob
 import com.wire.kalium.logic.data.message.ProtoContent
@@ -28,12 +29,23 @@ internal class PersistMigratedMessagesUseCaseImpl(
                 when (proto) {
                     is ProtoContent.ExternalMessageInstructions -> kaliumLogger.w("Ignoring external message")
                     is ProtoContent.Readable -> {
+                        val updatedProto =
+                            if (message.assetSize != null && message.assetName != null && proto.messageContent is MessageContent.Asset) {
+                                proto.copy(
+                                    messageContent = proto.messageContent.copy(
+                                        value = proto.messageContent.value.copy(
+                                            name = message.assetName,
+                                            sizeInBytes = message.assetSize.toLong()
+                                        )
+                                    )
+                                )
+                            } else proto
                         applicationMessageHandler.handleContent(
                             message.conversationId,
                             message.timestampIso,
                             message.senderUserId,
                             message.senderClientId,
-                            proto
+                            updatedProto
                         )
                     }
                 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
@@ -55,7 +55,9 @@ class PersistMigratedMessagesUseCaseTest {
             senderClientId = TestClient.CLIENT_ID,
             "",
             "some_content",
-            genericMessage.encodeToByteArray()
+            genericMessage.encodeToByteArray(),
+            null,
+            null
         )
 
         fun withSuccessfulHandling(): Arrangement {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we migration from the old scala app and have some assets from web to migrate, they are shown as empty in the new android app.

### Causes (Optional)

Sometimes there are two events with the same message id received: first with the metadata (name, size, etc.), second with remote data (key, etc.). Scala app stores the metadata in another table but replaces the whole proto in the Messages table, so when we migrate and take only the proto, we miss these data.

### Solutions

Take name and size from Assets table and include it in the migration message data.

### Testing

#### How to Test

Install scala app, send some assets and update to the AR.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
