### PR TITLE
ci: run jobs only if detekt succeeds

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,8 +1,6 @@
 name: "Check Codestyle"
 
-on:
-  pull_request:
-    types: [ opened, synchronize ] # Don't rerun on `edited` to save time
+on: [workflow_call]
 
 jobs:
   static-code-analysis:

--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -9,7 +9,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    detekt:
+        uses: ./.github/workflows/codestyle.yml
     gradle-run-tests:
+        needs: [detekt]
         runs-on: buildjet-4vcpu-ubuntu-2204
         strategy:
             matrix:

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -9,7 +9,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+  detekt:
+      uses: ./.github/workflows/codestyle.yml
   gradle-run-tests:
+    needs: [detekt]
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -12,7 +12,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+  detekt:
+      uses: ./.github/workflows/codestyle.yml
   gradle-run-tests:
+    needs: [detekt]
     runs-on: ubuntu-22.04
     # TODO: When migrating away from Cryptobox, use a regular Ubuntu machine with JDK 17 and caching
     container: wirebot/cryptobox:1.1.1


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Test run wether or not there are problems in with code style picked up by Detekt. This is wasteful since the we'll need to run the test again once Detekt succeeds. Runners are occupied for nothing. 

### Solutions

Change the test jobs to depends on the successful run of Detekt.

#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
