### PR TITLE
chore: improve logging

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -192,7 +192,7 @@ class CallManagerImpl internal constructor(
         message: Message.Signaling,
         content: MessageContent.Calling,
     ) = withCalling {
-        callingLogger.i("$TAG: { \"message\" : ${message.toLogString()}}")
+        callingLogger.i("$TAG - onCallingMessageReceived called: { \"message\" : ${message.toLogString()}}")
         val msg = content.value.toByteArray()
 
         val currTime = System.currentTimeMillis()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -223,7 +223,7 @@ internal class CallDataSource(
 
         callingLogger.i(
             "[CallRepository][createCall] -> lastCallStatus: [$lastCallStatus] |" +
-                    " ConversationId: [${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}] " +
+                    " ConversationId: [${conversationId.toLogString()}] " +
                     "| status: [$status]"
         )
         if (status == CallStatus.INCOMING && !isCallInCurrentSession) {
@@ -321,7 +321,7 @@ internal class CallDataSource(
     override suspend fun persistMissedCall(conversationId: ConversationId) {
         callingLogger.i(
             "[CallRepository] -> Persisting Missed Call for conversation : conversationId: " +
-                    "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}"
+                    "${conversationId.toLogString()}"
         )
         val qualifiedIDEntity = callMapper.fromConversationIdToQualifiedIDEntity(conversationId = conversationId)
         callDAO.getCallerIdByConversationId(conversationId = qualifiedIDEntity)?.let { callerId ->
@@ -377,7 +377,7 @@ internal class CallDataSource(
             if (call.participants != participants) {
                 callingLogger.i(
                     "updateCallParticipants() -" +
-                            " conversationId: ${conversationIdToLog.value.obfuscateId()}@${conversationIdToLog.domain.obfuscateDomain()}" +
+                            " conversationId: ${conversationIdToLog.toLogString()}" +
                             " with size of: ${participants.size}"
                 )
 
@@ -503,7 +503,7 @@ internal class CallDataSource(
     ): Either<CoreFailure, Unit> {
         callingLogger.i(
             "Joining MLS conference for conversation = " +
-                    "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}"
+                    "${conversationId.toLogString()}"
         )
 
         return joinSubconversation(conversationId, CALL_SUBCONVERSATION_ID).onSuccess {
@@ -520,7 +520,7 @@ internal class CallDataSource(
     override suspend fun leaveMlsConference(conversationId: ConversationId) {
         callingLogger.i(
             "Leaving MLS conference for conversation = " +
-                    "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}"
+                    "${conversationId.toLogString()}"
         )
 
         // Cancels flow observing epoch changes

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/CommitBundleEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/CommitBundleEventReceiver.kt
@@ -34,7 +34,7 @@ class CommitBundleEventReceiverImpl(
         when (event) {
             is Event.Conversation.MemberJoin -> memberJoinEventHandler.handle(event)
             is Event.Conversation.MemberLeave -> memberLeaveEventHandler.handle(event)
-            else -> kaliumLogger.w("Unexpected event received by commit bundle: $event")
+            else -> kaliumLogger.w("Unexpected event received by commit bundle: ${event.toLogString()}")
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.network.utils.toJsonElement
+import com.wire.kalium.util.serialization.toJsonElement
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import kotlinx.datetime.Instant
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -41,7 +41,23 @@ import kotlinx.serialization.json.JsonNull
 
 sealed class Event(open val id: String, open val transient: Boolean) {
 
+    private companion object {
+        const val typeKey = "type"
+        const val idKey = "id"
+        const val clientIdKey = "clientId"
+        const val userIdKey = "userId"
+        const val conversationIdKey = "conversationId"
+        const val senderUserIdKey = "senderUserId"
+        const val teamIdKey = "teamId"
+        const val memberIdKey = "memberId"
+        const val timestampIsoKey = "timestampIso"
+    }
+
     fun shouldUpdateLastProcessedEventId() = !transient
+
+    open fun toLogString(): String {
+        return "{ \"$typeKey\" : \"unknown\"}"
+    }
 
     sealed class Conversation(
         id: String,
@@ -55,11 +71,12 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val qualifiedFrom: UserId,
             override val transient: Boolean
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "qualifiedFrom" to "${qualifiedFrom.value.obfuscateId()}@${qualifiedFrom.domain.obfuscateDomain()}"
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    "qualifiedFrom" to "${qualifiedFrom.toLogString()}"
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -75,13 +92,14 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val content: String,
             val encryptedExternalContent: EncryptedData?
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}",
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    senderUserIdKey to "${senderUserId.toLogString()}",
                     "senderClientId" to senderClientId.value.obfuscateId(),
-                    "timestampIso" to timestampIso
+                    timestampIsoKey to timestampIso
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -96,12 +114,13 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val timestampIso: String,
             val content: String
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}",
-                    "timestampIso" to timestampIso
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    senderUserIdKey to "${senderUserId.toLogString()}",
+                    timestampIsoKey to timestampIso
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -114,11 +133,12 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val timestampIso: String,
             val conversation: ConversationResponse
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "timestampIso" to timestampIso
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    timestampIsoKey to timestampIso
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -132,13 +152,14 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val members: List<Member>,
             val timestampIso: String
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "addedBy" to "${addedBy.value.obfuscateId()}@${addedBy.domain.obfuscateDomain()}",
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    "addedBy" to "${addedBy.toLogString()}",
                     "members" to members.map { it.toMap() },
-                    "timestampIso" to timestampIso
+                    timestampIsoKey to timestampIso
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -152,12 +173,13 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val removedList: List<UserId>,
             val timestampIso: String
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "removedBy" to "${removedBy.value.obfuscateId()}@${removedBy.domain.obfuscateDomain()}",
-                    "timestampIso" to timestampIso
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    "removedBy" to "${removedBy.toLogString()}",
+                    timestampIsoKey to timestampIso
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -176,12 +198,13 @@ sealed class Event(open val id: String, open val transient: Boolean) {
                 override val transient: Boolean,
                 val member: Member?,
             ) : MemberChanged(id, conversationId, timestampIso, transient) {
-                override fun toString(): String {
+                override fun toLogString(): String {
                     val properties = mapOf(
-                        "id" to id.obfuscateId(),
-                        "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                        typeKey to this::class.qualifiedName,
+                        idKey to id.obfuscateId(),
+                        conversationIdKey to "${conversationId.toLogString()}",
                         "member" to (member?.toMap() ?: JsonNull),
-                        "timestampIso" to timestampIso
+                        timestampIsoKey to timestampIso
                     )
                     return "${properties.toJsonElement()}"
                 }
@@ -195,11 +218,12 @@ sealed class Event(open val id: String, open val transient: Boolean) {
                 val mutedConversationStatus: MutedConversationStatus,
                 val mutedConversationChangedTime: String
             ) : MemberChanged(id, conversationId, timestampIso, transient) {
-                override fun toString(): String {
+                override fun toLogString(): String {
                     val properties = mapOf(
-                        "id" to id.obfuscateId(),
-                        "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                        "timestampIso" to timestampIso,
+                        typeKey to this::class.qualifiedName,
+                        idKey to id.obfuscateId(),
+                        conversationIdKey to "${conversationId.toLogString()}",
+                        timestampIsoKey to timestampIso,
                         "mutedConversationStatus" to mutedConversationStatus.status,
                         "mutedConversationChangedTime" to mutedConversationChangedTime
                     )
@@ -212,10 +236,11 @@ sealed class Event(open val id: String, open val transient: Boolean) {
                 override val conversationId: ConversationId,
                 override val transient: Boolean
             ) : MemberChanged(id, conversationId, "", transient) {
-                override fun toString(): String {
+                override fun toLogString(): String {
                     val properties = mapOf(
-                        "id" to id.obfuscateId(),
-                        "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                        typeKey to this::class.qualifiedName,
+                        idKey to id.obfuscateId(),
+                        conversationIdKey to "${conversationId.toLogString()}",
                     )
                     return "${properties.toJsonElement()}"
                 }
@@ -230,12 +255,13 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val message: String,
             val timestampIso: String = DateTimeUtil.currentIsoDateTimeString()
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "timestampIso" to timestampIso,
-                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}"
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    timestampIsoKey to timestampIso,
+                    senderUserIdKey to "${senderUserId.toLogString()}"
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -248,12 +274,13 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val senderUserId: UserId,
             val timestampIso: String,
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "timestampIso" to timestampIso,
-                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}"
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    timestampIsoKey to timestampIso,
+                    senderUserIdKey to "${senderUserId.toLogString()}"
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -267,13 +294,14 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val senderUserId: UserId,
             val timestampIso: String,
         ) : Conversation(id, transient, conversationId) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
-                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}",
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
+                    senderUserIdKey to "${senderUserId.toLogString()}",
                     "conversationName" to conversationName,
-                    "timestampIso" to timestampIso,
+                    timestampIsoKey to timestampIso,
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -289,10 +317,11 @@ sealed class Event(open val id: String, open val transient: Boolean) {
 
             override fun toString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to "${conversationId.toLogString()}",
                     "receiptMode" to receiptMode.name,
-                    "senderUserId" to "${senderUserId.value.obfuscateId()}@${senderUserId.domain.obfuscateDomain()}",
+                    senderUserIdKey to "${senderUserId.toLogString()}",
                 )
 
                 return "${properties.toJsonElement()}"
@@ -312,10 +341,11 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val icon: String,
             val name: String,
         ) : Team(id, teamId, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "teamId" to teamId,
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    teamIdKey to teamId,
                     "icon" to icon,
                     "name" to name,
                 )
@@ -329,11 +359,12 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val transient: Boolean,
             val memberId: String,
         ) : Team(id, teamId, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "teamId" to teamId.obfuscateId(),
-                    "memberId" to memberId.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    teamIdKey to teamId.obfuscateId(),
+                    memberIdKey to memberId.obfuscateId(),
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -346,12 +377,13 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val memberId: String,
             val timestampIso: String,
         ) : Team(id, teamId, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "teamId" to teamId.obfuscateId(),
-                    "timestampIso" to timestampIso,
-                    "memberId" to memberId.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    teamIdKey to teamId.obfuscateId(),
+                    timestampIsoKey to timestampIso,
+                    memberIdKey to memberId.obfuscateId(),
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -364,12 +396,13 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val memberId: String,
             val permissionCode: Int?,
         ) : Team(id, teamId, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "teamId" to teamId.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    teamIdKey to teamId.obfuscateId(),
                     "permissionCode" to "$permissionCode",
-                    "memberId" to memberId.obfuscateId(),
+                    memberIdKey to memberId.obfuscateId(),
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -386,9 +419,10 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val transient: Boolean,
             val model: ConfigsStatusModel
         ) : FeatureConfig(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
                     "status" to model.status.name,
                 )
                 return "${properties.toJsonElement()}"
@@ -400,8 +434,10 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val transient: Boolean,
             val model: MLSModel
         ) : FeatureConfig(id, transient) {
-            override fun toString(): String {
-                val properties = mapOf("id" to id.obfuscateId(),
+            override fun toLogString(): String {
+                val properties = mapOf(
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
                     "status" to model.status.name,
                     "allowedUsers" to model.allowedUsers.map { it.value.obfuscateId() })
                 return "${properties.toJsonElement()}"
@@ -413,9 +449,10 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val transient: Boolean,
             val model: ClassifiedDomainsModel,
         ) : FeatureConfig(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
                     "status" to model.status.name,
                     "domains" to model.config.domains.map { it.obfuscateDomain() }
                 )
@@ -428,9 +465,10 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val transient: Boolean,
             val model: ConferenceCallingModel,
         ) : FeatureConfig(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
                     "status" to model.status.name,
                 )
                 return "${properties.toJsonElement()}"
@@ -442,9 +480,10 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val transient: Boolean,
             val model: ConfigsStatusModel,
         ) : FeatureConfig(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
                     "status" to model.status.name,
                 )
                 return "${properties.toJsonElement()}"
@@ -455,9 +494,10 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val id: String,
             override val transient: Boolean,
         ) : FeatureConfig(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -481,10 +521,11 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val previewAssetId: String?,
             val completeAssetId: String?,
         ) : User(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "userId" to userId.obfuscateId()
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    userIdKey to userId.obfuscateId()
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -495,9 +536,10 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val id: String,
             val connection: Connection
         ) : User(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
                     "connection" to connection.toMap()
                 )
                 return "${properties.toJsonElement()}"
@@ -509,10 +551,11 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val id: String,
             val clientId: ClientId
         ) : User(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "clientId" to clientId.value.obfuscateId()
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    clientIdKey to clientId.value.obfuscateId()
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -524,11 +567,12 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val userId: UserId,
             val timestampIso: String = DateTimeUtil.currentIsoDateTimeString() // TODO we are not receiving it from API
         ) : User(id, transient) {
-            override fun toString(): String {
+            override fun toLogString(): String {
                 val properties = mapOf(
-                    "id" to id.obfuscateId(),
-                    "userId" to "${userId.value.obfuscateId()}@${userId.domain.obfuscateDomain()}",
-                    "timestampIso" to timestampIso
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    userIdKey to "${userId.toLogString()}",
+                    timestampIsoKey to timestampIso
                 )
                 return "${properties.toJsonElement()}"
             }
@@ -544,17 +588,27 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             override val id: String,
             override val transient: Boolean,
             val value: Boolean,
-        ) : UserProperty(id, transient)
-
+        ) : UserProperty(id, transient) {
+            override fun toLogString(): String {
+                val properties = mapOf(
+                    typeKey to this::class.qualifiedName,
+                    idKey to id.obfuscateId(),
+                    "transient" to "$transient",
+                    "value" to "$value"
+                )
+                return "${properties.toJsonElement()}"
+            }
+        }
     }
 
     data class Unknown(
         override val id: String,
         override val transient: Boolean,
     ) : Event(id, transient) {
-        override fun toString(): String {
+        override fun toLogString(): String {
             val properties = mapOf(
-                "id" to id.obfuscateId(),
+                typeKey to this::class.qualifiedName,
+                idKey to id.obfuscateId(),
             )
             return "${properties.toJsonElement()}"
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -22,7 +22,6 @@ import com.wire.kalium.cryptography.utils.EncryptedData
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.Conversation.ReceiptMode
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
@@ -35,7 +34,7 @@ import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
-import com.wire.kalium.network.utils.toJsonElement
+import com.wire.kalium.util.serialization.toJsonElement
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.serialization.json.JsonNull
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -18,6 +18,8 @@
 
 package com.wire.kalium.logic.data.id
 
+import com.wire.kalium.logger.obfuscateDomain
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.serialization.SerialName
@@ -32,6 +34,12 @@ data class QualifiedID(
     val domain: String
 ) {
     override fun toString(): String = if (domain.isEmpty()) value else "$value$VALUE_DOMAIN_SEPARATOR$domain"
+
+    fun toLogString(): String = if (domain.isEmpty()) {
+        value.obfuscateId()
+    } else {
+        "${value.obfuscateId()}$VALUE_DOMAIN_SEPARATOR${domain.obfuscateDomain()}"
+    }
 
     fun toPlainID(): PlainId = PlainId(value)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -76,7 +76,7 @@ sealed interface Message {
         val expectsReadConfirmation: Boolean = false
     ) : Sendable, Standalone {
         @Suppress("LongMethod")
-        override fun toString(): String {
+        fun toLogString(): String {
             val typeKey = "type"
             val properties: MutableMap<String, String> = when (content) {
                 is MessageContent.Text -> mutableMapOf(
@@ -107,7 +107,8 @@ sealed interface Message {
                 }
 
                 is MessageContent.Knock -> mutableMapOf(
-                    typeKey to "knock"
+                    typeKey to "knock",
+                    "hot" to "${content.hotKnock}"
                 )
 
                 is MessageContent.Unknown -> mutableMapOf(
@@ -117,13 +118,13 @@ sealed interface Message {
 
             val standardProperties = mapOf(
                 "id" to id.obfuscateId(),
-                "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                "conversationId" to conversationId.toLogString(),
                 "date" to date,
                 "senderUserId" to senderUserId.value.obfuscateId(),
                 "status" to "$status",
                 "visibility" to "$visibility",
                 "senderClientId" to senderClientId.value.obfuscateId(),
-                "editStatus" to "$editStatus",
+                "editStatus" to editStatus.toLogString(),
                 "expectsReadConfirmation" to "$expectsReadConfirmation"
             )
 
@@ -144,7 +145,7 @@ sealed interface Message {
         override val senderUserName: String? = null,
         override val isSelfMessage: Boolean = false,
     ) : Sendable {
-        override fun toString(): String {
+        fun toLogString(): String {
             val typeKey = "type"
 
             val properties: MutableMap<String, String> = when (content) {
@@ -202,7 +203,7 @@ sealed interface Message {
 
             val standardProperties = mapOf(
                 "id" to id.obfuscateId(),
-                "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                "conversationId" to conversationId.toLogString(),
                 "date" to date,
                 "senderUserId" to senderUserId.value.obfuscateId(),
                 "senderClientId" to senderClientId.value.obfuscateId(),
@@ -227,7 +228,7 @@ sealed interface Message {
         //                 instead of having it nullable in all system messages
         val senderUserName: String? = null,
     ) : Message, Standalone {
-        override fun toString(): String {
+        fun toLogString(): String {
 
             val typeKey = "type"
             val properties: MutableMap<String, String> = when (content) {
@@ -267,7 +268,7 @@ sealed interface Message {
 
             val standardProperties = mapOf(
                 "id" to id.obfuscateId(),
-                "conversationId" to "${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}",
+                "conversationId" to "${conversationId.toLogString()}",
                 "date" to date,
                 "senderUserId" to senderUserId.value.obfuscateId(),
                 "status" to "$status",
@@ -287,6 +288,24 @@ sealed interface Message {
     sealed class EditStatus {
         object NotEdited : EditStatus()
         data class Edited(val lastTimeStamp: String) : EditStatus()
+
+        override fun toString(): String = when (this) {
+                is NotEdited -> "NOT_EDITED"
+                is Edited -> "EDITED_$lastTimeStamp"
+            }
+
+        fun toLogString(): String {
+            val properties: MutableMap<String, String> = when (this) {
+                is NotEdited -> mutableMapOf(
+                    "value" to "NOT_EDITED"
+                )
+                is Edited -> mutableMapOf(
+                    "value" to "EDITED",
+                    "time" to this.lastTimeStamp
+                )
+            }
+            return Json.encodeToString(properties.toMap())
+        }
     }
 
     enum class UploadStatus {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.network.utils.toJsonElement
+import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ObserveMessageReceiptsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ObserveMessageReceiptsUseCase.kt
@@ -18,8 +18,6 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.wire.kalium.logger.obfuscateDomain
-import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.receipt.DetailedReceipt
 import com.wire.kalium.logic.data.message.receipt.ReceiptRepository
@@ -58,6 +56,6 @@ internal class ObserveMessageReceiptsUseCaseImpl(
             type
         ).also {
             kaliumLogger.i("[ObserveMessageReceiptsUseCase] - Observing read receipts for " +
-                    "Conversation: ${conversationId.value.obfuscateId()}@${conversationId.domain.obfuscateDomain()}")
+                    "Conversation: ${conversationId.toLogString()}")
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCase.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.feature.message
 
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -38,6 +39,7 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.util.serialization.toJsonElement
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -130,12 +132,12 @@ internal class SendConfirmationUseCase internal constructor(
 
         val properties = mapOf(
             conversationIdKey to conversationId.toLogString(),
-            messageIdsKey to messageIds,
+            messageIdsKey to messageIds.map { it.obfuscateId() },
             statusKey to "ERROR",
             "errorInfo" to "$failure"
         )
 
-        val jsonLogString = Json.encodeToString(properties.toMap())
+        val jsonLogString = "${properties.toJsonElement()}"
         val logMessage = "$TAG: $jsonLogString"
 
         logger.e(logMessage)
@@ -145,10 +147,10 @@ internal class SendConfirmationUseCase internal constructor(
 
         val properties = mapOf(
             conversationIdKey to conversationId.toLogString(),
-            messageIdsKey to messageIds,
+            messageIdsKey to messageIds.map { it.obfuscateId() },
             statusKey to "CONFIRMED"
         )
-        val jsonLogString = Json.encodeToString(properties.toMap())
+        val jsonLogString = "${properties.toJsonElement()}"
         val logMessage = "$TAG: $jsonLogString"
 
         logger.i("$logMessage")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
@@ -50,10 +50,10 @@ internal class MemberChangeEventHandlerImpl(
                 conversationRepository.fetchConversationIfUnknown(event.conversationId)
                     .run {
                         onSuccess {
-                            logger.v("Succeeded fetching conversation details on MemberChange Event: $event")
+                            logger.v("Succeeded fetching conversation details on MemberChange Event: ${event.toLogString()}")
                         }
                         onFailure {
-                            logger.w("Failure fetching conversation details on MemberChange Event: $event")
+                            logger.w("Failure fetching conversation details on MemberChange Event: ${event.toLogString()}")
                         }
                         // Even if unable to fetch conversation details, at least attempt updating the member
                         conversationRepository.updateMemberFromEvent(event.member!!, event.conversationId)
@@ -61,7 +61,7 @@ internal class MemberChangeEventHandlerImpl(
             }
 
             else -> {
-                logger.w("Ignoring 'conversation.member-update' event, not handled yet: $event")
+                logger.w("Ignoring 'conversation.member-update' event, not handled yet: ${event.toLogString()}")
             }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -48,10 +48,10 @@ internal class MemberJoinEventHandlerImpl(
         conversationRepository.fetchConversationIfUnknown(event.conversationId)
             .run {
                 onSuccess {
-                    logger.v("Succeeded fetching conversation details on MemberJoin Event: $event")
+                    logger.v("Succeeded fetching conversation details on MemberJoin Event: ${event.toLogString()}")
                 }
                 onFailure {
-                    logger.w("Failure fetching conversation details on MemberJoin Event: $event")
+                    logger.w("Failure fetching conversation details on MemberJoin Event: ${event.toLogString()}")
                 }
                 // Even if unable to fetch conversation details, at least attempt adding the members
                 userRepository.fetchUsersIfUnknownByIds(event.members.map { it.id }.toSet())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logger.KaliumLogger
-import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ReceiptModeMapper
 import com.wire.kalium.logic.data.event.Event
@@ -68,7 +67,7 @@ internal class ReceiptModeUpdateEventHandlerImpl(
             }
             .onFailure { coreFailure ->
                 logger.d("[ReceiptModeUpdateEventHandler][Error] - Receipt Mode: [${event.receiptMode}] " +
-                        "| Conversation: [${event.conversationId.toString().obfuscateId()}] " +
+                        "| Conversation: [${event.conversationId.toLogString()}] " +
                         "| CoreFailure: [$coreFailure]")
             }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandler.kt
@@ -19,7 +19,6 @@
 package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.logger.KaliumLogger
-import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.toDao
@@ -45,7 +44,7 @@ internal class RenamedConversationEventHandlerImpl(
     override suspend fun handle(event: Event.Conversation.RenamedConversation) {
         updateConversationName(event.conversationId, event.conversationName, event.timestampIso)
             .onSuccess {
-                logger.d("The Conversation was renamed: ${event.conversationId.toString().obfuscateId()}")
+                logger.d("The Conversation was renamed: ${event.conversationId.toLogString()}")
                 val message = Message.System(
                     id = event.id,
                     content = MessageContent.ConversationRenamed(event.conversationName),
@@ -57,7 +56,7 @@ internal class RenamedConversationEventHandlerImpl(
                 persistMessage(message)
             }
             .onFailure { coreFailure ->
-                logger.e("Error renaming the conversation [${event.conversationId.toString().obfuscateId()}] $coreFailure")
+                logger.e("Error renaming the conversation [${event.conversationId.toLogString()}] $coreFailure")
             }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -197,7 +197,7 @@ internal class ApplicationMessageHandlerImpl(
     }
 
     private suspend fun processMessage(message: Message.Regular) {
-        logger.i(message = "Message received: { \"message\" : $message }")
+        logger.i(message = "Message received: { \"message\" : ${message.toLogString()} }")
 
         when (val content = message.content) {
             // Persist Messages - > lists
@@ -211,7 +211,7 @@ internal class ApplicationMessageHandlerImpl(
             is MessageContent.Asset -> assetMessageHandler.handle(message, content)
 
             is MessageContent.Unknown -> {
-                logger.i(message = "Unknown Message received: $message")
+                logger.i(message = "Unknown Message received: { \"message\" : ${message.toLogString()} }")
                 persistMessage(message)
             }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumHttpLogger.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/KaliumHttpLogger.kt
@@ -21,7 +21,7 @@ package com.wire.kalium.network
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.network.utils.obfuscatePath
 import com.wire.kalium.network.utils.obfuscatedJsonMessage
-import com.wire.kalium.network.utils.toJsonElement
+import com.wire.kalium.util.serialization.toJsonElement
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.request.HttpRequest

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
@@ -39,7 +39,7 @@ import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.TeamId
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.kaliumLogger
-import com.wire.kalium.network.utils.toJsonElement
+import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
@@ -23,6 +23,7 @@ package com.wire.kalium.network.utils
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logger.obfuscateUrlPath
+import com.wire.kalium.util.serialization.toJsonElement
 import io.ktor.http.Url
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                implementation(libs.ktxSerialization)
                 // coroutines
                 implementation(libs.coroutines.core)
                 implementation(libs.ktxDateTime)

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/serialization/SerializationUtils.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/serialization/SerializationUtils.kt
@@ -16,7 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.network.utils
+package com.wire.kalium.util.serialization
 
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`toString()` is abused to sometimes be an actual string representation, and sometimes to be a more complex representation for logging. Before disaster strikes and one is used in place of another, we should avoid confusion.


### Solutions

leave `toString()` alone and use `toLogString()` when logging

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
