### PR TITLE
feat: handle 2fa failures on login (AR-3088)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
-import com.wire.kalium.logic.util.stubs.newServerConfig
+import com.wire.kalium.logic.util.stubs.newTestServer
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -37,370 +37,472 @@ import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.random.Random
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LoginUseCaseTest {
 
-    @Mock
-    private val loginRepository = mock(classOf<LoginRepository>())
+    @Test
+    fun givenEmailHasLeadingOrTrailingSpaces_thenCleanEmailIsUsedToAuthenticate() = runTest {
+        val cleanEmail = TEST_EMAIL
+        val dirtyEmail = "   $cleanEmail  "
 
-    @Mock
-    private val validateEmailUseCase = mock(classOf<ValidateEmailUseCase>())
+        val (arrangement, loginUseCase) = Arrangement()
+            .withEmailValidationSucceeding(true, cleanEmail)
+            .arrange()
 
-    @Mock
-    private val validateUserHandleUseCase = mock(classOf<ValidateUserHandleUseCase>())
+        val loginUserCaseResult = loginUseCase(dirtyEmail, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
 
-    lateinit var loginUseCase: LoginUseCase
+        assertEquals(
+            loginUserCaseResult,
+            AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, PROXY_CREDENTIALS)
+        )
 
-    private val serverConfig = TEST_SERVER_CONFIG
+        verify(arrangement.validateEmailUseCase)
+            .invocation { invoke(cleanEmail) }
+            .wasInvoked(exactly = once)
 
-    val proxyCredentials = PROXY_CREDENTIALS
+        verify(arrangement.validateUserHandleUseCase)
+            .invocation { invoke(cleanEmail) }
+            .wasNotInvoked()
 
-    @BeforeTest
-    fun setup() {
-        loginUseCase =
-            LoginUseCaseImpl(
-                loginRepository,
-                validateEmailUseCase,
-                validateUserHandleUseCase,
-                serverConfig,
-                proxyCredentials
-            )
+        verify(arrangement.loginRepository)
+            .coroutine { loginWithEmail(cleanEmail, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT) }
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithHandle)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
     }
 
     @Test
-    fun givenEmailHasLeadingOrTrailingSpaces_thenCleanEmailIsUsedToAuthenticate() =
-        runTest {
-            val cleanEmail = TEST_EMAIL
-            val label = "label"
+    fun givenUserHandleHasLeadingOrTrailingSpaces_thenCleanUserIdentifierIsUsedToAuthenticate() = runTest {
+        val cleanHandle = TEST_HANDLE
+        val dirtyHandle = "   $cleanHandle  "
 
-            given(validateEmailUseCase).invocation { invoke(cleanEmail) }.then { true }
-            given(validateUserHandleUseCase).invocation { invoke(cleanEmail) }
-                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("", listOf()) }
-            given(loginRepository)
-                .coroutine { loginWithEmail(cleanEmail, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID) }
+        val (arrangement, loginUseCase) = Arrangement()
+            .withHandleValidationReturning(ValidateUserHandleResult.Valid(cleanHandle), dirtyHandle)
+            .arrange()
 
-            val loginUserCaseResult = loginUseCase("   $cleanEmail  ", TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
+        val loginUserCaseResult = loginUseCase(dirtyHandle, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
 
-            assertEquals(
-                loginUserCaseResult,
-                AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, proxyCredentials)
+        assertEquals(
+            loginUserCaseResult,
+            AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, PROXY_CREDENTIALS)
+        )
+
+        verify(arrangement.validateEmailUseCase)
+            .invocation { invoke(cleanHandle) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase)
+            .invocation { invoke(cleanHandle) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT) }
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithEmail)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenStoreSessionIsTrue_andEverythingElseSucceeds_whenLoggingInUsingEmail_thenStoreTheSessionAndReturnSuccess() = runTest {
+
+        val (arrangement, loginUseCase) = Arrangement().arrange()
+
+        val loginUserCaseResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+
+        assertEquals(
+            loginUserCaseResult,
+            AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, PROXY_CREDENTIALS)
+        )
+
+        verify(arrangement.validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase).function(arrangement.validateUserHandleUseCase::invoke).with(
+            any()
+        )
+            .wasNotInvoked()
+        verify(arrangement.loginRepository).coroutine {
+            loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository).suspendFunction(arrangement.loginRepository::loginWithHandle)
+            .with(any(), any(), any(), any()).wasNotInvoked()
+    }
+
+    @Test
+    fun givenStoreSessionIsTrue_andEverythingElseSucceeds_whenLoggingInUsingUserHandle_thenStoreTheSessionAndReturnSuccess() = runTest {
+
+        val (arrangement, loginUseCase) = Arrangement().arrange()
+
+        // when
+        val loginUserCaseResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, true, TEST_LABEL)
+
+        // then
+        assertEquals(
+            loginUserCaseResult,
+            AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, PROXY_CREDENTIALS)
+        )
+
+        verify(arrangement.validateEmailUseCase)
+            .invocation { invoke(TEST_HANDLE) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase)
+            .invocation { invoke(TEST_HANDLE) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, true) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithEmail).with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenStoreSessionIsFalse_andEverythingElseSucceeds_whenLoggingIn_thenReturnSuccess() = runTest {
+
+        val (_, loginUseCase) = Arrangement().arrange()
+
+        val loginUserCaseResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, false, TEST_LABEL)
+
+        assertEquals(
+            loginUserCaseResult,
+            AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, PROXY_CREDENTIALS)
+        )
+    }
+
+    @Test
+    fun givenEmailIsInvalid_whenLoggingInUsingEmail_thenReturnInvalidUserIdentifier() = runTest {
+        val (arrangement, loginUseCase) = Arrangement()
+            .withEmailValidationSucceeding(false, TEST_EMAIL)
+            .withHandleValidationReturning(
+                handleValidationResult = ValidateUserHandleResult.Invalid.InvalidCharacters("", listOf()),
+                handle = TEST_EMAIL
             )
+            .arrange()
 
-            verify(validateEmailUseCase)
-                .invocation { invoke(cleanEmail) }
-                .wasInvoked(exactly = once)
+        val loginUserCaseResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
 
-            verify(validateUserHandleUseCase)
-                .invocation { invoke(cleanEmail) }
-                .wasNotInvoked()
+        assertEquals(AuthenticationResult.Failure.InvalidUserIdentifier, loginUserCaseResult)
 
-            verify(loginRepository)
-                .coroutine { loginWithEmail(cleanEmail, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .wasInvoked(exactly = once)
-
-            verify(loginRepository)
-                .suspendFunction(loginRepository::loginWithHandle)
-                .with(any(), any(), any(), any())
-                .wasNotInvoked()
-        }
+        verify(arrangement.validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }.wasInvoked(exactly = once)
+    }
 
     @Test
-    fun givenUserHandleHasLeadingOrTrailingSpaces_thenCleanUserIdentifierIsUsedToAuthenticate() =
-        runTest {
-            val cleanHandle = TEST_HANDLE
-            val label = "label"
-            given(validateEmailUseCase).invocation { invoke(cleanHandle) }.then { false }
-            given(validateUserHandleUseCase).invocation { invoke(cleanHandle) }
-                .then { ValidateUserHandleResult.Valid(cleanHandle) }
-            given(loginRepository)
-                .coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID) }
+    fun givenWrongPassword_whenLoggingIn_thenReturnInvalidCredentials() = runTest {
+        val invalidCredentialsFailure =
+            NetworkFailure.ServerMiscommunication(TestNetworkException.invalidCredentials)
 
-            val loginUserCaseResult = loginUseCase("   $cleanHandle  ", TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
+        val (arrangement, loginUseCase) = Arrangement()
+            .withLoginUsingEmailResulting(Either.Left(invalidCredentialsFailure))
+            .withLoginUsingHandleResulting(Either.Left(invalidCredentialsFailure))
+            .arrange()
 
-            assertEquals(
-                loginUserCaseResult,
-                AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, proxyCredentials)
+        // email
+        val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(
+            AuthenticationResult.Failure.InvalidCredentials.InvalidPasswordIdentityCombination,
+            loginEmailResult
+        )
+
+        verify(arrangement.validateEmailUseCase)
+            .invocation { invoke(TEST_EMAIL) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase)
+            .function(arrangement.validateUserHandleUseCase::invoke)
+            .with(any()).wasNotInvoked()
+        verify(arrangement.loginRepository).coroutine {
+            loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithHandle)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+
+        // user handle
+        val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(
+            AuthenticationResult.Failure.InvalidCredentials.InvalidPasswordIdentityCombination,
+            loginHandleResult
+        )
+
+        verify(arrangement.validateEmailUseCase)
+            .invocation { invoke(TEST_HANDLE) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase)
+            .invocation { invoke(TEST_HANDLE) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.loginRepository).coroutine {
+            loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithEmail)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenBadRequest_whenLoggingIn_thenReturnInvalidCredentials() = runTest {
+        val badRequestFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.badRequest)
+
+        val (arrangement, loginUseCase) = Arrangement()
+            .withLoginUsingEmailResulting(Either.Left(badRequestFailure))
+            .withLoginUsingHandleResulting(Either.Left(badRequestFailure))
+            .arrange()
+
+        // email
+        val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(
+            AuthenticationResult.Failure.InvalidCredentials.InvalidPasswordIdentityCombination,
+            loginEmailResult
+        )
+
+        verify(arrangement.validateEmailUseCase)
+            .invocation { invoke(TEST_EMAIL) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase)
+            .function(arrangement.validateUserHandleUseCase::invoke)
+            .with(any()).wasNotInvoked()
+        verify(arrangement.loginRepository).coroutine {
+            loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithHandle)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+
+        // user handle
+        val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(
+            loginHandleResult,
+            AuthenticationResult.Failure.InvalidCredentials.InvalidPasswordIdentityCombination
+        )
+
+        verify(arrangement.validateEmailUseCase)
+            .invocation { invoke(TEST_HANDLE) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase)
+            .invocation { invoke(TEST_HANDLE) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.loginRepository).coroutine {
+            loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithEmail)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenMissingAuthenticationCode_whenLoggingIn_thenReturnMissing2FA() = runTest {
+        val missingAuthCodeFailure = NetworkFailure.ServerMiscommunication(
+            TestNetworkException.missingAuthenticationCode
+        )
+
+        val (arrangement, loginUseCase) = Arrangement()
+            .withLoginUsingEmailResulting(Either.Left(missingAuthCodeFailure))
+            .withLoginUsingHandleResulting(Either.Left(missingAuthCodeFailure))
+            .arrange()
+
+        // email
+        val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(
+            AuthenticationResult.Failure.InvalidCredentials.Missing2FA,
+            loginEmailResult
+        )
+
+        verify(arrangement.loginRepository).coroutine {
+            loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithHandle)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+
+        // user handle
+        val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(
+            AuthenticationResult.Failure.InvalidCredentials.Missing2FA,
+            loginHandleResult
+        )
+
+        verify(arrangement.loginRepository).coroutine {
+            loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithEmail)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenInvalidAuthenticationCode_whenLoggingIn_thenReturnInvalid2FA() = runTest {
+        val invalidAuthCodeFailure = NetworkFailure.ServerMiscommunication(
+            TestNetworkException.invalidAuthenticationCode
+        )
+
+        val (arrangement, loginUseCase) = Arrangement()
+            .withLoginUsingEmailResulting(Either.Left(invalidAuthCodeFailure))
+            .withLoginUsingHandleResulting(Either.Left(invalidAuthCodeFailure))
+            .arrange()
+
+        // email
+        val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(
+            AuthenticationResult.Failure.InvalidCredentials.Invalid2FA,
+            loginEmailResult
+        )
+
+        verify(arrangement.loginRepository).coroutine {
+            loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithHandle)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+
+        // user handle
+        val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(
+            AuthenticationResult.Failure.InvalidCredentials.Invalid2FA,
+            loginHandleResult
+        )
+
+        verify(arrangement.loginRepository).coroutine {
+            loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithEmail)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenUserHandleWithDots_whenLoggingInUsingUserHandle_thenReturnSuccess() = runTest {
+        val handle = "cool.user"
+
+        val (arrangement, loginUseCase) = Arrangement()
+            .withEmailValidationSucceeding(
+                isSucceeding = false,
+                email = handle
             )
-
-            verify(validateEmailUseCase)
-                .invocation { invoke(cleanHandle) }
-                .wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase)
-                .invocation { invoke(cleanHandle) }
-                .wasInvoked(exactly = once)
-            verify(loginRepository)
-                .coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .wasInvoked(exactly = once)
-
-            verify(loginRepository)
-                .suspendFunction(loginRepository::loginWithEmail)
-                .with(any(), any(), any(), any())
-                .wasNotInvoked()
-        }
-
-    @Test
-    fun givenStoreSessionIsTrue_andEverythingElseSucceeds_whenLoggingInUsingEmail_thenStoreTheSessionAndReturnSuccess() =
-        runTest {
-            val label = "label"
-            given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
-            given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("", listOf()) }
-            given(loginRepository)
-                .coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID) }
-
-            val loginUserCaseResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
-
-            assertEquals(
-                loginUserCaseResult,
-                AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, proxyCredentials)
+            .withHandleValidationReturning(
+                handleValidationResult = ValidateUserHandleResult.Invalid.InvalidCharacters("cooluser", listOf('.')),
+                handle = handle
             )
+            .withLoginUsingHandleResulting(Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID))
+            .arrange()
 
