### PR TITLE
chore: remove message size estimation logging

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
@@ -129,11 +129,6 @@ class MessageEnvelopeCreatorImpl(
         val totalClients = recipients.sumOf { recipient -> recipient.clients.size }
 
         val totalEstimatedSize = encryptedMessageSizeEstimate + totalClients
-        kaliumLogger.withFeatureId(MESSAGES).v(
-            "Original message size: ${encodedContent.data.size}; " +
-                    "Estimated total message size = $totalEstimatedSize, " +
-                    "for $totalClients clients"
-        )
 
         return if (totalEstimatedSize <= MAX_CONTENT_SIZE) {
             kaliumLogger.withFeatureId(MESSAGES).v("External message is not needed")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

4 meter tall log walls being added every time a message is encrypted, especially for big groups.

### Causes

I added this log message for debugging purposes and data validation while developing the External Messages feature and it slipped through.

### Solutions

Remove it!

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
