### PR TITLE
fix: client removed after hard logout

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
@@ -65,11 +65,7 @@ internal class LogoutDataSource(
 
     override suspend fun observeLogout(): Flow<LogoutReason?> = logoutEventsChannel.receiveAsFlow()
 
-    override suspend fun onLogout(reason: LogoutReason) {
-        logoutEventsChannel.send(reason)
-        // We need to clear channel state in case when user wants to login on the same session
-        logoutEventsChannel.send(null)
-    }
+    override suspend fun onLogout(reason: LogoutReason) = logoutEventsChannel.send(reason)
 
     override suspend fun logout(): Either<CoreFailure, Unit> =
         wrapApiRequest { logoutApi.logout() }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/logout/LogoutRepositoryTest.kt
@@ -78,10 +78,8 @@ class LogoutRepositoryTest {
         logoutRepository.observeLogout().test {
             logoutRepository.onLogout(LogoutReason.SELF_HARD_LOGOUT)
             assertEquals(LogoutReason.SELF_HARD_LOGOUT, awaitItem())
-            assertEquals(null, awaitItem())
             logoutRepository.onLogout(LogoutReason.SESSION_EXPIRED)
             assertEquals(LogoutReason.SESSION_EXPIRED, awaitItem())
-            assertEquals(null, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

HradLogout -> login again -> user will be surprised with a popup that the client has been removed

### Causes (Optional)

sync still holds a reference to the old DB  object,  including its cache

### Solutions

fix the cause

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
