### PR TITLE
fix: Broken injection source in testservice after functions marked suspend

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import javax.ws.rs.GET
 import javax.ws.rs.POST
@@ -68,9 +69,11 @@ class ClientResources(private val instanceService: InstanceService) {
             )
         ]
     )
-    suspend fun fingerprint(@PathParam("id") id: String): Response {
+    fun fingerprint(@PathParam("id") id: String): Response {
         instanceService.getInstance(id) ?: throw WebApplicationException("No instance found with id $id")
-        return instanceService.getFingerprint(id)
+        return runBlocking {
+            instanceService.getFingerprint(id)
+        }
     }
 
     // POST /api/v1/instance/{instanceId}/breakSession

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.testservice.models.SendPingRequest
 import com.wire.kalium.testservice.models.SendReactionRequest
 import com.wire.kalium.testservice.models.SendTextRequest
 import io.swagger.v3.oas.annotations.Operation
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import javax.validation.Valid
 import javax.ws.rs.POST
@@ -71,15 +72,17 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/delete")
     @Operation(summary = "Delete a message locally")
-    suspend fun delete(@PathParam("id") id: String, @Valid deleteMessageRequest: DeleteMessageRequest): Response {
+    fun delete(@PathParam("id") id: String, @Valid deleteMessageRequest: DeleteMessageRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         with(deleteMessageRequest) {
-            ConversationRepository.deleteConversation(
-                instance,
-                ConversationId(conversationId, conversationDomain),
-                messageId,
-                false
-            )
+            runBlocking {
+                ConversationRepository.deleteConversation(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    messageId,
+                    false
+                )
+            }
         }
         return Response.status(Response.Status.OK).build()
     }
@@ -87,28 +90,32 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/deleteEverywhere")
     @Operation(summary = "Delete a message for everyone")
-    suspend fun deleteEverywhere(@PathParam("id") id: String, @Valid deleteMessageRequest: DeleteMessageRequest): Response {
+    fun deleteEverywhere(@PathParam("id") id: String, @Valid deleteMessageRequest: DeleteMessageRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(deleteMessageRequest) {
-            ConversationRepository.deleteConversation(
-                instance,
-                ConversationId(conversationId, conversationDomain),
-                messageId,
-                true
-            )
+            runBlocking {
+                ConversationRepository.deleteConversation(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    messageId,
+                    true
+                )
+            }
         }
     }
 
     @POST
     @Path("/instance/{id}/getMessages")
     @Operation(summary = "Get all messages")
-    suspend fun getMessages(@PathParam("id") id: String, @Valid getMessagesRequest: GetMessagesRequest): List<Message> {
+    fun getMessages(@PathParam("id") id: String, @Valid getMessagesRequest: GetMessagesRequest): List<Message> {
         val instance = instanceService.getInstanceOrThrow(id)
         with(getMessagesRequest) {
-            return ConversationRepository.getMessages(
-                instance,
-                ConversationId(conversationId, conversationDomain)
-            )
+            return runBlocking {
+                ConversationRepository.getMessages(
+                    instance,
+                    ConversationId(conversationId, conversationDomain)
+                )
+            }
         }
     }
 
@@ -118,36 +125,40 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendConfirmationDelivered")
     @Operation(summary = "Send a delivery confirmation for a message")
-    suspend fun sendConfirmationDelivered(
+    fun sendConfirmationDelivered(
         @PathParam("id") id: String,
         @Valid sendConfirmationReadRequest: SendConfirmationReadRequest
     ): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendConfirmationReadRequest) {
-            ConversationRepository.sendConfirmation(
-                instance,
-                ConversationId(conversationId, conversationDomain),
-                ReceiptType.DELIVERED,
-                firstMessageId
-            )
+            runBlocking {
+                ConversationRepository.sendConfirmation(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    ReceiptType.DELIVERED,
+                    firstMessageId
+                )
+            }
         }
     }
 
     @POST
     @Path("/instance/{id}/sendConfirmationRead")
     @Operation(summary = "Send a read confirmation for a message")
-    suspend fun sendConfirmationRead(
+    fun sendConfirmationRead(
         @PathParam("id") id: String,
         @Valid sendConfirmationReadRequest: SendConfirmationReadRequest
     ): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendConfirmationReadRequest) {
-            ConversationRepository.sendConfirmation(
-                instance,
-                ConversationId(conversationId, conversationDomain),
-                ReceiptType.READ,
-                firstMessageId
-            )
+            runBlocking {
+                ConversationRepository.sendConfirmation(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    ReceiptType.READ,
+                    firstMessageId
+                )
+            }
         }
     }
 
@@ -160,37 +171,41 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendFile")
     @Operation(summary = "Send a file to a conversation")
-    suspend fun sendFile(@PathParam("id") id: String, @Valid sendFileRequest: SendFileRequest): Response {
+    fun sendFile(@PathParam("id") id: String, @Valid sendFileRequest: SendFileRequest): Response {
         log.info("Instance $id: Send file with name ${sendFileRequest.fileName}")
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendFileRequest) {
-            ConversationRepository.sendFile(
-                instance,
-                ConversationId(conversationId, conversationDomain),
-                data,
-                fileName,
-                type,
-                invalidHash,
-                otherAlgorithm,
-                otherHash
-            )
+            runBlocking {
+                ConversationRepository.sendFile(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    data,
+                    fileName,
+                    type,
+                    invalidHash,
+                    otherAlgorithm,
+                    otherHash
+                )
+            }
         }
     }
 
     @POST
     @Path("/instance/{id}/sendImage")
     @Operation(summary = "Send an image to a conversation")
-    suspend fun sendImage(@PathParam("id") id: String, @Valid sendImageRequest: SendImageRequest): Response {
+    fun sendImage(@PathParam("id") id: String, @Valid sendImageRequest: SendImageRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendImageRequest) {
-            ConversationRepository.sendImage(
-                instance,
-                ConversationId(conversationId, conversationDomain),
-                data,
-                type,
-                height,
-                width
-            )
+            runBlocking {
+                ConversationRepository.sendImage(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    data,
+                    type,
+                    height,
+                    width
+                )
+            }
         }
     }
 
@@ -200,13 +215,15 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendPing")
     @Operation(summary = "Send a ping to a conversation")
-    suspend fun sendPing(@PathParam("id") id: String, @Valid sendPingRequest: SendPingRequest): Response {
+    fun sendPing(@PathParam("id") id: String, @Valid sendPingRequest: SendPingRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendPingRequest) {
-            ConversationRepository.sendPing(
-                instance,
-                ConversationId(conversationId, conversationDomain)
-            )
+            runBlocking {
+                ConversationRepository.sendPing(
+                    instance,
+                    ConversationId(conversationId, conversationDomain)
+                )
+            }
         }
     }
 
@@ -219,15 +236,17 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendReaction")
     @Operation(summary = "Send a reaction to a message")
-    suspend fun sendReaction(@PathParam("id") id: String, @Valid sendReactionRequest: SendReactionRequest): Response {
+    fun sendReaction(@PathParam("id") id: String, @Valid sendReactionRequest: SendReactionRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendReactionRequest) {
-            ConversationRepository.sendReaction(
-                instance,
-                ConversationId(conversationId, conversationDomain),
-                originalMessageId,
-                type
-            )
+            runBlocking {
+                ConversationRepository.sendReaction(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    originalMessageId,
+                    type
+                )
+            }
         }
     }
 
@@ -237,7 +256,7 @@ class ConversationResources(private val instanceService: InstanceService) {
         summary = "Send a text message to a conversation",
         description = "This can include mentions and reply (buttons and link previews not yet implemented)"
     )
-    suspend fun sendText(@PathParam("id") id: String, @Valid sendTextRequest: SendTextRequest): Response {
+    fun sendText(@PathParam("id") id: String, @Valid sendTextRequest: SendTextRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         // TODO Implement buttons, link previews and ephemeral messages here
         val quotedMessageId = sendTextRequest.quote?.quotedMessageId
@@ -254,13 +273,15 @@ class ConversationResources(private val instanceService: InstanceService) {
             }
         }
         return with(sendTextRequest) {
-            ConversationRepository.sendTextMessage(
-                instance,
-                ConversationId(conversationId, conversationDomain),
-                text,
-                mentions,
-                quotedMessageId
-            )
+            runBlocking {
+                ConversationRepository.sendTextMessage(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    text,
+                    mentions,
+                    quotedMessageId
+                )
+            }
         }
     }
 

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
@@ -33,7 +33,6 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.testservice.models.Instance
 import com.wire.kalium.testservice.models.SendTextResponse
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import okio.Path.Companion.toOkioPath
 import org.slf4j.LoggerFactory
 import java.io.File

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -283,7 +283,7 @@ class InstanceService(val metricRegistry: MetricRegistry) : Managed {
         throw WebApplicationException("Instance $id: No client assigned to instance yet")
     }
 
-    suspend fun setAvailabilityStatus(id: String, status: UserAvailabilityStatus): Unit {
+    suspend fun setAvailabilityStatus(id: String, status: UserAvailabilityStatus) {
         log.info("Instance $id: Get fingerprint of client")
         val instance = getInstanceOrThrow(id)
         instance.coreLogic?.globalScope {

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
 import com.wire.kalium.logic.feature.auth.AuthenticationScope
@@ -253,36 +254,49 @@ class InstanceService(val metricRegistry: MetricRegistry) : Managed {
         log.info("Instance $id: Get fingerprint of client")
         val instance = getInstanceOrThrow(id)
         instance.coreLogic?.globalScope {
-            scope.async {
-                val result = session.currentSession()
-                if (result is CurrentSessionResult.Success) {
-                    instance.coreLogic.sessionScope(result.accountInfo.userId) {
-                        return@async runBlocking {
-                            when (val fingerprint = client.getProteusFingerprint()) {
-                                is GetProteusFingerprintResult.Success -> {
-                                    return@runBlocking Response.status(Response.Status.OK).entity(
-                                        FingerprintResponse(fingerprint.fingerprint, id)
-                                    ).build()
-                                }
+            val result = session.currentSession()
+            if (result is CurrentSessionResult.Success) {
+                instance.coreLogic.sessionScope(result.accountInfo.userId) {
+                    return runBlocking {
+                        when (val fingerprint = client.getProteusFingerprint()) {
+                            is GetProteusFingerprintResult.Success -> {
+                                return@runBlocking Response.status(Response.Status.OK).entity(
+                                    FingerprintResponse(fingerprint.fingerprint, id)
+                                ).build()
+                            }
 
-                                is GetProteusFingerprintResult.Failure -> {
-                                    return@runBlocking Response.status(Response.Status.NO_CONTENT)
-                                        .entity(
-                                            "Instance $id: Cannot get fingerprint: "
-                                                    + fingerprint.genericFailure
-                                        ).build()
-                                }
+                            is GetProteusFingerprintResult.Failure -> {
+                                return@runBlocking Response.status(Response.Status.NO_CONTENT)
+                                    .entity(
+                                        "Instance $id: Cannot get fingerprint: "
+                                                + fingerprint.genericFailure
+                                    ).build()
                             }
                         }
                     }
-                } else {
-                    return@async Response.status(Response.Status.NOT_FOUND)
-                        .entity("Instance $id: No current session found").build()
                 }
-            }.await()
-
+            } else {
+                return Response.status(Response.Status.NOT_FOUND)
+                    .entity("Instance $id: No current session found").build()
+            }
         }
         throw WebApplicationException("Instance $id: No client assigned to instance yet")
     }
 
+    suspend fun setAvailabilityStatus(id: String, status: UserAvailabilityStatus): Unit {
+        log.info("Instance $id: Get fingerprint of client")
+        val instance = getInstanceOrThrow(id)
+        instance.coreLogic?.globalScope {
+            scope.async {
+                val result = session.currentSession()
+                if (result is CurrentSessionResult.Success) {
+                    instance.coreLogic.sessionScope(result.accountInfo.userId) {
+                        runBlocking {
+                            users.updateSelfAvailabilityStatus(status)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Unfortunately the testservice broke after PR #1428 

### Causes (Optional)

Kotlin changes the function signature when functions are marked suspend. The injection framework in Dropwizard was not able to find the functions for the endpoints anymore when it was started (compilation worked) and threw an error.

### Solutions

Removed `suspend` from endpoint functions and used runBlocking blocks to be able to use the kalium library. The good part about this was that i could remove the runBlocking blocks from inside the scopes.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
