### PR TITLE
fix: notification pop-ups during sync [AR-2990]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -27,15 +27,11 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.di.MapperProvider
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.scan
 
 /**
  * Get notifications for the current user
@@ -66,7 +62,7 @@ internal class GetNotificationsUseCaseImpl internal constructor(
     @Suppress("LongMethod")
     override suspend operator fun invoke(): Flow<List<LocalNotificationConversation>> {
         return incrementalSyncRepository.incrementalSyncState
-            .isLiveDebounced()
+            .map { it != IncrementalSyncStatus.FetchingPendingEvents }
             .flatMapLatest { isLive ->
                 if (isLive) {
                     merge(
@@ -81,7 +77,6 @@ internal class GetNotificationsUseCaseImpl internal constructor(
             }
             .distinctUntilChanged()
             .filter { it.isNotEmpty() }
-            .buffer(capacity = 3) // to cover a case when all 3 flows emits at the same time
     }
 
     private suspend fun observeEphemeralNotifications(): Flow<List<LocalNotificationConversation>> =
@@ -94,26 +89,5 @@ internal class GetNotificationsUseCaseImpl internal constructor(
                     .filterIsInstance<ConversationDetails.Connection>()
                     .map { localNotificationMessageMapper.fromConnectionToLocalNotificationConversation(it) }
             }
-    }
-
-    /**
-     * In case of push notification we close the connection immediately after syncing finished.
-     * So event `IncrementalSyncStatus.Pending` after `IncrementalSyncStatus.Live` may come sooner
-     * than notifications are handled, and cancel it.
-     * This `debounce` only for the case when we were Live and non-Live event comes helps to avoid such a scenario.
-     */
-    private fun Flow<IncrementalSyncStatus>.isLiveDebounced(): Flow<Boolean> =
-        this.map { it == IncrementalSyncStatus.Live }
-            .distinctUntilChanged()
-            .scan(false to false) { prevPair, isLive -> prevPair.second to isLive }
-            .drop(1) // initial value of scan
-            .debounce { (prevValue, newValue) ->
-                if (prevValue && !newValue) AFTER_LIVE_DELAY_MS
-                else 0
-            }
-            .map { it.second }
-
-    companion object {
-        private const val AFTER_LIVE_DELAY_MS = 100L
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.feature.message
 
 import app.cash.turbine.test
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -50,15 +51,12 @@ import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
-import io.mockative.twice
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -95,6 +93,100 @@ class GetNotificationsUseCaseTest {
                 .wasInvoked(exactly = once)
 
             syncStatusFlow.emit(IncrementalSyncStatus.Live)
+
+            verify(arrange.messageRepository)
+                .suspendFunction(arrange.messageRepository::getNotificationMessage)
+                .with(any())
+                .wasInvoked(exactly = once)
+
+            verify(arrange.connectionRepository)
+                .suspendFunction(arrange.connectionRepository::observeConnectionRequestsForNotification)
+                .wasInvoked(exactly = once)
+
+            verify(arrange.ephemeralNotifications)
+                .suspendFunction(arrange.ephemeralNotifications::observeEphemeralNotifications)
+                .wasInvoked(atLeast = once)
+
+            val result = awaitItem()
+            assertContentEquals(expectedConversations, result)
+        }
+    }
+
+    @Test
+    fun givenSyncStateChangedToPending_thenRepositoriesAreUsedToFetchNotifications() = runTest {
+        val syncStatusFlow = MutableSharedFlow<IncrementalSyncStatus>(1)
+        val expectedMessages = listOf(notificationMessageText(), notificationMessageComment())
+        val expectedConversations = listOf(localNotificationConversation(messages = expectedMessages))
+        val (arrange, getNotifications) = Arrangement()
+            .withEphemeralNotification()
+            .withIncrementalSyncState(syncStatusFlow)
+            .withConnectionList(listOf())
+            .withConversationsForNotifications(flowOf(expectedConversations)).arrange()
+
+        getNotifications().test {
+            syncStatusFlow.emit(IncrementalSyncStatus.FetchingPendingEvents)
+
+            verify(arrange.messageRepository)
+                .suspendFunction(arrange.messageRepository::getNotificationMessage)
+                .with(any())
+                .wasNotInvoked()
+
+            verify(arrange.connectionRepository)
+                .suspendFunction(arrange.connectionRepository::observeConnectionRequestsForNotification)
+                .wasNotInvoked()
+
+            verify(arrange.ephemeralNotifications)
+                .suspendFunction(arrange.ephemeralNotifications::observeEphemeralNotifications)
+                .wasInvoked(exactly = once)
+
+            syncStatusFlow.emit(IncrementalSyncStatus.Pending)
+
+            verify(arrange.messageRepository)
+                .suspendFunction(arrange.messageRepository::getNotificationMessage)
+                .with(any())
+                .wasInvoked(exactly = once)
+
+            verify(arrange.connectionRepository)
+                .suspendFunction(arrange.connectionRepository::observeConnectionRequestsForNotification)
+                .wasInvoked(exactly = once)
+
+            verify(arrange.ephemeralNotifications)
+                .suspendFunction(arrange.ephemeralNotifications::observeEphemeralNotifications)
+                .wasInvoked(atLeast = once)
+
+            val result = awaitItem()
+            assertContentEquals(expectedConversations, result)
+        }
+    }
+
+    @Test
+    fun givenSyncStateChangedToFailure_thenRepositoriesAreUsedToFetchNotifications() = runTest {
+        val syncStatusFlow = MutableSharedFlow<IncrementalSyncStatus>(1)
+        val expectedMessages = listOf(notificationMessageText(), notificationMessageComment())
+        val expectedConversations = listOf(localNotificationConversation(messages = expectedMessages))
+        val (arrange, getNotifications) = Arrangement()
+            .withEphemeralNotification()
+            .withIncrementalSyncState(syncStatusFlow)
+            .withConnectionList(listOf())
+            .withConversationsForNotifications(flowOf(expectedConversations)).arrange()
+
+        getNotifications().test {
+            syncStatusFlow.emit(IncrementalSyncStatus.FetchingPendingEvents)
+
+            verify(arrange.messageRepository)
+                .suspendFunction(arrange.messageRepository::getNotificationMessage)
+                .with(any())
+                .wasNotInvoked()
+
+            verify(arrange.connectionRepository)
+                .suspendFunction(arrange.connectionRepository::observeConnectionRequestsForNotification)
+                .wasNotInvoked()
+
+            verify(arrange.ephemeralNotifications)
+                .suspendFunction(arrange.ephemeralNotifications::observeEphemeralNotifications)
+                .wasInvoked(exactly = once)
+
+            syncStatusFlow.emit(IncrementalSyncStatus.Failed(CoreFailure.Unknown(null)))
 
             verify(arrange.messageRepository)
                 .suspendFunction(arrange.messageRepository::getNotificationMessage)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Application was spammed by notifications during sync

### Causes (Optional)

When user was offline for a long time he will receive a lot of notification pop-ups during sync. 

### Solutions

Show notifications after sync complete or an error occurred

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
