### PR TITLE
feat: federation msg failed to send handling - part 2: test coverage (AR-3015) 

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -186,7 +186,8 @@ class MessageDataSource(
     private val selfUserId: UserId,
     private val messageMapper: MessageMapper = MapperProvider.messageMapper(selfUserId),
     private val messageMentionMapper: MessageMentionMapper = MapperProvider.messageMentionMapper(selfUserId),
-    private val receiptModeMapper: ReceiptModeMapper = MapperProvider.receiptModeMapper()
+    private val receiptModeMapper: ReceiptModeMapper = MapperProvider.receiptModeMapper(),
+    private val sendMessagePartialFailureMapper: SendMessagePartialFailureMapper = MapperProvider.sendMessagePartialFailureMapper(),
 ) : MessageRepository {
 
     override val extensions: MessageRepositoryExtensions = MessageRepositoryExtensionsImpl(messageDAO, messageMapper)
@@ -344,7 +345,7 @@ class MessageDataSource(
             Either.Left(failure)
         }, { response: QualifiedSendMessageResponse ->
             // not sure about this forced cast, but it seems should be the case here to receive a QualifiedSendMessageResponse.MessageSent
-            Either.Right(SendMessagePartialFailureMapperImpl.fromDTO(response as QualifiedSendMessageResponse.MessageSent))
+            Either.Right(sendMessagePartialFailureMapper.fromDTO(response as QualifiedSendMessageResponse.MessageSent))
         })
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -49,6 +49,7 @@ import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessa
 import com.wire.kalium.network.exceptions.ProteusClientsChangedError
 import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
