### PR TITLE
fix: logout state after removed device [AR-2989]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncCriteriaProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncCriteriaProvider.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.logic.sync.slow.SyncCriteriaResolution.MissingRequirement
 import com.wire.kalium.logic.sync.slow.SyncCriteriaResolution.Ready
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 
 /**
@@ -71,7 +70,6 @@ internal class SlowSlowSyncCriteriaProviderImpl(
      */
     private suspend fun logoutReasonFlow() = logoutRepository
         .observeLogout()
-        .map<LogoutReason, LogoutReason?> { it }
         .onStart { emit(null) }
 
     override suspend fun syncCriteriaFlow(): Flow<SyncCriteriaResolution> =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
@@ -74,12 +74,13 @@ class LogoutRepositoryTest {
             // Ignored, really
         }
 
-        logoutRepository.onLogout(LogoutReason.SELF_HARD_LOGOUT)
         logoutRepository.observeLogout().test {
+            logoutRepository.onLogout(LogoutReason.SELF_HARD_LOGOUT)
             assertEquals(LogoutReason.SELF_HARD_LOGOUT, awaitItem())
-
+            assertEquals(null, awaitItem())
             logoutRepository.onLogout(LogoutReason.SESSION_EXPIRED)
             assertEquals(LogoutReason.SESSION_EXPIRED, awaitItem())
+            assertEquals(null, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -83,10 +83,18 @@ class LogoutUseCaseTest {
                 .function(arrangement.userSessionScopeProvider::delete)
                 .with(any())
                 .wasInvoked(exactly = once)
-            verify(arrangement.pushTokenRepository)
-                .suspendFunction(arrangement.pushTokenRepository::setUpdateFirebaseTokenFlag)
-                .with(eq(true))
-                .wasInvoked(exactly = once)
+
+            if (reason == LogoutReason.SELF_HARD_LOGOUT) {
+                verify(arrangement.pushTokenRepository)
+                    .suspendFunction(arrangement.pushTokenRepository::setUpdateFirebaseTokenFlag)
+                    .with(eq(true))
+                    .wasNotInvoked()
+            } else {
+                verify(arrangement.pushTokenRepository)
+                    .suspendFunction(arrangement.pushTokenRepository::setUpdateFirebaseTokenFlag)
+                    .with(eq(true))
+                    .wasInvoked(exactly = once)
+            }
         }
     }
 


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/AR-2989
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Update logout state in LogoutRepository to not receive previous logout state after re-login
Fixed crash after hard logout

### Issues

After receiving `Removed Client` event user cannot sync after logging again.
After hard logout there was a crash

### Causes (Optional)

User cannot use app after login again.

### Solutions

For hard logout don't clear metadata because db was already cleared
For device removal reset logout state to be able login again in the same app session

