### PR TITLE
refactor: clean up conversation ID mapping for calls

### DIFF
--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
@@ -75,7 +75,7 @@ class OnCloseCallTest {
             .function(callRepository::getCallMetadataProfile)
             .whenInvoked()
             .thenReturn(
-                CallMetadataProfile(mapOf(conversationIdString to callMetadata))
+                CallMetadataProfile(mapOf(conversationId to callMetadata))
             )
         // when
         onCloseCall.onClosedCall(
@@ -91,7 +91,7 @@ class OnCloseCallTest {
         // then
         verify(callRepository)
             .suspendFunction(callRepository::updateCallStatusById)
-            .with(eq(conversationIdString), eq(CallStatus.STILL_ONGOING))
+            .with(eq(conversationId), eq(CallStatus.STILL_ONGOING))
             .wasInvoked(once)
     }
 
@@ -103,7 +103,7 @@ class OnCloseCallTest {
             .function(callRepository::getCallMetadataProfile)
             .whenInvoked()
             .thenReturn(
-                CallMetadataProfile(mapOf(conversationIdString to callMetadata))
+                CallMetadataProfile(mapOf(conversationId to callMetadata))
             )
 
 
@@ -121,7 +121,7 @@ class OnCloseCallTest {
         // then
         verify(callRepository)
             .suspendFunction(callRepository::updateCallStatusById)
-            .with(eq(conversationIdString), eq(CallStatus.MISSED))
+            .with(eq(conversationId), eq(CallStatus.MISSED))
             .wasInvoked(once)
 
         verify(callRepository)
@@ -136,7 +136,7 @@ class OnCloseCallTest {
             .function(callRepository::getCallMetadataProfile)
             .whenInvoked()
             .thenReturn(
-                CallMetadataProfile(mapOf(conversationIdString to callMetadata))
+                CallMetadataProfile(mapOf(conversationId to callMetadata))
             )
 
         onCloseCall.onClosedCall(
@@ -151,7 +151,7 @@ class OnCloseCallTest {
 
         verify(callRepository)
             .suspendFunction(callRepository::updateCallStatusById)
-            .with(eq(conversationIdString), eq(CallStatus.CLOSED))
+            .with(eq(conversationId), eq(CallStatus.CLOSED))
             .wasInvoked(once)
 
         verify(callRepository)

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -231,7 +231,6 @@ class CallManagerImpl internal constructor(
             "$TAG -> starting call for conversation = " +
                     "${conversationId.toLogString()}.."
         )
-        val federatedId = federatedIdMapper.parseToFederatedId(conversationId)
         val isCameraOn = callType == CallType.VIDEO
         val type = conversationRepository.getConversationById(conversationId)?.let {
             callMapper.fromConversationToConversationType(it)
@@ -252,7 +251,7 @@ class CallManagerImpl internal constructor(
             // TODO: Handle response. Possible failure?
             wcall_start(
                 deferredHandle.await(),
-                federatedId,
+                federatedIdMapper.parseToFederatedId(conversationId),
                 avsCallType.avsValue,
                 avsConversationType.avsValue,
                 isAudioCbr.toInt()
@@ -264,7 +263,7 @@ class CallManagerImpl internal constructor(
             )
         }
 
-        if (callRepository.getCallMetadataProfile().get(federatedId)?.protocol is Conversation.ProtocolInfo.MLS) {
+        if (callRepository.getCallMetadataProfile().get(conversationId)?.protocol is Conversation.ProtocolInfo.MLS) {
             callRepository.joinMlsConference(conversationId) { conversationId, epochInfo ->
                 updateEpochInfo(conversationId, epochInfo)
             }
@@ -272,8 +271,6 @@ class CallManagerImpl internal constructor(
     }
 
     override suspend fun answerCall(conversationId: ConversationId) {
-        val federatedId = federatedIdMapper.parseToFederatedId(conversationId)
-
         withCalling {
             callingLogger.d(
                 "$TAG -> answering call for conversation = " +
@@ -281,7 +278,7 @@ class CallManagerImpl internal constructor(
             )
             wcall_answer(
                 inst = deferredHandle.await(),
-                conversationId = federatedId,
+                conversationId = federatedIdMapper.parseToFederatedId(conversationId),
                 callType = CallTypeCalling.AUDIO.avsValue,
                 cbrEnabled = false
             )
@@ -291,7 +288,7 @@ class CallManagerImpl internal constructor(
             )
         }
 
-        if (callRepository.getCallMetadataProfile().get(federatedId)?.protocol is Conversation.ProtocolInfo.MLS) {
+        if (callRepository.getCallMetadataProfile().get(conversationId)?.protocol is Conversation.ProtocolInfo.MLS) {
             callRepository.joinMlsConference(conversationId) { conversationId, epochInfo ->
                 updateEpochInfo(conversationId, epochInfo)
             }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
@@ -37,7 +37,7 @@ class OnActiveSpeakers(
         val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
 
         callRepository.updateParticipantsActiveSpeaker(
-            conversationId = conversationIdWithDomain.toString(),
+            conversationId = conversationIdWithDomain,
             activeSpeakers = callActiveSpeakers
         )
     }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnAnsweredCall.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnAnsweredCall.kt
@@ -39,7 +39,7 @@ class OnAnsweredCall(
 
         scope.launch {
             callRepository.updateCallStatusById(
-                conversationIdString = conversationIdWithDomain.toString(),
+                conversationId = conversationIdWithDomain,
                 status = CallStatus.ANSWERED
             )
         }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnEstablishedCall.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnEstablishedCall.kt
@@ -44,7 +44,7 @@ class OnEstablishedCall(
 
         scope.launch {
             callRepository.updateCallStatusById(
-                conversationIdWithDomain.toString(),
+                conversationIdWithDomain,
                 CallStatus.ESTABLISHED
             )
         }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -64,7 +64,7 @@ class OnParticipantListChanged internal constructor(
             }
 
             callRepository.updateCallParticipants(
-                conversationId = conversationIdWithDomain.toString(),
+                conversationId = conversationIdWithDomain,
                 participants = participants
             )
             callingLogger.i(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
@@ -19,11 +19,12 @@
 package com.wire.kalium.logic.data.call
 
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
 
 data class CallMetadataProfile(
-    val data: Map<String, CallMetadata>
+    val data: Map<ConversationId, CallMetadata>
 ) {
-    operator fun get(conversationId: String): CallMetadata? = data[conversationId]
+    operator fun get(conversationId: ConversationId): CallMetadata? = data[conversationId]
 }
 
 data class CallMetadata(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -109,11 +109,11 @@ interface CallRepository {
         isMuted: Boolean,
         isCameraOn: Boolean
     )
-    suspend fun updateCallStatusById(conversationIdString: String, status: CallStatus)
-    fun updateIsMutedById(conversationId: String, isMuted: Boolean)
-    fun updateIsCameraOnById(conversationId: String, isCameraOn: Boolean)
-    fun updateCallParticipants(conversationId: String, participants: List<Participant>)
-    fun updateParticipantsActiveSpeaker(conversationId: String, activeSpeakers: CallActiveSpeakers)
+    suspend fun updateCallStatusById(conversationId: ConversationId, status: CallStatus)
+    fun updateIsMutedById(conversationId: ConversationId, isMuted: Boolean)
+    fun updateIsCameraOnById(conversationId: ConversationId, isCameraOn: Boolean)
+    fun updateCallParticipants(conversationId: ConversationId, participants: List<Participant>)
+    fun updateParticipantsActiveSpeaker(conversationId: ConversationId, activeSpeakers: CallActiveSpeakers)
     suspend fun getLastClosedCallCreatedByConversationId(conversationId: ConversationId): Flow<String?>
     suspend fun updateOpenCallsToClosedStatus()
     suspend fun persistMissedCall(conversationId: ConversationId)
@@ -241,7 +241,7 @@ internal class CallDataSource(
                 callingLogger.i("[CallRepository][createCall] -> Update.1 | callNewStatus: [$callNewStatus]")
                 // Update database
                 updateCallStatusById(
-                    conversationIdString = conversationId.toString(),
+                    conversationId = conversationId,
                     status = callNewStatus
                 )
             }
@@ -288,33 +288,33 @@ internal class CallDataSource(
         )
     }
 
-    override suspend fun updateCallStatusById(conversationIdString: String, status: CallStatus) {
+    override suspend fun updateCallStatusById(conversationId: ConversationId, status: CallStatus) {
         val callMetadataProfile = _callMetadataProfile.value
-        val modifiedConversationId = qualifiedIdMapper.fromStringToQualifiedID(conversationIdString)
+//         val modifiedConversationId = qualifiedIdMapper.fromStringToQualifiedID(conversationIdString)
 
         // Update Call in Database
         wrapStorageRequest {
             callDAO.updateLastCallStatusByConversationId(
                 status = callMapper.toCallEntityStatus(callStatus = status),
                 conversationId = callMapper.fromConversationIdToQualifiedIDEntity(
-                    conversationId = modifiedConversationId
+                    conversationId = conversationId
                 )
             )
             callingLogger.i(
                 "[CallRepository][UpdateCallStatusById] ->" +
-                        " ConversationId: [${modifiedConversationId.value.obfuscateId()}" +
-                        "@${modifiedConversationId.domain.obfuscateDomain()}]" +
+                        " ConversationId: [${conversationId.value.obfuscateId()}" +
+                        "@${conversationId.domain.obfuscateDomain()}]" +
                         " " + "| status: [$status]"
             )
         }
 
-        callMetadataProfile.data[modifiedConversationId.toString()]?.let { call ->
+        callMetadataProfile.data[conversationId.toString()]?.let { call ->
             val updatedCallMetadata = callMetadataProfile.data.toMutableMap().apply {
                 val establishedTime = if (status == CallStatus.ESTABLISHED) DateTimeUtil.currentIsoDateTimeString()
                 else call.establishedTime
 
                 // Update Metadata
-                this[modifiedConversationId.toString()] = call.copy(establishedTime = establishedTime)
+                this[conversationId.toString()] = call.copy(establishedTime = establishedTime)
             }
 
             _callMetadataProfile.value = callMetadataProfile.copy(
@@ -326,7 +326,7 @@ internal class CallDataSource(
     override suspend fun persistMissedCall(conversationId: ConversationId) {
         callingLogger.i(
             "[CallRepository] -> Persisting Missed Call for conversation : conversationId: " +
-                    "${conversationId.toLogString()}"
+                    conversationId.toLogString()
         )
         val qualifiedIDEntity = callMapper.fromConversationIdToQualifiedIDEntity(conversationId = conversationId)
         callDAO.getCallerIdByConversationId(conversationId = qualifiedIDEntity)?.let { callerId ->
@@ -345,11 +345,11 @@ internal class CallDataSource(
         } ?: callingLogger.i("[CallRepository] -> Unable to persist Missed Call due to missing Caller ID")
     }
 
-    override fun updateIsMutedById(conversationId: String, isMuted: Boolean) {
+    override fun updateIsMutedById(conversationId: ConversationId, isMuted: Boolean) {
         val callMetadataProfile = _callMetadataProfile.value
-        callMetadataProfile.data[conversationId]?.let { callMetadata ->
+        callMetadataProfile.data[conversationId.toString()]?.let { callMetadata ->
             val updatedCallMetaData = callMetadataProfile.data.toMutableMap().apply {
-                this[conversationId] = callMetadata.copy(
+                this[conversationId.toString()] = callMetadata.copy(
                     isMuted = isMuted
                 )
             }
@@ -360,11 +360,11 @@ internal class CallDataSource(
         }
     }
 
-    override fun updateIsCameraOnById(conversationId: String, isCameraOn: Boolean) {
+    override fun updateIsCameraOnById(conversationId: ConversationId, isCameraOn: Boolean) {
         val callMetadataProfile = _callMetadataProfile.value
-        callMetadataProfile.data[conversationId]?.let { call ->
+        callMetadataProfile.data[conversationId.toString()]?.let { call ->
             val updatedCallMetadata = callMetadataProfile.data.toMutableMap().apply {
-                this[conversationId] = call.copy(
+                this[conversationId.toString()] = call.copy(
                     isCameraOn = isCameraOn
                 )
             }
@@ -375,19 +375,18 @@ internal class CallDataSource(
         }
     }
 
-    override fun updateCallParticipants(conversationId: String, participants: List<Participant>) {
+    override fun updateCallParticipants(conversationId: ConversationId, participants: List<Participant>) {
         val callMetadataProfile = _callMetadataProfile.value
-        val conversationIdToLog = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
-        callMetadataProfile.data[conversationId]?.let { call ->
+        callMetadataProfile.data[conversationId.toString()]?.let { call ->
             if (call.participants != participants) {
                 callingLogger.i(
                     "updateCallParticipants() -" +
-                            " conversationId: ${conversationIdToLog.toLogString()}" +
+                            " conversationId: ${conversationId.toLogString()}" +
                             " with size of: ${participants.size}"
                 )
 
                 val updatedCallMetadata = callMetadataProfile.data.toMutableMap().apply {
-                    this[conversationId] = call.copy(
+                    this[conversationId.toString()] = call.copy(
                         participants = participants,
                         maxParticipants = max(call.maxParticipants, participants.size + 1)
                     )
@@ -399,12 +398,12 @@ internal class CallDataSource(
             }
         }
 
-        if (_callMetadataProfile.value[conversationId]?.protocol is Conversation.ProtocolInfo.MLS) {
+        if (_callMetadataProfile.value[conversationId.toString()]?.protocol is Conversation.ProtocolInfo.MLS) {
             participants.forEach { participant ->
                 if (participant.hasEstablishedAudio) {
                     clearStaleParticipantTimeout(participant)
                 } else {
-                    removeStaleParticipantAfterTimeout(participant, conversationIdToLog)
+                    removeStaleParticipantAfterTimeout(participant, conversationId)
                 }
             }
         }
@@ -438,15 +437,14 @@ internal class CallDataSource(
         }
     }
 
-    override fun updateParticipantsActiveSpeaker(conversationId: String, activeSpeakers: CallActiveSpeakers) {
+    override fun updateParticipantsActiveSpeaker(conversationId: ConversationId, activeSpeakers: CallActiveSpeakers) {
         val callMetadataProfile = _callMetadataProfile.value
-        val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
 
-        callMetadataProfile.data[conversationIdWithDomain.toString()]?.let { call ->
+        callMetadataProfile.data[conversationId.toString()]?.let { call ->
             callingLogger.i(
                 "updateActiveSpeakers() -" +
-                        " conversationId: ${conversationIdWithDomain.value.obfuscateId()}" +
-                        "@${conversationIdWithDomain.domain.obfuscateDomain()}" +
+                        " conversationId: ${conversationId.value.obfuscateId()}" +
+                        "@${conversationId.domain.obfuscateDomain()}" +
                         "with size of: ${activeSpeakers.activeSpeakers.size}"
             )
 
@@ -456,7 +454,7 @@ internal class CallDataSource(
             )
 
             val updatedCallMetadata = callMetadataProfile.data.toMutableMap().apply {
-                this[conversationIdWithDomain.toString()] = call.copy(
+                this[conversationId.toString()] = call.copy(
                     participants = updatedParticipants,
                     maxParticipants = max(call.maxParticipants, updatedParticipants.size + 1)
                 )
@@ -520,7 +518,7 @@ internal class CallDataSource(
     ): Either<CoreFailure, Unit> {
         callingLogger.i(
             "Joining MLS conference for conversation = " +
-                    "${conversationId.toLogString()}"
+                    conversationId.toLogString()
         )
 
         return joinSubconversation(conversationId, CALL_SUBCONVERSATION_ID).onSuccess {
@@ -537,7 +535,7 @@ internal class CallDataSource(
     override suspend fun leaveMlsConference(conversationId: ConversationId) {
         callingLogger.i(
             "Leaving MLS conference for conversation = " +
-                    "${conversationId.toLogString()}"
+                    conversationId.toLogString()
         )
 
         // Cancels flow observing epoch changes

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
@@ -44,10 +44,10 @@ class EndCallUseCase(
         persistMissedCallIfNeeded(conversationId)
 
         callingLogger.d("[EndCallUseCase] -> Updating call status to CLOSED_INTERNALLY")
-        callRepository.updateCallStatusById(conversationId.toString(), CallStatus.CLOSED_INTERNALLY)
+        callRepository.updateCallStatusById(conversationId, CallStatus.CLOSED_INTERNALLY)
 
         callManager.value.endCall(conversationId)
-        callRepository.updateIsCameraOnById(conversationId.toString(), false)
+        callRepository.updateIsCameraOnById(conversationId, false)
     }
 
     private suspend fun persistMissedCallIfNeeded(conversationId: ConversationId) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCase.kt
@@ -36,7 +36,7 @@ class MuteCallUseCase internal constructor(
      */
     suspend operator fun invoke(conversationId: ConversationId) {
         callRepository.updateIsMutedById(
-            conversationId = conversationId.toString(),
+            conversationId = conversationId,
             isMuted = true
         )
         val activeCall = callRepository.establishedCallsFlow().first().find {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/RejectCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/RejectCallUseCase.kt
@@ -38,7 +38,7 @@ class RejectCallUseCase(
 
     suspend operator fun invoke(conversationId: ConversationId) = withContext(dispatchers.default) {
         callingLogger.d("[RejectCallUseCase] -> Updating call status to REJECTED")
-        callRepository.updateCallStatusById(conversationId.toString(), CallStatus.REJECTED)
+        callRepository.updateCallStatusById(conversationId, CallStatus.REJECTED)
 
         callManager.value.rejectCall(conversationId)
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
@@ -36,7 +36,7 @@ class UnMuteCallUseCase(
      */
     suspend operator fun invoke(conversationId: ConversationId) {
         callRepository.updateIsMutedById(
-            conversationId = conversationId.toString(),
+            conversationId = conversationId,
             isMuted = false
         )
         val activeCall = callRepository.establishedCallsFlow().first().find {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UpdateVideoStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UpdateVideoStateUseCase.kt
@@ -41,7 +41,7 @@ class UpdateVideoStateUseCase(
         videoState: VideoState
     ) {
         if (videoState != VideoState.PAUSED)
-            callRepository.updateIsCameraOnById(conversationId.toString(), videoState == VideoState.STARTED)
+            callRepository.updateIsCameraOnById(conversationId, videoState == VideoState.STARTED)
 
         // updateVideoState should be called only when the call is established
         callRepository.establishedCallsFlow().first().find { call ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -139,7 +139,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false,
                         conversationName = "ONE_ON_ONE Name",
                         conversationType = Conversation.Type.ONE_ON_ONE,
@@ -234,7 +234,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false
                     )
                 )
@@ -258,7 +258,7 @@ class CallRepositoryTest {
 
         assertEquals(
             true,
-            callRepository.getCallMetadataProfile().data[Arrangement.conversationId.toString()]?.isMuted
+            callRepository.getCallMetadataProfile().data[Arrangement.conversationId]?.isMuted
         )
     }
 
@@ -303,7 +303,7 @@ class CallRepositoryTest {
             .wasInvoked(exactly = once)
 
         assertTrue(
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId.toString())
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId)
         )
     }
 
@@ -335,7 +335,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false
                     )
                 )
@@ -358,7 +358,7 @@ class CallRepositoryTest {
             .wasInvoked(exactly = Times(0))
 
         assertTrue(
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId.toString())
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId)
         )
     }
 
@@ -410,7 +410,7 @@ class CallRepositoryTest {
             .wasInvoked(exactly = once)
 
         assertTrue(
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId.toString())
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId)
         )
     }
 
@@ -456,7 +456,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false
                     )
                 )
@@ -485,7 +485,7 @@ class CallRepositoryTest {
 
         assertEquals(
             true,
-            callRepository.getCallMetadataProfile().data[Arrangement.conversationId.toString()]?.isMuted
+            callRepository.getCallMetadataProfile().data[Arrangement.conversationId]?.isMuted
         )
     }
 
@@ -521,7 +521,7 @@ class CallRepositoryTest {
             .wasInvoked(exactly = once)
 
         assertTrue(
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId.toString())
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId)
         )
     }
 
@@ -540,7 +540,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false
                     )
                 )
@@ -568,7 +568,7 @@ class CallRepositoryTest {
             .wasNotInvoked()
 
         assertTrue(
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId.toString())
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId)
         )
     }
 
@@ -604,7 +604,7 @@ class CallRepositoryTest {
             .wasInvoked(exactly = once)
 
         assertTrue(
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId.toString())
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.conversationId)
         )
     }
 
@@ -617,7 +617,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false
                     )
                 )
@@ -656,7 +656,7 @@ class CallRepositoryTest {
         callRepository.updateIsMutedById(Arrangement.randomConversationId, false)
 
         assertFalse {
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationIdString)
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationId)
         }
     }
 
@@ -668,7 +668,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = true
                     )
                 )
@@ -681,7 +681,7 @@ class CallRepositoryTest {
         // then
         assertEquals(
             expectedValue,
-            callRepository.getCallMetadataProfile().data[Arrangement.conversationId.toString()]?.isMuted
+            callRepository.getCallMetadataProfile().data[Arrangement.conversationId]?.isMuted
         )
     }
 
@@ -691,7 +691,7 @@ class CallRepositoryTest {
         callRepository.updateIsCameraOnById(Arrangement.randomConversationId, false)
 
         assertFalse {
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationIdString)
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationId)
         }
     }
 
@@ -703,7 +703,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isCameraOn = true
                     )
                 )
@@ -716,7 +716,7 @@ class CallRepositoryTest {
         // then
         assertEquals(
             expectedValue,
-            callRepository.getCallMetadataProfile().data[Arrangement.conversationId.toString()]?.isCameraOn
+            callRepository.getCallMetadataProfile().data[Arrangement.conversationId]?.isCameraOn
         )
     }
 
@@ -729,7 +729,7 @@ class CallRepositoryTest {
         )
 
         assertFalse {
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationIdString)
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationId)
         }
     }
 
@@ -753,7 +753,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         participants = emptyList(),
                         maxParticipants = 0
                     )
@@ -768,7 +768,7 @@ class CallRepositoryTest {
         )
 
         // then
-        val metadata = callRepository.getCallMetadataProfile().data[Arrangement.conversationId.toString()]
+        val metadata = callRepository.getCallMetadataProfile().data[Arrangement.conversationId]
         assertEquals(
             participantsList,
             metadata?.participants
@@ -784,7 +784,7 @@ class CallRepositoryTest {
         )
 
         assertFalse {
-            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationIdString)
+            callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationId)
         }
     }
 
@@ -808,7 +808,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         participants = emptyList(),
                         maxParticipants = 0
                     )
@@ -835,7 +835,7 @@ class CallRepositoryTest {
         callRepository.updateParticipantsActiveSpeaker(Arrangement.conversationId, activeSpeakers)
 
         // then
-        val metadata = callRepository.getCallMetadataProfile().data[Arrangement.conversationId.toString()]
+        val metadata = callRepository.getCallMetadataProfile().data[Arrangement.conversationId]
         assertEquals(
             expectedParticipantsList,
             metadata?.participants
@@ -866,7 +866,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false,
                         conversationName = "ONE_ON_ONE Name",
                         conversationType = Conversation.Type.ONE_ON_ONE,
@@ -906,7 +906,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false,
                         conversationName = "ONE_ON_ONE Name",
                         conversationType = Conversation.Type.ONE_ON_ONE,
@@ -951,7 +951,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false,
                         conversationName = "ONE_ON_ONE Name",
                         conversationType = Conversation.Type.ONE_ON_ONE,
@@ -1015,8 +1015,8 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to metadata,
-                    Arrangement.randomConversationId.toString() to metadata.copy(
+                    Arrangement.conversationId to metadata,
+                    Arrangement.randomConversationId to metadata.copy(
                         conversationName = "CLOSED CALL"
                     )
                 )
@@ -1068,7 +1068,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         isMuted = false,
                         conversationName = "ONE_ON_ONE Name",
                         conversationType = Conversation.Type.ONE_ON_ONE,
@@ -1305,7 +1305,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         protocol = Arrangement.mlsProtocolInfo,
                         maxParticipants = 0
                     )
@@ -1341,7 +1341,7 @@ class CallRepositoryTest {
         callRepository.updateCallMetadataProfileFlow(
             callMetadataProfile = CallMetadataProfile(
                 data = mapOf(
-                    Arrangement.conversationId.toString() to createCallMetadata().copy(
+                    Arrangement.conversationId to createCallMetadata().copy(
                         protocol = Arrangement.mlsProtocolInfo,
                         maxParticipants = 0
                     )
@@ -1629,8 +1629,7 @@ class CallRepositoryTest {
                 .thenReturn(Either.Right(Unit))
         }
 
-
-            fun givenObserveEpochChangesReturns(flow: Flow<GroupID>) = apply {
+        fun givenObserveEpochChangesReturns(flow: Flow<GroupID>) = apply {
             given(mlsConversationRepository)
                 .suspendFunction(mlsConversationRepository::observeEpochChanges)
                 .whenInvoked()
@@ -1688,7 +1687,6 @@ class CallRepositoryTest {
 
         companion object {
             const val CALL_CONFIG_API_RESPONSE = "{'call':'success','config':'dummy_config'}"
-            const val randomConversationIdString = "random@domain"
             val randomConversationId = ConversationId("value", "domain")
 
             val groupId = GroupID("groupid")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -625,7 +625,7 @@ class CallRepositoryTest {
         )
 
         // when
-        callRepository.updateCallStatusById(Arrangement.conversationId.toString(), CallStatus.ESTABLISHED)
+        callRepository.updateCallStatusById(Arrangement.conversationId, CallStatus.ESTABLISHED)
 
         // then
         verify(arrangement.callDAO)
@@ -641,7 +641,7 @@ class CallRepositoryTest {
     fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateCallStatusIsCalled_thenUpdateTheStatus() = runTest {
         val (arrangement, callRepository) = Arrangement().arrange()
 
-        callRepository.updateCallStatusById(Arrangement.randomConversationIdString, CallStatus.INCOMING)
+        callRepository.updateCallStatusById(Arrangement.randomConversationId, CallStatus.INCOMING)
 
         verify(arrangement.callDAO)
             .suspendFunction(arrangement.callDAO::updateLastCallStatusByConversationId)
@@ -653,7 +653,7 @@ class CallRepositoryTest {
     fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateIsMutedByIdIsCalled_thenDoNotUpdateTheFlow() = runTest {
         val (_, callRepository) = Arrangement().arrange()
 
-        callRepository.updateIsMutedById(Arrangement.randomConversationIdString, false)
+        callRepository.updateIsMutedById(Arrangement.randomConversationId, false)
 
         assertFalse {
             callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationIdString)
@@ -676,7 +676,7 @@ class CallRepositoryTest {
         )
 
         // when
-        callRepository.updateIsMutedById(Arrangement.conversationId.toString(), expectedValue)
+        callRepository.updateIsMutedById(Arrangement.conversationId, expectedValue)
 
         // then
         assertEquals(
@@ -688,7 +688,7 @@ class CallRepositoryTest {
     @Test
     fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateIsCameraOnByIdIsCalled_thenDoNotUpdateTheFlow() = runTest {
         val (_, callRepository) = Arrangement().arrange()
-        callRepository.updateIsCameraOnById(Arrangement.randomConversationIdString, false)
+        callRepository.updateIsCameraOnById(Arrangement.randomConversationId, false)
 
         assertFalse {
             callRepository.getCallMetadataProfile().data.containsKey(Arrangement.randomConversationIdString)
@@ -711,7 +711,7 @@ class CallRepositoryTest {
         )
 
         // when
-        callRepository.updateIsCameraOnById(Arrangement.conversationId.toString(), expectedValue)
+        callRepository.updateIsCameraOnById(Arrangement.conversationId, expectedValue)
 
         // then
         assertEquals(
@@ -724,7 +724,7 @@ class CallRepositoryTest {
     fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateCallParticipantsIsCalled_thenDoNotUpdateTheFlow() = runTest {
         val (_, callRepository) = Arrangement().arrange()
         callRepository.updateCallParticipants(
-            Arrangement.randomConversationIdString,
+            Arrangement.randomConversationId,
             emptyList()
         )
 
@@ -763,7 +763,7 @@ class CallRepositoryTest {
 
         // when
         callRepository.updateCallParticipants(
-            Arrangement.conversationId.toString(),
+            Arrangement.conversationId,
             participantsList
         )
 
@@ -779,7 +779,7 @@ class CallRepositoryTest {
     fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateParticipantsActiveSpeakerIsCalled_thenDoNotUpdateTheFlow() = runTest {
         val (_, callRepository) = Arrangement().arrange()
         callRepository.updateParticipantsActiveSpeaker(
-            Arrangement.randomConversationIdString,
+            Arrangement.randomConversationId,
             CallActiveSpeakers(emptyList())
         )
 
@@ -827,12 +827,12 @@ class CallRepositoryTest {
         )
 
         callRepository.updateCallParticipants(
-            Arrangement.conversationId.toString(),
+            Arrangement.conversationId,
             participantsList
         )
 
         // when
-        callRepository.updateParticipantsActiveSpeaker(Arrangement.conversationId.toString(), activeSpeakers)
+        callRepository.updateParticipantsActiveSpeaker(Arrangement.conversationId, activeSpeakers)
 
         // then
         val metadata = callRepository.getCallMetadataProfile().data[Arrangement.conversationId.toString()]
@@ -1313,7 +1313,7 @@ class CallRepositoryTest {
             )
         )
         callRepository.updateCallParticipants(
-            Arrangement.conversationId.toString(),
+            Arrangement.conversationId,
             listOf(
                 Arrangement.participant.copy(
                 hasEstablishedAudio = false
@@ -1349,7 +1349,7 @@ class CallRepositoryTest {
             )
         )
         callRepository.updateCallParticipants(
-            Arrangement.conversationId.toString(),
+            Arrangement.conversationId,
             listOf(
                 Arrangement.participant.copy(
                     hasEstablishedAudio = false
@@ -1364,7 +1364,7 @@ class CallRepositoryTest {
         yield()
 
         callRepository.updateCallParticipants(
-            Arrangement.conversationId.toString(),
+            Arrangement.conversationId,
             listOf(
                 Arrangement.participant.copy(
                     hasEstablishedAudio = true

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/EndCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/EndCallUseCaseTest.kt
@@ -68,7 +68,7 @@ class EndCallUseCaseTest {
 
         given(callRepository)
             .function(callRepository::updateIsCameraOnById)
-            .whenInvokedWith(eq(conversationId.toString()), eq(false))
+            .whenInvokedWith(eq(conversationId), eq(false))
             .thenDoNothing()
 
         endCall.invoke(conversationId)
@@ -80,12 +80,12 @@ class EndCallUseCaseTest {
 
         verify(callRepository)
             .function(callRepository::updateIsCameraOnById)
-            .with(eq(conversationId.toString()), eq(false))
+            .with(eq(conversationId), eq(false))
             .wasInvoked(once)
 
         verify(callRepository)
             .function(callRepository::persistMissedCall)
-            .with(eq(conversationId.toString()))
+            .with(eq(conversationId))
             .wasNotInvoked()
     }
 
@@ -107,7 +107,7 @@ class EndCallUseCaseTest {
 
         given(callRepository)
             .function(callRepository::updateIsCameraOnById)
-            .whenInvokedWith(eq(conversationId.toString()), eq(false))
+            .whenInvokedWith(eq(conversationId), eq(false))
             .thenDoNothing()
 
         endCall.invoke(conversationId)
@@ -119,7 +119,7 @@ class EndCallUseCaseTest {
 
         verify(callRepository)
             .function(callRepository::updateIsCameraOnById)
-            .with(eq(conversationId.toString()), eq(false))
+            .with(eq(conversationId), eq(false))
             .wasInvoked(once)
 
         verify(callRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/MuteCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/MuteCallUseCaseTest.kt
@@ -74,7 +74,7 @@ class MuteCallUseCaseTest {
 
         verify(callRepository)
             .function(callRepository::updateIsMutedById)
-            .with(eq(conversationId.toString()), eq(isMuted))
+            .with(eq(conversationId), eq(isMuted))
             .wasInvoked(once)
 
         verify(callManager)
@@ -95,7 +95,7 @@ class MuteCallUseCaseTest {
 
         verify(callRepository)
             .function(callRepository::updateIsMutedById)
-            .with(eq(conversationId.toString()), eq(isMuted))
+            .with(eq(conversationId), eq(isMuted))
             .wasInvoked(once)
 
         verify(callManager)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/RejectCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/RejectCallUseCaseTest.kt
@@ -61,7 +61,7 @@ class RejectCallUseCaseTest {
 
         given(callRepository)
             .suspendFunction(callRepository::updateCallStatusById)
-            .whenInvokedWith(eq(conversationId.toString()), eq(CallStatus.REJECTED))
+            .whenInvokedWith(eq(conversationId), eq(CallStatus.REJECTED))
             .thenDoNothing()
 
         rejectCallUseCase.invoke(conversationId)
@@ -73,7 +73,7 @@ class RejectCallUseCaseTest {
 
         verify(callRepository)
             .suspendFunction(callRepository::updateCallStatusById)
-            .with(eq(conversationId.toString()), eq(CallStatus.REJECTED))
+            .with(eq(conversationId), eq(CallStatus.REJECTED))
             .wasInvoked(once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/UnMuteCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/UnMuteCallUseCaseTest.kt
@@ -74,7 +74,7 @@ class UnMuteCallUseCaseTest {
 
         verify(callRepository)
             .function(callRepository::updateIsMutedById)
-            .with(eq(conversationId.toString()), eq(isMuted))
+            .with(eq(conversationId), eq(isMuted))
             .wasInvoked(once)
 
         verify(callManager)
@@ -95,7 +95,7 @@ class UnMuteCallUseCaseTest {
 
         verify(callRepository)
             .function(callRepository::updateIsMutedById)
-            .with(eq(conversationId.toString()), eq(isMuted))
+            .with(eq(conversationId), eq(isMuted))
             .wasInvoked(once)
 
         verify(callManager)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/UpdateVideoStateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/UpdateVideoStateUseCaseTest.kt
@@ -86,14 +86,14 @@ class UpdateVideoStateUseCaseTest {
             }
         given(callRepository)
             .function(callRepository::updateIsCameraOnById)
-            .whenInvokedWith(eq(conversationId.toString()), eq(isCameraOn))
+            .whenInvokedWith(eq(conversationId), eq(isCameraOn))
             .thenDoNothing()
 
         updateVideoStateUseCase(conversationId, videoState)
 
         verify(callRepository)
             .function(callRepository::updateIsCameraOnById)
-            .with(eq(conversationId.toString()), eq(isCameraOn))
+            .with(eq(conversationId), eq(isCameraOn))
             .wasInvoked(once)
 
         verify(callManager)
@@ -112,14 +112,14 @@ class UpdateVideoStateUseCaseTest {
             }
         given(callRepository)
             .function(callRepository::updateIsCameraOnById)
-            .whenInvokedWith(eq(conversationId.toString()), eq(isCameraOn))
+            .whenInvokedWith(eq(conversationId), eq(isCameraOn))
             .thenDoNothing()
 
         updateVideoStateUseCase(conversationId, videoState)
 
         verify(callRepository)
             .function(callRepository::updateIsCameraOnById)
-            .with(eq(conversationId.toString()), eq(isCameraOn))
+            .with(eq(conversationId), eq(isCameraOn))
             .wasInvoked(once)
 
         verify(callManager)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are inconsistently passing conversationId:s as string and sometimes as `ConverationId`, which forces us to map back and forth everywhere.

### Solutions

- Map to `ConversationId` immediately after receiving a conversation ID string from AVS.
- Always use `ConversationId`

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