-            verify(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase).function(validateUserHandleUseCase::invoke).with(any()).wasNotInvoked()
-            verify(loginRepository).coroutine {
-                loginWithEmail(TEST_EMAIL, TEST_PASSWORD, label, TEST_PERSIST_CLIENT)
-            }.wasInvoked(exactly = once)
-            verify(loginRepository).suspendFunction(loginRepository::loginWithHandle).with(any(), any(), any(), any()).wasNotInvoked()
-        }
+        val loginUserCaseResult = loginUseCase(handle, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
 
-    @Test
-    fun givenStoreSessionIsTrue_andEverythingElseSucceeds_whenLoggingInUsingUserHandle_thenStoreTheSessionAndReturnSuccess() =
-        runTest {
-            val label = "label"
-            // given
-            given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
-            given(validateUserHandleUseCase).invocation { invoke(TEST_HANDLE) }
-                .then { ValidateUserHandleResult.Valid(TEST_HANDLE) }
-            given(loginRepository).coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }.then {
-                Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID)
-            }
+        assertEquals(
+            AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, PROXY_CREDENTIALS),
+            loginUserCaseResult
+        )
 
-            // when
-            val loginUserCaseResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
+        verify(arrangement.validateEmailUseCase)
+            .invocation { invoke(handle) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.validateUserHandleUseCase)
+            .invocation { invoke(handle) }
+            .wasInvoked(exactly = once)
+        verify(arrangement.loginRepository)
+            .coroutine { loginWithHandle(handle, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT) }
+            .wasInvoked(exactly = once)
 
