### PR TITLE
fix: [RC] Notification issues (AR-3016)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -134,7 +134,6 @@ interface ConversationRepository {
         mutedStatusTimestamp: Long
     ): Either<NetworkFailure, Unit>
 
-    suspend fun getConversationsForNotifications(): Flow<List<Conversation>>
     suspend fun getConversationsByGroupState(
         groupState: Conversation.ProtocolInfo.MLS.GroupState
     ): Either<StorageFailure, List<Conversation>>
@@ -435,11 +434,6 @@ internal class ConversationDataSource internal constructor(
                 conversationID.toDao()
             )
         }
-
-    override suspend fun getConversationsForNotifications(): Flow<List<Conversation>> =
-        conversationDAO.getConversationsForNotifications()
-            .filterNotNull()
-            .map { it.map(conversationMapper::fromDaoModel) }
 
     override suspend fun getConversationsByGroupState(
         groupState: Conversation.ProtocolInfo.MLS.GroupState

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -188,20 +188,18 @@ class MessageDataSource(
     override suspend fun getNotificationMessage(
         messageSizePerConversation: Int
     ): Either<CoreFailure, Flow<List<LocalNotificationConversation>>> = wrapStorageRequest {
-        messageDAO.getNotificationMessage().mapLatest {
-            it.groupBy { item ->
-                item.conversationId
-            }.map { (conversationId, messages) ->
-                LocalNotificationConversation(
-                    // todo: needs some clean up!
-                    id = conversationId.toModel(),
-                    conversationName = messages.first().conversationName ?: "",
-                    messages = messages.take(messageSizePerConversation)
-                        .mapNotNull { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
-                    isOneToOneConversation = messages.first().conversationType?.let { type ->
-                        type == ConversationEntity.Type.ONE_ON_ONE
-                    } ?: false)
-            }
+        messageDAO.getNotificationMessage().mapLatest { notificationEntities ->
+            notificationEntities.groupBy { it.conversationId }
+                .map { (conversationId, messages) ->
+                    LocalNotificationConversation(
+                        // todo: needs some clean up!
+                        id = conversationId.toModel(),
+                        conversationName = messages.first().conversationName ?: "",
+                        messages = messages.take(messageSizePerConversation)
+                            .mapNotNull { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
+                        isOneToOneConversation = messages.first().conversationType == ConversationEntity.Type.ONE_ON_ONE
+                    )
+                }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
@@ -29,8 +29,7 @@ import com.wire.kalium.logic.functional.fold
  * @see GetNotificationsUseCase
  */
 class MarkMessagesAsNotifiedUseCase internal constructor(
-    private val conversationRepository: ConversationRepository,
-    private val messageRepository: MessageRepository
+    private val conversationRepository: ConversationRepository
 ) {
 
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.functional.fold
 
 /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -218,7 +218,7 @@ class MessageScope internal constructor(
         )
 
     val markMessagesAsNotified: MarkMessagesAsNotifiedUseCase
-        get() = MarkMessagesAsNotifiedUseCase(conversationRepository, messageRepository)
+        get() = MarkMessagesAsNotifiedUseCase(conversationRepository)
 
     val updateAssetMessageUploadStatus: UpdateAssetMessageUploadStatusUseCase
         get() = UpdateAssetMessageUploadStatusUseCaseImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCaseTest.kt
@@ -130,9 +130,7 @@ class MarkMessagesAsNotifiedUseCaseTest {
                 .thenReturn(result)
         }
 
-        fun arrange() = this to MarkMessagesAsNotifiedUseCase(
-            conversationRepository, messageRepository
-        )
+        fun arrange() = this to MarkMessagesAsNotifiedUseCase(conversationRepository)
 
     }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -224,9 +224,6 @@ SELECT * FROM ConversationDetails WHERE mls_group_state = ? AND protocol = ?;
 getConversationIdByGroupId:
 SELECT qualified_id FROM Conversation WHERE mls_group_id = ?;
 
-selectConversationsWithUnnotifiedMessages:
-SELECT * FROM ConversationDetails WHERE mutedStatus != 'ALL_MUTED' AND (lastNotifiedMessageDate ISNULL OR last_modified_date > lastNotifiedMessageDate);
-
 updateConversationMutingStatus:
 UPDATE Conversation
 SET muted_status = ?, muted_time = ?

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
@@ -21,7 +21,7 @@ LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_
 WHERE
 Message.visibility = 'VISIBLE' AND
 (Message.sender_user_id != SelfUser.id) AND
-(Message.creation_date > Conversation.last_read_date) AND
+(Message.creation_date > IFNULL(Conversation.last_notified_date, 0)) AND
 Conversation.muted_status != 'ALL_MUTED'
 ORDER BY Message.creation_date DESC;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -181,7 +181,6 @@ interface ConversationDAO {
         mutedStatusTimestamp: Long
     )
 
-    suspend fun getConversationsForNotifications(): Flow<List<ConversationViewEntity>>
     suspend fun updateAccess(
         conversationID: QualifiedIDEntity,
         accessList: List<ConversationEntity.Access>,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -460,14 +460,6 @@ class ConversationDAOImpl(
         conversationQueries.updateConversationMutingStatus(mutedStatus, mutedStatusTimestamp, conversationId)
     }
 
-    override suspend fun getConversationsForNotifications(): Flow<List<ConversationViewEntity>> {
-        return conversationQueries.selectConversationsWithUnnotifiedMessages()
-            .asFlow()
-            .flowOn(coroutineContext)
-            .mapToList()
-            .map { it.map(conversationMapper::toModel) }
-    }
-
     override suspend fun updateAccess(
         conversationID: QualifiedIDEntity,
         accessList: List<ConversationEntity.Access>,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.persistence.kaliumLogger
 import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -222,11 +223,11 @@ class MessageDAOImpl(
             .mapToList()
 
     override suspend fun getNotificationMessage(): Flow<List<NotificationMessageEntity>> =
-        notificationQueries.getNotificationsMessages(
-            mapper::toNotificationEntity
-        ).asFlow()
+        notificationQueries.getNotificationsMessages(mapper::toNotificationEntity)
+            .asFlow()
             .flowOn(coroutineContext)
             .mapToList()
+            .distinctUntilChanged()
 
     override suspend fun observeMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -253,58 +253,6 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    @IgnoreIOS
-    fun givenMultipleConversations_whenGettingConversationsForNotifications_thenOnlyUnnotifiedConversationsAreReturned() = runTest {
-
-        // GIVEN
-        conversationDAO.insertConversation(conversationEntity1)
-        conversationDAO.insertConversation(conversationEntity2)
-        conversationDAO.insertConversation(conversationEntity3)
-        insertTeamUserAndMember(team, user1, conversationEntity1.id)
-        insertTeamUserAndMember(team, user1, conversationEntity2.id)
-        insertTeamUserAndMember(team, user1, conversationEntity3.id)
-
-        // WHEN
-        // Updating the last notified date to later than last modified
-        conversationDAO
-            .updateConversationNotificationDate(
-                QualifiedIDEntity("2", "wire.com")
-            )
-
-        val result = conversationDAO.getConversationsForNotifications().first()
-
-        // THEN
-        // only conversation one should be selected for notifications
-        assertEquals(listOf(conversationEntity1.toViewEntity(user1), conversationEntity3.toViewEntity()), result)
-    }
-
-    @Test
-    @IgnoreIOS
-    fun givenMultipleConversations_whenGettingConversations_thenOrderIsCorrect() = runTest {
-        // GIVEN
-        conversationDAO.insertConversation(conversationEntity1)
-        conversationDAO.insertConversation(conversationEntity2)
-        conversationDAO.insertConversation(conversationEntity3)
-        insertTeamUserAndMember(team, user1, conversationEntity1.id)
-        insertTeamUserAndMember(team, user1, conversationEntity2.id)
-        insertTeamUserAndMember(team, user1, conversationEntity3.id)
-
-        // WHEN
-        // Updating the last notified date to later than last modified
-        conversationDAO
-            .updateConversationNotificationDate(
-                conversationEntity2.id
-            )
-
-        val result = conversationDAO.getConversationsForNotifications().first()
-        // THEN
-        // The order of the conversations is not affected
-        assertEquals(conversationEntity1.toViewEntity(user1), result.first())
-        assertEquals(conversationEntity3.toViewEntity(user1), result[1])
-
-    }
-
-    @Test
     fun givenConversation_whenInsertingMembers_thenMembersShouldNotBeDuplicated() = runTest {
         val expected = listOf(member1, member2)
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -18,16 +18,73 @@
 
 package com.wire.kalium.persistence.dao.message
 
+import app.cash.turbine.test
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
 
 class MessageNotificationsTest : BaseMessageTest() {
+
+    @Test
+    fun givenConversationLastNotifiedDateIsNull_whenNewMessageInserted_thenNotificationPropagated() = runTest {
+        val message = OTHER_MESSAGE
+        insertInitialData()
+
+        messageDAO.insertOrIgnoreMessage(message)
+
+        messageDAO.getNotificationMessage().test {
+            assertEquals(1, awaitItem().size)
+        }
+    }
+
+    @Test
+    fun givenConversationWithMessages_whenConversationLastNotifiedDateUpdated_thenNotificationListEmpty() = runTest {
+        val message = OTHER_MESSAGE
+        insertInitialData()
+        messageDAO.insertOrIgnoreMessage(message)
+
+        conversationDAO.updateConversationNotificationDate(TEST_CONVERSATION_1.id)
+
+        messageDAO.getNotificationMessage().test {
+            assertEquals(0, awaitItem().size)
+        }
+    }
+
+    @Test
+    fun givenConversationWithMessages_whenConversationModifiedDateUpdated_thenNotificationNotAffected() = runTest {
+        val message = OTHER_MESSAGE
+        val date = message.date.plus(2.0.hours).toIsoDateTimeString()
+        insertInitialData()
+        messageDAO.insertOrIgnoreMessage(message)
+
+        messageDAO.getNotificationMessage().test {
+            assertEquals(1, awaitItem().size)
+            conversationDAO.updateConversationModifiedDate(TEST_CONVERSATION_1.id, date)
+
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun givenMutedConversation_whenNewMessageInserted_thenNotificationEmpty() = runTest {
+        val message = OTHER_MESSAGE
+        insertInitialData()
+        conversationDAO.updateConversationMutedStatus(TEST_CONVERSATION_1.id, ConversationEntity.MutedStatus.ALL_MUTED, 0L)
+
+        messageDAO.insertOrIgnoreMessage(message)
+
+        messageDAO.getNotificationMessage().test {
+            assertEquals(0, awaitItem().size)
+        }
+    }
 
     @Test
     fun givenNewMessageInserted_whenConvInAllMutedState_thenNeedsToBeNotifyIsFalse() = runTest {
@@ -233,7 +290,7 @@ class MessageNotificationsTest : BaseMessageTest() {
     }
 
     private suspend fun setConversationMutedStatus(conversationId: QualifiedIDEntity, mutedStatus: ConversationEntity.MutedStatus) {
-        conversationDAO.updateConversationMutedStatus(TEST_CONVERSATION_1.id, mutedStatus, Clock.System.now().toEpochMilliseconds())
+        conversationDAO.updateConversationMutedStatus(conversationId, mutedStatus, Clock.System.now().toEpochMilliseconds())
     }
 
     override suspend fun insertInitialData() {


### PR DESCRIPTION
# What's new in this PR?

### Issues

Some notifications repeat sometimes

### Causes (Optional)

in getting notification DB query we were using the wrong date for filtering (`last_modified_date` while should be `last_notified_date`). This causes wrong behaviour when the same notification was propagated again. 

### Solutions

Fix the query and add tests to cover that case.
+ removed some deprecated code.
