### PR TITLE
feat: automatically reuse 2fa codes when registering client (AR-3088)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -80,6 +80,7 @@ actual class CoreLogic(
 
     override val userSessionScopeProvider: Lazy<UserSessionScopeProvider> = lazy {
         UserSessionScopeProviderImpl(
+            authenticationScopeProvider,
             rootPathsProvider,
             appContext,
             getGlobalScope(),

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.logic.di.UserStorageProvider
+import com.wire.kalium.logic.feature.auth.AuthenticationScopeProvider
 import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.featureFlags.FeatureSupportImpl
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
@@ -41,6 +42,7 @@ import com.wire.kalium.network.api.base.model.UserId as UserIdDTO
 
 @Suppress("LongParameterList")
 internal actual class UserSessionScopeProviderImpl(
+    private val authenticationScopeProvider: AuthenticationScopeProvider,
     private val rootPathsProvider: RootPathsProvider,
     private val appContext: Context,
     private val globalScope: GlobalKaliumScope,
@@ -76,6 +78,10 @@ internal actual class UserSessionScopeProviderImpl(
         val userDataSource = AuthenticatedDataSourceSet(
             rootAccountPath,
             networkContainer,
+            authenticationScopeProvider.provide(
+                sessionManager.getServerConfig(),
+                sessionManager.getProxyCredentials()
+            ),
             proteusClientProvider,
             userSessionWorkScheduler
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -53,7 +53,7 @@ abstract class CoreLogicCommon internal constructor(
     protected val userStorageProvider: UserStorageProvider = PlatformUserStorageProvider()
 
     val rootPathsProvider: RootPathsProvider = PlatformRootPathsProvider(rootPath)
-    private val authenticationScopeProvider: AuthenticationScopeProvider = AuthenticationScopeProvider()
+    protected val authenticationScopeProvider: AuthenticationScopeProvider = AuthenticationScopeProvider()
 
     fun getGlobalScope(): GlobalKaliumScope =
         GlobalKaliumScope(globalDatabase, globalPreferences, kaliumConfigs, userSessionScopeProvider, authenticationScopeProvider)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/SessionManagerExt.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/SessionManagerExt.kt
@@ -15,17 +15,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.kalium.logic.feature
 
-import com.wire.kalium.logic.feature.auth.AuthenticationScope
-import com.wire.kalium.logic.sync.UserSessionWorkScheduler
-import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
+import com.wire.kalium.logic.data.auth.login.ProxyCredentials
+import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.network.session.SessionManager
 
-class AuthenticatedDataSourceSet(
-    val authenticatedRootDir: String,
-    val authenticatedNetworkContainer: AuthenticatedNetworkContainer,
-    val authenticationScope: AuthenticationScope,
-    val proteusClientProvider: ProteusClientProvider,
-    val userSessionWorkScheduler: UserSessionWorkScheduler
-)
+internal fun SessionManager.getProxyCredentials(): ProxyCredentials? =
+    MapperProvider.sessionMapper().fromDTOToProxyCredentialsModel(proxyCredentials())
+
+internal fun SessionManager.getServerConfig() =
+    MapperProvider.serverConfigMapper().fromDTO(serverConfig())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -944,7 +944,8 @@ class UserSessionScope internal constructor(
             userId,
             isAllowedToRegisterMLSClient,
             clientIdProvider,
-            userStorage,
+            userRepository,
+            authenticatedDataSourceSet.authenticationScope.secondFactorVerificationRepository,
             slowSyncRepository
         )
     val conversations: ConversationScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -75,8 +75,8 @@ class AuthenticationScope(
     private val ssoLoginRepository: SSOLoginRepository
         get() = SSOLoginRepositoryImpl(unauthenticatedNetworkContainer.sso)
 
-    private val secondFactorVerificationRepository: SecondFactorVerificationRepository
-        get() = SecondFactorVerificationRepositoryImpl(unauthenticatedNetworkContainer.verificationCodeApi)
+    internal val secondFactorVerificationRepository: SecondFactorVerificationRepository =
+        SecondFactorVerificationRepositoryImpl(unauthenticatedNetworkContainer.verificationCodeApi)
 
     private val validateEmailUseCase: ValidateEmailUseCase get() = ValidateEmailUseCaseImpl()
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
@@ -90,7 +90,8 @@ class AuthenticationScope(
             validateEmailUseCase,
             validateUserHandleUseCase,
             serverConfig,
-            proxyCredentials
+            proxyCredentials,
+            secondFactorVerificationRepository
         )
     val requestSecondFactorVerificationCode: RequestSecondFactorVerificationCodeUseCase
         get() = RequestSecondFactorVerificationCodeUseCase(secondFactorVerificationRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.logic.configuration.notification.NotificationTokenRepository
+import com.wire.kalium.logic.data.auth.verification.SecondFactorVerificationRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
@@ -28,7 +29,7 @@ import com.wire.kalium.logic.data.prekey.PreKeyRepository
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.di.UserStorage
+import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCase
@@ -57,8 +58,9 @@ class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
     private val selfUserId: UserId,
     private val isAllowedToRegisterMLSClient: IsAllowedToRegisterMLSClientUseCase,
     private val clientIdProvider: CurrentClientIdProvider,
-    private val userStorage: UserStorage,
-    private val slowSyncRepository: SlowSyncRepository
+    private val userRepository: UserRepository,
+    private val secondFactorVerificationRepository: SecondFactorVerificationRepository,
+    private val slowSyncRepository: SlowSyncRepository,
 ) {
     @OptIn(DelicateKaliumApi::class)
     val register: RegisterClientUseCase
@@ -70,7 +72,9 @@ class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
             keyPackageLimitsProvider,
             mlsClientProvider,
             sessionRepository,
-            selfUserId
+            selfUserId,
+            userRepository,
+            secondFactorVerificationRepository
         )
 
     val selfClients: SelfClientsUseCase get() = SelfClientsUseCaseImpl(clientRepository, clientIdProvider)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/verification/FakeSecondFactorVerificationRepository.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/verification/FakeSecondFactorVerificationRepository.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.auth.verification
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.functional.Either
+
+class FakeSecondFactorVerificationRepository(
+    private val requestVerificationCodeResponse: Either<NetworkFailure, Unit> = Either.Right(Unit)
+) : SecondFactorVerificationRepository {
+
+    private val verificationCodes: MutableMap<String, String> = mutableMapOf()
+    override suspend fun requestVerificationCode(email: String, verifiableAction: VerifiableAction): Either<NetworkFailure, Unit> =
+        requestVerificationCodeResponse
+
+    override fun storeVerificationCode(email: String, verificationCode: String) {
+        verificationCodes[email] = verificationCode
+    }
+
+    override fun getStoredVerificationCode(email: String): String? = verificationCodes[email]
+
+    override suspend fun clearStoredVerificationCode(email: String) {
+        verificationCodes.remove(email)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/verification/SecondFactorVerificationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/verification/SecondFactorVerificationRepositoryTest.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 class SecondFactorVerificationRepositoryTest {
 
@@ -87,6 +88,47 @@ class SecondFactorVerificationRepositoryTest {
             .suspendFunction(arrangement.verificationCodeApi::sendVerificationCode)
             .with(eq(EMAIL), any())
             .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenStoredVerificationCodeForEmail_whenGettingVerificationCode_thenShouldReturnStoredCode() = runTest {
+        val (_, secondFactorVerificationRepository) = Arrangement().arrange()
+
+        val verificationCode = "111"
+
+        secondFactorVerificationRepository.storeVerificationCode(EMAIL, verificationCode)
+
+        val result = secondFactorVerificationRepository.getStoredVerificationCode(EMAIL)
+
+        assertEquals(verificationCode, result)
+    }
+
+    @Test
+    fun givenStoredVerificationCodeForEmail_whenGettingVerificationCodeForAnotherEmail_thenShouldReturnNull() = runTest {
+        val (_, secondFactorVerificationRepository) = Arrangement().arrange()
+
+        val verificationCode = "111"
+
+        secondFactorVerificationRepository.storeVerificationCode(EMAIL, verificationCode)
+
+        val result = secondFactorVerificationRepository.getStoredVerificationCode("SomeOtherEmail@example.org")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun givenClearedTheStoredVerificationCodeForEmail_whenGettingVerificationCodeForAnotherEmail_thenShouldReturnNull() = runTest {
+        val (_, secondFactorVerificationRepository) = Arrangement().arrange()
+
+        val verificationCode = "111"
+
+        secondFactorVerificationRepository.storeVerificationCode(EMAIL, verificationCode)
+
+        secondFactorVerificationRepository.clearStoredVerificationCode(EMAIL)
+
+        val result = secondFactorVerificationRepository.getStoredVerificationCode(EMAIL)
+
+        assertNull(result)
     }
 
     private class Arrangement {

--- a/logic/src/darwinMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/darwinMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -50,6 +50,7 @@ actual class CoreLogic(
     override val networkStateObserver: NetworkStateObserver = NetworkStateObserverImpl()
     override val userSessionScopeProvider: Lazy<UserSessionScopeProvider> = lazy {
         UserSessionScopeProviderImpl(
+            authenticationScopeProvider,
             rootPathsProvider,
             getGlobalScope(),
             kaliumConfigs,

--- a/logic/src/darwinMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/darwinMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.PlatformUserStorageProperties
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.logic.di.UserStorageProvider
+import com.wire.kalium.logic.feature.auth.AuthenticationScopeProvider
 import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.featureFlags.FeatureSupportImpl
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
@@ -39,6 +40,7 @@ import com.wire.kalium.network.api.base.model.UserId as UserIdDTO
 
 @Suppress("LongParameterList")
 internal actual class UserSessionScopeProviderImpl(
+    private val authenticationScopeProvider: AuthenticationScopeProvider,
     private val rootPathsProvider: RootPathsProvider,
     private val globalScope: GlobalKaliumScope,
     private val kaliumConfigs: KaliumConfigs,
@@ -71,6 +73,10 @@ internal actual class UserSessionScopeProviderImpl(
         val userDataSource = AuthenticatedDataSourceSet(
             rootAccountPath,
             networkContainer,
+            authenticationScopeProvider.provide(
+                sessionManager.getServerConfig(),
+                sessionManager.getProxyCredentials()
+            ),
             proteusClientProvider,
             userSessionWorkScheduler
         )
@@ -90,4 +96,5 @@ internal actual class UserSessionScopeProviderImpl(
             networkStateObserver
         )
     }
+
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -68,6 +68,7 @@ actual class CoreLogic(
     override val networkStateObserver: NetworkStateObserver = NetworkStateObserverImpl()
     override val userSessionScopeProvider: Lazy<UserSessionScopeProvider> = lazy {
         UserSessionScopeProviderImpl(
+            authenticationScopeProvider,
             rootPathsProvider,
             getGlobalScope(),
             kaliumConfigs,

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.PlatformUserStorageProperties
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.logic.di.UserStorageProvider
+import com.wire.kalium.logic.feature.auth.AuthenticationScopeProvider
 import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.featureFlags.FeatureSupportImpl
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
@@ -39,6 +40,7 @@ import com.wire.kalium.network.api.base.model.UserId as UserIdDTO
 
 @Suppress("LongParameterList")
 internal actual class UserSessionScopeProviderImpl(
+    private val authenticationScopeProvider: AuthenticationScopeProvider,
     private val rootPathsProvider: RootPathsProvider,
     private val globalScope: GlobalKaliumScope,
     private val kaliumConfigs: KaliumConfigs,
@@ -70,6 +72,10 @@ internal actual class UserSessionScopeProviderImpl(
         val userDataSource = AuthenticatedDataSourceSet(
             rootAccountPath,
             networkContainer,
+            authenticationScopeProvider.provide(
+                sessionManager.getServerConfig(),
+                sessionManager.getProxyCredentials()
+            ),
             proteusClientProvider,
             userSessionWorkScheduler
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When logging in, the user might need to input a 2FA code, and this 2FA code should be re-used when registering the client.

### Solutions

Add a in-memory storage of 2FA code using emails as keys.
The storage is unique per authentication scope, meaning that Kalium will hold a storage per backend.

When successfully logging in: persist the 2FA code in the storage.
When registering the client, check for existing 2FA code if there's no input from client.

In case of invalid 2FA code (user mistyped, or 2FA code is too old) clear whatever is in the storage and return the failure so the client can tell the user that a new 2FA code is being sent to their email address.

> **Note**: The more I look into `UserSessionScope`, `AuthenticationScope`, etc. the more I want to refactor and clean it up. One year after starting the project, we know more clearly what's needed, and there's plenty of space to simplify and make it cleaner now. Providing a `AuthenticationScope` to the `UserSessionScope` seems kind of a no-brainer, as the `User` should be able to access the scope it used to Authenticate in the past, but I was met with surprising friction in doing it.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
