### PR TITLE
fix(rc): datetime parsing error [AR-3189]

### DIFF
--- a/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -31,7 +31,7 @@ import java.util.TimeZone
 
 actual open class PlatformDateTimeUtil actual constructor() {
 
-    private val isoDateTimeFormat = SimpleDateFormat(DateTimeUtil.pattern, Locale.getDefault()).apply {
+    private val isoDateTimeFormat = SimpleDateFormat(DateTimeUtil.iso8601Pattern, Locale.getDefault()).apply {
         timeZone = TimeZone.getTimeZone("UTC")
     }
 

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
@@ -41,8 +41,8 @@ expect open class PlatformDateTimeUtil() {
 // TODO(qol): we need to think if it should return an either or should we catch the exception,
 // so far we assume that string date-times we use are always in valid ISO-8601 format so there shouldn't be any failed formatting
 object DateTimeUtil : PlatformDateTimeUtil() {
-    const val pattern: String = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
-    const val regex = "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d(([+-]\\d\\d:\\d\\d)|Z)?\$"
+    const val iso8601Pattern: String = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    const val iso8601Regex = "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\dZ\$"
     internal const val MILLISECONDS_DIGITS = 3
 
     /**

--- a/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilTest.kt
+++ b/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilTest.kt
@@ -32,7 +32,7 @@ class DateTimeUtilTest {
     private val isoDateTimeStringWith0Millis = "2022-12-20T17:30:00.000Z"
     private val isoDateTimeStringWith0MillisMinus1s = "2022-12-20T17:29:59.000Z"
     private val epochMillis = 1671557400000
-    private val regex = Regex(DateTimeUtil.regex)
+    private val regex = Regex(DateTimeUtil.iso8601Regex)
 
     @Test
     fun givenAValidIsoDateTimeString_whenMatchingRegex_thenShouldSucceed() {
@@ -46,6 +46,9 @@ class DateTimeUtilTest {
         assertTrue(!regex.matches("2022/12/20T17:30:00.000Z"))
         assertTrue(!regex.matches("2022-12-2017:30:00.000Z"))
         assertTrue(!regex.matches("2022-12-20T7:30:00Z"))
+        assertTrue(!regex.matches("2022-12-20T17:30:00.000+0100"))
+        assertTrue(!regex.matches("2022-12-20T17:30:00.000+01:00"))
+        assertTrue(!regex.matches("2022-12-20T17:30:00.000+01"))
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There's an error on Android 7 seen on the Play Store about parsing Instant.

### Causes (Optional)

Couldn't reproduce on any Android 7 device so it's probably related to some specific devices or weird date time values.

One thing noticed is that the formatter used on older Androids was using a format with `XXX` at the end instead of just `Z`, which means that it could append the timezone values at the end of the date time string (e.g. "2023-03-01T01:02:03.456+01:00"). The problem is that kotlin `Instant.parse` can handle time zones in some forms, like "+01:00" or "+01" but `XXX` also allows to use "+0100". 

### Solutions

Use format with `Z` as we use ISO 8601 date times with UTC time and don't allow different timezones.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
