### PR TITLE
fix: don't insert system message on MLS decryption errors AR-3092

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -63,17 +63,7 @@ internal class NewMessageEventHandlerImpl(
     override suspend fun handleNewMLSMessage(event: Event.Conversation.NewMLSMessage) {
         mlsMessageUnpacker.unpackMlsMessage(event)
             .onFailure {
-                applicationMessageHandler.handleDecryptionError(
-                    eventId = event.id,
-                    conversationId = event.conversationId,
-                    timestampIso = event.timestampIso,
-                    senderUserId = event.senderUserId,
-                    senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
-                    content = MessageContent.FailedDecryption(
-                        isDecryptionResolved = false,
-                        senderUserId = event.senderUserId
-                    )
-                )
+                // TODO handle encryption errors when we can differentiate them better.
             }.onSuccess {
                 handleSuccessfulResult(it)
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We insert false positive decryption errors

### Causes (Optional)

Backend currently forwards the sender own messages and we cause an error when an attempt is made to decrypt them.

### Solutions

Don't insert decryption system messages until we have way to ignore our own messages and/or backends stops forwarding them.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
