### PR TITLE
feat: other user id classified security banner use case (AR-2702)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1134,7 +1134,7 @@ class UserSessionScope internal constructor(
 
     val observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase
         get() = ObserveSecurityClassificationLabelUseCaseImpl(userId, conversationRepository, userConfigRepository)
-  val getOtherUserSecurityClassificationLabel: GetOtherUserSecurityClassificationLabelUseCase
+    val getOtherUserSecurityClassificationLabel: GetOtherUserSecurityClassificationLabelUseCase
         get() = GetOtherUserSecurityClassificationLabelUseCaseImpl(userId, userConfigRepository)
 
     val kaliumFileSystem: KaliumFileSystem by lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -133,6 +133,8 @@ import com.wire.kalium.logic.feature.conversation.ClearConversationContentImpl
 import com.wire.kalium.logic.feature.conversation.ConversationScope
 import com.wire.kalium.logic.feature.conversation.ConversationsRecoveryManager
 import com.wire.kalium.logic.feature.conversation.ConversationsRecoveryManagerImpl
+import com.wire.kalium.logic.feature.conversation.GetOtherUserSecurityClassificationLabelUseCase
+import com.wire.kalium.logic.feature.conversation.GetOtherUserSecurityClassificationLabelUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.feature.conversation.JoinExistingMLSConversationUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.JoinExistingMLSConversationsUseCase
@@ -1132,6 +1134,8 @@ class UserSessionScope internal constructor(
 
     val observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase
         get() = ObserveSecurityClassificationLabelUseCaseImpl(userId, conversationRepository, userConfigRepository)
+  val getOtherUserSecurityClassificationLabel: GetOtherUserSecurityClassificationLabelUseCase
+        get() = GetOtherUserSecurityClassificationLabelUseCaseImpl(userId, userConfigRepository)
 
     val kaliumFileSystem: KaliumFileSystem by lazy {
         // Create the cache and asset storage directories

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCase.kt
@@ -39,14 +39,16 @@ internal class GetOtherUserSecurityClassificationLabelUseCaseImpl(
 ) : GetOtherUserSecurityClassificationLabelUseCase {
 
     override suspend fun invoke(otherUserId: UserId): SecurityClassificationType {
-        return getClassifiedDomainsStatus()?.let { listedDomains ->
-            otherUserId.domain == selfUserId.domain || listedDomains.contains(otherUserId.domain)
-        }.let { computedClassificationStatus ->
-            when (computedClassificationStatus) {
-                true -> SecurityClassificationType.CLASSIFIED
-                false -> SecurityClassificationType.NOT_CLASSIFIED
-                null -> SecurityClassificationType.NONE
-            }
+        val trustedDomains = getClassifiedDomainsStatus()
+        val computedStatus = if (trustedDomains == null) {
+            null
+        } else {
+            otherUserId.domain == selfUserId.domain || trustedDomains.contains(otherUserId.domain)
+        }
+        return when (computedStatus) {
+            true -> SecurityClassificationType.CLASSIFIED
+            false -> SecurityClassificationType.NOT_CLASSIFIED
+            null -> SecurityClassificationType.NONE
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCase.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.onlyRight
+import kotlinx.coroutines.flow.firstOrNull
+
+interface GetOtherUserSecurityClassificationLabelUseCase {
+    /**
+     * This operation will compute if a given user [otherUserId] is classified or not.
+     *
+     * @param otherUserId to classify
+     * @return [SecurityClassificationType] with classification type
+     */
+    suspend operator fun invoke(otherUserId: UserId): SecurityClassificationType
+}
+
+internal class GetOtherUserSecurityClassificationLabelUseCaseImpl(
+    private val selfUserId: UserId,
+    private val userConfigRepository: UserConfigRepository
+) : GetOtherUserSecurityClassificationLabelUseCase {
+
+    override suspend fun invoke(otherUserId: UserId): SecurityClassificationType {
+        return getClassifiedDomainsStatus()?.let { listedDomains ->
+            otherUserId.domain == selfUserId.domain || listedDomains.contains(otherUserId.domain)
+        }.let { computedClassificationStatus ->
+            when (computedClassificationStatus) {
+                true -> SecurityClassificationType.CLASSIFIED
+                false -> SecurityClassificationType.NOT_CLASSIFIED
+                null -> SecurityClassificationType.NONE
+            }
+        }
+    }
+
+    private suspend fun getClassifiedDomainsStatus(): List<String>? {
+        val classifiedDomainsStatus = userConfigRepository.getClassifiedDomainsStatus().onlyRight().firstOrNull()
+        return if (classifiedDomainsStatus == null || !classifiedDomainsStatus.isClassifiedDomainsEnabled) {
+            null
+        } else {
+            classifiedDomainsStatus.trustedDomains
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCase.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 
-fun interface ObserveSecurityClassificationLabelUseCase {
+interface ObserveSecurityClassificationLabelUseCase {
     /**
      * Operation that lets compute if a given conversation [conversationId] in terms of compromising security or not.
      * This will observe the conversation and its participants and will return a [Flow] of [SecurityClassificationType]
@@ -55,7 +55,6 @@ internal class ObserveSecurityClassificationLabelUseCaseImpl(
                         participantDomain == selfUserId.domain || trustedDomains.contains(participantDomain)
                     }
                 }
-
             }.map { isClassified ->
                 when (isClassified) {
                     true -> SecurityClassificationType.CLASSIFIED

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCaseTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.configuration.ClassifiedDomainsStatus
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetOtherUserSecurityClassificationLabelUseCaseTest {
+
+    @Test
+    fun givenAOtherUserId_WhenNoClassifiedFeatureFlagEnabled_ThenClassificationIsNone() = runTest {
+        val (_, getOtherUserSecurityClassificationLabel) = Arrangement()
+            .withGettingClassifiedDomainsDisabled()
+            .arrange()
+
+        val result = getOtherUserSecurityClassificationLabel(TestUser.OTHER_USER_ID)
+
+        assertEquals(SecurityClassificationType.NONE, result)
+    }
+
+    @Test
+    fun givenAOtherUserId_WhenClassifiedFeatureFlagEnabledAndOtherUserInSameDomainAndTrusted_ThenClassificationIsClassified() =
+        runTest {
+            val (_, getOtherUserSecurityClassificationLabel) = Arrangement()
+                .withGettingClassifiedDomains()
+                .arrange()
+
+            val result = getOtherUserSecurityClassificationLabel(TestUser.OTHER_USER_ID.copy(domain = "bella.com"))
+
+            assertEquals(SecurityClassificationType.CLASSIFIED, result)
+        }
+
+    @Test
+    fun givenAOtherUserId_WhenClassifiedFeatureFlagEnabledAndOtherUserNotInSameDomain_ThenClassificationIsNotClassified() =
+        runTest {
+            val (_, getOtherUserSecurityClassificationLabel) = Arrangement()
+                .withGettingClassifiedDomains()
+                .arrange()
+
+            val result = getOtherUserSecurityClassificationLabel(TestUser.OTHER_USER_ID.copy(domain = "not-trusted.com"))
+
+            assertEquals(SecurityClassificationType.NOT_CLASSIFIED, result)
+        }
+
+    private class Arrangement {
+        @Mock
+        val userConfigRepository = mock(classOf<UserConfigRepository>())
+
+        fun withGettingClassifiedDomainsDisabled() = apply {
+            given(userConfigRepository)
+                .function(userConfigRepository::getClassifiedDomainsStatus)
+                .whenInvoked()
+                .thenReturn(emptyFlow())
+        }
+
+        fun withGettingClassifiedDomains() = apply {
+            given(userConfigRepository)
+                .function(userConfigRepository::getClassifiedDomainsStatus)
+                .whenInvoked()
+                .thenReturn(flowOf(Either.Right(ClassifiedDomainsStatus(true, listOf("wire.com", "bella.com")))))
+        }
+
+        fun arrange() = this to GetOtherUserSecurityClassificationLabelUseCaseImpl(
+            selfUserId, userConfigRepository
+        )
+
+        companion object {
+            val selfUserId = UserId("someValue", "wire.com")
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCaseTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.given
@@ -38,7 +39,7 @@ import kotlin.test.assertEquals
 class GetOtherUserSecurityClassificationLabelUseCaseTest {
 
     @Test
-    fun givenAOtherUserId_WhenNoClassifiedFeatureFlagEnabled_ThenClassificationIsNone() = runTest {
+    fun givenAOtherUserId_WhenNoClassifiedFeatureFlagEnabled_ThenClassificationIsNone() = runTest(dispatcher.io) {
         val (_, getOtherUserSecurityClassificationLabel) = Arrangement()
             .withGettingClassifiedDomainsDisabled()
             .arrange()
@@ -50,7 +51,7 @@ class GetOtherUserSecurityClassificationLabelUseCaseTest {
 
     @Test
     fun givenAOtherUserId_WhenClassifiedFeatureFlagEnabledAndOtherUserInSameDomainAndTrusted_ThenClassificationIsClassified() =
-        runTest {
+        runTest(dispatcher.io) {
             val (_, getOtherUserSecurityClassificationLabel) = Arrangement()
                 .withGettingClassifiedDomains()
                 .arrange()
@@ -62,7 +63,7 @@ class GetOtherUserSecurityClassificationLabelUseCaseTest {
 
     @Test
     fun givenAOtherUserId_WhenClassifiedFeatureFlagEnabledAndOtherUserNotInSameDomain_ThenClassificationIsNotClassified() =
-        runTest {
+        runTest(dispatcher.io) {
             val (_, getOtherUserSecurityClassificationLabel) = Arrangement()
                 .withGettingClassifiedDomains()
                 .arrange()
@@ -91,11 +92,15 @@ class GetOtherUserSecurityClassificationLabelUseCaseTest {
         }
 
         fun arrange() = this to GetOtherUserSecurityClassificationLabelUseCaseImpl(
-            selfUserId, userConfigRepository
+            selfUserId, userConfigRepository, dispatcher
         )
 
         companion object {
             val selfUserId = UserId("someValue", "wire.com")
         }
+    }
+
+    companion object {
+        val dispatcher = TestKaliumDispatcher
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to implement security classification banner for other user profile screen.

### Solutions

Creates a use case that returns the security classification label for a given user id.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
