### PR TITLE
feat(calling): support routing calling messages via self conversation AR-2761

### DIFF
--- a/calling/src/commonJvmAndroid/kotlin/com.wire.kalium.calling/callbacks/SendHandler.kt
+++ b/calling/src/commonJvmAndroid/kotlin/com.wire.kalium.calling/callbacks/SendHandler.kt
@@ -35,6 +35,7 @@ fun interface SendHandler : Callback {
         data: Pointer?,
         length: Size_t,
         isTransient: Boolean,
+        myClientsOnly: Boolean,
         arg: Pointer?
     ): Int
 }

--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.types.Handle
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
@@ -65,6 +66,9 @@ class CallManagerTest {
     private val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
     @Mock
+    private val selfConversationIdProvider = mock(classOf<SelfConversationIdProvider>())
+
+    @Mock
     private val conversationRepository = mock(classOf<ConversationRepository>())
 
     @Mock
@@ -89,6 +93,7 @@ class CallManagerTest {
             callRepository = callRepository,
             userRepository = userRepository,
             currentClientIdProvider = currentClientIdProvider,
+            selfConversationIdProvider = selfConversationIdProvider,
             conversationRepository = conversationRepository,
             messageSender = messageSender,
             kaliumDispatchers = dispatcher,

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.calling.types.Uint32_t
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallClientList
@@ -86,6 +87,7 @@ class CallManagerImpl internal constructor(
     private val callRepository: CallRepository,
     private val userRepository: UserRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
+    private val selfConversationIdProvider: SelfConversationIdProvider,
     private val conversationRepository: ConversationRepository,
     private val messageSender: MessageSender,
     private val callMapper: CallMapper,
@@ -154,6 +156,7 @@ class CallManagerImpl internal constructor(
                     selfUserId,
                     selfClientId,
                     messageSender,
+                    selfConversationIdProvider,
                     scope,
                     callMapper
                 ).keepingStrongReference(),
@@ -191,13 +194,19 @@ class CallManagerImpl internal constructor(
         val currTime = System.currentTimeMillis()
         val msgTime = message.date.toEpochMillis()
 
+        val targetConversationId = if (message.isSelfMessage) {
+            content.conversationId ?: message.conversationId
+        } else {
+            message.conversationId
+        }
+
         wcall_recv_msg(
             inst = deferredHandle.await(),
             msg = msg,
             len = msg.size,
             curr_time = Uint32_t(value = currTime / 1000),
             msg_time = Uint32_t(value = msgTime / 1000),
-            convId = federatedIdMapper.parseToFederatedId(message.conversationId),
+            convId = federatedIdMapper.parseToFederatedId(targetConversationId),
             userId = federatedIdMapper.parseToFederatedId(message.senderUserId),
             clientId = message.senderClientId.value
         )

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -22,6 +22,7 @@ import com.sun.jna.Pointer
 import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.ENVIRONMENT_DEFAULT
 import com.wire.kalium.calling.callbacks.LogHandler
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
@@ -72,6 +73,7 @@ actual class GlobalCallManager(
         callRepository: CallRepository,
         userRepository: UserRepository,
         currentClientIdProvider: CurrentClientIdProvider,
+        selfConversationIdProvider: SelfConversationIdProvider,
         conversationRepository: ConversationRepository,
         messageSender: MessageSender,
         callMapper: CallMapper,
@@ -84,6 +86,7 @@ actual class GlobalCallManager(
             callRepository = callRepository,
             userRepository = userRepository,
             currentClientIdProvider = currentClientIdProvider,
+            selfConversationIdProvider = selfConversationIdProvider,
             callMapper = callMapper,
             messageSender = messageSender,
             conversationRepository = conversationRepository,

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.callbacks.SendHandler
 import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.calling.types.Size_t
-import com.wire.kalium.logic.cache.ProteusSelfConversationIdProvider
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallClientList
@@ -34,7 +33,6 @@ import com.wire.kalium.logic.feature.call.AvsCallBackError
 import com.wire.kalium.logic.feature.call.CallManagerImpl
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.MessageTarget
-import com.wire.kalium.logic.functional.getOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.serialization.decodeFromString
@@ -53,7 +51,7 @@ internal class OnSendOTR(
     private val callingScope: CoroutineScope,
     private val callMapper: CallMapper
 ) : SendHandler {
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
     override fun onSend(
         context: Pointer?,
         remoteConversationId: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -150,7 +150,7 @@ sealed class MessageContent {
         val conversationId: ConversationId,
     ) : Signaling()
 
-    data class Calling(val value: String) : Signaling()
+    data class Calling(val value: String, val conversationId: ConversationId? = null) : Signaling()
 
     data class DeleteMessage(val messageId: String) : Signaling()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -754,6 +754,7 @@ class UserSessionScope internal constructor(
             userRepository = userRepository,
             currentClientIdProvider = clientIdProvider,
             conversationRepository = conversationRepository,
+            selfConversationIdProvider = selfConversationIdProvider,
             messageSender = messages.messageSender,
             federatedIdMapper = federatedIdMapper,
             qualifiedIdMapper = qualifiedIdMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
@@ -38,6 +39,7 @@ expect class GlobalCallManager {
         callRepository: CallRepository,
         userRepository: UserRepository,
         currentClientIdProvider: CurrentClientIdProvider,
+        selfConversationIdProvider: SelfConversationIdProvider,
         conversationRepository: ConversationRepository,
         messageSender: MessageSender,
         callMapper: CallMapper,

--- a/logic/src/darwinMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/darwinMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapper
@@ -37,6 +38,7 @@ actual class GlobalCallManager {
         callRepository: CallRepository,
         userRepository: UserRepository,
         currentClientIdProvider: CurrentClientIdProvider,
+        selfConversationIdProvider: SelfConversationIdProvider,
         conversationRepository: ConversationRepository,
         messageSender: MessageSender,
         callMapper: CallMapper,

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnHttpRequestTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnHttpRequestTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.scenario
+
+import com.wire.kalium.calling.Calling
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.scenario.OnHttpRequest
+import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.feature.message.MessageTarget
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Test
+
+class OnHttpRequestTest {
+
+    @Test
+    fun givenSendInSelfConversationIsTrue_whenSending_messageIsSentInSelfConversations() = runTest(TestKaliumDispatcher.main) {
+        val (arrangement, onHttpRequest) = Arrangement()
+            .givenSelfConversationIdProviderReturns(Either.Right(listOf(Arrangement.selfConversationId)))
+            .givenSendMessageSuccessful()
+            .arrange()
+
+        onHttpRequest.sendHandlerSuccess(
+            context = null,
+            messageString = "message",
+            conversationId = Arrangement.conversationId,
+            avsSelfUserId = Arrangement.selfUserId,
+            avsSelfClientId = Arrangement.selfUserCLientId,
+            messageTarget = MessageTarget.Conversation,
+            sendInSelfConversation = true
+        )
+        yield()
+
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(
+                matching { it.conversationId == Arrangement.selfConversationId },
+                eq(MessageTarget.Conversation)
+            )
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSendInSelfConversationIsFalse_whenSending_messageIsSentInTargetConversation() = runTest(TestKaliumDispatcher.main) {
+        val (arrangement, onHttpRequest) = Arrangement()
+            .givenSendMessageSuccessful()
+            .arrange()
+
+        onHttpRequest.sendHandlerSuccess(
+            context = null,
+            messageString = "message",
+            conversationId = Arrangement.conversationId,
+            avsSelfUserId = Arrangement.selfUserId,
+            avsSelfClientId = Arrangement.selfUserCLientId,
+            messageTarget = MessageTarget.Conversation,
+            sendInSelfConversation = false
+        )
+        yield()
+
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(
+                matching { it.conversationId == Arrangement.conversationId },
+                eq(MessageTarget.Conversation)
+            )
+            .wasInvoked(exactly = once)
+    }
+
+    internal class Arrangement {
+
+        @Mock
+        val calling = mock(classOf<Calling>())
+
+        @Mock
+        val messageSender = mock(classOf<MessageSender>())
+
+        @Mock
+        val selfConversationIdProvider = mock(classOf<SelfConversationIdProvider>())
+
+        fun arrange() = this to OnHttpRequest(
+            CompletableDeferred(),
+            calling,
+            messageSender,
+            CoroutineScope(TestKaliumDispatcher.main),
+            selfConversationIdProvider
+        )
+
+        companion object {
+            val conversationId = TestConversation.GROUP().id
+            val selfConversationId = TestConversation.SELF().id
+            val selfUserId = TestUser.SELF.id
+            val selfUserCLientId = ClientId("self_client")
+        }
+
+        fun givenSelfConversationIdProviderReturns(result: Either<StorageFailure, List<ConversationId>>) = apply {
+            given(selfConversationIdProvider)
+                .suspendFunction(selfConversationIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(result)
+        }
+
+        fun givenSendMessageSuccessful() = apply {
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Right(Unit))
+        }
+    }
+}

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnSendOTRTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnSendOTRTest.kt
@@ -106,7 +106,7 @@ class OnSendOTRTest {
             data = memory.share(0),
             length = Size_t(memory.size()),
             isTransient = true,
-            myClientsOnly = true,
+            myClientsOnly = false,
             arg = null
         )
         yield()

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnSendOTRTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnSendOTRTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.scenario
+
+import com.sun.jna.Memory
+import com.wire.kalium.calling.Calling
+import com.wire.kalium.calling.types.Size_t
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
+import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
+import com.wire.kalium.logic.feature.call.CallManagerImpl
+import com.wire.kalium.logic.feature.call.scenario.OnSendOTR
+import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.feature.message.MessageTarget
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Test
+
+class OnSendOTRTest {
+
+    @Test
+    fun givenMyClientsOnlyIsTrue_whenSending_messageIsSentInSelfConversations() = runTest(TestKaliumDispatcher.main) {
+        val (arrangement, onSendOTR) = Arrangement()
+            .givenSelfConversationIdProviderReturns(Either.Right(listOf(Arrangement.selfConversationId)))
+            .givenSendMessageSuccessful()
+            .arrange()
+
+        val content = "calling_content"
+        val memory = Memory((content.length + 1).toLong())
+        memory.setString(0, content, CallManagerImpl.UTF8_ENCODING)
+
+        onSendOTR.onSend(
+            context = null,
+            remoteConversationId = Arrangement.conversationId.toString(),
+            remoteSelfUserId = Arrangement.selfUserId.toString(),
+            remoteClientIdSelf = Arrangement.selfUserClientId.value,
+            targetRecipientsJson = null,
+            clientIdDestination = null,
+            data = memory.share(0),
+            length = Size_t(memory.size()),
+            isTransient = true,
+            myClientsOnly = true,
+            arg = null
+        )
+        yield()
+
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(
+                matching { it.conversationId == Arrangement.selfConversationId },
+                eq(MessageTarget.Conversation)
+            )
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenMyClientsOnlyIsFalse_whenSending_messageIsSentInTargetConversation() = runTest(TestKaliumDispatcher.main) {
+        val (arrangement, onSendOTR) = Arrangement()
+            .givenSendMessageSuccessful()
+            .arrange()
+
+        val content = "calling_content"
+        val memory = Memory((content.length + 1).toLong())
+        memory.setString(0, content, CallManagerImpl.UTF8_ENCODING)
+
+        onSendOTR.onSend(
+            context = null,
+            remoteConversationId = Arrangement.conversationId.toString(),
+            remoteSelfUserId = Arrangement.selfUserId.toString(),
+            remoteClientIdSelf = Arrangement.selfUserClientId.value,
+            targetRecipientsJson = null,
+            clientIdDestination = null,
+            data = memory.share(0),
+            length = Size_t(memory.size()),
+            isTransient = true,
+            myClientsOnly = true,
+            arg = null
+        )
+        yield()
+
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(
+                matching { it.conversationId == Arrangement.conversationId },
+                eq(MessageTarget.Conversation)
+            )
+            .wasInvoked(exactly = once)
+    }
+
+    internal class Arrangement {
+
+        @Mock
+        val calling = mock(classOf<Calling>())
+
+        @Mock
+        val messageSender = mock(classOf<MessageSender>())
+
+        @Mock
+        val selfConversationIdProvider = mock(classOf<SelfConversationIdProvider>())
+
+        val qualifiedIdMapper = QualifiedIdMapperImpl(TestUser.SELF.id)
+
+        val callMapper = CallMapperImpl(qualifiedIdMapper)
+
+        fun arrange() = this to OnSendOTR(
+            CompletableDeferred(),
+            calling,
+            qualifiedIdMapper,
+            TestUser.SELF.id.toString(),
+                    "self_client_id",
+            messageSender,
+            selfConversationIdProvider,
+            CoroutineScope(TestKaliumDispatcher.main),
+            callMapper
+        )
+
+        companion object {
+            val conversationId = TestConversation.GROUP().id
+            val selfConversationId = TestConversation.SELF().id
+            val selfUserId = TestUser.SELF.id
+            val selfUserClientId = ClientId("self_client")
+        }
+
+        fun givenSelfConversationIdProviderReturns(result: Either<StorageFailure, List<ConversationId>>) = apply {
+            given(selfConversationIdProvider)
+                .suspendFunction(selfConversationIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(result)
+        }
+
+        fun givenSendMessageSuccessful() = apply {
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Right(Unit))
+        }
+    }
+
+}

--- a/protobuf-codegen/src/main/proto/messages.proto
+++ b/protobuf-codegen/src/main/proto/messages.proto
@@ -332,6 +332,7 @@ message Reaction {
 
 message Calling {
     required string content = 1;
+    optional QualifiedConversationId qualified_conversation_id = 2;
 }
 
 message DataTransfer {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

AVS sometimes targets only your own self clients when sending calling messages like `REJECT` which tells your other devices that you've rejected a call and should stop ringing.

This is not possible with MLS so instead we add support routing calling messages via the self conversation to reach your self clients.

- Update `Calling` protobuf message to include a "target" conversation.
- Route calling messages via self conversation when AVS sets `onlyToMyClients` to `true`.
- Handle receiving a calling message received in the self conversation.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes

Test code has some code duplication, would need to refactor OnHttpRequest and OnSendOTR to avoid it.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
