### PR TITLE
refactor: remove redundant date mapping

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationOptions.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationOptions.kt
@@ -24,7 +24,6 @@ data class ConversationOptions(
     val accessRole: Set<Conversation.AccessRole>? = null,
     val readReceiptsEnabled: Boolean = false,
     val protocol: Protocol = Protocol.PROTEUS,
-    // TODO(qol): use ClientId class
     val creatorClientId: ClientId? = null
 ) {
     enum class Protocol {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -74,6 +74,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Instant
 
 interface ConversationRepository {
     @DelicateKaliumApi("This function does not get values from cache")
@@ -143,8 +144,8 @@ interface ConversationRepository {
 
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedID): Either<StorageFailure, Unit>
     suspend fun updateAllConversationsNotificationDate(): Either<StorageFailure, Unit>
-    suspend fun updateConversationModifiedDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit>
-    suspend fun updateConversationReadDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit>
+    suspend fun updateConversationModifiedDate(qualifiedID: QualifiedID, date: Instant): Either<StorageFailure, Unit>
+    suspend fun updateConversationReadDate(qualifiedID: QualifiedID, date: Instant): Either<StorageFailure, Unit>
     suspend fun updateAccessInfo(
         conversationID: ConversationId,
         access: List<Conversation.Access>,
@@ -469,7 +470,7 @@ internal class ConversationDataSource internal constructor(
 
     override suspend fun updateConversationModifiedDate(
         qualifiedID: QualifiedID,
-        date: String
+        date: Instant
     ): Either<StorageFailure, Unit> =
         wrapStorageRequest { conversationDAO.updateConversationModifiedDate(qualifiedID.toDao(), date) }
 
@@ -507,7 +508,7 @@ internal class ConversationDataSource internal constructor(
     /**
      * Update the conversation seen date, which is a date when the user sees the content of the conversation.
      */
-    override suspend fun updateConversationReadDate(qualifiedID: QualifiedID, date: String): Either<StorageFailure, Unit> =
+    override suspend fun updateConversationReadDate(qualifiedID: QualifiedID, date: Instant): Either<StorageFailure, Unit> =
         wrapStorageRequest { conversationDAO.updateConversationReadDate(qualifiedID.toDao(), date) }
 
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCase.kt
@@ -50,7 +50,7 @@ internal class AcceptConnectionRequestUseCaseImpl(
         return connectionRepository.updateConnectionStatus(userId, ConnectionState.ACCEPTED)
             .flatMap {
                 conversationRepository.fetchConversation(it.qualifiedConversationId)
-                conversationRepository.updateConversationModifiedDate(it.qualifiedConversationId, DateTimeUtil.currentIsoDateTimeString())
+                conversationRepository.updateConversationModifiedDate(it.qualifiedConversationId, DateTimeUtil.currentInstant())
             }
             .fold({
                 kaliumLogger.e("An error occurred when accepting the connection request from $userId")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
@@ -65,7 +65,8 @@ class CreateGroupConversationUseCase internal constructor(
         }.flatMap { clientId ->
             conversationGroupRepository.createGroupConversation(name, userIdList, options.copy(creatorClientId = clientId))
         }.flatMap { conversation ->
-            conversationRepository.updateConversationModifiedDate(conversation.id, DateTimeUtil.currentIsoDateTimeString())
+            // TODO(qol): this can be done in one query, e.g. pass current time when inserting
+            conversationRepository.updateConversationModifiedDate(conversation.id, DateTimeUtil.currentInstant())
                 .map { conversation }
         }.fold({
             if (it is NetworkFailure.NoNetworkConnection) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -33,7 +33,6 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.util.DateTimeUtil
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Instant
 
 /**
@@ -58,7 +57,7 @@ class UpdateConversationReadDateUseCase internal constructor(
      */
     suspend operator fun invoke(conversationId: QualifiedID, time: Instant) {
         sendConfirmation(conversationId)
-        conversationRepository.updateConversationReadDate(conversationId, time.toIsoDateTimeString())
+        conversationRepository.updateConversationReadDate(conversationId, time)
         selfConversationIdProvider().flatMap { selfConversationIds ->
            selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
                sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -57,7 +57,7 @@ internal class NewConversationEventHandlerImpl(
 
     override suspend fun handle(event: Event.Conversation.NewConversation): Either<CoreFailure, Unit> = conversationRepository
         .persistConversations(listOf(event.conversation), selfTeamIdProvider().getOrNull()?.value, originatedFromEvent = true)
-        .flatMap { conversationRepository.updateConversationModifiedDate(event.conversationId, DateTimeUtil.currentIsoDateTimeString()) }
+        .flatMap { conversationRepository.updateConversationModifiedDate(event.conversationId, DateTimeUtil.currentInstant()) }
         .flatMap {
             userRepository.fetchUsersIfUnknownByIds(event.conversation.members.otherMembers.map { it.id.toModel() }
                 .toSet())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/LastReadContentHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/message/LastReadContentHandler.kt
@@ -19,11 +19,10 @@
 package com.wire.kalium.logic.sync.receiver.message
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.message.IsMessageSentInSelfConversationUseCase
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.IsMessageSentInSelfConversationUseCase
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 
 interface LastReadContentHandler {
     suspend fun handle(
@@ -52,7 +51,7 @@ internal class LastReadContentHandlerImpl internal constructor(
             // to synchronize the state across the clients.
             conversationRepository.updateConversationReadDate(
                 qualifiedID = messageContent.conversationId,
-                date = messageContent.time.toIsoDateTimeString()
+                date = messageContent.time
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -642,7 +642,10 @@ class ConversationRepositoryTest {
             .arrange()
 
         // when
-        val result = conversationRepository.updateConversationReadDate(TestConversation.ID, "2022-03-30T15:36:00.000Z")
+        val result = conversationRepository.updateConversationReadDate(
+            TestConversation.ID,
+            Instant.fromEpochMilliseconds(1648654560000)
+        )
 
         // then
         verify(arrangement.conversationDAO)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCaseTest.kt
@@ -50,7 +50,6 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.toInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -164,7 +163,7 @@ class CreateGroupConversationUseCaseTest {
 
         verify(arrangement.conversationRepository)
             .suspendFunction(arrangement.conversationRepository::updateConversationModifiedDate)
-            .with(any(), matching { it.toInstant().wasInTheLastSecond })
+            .with(any(), matching { it.wasInTheLastSecond })
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -47,7 +47,6 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.toInstant
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -122,7 +121,7 @@ class NewConversationEventHandlerTest {
 
         verify(arrangement.conversationRepository)
             .suspendFunction(arrangement.conversationRepository::updateConversationModifiedDate)
-            .with(eq(event.conversationId), matching { it.toInstant().wasInTheLastSecond })
+            .with(eq(event.conversationId), matching { it.wasInTheLastSecond })
             .wasInvoked(exactly = once)
     }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -145,9 +145,9 @@ interface ConversationDAO {
     suspend fun insertConversations(conversationEntities: List<ConversationEntity>)
     suspend fun updateConversation(conversationEntity: ConversationEntity)
     suspend fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String)
-    suspend fun updateConversationModifiedDate(qualifiedID: QualifiedIDEntity, date: String)
+    suspend fun updateConversationModifiedDate(qualifiedID: QualifiedIDEntity, date: Instant)
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedIDEntity)
-    suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: String)
+    suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: Instant)
     suspend fun updateAllConversationsNotificationDate()
     suspend fun getAllConversations(): Flow<List<ConversationViewEntity>>
     suspend fun getAllConversationDetails(): Flow<List<ConversationViewEntity>>

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -281,8 +281,8 @@ class ConversationDAOImpl(
             conversationQueries.updateConversationGroupState(groupState, groupId)
         }
 
-    override suspend fun updateConversationModifiedDate(qualifiedID: QualifiedIDEntity, date: String) = withContext(coroutineContext) {
-        conversationQueries.updateConversationModifiedDate(date.toInstant(), qualifiedID)
+    override suspend fun updateConversationModifiedDate(qualifiedID: QualifiedIDEntity, date: Instant) = withContext(coroutineContext) {
+        conversationQueries.updateConversationModifiedDate(date, qualifiedID)
     }
 
     override suspend fun updateConversationNotificationDate(qualifiedID: QualifiedIDEntity) = withContext(coroutineContext) {
@@ -476,8 +476,8 @@ class ConversationDAOImpl(
         conversationQueries.updateAccess(accessList, accessRoleList, conversationID)
     }
 
-    override suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: String) = withContext(coroutineContext) {
-        conversationQueries.updateConversationReadDate(date.toInstant(), conversationID)
+    override suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: Instant) = withContext(coroutineContext) {
+        conversationQueries.updateConversationReadDate(date, conversationID)
     }
 
     override suspend fun updateConversationMemberRole(conversationId: QualifiedIDEntity, userId: UserIDEntity, role: Member.Role) =

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newSystemMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
 import com.wire.kalium.util.DateTimeUtil
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -391,12 +390,12 @@ class ConversationDAOTest : BaseDatabaseTest() {
     @Test
     fun givenExistingConversation_whenUpdatingTheConversationLastReadDate_ThenTheConversationHasTheDate() = runTest {
         // given
-        val expectedLastReadDate = "2022-03-30T15:36:00.000Z".toInstant()
+        val expectedLastReadDate = Instant.fromEpochMilliseconds(1648654560000)
 
         conversationDAO.insertConversation(conversationEntity1)
 
         // when
-        conversationDAO.updateConversationReadDate(conversationEntity1.id, expectedLastReadDate.toString())
+        conversationDAO.updateConversationReadDate(conversationEntity1.id, expectedLastReadDate)
 
         // then
         val actual = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
@@ -409,7 +408,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
     fun givenExistingConversation_whenUpdatingTheConversationSeenDate_thenEmitTheNewConversationStateWithTheUpdatedSeenDate() =
         runTest {
             // given
-            val expectedConversationSeenDate = "2022-03-30T15:36:00.000Z".toInstant()
+            val expectedConversationSeenDate = Instant.fromEpochMilliseconds(1648654560000)
+
             teamDAO.insertTeam(team)
             launch {
                 // when
@@ -425,7 +425,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
                     assertTrue(conversationAfterInsert != null)
 
-                    conversationDAO.updateConversationReadDate(conversationEntity1.id, expectedConversationSeenDate.toIsoDateTimeString())
+                    conversationDAO.updateConversationReadDate(conversationEntity1.id, expectedConversationSeenDate)
 
                     val conversationAfterUpdate = awaitItem()
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -22,11 +22,13 @@ import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MessageNotificationsTest : BaseMessageTest() {
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageUnreadCounterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageUnreadCounterTest.kt
@@ -3,7 +3,7 @@ package com.wire.kalium.persistence.dao.message
 import app.cash.turbine.test
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newSystemMessageEntity
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -14,6 +14,7 @@ import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MessageUnreadCounterTest : BaseMessageTest() {
 
     @Test
@@ -21,7 +22,7 @@ class MessageUnreadCounterTest : BaseMessageTest() {
         insertInitialData()
         val readDate = Instant.fromEpochSeconds(10)
         val convId = TEST_CONVERSATION_1.id
-        conversationDAO.updateConversationReadDate(convId, readDate.toIsoDateTimeString())
+        conversationDAO.updateConversationReadDate(convId, readDate)
 
         val unreadMessages = listOf(
             newRegularMessageEntity(
@@ -51,7 +52,7 @@ class MessageUnreadCounterTest : BaseMessageTest() {
         insertInitialData()
         val readDate = Instant.fromEpochSeconds(10)
         val convId = TEST_CONVERSATION_1.id
-        conversationDAO.updateConversationReadDate(convId, readDate.toIsoDateTimeString())
+        conversationDAO.updateConversationReadDate(convId, readDate)
 
         val unreadMessages = listOf(
             newRegularMessageEntity(
@@ -80,7 +81,7 @@ class MessageUnreadCounterTest : BaseMessageTest() {
         insertInitialData()
         val readDate = Instant.fromEpochSeconds(10)
         val convId = TEST_CONVERSATION_1.id
-        conversationDAO.updateConversationReadDate(convId, readDate.toIsoDateTimeString())
+        conversationDAO.updateConversationReadDate(convId, readDate)
 
         val unreadMessages = listOf(
             newSystemMessageEntity(
@@ -109,7 +110,7 @@ class MessageUnreadCounterTest : BaseMessageTest() {
         insertInitialData()
         val readDate = Instant.fromEpochSeconds(10)
         val convId = TEST_CONVERSATION_1.id
-        conversationDAO.updateConversationReadDate(convId, readDate.toIsoDateTimeString())
+        conversationDAO.updateConversationReadDate(convId, readDate)
 
         val unreadMessages = listOf(
             newRegularMessageEntity(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

leftovers form refactoring iso date string to Instant

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
