### PR TITLE
chore: re-enable sending of read receipt confirmation

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.SendConfirmationUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Instant
@@ -56,14 +57,13 @@ class UpdateConversationReadDateUseCase internal constructor(
      * @param time The last read date to update.
      */
     suspend operator fun invoke(conversationId: QualifiedID, time: Instant) {
-        // TODO: Disabled for now as we are still figuring out performance and STORAGE_ERROR issues.
-        // sendConfirmation(conversationId)
+        sendConfirmation(conversationId)
         conversationRepository.updateConversationReadDate(conversationId, time.toIsoDateTimeString())
-        // selfConversationIdProvider().flatMap { selfConversationIds ->
-        //    selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
-        //        sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
-        //    }
-        // }
+        selfConversationIdProvider().flatMap { selfConversationIds ->
+           selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
+               sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
+           }
+        }
     }
 
     private suspend fun sendLastReadMessageToOtherClients(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sending confirmation of read receipt was disabled due to some issues we encountered during playtest and performance tests.

### Solutions

Re-enabling due to:
- Read Receipts not being the main issue on performance
- `STORAGE_ERROR` being resolved in [this PR](https://github.com/wireapp/kalium/pull/1378)

### Testing

#### How to Test

- Run this branch on AR
- Open App
- Receive many messages in group or 1:1 conversation with Read Receipts ENABLED
- Read all of them (try to receive lots of message while in the conversation as well)
- Read Confirmation should be sent correctly and from the logs there shouldn't be any `STORAGE_ERROR` regarding read receipts.