### PR TITLE
feat(sync): insert history-lost systemMessage after 404 sync recovery…

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -50,6 +50,11 @@ sealed class CoreFailure {
     data class Unknown(val rootCause: Throwable?) : CoreFailure()
 
     abstract class FeatureFailure : CoreFailure()
+
+    /**
+     * It's only allowed to insert system messages as bulk for all conversations.
+     */
+    object OnlySystemMessageAllowed : FeatureFailure()
 }
 
 sealed class NetworkFailure : CoreFailure() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -253,6 +253,10 @@ sealed interface Message {
                 is MessageContent.CryptoSessionReset -> mutableMapOf(
                     typeKey to "cryptoSessionReset"
                 )
+
+                MessageContent.HistoryLost -> mutableMapOf(
+                    typeKey to "conversationMightLostHistory"
+                )
             }
 
             val standardProperties = mapOf(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -214,6 +214,8 @@ sealed class MessageContent {
     object ClientAction : Signaling()
 
     object CryptoSessionReset : System()
+
+    object HistoryLost : System()
 }
 
 sealed class MessagePreviewContent {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -302,6 +302,7 @@ class MessageMapperImpl(
         is MessageContent.MissedCall -> MessageEntityContent.MissedCall
         is MessageContent.ConversationRenamed -> MessageEntityContent.ConversationRenamed(conversationName)
         is MessageContent.TeamMemberRemoved -> MessageEntityContent.TeamMemberRemoved(userName)
+        is MessageContent.HistoryLost -> MessageEntityContent.HistoryLost
     }
 
     private fun MessageEntityContent.Regular.toMessageContent(hidden: Boolean): MessageContent.Regular = when (this) {
@@ -380,6 +381,7 @@ class MessageMapperImpl(
         is MessageEntityContent.ConversationRenamed -> MessageContent.ConversationRenamed(conversationName)
         is MessageEntityContent.TeamMemberRemoved -> MessageContent.TeamMemberRemoved(userName)
         is MessageEntityContent.CryptoSessionReset -> MessageContent.CryptoSessionReset
+        is MessageEntityContent.HistoryLost -> MessageContent.HistoryLost
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -89,5 +89,6 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.Receipt -> false
             is MessageContent.ClientAction -> false
             is MessageContent.CryptoSessionReset -> false
+            is MessageContent.HistoryLost -> false
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -147,6 +147,8 @@ import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
 import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCaseImpl
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManager
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManagerImpl
+import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCase
+import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCaseImpl
 import com.wire.kalium.logic.feature.message.EphemeralNotificationsManager
 import com.wire.kalium.logic.feature.message.MLSMessageCreator
 import com.wire.kalium.logic.feature.message.MLSMessageCreatorImpl
@@ -482,6 +484,9 @@ class UserSessionScope internal constructor(
     val persistMessage: PersistMessageUseCase
         get() = PersistMessageUseCaseImpl(messageRepository, userId)
 
+    private val addSystemMessageToAllConversationsUseCase: AddSystemMessageToAllConversationsUseCase
+        get() = AddSystemMessageToAllConversationsUseCaseImpl(messageRepository, slowSyncRepository, userId)
+
     private val callRepository: CallRepository by lazy {
         CallDataSource(
             callApi = authenticatedDataSourceSet.authenticatedNetworkContainer.callApi,
@@ -642,7 +647,8 @@ class UserSessionScope internal constructor(
     private val incrementalSyncRecoveryHandler: IncrementalSyncRecoveryHandlerImpl
         get() =
             IncrementalSyncRecoveryHandlerImpl(
-                slowSyncRepository
+                slowSyncRepository,
+                addSystemMessageToAllConversationsUseCase
             )
 
     private val incrementalSyncManager by lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -1,0 +1,43 @@
+package com.wire.kalium.logic.feature.message
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.data.user.UserId
+
+import com.wire.kalium.util.DateTimeUtil
+import kotlinx.coroutines.flow.first
+
+/**
+ * persist a local system message to all conversations
+ */
+interface AddSystemMessageToAllConversationsUseCase {
+    suspend operator fun invoke()
+}
+
+class AddSystemMessageToAllConversationsUseCaseImpl internal constructor(
+    private val messageRepository: MessageRepository,
+    private val slowSyncRepository: SlowSyncRepository,
+    private val selfUserId: UserId
+) : AddSystemMessageToAllConversationsUseCase {
+    override suspend operator fun invoke() {
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
+        val generatedMessageUuid = uuid4().toString()
+        val message = Message.System(
+            id = generatedMessageUuid,
+            content = MessageContent.HistoryLost,
+            // the conversation id will be ignored in the repo level!
+            conversationId = ConversationId("", ""),
+            date = DateTimeUtil.currentIsoDateTimeString(),
+            senderUserId = selfUserId,
+            status = Message.Status.SENT,
+        )
+        messageRepository.persistSystemMessageToAllConversations(message)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandler.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.sync.incremental
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCase
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.HttpErrorCodes
@@ -34,7 +35,8 @@ internal fun interface OnIncrementalSyncRetryCallback {
 }
 
 internal class IncrementalSyncRecoveryHandlerImpl(
-    private val slowSyncRepository: SlowSyncRepository
+    private val slowSyncRepository: SlowSyncRepository,
+    private val addSystemMessageToAllConversationsUseCase: AddSystemMessageToAllConversationsUseCase
 ) : IncrementalSyncRecoveryHandler {
 
     override suspend fun recover(failure: CoreFailure, onIncrementalSyncRetryCallback: OnIncrementalSyncRetryCallback) {
@@ -42,6 +44,7 @@ internal class IncrementalSyncRecoveryHandlerImpl(
         if (shouldRestartSlowSyncProcess(failure)) {
             slowSyncRepository.clearLastSlowSyncCompletionInstant()
             slowSyncRepository.setNeedsToRecoverMLSGroups(true)
+            addSystemMessageToAllConversationsUseCase()
         } else {
             kaliumLogger.i("$TAG Retrying to recover form the failure $failure, perform the incremental sync again")
             onIncrementalSyncRetryCallback.retry()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandlerTest.kt
@@ -19,11 +19,19 @@
 package com.wire.kalium.logic.sync.incremental
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCase
+import com.wire.kalium.logic.test_util.TestNetworkException
+import com.wire.kalium.network.api.base.model.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
 import io.mockative.Mock
+import io.mockative.Times
 import io.mockative.any
 import io.mockative.classOf
+import io.mockative.eq
 import io.mockative.mock
+import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -36,23 +44,28 @@ class IncrementalSyncRecoveryHandlerTest {
         val arrangement = Arrangement().arrange()
 
         // when
-        arrangement.recoverWithFailure(CoreFailure.Unknown(IllegalStateException()))
+        arrangement.recoverWithFailure(NetworkFailure.ServerMiscommunication(TestNetworkException.notFound))
 
         // then
         with(arrangement) {
             verify(slowSyncRepository)
                 .suspendFunction(slowSyncRepository::clearLastSlowSyncCompletionInstant)
-                .wasNotInvoked()
+                .wasInvoked(once)
 
             verify(slowSyncRepository)
                 .suspendFunction(slowSyncRepository::setNeedsToRecoverMLSGroups)
-                .with(any())
-                .wasNotInvoked()
+                .with(eq(true))
+                .wasInvoked(once)
+
+            verify(addSystemMessageToAllConversationsUseCase)
+                .function(addSystemMessageToAllConversationsUseCase::invoke)
+                .with()
+                .wasInvoked()
 
             verify(onIncrementalSyncRetryCallback)
                 .function(onIncrementalSyncRetryCallback::retry)
                 .with()
-                .wasInvoked()
+                .wasNotInvoked()
         }
     }
 
@@ -81,6 +94,11 @@ class IncrementalSyncRecoveryHandlerTest {
                 .function(onIncrementalSyncRetryCallback::retry)
                 .with()
                 .wasInvoked()
+
+            verify(addSystemMessageToAllConversationsUseCase)
+                .function(addSystemMessageToAllConversationsUseCase::invoke)
+                .with()
+                .wasNotInvoked()
         }
     }
 
@@ -90,10 +108,14 @@ class IncrementalSyncRecoveryHandlerTest {
         val onIncrementalSyncRetryCallback: OnIncrementalSyncRetryCallback = mock(classOf<OnIncrementalSyncRetryCallback>())
 
         @Mock
+        val addSystemMessageToAllConversationsUseCase: AddSystemMessageToAllConversationsUseCase =
+            mock(classOf<AddSystemMessageToAllConversationsUseCase>())
+
+        @Mock
         val slowSyncRepository: SlowSyncRepository = mock(classOf<SlowSyncRepository>())
 
         private val incrementalSyncRecoveryHandler by lazy {
-            IncrementalSyncRecoveryHandlerImpl(slowSyncRepository)
+            IncrementalSyncRecoveryHandlerImpl(slowSyncRepository, addSystemMessageToAllConversationsUseCase)
         }
 
         suspend fun recoverWithFailure(failure: CoreFailure) {

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -421,6 +421,10 @@ insertMessage:
 INSERT INTO Message(id, content_type, conversation_id, creation_date, sender_user_id, sender_client_id, status, visibility, expects_read_confirmation)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?);
 
+insertOrIgnoreBulkSystemMessage:
+INSERT OR IGNORE INTO Message(id, content_type, conversation_id, date, sender_user_id, sender_client_id, status, visibility, expects_read_confirmation)
+SELECT ?, ?, qualified_id, ?, ?, ?, ?, ?, ? FROM Conversation WHERE type IN ('ONE_ON_ONE', 'GROUP') ;
+
 insertMessageMention:
 INSERT OR IGNORE INTO MessageMention(message_id, conversation_id, start, length, user_id)
 VALUES (?, ?, ?, ?, ?);

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -56,6 +56,8 @@ interface MessageDAO {
      * @see insertOrIgnoreMessage
      */
     suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>)
+
+    suspend fun persistSystemMessageToAllConversations(message: MessageEntity.System)
     suspend fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
     suspend fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity)
     suspend fun updateMessageDate(date: String, id: String, conversationId: QualifiedIDEntity)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.ASSET
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.CONVERSATION_RENAMED
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.CRYPTO_SESSION_RESET
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.FAILED_DECRYPTION
+import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.HISTORY_LOST
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.KNOCK
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.MEMBER_CHANGE
 import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType.MISSED_CALL
@@ -107,6 +108,19 @@ class MessageDAOImpl(
         queries.transaction {
             messages.forEach { insertInDB(it) }
         }
+    }
+
+    override suspend fun persistSystemMessageToAllConversations(message: MessageEntity.System) {
+        queries.insertOrIgnoreBulkSystemMessage(
+            id = message.id,
+            date = message.date,
+            sender_user_id = message.senderUserId,
+            sender_client_id = null,
+            visibility = message.visibility,
+            status = message.status,
+            content_type = contentTypeOf(message.content),
+            expects_read_confirmation = false
+        )
     }
 
     /**

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -138,7 +138,7 @@ sealed class MessageEntity(
     @Serializable
     enum class ContentType {
         TEXT, ASSET, KNOCK, MEMBER_CHANGE, MISSED_CALL, RESTRICTED_ASSET,
-        CONVERSATION_RENAMED, UNKNOWN, FAILED_DECRYPTION, REMOVED_FROM_TEAM, CRYPTO_SESSION_RESET
+        CONVERSATION_RENAMED, UNKNOWN, FAILED_DECRYPTION, REMOVED_FROM_TEAM, CRYPTO_SESSION_RESET, HISTORY_LOST
     }
 
     enum class MemberChangeType {
@@ -257,6 +257,7 @@ sealed class MessageEntityContent {
     object CryptoSessionReset : System()
     data class ConversationRenamed(val conversationName: String) : System()
     data class TeamMemberRemoved(val userName: String) : System()
+    object HistoryLost : System()
 }
 
 /**

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -97,6 +97,7 @@ object MessageMapper {
         MessageEntity.ContentType.FAILED_DECRYPTION -> MessagePreviewEntityContent.Unknown
         MessageEntity.ContentType.REMOVED_FROM_TEAM -> MessagePreviewEntityContent.TeamMemberRemoved(userName = senderName)
         MessageEntity.ContentType.CRYPTO_SESSION_RESET -> MessagePreviewEntityContent.CryptoSessionReset
+        MessageEntity.ContentType.HISTORY_LOST -> MessagePreviewEntityContent.Unknown
     }
 
     @Suppress("ComplexMethod", "UNUSED_PARAMETER")
@@ -388,6 +389,7 @@ object MessageMapper {
             MessageEntity.ContentType.CONVERSATION_RENAMED -> MessageEntityContent.ConversationRenamed(conversationName.orEmpty())
             MessageEntity.ContentType.REMOVED_FROM_TEAM -> MessageEntityContent.TeamMemberRemoved(senderName.orEmpty())
             MessageEntity.ContentType.CRYPTO_SESSION_RESET -> MessageEntityContent.CryptoSessionReset
+            MessageEntity.ContentType.HISTORY_LOST -> MessageEntityContent.HistoryLost
         }
 
         return createMessageEntity(

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.ConversationDAO
+import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -1128,6 +1129,122 @@ class MessageDAOTest : BaseDatabaseTest() {
         val result = messageDAO.getPendingToConfirmMessagesByConversationAndVisibilityAfterDate(conversationEntity1.id)
 
         assertEquals(expected.sorted(), result.sorted())
+    }
+
+    @Test
+    fun givenOneOnOneConversations_WhenPersistSystemMessageInBulk_ThenPersistedForAllConversations() = runTest {
+        // given
+        val conversationId1 = QualifiedIDEntity("1", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = conversationId1))
+        val conversationId2 = QualifiedIDEntity("2", "someDomain")
+        conversationDAO.insertConversation(newConversationEntity(id = conversationId2))
+
+        val messageId = "systemMessage"
+        userDAO.insertUser(userEntity1)
+
+        // when
+        messageDAO.persistSystemMessageToAllConversations(
+            newSystemMessageEntity(
+                id = messageId,
+                date = "2000-01-01T13:00:00.000Z",
+                conversationId = conversationId1,
+                senderUserId = userEntity1.id,
+                content = MessageEntityContent.HistoryLost
+            )
+        )
+
+        // then
+        val result1 = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = conversationId1
+        )
+        val result2 = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = conversationId2
+        )
+        assertTrue {
+            result1.first()?.content == MessageEntityContent.HistoryLost &&
+                    result2.first()?.content == MessageEntityContent.HistoryLost
+        }
+    }
+
+    @Test
+    fun givenMixedTypeOfConversations_WhenPersistSystemMessageInBulk_ThenMessageShouldPersistedOnlyForOneOnOneAndGroups() = runTest {
+        // given
+        val selfConversation = QualifiedIDEntity("selfConversation", "someDomain")
+        conversationDAO.insertConversation(
+            newConversationEntity(id = selfConversation).copy(
+                type = ConversationEntity.Type.SELF
+            )
+        )
+        val oneOnOneConversation = QualifiedIDEntity("oneOnOneConversation", "someDomain")
+        conversationDAO.insertConversation(
+            newConversationEntity(id = oneOnOneConversation).copy(
+                type = ConversationEntity.Type.ONE_ON_ONE
+            )
+        )
+        val groupConversation = QualifiedIDEntity("groupConversation", "someDomain")
+        conversationDAO.insertConversation(
+            newConversationEntity(id = groupConversation).copy(
+                type = ConversationEntity.Type.GROUP
+            )
+        )
+        val connectionPendingConversation = QualifiedIDEntity("connectionPendingConversation", "someDomain")
+        conversationDAO.insertConversation(
+            newConversationEntity(id = connectionPendingConversation).copy(
+                type = ConversationEntity.Type.CONNECTION_PENDING
+            )
+        )
+        val globalTeamConversation = QualifiedIDEntity("globalTeamConversation", "someDomain")
+        conversationDAO.insertConversation(
+            newConversationEntity(id = globalTeamConversation).copy(
+                type = ConversationEntity.Type.GLOBAL_TEAM
+            )
+        )
+
+        val messageId = "systemMessage"
+        userDAO.insertUser(userEntity1)
+
+        // when
+        messageDAO.persistSystemMessageToAllConversations(
+            newSystemMessageEntity(
+                id = messageId,
+                date = "2000-01-01T13:00:00.000Z",
+                conversationId = selfConversation,
+                senderUserId = userEntity1.id,
+                content = MessageEntityContent.HistoryLost
+            )
+        )
+
+        // then
+        val resultForSelfConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = selfConversation
+        )
+        val resultForOneOnOneConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = oneOnOneConversation
+        )
+        val resultForGroupConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = groupConversation
+        )
+        val resultForConnectionPendingConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = connectionPendingConversation
+        )
+        val resultForGlobalTeamConversation = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = globalTeamConversation
+        )
+
+        assertTrue {
+            resultForSelfConversation.firstOrNull() == null &&
+                    resultForOneOnOneConversation.first()?.content == MessageEntityContent.HistoryLost &&
+                    resultForGroupConversation.first()?.content == MessageEntityContent.HistoryLost &&
+                    resultForConnectionPendingConversation.firstOrNull() == null &&
+                    resultForGlobalTeamConversation.firstOrNull() == null
+        }
     }
 
     private suspend fun insertInitialData() {


### PR DESCRIPTION
… (AR-2897) (#1338)

* feat(sync): insert history-lost systemMessage after 404 sync recovery

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
 Cherry pick inserting 404 recovery message after sync failure.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
