### PR TITLE
chore: enable sqlite wal journaling (RC)

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
             android:label="@string/app_name"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
-            android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
+            android:theme="@style/Theme.AppCompat.Light.DarkActionBar"
+            tools:replace="android:allowBackup,android:supportsRtl">
 
         <activity
                 android:name=".presentation.MainActivity" android:exported="true">

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ android-test-rules = "1.4.0"
 android-test-core = "1.4.0"
 androidx-arch = "2.1.0"
 androidx-test-orchestrator = "1.4.2"
-androidx-sqlite = "2.0.1"
+androidx-sqlite = "2.3.0"
 benasher-uuid = "0.6.0"
 ktx-datetime = { strictly = "0.4.0" }
 ktx-serialization = "1.4.1"
@@ -29,7 +29,7 @@ ktx-atomicfu = "0.18.5"
 multiplatform-settings = "1.0.0-RC"
 android-security = "1.1.0-alpha03"
 sqldelight = "2.0.0-alpha04"
-sqlcipher-android = "4.5.2"
+sqlcipher-android = "4.5.3"
 pbandk = "0.14.2"
 turbine = "0.12.1"
 avs = "9.0.8"
@@ -132,8 +132,8 @@ okio-core = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-test = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 
 # sql dependencies
-sqlite-androidx = { module = "androidx.sqlite:sqlite", version.ref = "androidx-sqlite"}
-sql-android-cipher = { module = "net.zetetic:android-database-sqlcipher", version.ref = "sqlcipher-android"}
+sqlite-androidx = { module = "androidx.sqlite:sqlite", version.ref = "androidx-sqlite" }
+sql-android-cipher = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher-android" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqldelight-coroutinesExtension = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-androidDriver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -15,7 +15,7 @@ import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
 import com.wire.kalium.persistence.util.FileNameUtil
 import com.wire.kalium.util.KaliumDispatcherImpl
-import net.sqlcipher.database.SupportFactory
+import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 import kotlin.coroutines.CoroutineContext
 
 // TODO(refactor): Unify creation just like it's done for UserDataBase
