### PR TITLE
fix: Logout is running on main thread

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/MLSClientProvider.kt
@@ -32,6 +32,9 @@ import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.util.SecurityHelper
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorage
 import com.wire.kalium.util.FileUtil
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
 
 interface MLSClientProvider {
     suspend fun getMLSClient(clientId: ClientId? = null): Either<CoreFailure, MLSClient>
@@ -41,13 +44,14 @@ class MLSClientProviderImpl(
     private val rootKeyStorePath: String,
     private val userId: UserId,
     private val currentClientIdProvider: CurrentClientIdProvider,
-    private val passphraseStorage: PassphraseStorage
+    private val passphraseStorage: PassphraseStorage,
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) : MLSClientProvider {
 
     private var mlsClient: MLSClient? = null
 
-    override suspend fun getMLSClient(clientId: ClientId?): Either<CoreFailure, MLSClient> {
-        val currentClientId = clientId ?: currentClientIdProvider().fold({ return Either.Left(it) }, { it })
+    override suspend fun getMLSClient(clientId: ClientId?): Either<CoreFailure, MLSClient> = withContext(dispatchers.io) {
+        val currentClientId = clientId ?: currentClientIdProvider().fold({ return@withContext Either.Left(it) }, { it })
         val cryptoUserId = CryptoUserID(value = userId.value, domain = userId.domain)
 
         val location = "$rootKeyStorePath/${currentClientId.value}".also {
@@ -55,7 +59,7 @@ class MLSClientProviderImpl(
             FileUtil.mkDirs(it)
         }
 
-        return mlsClient?.let {
+        return@withContext mlsClient?.let {
             Either.Right(it)
         } ?: run {
             val newClient = mlsClient(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logout is performed on main thread :
- when clearing Proteus files
- when getting MLS client

<img width="1273" alt="Screenshot 2023-01-30 at 15 22 29" src="https://user-images.githubusercontent.com/18124919/215503190-fb18bcc2-4e60-41b1-af2e-b142428bff02.png">

### Solutions

Switch dispatcher to use IO

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