-            // then
-            assertEquals(
-                loginUserCaseResult,
-                AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, proxyCredentials)
+        verify(arrangement.loginRepository)
+            .suspendFunction(arrangement.loginRepository::loginWithEmail)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val loginRepository = mock(classOf<LoginRepository>())
+
+        @Mock
+        val validateEmailUseCase = mock(classOf<ValidateEmailUseCase>())
+
+        @Mock
+        val validateUserHandleUseCase = mock(classOf<ValidateUserHandleUseCase>())
+
+        init {
+            withEmailValidationSucceeding(true, TEST_EMAIL)
+            withEmailValidationSucceeding(false, TEST_HANDLE)
+            withHandleValidationReturning(ValidateUserHandleResult.Valid(TEST_HANDLE), TEST_HANDLE)
+            withHandleValidationReturning(
+                handleValidationResult = ValidateUserHandleResult.Invalid.InvalidCharacters(
+                    "userexampleorg",
+                    listOf('@', '.')
+                ),
+                handle = TEST_EMAIL
             )
-
-            verify(validateEmailUseCase)
-                .invocation { invoke(TEST_HANDLE) }
-                .wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase)
-                .invocation { invoke(TEST_HANDLE) }
-                .wasInvoked(exactly = once)
-            verify(loginRepository)
-                .coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .wasInvoked(exactly = once)
-            verify(loginRepository)
-                .suspendFunction(loginRepository::loginWithEmail).with(any(), any(), any(), any())
-                .wasNotInvoked()
+            withLoginUsingEmailResulting(Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID))
+            withLoginUsingHandleResulting(Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID))
         }
 
