### PR TITLE
fix(dev): ConnectivityManager$TooManyRequestsException [AR-3134]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserver.kt
@@ -17,8 +17,7 @@
  */
 package com.wire.kalium.logic.network
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
@@ -27,7 +26,7 @@ import kotlin.time.Duration
 
 interface NetworkStateObserver {
 
-    fun observeNetworkState(): Flow<NetworkState>
+    fun observeNetworkState(): StateFlow<NetworkState>
 
     // Delay which will be completed earlier if there is a reconnection in the meantime.
     suspend fun delayUntilConnectedWithInternetAgain(delay: Duration) {
@@ -35,7 +34,6 @@ interface NetworkStateObserver {
         withTimeoutOrNull(delay) {
             // Drop the current value, so it will complete only if the connection changed again to connected during that time.
             observeNetworkState()
-                .distinctUntilChanged()
                 .drop(1)
                 .filter { it is NetworkState.ConnectedWithInternet }
                 .firstOrNull()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -41,6 +41,7 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.twice
 import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -48,13 +49,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class IncrementalSyncManagerTest {
 
     @Test
@@ -291,7 +292,7 @@ class IncrementalSyncManagerTest {
         }
 
         init {
-            withNetworkState(flowOf(NetworkState.ConnectedWithInternet))
+            withNetworkState(MutableStateFlow(NetworkState.ConnectedWithInternet))
         }
 
         fun withWorkerReturning(sourceFlow: Flow<EventSource>) = apply {
@@ -329,7 +330,7 @@ class IncrementalSyncManagerTest {
                 .then { _, onRetryCallback -> onRetryCallback.retry() }
         }
 
-        fun withNetworkState(networkStateFlow: Flow<NetworkState>) = apply {
+        fun withNetworkState(networkStateFlow: StateFlow<NetworkState>) = apply {
             given(networkStateObserver)
                 .function(networkStateObserver::observeNetworkState)
                 .whenInvoked()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -38,9 +38,12 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.twice
 import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
@@ -56,6 +59,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SlowSyncManagerTest {
 
     @Test
@@ -324,7 +328,7 @@ class SlowSyncManagerTest {
 
         init {
             withLastSlowSyncPerformedAt(flowOf(null))
-            withNetworkState(flowOf(NetworkState.ConnectedWithInternet))
+            withNetworkState(MutableStateFlow(NetworkState.ConnectedWithInternet))
         }
 
         fun withCriteriaProviderReturning(criteriaFlow: Flow<SyncCriteriaResolution>) = apply {
@@ -357,7 +361,7 @@ class SlowSyncManagerTest {
                 .then { _, onRetryCallback -> onRetryCallback.retry() }
         }
 
-        fun withNetworkState(networkStateFlow: Flow<NetworkState>) = apply {
+        fun withNetworkState(networkStateFlow: StateFlow<NetworkState>) = apply {
             given(networkStateObserver)
                 .function(networkStateObserver::observeNetworkState)
                 .whenInvoked()

--- a/logic/src/darwinMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/darwinMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -17,11 +17,11 @@
  */
 package com.wire.kalium.logic.network
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 actual class NetworkStateObserverImpl : NetworkStateObserver {
 
-    override fun observeNetworkState(): Flow<NetworkState> =
-        flowOf(NetworkState.ConnectedWithInternet) // TODO: for now we treat it as always connected
+    override fun observeNetworkState(): StateFlow<NetworkState> =
+        MutableStateFlow(NetworkState.ConnectedWithInternet) // TODO: for now we treat it as always connected
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -17,11 +17,11 @@
  */
 package com.wire.kalium.logic.network
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 actual class NetworkStateObserverImpl : NetworkStateObserver {
 
-    override fun observeNetworkState(): Flow<NetworkState> =
-        flowOf(NetworkState.ConnectedWithInternet) // TODO: for now we treat it as always connected
+    override fun observeNetworkState(): StateFlow<NetworkState> =
+        MutableStateFlow(NetworkState.ConnectedWithInternet) // TODO: for now we treat it as always connected
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We receive `android.net.ConnectivityManager$TooManyRequestsException`, because `registerDefaultNetworkCallback` has a limit of 100 registered callbacks per app and for some reason our app exceeds that limit.

### Causes (Optional)

The app doesn't call `unregisterNetworkCallback`. 
I checked multiple scenarios to find possible explanations and the issue probably is that `callbackFlow` which is suggested way of registering such callbacks, doesn't work well when used with `.first()` or `withTimeout { }`. Basically it won't unregister if the flow closes before the execution comes to the `awaitClose` line, so the flow doesn't even know that it has something to unregister.
Here are two examples:

![image](https://user-images.githubusercontent.com/30429749/220399595-ab0b78a9-d524-48ac-afff-6c093378b98a.png)
In this case it didn't unregister because timeout happened and flow was closed on long register operation (simulated by `delay`).

![image](https://user-images.githubusercontent.com/30429749/220399905-033de412-efff-46ce-a3a4-d439054fbed8.png)
Here it didn't unregister because it emits first value initially but we wait only for this first value, so it closed the flow right after receiving the first value, again before `awaitClose`.

### Solutions

Get rid of `callbackFlow` as it's problematic and register a single callback for the whole lifecycle of the app, every element can subscribe and start observing this flow and replay also works the way it used to because it's a `StateFlow`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
