### PR TITLE
fix(rc): crash loop when trying to create PendingMessageSenderWorker [AR-3041]

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WorkSchedulerImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WorkSchedulerImpl.kt
@@ -122,6 +122,10 @@ internal actual class UserSessionWorkSchedulerImpl(
         )
     }
 
+    override fun cancelScheduledSendingOfPendingMessages() {
+        WorkManager.getInstance(appContext).cancelUniqueWork(WORK_NAME_PREFIX_PER_USER + userId.value)
+    }
+
     private companion object {
         const val WORK_NAME_PREFIX_PER_USER = "scheduled-message-"
     }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WrapperWorker.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WrapperWorker.kt
@@ -144,8 +144,7 @@ class WrapperWorkerFactory(
                 userId
             )
             WrapperWorker(worker, appContext, workerParameters, foregroundNotificationDetailsProvider)
-        }
-        else null
+        } else null
     }
 
     private fun createDefaultWorker(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -47,6 +47,7 @@ import com.wire.kalium.logic.feature.server.StoreServerConfigUseCaseImpl
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCaseImpl
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
 import com.wire.kalium.logic.feature.session.SessionScope
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
@@ -117,6 +118,7 @@ class GlobalKaliumScope internal constructor(
         get() =
             AddAuthenticatedUserUseCase(sessionRepository, serverConfigRepository)
     val getSessions: GetSessionsUseCase get() = GetSessionsUseCase(sessionRepository)
+    val doesValidSessionExist: DoesValidSessionExistUseCase get() = DoesValidSessionExistUseCase(sessionRepository)
     val observeValidAccounts: ObserveValidAccountsUseCase
         get() = ObserveValidAccountsUseCaseImpl(sessionRepository, userSessionScopeProvider.value)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -989,7 +989,8 @@ class UserSessionScope internal constructor(
             clearUserData,
             userSessionScopeProvider,
             pushTokenRepository,
-            globalScope
+            globalScope,
+            authenticatedDataSourceSet.userSessionWorkScheduler
         )
     val persistPersistentWebSocketConnectionStatus: PersistPersistentWebSocketConnectionStatusUseCase
         get() = PersistPersistentWebSocketConnectionStatusUseCaseImpl(userId, globalScope.sessionRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingScheduler.kt
@@ -38,4 +38,10 @@ interface MessageSendingScheduler {
      *  it's OK to just don't do anything, ideally logging a warning about the lack of implementation.
      */
     fun scheduleSendingOfPendingMessages()
+
+    /**
+     * Cancels the scheduled execution of [PendingMessagesSenderWorker], which attempts to send
+     *  all pending messages of this user, because the account has been logged out for instance.
+     */
+    fun cancelScheduledSendingOfPendingMessages()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DoesValidSessionExistUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DoesValidSessionExistUseCase.kt
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.session
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.fold
+
+sealed class DoesValidSessionExistResult {
+    data class Success(val doesValidSessionExist: Boolean) : DoesValidSessionExistResult()
+
+    sealed class Failure : DoesValidSessionExistResult() {
+        @Suppress("UNUSED_PARAMETER") // It's used by consumers of Kalium
+        class Generic(coreFailure: CoreFailure) : Failure()
+    }
+}
+
+/**
+ * This use case will return the information whether the valid session exists for a given user id.
+ */
+class DoesValidSessionExistUseCase(private val sessionRepository: SessionRepository) {
+    suspend operator fun invoke(userId: UserId): DoesValidSessionExistResult =
+        sessionRepository.doesValidSessionExist(userId).fold({
+            when (it) {
+                StorageFailure.DataNotFound -> DoesValidSessionExistResult.Success(false)
+                is StorageFailure.Generic -> DoesValidSessionExistResult.Failure.Generic(it)
+            }
+        }, {
+            DoesValidSessionExistResult.Success(it)
+        })
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.feature.UserSessionScopeProvider
 import com.wire.kalium.logic.feature.client.ClearClientDataUseCase
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCase
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.UserSessionWorkScheduler
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -215,6 +216,9 @@ class LogoutUseCaseTest {
         @Mock
         val pushTokenRepository = mock(classOf<PushTokenRepository>())
 
+        @Mock
+        val userSessionWorkScheduler = configure(mock(classOf<UserSessionWorkScheduler>())) { stubsUnitByDefault = true }
+
         val globalTestScope = TestScope()
 
         private val logoutUseCase: LogoutUseCase = LogoutUseCaseImpl(
@@ -227,7 +231,8 @@ class LogoutUseCaseTest {
             clearUserDataUseCase,
             userSessionScopeProvider,
             pushTokenRepository,
-            globalTestScope
+            globalTestScope,
+            userSessionWorkScheduler
         )
 
         fun withDeregisterTokenResult(result: DeregisterTokenUseCase.Result): Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DoesValidSessionExistUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DoesValidSessionExistUseCaseTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.session
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okio.IOException
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DoesValidSessionExistUseCaseTest {
+
+    @Test
+    fun givenAUserId_whenValidSessionExists_thenReturnSuccessTrue() = runTest {
+        val userId = Arrangement.TEST_USER_ID
+        val (_, useCase) = Arrangement()
+            .withDoesValidSessionExist(userId, true)
+            .arrange()
+        val result = useCase(userId)
+        assertIs<DoesValidSessionExistResult.Success>(result)
+        assertTrue { result.doesValidSessionExist }
+    }
+
+    @Test
+    fun givenAUserId_whenValidSessionDoesNotExists_thenReturnSuccessFalse() = runTest {
+        val userId = Arrangement.TEST_USER_ID
+        val (_, useCase) = Arrangement()
+            .withDoesValidSessionExist(userId, false)
+            .arrange()
+        val result = useCase(userId)
+        assertIs<DoesValidSessionExistResult.Success>(result)
+        assertFalse { result.doesValidSessionExist }
+    }
+
+    @Test
+    fun givenAUserId_whenValidSessionReturnsDataNotFoundFailure_thenReturnSuccessFalse() = runTest {
+        val userId = Arrangement.TEST_USER_ID
+        val (_, useCase) = Arrangement()
+            .withDoesValidSessionExistFailure(StorageFailure.DataNotFound)
+            .arrange()
+        val result = useCase(userId)
+        assertIs<DoesValidSessionExistResult.Success>(result)
+        assertFalse { result.doesValidSessionExist }
+    }
+
+    @Test
+    fun givenAUserId_whenValidSessionReturnsOtherFailure_thenReturnFailure() = runTest {
+        val userId = Arrangement.TEST_USER_ID
+        val (_, useCase) = Arrangement()
+            .withDoesValidSessionExistFailure(StorageFailure.Generic(IOException()))
+            .arrange()
+        val result = useCase(userId)
+        assertIs<DoesValidSessionExistResult.Failure>(result)
+    }
+
+    class Arrangement {
+
+        @Mock
+        private val sessionRepository = mock(classOf<SessionRepository>())
+        private val doesValidSessionExistUseCase: DoesValidSessionExistUseCase by lazy {
+            DoesValidSessionExistUseCase(sessionRepository)
+        }
+
+        fun withDoesValidSessionExist(userId: UserId, exists: Boolean) = apply {
+            given(sessionRepository)
+                .suspendFunction(sessionRepository::doesValidSessionExist)
+                .whenInvokedWith(eq(userId))
+                .thenReturn(Either.Right(exists))
+        }
+
+        fun withDoesValidSessionExistFailure(failure: StorageFailure) = apply {
+            given(sessionRepository)
+                .suspendFunction(sessionRepository::doesValidSessionExist)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Left(failure))
+        }
+
+        fun arrange() = this to doesValidSessionExistUseCase
+
+        companion object {
+            val TEST_USER_ID = UserId("test", "domain")
+        }
+    }
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/sync/WorkSchedulerImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/sync/WorkSchedulerImpl.kt
@@ -53,4 +53,10 @@ internal actual class UserSessionWorkSchedulerImpl(
             "Scheduling of messages is not supported on JVM. Pending messages won't be scheduled for sending."
         )
     }
+
+    override fun cancelScheduledSendingOfPendingMessages() {
+        kaliumLogger.withFeatureId(SYNC).w(
+            "Cancelling scheduling of messages is not supported on JVM. Pending messages won't be scheduled for sending."
+        )
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is an `IllegalStateException` crash at random moments that happens multiple times for some users.

### Causes (Optional)

The app tries to fetch the server config for the session that doesn't exist anymore.
It's happens when `PendingMessageSenderWorker` is scheduled because the user tried to send a message and it failed for some reason. If the user logs out before this worker is executed successfully, then every time the app will try to create and run it, there will be this crash, and there's no way of stopping it because if there's a crash, the worker is rescheduled again and it tries to create it again after some time.

### Solutions

Cancel scheduled worker when logging out and if it's still being created, check if the session for which this worker was started still exists, if not then there's no point in creating this worker so just return null. Also, cancel 

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Send a message without the internet connection for instance to make this worker be scheduled and log out. Reconnect to see if it crashes.

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
