### PR TITLE
ci: re-enable buildjet

### DIFF
--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -13,7 +13,7 @@ jobs:
         uses: ./.github/workflows/codestyle.yml
     gradle-run-tests:
         needs: [detekt]
-        runs-on: macos-latest
+        runs-on: buildjet-4vcpu-ubuntu-2204
         strategy:
             matrix:
                 api-level: [30]
@@ -44,31 +44,38 @@ jobs:
               run: |
                   ./gradlew :samples:compileDebugSources
 
-            - name: AVD cache
-              uses: actions/cache@v3
-              id: avd-cache
-              with:
-                  path: |
-                      ~/.android/avd/*
-                      ~/.android/adb*
-                  key: avd-${{ matrix.api-level }}
+            # - name: AVD cache
+            #   uses: actions/cache@v3
+            #   id: avd-cache
+            #   with:
+            #       path: |
+            #           ~/.android/avd/*
+            #           ~/.android/adb*
+            #       key: avd-${{ matrix.api-level }}
 
-            - name: Create AVD and generate snapshot for caching
-              if: steps.avd-cache.outputs.cache-hit != 'true'
+            # - name: Create AVD and generate snapshot for caching
+            #   if: steps.avd-cache.outputs.cache-hit != 'true'
+            #   uses: reactivecircus/android-emulator-runner@v2.27.0
+            #   with:
+            #       api-level: ${{ matrix.api-level }}
+            #       force-avd-creation: false
+            #       target: google_apis
+            #       emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+            #       cores: 4
+            #       ram-size: 4096M
+            #       heap-size: 2048M
+            #       disable-animations: false
+            #       script: echo "Generated AVD snapshot for caching."
+
+            - name: Android Instrumentation Tests
               uses: reactivecircus/android-emulator-runner@v2.27.0
               with:
                   api-level: ${{ matrix.api-level }}
-                  force-avd-creation: false
                   target: google_apis
-                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                  disable-animations: false
-                  script: echo "Generated AVD snapshot for caching."
-
-            - name: Android Instrumentation Tests
-              uses: reactivecircus/android-emulator-runner@v2
-              with:
-                  api-level: ${{ matrix.api-level }}
-                  target: google_apis
+                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                  cores: 4
+                  ram-size: 4096M
+                  heap-size: 2048M
                   script: ./gradlew connectedAndroidOnlyAffectedTest
               env:
                   GITHUB_USER: ${{ github.actor }}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
@@ -76,6 +76,7 @@ object BackendMetaDataUtilImpl : BackendMetaDataUtil {
             }
         } ?: run {
             kaliumLogger.w("empty app/server config list")
+            kaliumLogger.w("remove me")
             ApiVersionDTO.Invalid.Unknown
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Builds are stalling waiting for the emulator to boot

### Causes (Optional)

ADV cache step seems to be the culprit 🤷‍♂️

### Solutions

Remove the ADV cache steps

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
