### PR TITLE
refactor: look up avs convType interally

### DIFF
--- a/cli/src/jvmMain/kotlin/com/wire/kalium/cli/commands/ConsoleCommand.kt
+++ b/cli/src/jvmMain/kotlin/com/wire/kalium/cli/commands/ConsoleCommand.kt
@@ -29,7 +29,6 @@ import com.sun.net.httpserver.HttpServer
 import com.wire.kalium.cli.getConversations
 import com.wire.kalium.cli.listConversations
 import com.wire.kalium.cli.selectConversation
-import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.feature.UserSessionScope
 import kotlinx.coroutines.Dispatchers
@@ -143,17 +142,9 @@ class ConsoleCommand : CliktCommand(name = "console") {
 
     private suspend fun startCallHandler(userSession: UserSessionScope, context: ConsoleContext): Int {
         val currentConversation = context.currentConversation ?: return -1
-        val isProteusConversation = currentConversation.protocol is Conversation.ProtocolInfo.Proteus
-
-        val convType = when (currentConversation.type) {
-            Conversation.Type.ONE_ON_ONE -> ConversationType.OneOnOne
-            Conversation.Type.GROUP -> if (isProteusConversation) ConversationType.Conference else ConversationType.ConferenceMls
-            else -> ConversationType.Unknown
-        }
 
         userSession.calls.startCall.invoke(
-            conversationId = currentConversation.id,
-            conversationType = convType
+            conversationId = currentConversation.id
         )
 
         return 0

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -46,10 +46,12 @@ private class Callbacks : CoreCryptoCallbacks {
     }
 
     override fun clientIsExistingGroupUser(conversationId: ConversationId, clientId: ClientId, existingClients: List<ClientId>): Boolean {
-        val userId = toClientID(clientId)?.userId ?: return false
-        return existingClients.find {
-            toClientID(it)?.userId == userId
-        } != null
+        // TODO disabled until we have subconversation support in CC
+//         val userId = toClientID(clientId)?.userId ?: return false
+//         return existingClients.find {
+//             toClientID(it)?.userId == userId
+//         } != null
+        return true
     }
 
     override fun userAuthorize(conversationId: ConversationId, externalClientId: ClientId, existingClients: List<ClientId>): Boolean {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -35,7 +35,6 @@ interface CallManager {
     suspend fun startCall(
         conversationId: ConversationId,
         callType: CallType,
-        conversationType: ConversationType,
         isAudioCbr: Boolean
     ) // TODO(calling): Audio CBR
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.logic.data.call.CallClientList
 import com.wire.kalium.logic.data.call.CallType
-import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.call.EpochInfo
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.ConversationId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
@@ -19,7 +19,6 @@
 package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.data.call.CallType
-import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase.Result

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
@@ -41,7 +41,6 @@ class StartCallUseCase internal constructor(
     suspend operator fun invoke(
         conversationId: ConversationId,
         callType: CallType = CallType.AUDIO,
-        conversationType: ConversationType,
         isAudioCbr: Boolean = false
     ) = syncManager.waitUntilLiveOrFailure().fold({
         Result.SyncFailure
@@ -49,7 +48,6 @@ class StartCallUseCase internal constructor(
         callManager.value.startCall(
             conversationId = conversationId,
             callType = callType,
-            conversationType = conversationType,
             isAudioCbr = isAudioCbr
         )
         Result.Success

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/StartCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/StartCallUseCaseTest.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.logic.feature.call
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.call.CallType
-import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
 import com.wire.kalium.logic.feature.conversation.JoinSubconversationUseCase
 import com.wire.kalium.logic.framework.TestConversation
@@ -50,11 +49,11 @@ class StartCallUseCaseTest {
             .withWaitingForSyncSucceeding()
             .arrange()
 
-        startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
+        startCall.invoke(conversationId, CallType.AUDIO)
 
         verify(arrangement.callManager)
             .suspendFunction(arrangement.callManager::startCall)
-            .with(eq(conversationId), eq(CallType.AUDIO), eq(ConversationType.OneOnOne), eq(false))
+            .with(eq(conversationId), eq(CallType.AUDIO), eq(false))
             .wasInvoked(once)
     }
 
@@ -66,7 +65,7 @@ class StartCallUseCaseTest {
             .withWaitingForSyncSucceeding()
             .arrange()
 
-        val result = startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
+        val result = startCall.invoke(conversationId, CallType.AUDIO)
 
         assertIs<StartCallUseCase.Result.Success>(result)
     }
@@ -79,11 +78,11 @@ class StartCallUseCaseTest {
             .withWaitingForSyncFailing()
             .arrange()
 
-        startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
+        startCall.invoke(conversationId, CallType.AUDIO)
 
         verify(arrangement.callManager)
             .suspendFunction(arrangement.callManager::startCall)
-            .with(any(), any(), any(), any())
+            .with(any(), any(), any())
             .wasNotInvoked()
     }
 
@@ -95,7 +94,7 @@ class StartCallUseCaseTest {
             .withWaitingForSyncFailing()
             .arrange()
 
-        val result = startCall.invoke(conversationId, CallType.AUDIO, ConversationType.OneOnOne)
+        val result = startCall.invoke(conversationId, CallType.AUDIO)
 
         assertIs<StartCallUseCase.Result.SyncFailure>(result)
     }

--- a/logic/src/darwinMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/darwinMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -36,7 +36,6 @@ class CallManagerImpl : CallManager {
     override suspend fun startCall(
         conversationId: ConversationId,
         callType: CallType,
-        conversationType: ConversationType,
         isAudioCbr: Boolean
     ) {
         TODO("Not yet implemented")

--- a/logic/src/darwinMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/darwinMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.logic.data.call.CallClientList
 import com.wire.kalium.logic.data.call.CallType
-import com.wire.kalium.logic.data.call.ConversationType
 import com.wire.kalium.logic.data.call.EpochInfo
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.ConversationId


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to provide the `convType` in several places now so it's much easier if we would do that look up internally and safer. It doesn't make sense to attempt to make a `conferenceMls` call in a proteus conversation.

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/1534

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