-    @Test
-    fun givenStoreSessionIsFalse_andEverythingElseSucceeds_whenLoggingIn_thenDoNotStoreTheSessionAndReturnSuccess() =
-        runTest {
-            val label: String = "cookie_label"
-
-            given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
-            given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("", listOf()) }
-            given(loginRepository).coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID) }
-
-            val loginUserCaseResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
-
-            assertEquals(
-                loginUserCaseResult,
-                AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, proxyCredentials)
-            )
+        fun withEmailValidationSucceeding(
+            isSucceeding: Boolean,
+            email: String = TEST_EMAIL,
+        ) = apply {
+            given(validateEmailUseCase)
+                .invocation { invoke(email) }
+                .thenReturn(isSucceeding)
         }
 
-    @Test
-    fun givenEmailIsInvalid_whenLoggingInUsingEmail_thenReturnInvalidUserIdentifier() =
-        runTest {
-            val label = "label"
-            given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { false }
-            given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("", listOf()) }
-
-            val loginUserCaseResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
-
-            assertEquals(loginUserCaseResult, AuthenticationResult.Failure.InvalidUserIdentifier)
-
-            verify(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }.wasInvoked(exactly = once)
-        }
-
-    @Test
-    fun givenWrongPassword_whenLoggingIn_thenReturnInvalidCredentials() =
-        runTest {
-            val invalidCredentialsFailure =
-                NetworkFailure.ServerMiscommunication(TestNetworkException.invalidCredentials)
-            val label: String = "cookie_label"
-
-            given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
-            given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("", listOf()) }
-            given(loginRepository).coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Left(invalidCredentialsFailure) }
-
-            given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
-            given(validateUserHandleUseCase).invocation { invoke(TEST_HANDLE) }
-                .then { ValidateUserHandleResult.Valid(TEST_HANDLE) }
-            given(loginRepository).coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Left(invalidCredentialsFailure) }
-
-            // email
-            val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
-            assertEquals(loginEmailResult, AuthenticationResult.Failure.InvalidCredentials)
-
-            verify(validateEmailUseCase)
-                .invocation { invoke(TEST_EMAIL) }
-                .wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase)
-                .function(validateUserHandleUseCase::invoke)
-                .with(any()).wasNotInvoked()
-            verify(loginRepository).coroutine {
-                loginWithEmail(TEST_EMAIL, TEST_PASSWORD, label, TEST_PERSIST_CLIENT)
-            }.wasInvoked(exactly = once)
-            verify(loginRepository)
-                .suspendFunction(loginRepository::loginWithHandle)
-                .with(any(), any(), any(), any())
-                .wasNotInvoked()
-
-            // user handle
-            val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
-            assertEquals(loginHandleResult, AuthenticationResult.Failure.InvalidCredentials)
-
-            verify(validateEmailUseCase)
-                .invocation { invoke(TEST_HANDLE) }
-                .wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase)
-                .invocation { invoke(TEST_HANDLE) }
-                .wasInvoked(exactly = once)
-            verify(loginRepository).coroutine {
-                loginWithHandle(TEST_HANDLE, TEST_PASSWORD, label, TEST_PERSIST_CLIENT)
-            }.wasInvoked(exactly = once)
-            verify(loginRepository)
-                .suspendFunction(loginRepository::loginWithEmail)
-                .with(any(), any(), any(), any())
-                .wasNotInvoked()
-        }
-
-    @Test
-    fun givenBadRequest_whenLoggingIn_thenReturnInvalidCredentials() =
-        runTest {
-            val badRequestFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.badRequest)
-            val label: String = "cookie_label"
-
-            given(validateEmailUseCase).invocation { invoke(TEST_EMAIL) }.then { true }
-            given(validateUserHandleUseCase).invocation { invoke(TEST_EMAIL) }
-                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("", listOf()) }
-            given(loginRepository)
-                .coroutine { loginWithEmail(TEST_EMAIL, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Left(badRequestFailure) }
-
-            given(validateEmailUseCase).invocation { invoke(TEST_HANDLE) }.then { false }
+        fun withHandleValidationReturning(
+            handleValidationResult: ValidateUserHandleResult,
+            handle: String = TEST_HANDLE,
+        ) = apply {
             given(validateUserHandleUseCase)
-                .invocation { invoke(TEST_HANDLE) }
-                .then { ValidateUserHandleResult.Valid(TEST_HANDLE) }
+                .invocation { invoke(handle) }
+                .thenReturn(handleValidationResult)
+        }
+
+        fun withLoginUsingEmailResulting(result: Either<NetworkFailure, Pair<AuthTokens, SsoId?>>) = apply {
             given(loginRepository)
-                .coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Left(badRequestFailure) }
+                .suspendFunction(loginRepository::loginWithEmail)
+                .whenInvokedWith(any(), any(), any(), any())
+                .thenReturn(result)
+        }
 
