### PR TITLE
feat: request second factor authentication code (AR-3088)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/verification/SecondFactorVerificationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/verification/SecondFactorVerificationRepository.kt
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.auth.verification
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.network.api.base.unauthenticated.VerificationCodeApi
+
+interface SecondFactorVerificationRepository {
+
+    suspend fun requestVerificationCode(
+        email: String,
+        verifiableAction: VerifiableAction,
+    ): Either<NetworkFailure, Unit>
+
+}
+
+internal class SecondFactorVerificationRepositoryImpl(
+    private val verificationCodeApi: VerificationCodeApi
+) : SecondFactorVerificationRepository {
+
+    override suspend fun requestVerificationCode(
+        email: String,
+        verifiableAction: VerifiableAction,
+    ): Either<NetworkFailure, Unit> = wrapApiRequest {
+        val action = when (verifiableAction) {
+            VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION -> VerificationCodeApi.ActionToBeVerified.LOGIN_OR_CLIENT_REGISTRATION
+            VerifiableAction.CREATE_SCIM_TOKEN -> VerificationCodeApi.ActionToBeVerified.CREATE_SCIM_TOKEN
+            VerifiableAction.DELETE_TEAM -> VerificationCodeApi.ActionToBeVerified.DELETE_TEAM
+        }
+        verificationCodeApi.sendVerificationCode(email, action)
+    }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/verification/VerifiableAction.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/verification/VerifiableAction.kt
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.auth.verification
+
+/**
+ * Actions that might require a second factor verification code.
+ */
+enum class VerifiableAction {
+    LOGIN_OR_CLIENT_REGISTRATION,
+    CREATE_SCIM_TOKEN,
+    DELETE_TEAM
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -26,12 +26,15 @@ import com.wire.kalium.logic.data.auth.login.LoginRepositoryImpl
 import com.wire.kalium.logic.data.auth.login.ProxyCredentials
 import com.wire.kalium.logic.data.auth.login.SSOLoginRepository
 import com.wire.kalium.logic.data.auth.login.SSOLoginRepositoryImpl
+import com.wire.kalium.logic.data.auth.verification.SecondFactorVerificationRepository
+import com.wire.kalium.logic.data.auth.verification.SecondFactorVerificationRepositoryImpl
 import com.wire.kalium.logic.data.register.RegisterAccountDataSource
 import com.wire.kalium.logic.data.register.RegisterAccountRepository
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.appVersioning.CheckIfUpdateRequiredUseCase
 import com.wire.kalium.logic.feature.appVersioning.CheckIfUpdateRequiredUseCaseImpl
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginScope
+import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.register.RegisterScope
 import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkContainer
 import io.ktor.util.collections.ConcurrentMap
@@ -72,6 +75,9 @@ class AuthenticationScope(
     private val ssoLoginRepository: SSOLoginRepository
         get() = SSOLoginRepositoryImpl(unauthenticatedNetworkContainer.sso)
 
+    private val secondFactorVerificationRepository: SecondFactorVerificationRepository
+        get() = SecondFactorVerificationRepositoryImpl(unauthenticatedNetworkContainer.verificationCodeApi)
+
     private val validateEmailUseCase: ValidateEmailUseCase get() = ValidateEmailUseCaseImpl()
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
 
@@ -86,6 +92,8 @@ class AuthenticationScope(
             serverConfig,
             proxyCredentials
         )
+    val requestSecondFactorVerificationCode: RequestSecondFactorVerificationCodeUseCase
+        get() = RequestSecondFactorVerificationCodeUseCase(secondFactorVerificationRepository)
     val registerScope: RegisterScope
         get() = RegisterScope(registerAccountRepository, serverConfig, proxyCredentials)
     val ssoLoginScope: SSOLoginScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/verification/RequestSecondFactorVerificationCodeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/verification/RequestSecondFactorVerificationCodeUseCase.kt
@@ -1,0 +1,65 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.auth.verification
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.auth.verification.SecondFactorVerificationRepository
+import com.wire.kalium.logic.data.auth.verification.VerifiableAction
+import com.wire.kalium.logic.feature.register.RequestActivationCodeUseCase
+import com.wire.kalium.logic.functional.fold
+
+/**
+ * Sends a verification code to an email.
+ *
+ * This code might be required when performing actions, such as:
+ * - Logging in or registering a new client;
+ * - Creating a SCIM token;
+ * - Deleting a team.
+ * See [VerifiableAction] for more.
+ *
+ * This is unrelated to [RequestActivationCodeUseCase], which is
+ * used when registering a new account.
+ *
+ * The user must open their email inbox and check the verification code.
+ * When invoking UseCases related to the actions mentioned above,
+ * the code must be provided in order to get a successful response.
+ *
+ * ## Important!
+ * In order to do not leak valid emails, the backend will return
+ * a successful response even if the email is not registered.
+ *
+ * @see VerifiableAction
+ */
+class RequestSecondFactorVerificationCodeUseCase(
+    private val secondFactorVerificationRepository: SecondFactorVerificationRepository,
+) {
+
+    suspend operator fun invoke(
+        email: String,
+        verifiableAction: VerifiableAction,
+    ): Result = secondFactorVerificationRepository.requestVerificationCode(email, verifiableAction).fold({
+        Result.Failure(it)
+    }, {
+        Result.Success
+    })
+
+    interface Result {
+        object Success : Result
+        data class Failure(val cause: CoreFailure) : Result
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/verification/SecondFactorVerificationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/verification/SecondFactorVerificationRepositoryTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.auth.verification
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.test_util.TestNetworkException
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.base.unauthenticated.VerificationCodeApi
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.http.HttpStatusCode
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class SecondFactorVerificationRepositoryTest {
+
+    @Test
+    fun givenApiSucceeds_whenInvokingSendVerificationCode_thenShouldPropagateSuccess() = runTest {
+        val (_, secondFactorVerificationRepository) = Arrangement()
+            .withCodeRequestSucceeding()
+            .arrange()
+
+        val result = secondFactorVerificationRepository.requestVerificationCode(
+            EMAIL,
+            VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION
+        )
+
+        result.shouldSucceed()
+    }
+
+    @Test
+    fun givenApiFails_whenInvokingSendVerificationCode_thenShouldPropagateFailure() = runTest {
+        val failure = TestNetworkException.badRequest
+        val (_, secondFactorVerificationRepository) = Arrangement()
+            .withCodeRequestFailingWith(failure)
+            .arrange()
+
+        val result = secondFactorVerificationRepository.requestVerificationCode(
+            EMAIL,
+            VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION
+        )
+
+        result.shouldFail { networkFailure ->
+            assertIs<NetworkFailure.ServerMiscommunication>(networkFailure)
+            assertEquals(networkFailure.kaliumException, failure)
+        }
+    }
+
+    @Test
+    fun givenAnEmail_whenInvokingSendVerificationCode_thenShouldPassTheCorrectEmailToTheApiSuccess() = runTest {
+        val (arrangement, secondFactorVerificationRepository) = Arrangement()
+            .withCodeRequestSucceeding()
+            .arrange()
+
+        secondFactorVerificationRepository.requestVerificationCode(
+            EMAIL,
+            VerifiableAction.LOGIN_OR_CLIENT_REGISTRATION
+        )
+
+        verify(arrangement.verificationCodeApi)
+            .suspendFunction(arrangement.verificationCodeApi::sendVerificationCode)
+            .with(eq(EMAIL), any())
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val verificationCodeApi = mock(classOf<VerificationCodeApi>())
+
+        fun withCodeRequestSucceeding() = withCodeRequestReturning(
+            NetworkResponse.Success(
+                value = Unit,
+                headers = mapOf(),
+                httpCode = HttpStatusCode.OK.value
+            )
+        )
+
+        fun withCodeRequestFailingWith(kaliumException: KaliumException) = withCodeRequestReturning(
+            NetworkResponse.Error(kaliumException)
+        )
+
+        fun withCodeRequestReturning(networkResponse: NetworkResponse<Unit>) = apply {
+            given(verificationCodeApi)
+                .suspendFunction(verificationCodeApi::sendVerificationCode)
+                .whenInvokedWith(any(), any())
+                .thenReturn(networkResponse)
+        }
+
+        fun arrange(): Pair<Arrangement, SecondFactorVerificationRepository> =
+            this to SecondFactorVerificationRepositoryImpl(verificationCodeApi)
+
+    }
+
+    private companion object {
+        const val EMAIL = "email"
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When failing to login or register client due to lack of 2FA code, we need to be able to request a new code to be sent via email

### Solutions

Add a simple Repository/UseCase pair to expose this API call to the clients.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
