### PR TITLE
fix(dev): reset exponential value after successful incremental sync

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.network.NetworkStateObserver
 import com.wire.kalium.logic.sync.SyncExceptionHandler
 import com.wire.kalium.logic.sync.slow.SlowSyncManager
 import com.wire.kalium.logic.util.ExponentialDurationHelper
+import com.wire.kalium.logic.util.ExponentialDurationHelperImpl
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -67,13 +68,15 @@ import kotlin.time.Duration.Companion.seconds
  * @see Event
  * @see SlowSyncManager
  */
+@Suppress("LongParameterList")
 internal class IncrementalSyncManager(
     private val slowSyncRepository: SlowSyncRepository,
     private val incrementalSyncWorker: IncrementalSyncWorker,
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val incrementalSyncRecoveryHandler: IncrementalSyncRecoveryHandler,
     private val networkStateObserver: NetworkStateObserver,
-    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
+    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl,
+    private val exponentialDurationHelper: ExponentialDurationHelper = ExponentialDurationHelperImpl(MIN_RETRY_DELAY, MAX_RETRY_DELAY)
 ) {
 
     /**
@@ -82,7 +85,6 @@ internal class IncrementalSyncManager(
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     private val eventProcessingDispatcher = kaliumDispatcher.default.limitedParallelism(1)
-    private val exponentialDurationHelper = ExponentialDurationHelper(MIN_RETRY_DELAY, MAX_RETRY_DELAY)
 
     private val coroutineExceptionHandler = SyncExceptionHandler(
         onCancellation = {
@@ -146,7 +148,10 @@ internal class IncrementalSyncManager(
             .collect {
                 val newState = when (it) {
                     EventSource.PENDING -> IncrementalSyncStatus.FetchingPendingEvents
-                    EventSource.LIVE -> IncrementalSyncStatus.Live
+                    EventSource.LIVE -> {
+                        exponentialDurationHelper.reset()
+                        IncrementalSyncStatus.Live
+                    }
                 }
                 incrementalSyncRepository.updateIncrementalSyncState(newState)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/ExponentialDurationHelper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/ExponentialDurationHelper.kt
@@ -19,18 +19,23 @@ package com.wire.kalium.logic.util
 
 import kotlin.time.Duration
 
-class ExponentialDurationHelper(
+interface ExponentialDurationHelper {
+    fun reset()
+    fun next(): Duration
+}
+
+class ExponentialDurationHelperImpl(
     private val initialDuration: Duration,
     private val maxDuration: Duration,
     private val factor: Double = 2.0,
-) {
+) : ExponentialDurationHelper {
     private var currentDuration = initialDuration
 
-    fun reset() {
+    override fun reset() {
         currentDuration = initialDuration
     }
 
-    fun next(): Duration = currentDuration.also {
+    override fun next(): Duration = currentDuration.also {
         currentDuration = currentDuration.times(factor).coerceAtMost(maxDuration)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.network.NetworkState
 import com.wire.kalium.logic.network.NetworkStateObserver
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import com.wire.kalium.logic.util.ExponentialDurationHelper
 import com.wire.kalium.logic.util.flowThatFailsOnFirstTime
 import com.wire.kalium.persistence.TestUserDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -54,6 +55,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class IncrementalSyncManagerTest {
@@ -263,6 +266,40 @@ class IncrementalSyncManagerTest {
                 .wasInvoked(exactly = twice)
         }
 
+    @Test
+    fun givenBothSyncsAreCompleted_whenWorkerEmitsSources_thenShouldResetExponentialDuration() = runTest(TestKaliumDispatcher.default) {
+        val sourceFlow = Channel<EventSource>(Channel.UNLIMITED)
+
+        val (arrangement, _) = Arrangement()
+            .withWorkerReturning(sourceFlow.consumeAsFlow())
+            .withKeepAliveConnectionPolicy()
+            .arrange()
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+        sourceFlow.send(EventSource.LIVE)
+        advanceUntilIdle()
+
+        verify(arrangement.exponentialDurationHelper)
+            .function(arrangement.exponentialDurationHelper::reset)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSlowSyncIsCompleted_whenRecovers_thenShouldCalculateNextExponentialDelay() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, _) = Arrangement()
+            .withWorkerReturning(flowThatFailsOnFirstTime())
+            .withDisconnectConnectionPolicy()
+            .withRecoveringFromFailure()
+            .withNextExponentialDuration(10.seconds)
+            .arrange()
+
+        arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+        advanceUntilIdle()
+
+        verify(arrangement.exponentialDurationHelper)
+            .function(arrangement.exponentialDurationHelper::next)
+            .wasInvoked(exactly = once)
+    }
     private class Arrangement {
 
         val database = TestUserDatabase(UserIDEntity("SELF_USER", "DOMAIN"))
@@ -280,6 +317,10 @@ class IncrementalSyncManagerTest {
         @Mock
         val networkStateObserver: NetworkStateObserver = mock(classOf<NetworkStateObserver>())
 
+        @Mock
+        val exponentialDurationHelper: ExponentialDurationHelper =
+            configure(mock(classOf<ExponentialDurationHelper>())) { stubsUnitByDefault = true }
+
         private val incrementalSyncManager by lazy {
             IncrementalSyncManager(
                 slowSyncRepository = slowSyncRepository,
@@ -288,11 +329,13 @@ class IncrementalSyncManagerTest {
                 incrementalSyncRecoveryHandler = incrementalSyncRecoveryHandler,
                 networkStateObserver = networkStateObserver,
                 kaliumDispatcher = TestKaliumDispatcher,
+                exponentialDurationHelper = exponentialDurationHelper,
             )
         }
 
         init {
             withNetworkState(MutableStateFlow(NetworkState.ConnectedWithInternet))
+            withNextExponentialDuration(10.seconds)
         }
 
         fun withWorkerReturning(sourceFlow: Flow<EventSource>) = apply {
@@ -335,6 +378,13 @@ class IncrementalSyncManagerTest {
                 .function(networkStateObserver::observeNetworkState)
                 .whenInvoked()
                 .thenReturn(networkStateFlow)
+        }
+
+        fun withNextExponentialDuration(duration: Duration) = apply {
+            given(exponentialDurationHelper)
+                .function(exponentialDurationHelper::next)
+                .whenInvoked()
+                .thenReturn(duration)
         }
 
         fun arrange() = this to incrementalSyncManager

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.sync.SlowSyncStep
 import com.wire.kalium.logic.network.NetworkState
 import com.wire.kalium.logic.network.NetworkStateObserver
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import com.wire.kalium.logic.util.ExponentialDurationHelper
 import com.wire.kalium.logic.util.flowThatFailsOnFirstTime
 import com.wire.kalium.util.DateTimeUtil
 import io.mockative.Mock
@@ -57,7 +58,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SlowSyncManagerTest {
@@ -309,6 +312,35 @@ class SlowSyncManagerTest {
         assertFalse(isCollected)
     }
 
+    @Test
+    fun givenCriteriaAreMet_whenStepsAreOver_thenShouldResetExponentialDuration() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, _) = Arrangement()
+            .withSatisfiedCriteria()
+            .withSlowSyncWorkerReturning(emptyFlow())
+            .arrange()
+
+        advanceUntilIdle()
+
+        verify(arrangement.exponentialDurationHelper)
+            .function(arrangement.exponentialDurationHelper::reset)
+            .wasInvoked(exactly = once)
+    }
+    @Test
+    fun givenCriteriaAreMet_whenRecovers_thenShouldRetry() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, _) = Arrangement()
+            .withSatisfiedCriteria()
+            .withSlowSyncWorkerReturning(flowThatFailsOnFirstTime())
+            .withRecoveringFromFailure()
+            .withNextExponentialDuration(10.seconds)
+            .arrange()
+
+        advanceUntilIdle()
+
+        verify(arrangement.exponentialDurationHelper)
+            .function(arrangement.exponentialDurationHelper::next)
+            .wasInvoked(exactly = once)
+    }
+
     private class Arrangement {
 
         @Mock
@@ -326,9 +358,14 @@ class SlowSyncManagerTest {
         @Mock
         val networkStateObserver: NetworkStateObserver = mock(classOf<NetworkStateObserver>())
 
+        @Mock
+        val exponentialDurationHelper: ExponentialDurationHelper =
+            configure(mock(classOf<ExponentialDurationHelper>())) { stubsUnitByDefault = true }
+
         init {
             withLastSlowSyncPerformedAt(flowOf(null))
             withNetworkState(MutableStateFlow(NetworkState.ConnectedWithInternet))
+            withNextExponentialDuration(10.seconds)
         }
 
         fun withCriteriaProviderReturning(criteriaFlow: Flow<SyncCriteriaResolution>) = apply {
@@ -368,13 +405,21 @@ class SlowSyncManagerTest {
                 .thenReturn(networkStateFlow)
         }
 
+        fun withNextExponentialDuration(duration: Duration) = apply {
+            given(exponentialDurationHelper)
+                .function(exponentialDurationHelper::next)
+                .whenInvoked()
+                .thenReturn(duration)
+        }
+
         private val slowSyncManager = SlowSyncManager(
-            slowSyncCriteriaProvider,
-            slowSyncRepository,
-            slowSyncWorker,
-            slowSyncRecoveryHandler,
-            networkStateObserver,
-            TestKaliumDispatcher
+            slowSyncCriteriaProvider = slowSyncCriteriaProvider,
+            slowSyncRepository = slowSyncRepository,
+            slowSyncWorker = slowSyncWorker,
+            slowSyncRecoveryHandler = slowSyncRecoveryHandler,
+            networkStateObserver = networkStateObserver,
+            kaliumDispatcher = TestKaliumDispatcher,
+            exponentialDurationHelper = exponentialDurationHelper,
         )
 
         fun arrange() = this to slowSyncManager


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Right now, after every failed incremental sync attempt, the exponential value that's used to retry is increased, but it's not reset after a success, so after some failures it can unnecessarily delay the sync for longer that it should.

### Solutions

Reset the value after a successful incremental sync.
