### PR TITLE
feat: get fingerprint of client devices on testservice (SQPIT-1591)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
@@ -10,6 +10,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapCryptoRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -24,7 +25,7 @@ interface PreKeyRepository {
 
     suspend fun generateNewPreKeys(firstKeyId: Int, keysCount: Int): Either<CoreFailure, List<PreKeyCrypto>>
     suspend fun generateNewLastKey(): Either<ProteusFailure, PreKeyCrypto>
-    suspend fun getLocalFingerprint(): Either<ProteusFailure, ByteArray>
+    suspend fun getLocalFingerprint(): Either<CoreFailure, ByteArray>
     suspend fun lastPreKeyId(): Either<StorageFailure, Int>
     suspend fun updateOTRLastPreKeyId(newId: Int): Either<StorageFailure, Unit>
     suspend fun forceInsertPrekeyId(newId: Int): Either<StorageFailure, Unit>
@@ -53,9 +54,11 @@ class PreKeyDataSource(
             proteusClientProvider.getOrCreate().newLastPreKey()
         }
 
-    override suspend fun getLocalFingerprint(): Either<ProteusFailure, ByteArray> =
-        wrapCryptoRequest {
-            proteusClientProvider.getOrCreate().getLocalFingerprint()
+    override suspend fun getLocalFingerprint(): Either<CoreFailure, ByteArray> =
+        proteusClientProvider.getOrError().flatMap { proteusClient ->
+                wrapCryptoRequest {
+                    proteusClient.getLocalFingerprint()
+                }
         }
 
     override suspend fun lastPreKeyId(): Either<StorageFailure, Int> = wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
@@ -24,6 +24,7 @@ interface PreKeyRepository {
 
     suspend fun generateNewPreKeys(firstKeyId: Int, keysCount: Int): Either<CoreFailure, List<PreKeyCrypto>>
     suspend fun generateNewLastKey(): Either<ProteusFailure, PreKeyCrypto>
+    suspend fun getLocalFingerprint(): Either<ProteusFailure, ByteArray>
     suspend fun lastPreKeyId(): Either<StorageFailure, Int>
     suspend fun updateOTRLastPreKeyId(newId: Int): Either<StorageFailure, Unit>
     suspend fun forceInsertPrekeyId(newId: Int): Either<StorageFailure, Unit>
@@ -50,6 +51,11 @@ class PreKeyDataSource(
     override suspend fun generateNewLastKey(): Either<ProteusFailure, PreKeyCrypto> =
         wrapCryptoRequest {
             proteusClientProvider.getOrCreate().newLastPreKey()
+        }
+
+    override suspend fun getLocalFingerprint(): Either<ProteusFailure, ByteArray> =
+        wrapCryptoRequest {
+            proteusClientProvider.getOrCreate().getLocalFingerprint()
         }
 
     override suspend fun lastPreKeyId(): Either<StorageFailure, Int> = wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -85,6 +85,9 @@ class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
     val clearClientData: ClearClientDataUseCase
         get() = ClearClientDataUseCaseImpl(mlsClientProvider, proteusClientProvider)
 
+    val getProteusFingerprint: GetProteusFingerprintUseCase
+        get() = GetProteusFingerprintUseCaseImpl(preKeyRepository)
+
     private val verifyExistingClientUseCase: VerifyExistingClientUseCase
         get() = VerifyExistingClientUseCaseImpl(clientRepository)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetProteusFingerprintUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetProteusFingerprintUseCase.kt
@@ -1,0 +1,30 @@
+package com.wire.kalium.logic.feature.client
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.prekey.PreKeyRepository
+import com.wire.kalium.logic.functional.fold
+
+/**
+ * Use case to get fingerprint of current user client (device). Only applies to proteus devices.
+ */
+interface GetProteusFingerprintUseCase {
+    suspend operator fun invoke(): GetProteusFingerprintResult
+}
+
+class GetProteusFingerprintUseCaseImpl internal constructor(
+    private val preKeyRepository: PreKeyRepository
+) : GetProteusFingerprintUseCase {
+    override suspend fun invoke(): GetProteusFingerprintResult {
+        return preKeyRepository.getLocalFingerprint().fold({
+            GetProteusFingerprintResult.Failure(it)
+        }, {
+            GetProteusFingerprintResult.Success(it.decodeToString())
+        })
+    }
+}
+
+sealed class GetProteusFingerprintResult {
+    data class Success(val fingerprint: String) : GetProteusFingerprintResult()
+
+    data class Failure(val genericFailure: CoreFailure) : GetProteusFingerprintResult()
+}

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/TestserviceApplication.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/TestserviceApplication.kt
@@ -58,7 +58,7 @@ class TestserviceApplication : Application<TestserviceConfiguration>() {
         )
 
         // resources
-        val clientResources = ClientResources()
+        val clientResources = ClientResources(instanceService)
         val conversationResources = ConversationResources(instanceService)
         val instanceLifecycle = InstanceLifecycle(instanceService, configuration)
         val logResources = LogResources(configuration)

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -1,20 +1,30 @@
 package com.wire.kalium.testservice.api.v1
 
+import com.wire.kalium.testservice.managed.InstanceService
 import com.wire.kalium.testservice.models.Instance
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.slf4j.LoggerFactory
+import javax.ws.rs.GET
 import javax.ws.rs.POST
 import javax.ws.rs.Path
 import javax.ws.rs.PathParam
 import javax.ws.rs.Produces
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
 
 @Path("/api/v1")
 @Produces(MediaType.APPLICATION_JSON)
-class ClientResources {
+class ClientResources(private val instanceService: InstanceService) {
 
-    // Set a user's availability.
+    private val log = LoggerFactory.getLogger(ClientResources::class.java.name)
+
     @POST
     @Path("/instance/{id}/availability")
+    @Operation(summary = "Set a user's availability")
     fun availability(@PathParam("id") id: String): Instance {
         throw WebApplicationException("Instance $id: Not yet implemented")
     }
@@ -22,8 +32,27 @@ class ClientResources {
     // GET /api/v1/instance/{instanceId}/clients
     // Get all clients of an instance.
 
-    // GET /api/v1/instance/{instanceId}/fingerprint
-    // Get the fingerprint from the instance's client.
+    @GET
+    @Path("/instance/{id}/fingerprint")
+    @Operation(summary = "Get the fingerprint from the instance's client")
+    @ApiResponse(
+        responseCode = "200",
+        content = [
+            Content(
+                mediaType = "application/json",
+                examples = [
+                    ExampleObject(
+                        value = "{ \"fingerprint\": \"0faf901703e040ee\","
+                                + "\"id\": \"1a3d8b57-ef71-4d0e-b046-ce6f4cb825c2\" }"
+                    )
+                ]
+            )
+        ]
+    )
+    fun fingerprint(@PathParam("id") id: String): Response {
+        instanceService.getInstance(id) ?: throw WebApplicationException("No instance found with id $id")
+        return instanceService.getFingerprint(id)
+    }
 
     // POST /api/v1/instance/{instanceId}/breakSession
     // Break a session to a specific device of a remote user (on purpose).

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -42,7 +42,8 @@ class ClientResources(private val instanceService: InstanceService) {
                 mediaType = "application/json",
                 examples = [
                     ExampleObject(
-                        value = "{ \"fingerprint\": \"0faf901703e040ee\","
+                        value = "{ \"fingerprint\": "
+                                +"\"5badc6060241ce1000eba81f09cd42cfc3b5d6a951870f22bc5b9a5acc5b14af\","
                                 + "\"id\": \"1a3d8b57-ef71-4d0e-b046-ce6f4cb825c2\" }"
                     )
                 ]

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -43,7 +43,7 @@ class ClientResources(private val instanceService: InstanceService) {
                 examples = [
                     ExampleObject(
                         value = "{ \"fingerprint\": "
-                                +"\"5badc6060241ce1000eba81f09cd42cfc3b5d6a951870f22bc5b9a5acc5b14af\","
+                                + "\"5badc6060241ce1000eba81f09cd42cfc3b5d6a951870f22bc5b9a5acc5b14af\","
                                 + "\"id\": \"1a3d8b57-ef71-4d0e-b046-ce6f4cb825c2\" }"
                     )
                 ]

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/FingerprintResponse.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/FingerprintResponse.kt
@@ -1,0 +1,6 @@
+package com.wire.kalium.testservice.models
+
+data class FingerprintResponse(
+    val fingerprint: String = "",
+    val instanceId: String = ""
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR implements a new endpoint (`/instance/{instanceid}/fingerprint`) on kalium testservice which returns the fingerprint of a device if it is using proteus encryption. This way the end to end tests of QA can check if the fingerprint shown in the UI actually match the fingerprint of the device. 

### Testing

Tested by running the tests which used the same behavior with ETS.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
