### PR TITLE
feat: testservice can change availability status (SQPIT-1609)

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -18,14 +18,16 @@
 
 package com.wire.kalium.testservice.api.v1
 
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.testservice.managed.InstanceService
-import com.wire.kalium.testservice.models.Instance
+import com.wire.kalium.testservice.models.AvailabilityRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
+import javax.validation.Valid
 import javax.ws.rs.GET
 import javax.ws.rs.POST
 import javax.ws.rs.Path
@@ -44,8 +46,22 @@ class ClientResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/availability")
     @Operation(summary = "Set a user's availability")
-    fun availability(@PathParam("id") id: String): Instance {
-        throw WebApplicationException("Instance $id: Not yet implemented")
+    fun availability(@PathParam("id") id: String, @Valid request: AvailabilityRequest): Response {
+        instanceService.getInstance(id) ?: throw WebApplicationException("No instance found with id $id")
+        val status = when (request.type) {
+            0 -> UserAvailabilityStatus.NONE
+            1 -> UserAvailabilityStatus.AVAILABLE
+            2 -> UserAvailabilityStatus.AWAY
+            3 -> UserAvailabilityStatus.BUSY
+            else -> {
+                return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("type should be one of 0, 1, 2 or 3").build()
+            }
+        }
+        runBlocking {
+            instanceService.setAvailabilityStatus(id, status)
+        }
+        return Response.status(Response.Status.OK).build()
     }
 
     // GET /api/v1/instance/{instanceId}/clients

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -46,6 +46,7 @@ class ClientResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/availability")
     @Operation(summary = "Set a user's availability")
+    @Suppress("MagicNumber")
     fun availability(@PathParam("id") id: String, @Valid request: AvailabilityRequest): Response {
         instanceService.getInstance(id) ?: throw WebApplicationException("No instance found with id $id")
         val status = when (request.type) {

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -284,16 +284,14 @@ class InstanceService(val metricRegistry: MetricRegistry) : Managed {
     }
 
     suspend fun setAvailabilityStatus(id: String, status: UserAvailabilityStatus) {
-        log.info("Instance $id: Get fingerprint of client")
+        log.info("Instance $id: Set availability status to ${status} of client")
         val instance = getInstanceOrThrow(id)
         instance.coreLogic?.globalScope {
             scope.async {
                 val result = session.currentSession()
                 if (result is CurrentSessionResult.Success) {
                     instance.coreLogic.sessionScope(result.accountInfo.userId) {
-                        runBlocking {
-                            users.updateSelfAvailabilityStatus(status)
-                        }
+                        users.updateSelfAvailabilityStatus(status)
                     }
                 }
             }

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -284,7 +284,7 @@ class InstanceService(val metricRegistry: MetricRegistry) : Managed {
     }
 
     suspend fun setAvailabilityStatus(id: String, status: UserAvailabilityStatus) {
-        log.info("Instance $id: Set availability status to ${status} of client")
+        log.info("Instance $id: Set availability status to $status of client")
         val instance = getInstanceOrThrow(id)
         instance.coreLogic?.globalScope {
             scope.async {

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/AvailabilityRequest.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/AvailabilityRequest.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.testservice.models
+
+data class AvailabilityRequest(
+    val teamId: String = "",
+    val type: Int = 0,
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR implements the endpoint /availability for testservice. Unfortunately the broadcast functionality is not implemented in kalium itself so this endpoint will not have any effect yet. But once it is implemented it should directly work.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
