### PR TITLE
feat: SCIM or provided users, readonly profiles handling (AR-2186)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
@@ -106,7 +106,8 @@ class PublicUserMapperImpl(
             availabilityStatus = availabilityStatusMapper.fromModelAvailabilityStatusToDao(availabilityStatus),
             userType = userEntityTypeMapper.fromUserType(userType),
             botService = botService?.let { BotEntity(it.id, it.provider) },
-            deleted = deleted
+            deleted = deleted,
+            managedBy = null
         )
     }
 
@@ -158,7 +159,8 @@ class PublicUserMapperImpl(
         availabilityStatus = UserAvailabilityStatusEntity.NONE,
         userType = userTypeEntity,
         botService = userDetailResponse.service?.let { BotEntity(it.id, it.provider) },
-        deleted = userDetailResponse.deleted ?: false
+        deleted = userDetailResponse.deleted ?: false,
+        managedBy = null
     )
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
@@ -134,7 +134,13 @@ data class SelfUser(
     override val completePicture: UserAssetId?,
     override val availabilityStatus: UserAvailabilityStatus,
     override val managedBy: ManagedBy
-) : User()
+) : User() {
+
+    /**
+     * When the self user is other than [WIRE] managed, it means that the user is provided user and cannot edit its profile details.
+     */
+    val isReadOnlyProfile = managedBy != WIRE
+}
 
 data class OtherUserMinimized(
     val id: UserId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.user.ManagedBy.WIRE
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.network.utils.toJsonElement
 import kotlinx.serialization.SerialName
@@ -41,6 +42,15 @@ sealed class User {
     abstract val previewPicture: UserAssetId?
     abstract val completePicture: UserAssetId?
     abstract val availabilityStatus: UserAvailabilityStatus
+    abstract val managedBy: ManagedBy?
+}
+
+/**
+ * Relevant field for self user.
+ * Indicating in only in case of [WIRE] that the user is managed by Wire therefore, can edit its profile.
+ */
+enum class ManagedBy {
+    WIRE, SCIM
 }
 
 // TODO we should extract ConnectionModel and ConnectionState to separate logic AR-1734
@@ -122,7 +132,8 @@ data class SelfUser(
     val connectionStatus: ConnectionState,
     override val previewPicture: UserAssetId?,
     override val completePicture: UserAssetId?,
-    override val availabilityStatus: UserAvailabilityStatus
+    override val availabilityStatus: UserAvailabilityStatus,
+    override val managedBy: ManagedBy
 ) : User()
 
 data class OtherUserMinimized(
@@ -146,7 +157,8 @@ data class OtherUser(
     val userType: UserType,
     override val availabilityStatus: UserAvailabilityStatus,
     val botService: BotService?,
-    val deleted: Boolean
+    val deleted: Boolean,
+    override val managedBy: ManagedBy? = null,
 ) : User() {
 
     /**

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrderTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.ManagedBy
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserRepository
@@ -176,7 +177,8 @@ class CallingParticipantsOrderTest {
             connectionStatus = ConnectionState.NOT_CONNECTED,
             previewPicture = null,
             completePicture = null,
-            availabilityStatus = UserAvailabilityStatus.AVAILABLE
+            availabilityStatus = UserAvailabilityStatus.AVAILABLE,
+            managedBy = ManagedBy.WIRE
         )
 
         const val selfClientId = "client1"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -388,7 +388,8 @@ class ConnectionRepositoryTest {
             availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
             userType = UserTypeEntity.EXTERNAL,
             botService = null,
-            deleted = false
+            deleted = false,
+            managedBy = null
         )
 
         val stubConversationID1 = QualifiedIDEntity("conversationId1", "domain")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.ManagedBy
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
@@ -567,7 +568,8 @@ class SearchUserRepositoryTest {
             availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
             userType = UserTypeEntity.EXTERNAL,
             botService = null,
-            deleted = false
+            deleted = false,
+            managedBy = null
         )
 
         val SELF_USER = SelfUser(
@@ -582,6 +584,7 @@ class SearchUserRepositoryTest {
             previewPicture = null,
             completePicture = null,
             availabilityStatus = UserAvailabilityStatus.AVAILABLE,
+            managedBy = ManagedBy.WIRE
         )
 
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.data.publicuser
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.ManagedBy
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserMapper
@@ -441,6 +442,7 @@ class UserSearchApiWrapperTest {
                     previewPicture = null,
                     completePicture = null,
                     availabilityStatus = UserAvailabilityStatus.AVAILABLE,
+                    managedBy = ManagedBy.WIRE
                 )
             }
 
@@ -456,6 +458,7 @@ class UserSearchApiWrapperTest {
                 previewPicture = null,
                 completePicture = null,
                 availabilityStatus = UserAvailabilityStatus.AVAILABLE,
+                managedBy = ManagedBy.WIRE
             )
 
             const val JSON_QUALIFIED_ID = """{"value":"test" , "domain":"test" }"""
@@ -474,7 +477,8 @@ class UserSearchApiWrapperTest {
                 availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
                 userType = UserTypeEntity.EXTERNAL,
                 botService = null,
-                deleted = false
+                deleted = false,
+                managedBy = null
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserMapperTest.kt
@@ -78,7 +78,8 @@ class UserMapperTest {
             availabilityStatus = UserAvailabilityStatusEntity.NONE,
             userType = UserTypeEntity.STANDARD,
             botService = null,
-            deleted = false
+            deleted = false,
+            managedBy = null
         )
         val (_, userMapper) = Arrangement().arrange()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MembersToMentionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MembersToMentionUseCaseTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.ManagedBy
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
@@ -121,7 +122,8 @@ class MembersToMentionUseCaseTest {
             ConnectionState.ACCEPTED,
             UserAssetId("value1", DOMAIN),
             UserAssetId("value2", DOMAIN),
-            UserAvailabilityStatus.NONE
+            UserAvailabilityStatus.NONE,
+            ManagedBy.WIRE
         )
         private val OTHER_USER = OtherUser(
             UserId(value = "other-id", DOMAIN),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.ManagedBy
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
@@ -95,7 +96,8 @@ class SendKnockUserCaseTest {
             ConnectionState.ACCEPTED,
             previewPicture = UserAssetId("value1", "domain"),
             completePicture = UserAssetId("value2", "domain"),
-            UserAvailabilityStatus.NONE
+            UserAvailabilityStatus.NONE,
+            ManagedBy.WIRE
         )
 
         fun withSuccessfulResponse(hotKnock: Boolean): Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCaseTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.login.ProxyCredentials
 import com.wire.kalium.logic.data.register.RegisterAccountRepository
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.ManagedBy
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
@@ -214,7 +215,8 @@ class RegisterAccountUseCaseTest {
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = null,
             completePicture = null,
-            availabilityStatus = UserAvailabilityStatus.NONE
+            availabilityStatus = UserAvailabilityStatus.NONE,
+            ManagedBy.WIRE
         )
         val TEST_AUTH_TOKENS = AuthTokens(
             accessToken = "access_token",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UploadUserAvatarUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UploadUserAvatarUseCaseTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.asset.UploadedAssetId
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.ManagedBy
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
@@ -129,7 +130,8 @@ class UploadUserAvatarUseCaseTest {
             ConnectionState.ACCEPTED,
             UserAssetId("value1", "domain"),
             UserAssetId("value2", "domain"),
-            UserAvailabilityStatus.NONE
+            UserAvailabilityStatus.NONE,
+            ManagedBy.WIRE
         )
 
         fun withStoredData(data: ByteArray, dataNamePath: Path): Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.framework
 
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.ManagedBy
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
@@ -63,7 +64,8 @@ object TestUser {
         connectionStatus = ConnectionState.ACCEPTED,
         previewPicture = UserAssetId("value1", "domain"),
         completePicture = UserAssetId("value2", "domain"),
-        availabilityStatus = UserAvailabilityStatus.NONE
+        availabilityStatus = UserAvailabilityStatus.NONE,
+        managedBy = ManagedBy.WIRE
     )
 
     val OTHER = OtherUser(
@@ -80,7 +82,8 @@ object TestUser {
         availabilityStatus = UserAvailabilityStatus.NONE,
         userType = UserType.EXTERNAL,
         botService = null,
-        deleted = false
+        deleted = false,
+        managedBy = null
     )
 
     val ENTITY = UserEntity(
@@ -97,7 +100,8 @@ object TestUser {
         availabilityStatus = UserAvailabilityStatusEntity.NONE,
         userType = UserTypeEntity.EXTERNAL,
         botService = null,
-        deleted = false
+        deleted = false,
+        managedBy = null
     )
 
     val USER_PROFILE_DTO = UserProfileDTO(

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -3,6 +3,7 @@ import com.wire.kalium.persistence.dao.ConnectionEntity;
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity;
 import com.wire.kalium.persistence.dao.UserTypeEntity;
+import com.wire.kalium.persistence.dao.ManagedByEntity;
 import kotlin.Int;
 import kotlin.Boolean;
 
@@ -20,7 +21,8 @@ CREATE TABLE User (
     user_availability_status TEXT AS UserAvailabilityStatusEntity NOT NULL DEFAULT 'NONE',
     user_type TEXT AS UserTypeEntity NOT NULL DEFAULT 'STANDARD',
     bot_service TEXT AS BotEntity,
-    deleted INTEGER AS Boolean NOT NULL DEFAULT 0
+    deleted INTEGER AS Boolean NOT NULL DEFAULT 0,
+    managed_by TEXT AS ManagedByEntity
 );
 CREATE INDEX user_team_index ON User(team);
 
@@ -31,8 +33,8 @@ deleteUser:
 DELETE FROM User WHERE qualified_id = ?;
 
 insertUser:
-INSERT INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service, deleted)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service, deleted, managed_by)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
 handle = excluded.handle,
@@ -45,7 +47,8 @@ preview_asset_id = excluded.preview_asset_id,
 complete_asset_id = excluded.complete_asset_id,
 user_type = excluded.user_type,
 bot_service = excluded.bot_service,
-deleted = excluded.deleted;
+deleted = excluded.deleted,
+managed_by = excluded.managed_by;
 
 insertOrIgnoreUser:
 INSERT OR IGNORE INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service, deleted)

--- a/persistence/src/commonMain/db_user/migrations/30.sqm
+++ b/persistence/src/commonMain/db_user/migrations/30.sqm
@@ -1,0 +1,4 @@
+import com.wire.kalium.persistence.dao.ManagedByEntity;
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+
+ALTER TABLE User ADD COLUMN managed_by TEXT AS ManagedByEntity;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
@@ -67,7 +67,8 @@ private class ConnectionMapper {
         user_availability_status: UserAvailabilityStatusEntity?,
         user_type: UserTypeEntity?,
         bot_service: BotEntity?,
-        deleted: Boolean?
+        deleted: Boolean?,
+        managed_by: ManagedByEntity?
     ): ConnectionEntity = ConnectionEntity(
         conversationId = conversation_id,
         from = from_id,
@@ -92,7 +93,8 @@ private class ConnectionMapper {
             userType = user_type.requireField("user_type"),
             botService = bot_service,
             deleted = deleted.requireField("deleted"),
-        ) else null
+            managedBy = managed_by
+            ) else null
     )
 
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -51,8 +51,17 @@ data class UserEntity(
     val availabilityStatus: UserAvailabilityStatusEntity,
     val userType: UserTypeEntity,
     val botService: BotEntity?,
-    val deleted: Boolean
+    val deleted: Boolean,
+    val managedBy: ManagedByEntity?
 )
+
+/**
+ * Relevant field for self user.
+ * Indicating in only in case of [WIRE] that the user is managed by Wire therefore, can edit its profile.
+ */
+enum class ManagedByEntity {
+    WIRE, SCIM
+}
 
 data class UserEntityMinimized(
     val id: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -49,7 +49,8 @@ class UserMapper {
             availabilityStatus = user.user_availability_status,
             userType = user.user_type,
             botService = user.bot_service,
-            deleted = user.deleted
+            deleted = user.deleted,
+            managedBy = user.managed_by
         )
     }
 
@@ -90,7 +91,8 @@ class UserDAOImpl internal constructor(
             user.completeAssetId,
             user.userType,
             user.botService,
-            user.deleted
+            user.deleted,
+            user.managedBy
         )
     }
 
@@ -146,7 +148,8 @@ class UserDAOImpl internal constructor(
                         user.completeAssetId,
                         user.userType,
                         user.botService,
-                        user.deleted
+                        user.deleted,
+                        user.managedBy
                     )
                 }
             }
