### PR TITLE
fix: fixed bug not showing correctly generic assets on other clients [AR-3187]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
@@ -32,18 +32,13 @@ data class AssetContent(
 
     private val isPreviewMessage = sizeInBytes > 0 && !hasValidRemoteData()
 
-    private val isValidAsset =
-        when (metadata) {
-            // in some cases back-end returns no width and height
-            // in that case we do not want to show the asset
-            // and mark it as invalid
-            is AssetMetadata.Image -> metadata.width > 0 && metadata.height > 0
-            is AssetMetadata.Audio -> true
-            is AssetMetadata.Video -> true
-            null -> false
-        }
+    private val hasValidImageMetadata = when (metadata) {
+        is AssetMetadata.Image -> metadata.width > 0 && metadata.height > 0
+        else -> false
+    }
 
-    val shouldBeDisplayed = !isPreviewMessage && isValidAsset
+    // We should not display Preview Assets (assets w/o valid encryption keys sent by Mac/Web clients) unless they include image metadata
+    val shouldBeDisplayed = !isPreviewMessage || hasValidImageMetadata
 
     sealed class AssetMetadata {
         data class Image(val width: Int, val height: Int) : AssetMetadata()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandler.kt
@@ -62,12 +62,7 @@ internal class AssetMessageHandlerImpl(
             ) {
                 // The second asset message received from Web/Mac clients contains the full asset decryption keys, so we need to update
                 // the preview message persisted previously with the rest of the data
-                persistMessage(
-                    updateAssetMessageWithDecryptionKeys(
-                        persistedMessage,
-                        validDecryptionKeys
-                    )
-                )
+                persistMessage(updateAssetMessageWithDecryptionKeys(persistedMessage, validDecryptionKeys))
             }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -208,7 +208,7 @@ internal class ApplicationMessageHandlerImpl(
             }
 
             is MessageContent.Knock -> handleKnock(message)
-            is MessageContent.Asset -> assetMessageHandler.handle(message, content)
+            is MessageContent.Asset -> assetMessageHandler.handle(message)
 
             is MessageContent.Unknown -> {
                 logger.i(message = "Unknown Message received: $message")
@@ -307,6 +307,6 @@ internal class ApplicationMessageHandlerImpl(
     }
 }
 
-fun AssetContent.hasValidRemoteData() = this.remoteData.let {
-    it.assetId.isNotEmpty() && it.sha256.isNotEmpty() && it.otrKey.isNotEmpty()
-}
+fun AssetContent.hasValidRemoteData() = this.remoteData.hasValidData()
+
+fun AssetContent.RemoteData.hasValidData() = assetId.isNotEmpty() && sha256.isNotEmpty() && otrKey.isNotEmpty()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
@@ -49,9 +49,11 @@ import io.mockative.given
 import io.mockative.matching
 import io.mockative.mock
 import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ApplicationMessageHandlerTest {
 
     @Test
@@ -180,7 +182,5 @@ class ApplicationMessageHandlerTest {
         }
 
         fun arrange() = this to applicationMessageHandler
-
     }
-
 }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandlerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandlerTest.kt
@@ -1,0 +1,242 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.asset
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.FileSharingStatus
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageEncryptionAlgorithm
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AssetMessageHandlerTest {
+
+    @Test
+    fun givenAValidNonRestrictedNewGenericAssetMessage_whenHandlingIt_isCorrectlyProcessedAndIsVisible() = runTest {
+        // Given
+        val assetMessage = TEST_ASSET_MESSAGE
+        val assetMessageContent = assetMessage.content as MessageContent.Asset
+        val isFileSharingEnabled = true
+        val (arrangement, assetMessageHandler) = Arrangement()
+            .withSuccessfulFileSharingFlag(isFileSharingEnabled)
+            .withSuccessfulStoredMessage(null)
+            .withSuccessfulPersistMessageUseCase(assetMessage)
+            .arrange()
+
+        // When
+        assetMessageHandler.handle(assetMessage, assetMessageContent)
+
+        // Then
+        verify(arrangement.persistMessage)
+            .suspendFunction(arrangement.persistMessage::invoke)
+            .with(matching {
+                it.id == assetMessage.id
+                        && it.conversationId.toString() == assetMessage.conversationId.toString()
+                        && it.visibility == Message.Visibility.VISIBLE
+            })
+            .wasInvoked(exactly = once)
+        verify(arrangement.messageRepository)
+            .suspendFunction(arrangement.messageRepository::getMessageById)
+            .with(eq(assetMessage.conversationId), eq(assetMessage.id))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAValidPreviewNewGenericAssetMessage_whenHandlingIt_isCorrectlyProcessedAndIsNotVisible() = runTest {
+        // Given
+        val assetMessage = TEST_ASSET_MESSAGE.copy(content = PREVIEW_ASSET_CONTENT)
+        val assetMessageContent = assetMessage.content as MessageContent.Asset
+        val isFileSharingEnabled = true
+        val (arrangement, assetMessageHandler) = Arrangement()
+            .withSuccessfulFileSharingFlag(isFileSharingEnabled)
+            .withSuccessfulStoredMessage(null)
+            .withSuccessfulPersistMessageUseCase(assetMessage)
+            .arrange()
+
+        // When
+        assetMessageHandler.handle(assetMessage, assetMessageContent)
+
+        // Then
+        verify(arrangement.persistMessage)
+            .suspendFunction(arrangement.persistMessage::invoke)
+            .with(matching {
+                it.id == assetMessage.id
+                        && it.conversationId.toString() == assetMessage.conversationId.toString()
+                        && it.visibility == Message.Visibility.HIDDEN
+            })
+            .wasInvoked(exactly = once)
+        verify(arrangement.messageRepository)
+            .suspendFunction(arrangement.messageRepository::getMessageById)
+            .with(eq(assetMessage.conversationId), eq(assetMessage.id))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAValidPreviewNewImageAssetMessage_whenHandlingIt_isCorrectlyProcessedAndItIsVisible() = runTest {
+        // Given
+        val assetMessage = TEST_ASSET_MESSAGE.copy(
+            content = PREVIEW_ASSET_CONTENT.copy(
+                value = PREVIEW_ASSET_CONTENT.value.copy(
+                    name = "some-image.jpg",
+                    mimeType = "image/jpg",
+                    metadata = AssetContent.AssetMetadata.Image(100, 100)
+                )
+            )
+        )
+        val assetMessageContent = assetMessage.content as MessageContent.Asset
+        val isFileSharingEnabled = true
+        val (arrangement, assetMessageHandler) = Arrangement()
+            .withSuccessfulFileSharingFlag(isFileSharingEnabled)
+            .withSuccessfulStoredMessage(null)
+            .withSuccessfulPersistMessageUseCase(assetMessage)
+            .arrange()
+
+        // When
+        assetMessageHandler.handle(assetMessage, assetMessageContent)
+
+        // Then
+        verify(arrangement.persistMessage)
+            .suspendFunction(arrangement.persistMessage::invoke)
+            .with(matching {
+                it.id == assetMessage.id
+                        && it.conversationId.toString() == assetMessage.conversationId.toString()
+                        && it.visibility == Message.Visibility.VISIBLE
+            })
+            .wasInvoked(exactly = once)
+        verify(arrangement.messageRepository)
+            .suspendFunction(arrangement.messageRepository::getMessageById)
+            .with(eq(assetMessage.conversationId), eq(assetMessage.id))
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val messageRepository = mock(classOf<MessageRepository>())
+
+        @Mock
+        val persistMessage = mock(classOf<PersistMessageUseCase>())
+
+        @Mock
+        val userConfigRepository = mock(classOf<UserConfigRepository>())
+
+        private val assetMessageHandlerImpl = AssetMessageHandlerImpl(messageRepository, persistMessage, userConfigRepository)
+
+        fun withSuccessfulFileSharingFlag(enabled: Boolean) = apply {
+            given(userConfigRepository)
+                .function(userConfigRepository::isFileSharingEnabled)
+                .whenInvoked()
+                .thenReturn(Either.Right(FileSharingStatus(isFileSharingEnabled = enabled, isStatusChanged = false)))
+        }
+
+        fun withSuccessfulPersistMessageUseCase(message: Message) = apply {
+            given(persistMessage)
+                .suspendFunction(persistMessage::invoke)
+                .whenInvokedWith(matching {
+                    it.id == message.id && it.conversationId == message.conversationId
+                })
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withSuccessfulStoredMessage(persistedMessage: Message?) = apply {
+            persistedMessage?.let { message ->
+                given(messageRepository)
+                    .suspendFunction(messageRepository::getMessageById)
+                    .whenInvokedWith(any(), any())
+                    .thenReturn(Either.Right(message))
+            } ?: given(messageRepository)
+                .suspendFunction(messageRepository::getMessageById)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        fun arrange() = this to assetMessageHandlerImpl
+    }
+
+    private companion object {
+        val ASSET_CONTENT = MessageContent.Asset(
+            AssetContent(
+                sizeInBytes = 100,
+                name = "some-asset.zip",
+                mimeType = "application/zip",
+                metadata = null,
+                remoteData = AssetContent.RemoteData(
+                    otrKey = "otrKey".toByteArray(),
+                    sha256 = "sha256".toByteArray(),
+                    assetId = "some-asset-id",
+                    assetDomain = "some-asset-domain",
+                    assetToken = "some-asset-token",
+                    encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
+                ),
+                uploadStatus = Message.UploadStatus.NOT_UPLOADED,
+                downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
+            )
+
+        )
+        val PREVIEW_ASSET_CONTENT = MessageContent.Asset(
+            AssetContent(
+                sizeInBytes = 100,
+                name = "some-asset.zip",
+                mimeType = "application/zip",
+                metadata = null,
+                remoteData = AssetContent.RemoteData(
+                    otrKey = byteArrayOf(),
+                    sha256 = byteArrayOf(),
+                    assetId = "",
+                    assetDomain = "",
+                    assetToken = "",
+                    encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
+                ),
+                uploadStatus = Message.UploadStatus.NOT_UPLOADED,
+                downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
+            )
+
+        )
+        val TEST_ASSET_MESSAGE = Message.Regular(
+            id = "uid",
+            content = ASSET_CONTENT,
+            conversationId = ConversationId("some-value", "some-domain.com"),
+            date = "1970-01-01T00:00:00.000Z",
+            senderUserId = UserId("some-sender-value", "some-sender-domain.com"),
+            senderClientId = ClientId("some-client-value"),
+            status = Message.Status.SENT,
+            editStatus = Message.EditStatus.NotEdited
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We recently introduced some bug when refactoring the way we handle asset messages. This caused other AR clients not to display generic asset messages sent from an AR client.

### Solutions

Change the implementation of `shouldBeDisplayed()` to not rule out assets that have no metadata information.


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test
Send a generic asset message from different clients, Android and/or web, and check that they are displayed correctly in AR. 

Unit tests will be coming soon too.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