-            // email
-            val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
-            assertEquals(loginEmailResult, AuthenticationResult.Failure.InvalidCredentials)
-
-            verify(validateEmailUseCase)
-                .invocation { invoke(TEST_EMAIL) }
-                .wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase)
-                .function(validateUserHandleUseCase::invoke)
-                .with(any()).wasNotInvoked()
-            verify(loginRepository).coroutine {
-                loginWithEmail(TEST_EMAIL, TEST_PASSWORD, label, TEST_PERSIST_CLIENT)
-            }.wasInvoked(exactly = once)
-            verify(loginRepository)
+        fun withLoginUsingHandleResulting(result: Either<NetworkFailure, Pair<AuthTokens, SsoId?>>) = apply {
+            given(loginRepository)
                 .suspendFunction(loginRepository::loginWithHandle)
-                .with(any(), any(), any(), any())
-                .wasNotInvoked()
-
-            // user handle
-            val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
-            assertEquals(loginHandleResult, AuthenticationResult.Failure.InvalidCredentials)
-
-            verify(validateEmailUseCase)
-                .invocation { invoke(TEST_HANDLE) }
-                .wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase)
-                .invocation { invoke(TEST_HANDLE) }
-                .wasInvoked(exactly = once)
-            verify(loginRepository).coroutine {
-                loginWithHandle(TEST_HANDLE, TEST_PASSWORD, label, TEST_PERSIST_CLIENT)
-            }.wasInvoked(exactly = once)
-            verify(loginRepository)
-                .suspendFunction(loginRepository::loginWithEmail)
-                .with(any(), any(), any(), any())
-                .wasNotInvoked()
+                .whenInvokedWith(any(), any(), any(), any())
+                .thenReturn(result)
         }
 
