### PR TITLE
fix: wipe MLS group when a MLS conversation gets deleted AR-3185

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.data.id.toCrypto
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.message.Message
@@ -48,6 +49,7 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.logic.wrapCryptoRequest
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -575,9 +577,24 @@ internal class ConversationDataSource internal constructor(
         }
     }
 
-    override suspend fun deleteConversation(conversationId: ConversationId) = wrapStorageRequest {
-        conversationDAO.deleteConversationByQualifiedID(conversationId.toDao())
-    }
+    override suspend fun deleteConversation(conversationId: ConversationId) =
+        getConversationProtocolInfo(conversationId).flatMap {
+            when (it) {
+                is Conversation.ProtocolInfo.MLS ->
+                    mlsClientProvider.getMLSClient().flatMap {mlsClient ->
+                        wrapCryptoRequest {
+                            mlsClient.wipeConversation(it.groupId.toCrypto())
+                        }
+                    }.flatMap {
+                        wrapStorageRequest {
+                            conversationDAO.deleteConversationByQualifiedID(conversationId.toDao())
+                        }
+                    }
+                is Conversation.ProtocolInfo.Proteus -> wrapStorageRequest {
+                    conversationDAO.deleteConversationByQualifiedID(conversationId.toDao())
+                }
+            }
+        }
 
     override suspend fun getAssetMessages(
         conversationId: ConversationId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.PersistenceQualifiedId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.data.id.toCrypto
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.message.UnreadEventType
 import com.wire.kalium.logic.data.user.OtherUser
@@ -94,6 +95,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -506,13 +508,38 @@ class ConversationRepositoryTest {
     }
 
     @Test
-    fun givenAConversation_WhenDeletingTheConversation_ThenShouldBeDeletedLocally() = runTest {
-        val (arrange, conversationRepository) = Arrangement().withSuccessfulConversationDeletion().arrange()
+    fun givenProteusConversation_WhenDeletingTheConversation_ThenShouldBeDeletedLocally() = runTest {
+        val (arrangement, conversationRepository) = Arrangement()
+            .withGetConversationProtocolInfoReturns(PROTEUS_PROTOCOL_INFO)
+            .withSuccessfulConversationDeletion()
+            .arrange()
         val conversationId = ConversationId("conv_id", "conv_domain")
 
         conversationRepository.deleteConversation(conversationId).shouldSucceed()
 
-        with(arrange) {
+        with(arrangement) {
+            verify(conversationDAO)
+                .suspendFunction(conversationDAO::deleteConversationByQualifiedID)
+                .with(eq(conversationId.toDao()))
+                .wasInvoked(once)
+        }
+    }
+
+    @Test
+    fun givenMlsConversation_WhenDeletingTheConversation_ThenShouldBeDeletedLocally() = runTest {
+        val (arrangement, conversationRepository) = Arrangement()
+            .withGetConversationProtocolInfoReturns(MLS_PROTOCOL_INFO)
+            .withSuccessfulConversationDeletion()
+            .arrange()
+        val conversationId = ConversationId("conv_id", "conv_domain")
+
+        conversationRepository.deleteConversation(conversationId).shouldSucceed()
+
+        with(arrangement) {
+            verify(mlsClient)
+                .function(mlsClient::wipeConversation)
+                .with(eq(GROUP_ID.toCrypto()))
+                .wasInvoked(once)
             verify(conversationDAO)
                 .suspendFunction(conversationDAO::deleteConversationByQualifiedID)
                 .with(eq(conversationId.toDao()))
@@ -986,6 +1013,13 @@ class ConversationRepositoryTest {
                 .thenReturn(Unit)
         }
 
+        fun withGetConversationProtocolInfoReturns(result: ConversationEntity.ProtocolInfo) = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::getConversationProtocolInfo)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
         fun withApiUpdateConversationMemberRoleReturns(response: NetworkResponse<Unit>) = apply {
             given(conversationApi)
                 .suspendFunction(conversationApi::updateConversationMemberRole)
@@ -1148,19 +1182,16 @@ class ConversationRepositoryTest {
         )
 
         private val TEST_QUALIFIED_ID_ENTITY = PersistenceQualifiedId("value", "domain")
-
-        val TEST_MESSAGE_PREVIEW_ENTITY =
-            MessagePreviewEntity(
-                id = "uid",
-                content = MessagePreviewEntityContent.Text("senderName", "body"),
-                conversationId = TEST_QUALIFIED_ID_ENTITY,
-                date = "date",
-                isSelfMessage = false,
-                visibility = MessageEntity.Visibility.VISIBLE,
-                senderUserId = TestUser.ENTITY_ID
-            )
-
         val OTHER_USER_ID = UserId("otherValue", "domain")
+
+        val PROTEUS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo.Proteus
+        val MLS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo.MLS(
+            RAW_GROUP_ID,
+            ConversationEntity.GroupState.ESTABLISHED,
+            0UL,
+            Clock.System.now(),
+            ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        )
 
         private val CONVERSATION_RENAME_RESPONSE = ConversationRenameResponse.Changed(
             EventContentDTO.Conversation.ConversationRenameDTO(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a MLS conversation got deleted it's corresponding MLS group would still live on.

### Solutions

Wipe MLS group upon deletion.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
