### PR TITLE
fix: emit only non empty notifications (RC)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -61,6 +62,7 @@ internal class GetNotificationsUseCaseImpl internal constructor(
                     .map { list -> list.filter { it.messages.isNotEmpty() } }
             }
             .distinctUntilChanged()
+            .filter { it.isNotEmpty() }
             .buffer(capacity = 3) // to cover a case when all 3 flows emits at the same time
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -36,23 +37,26 @@ import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetNotificationsUseCaseTest {
 
     @Test
-    fun givenSyncStateChangedToLive_thenAllNotificationsObserved() = runTest {
+    fun givenSyncStateChangedToLive_thenRepositoriesAreUsedToFetchNotifications() = runTest {
         val syncStatusFlow = MutableSharedFlow<IncrementalSyncStatus>(1)
+        val expectedMessages = listOf(notificationMessageText(), notificationMessageComment())
+        val expectedConversations = listOf(localNotificationConversation(messages = expectedMessages))
         val (arrange, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withIncrementalSyncState(syncStatusFlow)
             .withConnectionList(listOf())
-            .withConversationsForNotifications(listOf())
-            .arrange()
+            .withConversationsForNotifications(flowOf(expectedConversations)).arrange()
 
         getNotifications().test {
             syncStatusFlow.emit(IncrementalSyncStatus.FetchingPendingEvents)
@@ -85,12 +89,13 @@ class GetNotificationsUseCaseTest {
                 .suspendFunction(arrange.ephemeralNotifications::observeEphemeralNotifications)
                 .wasInvoked(atLeast = once)
 
-            awaitItem()
+            val result = awaitItem()
+            assertContentEquals(expectedConversations, result)
         }
     }
 
     @Test
-    fun givenEmptyConversationList_thenEmptyNotificationList() = runTest {
+    fun givenEmptyConversationList_thenNoItemsAreEmitted() = runTest {
         val (_, getNotifications) = Arrangement()
             .withEphemeralNotification(
                 LocalNotificationConversation(
@@ -98,18 +103,16 @@ class GetNotificationsUseCaseTest {
                 )
             )
             .withConnectionList(listOf())
-            .withConversationsForNotifications(listOf())
+            .withConversationsForNotifications(flowOf(listOf()))
             .arrange()
 
         getNotifications().test {
-            val actual1 = awaitItem()
-            assertEquals(0, actual1.size)
-            awaitComplete()
+            expectNoEvents()
         }
     }
 
     @Test
-    fun givenConversationWithEmptyMessageList_thenEmptyNotificationList() = runTest {
+    fun givenConversationWithEmptyMessageList_thenNoItemsAreEmitted() = runTest {
         val (_, getNotifications) = Arrangement()
             .withEphemeralNotification(
                 LocalNotificationConversation(
@@ -117,44 +120,37 @@ class GetNotificationsUseCaseTest {
                 )
             )
             .withConnectionList(listOf())
-            .withConversationsForNotifications(listOf(localNotificationConversation()))
+            .withConversationsForNotifications(flowOf(listOf(localNotificationConversation())))
             .arrange()
 
         getNotifications().test {
-            assertEquals(0, awaitItem().size)
-            awaitComplete()
+            expectNoEvents()
         }
     }
 
     @Test
-    fun givenConversationWithOnlyMyMessageList_thenEmptyNotificationList() = runTest {
+    fun givenConversationWithOnlyMyMessageList_thenNoItemsAreEmitted() = runTest {
         val (_, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(listOf())
-            .withConversationsForNotifications(listOf(localNotificationConversation()))
+            .withConversationsForNotifications(flowOf(listOf(localNotificationConversation(messages = emptyList()))))
             .arrange()
 
         getNotifications().test {
-            val actualToCheck = awaitItem()
-
-            assertEquals(0, actualToCheck.size)
-
-            awaitComplete()
+            expectNoEvents()
         }
     }
 
     @Test
-    fun givenSelfUserWithStatusAway_whenNewMessageCome_thenNoNotificationsAndAllConversationNotificationDateUpdated() = runTest {
+    fun givenSelfUserWithStatusAway_whenNewMessageCome_thenNoNotificationsAreEmitted() = runTest {
         val (_, getNotifications) = Arrangement()
             .withEphemeralNotification()
             .withConnectionList(listOf())
-            .withConversationsForNotifications(listOf(localNotificationConversation()))
+            .withConversationsForNotifications(flowOf(listOf(localNotificationConversation(messages = emptyList()))))
             .arrange()
 
         getNotifications().test {
-            val actualToCheck = awaitItem()
-            assertEquals(0, actualToCheck.size)
-            awaitComplete()
+            expectNoEvents()
         }
     }
 
@@ -162,7 +158,7 @@ class GetNotificationsUseCaseTest {
     fun givenConnectionRequests_thenNotificationListWithConnectionRequestMessage() = runTest {
         val (_, getNotifications) = Arrangement()
             .withConnectionList(listOf(connectionRequest()))
-            .withConversationsForNotifications(null)
+            .withConversationsForNotifications(emptyFlow())
             .withEphemeralNotification()
             .arrange()
 
@@ -177,6 +173,19 @@ class GetNotificationsUseCaseTest {
                 actualToCheck.first { message -> message.messages.any { it is LocalNotificationMessage.ConnectionRequest } }.messages
             )
             awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenNoNewNotifications_thenShouldNotEmitAnything() = runTest {
+        val (_, getNotifications) = Arrangement()
+            .withConnectionList(listOf())
+            .withConversationsForNotifications(emptyFlow())
+            .withEphemeralNotification(null)
+            .arrange()
+
+        getNotifications().test {
+            expectNoEvents()
         }
     }
 
@@ -218,11 +227,11 @@ class GetNotificationsUseCaseTest {
                 .then { flowOf(IncrementalSyncStatus.Live) }
         }
 
-        fun withConversationsForNotifications(list: List<LocalNotificationConversation>?): Arrangement {
+        fun withConversationsForNotifications(list: Flow<List<LocalNotificationConversation>> = emptyFlow()): Arrangement {
             given(messageRepository)
                 .suspendFunction(messageRepository::getNotificationMessage)
                 .whenInvokedWith(any())
-                .thenReturn(list?.let { flowOf(it) } ?: flowOf())
+                .thenReturn(list)
 
             return this
         }
@@ -263,12 +272,13 @@ class GetNotificationsUseCaseTest {
             QualifiedID("conversation_id_${number}_value", "conversation_id_${number}_domain")
 
         private fun localNotificationConversation(
-            number: Int = 0,
+            messages: List<LocalNotificationMessage> = emptyList(),
+            conversationIdSeed: Int = 0,
             isOneOnOne: Boolean = true,
         ) = LocalNotificationConversation(
-            conversationId(number),
-            conversationName = "conversation_$number",
-            messages = emptyList(),
+            conversationId(conversationIdSeed),
+            conversationName = "conversation_$conversationIdSeed",
+            messages = messages,
             isOneToOneConversation = isOneOnOne
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -24,7 +24,6 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We're emitting non-empty notifications unnecessarily.
Clients need to manually check if there's any notification.

Relodaded, for instance, is "marking as notified" without checking if there actually are notifications, causing an infinite loop of notification stream.

### Solutions

As it's a pain in the ass to write tests on Reloaded's `WireNotificationManager`, and as there are no purposes in emitting empty notifications, we might as well not do it from Kalium.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
