### PR TITLE
chore: log error code instead of stacktrace on proteus errors

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
@@ -75,7 +75,7 @@ internal class ProteusMessageUnpackerImpl(
             .onFailure {
                 when (it) {
                     is CoreFailure.Unknown -> logger.e("UnknownFailure when processing message: $it", it.rootCause)
-                    is ProteusFailure -> logger.e("ProteusFailure when processing message: $it", it.proteusException)
+                    is ProteusFailure -> logger.e("ProteusFailure when processing message: ${it.proteusException.code.name}")
                     else -> logger.e("Failure when processing message: $it")
                 }
             }.map { readableContent ->


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Decryption error logs from Cryptobox and CoreCrypto have different formatting.

### Causes

We are logging the stack trace of the underlaying cause which is implementation specific.

### Solutions

Log the name of the ProteusException.Code which is a mapping of the underlaying error into a common error.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
