### PR TITLE
refactor: clean up UserSessionScope

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/IdProviders.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/IdProviders.kt
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.functional.Either
+
+fun interface CurrentClientIdProvider {
+    suspend operator fun invoke(): Either<CoreFailure, ClientId>
+}
+
+fun interface SelfTeamIdProvider {
+    suspend operator fun invoke(): Either<CoreFailure, TeamId?>
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -111,12 +111,10 @@ import com.wire.kalium.logic.feature.auth.ClearUserDataUseCase
 import com.wire.kalium.logic.feature.auth.ClearUserDataUseCaseImpl
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
 import com.wire.kalium.logic.feature.auth.LogoutUseCaseImpl
+import com.wire.kalium.logic.feature.backup.BackupScope
 import com.wire.kalium.logic.feature.backup.CreateBackupUseCase
-import com.wire.kalium.logic.feature.backup.CreateBackupUseCaseImpl
 import com.wire.kalium.logic.feature.backup.RestoreBackupUseCase
-import com.wire.kalium.logic.feature.backup.RestoreBackupUseCaseImpl
 import com.wire.kalium.logic.feature.backup.VerifyBackupUseCase
-import com.wire.kalium.logic.feature.backup.VerifyBackupUseCaseImpl
 import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.call.CallsScope
 import com.wire.kalium.logic.feature.call.GlobalCallManager
@@ -160,16 +158,10 @@ import com.wire.kalium.logic.feature.keypackage.KeyPackageManagerImpl
 import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCase
 import com.wire.kalium.logic.feature.message.AddSystemMessageToAllConversationsUseCaseImpl
 import com.wire.kalium.logic.feature.message.EphemeralNotificationsManager
-import com.wire.kalium.logic.feature.message.MLSMessageCreator
-import com.wire.kalium.logic.feature.message.MLSMessageCreatorImpl
-import com.wire.kalium.logic.feature.message.MessageEnvelopeCreator
-import com.wire.kalium.logic.feature.message.MessageEnvelopeCreatorImpl
 import com.wire.kalium.logic.feature.message.MessageScope
 import com.wire.kalium.logic.feature.message.MessageSendingScheduler
 import com.wire.kalium.logic.feature.message.PendingProposalScheduler
 import com.wire.kalium.logic.feature.message.PendingProposalSchedulerImpl
-import com.wire.kalium.logic.feature.message.SessionEstablisher
-import com.wire.kalium.logic.feature.message.SessionEstablisherImpl
 import com.wire.kalium.logic.feature.migration.MigrationScope
 import com.wire.kalium.logic.feature.notificationToken.PushTokenUpdater
 import com.wire.kalium.logic.feature.session.GetProxyCredentialsUseCase
@@ -270,7 +262,6 @@ import com.wire.kalium.logic.sync.slow.SlowSyncRecoveryHandlerImpl
 import com.wire.kalium.logic.sync.slow.SlowSyncWorker
 import com.wire.kalium.logic.sync.slow.SlowSyncWorkerImpl
 import com.wire.kalium.logic.util.MessageContentEncoder
-import com.wire.kalium.logic.util.SecurityHelperImpl
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
 import com.wire.kalium.persistence.client.ClientRegistrationStorageImpl
@@ -283,14 +274,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
 import kotlin.coroutines.CoroutineContext
-
-fun interface CurrentClientIdProvider {
-    suspend operator fun invoke(): Either<CoreFailure, ClientId>
-}
-
-fun interface SelfTeamIdProvider {
-    suspend operator fun invoke(): Either<CoreFailure, TeamId?>
-}
 
 @Suppress("LongParameterList", "LargeClass")
 class UserSessionScope internal constructor(
@@ -492,27 +475,24 @@ class UserSessionScope internal constructor(
             userSearchApiWrapper
         )
 
-    val createBackup: CreateBackupUseCase
-        get() = CreateBackupUseCaseImpl(
+    val backup: BackupScope
+        get() = BackupScope(
             userId,
             clientIdProvider,
             userRepository,
             kaliumFileSystem,
-            userStorage.database.databaseExporter,
-            securityHelper = SecurityHelperImpl(globalPreferences.passphraseStorage)
+            userStorage,
+            globalPreferences
         )
 
-    val verifyBackupUseCase: VerifyBackupUseCase
-        get() = VerifyBackupUseCaseImpl(kaliumFileSystem)
+    @Deprecated("UseCases should be in their respective scopes", ReplaceWith("backup.create"))
+    val createBackup: CreateBackupUseCase get() = backup.create
 
-    val restoreBackup: RestoreBackupUseCase
-        get() = RestoreBackupUseCaseImpl(
-            userStorage.database.databaseImporter,
-            kaliumFileSystem,
-            userId,
-            userRepository,
-            clientIdProvider
-        )
+    @Deprecated("UseCases should be in their respective scopes", ReplaceWith("backup.verify"))
+    val verifyBackupUseCase: VerifyBackupUseCase get() = backup.verify
+
+    @Deprecated("UseCases should be in their respective scopes", ReplaceWith("backup.restore"))
+    val restoreBackup: RestoreBackupUseCase get() = backup.restore
 
     val persistMessage: PersistMessageUseCase
         get() = PersistMessageUseCaseImpl(messageRepository, userId)
@@ -558,19 +538,6 @@ class UserSessionScope internal constructor(
             userStorage.database.clientDAO,
         )
 
-    private val sessionEstablisher: SessionEstablisher
-        get() = SessionEstablisherImpl(authenticatedDataSourceSet.proteusClientProvider, preKeyRepository, userStorage.database.clientDAO)
-
-    private val messageEnvelopeCreator: MessageEnvelopeCreator
-        get() = MessageEnvelopeCreatorImpl(
-            proteusClientProvider = authenticatedDataSourceSet.proteusClientProvider, selfUserId = userId
-        )
-
-    private val mlsMessageCreator: MLSMessageCreator
-        get() = MLSMessageCreatorImpl(
-            mlsClientProvider = mlsClientProvider, selfUserId = userId
-        )
-
     private val messageSendingScheduler: MessageSendingScheduler
         get() = authenticatedDataSourceSet.userSessionWorkScheduler
 
@@ -611,7 +578,7 @@ class UserSessionScope internal constructor(
     private val syncConversations: SyncConversationsUseCase
         get() = SyncConversationsUseCase(conversationRepository)
 
-    internal val syncConnections: SyncConnectionsUseCase
+    private val syncConnections: SyncConnectionsUseCase
         get() = SyncConnectionsUseCaseImpl(
             connectionRepository = connectionRepository
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupScope.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.backup
+
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.di.UserStorage
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
+import com.wire.kalium.logic.util.SecurityHelperImpl
+import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
+
+class BackupScope internal constructor(
+    private val userId: UserId,
+    private val clientIdProvider: CurrentClientIdProvider,
+    private val userRepository: UserRepository,
+    private val kaliumFileSystem: KaliumFileSystem,
+    private val userStorage: UserStorage,
+    val globalPreferences: GlobalPrefProvider,
+) {
+    val create: CreateBackupUseCase
+        get() = CreateBackupUseCaseImpl(
+            userId,
+            clientIdProvider,
+            userRepository,
+            kaliumFileSystem,
+            userStorage.database.databaseExporter,
+            securityHelper = SecurityHelperImpl(globalPreferences.passphraseStorage)
+        )
+
+    val verify: VerifyBackupUseCase
+        get() = VerifyBackupUseCaseImpl(kaliumFileSystem)
+
+    val restore: RestoreBackupUseCase
+        get() = RestoreBackupUseCaseImpl(
+            userStorage.database.databaseImporter,
+            kaliumFileSystem,
+            userId,
+            userRepository,
+            clientIdProvider
+        )
+}


### PR DESCRIPTION
Move backup-specific stuff to its own scope, making the current one @Deprecated. Also, remove some message-sending instances

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`UserSessionScope` is bloated with stuff. We need to start reducing and scoping things to make it more maintainable.

It's so long and confusing, in fact, that it's hard to use.
It has become a jack-of-all-trades, and a place where UseCases without groups go to meet other random misfits.
`userScope.restoreBackup` and `userScope.observeSyncState` can be in the same instance, for example.

It's also error prone, as seen in this PR, there's unused code in there that went unnoticed.

### Solutions

- Remove the unused code
- Move Backup-related UseCases to a `BackupScope`.
- Move the `IdProviders` to their own file.

This currently _adds_ a bit of code, as it keeps the old UseCases with `@Deprecated` annotation and adds the `BackupScope` class. Also, some extra `+++` due to Copyright headers.

> **Note**: This is just a first step, a quick-win that I found. I want to revisit this in the future and bring more changes aboard.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
