### PR TITLE
fix(rc): path enhancement checks for import backup feature (AR-2976)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupConstants.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupConstants.kt
@@ -8,4 +8,10 @@ object BackupConstants {
     const val BACKUP_ENCRYPTED_EXTENSION = "cc20"
     const val BACKUP_DB_EXTENSION = "db"
     const val BACKUP_METADATA_EXTENSION = "json"
+
+    val ACCEPTED_EXTENSIONS = listOf(
+        BACKUP_ENCRYPTED_EXTENSION,
+        BACKUP_DB_EXTENSION,
+        BACKUP_METADATA_EXTENSION
+    )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
@@ -61,7 +61,7 @@ internal class RestoreBackupUseCaseImpl(
 
     override suspend operator fun invoke(backupFilePath: Path, password: String?): RestoreBackupResult =
         withContext(dispatchers.io) {
-            extractCompressedBackup(backupFilePath)
+            extractCompressedBackup(backupFilePath.normalized())
                 .flatMap { extractedBackupRootPath ->
                     runSanityChecks(extractedBackupRootPath, password)
                         .map { (encryptedFilePath, isPasswordProtected) ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/VerifyBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/VerifyBackupUseCase.kt
@@ -23,15 +23,13 @@ internal class VerifyBackupUseCaseImpl(
         checkIfCompressedFileContainsFileTypes(
             compressedBackupFilePath,
             kaliumFileSystem,
-            listOf(
-                BackupConstants.BACKUP_ENCRYPTED_EXTENSION,
-                BackupConstants.BACKUP_DB_EXTENSION,
-                BackupConstants.BACKUP_METADATA_EXTENSION
-            )
+            BackupConstants.ACCEPTED_EXTENSIONS
         ).fold({
             VerifyBackupResult.Failure.Generic(it)
         }, {
             when {
+                it.keys.any { it !in BackupConstants.ACCEPTED_EXTENSIONS } -> VerifyBackupResult.Failure.InvalidBackupFile
+
                 it[BackupConstants.BACKUP_ENCRYPTED_EXTENSION] == true ->
                     VerifyBackupResult.Success.Encrypted
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds additional checks to back up importer feature, so we avoid certain undesired behavior like writing on directories we are not supposed to do so.

### Solutions

- Check and enforce only allowed file extensions
- When unzipping, check for patters that would lead to a write-in other directory level

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
