### PR TITLE
refactor: start logout from an app global scope

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -78,7 +78,7 @@ class GlobalKaliumScope internal constructor(
     private val kaliumConfigs: KaliumConfigs,
     private val userSessionScopeProvider: Lazy<UserSessionScopeProvider>,
     private val authenticationScopeProvider: AuthenticationScopeProvider
-): CoroutineScope {
+) : CoroutineScope {
 
     override val coroutineContext: CoroutineContext = SupervisorJob()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -58,6 +58,9 @@ import com.wire.kalium.network.networkContainer.UnboundNetworkContainer
 import com.wire.kalium.network.networkContainer.UnboundNetworkContainerCommon
 import com.wire.kalium.persistence.db.GlobalDatabaseProvider
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Scope that exposes all operations that are user and backend agnostic, like
@@ -75,7 +78,9 @@ class GlobalKaliumScope internal constructor(
     private val kaliumConfigs: KaliumConfigs,
     private val userSessionScopeProvider: Lazy<UserSessionScopeProvider>,
     private val authenticationScopeProvider: AuthenticationScopeProvider
-) {
+): CoroutineScope {
+
+    override val coroutineContext: CoroutineContext = SupervisorJob()
 
     private val unboundNetworkContainer: UnboundNetworkContainer by lazy {
         UnboundNetworkContainerCommon(developmentApiEnabled = kaliumConfigs.developmentApiEnabled)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -988,7 +988,8 @@ class UserSessionScope internal constructor(
             client.clearClientData,
             clearUserData,
             userSessionScopeProvider,
-            pushTokenRepository
+            pushTokenRepository,
+            globalScope
         )
     val persistPersistentWebSocketConnectionStatus: PersistPersistentWebSocketConnectionStatusUseCase
         get() = PersistPersistentWebSocketConnectionStatusUseCaseImpl(userId, globalScope.sessionRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -73,6 +73,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
             when (reason) {
                 LogoutReason.SELF_HARD_LOGOUT -> {
                     // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
+                    delay(CLEAR_DATA_DELAY)
                     clearClientDataUseCase()
                     clearUserDataUseCase() // this clears also current client id
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -27,11 +27,7 @@ import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.feature.UserSessionScopeProvider
 import com.wire.kalium.logic.feature.client.ClearClientDataUseCase
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCase
-import kotlinx.coroutines.AbstractCoroutine
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -97,7 +93,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
 
             userSessionScopeProvider.get(userId)?.cancel()
             userSessionScopeProvider.delete(userId)
-        }
+        }.join()
     }
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -93,7 +93,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
 
             userSessionScopeProvider.get(userId)?.cancel()
             userSessionScopeProvider.delete(userId)
-        }.join()
+        }
     }
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -27,8 +27,14 @@ import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.feature.UserSessionScopeProvider
 import com.wire.kalium.logic.feature.client.ClearClientDataUseCase
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCase
+import kotlinx.coroutines.AbstractCoroutine
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Logs out the user from the current session
@@ -50,46 +56,47 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
     private val clearClientDataUseCase: ClearClientDataUseCase,
     private val clearUserDataUseCase: ClearUserDataUseCase,
     private val userSessionScopeProvider: UserSessionScopeProvider,
