### PR TITLE
fix: db being recreated when upgrading (RC)

### DIFF
--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabaseProvider.kt
@@ -31,9 +31,10 @@ import com.wire.kalium.persistence.daokaliumdb.AccountsDAOImpl
 import com.wire.kalium.persistence.daokaliumdb.LogoutReasonAdapter
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAO
 import com.wire.kalium.persistence.daokaliumdb.ServerConfigurationDAOImpl
+import com.wire.kalium.persistence.db.support.SqliteCallback
+import com.wire.kalium.persistence.db.support.SupportOpenHelperFactory
 import com.wire.kalium.persistence.util.FileNameUtil
 import com.wire.kalium.util.KaliumDispatcherImpl
-import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 import kotlin.coroutines.CoroutineContext
 
 // TODO(refactor): Unify creation just like it's done for UserDataBase
@@ -55,7 +56,7 @@ actual class GlobalDatabaseProvider(
                 schema = schema,
                 context = context,
                 name = dbName,
-                factory = SupportOpenHelperFactory(passphrase.value, null, true)
+                factory = SupportOpenHelperFactory(passphrase.value, true)
             )
         } else {
             AndroidSqliteDriver(

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -24,9 +24,10 @@ import android.content.Context
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.wire.kalium.persistence.UserDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.db.support.SqliteCallback
+import com.wire.kalium.persistence.db.support.SupportOpenHelperFactory
 import com.wire.kalium.persistence.util.FileNameUtil
 import kotlinx.coroutines.CoroutineDispatcher
-import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 
 sealed interface DatabaseCredentials {
     data class Passphrase(val value: UserDBSecret) : DatabaseCredentials
@@ -58,7 +59,7 @@ fun userDatabaseBuilder(
             schema = UserDatabase.Schema,
             context = context,
             name = dbName,
-            factory = SupportOpenHelperFactory(passphrase.value, null, true)
+            factory = SupportOpenHelperFactory(passphrase.value, true)
         )
     } else {
         AndroidSqliteDriver(

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/support/SqliteCallback.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/support/SqliteCallback.kt
@@ -16,7 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.persistence.db
+package com.wire.kalium.persistence.db.support
 
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/support/SupportOpenHelperFactory.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/support/SupportOpenHelperFactory.kt
@@ -1,0 +1,46 @@
+package com.wire.kalium.persistence.db.support
+
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import net.zetetic.database.sqlcipher.SQLiteDatabase
+import net.zetetic.database.sqlcipher.SQLiteDatabaseHook
+import net.zetetic.database.sqlcipher.SQLiteOpenHelper
+
+class SupportOpenHelperFactory(
+    private val password: ByteArray,
+    private val enableWriteAheadLogging: Boolean = false,
+    private val hook: SQLiteDatabaseHook? = null,
+    private val minimumSupportedDatabaseVersion: Int = 1
+) : SupportSQLiteOpenHelper.Factory {
+    override fun create(configuration: SupportSQLiteOpenHelper.Configuration): SupportSQLiteOpenHelper =
+        object : SQLiteOpenHelper(
+            configuration.context,
+            configuration.name,
+            password,
+            null,
+            configuration.callback.version,
+            minimumSupportedDatabaseVersion,
+            null,
+            hook,
+            enableWriteAheadLogging
+        ) {
+            override fun onCreate(db: SQLiteDatabase) {
+                configuration.callback.onCreate(db)
+            }
+
+            override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+                configuration.callback.onUpgrade(db, oldVersion, newVersion)
+            }
+
+            override fun onDowngrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+                configuration.callback.onDowngrade(db, oldVersion, newVersion)
+            }
+
+            override fun onOpen(db: SQLiteDatabase) {
+                configuration.callback.onOpen(db)
+            }
+
+            override fun onConfigure(db: SQLiteDatabase) {
+                configuration.callback.onConfigure(db)
+            }
+        }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When performing a DB migration, the DB will _always_ be recreated when using the new SQLCipher.

### Causes


The `minimumSupportedVersion` is being always set to the new DB version, so the DB is being recreated as "it's not supported".

- https://github.com/sqlcipher/sqlcipher-android/issues/11

### Solutions

I've opened [a PR on SQLCipher's repo](https://github.com/sqlcipher/sqlcipher-android/pull/12). But in the meanwhile, it's faster to do it ourselves here until a newer version is deployed.

### Testing

#### Test Coverage (Optional)

Not sure if applicable, as the dependency is the one that needs fixing.
SQLCipher doesn't seem to have automated tests to assert that, so I did manual testing

- [ ] I have added automated test to this contribution

#### How to Test

Write a DB migration, like `26.sqm` with some simple `SELECT 'hello'`, start the app.

Current behaviour:
The DB will be clear and user will be asked to register a client/type-in the password.

After this PR:
DB is happy and upgrades normally.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
