### PR TITLE
fix: Sync not working after my device was deleted and I logged in again

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/logout/LogoutRepository.kt
@@ -36,7 +36,7 @@ interface LogoutRepository {
      * Listen to a logout event.
      * The event caries a [LogoutReason].
      */
-    suspend fun observeLogout(): Flow<LogoutReason?>
+    suspend fun observeLogout(): Flow<LogoutReason>
 
     /**
      * Propagates the logout event and [reason],
@@ -61,9 +61,9 @@ internal class LogoutDataSource(
     private val metadataDAO: MetadataDAO
 ) : LogoutRepository {
 
-    private val logoutEventsChannel = Channel<LogoutReason?>(capacity = Channel.CONFLATED)
+    private val logoutEventsChannel = Channel<LogoutReason>(capacity = Channel.CONFLATED)
 
-    override suspend fun observeLogout(): Flow<LogoutReason?> = logoutEventsChannel.receiveAsFlow()
+    override suspend fun observeLogout(): Flow<LogoutReason> = logoutEventsChannel.receiveAsFlow()
 
     override suspend fun onLogout(reason: LogoutReason) = logoutEventsChannel.send(reason)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -55,6 +55,8 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
     // TODO(refactor): Maybe we can simplify by taking some of the responsibility away from here.
     //                 Perhaps [UserSessionScope] (or another specialised class) can observe
     //                 the [LogoutRepository.observeLogout] and invalidating everything in [CoreLogic] level.
+
+    // TODO: logout should not be cancelable
     override suspend operator fun invoke(reason: LogoutReason) {
         deregisterTokenUseCase()
         logoutRepository.logout()
@@ -71,7 +73,6 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
 
             LogoutReason.REMOVED_CLIENT, LogoutReason.DELETED_ACCOUNT -> {
                 // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
-                delay(CLEAR_DATA_DELAY)
                 clearClientDataUseCase()
                 logoutRepository.clearClientRelatedLocalMetadata()
                 clientRepository.clearCurrentClientId()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncCriteriaProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncCriteriaProvider.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.sync.slow.SyncCriteriaResolution.MissingRequirement
 import com.wire.kalium.logic.sync.slow.SyncCriteriaResolution.Ready
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 
 /**
@@ -70,6 +71,7 @@ internal class SlowSlowSyncCriteriaProviderImpl(
      */
     private suspend fun logoutReasonFlow() = logoutRepository
         .observeLogout()
+        .map<LogoutReason, LogoutReason?> { it }
         .onStart { emit(null) }
 
     override suspend fun syncCriteriaFlow(): Flow<SyncCriteriaResolution> =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sync not working after my device was deleted and I logged in again

### Solutions

the logout was triggered from sync, but it is also canceling sync, which stops the logout midway
TODO: we need to make sure that the logout is NOT cancelable.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
