### PR TITLE
fix: disable read receipts

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -13,7 +13,6 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.SendConfirmationUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
-import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Instant

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -40,9 +40,10 @@ class UpdateConversationReadDateUseCase internal constructor(
             // TODO: Disabled for now as we are still figuring out performance and STORAGE_ERROR issues.
             // sendConfirmation(conversationId)
             conversationRepository.updateConversationReadDate(conversationId, time.toIsoDateTimeString())
-            selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
-                sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
-            }
+            // TODO: Also disable sending of conversation last read as we only want to keep it local.
+            // selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
+            //    sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
+            // }
         }
         return
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -37,7 +37,8 @@ class UpdateConversationReadDateUseCase internal constructor(
      */
     suspend operator fun invoke(conversationId: QualifiedID, time: Instant) {
         selfConversationIdProvider().flatMap { selfConversationIds ->
-            sendConfirmation(conversationId)
+            // TODO: Disabled for now as we are still figuring out performance and STORAGE_ERROR issues.
+            // sendConfirmation(conversationId)
             conversationRepository.updateConversationReadDate(conversationId, time.toIsoDateTimeString())
             selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
                 sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sending read receipt confirmation for messages are very slow.

### Causes (Optional)

Probably due to current performance issues and `STORAGE_ERROR` issue, although with upcoming improvements this issue won't be happening.

### Solutions

Disable for now until we find solutions.