### PR TITLE
fix: [DEV] file sharing changed dialog keep repeating (#1464)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.map
 
 interface UserConfigRepository {
     fun setFileSharingStatus(status: Boolean, isStatusChanged: Boolean?): Either<StorageFailure, Unit>
+    fun setFileSharingAsNotified(): Either<StorageFailure, Unit>
     fun isFileSharingEnabled(): Either<StorageFailure, FileSharingStatus>
     fun isFileSharingEnabledFlow(): Flow<Either<StorageFailure, FileSharingStatus>>
     fun setClassifiedDomainsStatus(enabled: Boolean, domains: List<String>): Either<StorageFailure, Unit>
@@ -46,6 +47,10 @@ class UserConfigDataSource(
 
     override fun setFileSharingStatus(status: Boolean, isStatusChanged: Boolean?): Either<StorageFailure, Unit> =
         wrapStorageRequest { userConfigStorage.persistFileSharingStatus(status, isStatusChanged) }
+
+    override fun setFileSharingAsNotified(): Either<StorageFailure, Unit> = wrapStorageRequest {
+        userConfigStorage.setFileSharingAsNotified()
+    }
 
     override fun isFileSharingEnabled(): Either<StorageFailure, FileSharingStatus> =
         wrapStorageRequest { userConfigStorage.isFileSharingEnabled() }.map {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -177,6 +177,7 @@ import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCaseImpl
+import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCase
 import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCaseImpl
 import com.wire.kalium.logic.feature.user.SyncContactsUseCase
@@ -1041,6 +1042,10 @@ class UserSessionScope internal constructor(
     val isFileSharingEnabled: IsFileSharingEnabledUseCase get() = IsFileSharingEnabledUseCaseImpl(userConfigRepository)
     val observeFileSharingStatus: ObserveFileSharingStatusUseCase
         get() = ObserveFileSharingStatusUseCaseImpl(userConfigRepository)
+
+    val markFileSharingStatusAsNotified: MarkFileSharingChangeAsNotifiedUseCase
+        get() = MarkFileSharingChangeAsNotifiedUseCase(userConfigRepository)
+
     val isMLSEnabled: IsMLSEnabledUseCase get() = IsMLSEnabledUseCaseImpl(featureSupport, userConfigRepository)
 
     @OptIn(DelicateKaliumApi::class)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/MarkFileSharingChangeAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/MarkFileSharingChangeAsNotifiedUseCase.kt
@@ -1,0 +1,16 @@
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+
+/**
+ * Mark the file sharing status as notified
+ * need to be called after notifying the user about the change
+ * e.g. after showing a dialog, or a toast etc.
+ */
+class MarkFileSharingChangeAsNotifiedUseCase(
+    private val userConfigRepository: UserConfigRepository
+) {
+    suspend operator fun invoke() {
+        userConfigRepository.setFileSharingAsNotified()
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger
 
 internal interface FeatureConfigEventReceiver : EventReceiver<Event.FeatureConfig>
@@ -45,15 +46,20 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
                 if (kaliumConfigs.fileRestrictionEnabled) {
                     userConfigRepository.setFileSharingStatus(false, null)
                 } else {
+
+                    val currentFileSharingStatus: Boolean = userConfigRepository
+                        .isFileSharingEnabled()
+                        .fold({ false }, { it.isFileSharingEnabled ?: false })
+
                     when (event.model.status) {
                         Status.ENABLED -> userConfigRepository.setFileSharingStatus(
                             status = true,
-                            isStatusChanged = true
+                            isStatusChanged = !currentFileSharingStatus
                         )
 
                         Status.DISABLED -> userConfigRepository.setFileSharingStatus(
                             status = false,
-                            isStatusChanged = true
+                            isStatusChanged = currentFileSharingStatus
                         )
                     }
                 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/config/UserConfigStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/config/UserConfigStorageTest.kt
@@ -22,6 +22,7 @@ import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
 import com.wire.kalium.persistence.kmmSettings.KaliumPreferences
 import com.wire.kalium.persistence.kmmSettings.KaliumPreferencesSettings
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
@@ -30,6 +31,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class UserConfigStorageTest {
     private val settings: Settings = MapSettings()
 
@@ -77,6 +79,13 @@ class UserConfigStorageTest {
     fun givenAReadReceiptsSetValue_whenPersistingIt_saveAndThenRestoreTheValueLocally() = runTest {
         userConfigStorage.persistReadReceipts(true)
         assertTrue(userConfigStorage.isReadReceiptsEnabled().first())
+    }
+
+    @Test
+    fun whenMarkingFileSharingAsNotified_thenIsChangedIsSetToFalse() = runTest {
+        userConfigStorage.persistFileSharingStatus(true, true)
+        userConfigStorage.setFileSharingAsNotified()
+        assertEquals(IsFileSharingEnabledEntity(true, false), userConfigStorage.isFileSharingEnabled())
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Receiving a file sharing status update event, the dialog is keep repeating

### Causes (Optional)

only the UI state is updated when dismissing the dialog and the local flag is still true for is changed which means the next app launch will display the dialog again

### Solutions

update the the state locally

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
