### PR TITLE
fix: Revert "fix: cleaning logs from request headers (AR-2977) (#1369)"

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumHttpLogger.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumHttpLogger.kt
@@ -2,7 +2,6 @@ package com.wire.kalium.network
 
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.network.utils.obfuscatePath
-import com.wire.kalium.network.utils.obfuscateSensitiveHeaderValues
 import com.wire.kalium.network.utils.obfuscatedJsonMessage
 import com.wire.kalium.network.utils.toJsonElement
 import io.ktor.client.plugins.logging.LogLevel
@@ -149,7 +148,7 @@ internal class KaliumHttpLogger(
     }
 
     private fun obfuscatedHeaders(headers: List<Pair<String, List<String>>>): Map<String, String> =
-        headers.associate { (key, values) ->
-            obfuscateSensitiveHeaderValues(key, values)
+        headers.associate {
+            it.first to it.second.joinToString(",")
         }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
@@ -106,17 +106,6 @@ fun deleteSensitiveItemsFromJson(text: String): String {
     }
 }
 
-/**
- * Helps to obfcuscate sensitive data in json header from the request
- */
-fun obfuscateSensitiveHeaderValues(headerKey: String, values: List<String>): Pair<String, String> {
-    return if (sensitiveJsonKeys.contains(headerKey.lowercase())) {
-        headerKey to values.joinToString(",") { "***" }
-    } else {
-        headerKey to values.joinToString(",")
-    }
-}
-
 val sensitiveJsonKeys by lazy {
     listOf(
         "password",


### PR DESCRIPTION
This reverts commit 30142ba41e208df6480e7e1ce751d88d107a6d91.


# What's new in this PR?

### Issues

As part of the refactor of logging, this was also covered there, so I'm reverting this back