-    private val pushTokenRepository: PushTokenRepository
+    private val pushTokenRepository: PushTokenRepository,
+    private val globalCoroutineScope: CoroutineScope
 ) : LogoutUseCase {
     // TODO(refactor): Maybe we can simplify by taking some of the responsibility away from here.
     //                 Perhaps [UserSessionScope] (or another specialised class) can observe
     //                 the [LogoutRepository.observeLogout] and invalidating everything in [CoreLogic] level.
 
-    // TODO: logout should not be cancelable
     override suspend operator fun invoke(reason: LogoutReason) {
-        deregisterTokenUseCase()
-        logoutRepository.logout()
-        sessionRepository.logout(userId = userId, reason)
-        logoutRepository.onLogout(reason)
+        globalCoroutineScope.launch {
+            deregisterTokenUseCase()
+            logoutRepository.logout()
+            sessionRepository.logout(userId = userId, reason)
+            logoutRepository.onLogout(reason)
 
-        when (reason) {
-            LogoutReason.SELF_HARD_LOGOUT -> {
-                // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
-                delay(CLEAR_DATA_DELAY)
-                clearClientDataUseCase()
-                clearUserDataUseCase() // this clears also current client id
+            when (reason) {
+                LogoutReason.SELF_HARD_LOGOUT -> {
+                    // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
+                    clearClientDataUseCase()
+                    clearUserDataUseCase() // this clears also current client id
+                }
+
+                LogoutReason.REMOVED_CLIENT, LogoutReason.DELETED_ACCOUNT -> {
+                    // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
+                    clearClientDataUseCase()
+                    logoutRepository.clearClientRelatedLocalMetadata()
+                    clientRepository.clearCurrentClientId()
+                    clientRepository.clearHasRegisteredMLSClient()
+                    // After logout we need to mark the Firebase token as invalid locally so that we can register a new one on the next login.
+                    pushTokenRepository.setUpdateFirebaseTokenFlag(true)
+                }
+
+                LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SESSION_EXPIRED -> {
+                    clientRepository.clearCurrentClientId()
+                    // After logout we need to mark the Firebase token as invalid locally so that we can register a new one on the next login.
+                    pushTokenRepository.setUpdateFirebaseTokenFlag(true)
+                }
             }
 
-            LogoutReason.REMOVED_CLIENT, LogoutReason.DELETED_ACCOUNT -> {
-                // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
-                clearClientDataUseCase()
-                logoutRepository.clearClientRelatedLocalMetadata()
-                clientRepository.clearCurrentClientId()
-                clientRepository.clearHasRegisteredMLSClient()
-                // After logout we need to mark the Firebase token as invalid locally so that we can register a new one on the next login.
-                pushTokenRepository.setUpdateFirebaseTokenFlag(true)
-            }
-
-            LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SESSION_EXPIRED -> {
-                clientRepository.clearCurrentClientId()
-                // After logout we need to mark the Firebase token as invalid locally so that we can register a new one on the next login.
-                pushTokenRepository.setUpdateFirebaseTokenFlag(true)
-            }
+            userSessionScopeProvider.get(userId)?.cancel()
+            userSessionScopeProvider.delete(userId)
         }
-
-        userSessionScopeProvider.get(userId)?.cancel()
-        userSessionScopeProvider.delete(userId)
     }
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -68,25 +68,29 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
 
             when (reason) {
                 LogoutReason.SELF_HARD_LOGOUT -> {
-                    // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
+                    // we put this delay here to avoid a race condition when
+                    // receiving web socket events at the exact time of logging put
                     delay(CLEAR_DATA_DELAY)
                     clearClientDataUseCase()
                     clearUserDataUseCase() // this clears also current client id
                 }
 
                 LogoutReason.REMOVED_CLIENT, LogoutReason.DELETED_ACCOUNT -> {
-                    // we put this delay here to avoid a race condition when receiving web socket events at the exact time of logging put
+                    // we put this delay here to avoid a race condition when
+                    // receiving web socket events at the exact time of logging put
                     clearClientDataUseCase()
                     logoutRepository.clearClientRelatedLocalMetadata()
                     clientRepository.clearCurrentClientId()
                     clientRepository.clearHasRegisteredMLSClient()
-                    // After logout we need to mark the Firebase token as invalid locally so that we can register a new one on the next login.
+                    // After logout we need to mark the Firebase token as invalid
+                    // locally so that we can register a new one on the next login.
                     pushTokenRepository.setUpdateFirebaseTokenFlag(true)
                 }
 
                 LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SESSION_EXPIRED -> {
                     clientRepository.clearCurrentClientId()
-                    // After logout we need to mark the Firebase token as invalid locally so that we can register a new one on the next login.
+                    // After logout we need to mark the Firebase token as invalid
+                    // locally so that we can register a new one on the next login.
                     pushTokenRepository.setUpdateFirebaseTokenFlag(true)
                 }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -42,6 +42,8 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
@@ -64,6 +66,7 @@ class LogoutUseCaseTest {
                 .arrange()
 
             logoutUseCase.invoke(reason)
+            arrangement.globalTestScope.advanceUntilIdle()
 
             verify(arrangement.deregisterTokenUseCase)
                 .suspendFunction(arrangement.deregisterTokenUseCase::invoke)
@@ -113,6 +116,7 @@ class LogoutUseCaseTest {
             .arrange()
 
         logoutUseCase.invoke(reason)
+        arrangement.globalTestScope.advanceUntilIdle()
 
         verify(arrangement.clearClientDataUseCase)
             .suspendFunction(arrangement.clearClientDataUseCase::invoke)
@@ -138,6 +142,7 @@ class LogoutUseCaseTest {
                 .arrange()
 
             logoutUseCase.invoke(reason)
+            arrangement.globalTestScope.advanceUntilIdle()
 
             verify(arrangement.clearClientDataUseCase)
                 .suspendFunction(arrangement.clearClientDataUseCase::invoke)
@@ -169,6 +174,7 @@ class LogoutUseCaseTest {
             .arrange()
 
         logoutUseCase.invoke(reason)
+        arrangement.globalTestScope.advanceUntilIdle()
 
         verify(arrangement.clearClientDataUseCase)
             .suspendFunction(arrangement.clearClientDataUseCase::invoke)
@@ -209,6 +215,8 @@ class LogoutUseCaseTest {
         @Mock
         val pushTokenRepository = mock(classOf<PushTokenRepository>())
 
+        val globalTestScope = TestScope()
+
         private val logoutUseCase: LogoutUseCase = LogoutUseCaseImpl(
             logoutRepository,
             sessionRepository,
@@ -218,7 +226,8 @@ class LogoutUseCaseTest {
             clearClientDataUseCase,
             clearUserDataUseCase,
             userSessionScopeProvider,
-            pushTokenRepository
+            pushTokenRepository,
+            globalTestScope
         )
 
         fun withDeregisterTokenResult(result: DeregisterTokenUseCase.Result): Arrangement {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

logout is canceled when triggered from sync aka client deleted

### Solutions

start logout from the app global scope so it is not canceled

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
