### PR TITLE
ci: enable android tests for merge queue

### DIFF
--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -1,6 +1,7 @@
 name: "Android Tests"
 
 on:
+    merge_group:
     pull_request:
         types: [ opened, synchronize ] # Don't rerun on `edited` to save time
 

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -20,7 +20,7 @@ jobs:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
       - name: Run Semantic Commint Linter
-        uses: amannn/action-semantic-pull-request@v3.4.6
+        uses: amannn/action-semantic-pull-request@v5.1.0
         with:
           # Configure which types are allowed.
           # Default: https://github.com/commitizen/conventional-commit-types

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -1,6 +1,7 @@
 name: "Semantic Commit Linting of PR titles"
 
 on:
+  merge_group:
   pull_request:
     types: [ opened, edited, synchronize ]
 

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -1,7 +1,6 @@
 name: "Semantic Commit Linting of PR titles"
 
 on:
-  merge_group:
   pull_request:
     types: [ opened, edited, synchronize ]
 
@@ -20,7 +19,7 @@ jobs:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
       - name: Run Semantic Commint Linter
-        uses: amannn/action-semantic-pull-request@v5.1.0
+        uses: amannn/action-semantic-pull-request@v3.4.6
         with:
           # Configure which types are allowed.
           # Default: https://github.com/commitizen/conventional-commit-types


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Android jobs are not running on the merge queue, making it fail.

### Solutions

Make them run there too.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
