### PR TITLE
fix: (RC) conversation mapper crash (AR-3136)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -258,10 +258,10 @@ internal class ConnectionDataSource(
             }
 
             ACCEPTED -> {
-                kaliumLogger.i("INSERT CONVERSATION FROM CONNECTION NOT ENGAGED FOR $connection")
-                conversationDAO.updateConversationType(
-                    connection.qualifiedConversationId.toDao(),
-                    ConversationEntity.Type.ONE_ON_ONE
+                conversationDAO.updateOrInsertOneOnOneMemberWithConnectionStatus(
+                    member = Member(user = connection.qualifiedToId.toDao(), Member.Role.Member),
+                    conversationID = connection.qualifiedConversationId.toDao(),
+                    status = connectionStatusMapper.toDaoModel(connection.status)
                 )
             }
 
@@ -279,7 +279,6 @@ internal class ConnectionDataSource(
     private suspend fun updateConversationMemberFromConnection(connection: Connection) =
         wrapStorageRequest {
             conversationDAO.updateOrInsertOneOnOneMemberWithConnectionStatus(
-                // TODO(IMPORTANT!!!!!!): setting a default value for member role is incorrect and can lead to unexpected behaviour
                 member = Member(user = connection.qualifiedToId.toDao(), Member.Role.Member),
                 status = connectionStatusMapper.toDaoModel(connection.status),
                 conversationID = connection.qualifiedConversationId.toDao()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -234,7 +234,7 @@ class ConnectionRepositoryTest {
         verify(arrangement.conversationDAO)
             .suspendFunction(arrangement.conversationDAO::updateOrInsertOneOnOneMemberWithConnectionStatus)
             .with(any(), any(), any())
-            .wasInvoked(once)
+            .wasInvoked(exactly = twice)
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-3136 - App crashing in Conversation Mapper](https://wearezeta.atlassian.net/browse/AR-3136)

### Issues

When a connection request was accepted from another client, current client did not create a Member, thus not having the not-created member in the conversation.
When receiving a notification and clicking it, when opening the Conversation Screen we would try to get info from an user that was not a Member in our DB, thus failing and crashing the app.

### Solutions

Add User from accepted connection request in another client to current Member table.

### Testing

#### How to Test

== TO REPRODUCE THE CRASH IN AN EARLIER BUILD ==
**Devices**: 2x AR (device1 and device2) | 1x Web
**Note**: Both AR is logged in with same user
**Flow**:
- AR(device1) sits on Conversation List or whatever (just don't accept incoming connection request)
- Web sends connection request
- AR(device2) accepts connection
- AR(device1) (doesn't see new connection/chat)
- Web sends message
- AR(device1) receives notification -> clicks notification, when trying to open chat app crashes.

== To check if its fixed, just go through steps above and app shouldn't crash (and should see new conversation) ==

### Notes (Optional)

Needs to run branch on AR.