### PR TITLE
fix: clear firebase token only on soft logout [AR-3012]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -83,10 +83,18 @@ class LogoutUseCaseTest {
                 .function(arrangement.userSessionScopeProvider::delete)
                 .with(any())
                 .wasInvoked(exactly = once)
-            verify(arrangement.pushTokenRepository)
-                .suspendFunction(arrangement.pushTokenRepository::setUpdateFirebaseTokenFlag)
-                .with(eq(true))
-                .wasInvoked(exactly = once)
+
+            if(reason == LogoutReason.SELF_HARD_LOGOUT) {
+                verify(arrangement.pushTokenRepository)
+                    .suspendFunction(arrangement.pushTokenRepository::setUpdateFirebaseTokenFlag)
+                    .with(eq(true))
+                    .wasNotInvoked()
+            } else {
+                verify(arrangement.pushTokenRepository)
+                    .suspendFunction(arrangement.pushTokenRepository::setUpdateFirebaseTokenFlag)
+                    .with(eq(true))
+                    .wasInvoked(exactly = once)
+            }
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user tries to logout with clearing all data, application sometimes crashes. 

The reason about it was that updating firebase token flag in past was moved from SharedPreferences to SqlDelight DB. When user do the hard logout we don't need to clear token flag, because db is already cleared.

### Causes (Optional)

After opening app user has empty conversation list and he can't do nothing before clearing app data.

### Solutions

Update firebase token flag only when we do not do hard logout.


### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

1. Logout with clearing data when you are receiving messages
2. Logs should not contain any errors for MetadataDAO queries
