### PR TITLE
chore(messages): wrap getNotificationsMessages query with wrapStorage [DEV]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -26,10 +26,12 @@ import com.wire.kalium.logic.data.notification.LocalNotificationMessageMapper
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 
@@ -66,7 +68,7 @@ internal class GetNotificationsUseCaseImpl internal constructor(
             .flatMapLatest { isLive ->
                 if (isLive) {
                     merge(
-                        messageRepository.getNotificationMessage(),
+                        messageRepository.getNotificationMessage().fold({ flowOf() }, { it }),
                         observeConnectionRequests(),
                         observeEphemeralNotifications()
                     )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -343,7 +343,7 @@ class GetNotificationsUseCaseTest {
             given(messageRepository)
                 .suspendFunction(messageRepository::getNotificationMessage)
                 .whenInvokedWith(any())
-                .thenReturn(list)
+                .thenReturn(Either.Right(list))
 
             return this
         }


### PR DESCRIPTION
* chore(messages): wrap getNotificationsMessages query with wrap storage handler


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Wrap getNotificationsMessages query with WrapStorage.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
