### PR TITLE
feat: enable simplified message counter (RC)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -314,10 +314,8 @@ internal class ConversationDataSource internal constructor(
             messageDAO.observeLastMessages(),
             messageDAO.observeUnreadMessageCounter(),
         ) { conversationList, lastMessageList, unreadMessageCount ->
-            kaliumLogger.w("UNREAD COUNT MAP ${unreadMessageCount.size}")
             val lastMessageMap = lastMessageList.associateBy { it.conversationId }
             conversationList.map { conversation ->
-                kaliumLogger.w("UNREAD COUNT MAP FOR CONVO ${conversation.name}= ${unreadMessageCount[conversation.id]}")
                 conversationMapper.fromDaoModelToDetails(conversation,
                     lastMessageMap[conversation.id]?.let { messageMapper.fromEntityToMessagePreview(it) },
                     unreadMessageCount[conversation.id]?.let { mapOf(UnreadEventType.MESSAGE to it) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -14,6 +14,7 @@ import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageMapper
+import com.wire.kalium.logic.data.message.UnreadEventType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.SelfTeamIdProvider
@@ -311,16 +312,15 @@ internal class ConversationDataSource internal constructor(
         combine(
             conversationDAO.getAllConversationDetails(),
             messageDAO.observeLastMessages(),
-            messageDAO.observeUnreadMessages(),
-        ) { conversationList, lastMessageList, unreadMessageList ->
-            val groupedMessages = unreadMessageList.groupBy { it.conversationId }
+            messageDAO.observeUnreadMessageCounter(),
+        ) { conversationList, lastMessageList, unreadMessageCount ->
+            kaliumLogger.w("UNREAD COUNT MAP ${unreadMessageCount.size}")
             val lastMessageMap = lastMessageList.associateBy { it.conversationId }
             conversationList.map { conversation ->
+                kaliumLogger.w("UNREAD COUNT MAP FOR CONVO ${conversation.name}= ${unreadMessageCount[conversation.id]}")
                 conversationMapper.fromDaoModelToDetails(conversation,
                     lastMessageMap[conversation.id]?.let { messageMapper.fromEntityToMessagePreview(it) },
-                    groupedMessages[conversation.id]?.mapNotNull { message ->
-                        messageMapper.fromPreviewEntityToUnreadEventCount(message)
-                    }?.groupingBy { it }?.eachCount()
+                    unreadMessageCount[conversation.id]?.let { mapOf(UnreadEventType.MESSAGE to it) }
                 )
             }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -513,17 +513,11 @@ class ConversationRepositoryTest {
 
         val unreadMessagesCount = 5
 
-        val unreadMessages = List(unreadMessagesCount) {
-            TEST_MESSAGE_PREVIEW_ENTITY.copy(
-                id = "message$it",
-                conversationId = conversationIdEntity,
-                content = MessagePreviewEntityContent.Text("senderName", "body")
-            )
-        }
+        val unreadMessages = mapOf(conversationIdEntity to unreadMessagesCount)
         val (_, conversationRepository) = Arrangement()
             .withConversations(listOf(conversationEntity))
             .withLastMessages(listOf())
-            .withUnreadMessages(unreadMessages)
+            .withUnreadMessageCounter(unreadMessages)
             .arrange()
 
         // when
@@ -599,17 +593,11 @@ class ConversationRepositoryTest {
         )
         val unreadMessagesCount = 5
 
-        val unreadMessages = List(unreadMessagesCount) {
-            TEST_MESSAGE_PREVIEW_ENTITY.copy(
-                id = "message$it",
-                conversationId = conversationIdEntity,
-                content = MessagePreviewEntityContent.Text("senderName", "body")
-            )
-        }
+        val unreadMessages = mapOf(conversationIdEntity to unreadMessagesCount)
         val (_, conversationRepository) = Arrangement()
             .withConversations(listOf(conversationEntity))
             .withLastMessages(listOf())
-            .withUnreadMessages(unreadMessages)
+            .withUnreadMessageCounter(unreadMessages)
             .arrange()
 
         // when
@@ -624,36 +612,6 @@ class ConversationRepositoryTest {
 
             awaitComplete()
         }
-    }
-
-    @Test
-    fun givenUserHasUnReadMessagesInConversation_whenObservingConversationListDetails_ThenCorrectlyGetTheCount() = runTest {
-        // given
-        val conversationIdEntity = ConversationIDEntity("some_value", "some_domain")
-        val conversationId = QualifiedID("some_value", "some_domain")
-
-        val conversationEntity = TestConversation.VIEW_ENTITY.copy(id = conversationIdEntity, type = ConversationEntity.Type.GROUP)
-        val message = TEST_MESSAGE_PREVIEW_ENTITY.copy(conversationId = conversationIdEntity)
-        val (_, conversationRepository) = Arrangement()
-            .withConversations(listOf(conversationEntity))
-            .withLastMessages(listOf())
-            .withUnreadMessages(listOf(message))
-            .arrange()
-
-        // when
-        conversationRepository.observeConversationListDetails().test {
-            val result = awaitItem()
-
-            // then
-            assertContains(result.map { it.conversation.id }, conversationId)
-            val conversation = result.first { it.conversation.id == conversationId }
-
-            assertIs<ConversationDetails.Group>(conversation)
-            assertEquals(conversation.unreadEventCount.size, 1)
-
-            awaitComplete()
-        }
-
     }
 
     @Test
@@ -932,12 +890,19 @@ class ConversationRepositoryTest {
                 .whenInvokedWith(any(), any())
                 .thenReturn(response)
         }
+//
+//         fun withUnreadMessages(messages: List<MessagePreviewEntity>) = apply {
+//             given(messageDAO)
+//                 .suspendFunction(messageDAO::observeUnreadMessages)
+//                 .whenInvoked()
+//                 .thenReturn(flowOf(messages))
+//         }
 
-        fun withUnreadMessages(messages: List<MessagePreviewEntity>) = apply {
+        fun withUnreadMessageCounter(unreadCounter: Map<ConversationIDEntity, Int>) = apply {
             given(messageDAO)
-                .suspendFunction(messageDAO::observeUnreadMessages)
+                .suspendFunction(messageDAO::observeUnreadMessageCounter)
                 .whenInvoked()
-                .thenReturn(flowOf(messages))
+                .thenReturn(flowOf(unreadCounter))
         }
 
         fun withConversations(conversations: List<ConversationViewEntity>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -890,13 +890,13 @@ class ConversationRepositoryTest {
                 .whenInvokedWith(any(), any())
                 .thenReturn(response)
         }
-//
-//         fun withUnreadMessages(messages: List<MessagePreviewEntity>) = apply {
-//             given(messageDAO)
-//                 .suspendFunction(messageDAO::observeUnreadMessages)
-//                 .whenInvoked()
-//                 .thenReturn(flowOf(messages))
-//         }
+
+        fun withUnreadMessages(messages: List<MessagePreviewEntity>) = apply {
+            given(messageDAO)
+                .suspendFunction(messageDAO::observeUnreadMessages)
+                .whenInvoked()
+                .thenReturn(flowOf(messages))
+        }
 
         fun withUnreadMessageCounter(unreadCounter: Map<ConversationIDEntity, Int>) = apply {
             given(messageDAO)

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -369,6 +369,19 @@ SELECT * FROM MessagePreview AS message
 WHERE isUnread AND isSelfMessage = 0
 AND visibility = 'VISIBLE' AND contentType IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL');
 
+getUnreadMessagesCount:
+SELECT
+    conversation_id,
+    COUNT()
+FROM Message
+JOIN SelfUser
+JOIN Conversation ON Conversation.qualified_id = Message.conversation_id
+WHERE Message.creation_date > Conversation.last_read_date
+AND Message.sender_user_id != SelfUser.id
+AND visibility = 'VISIBLE'
+AND content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL')
+GROUP BY conversation_id;
+
 deleteAllMessages:
 DELETE FROM Message;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -1,6 +1,7 @@
 package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.dao.ConversationEntity
+import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import kotlinx.coroutines.flow.Flow
@@ -82,6 +83,7 @@ interface MessageDAO {
     suspend fun observeLastMessages(): Flow<List<MessagePreviewEntity>>
 
     suspend fun observeUnreadMessages(): Flow<List<MessagePreviewEntity>>
+    suspend fun observeUnreadMessageCounter(): Flow<Map<ConversationIDEntity, Int>>
 
     suspend fun resetAssetUploadStatus()
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -5,6 +5,7 @@ import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.ReactionsQueries
 import com.wire.kalium.persistence.dao.ConversationEntity
+import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.ASSET
@@ -24,6 +25,7 @@ import com.wire.kalium.persistence.util.mapToOneOrNull
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
@@ -441,8 +443,13 @@ class MessageDAOImpl(
 
     override suspend fun observeUnreadMessages(): Flow<List<MessagePreviewEntity>> =
         flowOf(emptyList())
-        // FIXME: Re-enable gradually as we improve its performance
-        //        queries.getUnreadMessages(mapper::toPreviewEntity).asFlow().flowOn(coroutineContext).mapToList()
+
+    // FIXME: Re-enable gradually as we improve its performance
+    //        queries.getUnreadMessages(mapper::toPreviewEntity).asFlow().flowOn(coroutineContext).mapToList()
+    override suspend fun observeUnreadMessageCounter(): Flow<Map<ConversationIDEntity, Int>> =
+        queries.getUnreadMessagesCount { conversationId, count ->
+            conversationId to count.toInt()
+        }.asFlow().flowOn(coroutineContext).mapToList().map { it.toMap() }
 
     private fun contentTypeOf(content: MessageEntityContent): MessageEntity.ContentType = when (content) {
         is MessageEntityContent.Text -> TEXT

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -443,9 +443,9 @@ class MessageDAOImpl(
 
     override suspend fun observeUnreadMessages(): Flow<List<MessagePreviewEntity>> =
         flowOf(emptyList())
-
     // FIXME: Re-enable gradually as we improve its performance
     //        queries.getUnreadMessages(mapper::toPreviewEntity).asFlow().flowOn(coroutineContext).mapToList()
+
     override suspend fun observeUnreadMessageCounter(): Flow<Map<ConversationIDEntity, Int>> =
         queries.getUnreadMessagesCount { conversationId, count ->
             conversationId to count.toInt()

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageUnreadCounterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageUnreadCounterTest.kt
@@ -145,5 +145,4 @@ class MessageUnreadCounterTest : BaseMessageTest() {
             }
         }
     }
-
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageUnreadCounterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageUnreadCounterTest.kt
@@ -1,0 +1,149 @@
+package com.wire.kalium.persistence.dao.message
+
+import app.cash.turbine.test
+import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import com.wire.kalium.persistence.utils.stubs.newSystemMessageEntity
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class MessageUnreadCounterTest : BaseMessageTest() {
+
+    @Test
+    fun givenUnreadRegularMessagesFromOthers_thenShouldCount() = runTest {
+        insertInitialData()
+        val readDate = Instant.fromEpochSeconds(10)
+        val convId = TEST_CONVERSATION_1.id
+        conversationDAO.updateConversationReadDate(convId, readDate.toIsoDateTimeString())
+
+        val unreadMessages = listOf(
+            newRegularMessageEntity(
+                id = "1",
+                conversationId = convId,
+                senderUserId = OTHER_USER.id,
+                content = MessageEntityContent.Text("Hi"),
+                date = readDate + 1.seconds
+            ),
+            newRegularMessageEntity(
+                id = "2",
+                conversationId = convId,
+                senderUserId = OTHER_USER.id,
+                content = MessageEntityContent.Knock(true),
+                date = readDate + 1.minutes
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(unreadMessages)
+
+        val result = messageDAO.observeUnreadMessageCounter().first()[convId]
+        assertNotNull(result)
+        assertEquals(unreadMessages.size, result)
+    }
+
+    @Test
+    fun givenOnlyReadTextMessages_thenShouldEmitEmptyMap() = runTest {
+        insertInitialData()
+        val readDate = Instant.fromEpochSeconds(10)
+        val convId = TEST_CONVERSATION_1.id
+        conversationDAO.updateConversationReadDate(convId, readDate.toIsoDateTimeString())
+
+        val unreadMessages = listOf(
+            newRegularMessageEntity(
+                id = "1",
+                conversationId = convId,
+                senderUserId = OTHER_USER.id,
+                content = MessageEntityContent.Text("Hi"),
+                date = readDate - 1.seconds
+            ),
+            newRegularMessageEntity(
+                id = "2",
+                conversationId = convId,
+                senderUserId = OTHER_USER.id,
+                content = MessageEntityContent.Knock(true),
+                date = readDate - 1.minutes
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(unreadMessages)
+
+        val result = messageDAO.observeUnreadMessageCounter().first()[convId]
+        assertNull(result)
+    }
+
+    @Test
+    fun givenUnreadSystemMessages_thenShouldNotCount() = runTest {
+        insertInitialData()
+        val readDate = Instant.fromEpochSeconds(10)
+        val convId = TEST_CONVERSATION_1.id
+        conversationDAO.updateConversationReadDate(convId, readDate.toIsoDateTimeString())
+
+        val unreadMessages = listOf(
+            newSystemMessageEntity(
+                id = "1",
+                conversationId = convId,
+                senderUserId = OTHER_USER.id,
+                content = MessageEntityContent.ConversationRenamed("Hehe"),
+                date = readDate + 1.seconds
+            ),
+            newSystemMessageEntity(
+                id = "2",
+                conversationId = convId,
+                senderUserId = OTHER_USER.id,
+                content = MessageEntityContent.TeamMemberRemoved("Hehe"),
+                date = readDate + 1.minutes
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(unreadMessages)
+
+        val result = messageDAO.observeUnreadMessageCounter().first()[convId]
+        assertNull(result)
+    }
+
+    @Test
+    fun givenNewUnreadMessageIsInserted_thenShouldEmitUpdate() = runTest {
+        insertInitialData()
+        val readDate = Instant.fromEpochSeconds(10)
+        val convId = TEST_CONVERSATION_1.id
+        conversationDAO.updateConversationReadDate(convId, readDate.toIsoDateTimeString())
+
+        val unreadMessages = listOf(
+            newRegularMessageEntity(
+                id = "1",
+                conversationId = convId,
+                senderUserId = OTHER_USER.id,
+                content = MessageEntityContent.Text("Hi"),
+                date = readDate + 1.seconds
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(unreadMessages)
+
+        messageDAO.observeUnreadMessageCounter().test {
+
+            awaitItem()[convId].also {
+                assertNotNull(it)
+                assertEquals(unreadMessages.size, it)
+            }
+
+            messageDAO.insertOrIgnoreMessage(
+                newRegularMessageEntity(
+                    id = "2",
+                    conversationId = convId,
+                    senderUserId = OTHER_USER.id,
+                    content = MessageEntityContent.Knock(true),
+                    date = readDate + 1.minutes
+                )
+            )
+
+            awaitItem()[convId].also {
+                assertNotNull(it)
+                assertEquals(unreadMessages.size + 1, it)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The Unread Event counter was disabled due to performance issues in the PR:
- #1377 

### Solutions

Enable a simple counter that does not fetch ALL unread messages, but just the simplified count.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