@@ -445,7 +446,7 @@ class MessageDataSource(
             conversationId.toDao(),
             messageSent.failed.map { it.key to it.value.keys }
                 .map { (domain, userIds) ->
-                    userIds.map { user -> QualifiedIDEntity(user, domain) }
+                    userIds.map { user -> UserIDEntity(user, domain) }
                 }.flatten(),
             RecipientFailureTypeEntity.MESSAGE_DELIVERY_FAILED
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.data.message
 
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
 
 /**
@@ -29,15 +30,16 @@ object SendMessagePartialFailureMapperImpl {
     fun fromDTO(sendMessageResponse: QualifiedSendMessageResponse.MessageSent): MessageSent {
         return MessageSent(
             time = sendMessageResponse.time,
-            failed = sendMessageResponse.failed.orEmpty()
+            failed = sendMessageResponse.failed
+                ?.map { it.key to it.value.keys }
+                ?.map { (domain, userIds) ->
+                    userIds.map { user -> UserId(user, domain) }
+                }?.flatten().orEmpty()
         )
     }
 }
 
 data class MessageSent(
     val time: String,
-    val missing: Map<String, Map<String, List<String>>> = mapOf(),
-    val redundant: Map<String, Map<String, List<String>>> = mapOf(),
-    val deleted: Map<String, Map<String, List<String>>> = mapOf(),
-    val failed: Map<String, Map<String, List<String>>> = mapOf(),
+    val failed: List<UserId> = listOf(),
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
@@ -26,8 +26,12 @@ import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessa
  * This mapper is useful in case we receive a successful response from the backend, but there are some
  * users that failed to receive the message. ie: federated users and/or conversations.
  */
-object SendMessagePartialFailureMapperImpl {
-    fun fromDTO(sendMessageResponse: QualifiedSendMessageResponse.MessageSent): MessageSent {
+interface SendMessagePartialFailureMapper {
+    fun fromDTO(sendMessageResponse: QualifiedSendMessageResponse.MessageSent): MessageSent
+}
+
+internal class SendMessagePartialFailureMapperImpl : SendMessagePartialFailureMapper {
+    override fun fromDTO(sendMessageResponse: QualifiedSendMessageResponse.MessageSent): MessageSent {
         return MessageSent(
             time = sendMessageResponse.time,
             failed = sendMessageResponse.failed

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -64,6 +64,8 @@ import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.message.ProtoContentMapperImpl
 import com.wire.kalium.logic.data.message.SendMessageFailureMapper
 import com.wire.kalium.logic.data.message.SendMessageFailureMapperImpl
+import com.wire.kalium.logic.data.message.SendMessagePartialFailureMapper
+import com.wire.kalium.logic.data.message.SendMessagePartialFailureMapperImpl
 import com.wire.kalium.logic.data.message.mention.MessageMentionMapper
 import com.wire.kalium.logic.data.message.mention.MessageMentionMapperImpl
 import com.wire.kalium.logic.data.message.reaction.ReactionsMapper
@@ -171,5 +173,6 @@ internal object MapperProvider {
 
     fun protocolInfoMapper(): ProtocolInfoMapper = ProtocolInfoMapperImpl()
     fun receiptModeMapper(): ReceiptModeMapper = ReceiptModeMapperImpl()
+    fun sendMessagePartialFailureMapper(): SendMessagePartialFailureMapper = SendMessagePartialFailureMapperImpl()
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -253,7 +253,7 @@ internal class MessageSenderImpl internal constructor(
         if (messageSent.failed.isEmpty()) {
             Either.Right(Unit)
         } else {
-            messageRepository.persistRecipientsDeliveryFailure(message.conversationId, message.id, messageSent)
+            messageRepository.persistRecipientsDeliveryFailure(message.conversationId, message.id, messageSent.failed)
         }
 
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -251,14 +251,14 @@ class MessageRepositoryTest {
     fun whenPersistingFailedDeliveryRecipients_thenDAOFunctionIsCalled() = runTest {
         val messageID = TEST_MESSAGE_ID
         val conversationID = TEST_CONVERSATION_ID
-        val expectedMessageSent = MessageSent(time = TEST_DATETIME, failed = TEST_FAILED_DELIVERY_USERS)
-        val expectedFailedUsers = listOf(TEST_USER_ID.toDao(), OTHER_USER_ID_2.toDao())
+        val listOfUserIds = listOf(TEST_USER_ID, OTHER_USER_ID_2)
+        val expectedFailedUsers = listOfUserIds.map { it.toDao() }
 
         val (arrangement, messageRepository) = Arrangement()
             .withInsertFailedRecipients()
             .arrange()
 
-        messageRepository.persistRecipientsDeliveryFailure(conversationID, messageID, expectedMessageSent).shouldSucceed()
+        messageRepository.persistRecipientsDeliveryFailure(conversationID, messageID, listOfUserIds).shouldSucceed()
 
         verify(arrangement.messageDAO)
             .suspendFunction(arrangement.messageDAO::insertFailedRecipientDelivery)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapperTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCaseTest.Arrangement.Companion.TEST_USER_ID
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestUser.OTHER_USER_ID_2
+import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SendMessagePartialFailureMapperTest {
+
+    private val mapper = SendMessagePartialFailureMapperImpl()
+
+    @Test
+    fun testFromDTOMapping() {
+        assertEquals(
+            MessageSent("2022-04-21T20:56:22.393Z", listOf(TEST_USER_ID, OTHER_USER_ID_2)), mapper.fromDTO(RESULT_DTO)
+        )
+    }
+
+    companion object {
+        private val RESULT_DTO = QualifiedSendMessageResponse.MessageSent(
+            time = "2022-04-21T20:56:22.393Z",
+            missing = mapOf(),
+            redundant = mapOf(),
+            deleted = mapOf(),
+            failed = mapOf(
+                TEST_USER_ID.domain to mapOf(
+                    TEST_USER_ID.value to listOf(TestClient.CLIENT_ID.value, ClientId("clientId12").value),
+                    OTHER_USER_ID_2.value to listOf(
+                        OTHER_USER_ID_2.value, ClientId("clientId21").value
+                    )
+                )
+            )
+        )
+    }
+}

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -1332,6 +1332,47 @@ class MessageDAOTest : BaseDatabaseTest() {
         }
     }
 
+    @Test
+    fun givenAFederatedConversation_WhenSendingAMessageWithPartialSuccess_ThenTheUsersIdsWithFailuresShouldBeInserted() = runTest {
+        // given
+        val conversationId = QualifiedIDEntity("1", "someDomain")
+        val messageId = "Conversation MessageSent With Partial Success"
+        conversationDAO.insertConversation(newConversationEntity(id = conversationId))
+        userDAO.insertUser(userEntity1)
+        userDAO.insertUser(userEntity2)
+
+        messageDAO.insertOrIgnoreMessages(
+            listOf(
+                newRegularMessageEntity(
+                    messageId,
+                    conversationId = conversationId,
+                    senderUserId = userEntity1.id,
+                    status = MessageEntity.Status.PENDING,
+                    // date after
+                    date = "2022-03-30T15:37:00.000Z".toInstant(),
+                    senderName = userEntity1.name!!,
+                    expectsReadConfirmation = true
+                )
+            )
+        )
+
+        // when
+        messageDAO.insertFailedRecipientDelivery(
+            messageId, conversationId, listOf(userEntity1.id, userEntity2.id), RecipientFailureTypeEntity.MESSAGE_DELIVERY_FAILED
+        )
+
+        // then
+        val result = messageDAO.getMessageById(
+            id = messageId,
+            conversationId = conversationId
+        )
+
+        assertTrue {
+            ((result as MessageEntity.Regular).recipientsFailure as RecipientFailureEntity.PartialDeliveryError)
+                .recipientsFailedDelivery.size == 2
+        }
+    }
+
     private suspend fun insertInitialData() {
         userDAO.upsertUsers(listOf(userEntity1, userEntity2))
         conversationDAO.insertConversation(conversationEntity1)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/RecipientDeliveryFailureMapperTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/RecipientDeliveryFailureMapperTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.persistence.dao.message
+
+import com.wire.kalium.persistence.dao.UserIDEntity
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RecipientDeliveryFailureMapperTest {
+    @Test
+    fun givenNoDeliveryErrors_whenMappingFromDB_shouldReturnNoDeliveryError() = runTest {
+        val result = RecipientDeliveryFailureMapper.toEntity(listOf(), listOf())
+
+        assertEquals(
+            RecipientFailureEntity.NoDeliveryError,
+            result
+        )
+    }
+
+    @Test
+    fun givenThereAreErrors_whenMappingFromDB_shouldReturnPartialDeliveryErrorWithUsersIds() = runTest {
+        val result =
+            RecipientDeliveryFailureMapper.toEntity(
+                recipientsFailedWithNoClientsList = listOf(UserIDEntity("user1", "domain1.com")),
+                recipientsFailedDeliveryList = listOf(UserIDEntity("user2", "domain1.com"))
+            )
+
+        assertTrue(result is RecipientFailureEntity.PartialDeliveryError)
+        assertTrue(result.recipientsFailedWithNoClients.isNotEmpty() && result.recipientsFailedDelivery.isNotEmpty())
+        assertEquals(result.recipientsFailedDelivery.first(), UserIDEntity("user2", "domain1.com"))
+        assertEquals(result.recipientsFailedWithNoClients.first(), UserIDEntity("user1", "domain1.com"))
+    }
+}
+


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This is the second part of the work for handling the sent message response with a partial success adding the code coverage for the changes made on part 1, See: #1525 

### Solutions

Added some small refactors to simplify and tests better the mappers

### Dependencies (Optional)

Previous related work (already merged)

#1493 
#1466 

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