-    @Test
-    fun givenUserHandleWithDots_whenLoggingInUsingUserHandle_thenStoreTheSessionAndReturnSuccess() =
-        runTest {
-            val handle = "cool.user"
-            val label: String = "cookie_label"
-            given(validateEmailUseCase).invocation { invoke(handle) }.then { false }
-            given(validateUserHandleUseCase).invocation { invoke(handle) }
-                .then { ValidateUserHandleResult.Invalid.InvalidCharacters("cooluser", listOf('.')) }
-            given(loginRepository)
-                .coroutine { loginWithHandle(handle, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .then { Either.Right(TEST_AUTH_TOKENS to TEST_SSO_ID) }
+        fun arrange(): Pair<Arrangement, LoginUseCase> = this to LoginUseCaseImpl(
+            loginRepository,
+            validateEmailUseCase,
+            validateUserHandleUseCase,
+            TEST_SERVER_CONFIG,
+            PROXY_CREDENTIALS
+        )
 
-            val loginUserCaseResult = loginUseCase(handle, TEST_PASSWORD, TEST_PERSIST_CLIENT, label)
-
-            assertEquals(
-                loginUserCaseResult,
-                AuthenticationResult.Success(TEST_AUTH_TOKENS, TEST_SSO_ID, TEST_SERVER_CONFIG.id, proxyCredentials)
-            )
-
-            verify(validateEmailUseCase)
-                .invocation { invoke(handle) }
-                .wasInvoked(exactly = once)
-            verify(validateUserHandleUseCase)
-                .invocation { invoke(handle) }
-                .wasInvoked(exactly = once)
-            verify(loginRepository)
-                .coroutine { loginWithHandle(handle, TEST_PASSWORD, label, TEST_PERSIST_CLIENT) }
-                .wasInvoked(exactly = once)
-
-            verify(loginRepository)
-                .suspendFunction(loginRepository::loginWithEmail)
-                .with(any(), any(), any(), any())
-                .wasNotInvoked()
-        }
+    }
 
     private companion object {
-        const val TEST_EMAIL = "email@fu-berlin.de"
+        const val TEST_EMAIL = "user@example.org"
         const val TEST_HANDLE = "cool_user"
         const val TEST_PASSWORD = "123456"
+        const val TEST_LABEL = "cookie_label"
+
+        // TODO: Remove random value from tests
         val TEST_PERSIST_CLIENT = Random.nextBoolean()
-        val TEST_SERVER_CONFIG: ServerConfig = newServerConfig(1)
+        val TEST_SERVER_CONFIG: ServerConfig = newTestServer(1)
         val TEST_AUTH_TOKENS = AuthTokens(
             userId = UserId("user_id", "domain.de"),
             accessToken = "access_token",
             refreshToken = "refresh_token",
             tokenType = "token_type",
-            cookieLabel = "cookie_label",
+            cookieLabel = TEST_LABEL,
         )
         val PROXY_CREDENTIALS = ProxyCredentials("user_name", "password")
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.test_util
 
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.network.api.base.model.ErrorResponse
+import com.wire.kalium.network.exceptions.AuthenticationCodeFailure
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import io.ktor.http.HttpStatusCode
@@ -44,6 +45,22 @@ object TestNetworkException {
 
     val invalidCredentials = KaliumException.InvalidRequestError(
         ErrorResponse(403, message = "invalid credentials", label = "invalid-credentials")
+    )
+
+    val missingAuthenticationCode = KaliumException.InvalidRequestError(
+        ErrorResponse(
+            code = 403,
+            message = "missing authentication code",
+            label = AuthenticationCodeFailure.MISSING_AUTHENTICATION_CODE.responseLabel
+        )
+    )
+
+    val invalidAuthenticationCode = KaliumException.InvalidRequestError(
+        ErrorResponse(
+            code = 403,
+            message = "invalid authentication code",
+            label = AuthenticationCodeFailure.INVALID_OR_EXPIRED_AUTHENTICATION_CODE.responseLabel
+        )
     )
 
     val invalidHandle = KaliumException.InvalidRequestError(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/LoginApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/LoginApi.kt
@@ -25,19 +25,37 @@ import com.wire.kalium.network.utils.NetworkResponse
 interface LoginApi {
     sealed class LoginParam(
         open val password: String,
-        open val label: String?
+        open val label: String?,
+        /**
+         * Two-factor authentication code received in the user's email.
+         * Optional as it may or may not be required depending on team settings.
+         * @see VerificationCodeApi
+         */
+        open val verificationCode: String?
     ) {
         data class LoginWithEmail(
             val email: String,
             override val password: String,
-            override val label: String?
-        ) : LoginParam(password, label)
+            override val label: String?,
+            /**
+             * Two-factor authentication code received in the user's email.
+             * Optional as it may or may not be required depending on team settings.
+             * @see VerificationCodeApi
+             */
+            override val verificationCode: String? = null,
+        ) : LoginParam(password, label, verificationCode)
 
         data class LoginWithHandel(
             val handle: String,
             override val password: String,
-            override val label: String?
-        ) : LoginParam(password, label)
+            override val label: String?,
+            /**
+             * Two-factor authentication code received in the user's email.
+             * Optional as it may or may not be required depending on team settings.
+             * @see VerificationCodeApi
+             */
+            override val verificationCode: String? = null,
+        ) : LoginParam(password, label, verificationCode)
     }
 
     suspend fun login(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
@@ -49,7 +49,8 @@ internal open class LoginApiV0 internal constructor(
         @SerialName("email") val email: String? = null,
         @SerialName("handle") val handle: String? = null,
         @SerialName("password") val password: String,
-        @SerialName("label") val label: String?
+        @SerialName("label") val label: String?,
+        @SerialName("verification_code") val verificationCode: String? = null,
     )
 
     private fun LoginApi.LoginParam.toRequestBody(): LoginRequest {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -51,7 +51,7 @@ import com.wire.kalium.network.exceptions.NetworkErrorLabel.UNKNOWN_CLIENT
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.USER_CREATION_RESTRICTED
 import io.ktor.http.HttpStatusCode
 
-sealed class KaliumException() : Exception() {
+sealed class KaliumException : Exception() {
 
     class Unauthorized(val errorCode: Int) : KaliumException()
 
@@ -63,7 +63,7 @@ sealed class KaliumException() : Exception() {
     /**
      * http error 400 .. 499
      */
-    class InvalidRequestError(val errorResponse: ErrorResponse) : KaliumException() {
+    open class InvalidRequestError(val errorResponse: ErrorResponse) : KaliumException() {
         override fun toString(): String {
             return "InvalidRequestError(response = $errorResponse"
         }
@@ -84,7 +84,7 @@ sealed class KaliumException() : Exception() {
      */
     class FederationError(val errorResponse: ErrorResponse) : KaliumException()
 
-    sealed class FeatureError() : KaliumException()
+    sealed class FeatureError : KaliumException()
 }
 
 sealed class SendMessageError : KaliumException.FeatureError() {
@@ -202,3 +202,8 @@ fun KaliumException.InvalidRequestError.isGuestLinkDisabled(): Boolean {
 fun KaliumException.InvalidRequestError.isAccessDenied(): Boolean {
     return errorResponse.label == ACCESS_DENIED
 }
+
+val KaliumException.InvalidRequestError.authenticationCodeFailure: AuthenticationCodeFailure?
+    get() = AuthenticationCodeFailure.values().firstOrNull {
+        errorResponse.label == it.responseLabel
+    }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -52,4 +52,10 @@ internal object NetworkErrorLabel {
     object KaliumCustom {
         const val MISSING_REFRESH_TOKEN = "missing-refresh_token"
     }
+
+}
+
+enum class AuthenticationCodeFailure(val responseLabel: String) {
+    MISSING_AUTHENTICATION_CODE("code-authentication-required"),
+    INVALID_OR_EXPIRED_AUTHENTICATION_CODE("code-authentication-failed");
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`login` endpoint now returns two new error messages, as seen in the [tech spec](https://wearezeta.atlassian.net/wiki/spaces/SER/pages/557580675/Tech+spec+BSI+-+1.8+Improve+User+Authentication#Additional-failure-responses):

* `403 code-authentication-required`
* `403 code-authentication-failed`

### Solutions

Handle these failures, making sure they're reflected on the UseCase, so the UI can figure out what to do.

I kept the `InvalidCredentials` class, but add children to it so the UI can figure out what to do.

### Testing

Most of this PR changes are refactoring the `LoginUseCaseTest` so it now has a `Arrangement` to simplify stuff. Otherwise this PR wouldn't be so big.
#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
