### PR TITLE
fix(android): improve performance of instant to ISO string

### DIFF
--- a/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -2,12 +2,11 @@ package com.wire.kalium.util
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.wire.kalium.util.DateTimeUtil.MILLISECONDS_DIGITS
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
 import java.text.SimpleDateFormat
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
@@ -19,9 +18,7 @@ actual open class PlatformDateTimeUtil actual constructor() {
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private val isoDateTimeFormatter = DateTimeFormatter.ofPattern(DateTimeUtil.pattern)
-        .withLocale(Locale.getDefault())
-        .withZone(ZoneId.from(ZoneOffset.UTC))
+    private val isoDateTimeFormatter = DateTimeFormatterBuilder().appendInstant(MILLISECONDS_DIGITS).toFormatter()
 
     /**
      * Parse [kotlinx.datetime.Instant] into date-time string in ISO-8601 format.

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
@@ -25,6 +25,7 @@ expect open class PlatformDateTimeUtil() {
 object DateTimeUtil : PlatformDateTimeUtil() {
     const val pattern: String = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
     const val regex = "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d(([+-]\\d\\d:\\d\\d)|Z)?\$"
+    internal const val MILLISECONDS_DIGITS = 3
 
     /**
      * Calculate the difference between two date-times provided to it

--- a/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilBenchmark.kt
+++ b/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilBenchmark.kt
@@ -1,0 +1,30 @@
+package com.wire.kalium.util
+
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.random.Random
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTime
+
+@Ignore
+class DateTimeUtilBenchmark {
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun instantToIso() = runTest {
+        val numberOfInstants = 1_000_000
+
+        val instants = Array(numberOfInstants) {
+            Instant.fromEpochMilliseconds(Random.nextLong())
+        }
+
+        measureTime {
+            instants.forEach { it.toIsoDateTimeString() }
+        }.also {
+            println("Took $it to convert $numberOfInstants into ISO date time")
+        }
+    }
+}

--- a/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilTest.kt
+++ b/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilTest.kt
@@ -1,9 +1,9 @@
-package com.wire.kalium.logic.util
+package com.wire.kalium.util
 
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.datetime.Instant
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DateTimeUtilTest {
 
@@ -14,43 +14,43 @@ class DateTimeUtilTest {
 
     @Test
     fun givenAValidIsoDateTimeString_whenMatchingRegex_thenShouldSucceed() {
-        assert(regex.matches(isoDateTimeStringWith0Millis))
+        assertTrue(regex.matches(isoDateTimeStringWith0Millis))
     }
 
     @Test
     fun givenAnInvalidIsoDateTimeString_whenMatchingRegex_thenShouldSucceed() {
-        assert(!regex.matches("2022-12-20T17:30:00Z"))
-        assert(!regex.matches("2022-12-20T17:30:00.AZ"))
-        assert(!regex.matches("2022/12/20T17:30:00.000Z"))
-        assert(!regex.matches("2022-12-2017:30:00.000Z"))
-        assert(!regex.matches("2022-12-20T7:30:00Z"))
+        assertTrue(!regex.matches("2022-12-20T17:30:00Z"))
+        assertTrue(!regex.matches("2022-12-20T17:30:00.AZ"))
+        assertTrue(!regex.matches("2022/12/20T17:30:00.000Z"))
+        assertTrue(!regex.matches("2022-12-2017:30:00.000Z"))
+        assertTrue(!regex.matches("2022-12-20T7:30:00Z"))
     }
 
     @Test
     fun givenAnInstantWithMillisEqualTo0_whenParsingToIsoString_thenMillisShouldNotBeIgnored() {
         val instant = Instant.fromEpochMilliseconds(epochMillis)
         val result = DateTimeUtil.fromInstantToIsoDateTimeString(instant)
-        assert(regex.matches(result))
+        assertTrue(regex.matches(result))
     }
 
     @Test
     fun givenAnIsoDateTimeStringMillisEqualTo0_whenParsingToInstantAndBackToIsoString_thenMillisShouldNotBeIgnored() {
         val instant = Instant.parse(isoDateTimeStringWith0Millis)
         val result = DateTimeUtil.fromInstantToIsoDateTimeString(instant)
-        assert(regex.matches(result))
+        assertTrue(regex.matches(result))
     }
 
     @Test
     fun givenAnIsoDateTimeStringMillisEqualTo0_whenParsingToEpochMillisAndBackToIsoString_thenMillisShouldNotBeIgnored() {
         val epochMillis = DateTimeUtil.fromIsoDateTimeStringToEpochMillis(isoDateTimeStringWith0Millis)
         val result = DateTimeUtil.fromEpochMillisToIsoDateTimeString(epochMillis)
-        assert(regex.matches(result))
+        assertTrue(regex.matches(result))
     }
 
     @Test
     fun givenAnIsoDateTimeStringMillisEqualTo0_whenSubtractingMillis_thenMillisShouldNotBeIgnored() {
         val result = DateTimeUtil.minusMilliseconds(isoDateTimeStringWith0Millis, 1000)
-        assert(regex.matches(result))
+        assertTrue(regex.matches(result))
     }
 
     @Test
@@ -63,7 +63,7 @@ class DateTimeUtilTest {
     @Test
     fun whenGettingCurrentIsoDateTimeString_thenMillisShouldNotBeIgnored() {
         val result = DateTimeUtil.currentIsoDateTimeString()
-        assert(regex.matches(result))
+        assertTrue(regex.matches(result))
     }
 
     @Test

--- a/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilTest.kt
+++ b/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilTest.kt
@@ -1,10 +1,14 @@
 package com.wire.kalium.util
 
+import com.wire.kalium.util.string.IgnoreIOS
+import com.wire.kalium.util.string.IgnoreJS
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@IgnoreIOS
+@IgnoreJS
 class DateTimeUtilTest {
 
     private val isoDateTimeStringWith0Millis = "2022-12-20T17:30:00.000Z"

--- a/util/src/jvmMain/kotlin/com/wire/kalium/util/PlatformDateTimeUtil.kt
+++ b/util/src/jvmMain/kotlin/com/wire/kalium/util/PlatformDateTimeUtil.kt
@@ -1,16 +1,12 @@
 package com.wire.kalium.util
 
+import com.wire.kalium.util.DateTimeUtil.MILLISECONDS_DIGITS
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
-import java.util.Locale
+import java.time.format.DateTimeFormatterBuilder
 
 actual open class PlatformDateTimeUtil actual constructor() {
-    private val isoDateTimeFormatter = DateTimeFormatter.ofPattern(DateTimeUtil.pattern)
-        .withLocale(Locale.getDefault())
-        .withZone(ZoneId.from(ZoneOffset.UTC))
+    private val isoDateTimeFormatter = DateTimeFormatterBuilder().appendInstant(MILLISECONDS_DIGITS).toFormatter()
 
     /**
      * Parse [kotlinx.datetime.Instant] into date-time string in ISO-8601 format.


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Converting Instant to ISO 8601 string is not performant on Android at the moment.

### Causes

Whilst I can't exactly pinpoint to the exact cause, I didn't observe the same under-performance on JVM. Maybe the way Android implemented this API is different from regular JVMs.

### Solutions

Replace the date/time format with a default `DateFormatterBuilder` with a `appendInstant(int fractionalDigits)`, passing `3` to make sure it always adds 3 digits to the milliseconds.

See the benchmark below.

#### Also

Moved `DateUtilsTest` stuff to `utils` package.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

I've added a benchmark for the future.

Running this benchmark, that transforms _one million_ random instants into ISO date time string:

##### Current implementation, using DateTimeFormatter
- 9.215483600s
- 8.698548s
- 8.898969300s
- 8.793911400s
- 9.084778500s

##### Doing Instant.toString()
- 855.682ms
- 904.086400ms
- 1.109003500s
- 1.080615400s
- 849.341700ms

##### Using DateTimeFormatter.appendInstant(3) to keep milliseconds
- 1.275490s
- 1.054792100s
- 1.021491900s
- 984.369100ms
- 1.196082400s

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