@@ -30,18 +30,21 @@ actual class GlobalDatabaseProvider(
     private val database: GlobalDatabase
 
     init {
+        val schema = GlobalDatabase.Schema
         driver = if (encrypt) {
+            System.loadLibrary("sqlcipher")
             AndroidSqliteDriver(
-                schema = GlobalDatabase.Schema,
+                schema = schema,
                 context = context,
                 name = dbName,
-                factory = SupportFactory(passphrase.value)
+                factory = SupportOpenHelperFactory(passphrase.value, null, true)
             )
         } else {
             AndroidSqliteDriver(
-                schema = GlobalDatabase.Schema,
+                schema = schema,
                 context = context,
-                name = dbName
+                name = dbName,
+                callback = SqliteCallback(schema)
             )
         }
 

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/SqliteCallback.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/SqliteCallback.kt
@@ -1,0 +1,23 @@
+package com.wire.kalium.persistence.db
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+
+internal class SqliteCallback(schema: SqlSchema) : SupportSQLiteOpenHelper.Callback(schema.version) {
+    private val baseCallback = AndroidSqliteDriver.Callback(schema)
+    override fun onCreate(db: SupportSQLiteDatabase) = baseCallback.onCreate(db)
+
+    override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) =
+        baseCallback.onUpgrade(
+            db,
+            oldVersion,
+            newVersion
+        )
+
+    override fun onConfigure(db: SupportSQLiteDatabase) {
+        super.onConfigure(db)
+        db.enableWriteAheadLogging()
+    }
+}

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -8,7 +8,7 @@ import com.wire.kalium.persistence.UserDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.util.FileNameUtil
 import kotlinx.coroutines.CoroutineDispatcher
-import net.sqlcipher.database.SupportFactory
+import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 
 sealed interface DatabaseCredentials {
     data class Passphrase(val value: UserDBSecret) : DatabaseCredentials
@@ -35,17 +35,19 @@ fun userDatabaseBuilder(
     val dbName = FileNameUtil.userDBName(userId)
 
     val driver: AndroidSqliteDriver = if (encrypt) {
+        System.loadLibrary("sqlcipher")
         AndroidSqliteDriver(
             schema = UserDatabase.Schema,
             context = context,
             name = dbName,
-            factory = SupportFactory(passphrase.value)
+            factory = SupportOpenHelperFactory(passphrase.value, null, true)
         )
     } else {
         AndroidSqliteDriver(
             schema = UserDatabase.Schema,
             context = context,
-            name = dbName
+            name = dbName,
+            callback = SqliteCallback(UserDatabase.Schema)
         )
     }
     val credentials = if (encrypt) {
@@ -66,11 +68,15 @@ fun inMemoryDatabase(
         schema = UserDatabase.Schema,
         context = context,
         name = null,
-        factory = SupportFactory(passphrase)
+        factory = SupportOpenHelperFactory(passphrase)
     )
     return UserDatabaseBuilder(
-        userId, driver, dispatcher, PlatformDatabaseData(
-            context, DatabaseCredentials.Passphrase(
+        userId = userId,
+        sqlDriver = driver,
+        dispatcher = dispatcher,
+        platformDatabaseData = PlatformDatabaseData(
+            context = context,
+            databaseCredentials = DatabaseCredentials.Passphrase(
                 UserDBSecret(passphrase)
             )
         )

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -64,6 +64,7 @@ fun inMemoryDatabase(
     dispatcher: CoroutineDispatcher
 ): UserDatabaseBuilder {
     val passphrase = "testPass".toByteArray()
+    System.loadLibrary("sqlcipher")
     val driver = AndroidSqliteDriver(
         schema = UserDatabase.Schema,
         context = context,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOBenchmarkTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOBenchmarkTest.kt
@@ -3,13 +3,16 @@ package com.wire.kalium.persistence.dao.message
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.persistence.dao.UserDAO
-import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.utils.stubs.newConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.random.Random
+import kotlin.random.nextInt
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -37,9 +40,9 @@ class MessageDAOBenchmarkTest : BaseDatabaseTest() {
         userDAO = db.userDAO
     }
 
-    @OptIn(ExperimentalTime::class)
+    @OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
     @Test
-    fun insertTextMessages() = runTest {
+    fun insertRandomMessages() = runTest {
         setupData()
         val count = MESSAGE_COUNT
         val messagesToInsert = generateRandomMessages(count)
@@ -47,15 +50,14 @@ class MessageDAOBenchmarkTest : BaseDatabaseTest() {
             messageDAO.insertOrIgnoreMessages(messagesToInsert)
         }
 
-        println("Took $duration to insert $count text messages")
+        println("Took $duration to insert $count random messages")
     }
 
-    @Suppress("LongMethod")
     private fun generateRandomMessages(count: Int): List<MessageEntity> {
         val conversations = listOf(conversationEntity1)
         val users = listOf(userEntity1, userEntity2)
         return buildList {
-            repeat(count / 4) {
+            repeat(count) {
                 add(
                     MessageEntity.Regular(
                         id = it.toString(),
@@ -64,71 +66,7 @@ class MessageDAOBenchmarkTest : BaseDatabaseTest() {
                         senderUserId = users.random().id,
                         status = MessageEntity.Status.values().random(),
                         visibility = MessageEntity.Visibility.values().random(),
-                        content = MessageEntityContent.Text("Text content for message $it"),
-                        senderClientId = Random.nextLong(2_000).toString(),
-                        editStatus = MessageEntity.EditStatus.NotEdited,
-                        senderName = "senderName"
-                    )
-                )
-
-                add(
-                    MessageEntity.System(
-                        id = it.toString(),
-                        conversationId = conversations.random().id,
-                        date = Instant.fromEpochSeconds(it.toLong()),
-                        senderUserId = users.random().id,
-                        status = MessageEntity.Status.values().random(),
-                        visibility = MessageEntity.Visibility.values().random(),
-                        content = MessageEntityContent.MemberChange(
-                            listOf(UserIDEntity("value", "domain")),
-                            MessageEntity.MemberChangeType.REMOVED
-                        ),
-                        senderName = "senderName"
-                    )
-                )
-
-                add(
-                    MessageEntity.Regular(
-                        id = it.toString(),
-                        conversationId = conversations.random().id,
-                        date = Instant.fromEpochSeconds(it.toLong()),
-                        senderUserId = users.random().id,
-                        status = MessageEntity.Status.values().random(),
-                        visibility = MessageEntity.Visibility.values().random(),
-                        content = MessageEntityContent.Asset(
-                            1000,
-                            assetName = "test name",
-                            assetMimeType = "MP4",
-                            assetDownloadStatus = null,
-                            assetOtrKey = byteArrayOf(1),
-                            assetSha256Key = byteArrayOf(1),
-                            assetId = "assetId",
-                            assetToken = "",
-                            assetDomain = "domain",
-                            assetEncryptionAlgorithm = "",
-                            assetWidth = 111,
-                            assetHeight = 111,
-                            assetDurationMs = 10,
-                            assetNormalizedLoudness = byteArrayOf(1),
-                        ),
-                        senderClientId = Random.nextLong(2_000).toString(),
-                        editStatus = MessageEntity.EditStatus.NotEdited,
-                        senderName = "senderName"
-                    )
-                )
-
-                add(
-                    MessageEntity.Regular(
-                        id = it.toString(),
-                        conversationId = conversations.random().id,
-                        date = Instant.fromEpochSeconds(it.toLong()),
-                        senderUserId = users.random().id,
-                        status = MessageEntity.Status.values().random(),
-                        visibility = MessageEntity.Visibility.values().random(),
-                        content = MessageEntityContent.Unknown(
-                            typeName = null,
-                            Random.nextBytes(100000)
-                        ),
+                        content = generateRandomMessageContent(),
                         senderClientId = Random.nextLong(2_000).toString(),
                         editStatus = MessageEntity.EditStatus.NotEdited,
                         senderName = "senderName"
@@ -138,24 +76,80 @@ class MessageDAOBenchmarkTest : BaseDatabaseTest() {
         }
     }
 
-    @OptIn(ExperimentalTime::class)
+    private fun generateRandomMessageContent() = when (Random.nextInt(0..3)) {
+        0 -> MessageEntityContent.Unknown(typeName = null, Random.nextBytes(1000))
+        1 -> MessageEntityContent.Text(Random.nextBytes(100).toString())
+        2 -> MessageEntityContent.Asset(
+            1000,
+            assetName = "test name",
+            assetMimeType = "MP4",
+            assetDownloadStatus = null,
+            assetOtrKey = byteArrayOf(1),
+            assetSha256Key = byteArrayOf(1),
+            assetId = "assetId",
+            assetToken = "",
+            assetDomain = "domain",
+            assetEncryptionAlgorithm = "",
+            assetWidth = 111,
+            assetHeight = 111,
+            assetDurationMs = 10,
+            assetNormalizedLoudness = byteArrayOf(1),
+        )
+
+        else -> MessageEntityContent.Knock(Random.nextBoolean())
+    }
+
+    @OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
     @Test
-    fun queryTextMessagesNormal() = runTest {
+    fun queryIncreasinglyBiggerAmountByConversationAndVisibility() = runTest {
         setupData()
-        val totalMessageCount = MESSAGE_COUNT
-        val messagesToInsert = generateRandomMessages(totalMessageCount)
-        messageDAO.insertOrIgnoreMessages(messagesToInsert)
-        repeat(4) {
+        var totalMessageCount = MESSAGE_COUNT
+        repeat(3) { count ->
+            val messagesToInsert = generateRandomMessages(totalMessageCount)
+            messageDAO.insertOrIgnoreMessages(messagesToInsert)
             measureTime {
                 messageDAO.getMessagesByConversationAndVisibility(
                     conversationEntity1.id,
                     totalMessageCount,
                     0,
-                    MessageEntity.Visibility.values().toList()
+                    listOf(MessageEntity.Visibility.VISIBLE)
                 ).first()
             }.also {
-                println("Took $it to query $totalMessageCount messages")
+                println("Took $it to query visible messages from a single conversation, with $totalMessageCount random messages inserted")
             }
+            totalMessageCount += MESSAGE_COUNT
+        }
+    }
+
+    @OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
+    @Test
+    fun concurrentInsertAndQuery() = runTest {
+        setupData()
+        val totalMessageCount = MESSAGE_COUNT
+        val pageSize = 50
+        val messagesToInsert = generateRandomMessages(totalMessageCount)
+        measureTime {
+            val insertingJob = launch(KaliumDispatcherImpl.io) {
+                messagesToInsert.forEach { messageEntity ->
+                    messageDAO.insertOrIgnoreMessage(messageEntity)
+                }
+            }
+            launch(KaliumDispatcherImpl.io) {
+                while (insertingJob.isActive) {
+                    messageDAO.getMessagesByConversationAndVisibility(
+                        conversationId = conversationEntity1.id,
+                        limit = pageSize,
+                        offset = 0,
+                        visibility = listOf(MessageEntity.Visibility.VISIBLE)
+                    ).first()
+                }
+            }.join()
+        }.also {
+            println(
+                """
+                Took $it to insert $totalMessageCount random messages while a worker was constantly querying the database.
+                """.trimIndent()
+            )
         }
     }
 
@@ -166,6 +160,6 @@ class MessageDAOBenchmarkTest : BaseDatabaseTest() {
     }
 
     private companion object {
-        const val MESSAGE_COUNT = 1000
+        const val MESSAGE_COUNT = 1_000
     }
 }

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -37,7 +37,10 @@ fun userDatabaseBuilder(
 
 private fun sqlDriver(driverUri: String): SqlDriver = JdbcSqliteDriver(
     driverUri,
-    Properties(1).apply { put("foreign_keys", "true") }
+    Properties(1).apply {
+        put("foreign_keys", "true")
+        put("journal_mode", "wal")
+    }
 )
 
 fun inMemoryDatabase(userId: UserIDEntity, dispatcher: CoroutineDispatcher): UserDatabaseBuilder {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Reloaded spends too much time locking/unlocking the Datbase.

### Causes

In an app as complex as Reloaded, it's expected that we perform multiple read and write operations during long periods of time, especially when processing events.

However, the current SQLCipher build we're using is not great when it comes to optimise locks and unlocks, as explained [here](https://www.zetetic.net/blog/2022/05/11/sqlcipher-android-refresh/).

### Solutions

- Use the new SQLCipher "refresh"
- Enable [WAL Journal Mode](https://www.sqlite.org/wal.html) for the database.
- Pass `journal_mode=wal` to JVM's SQLite Driver.

> **Warning**: Small breaking change on Android. Some internal library has `allowBackup:true` and `supportsRtl:true` on their manifest, so we need to add `tools:replace="android:allowBackup,android:supportsRtl"` to Reloaded's `AndroidManifest.xml`

### Benchmark

Running on an **Android Emulator**:

#### Inserting 5k messages, each message in its own transaction

| Old SQLCipher | New SQLCipher & WAL |
|---------------|---------------------|
| 25.091472500s | 10.675776300s       |


#### Inserting 5_000 random messages, each message in its own transaction, while another thread is constantly querying the last 50 messages

| Old SQLCipher | New SQLCipher & WAL |
|---------------|---------------------|
| 30.714321900s | 14.509833300s       |

Same test, but on JVM (both without SQLCipher)

| WAL OFF       | WAL ON       |
|---------------|--------------|
| 15.552227300s | 5.173206700s | 

It's a huge difference.


### Testing

#### Test Coverage

A new benchmark for concurrent DB read/write.

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