@@ -184,7 +187,8 @@ class UserDAOImpl internal constructor(
                         user.completeAssetId,
                         user.userType,
                         user.botService,
-                        user.deleted
+                        user.deleted,
+                        user.managedBy
                     )
                 }
             }
@@ -210,7 +214,8 @@ class UserDAOImpl internal constructor(
                         user.completeAssetId,
                         user.userType,
                         user.botService,
-                        user.deleted
+                        user.deleted,
+                        user.managedBy
                     )
                 }
             }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
@@ -152,7 +152,8 @@ internal object TableMapper {
         preview_asset_idAdapter = QualifiedIDAdapter,
         complete_asset_idAdapter = QualifiedIDAdapter,
         user_typeAdapter = EnumColumnAdapter(),
-        bot_serviceAdapter = BotServiceAdapter()
+        bot_serviceAdapter = BotServiceAdapter(),
+        managed_byAdapter = EnumColumnAdapter()
     )
     val messageNewConversationReceiptModeContentAdapter = MessageNewConversationReceiptModeContent.Adapter(
         conversation_idAdapter = QualifiedIDAdapter

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
@@ -188,7 +188,8 @@ class UserDatabaseDataGenerator(
             connectionStatus = ConnectionEntity.State.values()[generatedUsersCount % ConnectionEntity.State.values().size],
             previewAssetId = null,
             completeAssetId = null,
-            botService = null
+            botService = null,
+            managedBy = null
         )
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -94,7 +94,8 @@ class UserDAOTest : BaseDatabaseTest() {
             UserAvailabilityStatusEntity.NONE,
             UserTypeEntity.STANDARD,
             botService = null,
-            false
+            false,
+            null
         )
         db.userDAO.updateUser(updatedUser1)
         val result = db.userDAO.getUserByQualifiedID(user1.id).first()
@@ -121,7 +122,8 @@ class UserDAOTest : BaseDatabaseTest() {
             UserAvailabilityStatusEntity.NONE,
             UserTypeEntity.STANDARD,
             botService = null,
-            false
+            false,
+            null
         )
 
         db.userDAO.getUserByQualifiedID(user1.id).take(2).collect {
@@ -220,7 +222,8 @@ class UserDAOTest : BaseDatabaseTest() {
                     UserAvailabilityStatusEntity.NONE,
                     UserTypeEntity.STANDARD,
                     botService = null,
-                    false
+                    false,
+                    null
                 ),
                 UserEntity(
                     id = QualifiedIDEntity("5", "wire.com"),
@@ -236,7 +239,8 @@ class UserDAOTest : BaseDatabaseTest() {
                     UserAvailabilityStatusEntity.NONE,
                     UserTypeEntity.STANDARD,
                     botService = null,
-                    deleted = false
+                    deleted = false,
+                    null
                 )
             )
             val mockUsers = commonEmailUsers + notCommonEmailUsers

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/UserStubs.kt
@@ -39,7 +39,8 @@ fun newUserEntity(id: String = "test") =
         UserAvailabilityStatusEntity.NONE,
         UserTypeEntity.STANDARD,
         botService = null,
-        deleted = false
+        deleted = false,
+        managedBy = null
     )
 
 fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
@@ -57,5 +58,6 @@ fun newUserEntity(qualifiedID: QualifiedIDEntity, id: String = "test") =
         UserAvailabilityStatusEntity.NONE,
         UserTypeEntity.STANDARD,
         botService = null,
-        deleted = false
+        deleted = false,
+        managedBy = null
     )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to handle checks for read only profiles, namely, users that are provided.
In simple words, users not managed by wire, their profiles are readonly.

We already had the network mapping for the SelfUser, now we add the persistence layer to it and mapping to model, in order to check on Reloaded.


### Testing

#### Test Coverage (Optional)

_*Will add later, before merge*_

- [ ] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
