### PR TITLE
fix: Reverse message order in testservice like in ETS (SQPIT-1605)

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
@@ -39,6 +39,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.nio.file.Files
 import java.util.Base64
+import java.util.Collections
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response
 
@@ -174,7 +175,10 @@ sealed class ConversationRepository {
                     is CurrentSessionResult.Success -> {
                         instance.coreLogic.sessionScope(session.accountInfo.userId) {
                             log.info("Instance ${instance.instanceId}: Get recent messages...")
-                            return messages.getRecentMessages(conversationId).first()
+                            val messages = messages.getRecentMessages(conversationId).first()
+                            // We need to reverse order of messages because ETS did the same
+                            Collections.reverse(messages)
+                            return messages
                         }
                     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The /getMessages endpoint is used in tests that delete messages. The test failed because they deleted the wrong messages.

### Causes (Optional)

The order of messages on the endpoint was different in ETS

### Solutions

Our goal is to reach feature parity of testservice and ETS. So the testservice will also deliver messages on /getMessages endpoint in order of newest first to oldest.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
