### PR TITLE
refactor: update message data after send in one query

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -134,7 +134,6 @@ interface ConversationRepository {
         mutedStatusTimestamp: Long
     ): Either<NetworkFailure, Unit>
 
-    suspend fun getConversationsForNotifications(): Flow<List<Conversation>>
     suspend fun getConversationsByGroupState(
         groupState: Conversation.ProtocolInfo.MLS.GroupState
     ): Either<StorageFailure, List<Conversation>>
@@ -435,11 +434,6 @@ internal class ConversationDataSource internal constructor(
                 conversationID.toDao()
             )
         }
-
-    override suspend fun getConversationsForNotifications(): Flow<List<Conversation>> =
-        conversationDAO.getConversationsForNotifications()
-            .filterNotNull()
-            .map { it.map(conversationMapper::fromDaoModel) }
 
     override suspend fun getConversationsByGroupState(
         groupState: Conversation.ProtocolInfo.MLS.GroupState

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -188,20 +188,18 @@ class MessageDataSource(
     override suspend fun getNotificationMessage(
         messageSizePerConversation: Int
     ): Either<CoreFailure, Flow<List<LocalNotificationConversation>>> = wrapStorageRequest {
-        messageDAO.getNotificationMessage().mapLatest {
-            it.groupBy { item ->
-                item.conversationId
-            }.map { (conversationId, messages) ->
-                LocalNotificationConversation(
-                    // todo: needs some clean up!
-                    id = conversationId.toModel(),
-                    conversationName = messages.first().conversationName ?: "",
-                    messages = messages.take(messageSizePerConversation)
-                        .mapNotNull { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
-                    isOneToOneConversation = messages.first().conversationType?.let { type ->
-                        type == ConversationEntity.Type.ONE_ON_ONE
-                    } ?: false)
-            }
+        messageDAO.getNotificationMessage().mapLatest { notificationEntities ->
+            notificationEntities.groupBy { it.conversationId }
+                .map { (conversationId, messages) ->
+                    LocalNotificationConversation(
+                        // todo: needs some clean up!
+                        id = conversationId.toModel(),
+                        conversationName = messages.first().conversationName ?: "",
+                        messages = messages.take(messageSizePerConversation)
+                            .mapNotNull { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
+                        isOneToOneConversation = messages.first().conversationType == ConversationEntity.Type.ONE_ON_ONE
+                    )
+                }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -94,12 +94,6 @@ interface MessageRepository {
         conversationId: ConversationId,
         messageUuid: String
     ): Either<CoreFailure, Unit>
-
-    @Deprecated("")
-    suspend fun updateMessageDate(conversationId: ConversationId, messageUuid: String, date: String): Either<CoreFailure, Unit>
-
-    @Deprecated("")
-    suspend fun updatePendingMessagesAddMillisToDate(conversationId: ConversationId, millis: Long): Either<CoreFailure, Unit>
     suspend fun getMessageById(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Message>
     suspend fun getMessagesByConversationIdAndVisibility(
         conversationId: ConversationId,
@@ -295,16 +289,6 @@ class MessageDataSource(
                 messageUuid,
                 conversationId.toDao()
             )
-        }
-
-    override suspend fun updateMessageDate(conversationId: ConversationId, messageUuid: String, date: String) =
-        wrapStorageRequest {
-            messageDAO.updateMessageDate(date, messageUuid, conversationId.toDao())
-        }
-
-    override suspend fun updatePendingMessagesAddMillisToDate(conversationId: ConversationId, millis: Long) =
-        wrapStorageRequest {
-            messageDAO.updateMessagesAddMillisToDate(millis, conversationId.toDao(), MessageEntity.Status.PENDING)
         }
 
     override suspend fun sendEnvelope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCase.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.functional.fold
 
 /**
@@ -29,8 +28,7 @@ import com.wire.kalium.logic.functional.fold
  * @see GetNotificationsUseCase
  */
 class MarkMessagesAsNotifiedUseCase internal constructor(
-    private val conversationRepository: ConversationRepository,
-    private val messageRepository: MessageRepository
+    private val conversationRepository: ConversationRepository
 ) {
 
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -218,7 +218,7 @@ class MessageScope internal constructor(
         )
 
     val markMessagesAsNotified: MarkMessagesAsNotifiedUseCase
-        get() = MarkMessagesAsNotifiedUseCase(conversationRepository, messageRepository)
+        get() = MarkMessagesAsNotifiedUseCase(conversationRepository)
 
     val updateAssetMessageUploadStatus: UpdateAssetMessageUploadStatusUseCase
         get() = UpdateAssetMessageUploadStatusUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -45,6 +45,7 @@ import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.toInstant
 
 /**
  * Responsible for orchestrating all the pieces necessary
@@ -130,29 +131,13 @@ internal class MessageSenderImpl internal constructor(
 
     override suspend fun sendMessage(message: Message.Sendable, messageTarget: MessageTarget): Either<CoreFailure, Unit> =
         messageSendingInterceptor.prepareMessage(message).flatMap { processedMessage ->
-            attemptToSend(processedMessage, messageTarget).map { messageRemoteTime ->
-                updateDatesOfMessagesWithServerTime(processedMessage, messageRemoteTime)
+            attemptToSend(processedMessage, messageTarget).flatMap { messageRemoteTime ->
+                val serverDate = messageRemoteTime.toInstant()
+                val localDate = message.date.toInstant()
+                val millis = DateTimeUtil.calculateMillisDifference(localDate, serverDate)
+                messageRepository.updateMessagesAfterOneIsSent(processedMessage.conversationId, processedMessage.id, serverDate, millis)
             }
         }
-
-    private suspend fun updateDatesOfMessagesWithServerTime(
-        message: Message.Sendable,
-        messageRemoteTime: String
-    ) {
-        messageRepository.updateMessageStatus(MessageEntity.Status.SENT, message.conversationId, message.id)
-            .flatMap {
-                messageRepository.updateMessageDate(message.conversationId, message.id, messageRemoteTime)
-            }.flatMap {
-                // this should make sure that pending messages are ordered correctly after one of them is sent
-                messageRepository.updatePendingMessagesAddMillisToDate(
-                    message.conversationId,
-                    DateTimeUtil.calculateMillisDifference(message.date, messageRemoteTime)
-                )
-            }.onFailure {
-                val cause = (it as? CoreFailure.Unknown)?.rootCause ?: (it as? StorageFailure.Generic)?.rootCause
-                logger.w("Failure '$it' on updating dates after sending message '${message.id}'", cause)
-            }
-    }
 
     override suspend fun sendClientDiscoveryMessage(message: Message.Regular): Either<CoreFailure, String> = attemptToSend(message)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -131,11 +131,12 @@ internal class MessageSenderImpl internal constructor(
 
     override suspend fun sendMessage(message: Message.Sendable, messageTarget: MessageTarget): Either<CoreFailure, Unit> =
         messageSendingInterceptor.prepareMessage(message).flatMap { processedMessage ->
-            attemptToSend(processedMessage, messageTarget).flatMap { messageRemoteTime ->
+            attemptToSend(processedMessage, messageTarget).map { messageRemoteTime ->
                 val serverDate = messageRemoteTime.toInstant()
                 val localDate = message.date.toInstant()
                 val millis = DateTimeUtil.calculateMillisDifference(localDate, serverDate)
                 messageRepository.updateMessagesAfterOneIsSent(processedMessage.conversationId, processedMessage.id, serverDate, millis)
+                Unit
             }
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -25,8 +25,10 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.NetworkQualifiedId
 import com.wire.kalium.logic.data.id.PersistenceQualifiedId
+import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.MessageTarget
+import com.wire.kalium.logic.framework.TestMessage.TEST_MESSAGE_ID
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.api.base.authenticated.message.MessageApi
@@ -225,6 +227,25 @@ class MessageRepositoryTest {
             )
     }
 
+    @Test
+    fun whenUpdatingMessageAfterSending_thenDAOFunctionIsCalled() = runTest {
+        val messageID = TEST_MESSAGE_ID
+        val conversationID = TEST_CONVERSATION_ID
+        val millis = 500L
+        val newServerData = Instant.DISTANT_FUTURE
+
+        val (arrangement, messageRepository) = Arrangement()
+            .withUpdateMessageAfterSend()
+            .arrange()
+
+        messageRepository.updateMessagesAfterOneIsSent(conversationID, messageID, newServerData, millis).shouldSucceed()
+
+        verify(arrangement.messageDAO)
+            .suspendFunction(arrangement.messageDAO::updateMessageTableAfterOneIsSent)
+            .with(eq(conversationID.toDao()), eq(messageID), eq(newServerData), eq(millis))
+            .wasInvoked(exactly = once)
+    }
+
     private class Arrangement {
 
         @Mock
@@ -287,6 +308,13 @@ class MessageRepositoryTest {
                     )
                 }
             return this
+        }
+
+        fun withUpdateMessageAfterSend() = apply {
+            given(messageDAO)
+                .suspendFunction(messageDAO::updateMessageTableAfterOneIsSent)
+                .whenInvokedWith(anything(), anything(), anything(), anything())
+                .then { _, _, _, _ -> Unit }
         }
 
         fun arrange() = this to MessageDataSource(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MarkMessagesAsNotifiedUseCaseTest.kt
@@ -130,9 +130,7 @@ class MarkMessagesAsNotifiedUseCaseTest {
                 .thenReturn(result)
         }
 
-        fun arrange() = this to MarkMessagesAsNotifiedUseCase(
-            conversationRepository, messageRepository
-        )
+        fun arrange() = this to MarkMessagesAsNotifiedUseCase(conversationRepository)
 
     }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -224,9 +224,6 @@ SELECT * FROM ConversationDetails WHERE mls_group_state = ? AND protocol = ?;
 getConversationIdByGroupId:
 SELECT qualified_id FROM Conversation WHERE mls_group_id = ?;
 
-selectConversationsWithUnnotifiedMessages:
-SELECT * FROM ConversationDetails WHERE mutedStatus != 'ALL_MUTED' AND (lastNotifiedMessageDate ISNULL OR last_modified_date > lastNotifiedMessageDate);
-
 updateConversationMutingStatus:
 UPDATE Conversation
 SET muted_status = ?, muted_time = ?

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -30,6 +30,7 @@ CREATE INDEX message_content_type_index ON Message(content_type);
 CREATE INDEX message_visibility_index ON Message(visibility);
 CREATE INDEX message_sender_user_index ON Message(sender_user_id);
 CREATE INDEX message_conversation_index ON Message(conversation_id);
+CREATE INDEX message_status_index ON Message(status);
 
 CREATE TABLE MessageMention (
       message_id TEXT NOT NULL,
@@ -499,11 +500,13 @@ updateAssetContent {
     WHERE id = :messageId AND conversation_id = : conversationId;
 }
 
+-- TODO: DELETE
 updateMessageDate:
 UPDATE Message
 SET creation_date = ?
 WHERE id = ? AND conversation_id = ?;
 
+-- TODO: DELETE
 updateMessagesAddMillisToDate:
 UPDATE Message
 SET creation_date = creation_date +  ?
@@ -577,3 +580,13 @@ markMessagesAsDecryptionResolved:
 UPDATE MessageFailedToDecryptContent
 SET is_decryption_resolved = 1
 WHERE message_id IN ?;
+
+updateMessagesTableAfterOneIsSent {
+UPDATE Message
+SET creation_date = :server_creation_date, status = 'SENT'
+WHERE id = :message_id AND conversation_id = :conversation_id;
+
+UPDATE Message
+SET creation_date = creation_date + :millis
+WHERE conversation_id = :conversation_id AND status = 'PENDING';
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
@@ -21,7 +21,7 @@ LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_
 WHERE
 Message.visibility = 'VISIBLE' AND
 (Message.sender_user_id != SelfUser.id) AND
-(Message.creation_date > Conversation.last_read_date) AND
+(Message.creation_date > IFNULL(Conversation.last_notified_date, 0)) AND
 Conversation.muted_status != 'ALL_MUTED'
 ORDER BY Message.creation_date DESC;
 

--- a/persistence/src/commonMain/db_user/migrations/27.sqm
+++ b/persistence/src/commonMain/db_user/migrations/27.sqm
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS message_status_index ON Message(status);

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -181,7 +181,6 @@ interface ConversationDAO {
         mutedStatusTimestamp: Long
     )
 
-    suspend fun getConversationsForNotifications(): Flow<List<ConversationViewEntity>>
     suspend fun updateAccess(
         conversationID: QualifiedIDEntity,
         accessList: List<ConversationEntity.Access>,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -460,14 +460,6 @@ class ConversationDAOImpl(
         conversationQueries.updateConversationMutingStatus(mutedStatus, mutedStatusTimestamp, conversationId)
     }
 
-    override suspend fun getConversationsForNotifications(): Flow<List<ConversationViewEntity>> {
-        return conversationQueries.selectConversationsWithUnnotifiedMessages()
-            .asFlow()
-            .flowOn(coroutineContext)
-            .mapToList()
-            .map { it.map(conversationMapper::toModel) }
-    }
-
     override suspend fun updateAccess(
         conversationID: QualifiedIDEntity,
         accessList: List<ConversationEntity.Access>,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
 
 @Suppress("TooManyFunctions")
 interface MessageDAO {
@@ -113,6 +114,13 @@ interface MessageDAO {
     ): List<String>
 
     suspend fun getReceiptModeFromGroupConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity.ReceiptMode?
+
+    suspend fun updateMessageTableAfterOneIsSent(
+        conversationId: ConversationIDEntity,
+        messageUuid: String,
+        serverDate: Instant,
+        millis: Long
+    )
 
     val platformExtensions: MessageExtensions
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -59,8 +59,6 @@ interface MessageDAO {
     suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>)
     suspend fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
     suspend fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity)
-    suspend fun updateMessageDate(date: String, id: String, conversationId: QualifiedIDEntity)
-    suspend fun updateMessagesAddMillisToDate(millis: Long, conversationId: QualifiedIDEntity, status: MessageEntity.Status)
     suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?>
     suspend fun getMessagesByConversationAndVisibility(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -188,16 +188,6 @@ class MessageDAOImpl(
             queries.updateMessageStatus(status, id, conversationId)
         }
 
-    override suspend fun updateMessageDate(date: String, id: String, conversationId: QualifiedIDEntity) =
-        withContext(coroutineContext) {
-            queries.updateMessageDate(date.toInstant(), id, conversationId)
-        }
-
-    override suspend fun updateMessagesAddMillisToDate(millis: Long, conversationId: QualifiedIDEntity, status: MessageEntity.Status) =
-        withContext(coroutineContext) {
-            queries.updateMessagesAddMillisToDate(Instant.fromEpochMilliseconds(millis), conversationId, status)
-        }
-
     // TODO: mark internal since it is used for tests only
     override suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): Flow<MessageEntity?> =
         queries.selectById(id, conversationId, mapper::toEntityMessageFromView)
@@ -346,12 +336,12 @@ class MessageDAOImpl(
         serverDate: Instant,
         millis: Long
     ) = withContext(coroutineContext) {
-            queries.updateMessagesTableAfterOneIsSent(
-                server_creation_date = serverDate,
-                conversation_id = conversationId,
-                message_id = messageUuid,
-                millis = Instant.fromEpochMilliseconds(millis)
-            )
+        queries.updateMessagesTableAfterOneIsSent(
+            server_creation_date = serverDate,
+            conversation_id = conversationId,
+            message_id = messageUuid,
+            millis = Instant.fromEpochMilliseconds(millis)
+        )
     }
 
     override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, mapper, coroutineContext)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -340,6 +340,20 @@ class MessageDAOImpl(
                 .executeAsOneOrNull()
         }
 
+    override suspend fun updateMessageTableAfterOneIsSent(
+        conversationId: ConversationIDEntity,
+        messageUuid: String,
+        serverDate: Instant,
+        millis: Long
+    ) = withContext(coroutineContext) {
+            queries.updateMessagesTableAfterOneIsSent(
+                server_creation_date = serverDate,
+                conversation_id = conversationId,
+                message_id = messageUuid,
+                millis = Instant.fromEpochMilliseconds(millis)
+            )
+    }
+
     override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, mapper, coroutineContext)
 
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.persistence.kaliumLogger
 import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -222,11 +223,11 @@ class MessageDAOImpl(
             .mapToList()
 
     override suspend fun getNotificationMessage(): Flow<List<NotificationMessageEntity>> =
-        notificationQueries.getNotificationsMessages(
-            mapper::toNotificationEntity
-        ).asFlow()
+        notificationQueries.getNotificationsMessages(mapper::toNotificationEntity)
+            .asFlow()
             .flowOn(coroutineContext)
             .mapToList()
+            .distinctUntilChanged()
 
     override suspend fun observeMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -253,58 +253,6 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    @IgnoreIOS
-    fun givenMultipleConversations_whenGettingConversationsForNotifications_thenOnlyUnnotifiedConversationsAreReturned() = runTest {
-
-        // GIVEN
-        conversationDAO.insertConversation(conversationEntity1)
-        conversationDAO.insertConversation(conversationEntity2)
-        conversationDAO.insertConversation(conversationEntity3)
-        insertTeamUserAndMember(team, user1, conversationEntity1.id)
-        insertTeamUserAndMember(team, user1, conversationEntity2.id)
-        insertTeamUserAndMember(team, user1, conversationEntity3.id)
-
-        // WHEN
-        // Updating the last notified date to later than last modified
-        conversationDAO
-            .updateConversationNotificationDate(
-                QualifiedIDEntity("2", "wire.com")
-            )
-
-        val result = conversationDAO.getConversationsForNotifications().first()
-
-        // THEN
-        // only conversation one should be selected for notifications
-        assertEquals(listOf(conversationEntity1.toViewEntity(user1), conversationEntity3.toViewEntity()), result)
-    }
-
-    @Test
-    @IgnoreIOS
-    fun givenMultipleConversations_whenGettingConversations_thenOrderIsCorrect() = runTest {
-        // GIVEN
-        conversationDAO.insertConversation(conversationEntity1)
-        conversationDAO.insertConversation(conversationEntity2)
-        conversationDAO.insertConversation(conversationEntity3)
-        insertTeamUserAndMember(team, user1, conversationEntity1.id)
-        insertTeamUserAndMember(team, user1, conversationEntity2.id)
-        insertTeamUserAndMember(team, user1, conversationEntity3.id)
-
-        // WHEN
-        // Updating the last notified date to later than last modified
-        conversationDAO
-            .updateConversationNotificationDate(
-                conversationEntity2.id
-            )
-
-        val result = conversationDAO.getConversationsForNotifications().first()
-        // THEN
-        // The order of the conversations is not affected
-        assertEquals(conversationEntity1.toViewEntity(user1), result.first())
-        assertEquals(conversationEntity3.toViewEntity(user1), result[1])
-
-    }
-
-    @Test
     fun givenConversation_whenInsertingMembers_thenMembersShouldNotBeDuplicated() = runTest {
         val expected = listOf(member1, member2)
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -18,16 +18,73 @@
 
 package com.wire.kalium.persistence.dao.message
 
+import app.cash.turbine.test
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
 
 class MessageNotificationsTest : BaseMessageTest() {
+
+    @Test
+    fun givenConversationLastNotifiedDateIsNull_whenNewMessageInserted_thenNotificationPropagated() = runTest {
+        val message = OTHER_MESSAGE
+        insertInitialData()
+
+        messageDAO.insertOrIgnoreMessage(message)
+
+        messageDAO.getNotificationMessage().test {
+            assertEquals(1, awaitItem().size)
+        }
+    }
+
+    @Test
+    fun givenConversationWithMessages_whenConversationLastNotifiedDateUpdated_thenNotificationListEmpty() = runTest {
+        val message = OTHER_MESSAGE
+        insertInitialData()
+        messageDAO.insertOrIgnoreMessage(message)
+
+        conversationDAO.updateConversationNotificationDate(TEST_CONVERSATION_1.id)
+
+        messageDAO.getNotificationMessage().test {
+            assertEquals(0, awaitItem().size)
+        }
+    }
+
+    @Test
+    fun givenConversationWithMessages_whenConversationModifiedDateUpdated_thenNotificationNotAffected() = runTest {
+        val message = OTHER_MESSAGE
+        val date = message.date.plus(2.0.hours).toIsoDateTimeString()
+        insertInitialData()
+        messageDAO.insertOrIgnoreMessage(message)
+
+        messageDAO.getNotificationMessage().test {
+            assertEquals(1, awaitItem().size)
+            conversationDAO.updateConversationModifiedDate(TEST_CONVERSATION_1.id, date)
+
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun givenMutedConversation_whenNewMessageInserted_thenNotificationEmpty() = runTest {
+        val message = OTHER_MESSAGE
+        insertInitialData()
+        conversationDAO.updateConversationMutedStatus(TEST_CONVERSATION_1.id, ConversationEntity.MutedStatus.ALL_MUTED, 0L)
+
+        messageDAO.insertOrIgnoreMessage(message)
+
+        messageDAO.getNotificationMessage().test {
+            assertEquals(0, awaitItem().size)
+        }
+    }
 
     @Test
     fun givenNewMessageInserted_whenConvInAllMutedState_thenNeedsToBeNotifyIsFalse() = runTest {
@@ -233,7 +290,7 @@ class MessageNotificationsTest : BaseMessageTest() {
     }
 
     private suspend fun setConversationMutedStatus(conversationId: QualifiedIDEntity, mutedStatus: ConversationEntity.MutedStatus) {
-        conversationDAO.updateConversationMutedStatus(TEST_CONVERSATION_1.id, mutedStatus, Clock.System.now().toEpochMilliseconds())
+        conversationDAO.updateConversationMutedStatus(conversationId, mutedStatus, Clock.System.now().toEpochMilliseconds())
     }
 
     override suspend fun insertInitialData() {

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
@@ -52,7 +52,16 @@ object DateTimeUtil : PlatformDateTimeUtil() {
      * @return difference between two provided date-times in milliseconds
      */
     fun calculateMillisDifference(isoDateTime1: String, isoDateTime2: String): Long =
-        isoDateTime1.toInstant().until(isoDateTime2.toInstant(), DateTimeUnit.MILLISECOND)
+        calculateMillisDifference(isoDateTime1.toInstant(), isoDateTime2.toInstant())
+
+    /**
+     * Calculate the difference between two date-times provided to it
+     * @param instant1 date-time as Instant
+     * @param instant2 date-time as Instant
+     * @return difference between two provided date-times in milliseconds
+     */
+    fun calculateMillisDifference(instant1: Instant, instant2: Instant): Long =
+        instant1.until(instant2, DateTimeUnit.MILLISECOND)
 
     /**
      * Subtract milliseconds from the given date-time


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

message send takes long time when the DB have too many messages

### Causes (Optional)

update message date after send does an UPDATE query on all messages with PENDING status, but status is not indexed 

### Solutions

refactor message send to do all of the updates in one query and add index to status

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
