### PR TITLE
fix: dev - cleaning logs from request headers (AR-2677)

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumHttpLogger.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumHttpLogger.kt
@@ -2,6 +2,7 @@ package com.wire.kalium.network
 
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.network.utils.obfuscatePath
+import com.wire.kalium.network.utils.obfuscateSensitiveHeaderValues
 import com.wire.kalium.network.utils.obfuscatedJsonMessage
 import com.wire.kalium.network.utils.toJsonElement
 import io.ktor.client.plugins.logging.LogLevel
@@ -148,7 +149,7 @@ internal class KaliumHttpLogger(
     }
 
     private fun obfuscatedHeaders(headers: List<Pair<String, List<String>>>): Map<String, String> =
-        headers.associate {
-            it.first to it.second.joinToString(",")
+        headers.associate { (key, values) ->
+            obfuscateSensitiveHeaderValues(key, values)
         }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
@@ -106,6 +106,17 @@ fun deleteSensitiveItemsFromJson(text: String): String {
     }
 }
 
+/**
+ * Helps to obfcuscate sensitive data in json header from the request
+ */
+fun obfuscateSensitiveHeaderValues(headerKey: String, values: List<String>): Pair<String, String> {
+    return if (sensitiveJsonKeys.contains(headerKey.lowercase())) {
+        headerKey to values.joinToString(",") { "***" }
+    } else {
+        headerKey to values.joinToString(",")
+    }
+}
+
 val sensitiveJsonKeys by lazy {
     listOf(
         "password",

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
@@ -107,7 +107,7 @@ fun deleteSensitiveItemsFromJson(text: String): String {
 }
 
 /**
- * Helps to obfcuscate sensitive data in json header from the request
+ * Helps to obfuscate sensitive data in json header from the request
  */
 fun obfuscateSensitiveHeaderValues(headerKey: String, values: List<String>): Pair<String, String> {
     return if (sensitiveJsonKeys.contains(headerKey.lowercase())) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are logging on request the plain headers

### Causes (Optional)

Exposing undesired data to logs

Now logs looks like this on request:

```
REQUEST: {"method":"GET","endpoint":"prod-nginz-ssl.wire.com/awa***?client=eae***","headers":{"Content-Type":"application/json","Accept-Encoding":"gzip,identity","Authorization":"***","Accept":"application/json,message/mls,application/x-protobuf","Accept-Charset":"UTF-8","Upgrade":"websocket","Connection":"upgrade","Sec-WebSocket-Key":"***","Sec-WebSocket-Version":"***"}}
```

### Solutions

Apply obfuscation on request headers using our ["not-allowed" list](https://www.vice.com/en/article/v7dd3d/we-need-to-stop-saying-blacklist-and-whitelist)  =)

#### How to Test

We should not see plain elements logged in REQUEST block, like Authorization, Cookie, etc.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
