### PR TITLE
fix: ongoing call when importing backup

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.util.Collections
 
 @Suppress("LongParameterList", "TooManyFunctions")
 class CallManagerImpl internal constructor(
@@ -95,7 +96,7 @@ class CallManagerImpl internal constructor(
     private val scope = CoroutineScope(job + kaliumDispatchers.io)
     private val deferredHandle: Deferred<Handle> = startHandleAsync()
 
-    private val strongReferences = mutableListOf<Any>()
+    private val strongReferences = Collections.synchronizedList(mutableListOf<Any>())
     private fun <T : Any> T.keepingStrongReference(): T {
         strongReferences.add(this)
         return this

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.util.Collections
 
 @Suppress("LongParameterList", "TooManyFunctions")
 class CallManagerImpl internal constructor(
@@ -95,7 +96,7 @@ class CallManagerImpl internal constructor(
     private val scope = CoroutineScope(job + kaliumDispatchers.io)
     private val deferredHandle: Deferred<Handle> = startHandleAsync()
 
-    private val strongReferences = mutableListOf<Any>()
+    private val strongReferences = Collections.synchronizedList(mutableListOf<Any>())
     private fun <T : Any> T.keepingStrongReference(): T {
         strongReferences.add(this)
         return this

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/backup/DatabaseImporter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/backup/DatabaseImporter.kt
@@ -47,7 +47,7 @@ class DatabaseImporterImpl(private val sqlDriver: SqlDriver) : DatabaseImporter 
         restoreTable("User")
         restoreConversations()
         restoreTable("Message")
-        if (!fromOtherClient) restoreTable("Call")
+        if (!fromOtherClient) restoreCalls()
         restoreAssets()
         restoreTable("MessageConversationChangedContent")
         restoreTable("MessageFailedToDecryptContent")
@@ -67,6 +67,13 @@ class DatabaseImporterImpl(private val sqlDriver: SqlDriver) : DatabaseImporter 
         )
         restoreTable("MessageAssetContent")
         restoreTable("MessageRestrictedAssetContent")
+    }
+
+    private fun restoreCalls() {
+        sqlDriver.execute(
+            """UPDATE $BACKUP_DB_ALIAS.Call SET status = 'CLOSED' WHERE status != 'CLOSED' AND status != 'MISSED'""".trimMargin()
+        )
+        restoreTable("Call")
     }
 
     private fun restoreConversations() {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.persistence.dao.ConversationViewEntity
 import com.wire.kalium.persistence.dao.MLS_DEFAULT_LAST_KEY_MATERIAL_UPDATE_MILLI
 import com.wire.kalium.persistence.dao.Member
 import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.dao.call.CallEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
 import com.wire.kalium.persistence.db.UserDatabaseBuilder
@@ -360,7 +361,16 @@ class DatabaseImporterTest : BaseDatabaseTest() {
         // then
         val conversationsAfterBackup: List<ConversationViewEntity> = userDatabaseBuilder.conversationDAO.getAllConversations().first()
 
-        val calls = conversationsWithCallToBackup.map { it.second }
+        val calls = conversationsWithCallToBackup.map {
+            val call = it.second
+            call.copy(
+                status = if (call.status != CallEntity.Status.CLOSED && call.status != CallEntity.Status.MISSED) {
+                    CallEntity.Status.CLOSED
+                } else {
+                    call.status
+                }
+            )
+        }
 
         assertEquals(backupConversationAmount + userConversationAmount, conversationsAfterBackup.size)
 
@@ -379,7 +389,16 @@ class DatabaseImporterTest : BaseDatabaseTest() {
         userDatabaseBuilder.databaseImporter.importFromFile(databasePath(backupUserIdEntity), false, encryptedDBSecret)
 
         // then
-        val calls = conversationsWithCallToBackup.map { it.second }
+        val calls = conversationsWithCallToBackup.map {
+            val call = it.second
+            call.copy(
+                status = if (call.status != CallEntity.Status.CLOSED && call.status != CallEntity.Status.MISSED) {
+                    CallEntity.Status.CLOSED
+                } else {
+                    call.status
+                }
+            )
+        }
 
         val allCalls = userDatabaseBuilder.callDAO.observeCalls().first()
         assertEquals(calls, allCalls)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When importing backup data with ongoing calls, when joining an ongoing call from backup it would crash the app, there are two reasons:

- Open Calls [Ongoing / Started / Answering or other] would differ from what would be received when receiving CONFCHECK or other AVS Signals.
- Multiple usages of current `keepReference` list resulting into `ArrayIndexOutOfBoundsException` from `add` into the `arrayList`.

### Solutions

- Added query to close all open calls from the backup as we are doing when user opens the app.
- Change current `mutableListOf<Any>` for `strongKeepReference` to `Collections.synchronizedList(mutableListOf<Any>())` so it doesn't throws `ArrayIndexOutOfBoundsException` anymore.
