### PR TITLE
fix: [DEV] optimise notification query [#1432]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -33,7 +33,6 @@ import com.wire.kalium.logic.data.notification.LocalNotificationMessageAuthor
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.persistence.dao.message.AssetTypeEntity
-import com.wire.kalium.persistence.dao.message.AssetTypeEntity.IMAGE
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
 import com.wire.kalium.persistence.dao.message.MessagePreviewEntity
@@ -48,8 +47,8 @@ interface MessageMapper {
     fun fromEntityToMessage(message: MessageEntity): Message.Standalone
     fun fromEntityToMessagePreview(message: MessagePreviewEntity): MessagePreview
     fun fromPreviewEntityToUnreadEventCount(message: MessagePreviewEntity): UnreadEventType?
-    fun fromMessageToLocalNotificationMessage(message: NotificationMessageEntity): LocalNotificationMessage
-    fun toMessageEntityContent(regularMessage: MessageContent.Regular): MessageEntityContent.Regular
+    fun fromMessageToLocalNotificationMessage(message: NotificationMessageEntity): LocalNotificationMessage?
+    fun toMessageEntityContent(regulerMessage: MessageContent.Regular): MessageEntityContent.Regular
 }
 
 class MessageMapperImpl(
@@ -176,53 +175,51 @@ class MessageMapperImpl(
     @Suppress("ComplexMethod")
     override fun fromMessageToLocalNotificationMessage(
         message: NotificationMessageEntity
-    ): LocalNotificationMessage =
-        when (val content = message.content) {
-            is MessagePreviewEntityContent.Text -> LocalNotificationMessage.Text(
-                LocalNotificationMessageAuthor(
-                    content.senderName ?: "",
-                    null
-                ), message.date, content.messageBody
+    ): LocalNotificationMessage? {
+        val sender = LocalNotificationMessageAuthor(
+            message.senderName.orEmpty(),
+            message.senderImage?.toModel()
+        )
+        return when (message.contentType) {
+            MessageEntity.ContentType.TEXT -> LocalNotificationMessage.Text(
+                author = sender,
+                text = message.text.orEmpty(),
+                time = message.date,
             )
 
-            is MessagePreviewEntityContent.Asset -> {
-                val type = if (content.type == IMAGE) LocalNotificationCommentType.PICTURE
-                else LocalNotificationCommentType.FILE
-                LocalNotificationMessage.Comment(LocalNotificationMessageAuthor(content.senderName ?: "", null), message.date, type)
+            MessageEntity.ContentType.ASSET -> {
+                val type = message.assetMimeType?.contains("image/")?.let {
+                    if (it) LocalNotificationCommentType.PICTURE else LocalNotificationCommentType.FILE
+                } ?: LocalNotificationCommentType.FILE
+
+                LocalNotificationMessage.Comment(sender, message.date, type)
             }
 
-            is MessagePreviewEntityContent.MissedCall ->
+            MessageEntity.ContentType.KNOCK -> {
                 LocalNotificationMessage.Comment(
-                    LocalNotificationMessageAuthor(content.senderName ?: "", null),
+                    sender,
+                    message.date,
+                    LocalNotificationCommentType.KNOCK
+                )
+            }
+
+            MessageEntity.ContentType.MEMBER_CHANGE -> null
+            MessageEntity.ContentType.MISSED_CALL -> {
+                LocalNotificationMessage.Comment(
+                    sender,
                     message.date,
                     LocalNotificationCommentType.MISSED_CALL
                 )
+            }
 
-            is MessagePreviewEntityContent.Knock -> LocalNotificationMessage.Knock(
-                LocalNotificationMessageAuthor(content.senderName ?: "", null),
-                message.date
-            )
-
-            is MessagePreviewEntityContent.MentionedSelf -> LocalNotificationMessage.Text(
-                author = LocalNotificationMessageAuthor(content.senderName ?: "", null),
-                time = message.date,
-                text = content.messageBody,
-                isMentionedSelf = true,
-            )
-
-            is MessagePreviewEntityContent.QuotedSelf -> LocalNotificationMessage.Text(
-                author = LocalNotificationMessageAuthor(name = content.senderName ?: "", imageUri = null),
-                time = message.date,
-                text = content.messageBody,
-                isQuotingSelfUser = true
-            )
-            // TODO(notifications): Handle other message types
-            else -> LocalNotificationMessage.Comment(
-                LocalNotificationMessageAuthor("", null),
-                message.date,
-                LocalNotificationCommentType.NOT_SUPPORTED_YET
-            )
+            MessageEntity.ContentType.RESTRICTED_ASSET -> null
+            MessageEntity.ContentType.CONVERSATION_RENAMED -> null
+            MessageEntity.ContentType.UNKNOWN -> null
+            MessageEntity.ContentType.FAILED_DECRYPTION -> null
+            MessageEntity.ContentType.REMOVED_FROM_TEAM -> null
+            MessageEntity.ContentType.CRYPTO_SESSION_RESET -> null
         }
+    }
 
     @Suppress("ComplexMethod")
     override fun toMessageEntityContent(regularMessage: MessageContent.Regular): MessageEntityContent.Regular = when (regularMessage) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -48,7 +48,7 @@ interface MessageMapper {
     fun fromEntityToMessagePreview(message: MessagePreviewEntity): MessagePreview
     fun fromPreviewEntityToUnreadEventCount(message: MessagePreviewEntity): UnreadEventType?
     fun fromMessageToLocalNotificationMessage(message: NotificationMessageEntity): LocalNotificationMessage?
-    fun toMessageEntityContent(regulerMessage: MessageContent.Regular): MessageEntityContent.Regular
+    fun toMessageEntityContent(regularMessage: MessageContent.Regular): MessageEntityContent.Regular
 }
 
 class MessageMapperImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -203,7 +203,6 @@ class MessageMapperImpl(
                 )
             }
 
-            MessageEntity.ContentType.MEMBER_CHANGE -> null
             MessageEntity.ContentType.MISSED_CALL -> {
                 LocalNotificationMessage.Comment(
                     sender,
@@ -211,13 +210,16 @@ class MessageMapperImpl(
                     LocalNotificationCommentType.MISSED_CALL
                 )
             }
-
+            MessageEntity.ContentType.MEMBER_CHANGE -> null
             MessageEntity.ContentType.RESTRICTED_ASSET -> null
             MessageEntity.ContentType.CONVERSATION_RENAMED -> null
             MessageEntity.ContentType.UNKNOWN -> null
             MessageEntity.ContentType.FAILED_DECRYPTION -> null
             MessageEntity.ContentType.REMOVED_FROM_TEAM -> null
             MessageEntity.ContentType.CRYPTO_SESSION_RESET -> null
+            MessageEntity.ContentType.NEW_CONVERSATION_RECEIPT_MODE -> null
+            MessageEntity.ContentType.CONVERSATION_RECEIPT_MODE_CHANGED -> null
+            MessageEntity.ContentType.HISTORY_LOST -> null
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -38,7 +38,6 @@ import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.wrapApiRequest
@@ -191,15 +190,7 @@ class MessageDataSource(
     override suspend fun getNotificationMessage(
         messageSizePerConversation: Int
     ): Either<CoreFailure, Flow<List<LocalNotificationConversation>>> = wrapStorageRequest {
-        messageDAO.getNotificationMessage(
-            listOf(
-                MessageEntity.ContentType.TEXT,
-                MessageEntity.ContentType.RESTRICTED_ASSET,
-                MessageEntity.ContentType.ASSET,
-                MessageEntity.ContentType.KNOCK,
-                MessageEntity.ContentType.MISSED_CALL
-            )
-        ).mapLatest {
+        messageDAO.getNotificationMessage().mapLatest {
             it.groupBy { item ->
                 item.conversationId
             }.map { (conversationId, messages) ->
@@ -208,7 +199,7 @@ class MessageDataSource(
                     id = conversationId.toModel(),
                     conversationName = messages.first().conversationName ?: "",
                     messages = messages.take(messageSizePerConversation)
-                        .map { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
+                        .mapNotNull { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
                     isOneToOneConversation = messages.first().conversationType?.let { type ->
                         type == ConversationEntity.Type.ONE_ON_ONE
                     } ?: false)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
@@ -56,7 +56,7 @@ sealed class LocalNotificationMessage(
 
     data class Knock(
         override val author: LocalNotificationMessageAuthor,
-        override val time: String
+        override val time: Instant
     ) : LocalNotificationMessage(author, time)
 
     data class ConnectionRequest(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
@@ -20,6 +20,8 @@ package com.wire.kalium.logic.data.notification
 
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.user.UserAssetId
+import kotlinx.datetime.Instant
 
 /**
  * Kalium local data classes that contains all the necessary data for displaying Message Notifications,
@@ -32,10 +34,13 @@ data class LocalNotificationConversation(
     val isOneToOneConversation: Boolean
 )
 
-sealed class LocalNotificationMessage(open val author: LocalNotificationMessageAuthor, open val time: String) {
+sealed class LocalNotificationMessage(
+    open val author: LocalNotificationMessageAuthor,
+    open val time: Instant
+) {
     data class Text(
         override val author: LocalNotificationMessageAuthor,
-        override val time: String,
+        override val time: Instant,
         val text: String,
         val isQuotingSelfUser: Boolean = false,
         val isMentionedSelf: Boolean = false
@@ -45,7 +50,7 @@ sealed class LocalNotificationMessage(open val author: LocalNotificationMessageA
     // shared file, picture, reaction
     data class Comment(
         override val author: LocalNotificationMessageAuthor,
-        override val time: String,
+        override val time: Instant,
         val type: LocalNotificationCommentType
     ) : LocalNotificationMessage(author, time)
 
@@ -56,17 +61,17 @@ sealed class LocalNotificationMessage(open val author: LocalNotificationMessageA
 
     data class ConnectionRequest(
         override val author: LocalNotificationMessageAuthor,
-        override val time: String,
+        override val time: Instant,
         val authorId: QualifiedID
     ) : LocalNotificationMessage(author, time)
 
     data class ConversationDeleted(
         override val author: LocalNotificationMessageAuthor,
-        override val time: String
+        override val time: Instant
     ) : LocalNotificationMessage(author, time)
 }
 
-data class LocalNotificationMessageAuthor(val name: String, val imageUri: String?)
+data class LocalNotificationMessageAuthor(val name: String, val imageUri: UserAssetId?)
 
 enum class LocalNotificationCommentType {
     PICTURE, FILE, REACTION, MISSED_CALL, NOT_SUPPORTED_YET

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
@@ -74,5 +74,5 @@ sealed class LocalNotificationMessage(
 data class LocalNotificationMessageAuthor(val name: String, val imageUri: UserAssetId?)
 
 enum class LocalNotificationCommentType {
-    PICTURE, FILE, REACTION, MISSED_CALL, NOT_SUPPORTED_YET
+    PICTURE, FILE, REACTION, MISSED_CALL, KNOCK, NOT_SUPPORTED_YET
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.User
+import kotlinx.datetime.toInstant
 
 interface LocalNotificationMessageMapper {
     fun fromPublicUserToLocalNotificationMessageAuthor(author: OtherUser?): LocalNotificationMessageAuthor
@@ -41,7 +42,12 @@ class LocalNotificationMessageMapperImpl : LocalNotificationMessageMapper {
 
     override fun fromConnectionToLocalNotificationConversation(connection: ConversationDetails.Connection): LocalNotificationConversation {
         val author = fromPublicUserToLocalNotificationMessageAuthor(connection.otherUser)
-        val message = LocalNotificationMessage.ConnectionRequest(author, connection.lastModifiedDate, connection.connection.qualifiedToId)
+        val message = LocalNotificationMessage.ConnectionRequest(
+            author,
+            // TODO: change time to Instant
+            connection.lastModifiedDate.toInstant(),
+            connection.connection.qualifiedToId
+        )
         return LocalNotificationConversation(
             connection.conversationId,
             connection.conversation.name ?: "",
@@ -59,7 +65,8 @@ class LocalNotificationMessageMapperImpl : LocalNotificationMessageMapper {
             is Event.Conversation.DeletedConversation -> {
                 val notificationMessage = LocalNotificationMessage.ConversationDeleted(
                     author = LocalNotificationMessageAuthor(author?.name ?: "", null),
-                    time = conversationEvent.timestampIso
+                    // TODO: change time to Instant
+                    time = conversationEvent.timestampIso.toInstant()
                 )
                 LocalNotificationConversation(
                     id = conversation.id,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -45,6 +45,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -58,6 +59,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -378,7 +380,8 @@ class GetNotificationsUseCaseTest {
     companion object {
         val SELF_USER_ID = UserId("user-id", "domain")
         private val MY_ID = TestUser.USER_ID
-        private const val TIME = "2000-01-23T01:23:35.678+09:00"
+        private val TIME = Instant.fromEpochMilliseconds(948558215).toIsoDateTimeString()
+        private val TIME_INSTANCE = Instant.fromEpochMilliseconds(948558215)
         private const val TIME_EARLIER = "2000-01-23T01:23:30.678+09:00"
 
         private fun conversationId(number: Int = 0) =
@@ -463,7 +466,7 @@ class GetNotificationsUseCaseTest {
 
         private fun notificationMessageText(
             authorName: String = "Author Name",
-            time: String = TIME,
+            time: Instant = TIME_INSTANCE,
             text: String = "test text"
         ) =
             LocalNotificationMessage.Text(
@@ -474,7 +477,7 @@ class GetNotificationsUseCaseTest {
 
         private fun notificationMessageComment(
             authorName: String = "Author Name",
-            time: String = TIME,
+            time: Instant = TIME_INSTANCE,
             commentType: LocalNotificationCommentType = LocalNotificationCommentType.PICTURE
         ) =
             LocalNotificationMessage.Comment(
@@ -485,7 +488,7 @@ class GetNotificationsUseCaseTest {
 
         private fun notificationMessageConnectionRequest(
             authorName: String = "Author Name",
-            time: String = TIME
+            time: Instant = TIME_INSTANCE
         ) =
             LocalNotificationMessage.ConnectionRequest(
                 LocalNotificationMessageAuthor(authorName, null),
@@ -495,7 +498,7 @@ class GetNotificationsUseCaseTest {
 
         private fun notificationConversationDeleted(
             authorName: String = "Author Name",
-            time: String = TIME
+            time: Instant = TIME_INSTANCE
         ) = LocalNotificationMessage.ConversationDeleted(
             LocalNotificationMessageAuthor(authorName, null),
             time

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -29,6 +29,7 @@ CREATE INDEX message_creation_date_index ON Message(creation_date);
 CREATE INDEX message_content_type_index ON Message(content_type);
 CREATE INDEX message_visibility_index ON Message(visibility);
 CREATE INDEX message_sender_user_index ON Message(sender_user_id);
+CREATE INDEX message_conversation_index ON Message(conversation_id);
 
 CREATE TABLE MessageMention (
       message_id TEXT NOT NULL,
@@ -50,6 +51,7 @@ CREATE TABLE MessageTextContent (
       text_body TEXT,
       quoted_message_id TEXT,
       is_quote_verified INTEGER AS Boolean,
+      is_quoting_self INTEGER AS Boolean NOT NULL,
 
       FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
       PRIMARY KEY (message_id, conversation_id)
@@ -326,7 +328,7 @@ AS SELECT
     ConversationNameChangedContent.conversation_name AS updateConversationName,
     Conversation.name AS conversationName,
     (Mention.user_id IS NOT NULL) AS isMentioningSelfUser,
-    QuotedMessage.isQuotingSelfUser AS isQuotingSelfUser,
+    TextContent.is_quoting_self AS isQuotingSelfUser,
     TextContent.text_body AS text,
     AssetContent.asset_mime_type AS assetMimeType,
     (Message.creation_date > Conversation.last_read_date) AS isUnread,
@@ -336,7 +338,6 @@ AS SELECT
 FROM Message
 LEFT JOIN SelfUser
 LEFT JOIN User ON Message.sender_user_id = User.qualified_id
-LEFT JOIN MessageQuoteDetails AS QuotedMessage ON Message.id = QuotedMessage.messageId AND Message.conversation_id = QuotedMessage.conversationId
 LEFT JOIN Conversation AS Conversation ON Message.conversation_id == Conversation.qualified_id
 LEFT JOIN MessageMemberChangeContent AS MemberChangeContent ON Message.id = MemberChangeContent.message_id AND Message.conversation_id = MemberChangeContent.conversation_id
 LEFT JOIN MessageMention AS Mention ON Message.id == Mention.message_id AND SelfUser.id == Mention.user_id
@@ -428,8 +429,8 @@ markMessageAsDeleted {
    DELETE FROM MessageMemberChangeContent WHERE message_id = :message_id AND conversation_id = :conversation_id;
    DELETE FROM MessageUnknownContent WHERE message_id = :message_id AND conversation_id = :conversation_id;
    DELETE FROM MessageRestrictedAssetContent WHERE message_id = :message_id AND conversation_id = :conversation_id;
-
-   INSERT INTO MessageTextContent(message_id, conversation_id, text_body) VALUES(:message_id, :conversation_id, NULL);
+   -- deleted messages will not have a quote 100%
+   INSERT INTO MessageTextContent(message_id, conversation_id, text_body, is_quoting_self) VALUES(:message_id, :conversation_id, NULL, 0);
 }
 
 markMessageAsEdited:
@@ -454,8 +455,20 @@ INSERT OR IGNORE INTO MessageMention(message_id, conversation_id, start, length,
 VALUES (?, ?, ?, ?, ?);
 
 insertMessageTextContent:
-INSERT OR IGNORE INTO MessageTextContent(message_id, conversation_id, text_body, quoted_message_id, is_quote_verified)
-VALUES(?, ?, ?, ?, ?);
+INSERT OR IGNORE INTO MessageTextContent(message_id, conversation_id, text_body, quoted_message_id, is_quote_verified, is_quoting_self)
+VALUES(:message_id, :conversation_id, :text_body, :quoted_message_id, :is_quote_verified,
+CASE WHEN
+                :quoted_message_id IS NULL
+                    THEN 0
+                    ELSE (
+                        IFNULL(
+                        (SELECT (Message.sender_user_id == SelfUser.id)
+                            FROM Message
+                            LEFT JOIN SelfUser
+                            WHERE
+                                Message.id = :quoted_message_id AND
+                                conversation_id = :conversation_id),
+                        0 ))END);
 
 insertMessageRestrictedAssetContent:
 INSERT OR IGNORE INTO MessageRestrictedAssetContent(message_id, conversation_id, asset_mime_type,asset_size,asset_name)
@@ -568,13 +581,6 @@ WHERE MessageDetailsView.conversationId = :conversation_id AND contentType = :co
 deleteAllConversationMessages:
 DELETE FROM Message
 WHERE conversation_id IS :conversation_id;
-
-getNotificationsMessages:
-SELECT * FROM MessagePreview AS message
-WHERE shouldNotify == 1
-AND visibility = 'VISIBLE'
-AND isSelfMessage == 0
-AND contentType IN ? ORDER BY message.date DESC;
 
 selectByConversationIdAndSenderIdAndTimeAndType:
 SELECT * FROM MessageDetailsView WHERE conversationId = ? AND senderUserId = ? AND date = ? AND contentType = ?;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
@@ -1,0 +1,27 @@
+getNotificationsMessages:
+SELECT
+    Message.id AS id,
+    Message.conversation_id AS conversationId,
+    Message.content_type AS contentType,
+    Message.creation_date AS date,
+    Message.sender_user_id AS senderUserId,
+    User.name AS senderName,
+    User.preview_asset_id AS senderPreviewAssetId,
+    Conversation.name AS conversationName,
+    TextContent.text_body AS text,
+    AssetContent.asset_mime_type AS assetMimeType,
+    Conversation.muted_status AS mutedStatus,
+    Conversation.type AS conversationType
+FROM Message
+LEFT JOIN SelfUser
+JOIN User ON Message.sender_user_id = User.qualified_id AND Message.content_type IN  ('TEXT', 'RESTRICTED_ASSET', 'ASSET', 'KNOCK', 'MISSED_CALL')
+JOIN Conversation AS Conversation ON Message.conversation_id == Conversation.qualified_id AND (Message.creation_date > IFNULL(Conversation.last_notified_date, 0))
+LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
+LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
+WHERE
+Message.visibility = 'VISIBLE' AND
+(Message.sender_user_id != SelfUser.id) AND
+(Message.creation_date > Conversation.last_read_date) AND
+Conversation.muted_status != 'ALL_MUTED'
+ORDER BY Message.creation_date DESC;
+

--- a/persistence/src/commonMain/db_user/migrations/26.sqm
+++ b/persistence/src/commonMain/db_user/migrations/26.sqm
@@ -1,31 +1,105 @@
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
 
--- Delete MessageDetails View
-DROP VIEW IF EXISTS MessageDetailsView;
+PRAGMA foreign_keys = 0;
+
 DROP VIEW IF EXISTS MessagePreview;
+DROP VIEW IF EXISTS MessageQuoteDetails;
+DROP VIEW IF EXISTS MessageDetailsView;
 
--- Create new table for New Conversation Receipt Mode Content
-CREATE TABLE MessageNewConversationReceiptModeContent (
+CREATE TABLE Temp_MessageTextContent (
       message_id TEXT NOT NULL,
       conversation_id TEXT AS QualifiedIDEntity NOT NULL,
 
-      receipt_mode INTEGER AS Boolean  NOT NULL DEFAULT(0),
+      text_body TEXT,
+      quoted_message_id TEXT,
+      is_quote_verified INTEGER AS Boolean,
+      is_quoting_self INTEGER AS Boolean NOT NULL,
 
       FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
       PRIMARY KEY (message_id, conversation_id)
 );
 
--- Create new table for Conversation Receipt Mode Changed Content
+INSERT INTO Temp_MessageTextContent(message_id, conversation_id, text_body, quoted_message_id, is_quote_verified, is_quoting_self)
+SELECT message_id, conversation_id, text_body, quoted_message_id, is_quote_verified, (
+    CASE WHEN
+        quoted_message_id IS NULL
+            THEN 0
+            ELSE (
+                IFNULL(
+                    (SELECT (Message.sender_user_id == SelfUser.id)
+                        FROM Message
+                        LEFT JOIN SelfUser
+                     WHERE
+                        Message.id = :quoted_message_id AND
+                        conversation_id = :conversation_id),
+                0 )
+                )END
+) FROM MessageTextContent;
 
-CREATE TABLE MessageConversationReceiptModeChangedContent (
-      message_id TEXT NOT NULL,
-      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+DROP INDEX message_text_content_quoted_id_index;
+DROP TABLE MessageTextContent;
 
-      receipt_mode INTEGER AS Boolean  NOT NULL DEFAULT(0),
+ALTER TABLE Temp_MessageTextContent RENAME TO MessageTextContent;
+CREATE INDEX message_text_content_quoted_id_index ON MessageTextContent(quoted_message_id) WHERE quoted_message_id IS NOT NULL;
+CREATE INDEX message_conversation_index ON Message(conversation_id); -- this index hahe been added to the schema
 
-      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
-      PRIMARY KEY (message_id, conversation_id)
-);
+CREATE VIEW IF NOT EXISTS MessagePreview
+AS SELECT
+    Message.id AS id,
+    Message.conversation_id AS conversationId,
+    Message.content_type AS contentType,
+    Message.creation_date AS date,
+    Message.visibility AS visibility,
+    User.name AS senderName,
+    User.connection_status AS senderConnectionStatus,
+    User.deleted AS senderIsDeleted,
+    SelfUser.id AS selfUserId,
+    (Message.sender_user_id == SelfUser.id) AS isSelfMessage,
+    MemberChangeContent.member_change_list AS memberChangeList,
+    MemberChangeContent.member_change_type AS memberChangeType,
+    ConversationNameChangedContent.conversation_name AS updateConversationName,
+    Conversation.name AS conversationName,
+    (Mention.user_id IS NOT NULL) AS isMentioningSelfUser,
+    TextContent.is_quoting_self AS isQuotingSelfUser,
+    TextContent.text_body AS text,
+    AssetContent.asset_mime_type AS assetMimeType,
+    (Message.creation_date > Conversation.last_read_date) AS isUnread,
+    IFNULL((Message.creation_date > IFNULL(Conversation.last_notified_date, 0)), FALSE) AS shouldNotify,
+    Conversation.muted_status AS mutedStatus,
+    Conversation.type AS conversationType
+FROM Message
+LEFT JOIN SelfUser
+LEFT JOIN User ON Message.sender_user_id = User.qualified_id
+LEFT JOIN Conversation AS Conversation ON Message.conversation_id == Conversation.qualified_id
+LEFT JOIN MessageMemberChangeContent AS MemberChangeContent ON Message.id = MemberChangeContent.message_id AND Message.conversation_id = MemberChangeContent.conversation_id
+LEFT JOIN MessageMention AS Mention ON Message.id == Mention.message_id AND SelfUser.id == Mention.user_id
+LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
+LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
+LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id;
+
+
+CREATE VIEW IF NOT EXISTS MessageQuoteDetails
+AS SELECT
+    MessageTextContent.message_id AS messageId,
+    MessageTextContent.conversation_id AS conversationId,
+    MessageTextContent.quoted_message_id AS quotedMessageId,
+    MessageTextContent.is_quote_verified AS isQuoteVerified,
+    QuotedSender.qualified_id AS quotedSenderId,
+    (qualified_id == SelfUser.id) AS isQuotingSelfUser,
+    QuotedSender.name AS quotedSenderName,
+    QuotedMessage.creation_date quotedMessageCreationInstant,
+    QuotedMessage.last_edit_date AS quotedMessageEditInstant,
+    QuotedMessage.visibility AS quotedMessageVisibility,
+    QuotedMessage.content_type AS quotedMessageContentType,
+    QuotedTextContent.text_body AS quotedTextBody,
+    QuotedAssetContent.asset_mime_type AS quotedAssetMimeType,
+    QuotedAssetContent.asset_name AS quotedAssetName
+FROM MessageTextContent
+LEFT JOIN Message AS QuotedMessage ON QuotedMessage.id = MessageTextContent.quoted_message_id AND QuotedMessage.conversation_id = MessageTextContent.conversation_id
+INNER JOIN User AS QuotedSender ON QuotedMessage.sender_user_id = QuotedSender.qualified_id
+INNER JOIN SelfUser AS SelfUser
+LEFT JOIN MessageTextContent AS QuotedTextContent ON QuotedTextContent.message_id = QuotedMessage.id AND QuotedMessage.conversation_id = MessageTextContent.conversation_id
+LEFT JOIN MessageAssetContent AS QuotedAssetContent ON QuotedAssetContent.message_id = QuotedMessage.id AND QuotedMessage.conversation_id = MessageTextContent.conversation_id;
 
 CREATE VIEW IF NOT EXISTS MessageDetailsView
 AS SELECT
@@ -123,9 +197,7 @@ QuotedMessage.quotedMessageVisibility AS quotedMessageVisibility,
 QuotedMessage.quotedMessageContentType AS quotedMessageContentType,
 QuotedMessage.quotedTextBody AS quotedTextBody,
 QuotedMessage.quotedAssetMimeType AS quotedAssetMimeType,
-QuotedMessage.quotedAssetName AS quotedAssetName,
-NewConversationReceiptMode.receipt_mode AS newConversationReceiptMode,
-ConversationReceiptModeChanged.receipt_mode AS conversationReceiptModeChanged
+QuotedMessage.quotedAssetName AS quotedAssetName
 FROM Message
 LEFT JOIN User ON Message.sender_user_id = User.qualified_id
 LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
@@ -137,42 +209,6 @@ LEFT JOIN MessageRestrictedAssetContent AS RestrictedAssetContent ON Message.id 
 LEFT JOIN MessageFailedToDecryptContent AS FailedToDecryptContent ON Message.id = FailedToDecryptContent.message_id AND Message.conversation_id = FailedToDecryptContent.conversation_id
 LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
 LEFT JOIN MessageQuoteDetails AS QuotedMessage ON Message.id = QuotedMessage.messageId AND Message.conversation_id = QuotedMessage.conversationId
-LEFT JOIN MessageNewConversationReceiptModeContent AS NewConversationReceiptMode ON Message.id = NewConversationReceiptMode.message_id AND Message.conversation_id = NewConversationReceiptMode.conversation_id
-LEFT JOIN MessageConversationReceiptModeChangedContent AS ConversationReceiptModeChanged ON Message.id = ConversationReceiptModeChanged.message_id AND Message.conversation_id = ConversationReceiptModeChanged.conversation_id
 LEFT JOIN SelfUser;
 
-CREATE VIEW IF NOT EXISTS MessagePreview
-AS SELECT
-    Message.id AS id,
-    Message.conversation_id AS conversationId,
-    Message.content_type AS contentType,
-    Message.creation_date AS date,
-    Message.visibility AS visibility,
-    Message.sender_user_id AS senderUserId,
-    User.name AS senderName,
-    User.connection_status AS senderConnectionStatus,
-    User.deleted AS senderIsDeleted,
-    SelfUser.id AS selfUserId,
-    (Message.sender_user_id == SelfUser.id) AS isSelfMessage,
-    MemberChangeContent.member_change_list AS memberChangeList,
-    MemberChangeContent.member_change_type AS memberChangeType,
-    ConversationNameChangedContent.conversation_name AS updateConversationName,
-    Conversation.name AS conversationName,
-    (Mention.user_id IS NOT NULL) AS isMentioningSelfUser,
-    QuotedMessage.isQuotingSelfUser AS isQuotingSelfUser,
-    TextContent.text_body AS text,
-    AssetContent.asset_mime_type AS assetMimeType,
-    (Message.creation_date > Conversation.last_read_date) AS isUnread,
-    IFNULL((Message.creation_date > IFNULL(Conversation.last_notified_date, 0)), FALSE) AS shouldNotify,
-    Conversation.muted_status AS mutedStatus,
-    Conversation.type AS conversationType
-FROM Message
-LEFT JOIN SelfUser
-LEFT JOIN User ON Message.sender_user_id = User.qualified_id
-LEFT JOIN MessageQuoteDetails AS QuotedMessage ON Message.id = QuotedMessage.messageId AND Message.conversation_id = QuotedMessage.conversationId
-LEFT JOIN Conversation AS Conversation ON Message.conversation_id == Conversation.qualified_id
-LEFT JOIN MessageMemberChangeContent AS MemberChangeContent ON Message.id = MemberChangeContent.message_id AND Message.conversation_id = MemberChangeContent.conversation_id
-LEFT JOIN MessageMention AS Mention ON Message.id == Mention.message_id AND SelfUser.id == Mention.user_id
-LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
-LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
-LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id;
+PRAGMA foreign_keys = 1;

--- a/persistence/src/commonMain/db_user/migrations/27.sqm
+++ b/persistence/src/commonMain/db_user/migrations/27.sqm
@@ -1,0 +1,177 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+
+-- Delete MessageDetails View
+DROP VIEW IF EXISTS MessageDetailsView;
+DROP VIEW IF EXISTS MessagePreview;
+
+-- Create new table for New Conversation Receipt Mode Content
+CREATE TABLE MessageNewConversationReceiptModeContent (
+      message_id TEXT NOT NULL,
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+
+      receipt_mode INTEGER AS Boolean  NOT NULL DEFAULT(0),
+
+      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      PRIMARY KEY (message_id, conversation_id)
+);
+
+-- Create new table for Conversation Receipt Mode Changed Content
+
+CREATE TABLE MessageConversationReceiptModeChangedContent (
+      message_id TEXT NOT NULL,
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+
+      receipt_mode INTEGER AS Boolean  NOT NULL DEFAULT(0),
+
+      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      PRIMARY KEY (message_id, conversation_id)
+);
+
+CREATE VIEW IF NOT EXISTS MessageDetailsView
+AS SELECT
+Message.id AS id,
+Message.conversation_id AS conversationId,
+Message.content_type AS contentType,
+Message.creation_date AS date,
+Message.sender_user_id AS senderUserId,
+Message.sender_client_id AS senderClientId,
+Message.status AS status,
+Message.last_edit_date AS lastEditTimestamp,
+Message.visibility AS visibility,
+Message.expects_read_confirmation AS expectsReadConfirmation,
+User.name AS senderName,
+User.handle AS senderHandle,
+User.email AS senderEmail,
+User.phone AS senderPhone,
+User.accent_id AS senderAccentId,
+User.team AS senderTeamId,
+User.connection_status AS senderConnectionStatus,
+User.preview_asset_id AS senderPreviewAssetId,
+User.complete_asset_id AS senderCompleteAssetId,
+User.user_availability_status AS senderAvailabilityStatus,
+User.user_type AS senderUserType,
+User.bot_service AS senderBotService,
+User.deleted AS senderIsDeleted,
+(Message.sender_user_id == SelfUser.id) AS isSelfMessage,
+TextContent.text_body AS text,
+AssetContent.asset_size AS assetSize,
+AssetContent.asset_name AS assetName,
+AssetContent.asset_mime_type AS assetMimeType,
+AssetContent.asset_upload_status AS assetUploadStatus,
+AssetContent.asset_download_status AS assetDownloadStatus,
+AssetContent.asset_otr_key AS assetOtrKey,
+AssetContent.asset_sha256 AS assetSha256,
+AssetContent.asset_id AS assetId,
+AssetContent.asset_token AS assetToken,
+AssetContent.asset_domain AS assetDomain,
+AssetContent.asset_encryption_algorithm AS assetEncryptionAlgorithm,
+AssetContent.asset_width AS assetWidth,
+AssetContent.asset_height AS assetHeight,
+AssetContent.asset_duration_ms AS assetDuration,
+AssetContent.asset_normalized_loudness AS assetNormalizedLoudness,
+MissedCallContent.caller_id AS callerId,
+MemberChangeContent.member_change_list AS memberChangeList,
+MemberChangeContent.member_change_type AS memberChangeType,
+UnknownContent.unknown_type_name AS unknownContentTypeName,
+UnknownContent.unknown_encoded_data AS unknownContentData,
+RestrictedAssetContent.asset_mime_type AS restrictedAssetMimeType,
+RestrictedAssetContent.asset_size AS restrictedAssetSize,
+RestrictedAssetContent.asset_name AS restrictedAssetName,
+FailedToDecryptContent.unknown_encoded_data AS failedToDecryptData,
+FailedToDecryptContent.is_decryption_resolved AS isDecryptionResolved,
+ConversationNameChangedContent.conversation_name AS conversationName,
+'{' || IFNULL(
+    (SELECT GROUP_CONCAT('"' || emoji || '":' || count)
+    FROM (
+        SELECT COUNT(*) count, Reaction.emoji emoji
+        FROM Reaction
+        WHERE Reaction.message_id = Message.id
+        AND Reaction.conversation_id = Message.conversation_id
+        GROUP BY Reaction.emoji
+    )),
+    '')
+|| '}' AS allReactionsJson,
+IFNULL(
+    (SELECT '[' || GROUP_CONCAT('"' || Reaction.emoji || '"') || ']'
+    FROM Reaction
+    WHERE Reaction.message_id = Message.id
+        AND Reaction.conversation_id = Message.conversation_id
+        AND Reaction.sender_id = SelfUser.id
+    ),
+    '[]'
+) AS selfReactionsJson,
+IFNULL(
+    (SELECT '[' || GROUP_CONCAT(
+        '{"start":' || start || ', "length":' || length ||
+        ', "userId":{"value":"' || replace(substr(user_id, 0, instr(user_id, '@')), '@', '') || '"' ||
+        ',"domain":"' || replace(substr(user_id, instr(user_id, '@')+1, length(user_id)), '@', '') || '"' ||
+        '}' || '}') || ']'
+    FROM MessageMention
+    WHERE MessageMention.message_id = Message.id
+        AND MessageMention.conversation_id = Message.conversation_id
+    ),
+    '[]'
+) AS mentions,
+QuotedMessage.quotedMessageId AS quotedMessageId,
+QuotedMessage.quotedSenderId AS quotedSenderId,
+QuotedMessage.isQuotingSelfUser AS isQuotingSelfUser,
+QuotedMessage.isQuoteVerified AS isQuoteVerified,
+QuotedMessage.quotedSenderName AS quotedSenderName,
+QuotedMessage.quotedMessageCreationInstant AS quotedMessageDateTime,
+QuotedMessage.quotedMessageEditInstant AS quotedMessageEditTimestamp,
+QuotedMessage.quotedMessageVisibility AS quotedMessageVisibility,
+QuotedMessage.quotedMessageContentType AS quotedMessageContentType,
+QuotedMessage.quotedTextBody AS quotedTextBody,
+QuotedMessage.quotedAssetMimeType AS quotedAssetMimeType,
+QuotedMessage.quotedAssetName AS quotedAssetName,
+NewConversationReceiptMode.receipt_mode AS newConversationReceiptMode,
+ConversationReceiptModeChanged.receipt_mode AS conversationReceiptModeChanged
+FROM Message
+LEFT JOIN User ON Message.sender_user_id = User.qualified_id
+LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
+LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
+LEFT JOIN MessageMissedCallContent AS MissedCallContent ON Message.id = MissedCallContent.message_id AND Message.conversation_id = MissedCallContent.conversation_id
+LEFT JOIN MessageMemberChangeContent AS MemberChangeContent ON Message.id = MemberChangeContent.message_id AND Message.conversation_id = MemberChangeContent.conversation_id
+LEFT JOIN MessageUnknownContent AS UnknownContent ON Message.id = UnknownContent.message_id AND Message.conversation_id = UnknownContent.conversation_id
+LEFT JOIN MessageRestrictedAssetContent AS RestrictedAssetContent ON Message.id = RestrictedAssetContent.message_id AND RestrictedAssetContent.conversation_id = RestrictedAssetContent.conversation_id
+LEFT JOIN MessageFailedToDecryptContent AS FailedToDecryptContent ON Message.id = FailedToDecryptContent.message_id AND Message.conversation_id = FailedToDecryptContent.conversation_id
+LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
+LEFT JOIN MessageQuoteDetails AS QuotedMessage ON Message.id = QuotedMessage.messageId AND Message.conversation_id = QuotedMessage.conversationId
+LEFT JOIN MessageNewConversationReceiptModeContent AS NewConversationReceiptMode ON Message.id = NewConversationReceiptMode.message_id AND Message.conversation_id = NewConversationReceiptMode.conversation_id
+LEFT JOIN MessageConversationReceiptModeChangedContent AS ConversationReceiptModeChanged ON Message.id = ConversationReceiptModeChanged.message_id AND Message.conversation_id = ConversationReceiptModeChanged.conversation_id
+LEFT JOIN SelfUser;
+
+CREATE VIEW IF NOT EXISTS MessagePreview
+AS SELECT
+    Message.id AS id,
+    Message.conversation_id AS conversationId,
+    Message.content_type AS contentType,
+    Message.creation_date AS date,
+    Message.visibility AS visibility,
+    Message.sender_user_id AS senderUserId,
+    User.name AS senderName,
+    User.connection_status AS senderConnectionStatus,
+    User.deleted AS senderIsDeleted,
+    SelfUser.id AS selfUserId,
+    (Message.sender_user_id == SelfUser.id) AS isSelfMessage,
+    MemberChangeContent.member_change_list AS memberChangeList,
+    MemberChangeContent.member_change_type AS memberChangeType,
+    ConversationNameChangedContent.conversation_name AS updateConversationName,
+    Conversation.name AS conversationName,
+    (Mention.user_id IS NOT NULL) AS isMentioningSelfUser,
+    TextContent.is_quoting_self AS isQuotingSelfUser,
+    TextContent.text_body AS text,
+    AssetContent.asset_mime_type AS assetMimeType,
+    (Message.creation_date > Conversation.last_read_date) AS isUnread,
+    IFNULL((Message.creation_date > IFNULL(Conversation.last_notified_date, 0)), FALSE) AS shouldNotify,
+    Conversation.muted_status AS mutedStatus,
+    Conversation.type AS conversationType
+FROM Message
+LEFT JOIN SelfUser
+LEFT JOIN User ON Message.sender_user_id = User.qualified_id
+LEFT JOIN Conversation AS Conversation ON Message.conversation_id == Conversation.qualified_id
+LEFT JOIN MessageMemberChangeContent AS MemberChangeContent ON Message.id = MemberChangeContent.message_id AND Message.conversation_id = MemberChangeContent.conversation_id
+LEFT JOIN MessageMention AS Mention ON Message.id == Mention.message_id AND SelfUser.id == Mention.user_id
+LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
+LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
+LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -70,9 +70,7 @@ interface MessageDAO {
         visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.values().toList()
     ): Flow<List<MessageEntity>>
 
-    suspend fun getNotificationMessage(
-        filteredContent: List<MessageEntity.ContentType>
-    ): Flow<List<NotificationMessageEntity>>
+    suspend fun getNotificationMessage(): Flow<List<NotificationMessageEntity>>
 
     suspend fun observeMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.persistence.dao.message
 import app.cash.sqldelight.coroutines.asFlow
 import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MessagesQueries
+import com.wire.kalium.persistence.NotificationQueries
 import com.wire.kalium.persistence.ReactionsQueries
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.ConversationIDEntity
@@ -40,6 +41,7 @@ import kotlin.coroutines.CoroutineContext
 @Suppress("TooManyFunctions")
 class MessageDAOImpl(
     private val queries: MessagesQueries,
+    private val notificationQueries: NotificationQueries,
     private val conversationsQueries: ConversationsQueries,
     private val selfUserId: UserIDEntity,
     private val reactionsQueries: ReactionsQueries,
@@ -220,11 +222,8 @@ class MessageDAOImpl(
             .flowOn(coroutineContext)
             .mapToList()
 
-    override suspend fun getNotificationMessage(
-        filteredContent: List<MessageEntity.ContentType>
-    ): Flow<List<NotificationMessageEntity>> =
-        queries.getNotificationsMessages(
-            filteredContent,
+    override suspend fun getNotificationMessage(): Flow<List<NotificationMessageEntity>> =
+        notificationQueries.getNotificationsMessages(
             mapper::toNotificationEntity
         ).asFlow()
             .flowOn(coroutineContext)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserAssetIdEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.reaction.ReactionsEntity
 import kotlinx.datetime.Instant
@@ -285,11 +286,19 @@ data class MessagePreviewEntity(
 
 data class NotificationMessageEntity(
     val id: String,
-    val content: MessagePreviewEntityContent,
+    val contentType: MessageEntity.ContentType,
+    val senderUserId: QualifiedIDEntity,
+    val senderImage: UserAssetIdEntity?,
+
+    val date: Instant,
+    val senderName: String?,
+    val text: String?,
+    val assetMimeType: String?,
+
     val conversationId: QualifiedIDEntity,
     val conversationName: String?,
-    val conversationType: ConversationEntity.Type?,
-    val date: String
+    val mutedStatus: ConversationEntity.MutedStatus,
+    val conversationType: ConversationEntity.Type,
 )
 
 sealed class MessagePreviewEntityContent {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -56,18 +56,22 @@ object MessageMapper {
                 senderName = senderName,
                 messageBody = text.requireField("text")
             )
+
             (isQuotingSelfUser ?: false) -> MessagePreviewEntityContent.QuotedSelf(
                 senderName = senderName,
                 messageBody = text.requireField("text")
             )
+
             (isMentioningSelfUser) -> MessagePreviewEntityContent.MentionedSelf(
                 senderName = senderName, messageBody = text.requireField("text")
             )
+
             else -> MessagePreviewEntityContent.Text(
                 senderName = senderName,
                 messageBody = text.requireField("text")
             )
         }
+
         MessageEntity.ContentType.ASSET -> MessagePreviewEntityContent.Asset(
             senderName = senderName,
             type = assetMimeType?.let {
@@ -116,6 +120,7 @@ object MessageMapper {
             senderName = senderName,
             type = AssetTypeEntity.ASSET
         )
+
         MessageEntity.ContentType.CONVERSATION_RENAMED -> MessagePreviewEntityContent.ConversationNameChange(
             adminName = senderName
         )
@@ -187,50 +192,29 @@ object MessageMapper {
         conversationId: QualifiedIDEntity,
         contentType: MessageEntity.ContentType,
         date: Instant,
-        visibility: MessageEntity.Visibility,
+        senderUserId: QualifiedIDEntity,
         senderUserId: UserIDEntity,
         senderName: String?,
-        senderConnectionStatus: ConnectionEntity.State?,
-        senderIsDeleted: Boolean?,
-        selfUserId: QualifiedIDEntity?,
-        isSelfMessage: Boolean,
-        memberChangeList: List<QualifiedIDEntity>?,
-        memberChangeType: MessageEntity.MemberChangeType?,
-        updatedConversationName: String?,
+        senderPreviewAssetId: QualifiedIDEntity?,
         conversationName: String?,
-        isMentioningSelfUser: Boolean,
-        isQuotingSelfUser: Boolean?,
         text: String?,
         assetMimeType: String?,
-        isUnread: Boolean,
-        isNotified: Long,
-        mutedStatus: ConversationEntity.MutedStatus?,
-        conversationType: ConversationEntity.Type?
-    ): NotificationMessageEntity {
-        val content = toMessagePreviewEntityContent(
-            contentType = contentType,
-            senderName = senderName,
-            isSelfMessage = isSelfMessage,
-            memberChangeList = memberChangeList,
-            memberChangeType = memberChangeType,
-            isMentioningSelfUser = isMentioningSelfUser,
-            isQuotingSelfUser = isQuotingSelfUser,
-            text = text,
-            assetMimeType = assetMimeType,
-            selfUserId = selfUserId,
-            senderUserId = senderUserId
-        )
-
-        return NotificationMessageEntity(
-            id = id,
-            content = content,
-            conversationId = conversationId,
-            conversationName = conversationName,
-            conversationType = conversationType,
-            date = date.toIsoDateTimeString()
-        )
-
-    }
+        mutedStatus: ConversationEntity.MutedStatus,
+        conversationType: ConversationEntity.Type,
+    ): NotificationMessageEntity = NotificationMessageEntity(
+        id = id,
+        contentType = contentType,
+        senderUserId = senderUserId,
+        senderImage = senderPreviewAssetId,
+        date = date,
+        senderName = senderName,
+        text = text,
+        assetMimeType = assetMimeType,
+        conversationId = conversationId,
+        conversationName = conversationName,
+        mutedStatus = mutedStatus,
+        conversationType = conversationType
+    )
 
     private fun createMessageEntity(
         id: String,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -192,7 +192,6 @@ object MessageMapper {
         conversationId: QualifiedIDEntity,
         contentType: MessageEntity.ContentType,
         date: Instant,
-        senderUserId: QualifiedIDEntity,
         senderUserId: UserIDEntity,
         senderName: String?,
         senderPreviewAssetId: QualifiedIDEntity?,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -159,6 +159,7 @@ class UserDatabaseBuilder internal constructor(
     val messageDAO: MessageDAO
         get() = MessageDAOImpl(
             database.messagesQueries,
+            database.notificationQueries,
             database.conversationsQueries,
             userId,
             database.reactionsQueries,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Querying from MessagePreview can be slow

### Solutions

1. reduce complexity by add a new column is_quoting_self by to the MessageTextContent
2. get notification its query instead of using MessagePreview.


### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
