### PR TITLE
fix: metadata table is not cleared when client get deleted

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
@@ -19,9 +19,13 @@
 package com.wire.kalium.logic.data.logout
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.user.UserDataSource
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.logout.LogoutApi
+import com.wire.kalium.persistence.client.ClientRegistrationStorageImpl
+import com.wire.kalium.persistence.dao.MetadataDAO
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -45,10 +49,16 @@ interface LogoutRepository {
      * invalidating the current credentials.
      */
     suspend fun logout(): Either<CoreFailure, Unit>
+
+    /**
+     * Clears all client related local metadata.
+     */
+    suspend fun clearClientRelatedLocalMetadata()
 }
 
 internal class LogoutDataSource(
     private val logoutApi: LogoutApi,
+    private val metadataDAO: MetadataDAO
 ) : LogoutRepository {
 
     private val logoutEventsChannel = Channel<LogoutReason?>(capacity = Channel.CONFLATED)
@@ -64,4 +74,14 @@ internal class LogoutDataSource(
     override suspend fun logout(): Either<CoreFailure, Unit> =
         wrapApiRequest { logoutApi.logout() }
 
+    override suspend fun clearClientRelatedLocalMetadata() {
+        wrapStorageRequest {
+            metadataDAO.clear(
+                keysToKeep = listOf(
+                    ClientRegistrationStorageImpl.RETAINED_CLIENT_ID_KEY,
+                    UserDataSource.SELF_USER_ID_KEY
+                )
+            )
+        }
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -365,6 +365,6 @@ internal class UserDataSource internal constructor(
         }
 
     companion object {
-        const val SELF_USER_ID_KEY = "selfUserID"
+        internal const val SELF_USER_ID_KEY = "selfUserID"
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -862,7 +862,10 @@ class UserSessionScope internal constructor(
             clientIdProvider, authenticatedDataSourceSet.authenticatedNetworkContainer.keyPackageApi, mlsClientProvider, userId
         )
 
-    private val logoutRepository: LogoutRepository = LogoutDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.logoutApi, userStorage.database.metadataDAO)
+    private val logoutRepository: LogoutRepository = LogoutDataSource(
+        authenticatedDataSourceSet.authenticatedNetworkContainer.logoutApi,
+        userStorage.database.metadataDAO
+    )
 
     val observeSyncState: ObserveSyncStateUseCase
         get() = ObserveSyncStateUseCase(slowSyncRepository, incrementalSyncRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -862,7 +862,7 @@ class UserSessionScope internal constructor(
             clientIdProvider, authenticatedDataSourceSet.authenticatedNetworkContainer.keyPackageApi, mlsClientProvider, userId
         )
 
-    private val logoutRepository: LogoutRepository = LogoutDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.logoutApi)
+    private val logoutRepository: LogoutRepository = LogoutDataSource(authenticatedDataSourceSet.authenticatedNetworkContainer.logoutApi, userStorage.database.metadataDAO)
 
     val observeSyncState: ObserveSyncStateUseCase
         get() = ObserveSyncStateUseCase(slowSyncRepository, incrementalSyncRepository)
@@ -885,7 +885,8 @@ class UserSessionScope internal constructor(
             upgradeCurrentSessionUseCase,
             userId,
             isAllowedToRegisterMLSClient,
-            clientIdProvider
+            clientIdProvider,
+            userStorage
         )
     val conversations: ConversationScope
         get() = ConversationScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -73,6 +73,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
                 // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
                 delay(CLEAR_DATA_DELAY)
                 clearClientDataUseCase()
+                logoutRepository.clearClientRelatedLocalMetadata()
                 clientRepository.clearCurrentClientId()
                 clientRepository.clearHasRegisteredMLSClient()
                 // After logout we need to mark the Firebase token as invalid locally so that we can register a new one on the next login.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCase.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapCryptoRequest
 import com.wire.kalium.logic.wrapMLSRequest
+import com.wire.kalium.persistence.dao.MetadataDAO
 
 /**
  * This use case is responsible for clearing the client data.
@@ -39,7 +40,8 @@ interface ClearClientDataUseCase {
 
 internal class ClearClientDataUseCaseImpl internal constructor(
     private val mlsClientProvider: MLSClientProvider,
-    private val proteusClientProvider: ProteusClientProvider
+    private val proteusClientProvider: ProteusClientProvider,
+    private val metadataDAO: MetadataDAO
 ) : ClearClientDataUseCase {
 
     override suspend operator fun invoke() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.di.UserStorage
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCase
@@ -52,7 +53,8 @@ class ClientScope @OptIn(DelicateKaliumApi::class) constructor(
     private val upgradeCurrentSessionUseCase: UpgradeCurrentSessionUseCase,
     private val selfUserId: UserId,
     private val isAllowedToRegisterMLSClient: IsAllowedToRegisterMLSClientUseCase,
-    private val clientIdProvider: CurrentClientIdProvider
+    private val clientIdProvider: CurrentClientIdProvider,
+    private val userStorage: UserStorage
 ) {
     @OptIn(DelicateKaliumApi::class)
     val register: RegisterClientUseCase
@@ -93,7 +95,7 @@ class ClientScope @OptIn(DelicateKaliumApi::class) constructor(
         get() = ObserveCurrentClientIdUseCaseImpl(clientRepository)
 
     val clearClientData: ClearClientDataUseCase
-        get() = ClearClientDataUseCaseImpl(mlsClientProvider, proteusClientProvider)
+        get() = ClearClientDataUseCaseImpl(mlsClientProvider, proteusClientProvider, userStorage.database.metadataDAO)
 
     private val verifyExistingClientUseCase: VerifyExistingClientUseCase
         get() = VerifyExistingClientUseCaseImpl(clientRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.data.logout
 
 import app.cash.turbine.test
 import com.wire.kalium.network.api.base.authenticated.logout.LogoutApi
+import com.wire.kalium.persistence.dao.MetadataDAO
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.mock
@@ -90,7 +91,10 @@ class LogoutRepositoryTest {
         @Mock
         private val logoutApi = mock(classOf<LogoutApi>())
 
-        private val logoutDataSource = LogoutDataSource(logoutApi)
+        @Mock
+        private val metadataDAO = mock(classOf<MetadataDAO>())
+
+        private val logoutDataSource = LogoutDataSource(logoutApi, metadataDAO)
 
         fun arrange() = this to logoutDataSource
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Metadata.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Metadata.sq
@@ -13,3 +13,9 @@ SELECT stringValue FROM Metadata WHERE key = ?;
 
 deleteValue:
 DELETE FROM Metadata WHERE key = ?;
+
+deleteAllExpect:
+DELETE FROM Metadata WHERE key NOT IN ?;
+
+deleteAll:
+DELETE FROM Metadata;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Metadata.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Metadata.sq
@@ -14,7 +14,7 @@ SELECT stringValue FROM Metadata WHERE key = ?;
 deleteValue:
 DELETE FROM Metadata WHERE key = ?;
 
-deleteAllExpect:
+deleteAllExcept:
 DELETE FROM Metadata WHERE key NOT IN ?;
 
 deleteAll:

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/ClientRegistrationStorageImpl.kt
@@ -49,15 +49,16 @@ class ClientRegistrationStorageImpl(private val metadataDAO: MetadataDAO) : Clie
     override suspend fun getRetainedClientId(): String? = metadataDAO.valueByKey(RETAINED_CLIENT_ID_KEY)
     override suspend fun clearRegisteredClientId() = metadataDAO.deleteValue(REGISTERED_CLIENT_ID_KEY)
     override suspend fun clearRetainedClientId() = metadataDAO.deleteValue(RETAINED_CLIENT_ID_KEY)
+
     // todo: re-enable mls!
     // metadataDAO.valueByKey(HAS_REGISTERED_MLS_CLIENT_KEY).toBoolean()
     override suspend fun hasRegisteredMLSClient(): Boolean = false
     override suspend fun setHasRegisteredMLSClient() = metadataDAO.insertValue(true.toString(), HAS_REGISTERED_MLS_CLIENT_KEY)
     override suspend fun clearHasRegisteredMLSClient() = metadataDAO.deleteValue(HAS_REGISTERED_MLS_CLIENT_KEY)
 
-    private companion object {
-        const val REGISTERED_CLIENT_ID_KEY = "registered_client_id"
+    companion object {
+        private const val REGISTERED_CLIENT_ID_KEY = "registered_client_id"
         const val RETAINED_CLIENT_ID_KEY = "retained_client_id"
-        const val HAS_REGISTERED_MLS_CLIENT_KEY = "has_registered_mls_client"
+        private const val HAS_REGISTERED_MLS_CLIENT_KEY = "has_registered_mls_client"
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAO.kt
@@ -25,4 +25,5 @@ interface MetadataDAO {
     suspend fun deleteValue(key: String)
     suspend fun valueByKeyFlow(key: String): Flow<String?>
     suspend fun valueByKey(key: String): String?
+    suspend fun clear(keysToKeep: List<String>?)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
@@ -61,7 +61,7 @@ class MetadataDAOImpl internal constructor(
         if (keysToKeep == null) {
             metadataQueries.deleteAll()
         } else {
-            metadataQueries.deleteAllExpect(keysToKeep)
+            metadataQueries.deleteAllExcept(keysToKeep)
         }
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
@@ -56,4 +56,12 @@ class MetadataDAOImpl internal constructor(
     override suspend fun valueByKey(key: String): String? = withContext(queriesContext) {
         metadataQueries.selectValueByKey(key).executeAsOneOrNull()
     }
+
+    override suspend fun clear(keysToKeep: List<String>?) = withContext(queriesContext) {
+        if (keysToKeep == null) {
+            metadataQueries.deleteAll()
+        } else {
+            metadataQueries.deleteAllExpect(keysToKeep)
+        }
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

sync fails with 404 after removing client

### Causes (Optional)

some metadata values are not cleared

### Solutions

clear client related metadata values

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
