### PR TITLE
feat: Wipe data when wipe on device removal or cookie invalid [AR-3140]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1078,7 +1078,8 @@ class UserSessionScope internal constructor(
             userSessionScopeProvider,
             pushTokenRepository,
             globalScope,
-            authenticatedDataSourceSet.userSessionWorkScheduler
+            authenticatedDataSourceSet.userSessionWorkScheduler,
+            kaliumConfigs
         )
     val persistPersistentWebSocketConnectionStatus: PersistPersistentWebSocketConnectionStatusUseCase
         get() = PersistPersistentWebSocketConnectionStatusUseCaseImpl(userId, globalScope.sessionRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -80,22 +80,26 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
                         wipeTokenAndMetadata()
                     }
                 }
-
-                LogoutReason.SELF_SOFT_LOGOUT, LogoutReason.SESSION_EXPIRED -> {
+                LogoutReason.SESSION_EXPIRED -> {
                     if (kaliumConfigs.wipeOnCookieInvalid) {
                         wipeAllData()
                     } else {
-                        clientRepository.clearCurrentClientId()
-                        // After logout we need to mark the Firebase token as invalid
-                        // locally so that we can register a new one on the next login.
-                        pushTokenRepository.setUpdateFirebaseTokenFlag(true)
+                        clearCurrentClientIdAndFirebaseTokenFlag()
                     }
                 }
+                LogoutReason.SELF_SOFT_LOGOUT -> clearCurrentClientIdAndFirebaseTokenFlag()
             }
 
             userSessionScopeProvider.get(userId)?.cancel()
             userSessionScopeProvider.delete(userId)
         }
+    }
+
+    private suspend fun clearCurrentClientIdAndFirebaseTokenFlag() {
+        clientRepository.clearCurrentClientId()
+        // After logout we need to mark the Firebase token as invalid
+        // locally so that we can register a new one on the next login.
+        pushTokenRepository.setUpdateFirebaseTokenFlag(true)
     }
 
     private suspend fun wipeAllData() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -37,5 +37,7 @@ data class KaliumConfigs(
     val blacklistHost: String = "",
     val maxAccount: Int = 0,
     val developmentApiEnabled: Boolean = false,
-    val guestRoomLink: Boolean = true
+    val guestRoomLink: Boolean = true,
+    val wipeOnCookieInvalid: Boolean = false,
+    val wipeOnDeviceRemoval: Boolean = false
 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.UserSessionScopeProvider
 import com.wire.kalium.logic.feature.client.ClearClientDataUseCase
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCase
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.UserSessionWorkScheduler
 import io.mockative.Mock
@@ -114,6 +115,58 @@ class LogoutUseCaseTest {
             .withClearRetainedClientIdResult(Either.Right(Unit))
             .withUserSessionScopeGetResult(null)
             .withFirebaseTokenUpdate()
+            .arrange()
+
+        logoutUseCase.invoke(reason)
+        arrangement.globalTestScope.advanceUntilIdle()
+
+        verify(arrangement.clearClientDataUseCase)
+            .suspendFunction(arrangement.clearClientDataUseCase::invoke)
+            .wasInvoked(exactly = once)
+        verify(arrangement.clearUserDataUseCase)
+            .suspendFunction(arrangement.clearUserDataUseCase::invoke)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenRemovedClientOrDeletedAccount_whenLoggingOutWithWipeOnDeviceRemovalEnabled_thenExecuteAllRequiredActions() = runTest {
+        val reason = LogoutReason.REMOVED_CLIENT
+        val (arrangement, logoutUseCase) = Arrangement()
+            .withLogoutResult(Either.Right(Unit))
+            .withSessionLogoutResult(Either.Right(Unit))
+            .withAllValidSessionsResult(Either.Right(listOf(Arrangement.VALID_ACCOUNT_INFO)))
+            .withDeregisterTokenResult(DeregisterTokenUseCase.Result.Success)
+            .withClearCurrentClientIdResult(Either.Right(Unit))
+            .withClearRetainedClientIdResult(Either.Right(Unit))
+            .withUserSessionScopeGetResult(null)
+            .withFirebaseTokenUpdate()
+            .withKaliumConfigs { it.copy(wipeOnDeviceRemoval = true) }
+            .arrange()
+
+        logoutUseCase.invoke(reason)
+        arrangement.globalTestScope.advanceUntilIdle()
+
+        verify(arrangement.clearClientDataUseCase)
+            .suspendFunction(arrangement.clearClientDataUseCase::invoke)
+            .wasInvoked(exactly = once)
+        verify(arrangement.clearUserDataUseCase)
+            .suspendFunction(arrangement.clearUserDataUseCase::invoke)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSessionExpired_whenLoggingOutWithWipeOnInvalidCookieEnabled_thenExecuteAllRequiredActions() = runTest {
+        val reason = LogoutReason.SESSION_EXPIRED
+        val (arrangement, logoutUseCase) = Arrangement()
+            .withLogoutResult(Either.Right(Unit))
+            .withSessionLogoutResult(Either.Right(Unit))
+            .withAllValidSessionsResult(Either.Right(listOf(Arrangement.VALID_ACCOUNT_INFO)))
+            .withDeregisterTokenResult(DeregisterTokenUseCase.Result.Success)
+            .withClearCurrentClientIdResult(Either.Right(Unit))
+            .withClearRetainedClientIdResult(Either.Right(Unit))
+            .withUserSessionScopeGetResult(null)
+            .withFirebaseTokenUpdate()
+            .withKaliumConfigs { it.copy(wipeOnCookieInvalid = true) }
             .arrange()
 
         logoutUseCase.invoke(reason)
@@ -219,9 +272,12 @@ class LogoutUseCaseTest {
         @Mock
         val userSessionWorkScheduler = configure(mock(classOf<UserSessionWorkScheduler>())) { stubsUnitByDefault = true }
 
+        var kaliumConfigs = KaliumConfigs()
+
         val globalTestScope = TestScope()
 
-        private val logoutUseCase: LogoutUseCase = LogoutUseCaseImpl(
+        private val logoutUseCase
+            get() = LogoutUseCaseImpl(
             logoutRepository,
             sessionRepository,
             clientRepository,
@@ -232,7 +288,8 @@ class LogoutUseCaseTest {
             userSessionScopeProvider,
             pushTokenRepository,
             globalTestScope,
-            userSessionWorkScheduler
+            userSessionWorkScheduler,
+            kaliumConfigs
         )
 
         fun withDeregisterTokenResult(result: DeregisterTokenUseCase.Result): Arrangement {
@@ -304,6 +361,10 @@ class LogoutUseCaseTest {
                 .suspendFunction(pushTokenRepository::setUpdateFirebaseTokenFlag)
                 .whenInvokedWith(any())
                 .thenReturn(Either.Right(Unit))
+        }
+
+        fun withKaliumConfigs(changeConfigs: (KaliumConfigs) -> KaliumConfigs) = apply {
+            this.kaliumConfigs = changeConfigs(this.kaliumConfigs)
         }
 
         fun arrange() = this to logoutUseCase


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Added config flags `wipeOnCookieInvalid` and `wipeOnDeviceRemoval` to control if after logout by reason `DELETED_ACCOUNT`, `REMOVED_CLIENT` or `SESSION_EXPIRED` should wipe all user data

Documentation links:
- https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/157321371/Use+case+delete+local+data+if+the+cookie+is+invalid
- https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/763166985/Use+case+delete+local+data+when+noticing+that+the+account+or+client+get+deleted


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
