### PR TITLE
fix: add more descriptive backup name [AR-2260]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -486,6 +486,7 @@ class UserSessionScope internal constructor(
         get() = CreateBackupUseCaseImpl(
             userId,
             clientIdProvider,
+            userRepository,
             kaliumFileSystem,
             userStorage.database.databaseExporter,
             securityHelper = SecurityHelperImpl(globalPreferences.passphraseStorage)
@@ -499,6 +500,7 @@ class UserSessionScope internal constructor(
             userStorage.database.databaseImporter,
             kaliumFileSystem,
             userId,
+            userRepository,
             clientIdProvider
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupConstants.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupConstants.kt
@@ -19,14 +19,15 @@
 package com.wire.kalium.logic.feature.backup
 
 object BackupConstants {
-    // TODO: change the name to something more meaningful (e.g. "Wire-{user handle}-backup-timestamp.zip")
-    const val BACKUP_ZIP_FILE_NAME = "user-backup.zip"
+    const val BACKUP_FILE_NAME_PREFIX = "WBX"
     const val BACKUP_ENCRYPTED_FILE_NAME = "user-backup.cc20"
     const val BACKUP_USER_DB_NAME = "user-backup-database.db"
     const val BACKUP_METADATA_FILE_NAME = "export.json"
     const val BACKUP_ENCRYPTED_EXTENSION = "cc20"
     const val BACKUP_DB_EXTENSION = "db"
     const val BACKUP_METADATA_EXTENSION = "json"
+
+    fun createBackupFileName(userHandle: String?, timestampIso: String) = "$BACKUP_FILE_NAME_PREFIX-$userHandle-$timestampIso.zip"
 
     val ACCEPTED_EXTENSIONS = listOf(
         BACKUP_ENCRYPTED_EXTENSION,

--- a/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.util
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.wire.kalium.util.DateTimeUtil.MILLISECONDS_DIGITS
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
 import java.text.SimpleDateFormat
@@ -31,9 +32,11 @@ import java.util.TimeZone
 
 actual open class PlatformDateTimeUtil actual constructor() {
 
-    private val isoDateTimeFormat = SimpleDateFormat(DateTimeUtil.pattern, Locale.getDefault()).apply {
+    private val isoDateTimeFormat = SimpleDateFormat(DateTimeUtil.millisPattern, Locale.getDefault()).apply {
         timeZone = TimeZone.getTimeZone("UTC")
     }
+
+    private val secondsDateTimeFormat = SimpleDateFormat(DateTimeUtil.secondsPattern, Locale.getDefault())
 
     @RequiresApi(Build.VERSION_CODES.O)
     private val isoDateTimeFormatter = DateTimeFormatterBuilder().appendInstant(MILLISECONDS_DIGITS).toFormatter()
@@ -51,4 +54,17 @@ actual open class PlatformDateTimeUtil actual constructor() {
             isoDateTimeFormatter.format(instant.toJavaInstant())
         else
             isoDateTimeFormat.format(Date(instant.toEpochMilliseconds()))
+
+
+    /**
+     * Parse current [kotlinx.datetime.Instant] into date-time string in ISO-8601 format with up to seconds precision.
+     * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)
+     */
+    actual fun fromCurrentInstantToSimpleDateTimeString(): String {
+        val instant = Clock.System.now()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            secondsDateTimeFormat.format(instant)
+        else
+            secondsDateTimeFormat.format(Date(instant.toEpochMilliseconds()))
+    }
 }

--- a/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -54,7 +54,7 @@ actual open class PlatformDateTimeUtil actual constructor() {
             isoDateTimeFormatter.format(instant.toJavaInstant())
         else
             isoDateTimeFormat.format(Date(instant.toEpochMilliseconds()))
-    
+
     /**
      * Parse current [kotlinx.datetime.Instant] into date-time string in ISO-8601 format with up to seconds precision.
      * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)

--- a/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -54,8 +54,7 @@ actual open class PlatformDateTimeUtil actual constructor() {
             isoDateTimeFormatter.format(instant.toJavaInstant())
         else
             isoDateTimeFormat.format(Date(instant.toEpochMilliseconds()))
-
-
+    
     /**
      * Parse current [kotlinx.datetime.Instant] into date-time string in ISO-8601 format with up to seconds precision.
      * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)

--- a/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -61,10 +61,9 @@ actual open class PlatformDateTimeUtil actual constructor() {
      * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)
      */
     actual fun fromCurrentInstantToSimpleDateTimeString(): String {
-        val instant = Clock.System.now()
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            secondsDateTimeFormat.format(instant)
+            secondsDateTimeFormat.format(System.currentTimeMillis())
         else
-            secondsDateTimeFormat.format(Date(instant.toEpochMilliseconds()))
+            secondsDateTimeFormat.format(Date(Clock.System.now().toEpochMilliseconds()))
     }
 }

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
@@ -36,12 +36,19 @@ expect open class PlatformDateTimeUtil() {
      * @return date in ISO-8601 format (YYYY-MM-DDTHH:mm:ss.SSSZ)
      */
     fun fromInstantToIsoDateTimeString(instant: Instant): String
+
+    /**
+     * Parse current [kotlinx.datetime.Instant] into date-time string in ISO-8601 format with up to seconds precision.
+     * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)
+     */
+    fun fromCurrentInstantToSimpleDateTimeString(): String
 }
 
 // TODO(qol): we need to think if it should return an either or should we catch the exception,
 // so far we assume that string date-times we use are always in valid ISO-8601 format so there shouldn't be any failed formatting
 object DateTimeUtil : PlatformDateTimeUtil() {
-    const val pattern: String = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+    const val millisPattern: String = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+    const val secondsPattern: String = "yyyy-MM-dd'T'HH:mm:ss"
     const val regex = "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d(([+-]\\d\\d:\\d\\d)|Z)?\$"
     internal const val MILLISECONDS_DIGITS = 3
 
@@ -78,6 +85,12 @@ object DateTimeUtil : PlatformDateTimeUtil() {
      */
     fun currentIsoDateTimeString(): String =
         fromInstantToIsoDateTimeString(Clock.System.now())
+
+    /**
+     * Return the current date-time as a simple string
+     * @return current date-time in simplified ISO-8601 format, i.e. until seconds precision (YYYY-MM-DDTHH:mm:ssZ)
+     */
+    fun currentSimpleDateTimeString(): String = fromCurrentInstantToSimpleDateTimeString()
 
     /**
      * Return the current date-time as [kotlinx.datetime.Instant].

--- a/util/src/darwinMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/util/src/darwinMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.util
 
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 actual open class PlatformDateTimeUtil actual constructor() {
@@ -32,4 +33,11 @@ actual open class PlatformDateTimeUtil actual constructor() {
      */
     actual fun fromInstantToIsoDateTimeString(instant: Instant): String =
         instant.toString() // TODO:"Implement own iOS method"
+
+    /**
+     * Parse current [kotlinx.datetime.Instant] into date-time string in ISO-8601 format with up to seconds precision.
+     * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)
+     */
+    actual fun fromCurrentInstantToSimpleDateTimeString(): String =
+        Clock.System.now().toString() // TODO:"Implement own iOS method"
 }

--- a/util/src/jsMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/util/src/jsMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.util
 
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 actual open class PlatformDateTimeUtil actual constructor() {
@@ -32,4 +33,11 @@ actual open class PlatformDateTimeUtil actual constructor() {
      */
     actual fun fromInstantToIsoDateTimeString(instant: Instant): String =
         instant.toString() // TODO:"Implement own JS method"
+
+    /**
+     * Parse current [kotlinx.datetime.Instant] into date-time string in ISO-8601 format with up to seconds precision.
+     * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)
+     */
+    actual fun fromCurrentInstantToSimpleDateTimeString(): String =
+        Clock.System.now().toString() // TODO:"Implement own JS method"
 }

--- a/util/src/jvmMain/kotlin/com/wire/kalium/util/PlatformDateTimeUtil.kt
+++ b/util/src/jvmMain/kotlin/com/wire/kalium/util/PlatformDateTimeUtil.kt
@@ -25,6 +25,7 @@ import java.time.format.DateTimeFormatterBuilder
 
 actual open class PlatformDateTimeUtil actual constructor() {
     private val isoDateTimeFormatter = DateTimeFormatterBuilder().appendInstant(MILLISECONDS_DIGITS).toFormatter()
+    private val simpleIsoDateTimeFormatter = DateTimeFormatterBuilder().appendInstant(0).toFormatter()
 
     /**
      * Parse [kotlinx.datetime.Instant] into date-time string in ISO-8601 format.
@@ -36,4 +37,11 @@ actual open class PlatformDateTimeUtil actual constructor() {
      */
     actual fun fromInstantToIsoDateTimeString(instant: Instant): String =
         isoDateTimeFormatter.format(instant.toJavaInstant())
+
+    /**
+     * Parse current [kotlinx.datetime.Instant] into date-time string in ISO-8601 format with up to seconds precision.
+     * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)
+     */
+    actual fun fromCurrentInstantToSimpleDateTimeString(): String =
+        simpleIsoDateTimeFormatter.format(Instant.now().toJavaInstant())
 }

--- a/util/src/jvmMain/kotlin/com/wire/kalium/util/PlatformDateTimeUtil.kt
+++ b/util/src/jvmMain/kotlin/com/wire/kalium/util/PlatformDateTimeUtil.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.util
 
 import com.wire.kalium.util.DateTimeUtil.MILLISECONDS_DIGITS
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
 import java.time.format.DateTimeFormatterBuilder
@@ -43,5 +44,5 @@ actual open class PlatformDateTimeUtil actual constructor() {
      * @returndate in ISO-8601 format (YYYY-MM-DDTHH:mm:ssZ)
      */
     actual fun fromCurrentInstantToSimpleDateTimeString(): String =
-        simpleIsoDateTimeFormatter.format(Instant.now().toJavaInstant())
+        simpleIsoDateTimeFormatter.format(Clock.System.now().toJavaInstant())
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Backup created zip files have a not so specific file name so we want to give it a more descriptive one, with the user handle and the creation timestamp.

### Solutions
In order to achieve that, we had to add an extra kmp method on the `PlatformDateTimeUtil` class formatting the current timestamp with only seconds precision, as the previous one was using milliseconds precision.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Attachments (Optional)

![Sin título](https://user-images.githubusercontent.com/2468164/221814784-cb4818ff-8a2f-4e78-a6c2-66daeb346494.jpg)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
