### PR TITLE
fix(rc): file extensions, splitting and building file names and duplicates [AR-2985] [AR-2984]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/CommonUtils.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/CommonUtils.kt
@@ -23,15 +23,42 @@ import kotlin.contracts.contract
 
 internal fun Boolean.toInt() = if (this) 1 else 0
 
-fun String.fileExtension(): String? {
-    val splitElements = split(".")
-    val extension: String = when {
-        splitElements.size <= 1 -> this
-        splitElements.size == 2 -> splitElements[1]
-        else -> splitElements.subList(1, splitElements.size).joinToString(".")
-    }
-    return extension.ifBlank { null }
+/*
+    Proper file name with copy counter has a space between, like this: "file_name (1).jpg", if the name has a number in brackets but without
+    a space then it's considered a part of its name: copy of "file_name(1).jpg" will be "file_name(1) (1).jpg".
+    This is how it usually works on many operating systems.
+ */
+fun buildFileName(name: String, extension: String? = null, copyCounter: Int = 0): String {
+    val nameWithCopyCounter = if (copyCounter <= 0) name else "$name ($copyCounter)"
+    return extension?.let { "$nameWithCopyCounter.$extension" } ?: nameWithCopyCounter
 }
+
+fun String.splitFileExtension(): Pair<String, String?> {
+    val splitElements = split(".")
+    val startsWithADot = splitElements.isNotEmpty() && splitElements.first().isEmpty()
+    // Most authors define extension in a way that doesn't allow more than one in the same file name,
+    // .tar.gz actually represents nested transformations, .tar is only for informational purposes and `gz` is the final extension.
+    val extension: String? = when {
+        startsWithADot && splitElements.size > 2 -> splitElements.last()
+        !startsWithADot && splitElements.size > 1 -> splitElements.last()
+        else -> null
+    }
+    val name = extension?.let { this.removeSuffix(".$it") } ?: this
+    return (name to extension)
+}
+
+fun String.splitFileExtensionAndCopyCounter(): Triple<String, Int, String?> {
+    val (name, extension) = this.splitFileExtension()
+    val copyCounterRegex = " \\(\\d+\\)\$".toRegex()
+    val (nameWithoutCopyCounter, copyCounter) = copyCounterRegex.find(name)?.let {
+        val copyCounter = it.value.removePrefix(" (").removeSuffix(")").toIntOrNull() ?: 0
+        val nameWithoutCopyCounter = name.removeSuffix(it.value)
+        (nameWithoutCopyCounter to copyCounter)
+    } ?: (name to 0)
+    return Triple(nameWithoutCopyCounter, copyCounter, extension)
+}
+
+fun String.fileExtension(): String? = splitFileExtension().second
 
 @OptIn(ExperimentalContracts::class)
 fun Int?.isGreaterThan(other: Int?): Boolean {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/CommonUtilsTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/CommonUtilsTest.kt
@@ -34,9 +34,50 @@ class CommonUtilsTest {
     }
 
     @Test
+    fun givenAFileNameWithMultipleDots_whenGettingItsFileExtension_itReturnsItCorrectly() {
+        val fileName = "some.dummy.file.jpg"
+        val expectedFileExtension = "jpg"
+
+        val fileExtension = fileName.fileExtension()
+
+        assertEquals(expectedFileExtension, fileExtension)
+    }
+    @Test
+    fun givenAFileNameWithMultipleDotsAndStartingWithADot_whenGettingItsFileExtension_itReturnsItCorrectly() {
+        val fileName = ".dummy.file.jpg"
+        val expectedFileExtension = "jpg"
+
+        val fileExtension = fileName.fileExtension()
+
+        assertEquals(expectedFileExtension, fileExtension)
+    }
+
+    @Test
     fun givenAFileNameWithMultipleExtensionDots_whenGettingItsFileExtension_itReturnsItCorrectly() {
         val fileName = "some_dummy_file.tar.gz"
-        val expectedFileExtension = "tar.gz"
+        // Most authors define extension in a way that doesn't allow more than one in the same file name,
+        // .tar.gz actually represents nested transformations, .tar is only for informational purposes and `gz` is the final extension.
+        val expectedFileExtension = "gz"
+
+        val fileExtension = fileName.fileExtension()
+
+        assertEquals(expectedFileExtension, fileExtension)
+    }
+
+    @Test
+    fun givenAFileNameStartingWithADotAndWithoutExtension_whenGettingItsFileExtension_itReturnsNull() {
+        val fileName = ".dummy"
+        val expectedFileExtension = null
+
+        val fileExtension = fileName.fileExtension()
+
+        assertEquals(expectedFileExtension, fileExtension)
+    }
+
+    @Test
+    fun givenAFileNameWithoutExtension_whenGettingItsFileExtension_itReturnsNull() {
+        val fileName = "file"
+        val expectedFileExtension = null
 
         val fileExtension = fileName.fileExtension()
 
@@ -51,5 +92,216 @@ class CommonUtilsTest {
         val fileExtension = fileName.fileExtension()
 
         assertEquals(expectedFileExtension, fileExtension)
+    }
+
+    @Test
+    fun givenNameWithoutCopyCounterAndWithoutExtension_whenBuildingFileName_thenReturnTheSameName() {
+        val name = "abc"
+        val copyCounter = 0
+        val extension = null
+        val expected = "abc"
+
+        val result = buildFileName(name, extension, copyCounter)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenNameWithCopyCounterAndWithoutExtension_whenBuildingFileName_thenReturnProperNameWithCopyCounter() {
+        val name = "abc"
+        val copyCounter = 2
+        val extension = null
+        val expected = "abc (2)"
+
+        val result = buildFileName(name, extension, copyCounter)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenNameWithoutCopyCounterAndWithExtension_whenBuildingFileName_thenReturnProperNameWithExtension() {
+        val name = "abc"
+        val copyCounter = 0
+        val extension = "jpg"
+        val expected = "abc.jpg"
+
+        val result = buildFileName(name, extension, copyCounter)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenNameWithCopyCounterAndWithExtension_whenBuildingFileName_thenReturnProperNameWithCopyCounterAndWithExtension() {
+        val name = "abc"
+        val copyCounter = 2
+        val extension = "jpg"
+        val expected = "abc (2).jpg"
+
+        val result = buildFileName(name, extension, copyCounter)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenNameWithDotAndWithCopyCounterAndWithExtension_whenBuildingFileName_thenReturnProperNameWithCopyCounterAndWithExtension() {
+        val name = "ab.c"
+        val copyCounter = 2
+        val extension = "jpg"
+        val expected = "ab.c (2).jpg"
+
+        val result = buildFileName(name, extension, copyCounter)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenNameWithBracketsAndWithCopyCounterAndWithExtension_whenBuildingFileName_thenReturnProperNameWithCopyCounterAndWithExtension() {
+        val name = "ab(1)"
+        val copyCounter = 2
+        val extension = "jpg"
+        val expected = "ab(1) (2).jpg"
+
+        val result = buildFileName(name, extension, copyCounter)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenAFileNameWithoutCopyCounterAndWithExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = "some_dummy_image_file.jpg"
+        val expectedCoreName = "some_dummy_image_file"
+        val expectedFileExtension = "jpg"
+        val expectedCopyCounter = 0
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameWithoutCopyCounterAndWithMultipleExtensionDots_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = "some_dummy_image_file.tar.gz"
+        // Most authors define extension in a way that doesn't allow more than one in the same file name,
+        // .tar.gz actually represents nested transformations, .tar is only for informational purposes and `gz` is the final extension.
+        val expectedCoreName = "some_dummy_image_file.tar"
+        val expectedFileExtension = "gz"
+        val expectedCopyCounter = 0
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameWithCopyCounterAndWithExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = "some_dummy_image_file (2).jpg"
+        val expectedCoreName = "some_dummy_image_file"
+        val expectedFileExtension = "jpg"
+        val expectedCopyCounter = 2
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameWithoutCopyCounterAndWithoutExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = "some_dummy_image_file"
+        val expectedCoreName = "some_dummy_image_file"
+        val expectedFileExtension = null
+        val expectedCopyCounter = 0
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameWithCopyCounterAndWithoutExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = "some_dummy_image_file (2)"
+        val expectedCoreName = "some_dummy_image_file"
+        val expectedFileExtension = null
+        val expectedCopyCounter = 2
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameWithBracketsAndWithoutCopyCounterAndWithExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = "some_dummy_image_file(1).jpg"
+        val expectedCoreName = "some_dummy_image_file(1)"
+        val expectedFileExtension = "jpg"
+        val expectedCopyCounter = 0
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameWithBracketsAndWithCopyCounterAndWithExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = "some_dummy_image_file(1) (2).jpg"
+        val expectedCoreName = "some_dummy_image_file(1)"
+        val expectedFileExtension = "jpg"
+        val expectedCopyCounter = 2
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameStartingWithADotWithCopyCounterAndWithExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = ".some_dummy_image_file (2).jpg"
+        val expectedCoreName = ".some_dummy_image_file"
+        val expectedFileExtension = "jpg"
+        val expectedCopyCounter = 2
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameStartingWithADotWithCopyCounterAndWithoutExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = ".some_dummy_image_file (2)"
+        val expectedCoreName = ".some_dummy_image_file"
+        val expectedFileExtension = null
+        val expectedCopyCounter = 2
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameStartingWithADotWithoutCopyCounterAndWithExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = ".some_dummy_image_file.jpg"
+        val expectedCoreName = ".some_dummy_image_file"
+        val expectedFileExtension = "jpg"
+        val expectedCopyCounter = 0
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAFileNameStartingWithADotWithoutCopyCounterAndWithoutExtension_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = ".some_dummy_image_file"
+        val expectedCoreName = ".some_dummy_image_file"
+        val expectedFileExtension = null
+        val expectedCopyCounter = 0
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    @Test
+    fun givenAnEmptyFileName_whenSplittingExtensionAndCopyCounter_itReturnsItCorrectly() {
+        val fileName = ""
+        val expectedCoreName = ""
+        val expectedFileExtension = null
+        val expectedCopyCounter = 0
+
+        fileName.splitFileExtensionAndCopyCounter()
+            .assertSplitResult(expectedCoreName, expectedCopyCounter, expectedFileExtension)
+    }
+
+    private fun Triple<String, Int, String?>.assertSplitResult(
+        expectedCoreName: String,
+        expectedCopyCounter: Int,
+        expectedExtension: String?
+    ) {
+        val (coreName, copyCounter, extension) = this
+        assertEquals(expectedCoreName, coreName)
+        assertEquals(expectedCopyCounter, copyCounter)
+        assertEquals(expectedExtension, extension)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Copy of already approved one for `develop`: https://github.com/wireapp/kalium/pull/1410

### Issues

We don't have any unified way of building names, especially when we need to create unique name containing a copy counter (`filename (2).jpg)`) if the file already exists and then split such names into parts: core name, copy counter and extension. We take all parts after the first dot as extension, but most authors actually define extension in a way that doesn't allow more than one in the same file name. 

### Solutions

- add `buildFileName` method that can generate unified file names
- add `splitFileExtension` and `splitFileExtensionAndCopyCounter` to split the given file name into two (core name with optional copy counter and extension) or three (core name, copy counter and extension) parts
- update `fileExtension` to use the methods described above and keep the consistency across the whole app

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
