### PR TITLE
fix: (DEV) OnClose call crashing

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -257,20 +257,20 @@ internal class CallDataSource(
                     "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}"
         )
         val qualifiedIDEntity = callMapper.fromConversationIdToQualifiedIDEntity(conversationId = conversationId)
-        val callerId = callDAO.getCallerIdByConversationId(conversationId = qualifiedIDEntity)
+        callDAO.getCallerIdByConversationId(conversationId = qualifiedIDEntity)?.let { callerId ->
+            val qualifiedUserId = qualifiedIdMapper.fromStringToQualifiedID(callerId)
 
-        val qualifiedUserId = qualifiedIdMapper.fromStringToQualifiedID(callerId)
-
-        val message = Message.System(
-            uuid4().toString(),
-            MessageContent.MissedCall,
-            conversationId,
-            DateTimeUtil.currentIsoDateTimeString(),
-            qualifiedUserId,
-            Message.Status.SENT,
-            Message.Visibility.VISIBLE
-        )
-        persistMessage(message)
+            val message = Message.System(
+                uuid4().toString(),
+                MessageContent.MissedCall,
+                conversationId,
+                DateTimeUtil.currentIsoDateTimeString(),
+                qualifiedUserId,
+                Message.Status.SENT,
+                Message.Visibility.VISIBLE
+            )
+            persistMessage(message)
+        } ?: callingLogger.i("[CallRepository] -> Unable to persist Missed Call due to missing Caller ID")
     }
 
     override fun updateIsMutedById(conversationId: String, isMuted: Boolean) {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAO.kt
@@ -49,7 +49,7 @@ interface CallDAO {
     suspend fun observeEstablishedCalls(): Flow<List<CallEntity>>
     suspend fun observeOngoingCalls(): Flow<List<CallEntity>>
     suspend fun updateLastCallStatusByConversationId(status: CallEntity.Status, conversationId: QualifiedIDEntity)
-    suspend fun getCallerIdByConversationId(conversationId: QualifiedIDEntity): String
+    suspend fun getCallerIdByConversationId(conversationId: QualifiedIDEntity): String?
     suspend fun getCallStatusByConversationId(conversationId: QualifiedIDEntity): CallEntity.Status?
     suspend fun getLastClosedCallByConversationId(conversationId: QualifiedIDEntity): Flow<String?>
     suspend fun getLastCallConversationTypeByConversationId(conversationId: QualifiedIDEntity): ConversationEntity.Type?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
@@ -108,8 +108,8 @@ internal class CallDAOImpl(
             )
         }
 
-    override suspend fun getCallerIdByConversationId(conversationId: QualifiedIDEntity): String = withContext(queriesContext) {
-        callsQueries.lastCallCallerIdByConversationId(conversationId).executeAsOne()
+    override suspend fun getCallerIdByConversationId(conversationId: QualifiedIDEntity): String? = withContext(queriesContext) {
+        callsQueries.lastCallCallerIdByConversationId(conversationId).executeAsOneOrNull()
     }
 
     override suspend fun getCallStatusByConversationId(conversationId: QualifiedIDEntity): CallEntity.Status? =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-3029 - App Crashing when receiving OnClose call from AVS when there is no call in db](https://wearezeta.atlassian.net/browse/AR-3029)

### Issues

From a fresh install build that doesn't have any (or at least the expected Call) saved in the database, when receiving a `OnCloseCall` signal from AVS it would trigger to save a `MissedCall` system message, but it requires a `CallerId` which it doesn't have and thus its crashing.

### Solutions

- Update DB to return `executeAsOneOrNull`, in case it returns null the `MissedCall` system message won't be saved as the user did not have any info about that call anyway.
- In case it returns a correct `CallerId` (from a Call that exists in DB) it will persist the message as normal.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Fresh install
- Receive a `OnCloseCall` signal from AVS without having any call prior
- App should not crash anymore
