### PR TITLE
fix: repeating notification (RC) (AR-2978)

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -78,11 +78,9 @@ UPDATE Conversation
 SET last_notified_date = ?
 WHERE qualified_id = ?;
 
-updateAllUnNotifiedConversationsNotificationsDate:
+updateAllNotifiedConversationsNotificationsDate:
 UPDATE Conversation
-SET last_notified_date = ?
-WHERE last_notified_date ISNULL
-OR last_modified_date > last_notified_date;
+SET last_notified_date = ?;
 
 updateConversationModifiedDate:
 UPDATE Conversation

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -272,7 +272,7 @@ class ConversationDAOImpl(
     }
 
     override suspend fun updateAllConversationsNotificationDate(date: Instant) = withContext(coroutineContext) {
-        conversationQueries.updateAllUnNotifiedConversationsNotificationsDate(date)
+        conversationQueries.updateAllNotifiedConversationsNotificationsDate(date)
     }
 
     override suspend fun getAllConversations(): Flow<List<ConversationViewEntity>> {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -981,7 +981,6 @@ class ConversationDAOTest : BaseDatabaseTest() {
         )
     }
 
-
     private companion object {
         const val teamId = "teamId"
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -892,6 +892,29 @@ class ConversationDAOTest : BaseDatabaseTest() {
         assertEquals(conversationEntity1.protocolInfo, result)
     }
 
+    @Test
+    fun givenConversations_whenUpdatingAllNotificationDates_thenAllConversationsAreUpdated() = runTest {
+        conversationDAO.insertConversation(
+            conversationEntity1.copy(
+                lastNotificationDate = Instant.DISTANT_FUTURE,
+                lastModifiedDate = Instant.fromEpochSeconds(0)
+            )
+        )
+        conversationDAO.insertConversation(
+            conversationEntity2.copy(
+                lastNotificationDate = null,
+                lastModifiedDate = Instant.DISTANT_FUTURE
+            )
+        )
+        val instant = Clock.System.now()
+
+        conversationDAO.updateAllConversationsNotificationDate(instant)
+
+        conversationDAO.getAllConversations().first().forEach {
+            assertEquals(instant.toEpochMilliseconds(), it.lastNotificationDate!!.toEpochMilliseconds())
+        }
+    }
+
     private suspend fun insertTeamUserAndMember(team: TeamEntity, user: UserEntity, conversationId: QualifiedIDEntity) {
         teamDAO.insertTeam(team)
         userDAO.insertUser(user)
@@ -957,6 +980,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             receiptMode = ConversationEntity.ReceiptMode.DISABLED
         )
     }
+
 
     private companion object {
         const val teamId = "teamId"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

I've noticed some notifications showing up again after I dismiss them.

### Causes

1. The `ConversationDAO` function `updateAllConversationsNotificationDate` is calling the `updateAllUnNotifiedConversationsNotificationsDate`; The DAO function doesn't do what it claims to do.
2. This function only updates if the modification date of the function is newer than the notification date.
3. We consider the `conversation.creationDate` as the value to update the modification date of a converstion. However, this is a value our local device clock can alter, so there's the possibility we mark as notified and our own client modifies the conversation to a `modifiedDate` that is smaller than the `notifiedDate`.

### Solutions

Make sure that `ConversationDAO.updateAllConversationsNotificationDate` actually does what its name suggest, and update the notification date for all conversations.

The only usage of this function is when `MarkMessagesAsNotifiedUseCase` is called for `AllConversations`. I don't see any benefit in not updating that value for all conversations. WYSIWYG

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
