### PR TITLE
fix: create group guest link AR-3188

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -18,8 +18,6 @@
 
 package com.wire.kalium.logic.data.conversation
 
-import com.wire.kalium.logger.obfuscateDomain
-import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.PlainId
@@ -50,6 +48,71 @@ data class Conversation(
     val creatorId: String?,
     val receiptMode: ReceiptMode,
 ) {
+
+    companion object {
+        /**
+         * A set of default [AccessRole] valid for Group Conversations
+         * for both personal and team users.
+         *
+         * @see [AccessRole]
+         */
+        val defaultGroupAccessRoles = setOf(AccessRole.TEAM_MEMBER, AccessRole.NON_TEAM_MEMBER)
+
+        /**
+         * A set of default [Access] modes valid for Group Conversations
+         * for both personal and team users.
+         *
+         * @see [Access]
+         */
+        val defaultGroupAccess = setOf(Access.INVITE)
+
+        /**
+         * Returns a sensible set of [AccessRole] given a combination of
+         * flags
+         *
+         * @see [AccessRole]
+         */
+        fun accessRolesFor(
+            guestAllowed: Boolean,
+            servicesAllowed: Boolean,
+            nonTeamMembersAllowed: Boolean
+        ): Set<AccessRole> =
+            defaultGroupAccessRoles.toMutableSet().apply {
+                if (servicesAllowed) {
+                    add(AccessRole.SERVICE)
+                } else {
+                    remove(AccessRole.SERVICE)
+                }
+
+                if (guestAllowed) {
+                    add(AccessRole.GUEST)
+                } else {
+                    remove(AccessRole.GUEST)
+                }
+
+                if (nonTeamMembersAllowed) {
+                    add(AccessRole.NON_TEAM_MEMBER)
+                } else {
+                    remove(AccessRole.NON_TEAM_MEMBER)
+                }
+            }.toSet()
+
+        /**
+         * Returns a sensible set of [Access] given a combination of
+         * flags
+         *
+         * @see [Access]
+         */
+        fun accessFor(
+            guestsAllowed: Boolean,
+        ): Set<Access> =
+            defaultGroupAccess.toMutableSet().apply {
+                if (guestsAllowed) {
+                    add(Access.CODE)
+                }
+            }.toSet()
+
+    }
 
     fun isTeamGroup(): Boolean = (teamId != null)
 
@@ -149,7 +212,7 @@ data class Conversation(
         }
 
         fun toMap(): Map<String, String> = mapOf(
-            "id" to "${id.value.obfuscateId()}@${id.domain.obfuscateDomain()}",
+            "id" to id.toLogString(),
             "role" to "$role"
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -149,8 +149,8 @@ interface ConversationRepository {
     suspend fun updateConversationReadDate(qualifiedID: QualifiedID, date: Instant): Either<StorageFailure, Unit>
     suspend fun updateAccessInfo(
         conversationID: ConversationId,
-        access: List<Conversation.Access>,
-        accessRole: List<Conversation.AccessRole>
+        access: Set<Conversation.Access>,
+        accessRole: Set<Conversation.AccessRole>
     ): Either<CoreFailure, Unit>
 
     suspend fun updateConversationMemberRole(
@@ -472,8 +472,8 @@ internal class ConversationDataSource internal constructor(
 
     override suspend fun updateAccessInfo(
         conversationID: ConversationId,
-        access: List<Conversation.Access>,
-        accessRole: List<Conversation.AccessRole>
+        access: Set<Conversation.Access>,
+        accessRole: Set<Conversation.AccessRole>
     ): Either<CoreFailure, Unit> =
         UpdateConversationAccessRequest(
             access.map { conversationMapper.toApiModel(it) }.toSet(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessRoleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessRoleUseCase.kt
@@ -22,70 +22,43 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.logic.functional.map
 
 /**
- * This use case will update the access role configuration of a conversation.
+ * This use case will update the access and access role configuration of a conversation.
  * So we can operate and allow or not operation based on these roles:
  * - [Conversation.isGuestAllowed]
  * - [Conversation.isServicesAllowed]
  * - [Conversation.isTeamGroup]
  * - [Conversation.isNonTeamMemberAllowed]
- *
  * @see Conversation.AccessRole
+ *
+ * and based on access
+ * - [Conversation.Access.CODE]
+ * - [Conversation.Access.INVITE]
+ * - [Conversation.Access.LINK]
+ * - [Conversation.Access.PRIVATE]
+ * - [Conversation.Access.SELF_INVITE]
+ *
+ * @see Conversation.Access
  */
+
 class UpdateConversationAccessRoleUseCase internal constructor(
     private val conversationRepository: ConversationRepository
 ) {
     suspend operator fun invoke(
         conversationId: ConversationId,
-        allowGuest: Boolean,
-        allowServices: Boolean,
-        allowNonTeamMember: Boolean
+        accessRoles: Set<Conversation.AccessRole>,
+        access: Set<Conversation.Access>,
     ): Result {
-        return conversationRepository.baseInfoById(conversationId)
-            .map { conversation ->
-                // TODO: handle edge case where accessRole is null
-                val newAccessRoles: List<Conversation.AccessRole> = conversation.accessRole.toMutableSet().apply {
-                    handleGuestsState(allowGuest)
-                    handleServicesState(allowServices)
-                    handleNonTeamMemberState(allowNonTeamMember)
-                }.toList()
 
-                Triple(conversation.id, newAccessRoles, conversation.access)
-            }.flatMap { (conversationId, newAccessRole, access) ->
-                conversationRepository.updateAccessInfo(conversationId, access, newAccessRole)
-            }.fold({
+        return conversationRepository
+            .updateAccessInfo(conversationId, access, accessRoles)
+            .fold({
                 Result.Failure(it)
             }, {
                 Result.Success
             })
-    }
-
-    private fun MutableSet<Conversation.AccessRole>.handleServicesState(allowServices: Boolean) {
-        if (allowServices) {
-            add(Conversation.AccessRole.SERVICE)
-        } else {
-            remove(Conversation.AccessRole.SERVICE)
-        }
-    }
-
-    private fun MutableSet<Conversation.AccessRole>.handleGuestsState(allowGuest: Boolean) {
-        if (allowGuest) {
-            add(Conversation.AccessRole.GUEST)
-        } else {
-            remove(Conversation.AccessRole.GUEST)
-        }
-    }
-
-    private fun MutableSet<Conversation.AccessRole>.handleNonTeamMemberState(allowNonTeamMember: Boolean) {
-        if (allowNonTeamMember) {
-            add(Conversation.AccessRole.NON_TEAM_MEMBER)
-        } else {
-            remove(Conversation.AccessRole.NON_TEAM_MEMBER)
-        }
     }
 
     sealed interface Result {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -423,13 +423,13 @@ class ConversationRepositoryTest {
 
         conversationRepository.updateAccessInfo(
             conversationID = ConversationId(conversationIdDTO.value, conversationIdDTO.domain),
-            access = listOf(
+            access = setOf(
                 Conversation.Access.INVITE,
                 Conversation.Access.CODE,
                 Conversation.Access.PRIVATE,
                 Conversation.Access.LINK
             ),
-            accessRole = listOf(
+            accessRole = setOf(
                 Conversation.AccessRole.TEAM_MEMBER,
                 Conversation.AccessRole.NON_TEAM_MEMBER,
                 Conversation.AccessRole.SERVICE,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.logic.framework.TestConversation
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -59,5 +60,93 @@ class ConversationTest {
     fun givenConversationWithNoServiceAccessRole_thenIsNonTeamMemberAllowedIsFalse() {
         val conversation = TestConversation.CONVERSATION.copy(accessRole = listOf(Conversation.AccessRole.TEAM_MEMBER))
         assertFalse(conversation.isServicesAllowed())
+    }
+
+    @Test
+    fun givenACombinationOfFlags_thenTheSetOfAccessRolesIsCorrect() {
+
+        var accessRoles = Conversation.accessRolesFor(guestAllowed = false, servicesAllowed = false, nonTeamMembersAllowed = false)
+        assertEquals(setOf(Conversation.AccessRole.TEAM_MEMBER), accessRoles)
+
+        accessRoles = Conversation.accessRolesFor(guestAllowed = true, servicesAllowed = false, nonTeamMembersAllowed = false)
+        assertEquals(
+            setOf(Conversation.AccessRole.TEAM_MEMBER, Conversation.AccessRole.GUEST),
+            accessRoles
+        )
+
+        accessRoles = Conversation.accessRolesFor(guestAllowed = true, servicesAllowed = true, nonTeamMembersAllowed = false)
+        assertEquals(
+            setOf(Conversation.AccessRole.TEAM_MEMBER, Conversation.AccessRole.GUEST, Conversation.AccessRole.SERVICE),
+            accessRoles
+        )
+
+        accessRoles = Conversation.accessRolesFor(guestAllowed = true, servicesAllowed = true, nonTeamMembersAllowed = true)
+        assertEquals(
+            setOf(
+                Conversation.AccessRole.TEAM_MEMBER,
+                Conversation.AccessRole.GUEST,
+                Conversation.AccessRole.SERVICE,
+                Conversation.AccessRole.NON_TEAM_MEMBER
+            ),
+            accessRoles
+        )
+
+        accessRoles = Conversation.accessRolesFor(guestAllowed = false, servicesAllowed = true, nonTeamMembersAllowed = false)
+        assertEquals(
+            setOf(
+                Conversation.AccessRole.TEAM_MEMBER,
+                Conversation.AccessRole.SERVICE,
+            ),
+            accessRoles
+        )
+
+        accessRoles = Conversation.accessRolesFor(guestAllowed = false, servicesAllowed = true, nonTeamMembersAllowed = true)
+        assertEquals(
+            setOf(
+                Conversation.AccessRole.TEAM_MEMBER,
+                Conversation.AccessRole.SERVICE,
+                Conversation.AccessRole.NON_TEAM_MEMBER
+            ),
+            accessRoles
+        )
+
+        accessRoles = Conversation.accessRolesFor(guestAllowed = false, servicesAllowed = false, nonTeamMembersAllowed = true)
+        assertEquals(
+            setOf(
+                Conversation.AccessRole.TEAM_MEMBER,
+                Conversation.AccessRole.NON_TEAM_MEMBER
+            ),
+            accessRoles
+        )
+
+        accessRoles = Conversation.accessRolesFor(guestAllowed = true, servicesAllowed = false, nonTeamMembersAllowed = true)
+        assertEquals(
+            setOf(
+                Conversation.AccessRole.TEAM_MEMBER,
+                Conversation.AccessRole.NON_TEAM_MEMBER,
+                Conversation.AccessRole.GUEST
+                ),
+            accessRoles
+        )
+    }
+
+    @Test
+    fun givenACombinationOfFlags_thenTheSetOfAccessIsCorrect() {
+        var access = Conversation.accessFor(false)
+        assertEquals(
+            setOf(
+                Conversation.Access.INVITE,
+            ),
+            access
+        )
+
+        access = Conversation.accessFor(true)
+        assertEquals(
+            setOf(
+                Conversation.Access.INVITE,
+                Conversation.Access.CODE,
+                ),
+            access
+        )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
@@ -52,58 +52,90 @@ class UpdateConversationAccessUseCaseTest {
                 Conversation.AccessRole.NON_TEAM_MEMBER,
                 Conversation.AccessRole.GUEST,
                 Conversation.AccessRole.SERVICE
+            ),
+            access = listOf(Conversation.Access.INVITE, Conversation.Access.CODE),
             )
-        )
 
-        val (arrangement, updateConversationAccess) = Arrangement().withbaseInfoByIdReturning(Either.Right(conversation))
-            .withUpdateAccessInfoRetuning(Either.Right(Unit)).arrange()
+        val (arrangement, updateConversationAccess) = Arrangement()
+            .withbaseInfoByIdReturning(Either.Right(conversation))
+            .withUpdateAccessInfoRetuning(Either.Right(Unit))
+            .arrange()
 
-        updateConversationAccess(conversation.id, allowGuest = true, allowNonTeamMember = true, allowServices = false).also { result ->
+        updateConversationAccess(
+            conversationId = conversation.id,
+            accessRoles = Conversation
+                .accessRolesFor(
+                    guestAllowed = true,
+                    servicesAllowed = false,
+                    nonTeamMembersAllowed = true
+                ),
+            access = Conversation.accessFor(guestsAllowed = true)
+        ).also { result ->
             assertIs<UpdateConversationAccessRoleUseCase.Result.Success>(result)
         }
 
-        verify(arrangement.conversationRepository).coroutine { arrangement.conversationRepository.baseInfoById(conversation.id) }
-            .wasInvoked(exactly = once)
-
         verify(arrangement.conversationRepository).coroutine {
-            arrangement.conversationRepository.updateAccessInfo(
-                conversation.id, conversation.access, accessRole = listOf(
-                    Conversation.AccessRole.TEAM_MEMBER, Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST
+            arrangement
+                .conversationRepository
+                .updateAccessInfo(
+                    conversation.id,
+                    access = setOf(Conversation.Access.INVITE, Conversation.Access.CODE),
+                    accessRole = Conversation
+                        .defaultGroupAccessRoles
+                        .toMutableSet()
+                        .apply { add(Conversation.AccessRole.GUEST) }
                 )
-            )
         }.wasInvoked(exactly = once)
     }
 
     @Test
     fun givenConversation_whenEnablingServices_thenUpdateAccessInfoIsCalledWithTheCorrectRoles() = runTest {
-        val conversation = conversationStub.copy(
-            accessRole = listOf(
-                Conversation.AccessRole.TEAM_MEMBER,
-                Conversation.AccessRole.NON_TEAM_MEMBER,
-                Conversation.AccessRole.SERVICE,
-                Conversation.AccessRole.GUEST
 
-            )
+        // Given a conversation where TEAM_MEMBER(s), NON_TEAM_MEMBER(s) and GUEST(s) but not SERVICE(s)
+        val givenAccessRoles = Conversation
+            .defaultGroupAccessRoles
+            .toMutableList()
+            .apply {
+                add(Conversation.AccessRole.SERVICE)
+            }
+
+        // Given the access mode is CODE only
+        val conversation = conversationStub.copy(
+            accessRole = givenAccessRoles,
+            access = Conversation.defaultGroupAccess.toMutableList().apply { add(Conversation.Access.INVITE) }
         )
 
-        val (arrangement, updateConversationAccess) = Arrangement().withbaseInfoByIdReturning(Either.Right(conversation))
-            .withUpdateAccessInfoRetuning(Either.Right(Unit)).arrange()
+        val (arrangement, updateConversationAccess) = Arrangement()
+            .withbaseInfoByIdReturning(Either.Right(conversation))
+            .withUpdateAccessInfoRetuning(Either.Right(Unit))
+            .arrange()
 
-        updateConversationAccess(conversation.id, allowGuest = true, allowNonTeamMember = true, allowServices = true).also { result ->
+        updateConversationAccess(
+            conversationId = conversation.id,
+            accessRoles = Conversation
+                .accessRolesFor(
+                    guestAllowed = true,
+                    servicesAllowed = true,
+                    nonTeamMembersAllowed = true
+                ),
+            access = Conversation.accessFor(guestsAllowed = true)
+        ).also { result ->
             assertIs<UpdateConversationAccessRoleUseCase.Result.Success>(result)
         }
-        verify(arrangement.conversationRepository).coroutine { arrangement.conversationRepository.baseInfoById(conversation.id) }
-            .wasInvoked(exactly = once)
 
         verify(arrangement.conversationRepository).coroutine {
-            arrangement.conversationRepository.updateAccessInfo(
-                conversation.id, conversation.access, accessRole = listOf(
-                    Conversation.AccessRole.TEAM_MEMBER,
-                    Conversation.AccessRole.NON_TEAM_MEMBER,
-                    Conversation.AccessRole.SERVICE,
-                    Conversation.AccessRole.GUEST
+            arrangement
+                .conversationRepository
+                .updateAccessInfo(
+                    conversationID = conversation.id,
+                    accessRole = setOf(
+                        Conversation.AccessRole.TEAM_MEMBER,
+                        Conversation.AccessRole.NON_TEAM_MEMBER,
+                        Conversation.AccessRole.SERVICE,
+                        Conversation.AccessRole.GUEST
+                    ),
+                    access = setOf(Conversation.Access.CODE, Conversation.Access.INVITE)
                 )
-            )
         }.wasInvoked(exactly = once)
     }
 
@@ -118,22 +150,33 @@ class UpdateConversationAccessUseCaseTest {
             )
         )
 
-        val (arrangement, updateConversationAccess) = Arrangement().withbaseInfoByIdReturning(Either.Right(conversation))
-            .withUpdateAccessInfoRetuning(Either.Right(Unit)).arrange()
+        val (arrangement, updateConversationAccess) = Arrangement()
+            .withbaseInfoByIdReturning(Either.Right(conversation))
+            .withUpdateAccessInfoRetuning(Either.Right(Unit))
+            .arrange()
 
-        updateConversationAccess(conversation.id, allowGuest = true, allowNonTeamMember = false, allowServices = true).also { result ->
+        updateConversationAccess(
+            conversationId = conversation.id,
+            accessRoles = Conversation
+                .accessRolesFor(
+                    guestAllowed = true,
+                    servicesAllowed = true,
+                    nonTeamMembersAllowed = false
+                ),
+            Conversation.accessFor(guestsAllowed = true)
+        ).also { result ->
             assertIs<UpdateConversationAccessRoleUseCase.Result.Success>(result)
         }
 
-        verify(arrangement.conversationRepository).coroutine { arrangement.conversationRepository.baseInfoById(conversation.id) }
-            .wasInvoked(exactly = once)
-
         verify(arrangement.conversationRepository).coroutine {
             arrangement.conversationRepository.updateAccessInfo(
-                conversation.id, conversation.access, accessRole = listOf(
-                    Conversation.AccessRole.TEAM_MEMBER, Conversation.AccessRole.SERVICE, Conversation.AccessRole.GUEST
-
-                )
+                conversationID = conversation.id,
+                accessRole = setOf(
+                    Conversation.AccessRole.TEAM_MEMBER,
+                    Conversation.AccessRole.SERVICE,
+                    Conversation.AccessRole.GUEST
+                ),
+                access = conversation.access.toSet()
             )
         }.wasInvoked(exactly = once)
     }
@@ -149,21 +192,29 @@ class UpdateConversationAccessUseCaseTest {
         val (arrangement, updateConversationAccess) = Arrangement().withbaseInfoByIdReturning(Either.Right(conversation))
             .withUpdateAccessInfoRetuning(Either.Right(Unit)).arrange()
 
-        updateConversationAccess(conversation.id, allowGuest = true, allowNonTeamMember = true, allowServices = true).also { result ->
+        updateConversationAccess(
+            conversationId = conversation.id,
+            accessRoles = Conversation
+                .accessRolesFor(
+                    guestAllowed = true,
+                    servicesAllowed = true,
+                    nonTeamMembersAllowed = true
+                ),
+            access = Conversation.accessFor(guestsAllowed = true)
+        ).also { result ->
             assertIs<UpdateConversationAccessRoleUseCase.Result.Success>(result)
         }
 
-        verify(arrangement.conversationRepository).coroutine { arrangement.conversationRepository.baseInfoById(conversation.id) }
-            .wasInvoked(exactly = once)
-
         verify(arrangement.conversationRepository).coroutine {
             arrangement.conversationRepository.updateAccessInfo(
-                conversation.id, conversation.access, accessRole = listOf(
+                conversationID = conversation.id,
+                accessRole = setOf(
                     Conversation.AccessRole.TEAM_MEMBER,
                     Conversation.AccessRole.SERVICE,
                     Conversation.AccessRole.GUEST,
                     Conversation.AccessRole.NON_TEAM_MEMBER
-                )
+                ),
+                access = conversation.access.toSet()
             )
         }.wasInvoked(exactly = once)
     }
@@ -176,72 +227,84 @@ class UpdateConversationAccessUseCaseTest {
                 Conversation.AccessRole.NON_TEAM_MEMBER,
                 Conversation.AccessRole.SERVICE,
                 Conversation.AccessRole.GUEST
-            )
+            ),
+            access = listOf(Conversation.Access.INVITE)
         )
 
-        val (arrangement, updateConversationAccess) = Arrangement().withbaseInfoByIdReturning(Either.Right(conversation))
-            .withUpdateAccessInfoRetuning(Either.Right(Unit)).arrange()
+        val (arrangement, updateConversationAccess) = Arrangement()
+            .withbaseInfoByIdReturning(Either.Right(conversation))
+            .withUpdateAccessInfoRetuning(Either.Right(Unit))
+            .arrange()
 
-        updateConversationAccess(conversation.id, allowGuest = false, allowNonTeamMember = true, allowServices = true).also { result ->
+        updateConversationAccess(
+            conversationId = conversation.id,
+            accessRoles = Conversation
+                .accessRolesFor(
+                    guestAllowed = false,
+                    servicesAllowed = true,
+                    nonTeamMembersAllowed = true
+                ),
+            access = Conversation.accessFor(guestsAllowed = false)
+        ).also { result ->
             assertIs<UpdateConversationAccessRoleUseCase.Result.Success>(result)
         }
 
-        verify(arrangement.conversationRepository).coroutine { arrangement.conversationRepository.baseInfoById(conversation.id) }
-            .wasInvoked(exactly = once)
-
         verify(arrangement.conversationRepository).coroutine {
             arrangement.conversationRepository.updateAccessInfo(
-                conversation.id, conversation.access, accessRole = listOf(
-                    Conversation.AccessRole.TEAM_MEMBER, Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.SERVICE
-                )
+                conversationID = conversation.id,
+                accessRole = setOf(
+                    Conversation.AccessRole.TEAM_MEMBER,
+                    Conversation.AccessRole.NON_TEAM_MEMBER,
+                    Conversation.AccessRole.SERVICE
+                ),
+                access = Conversation.defaultGroupAccess
             )
         }.wasInvoked(exactly = once)
     }
 
     @Test
     fun givenConversation_whenEnablingGuests_thenUpdateAccessInfoIsCalledWithTheCorrectRoles() = runTest {
+
+        // Given a conversation where TEAM_MEMBER(s), NON_TEAM_MEMBER(s) and SERVICE(s) have access and GUEST(s) don't
+        val givenAccessRoles = Conversation
+            .defaultGroupAccessRoles
+            .toMutableList()
+            .apply {
+                add(Conversation.AccessRole.SERVICE)
+            }
+
+        // Given the access mode is CODE only
         val conversation = conversationStub.copy(
-            accessRole = listOf(
-                Conversation.AccessRole.TEAM_MEMBER, Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.SERVICE
-            )
+            accessRole = givenAccessRoles,
+            access = Conversation.defaultGroupAccess.toList()
         )
 
-        val (arrangement, updateConversationAccess) = Arrangement().withbaseInfoByIdReturning(Either.Right(conversation))
-            .withUpdateAccessInfoRetuning(Either.Right(Unit)).arrange()
+        // Given
+        val (arrangement, updateConversationAccess) = Arrangement()
+            .withbaseInfoByIdReturning(Either.Right(conversation))
+            .withUpdateAccessInfoRetuning(Either.Right(Unit))
+            .arrange()
 
-        updateConversationAccess(conversation.id, allowGuest = false, allowNonTeamMember = true, allowServices = true).also { result ->
+        // When Guests are allowed
+        updateConversationAccess(
+            conversationId = conversation.id,
+            accessRoles = Conversation.accessRolesFor(guestAllowed = true, servicesAllowed = true, nonTeamMembersAllowed = true),
+            access = Conversation.accessFor(guestsAllowed = true)
+        ).also { result ->
             assertIs<UpdateConversationAccessRoleUseCase.Result.Success>(result)
         }
 
-        verify(arrangement.conversationRepository).coroutine { arrangement.conversationRepository.baseInfoById(conversation.id) }
-            .wasInvoked(exactly = once)
-
+        // Then
         verify(arrangement.conversationRepository).coroutine {
             arrangement.conversationRepository.updateAccessInfo(
-                conversation.id, conversation.access, accessRole = listOf(
-                    Conversation.AccessRole.TEAM_MEMBER, Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.SERVICE
-                )
+                conversationID = conversation.id,
+                accessRole = Conversation.defaultGroupAccessRoles.toMutableSet().apply {
+                    add(Conversation.AccessRole.GUEST)
+                    add(Conversation.AccessRole.SERVICE)
+                },
+                access = setOf(Conversation.Access.INVITE, Conversation.Access.CODE)
             )
         }.wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenError_whenCallingbaseInfoById_thenFailureIsPropagated() = runTest {
-        val conversation = conversationStub
-
-        val (arrangement, updateConversationAccess) = Arrangement().withbaseInfoByIdReturning(Either.Left(StorageFailure.DataNotFound))
-            .arrange()
-
-        updateConversationAccess(conversation.id, allowGuest = false, allowNonTeamMember = true, allowServices = true).also { result ->
-            assertIs<UpdateConversationAccessRoleUseCase.Result.Failure>(result)
-            assertEquals(StorageFailure.DataNotFound, result.cause)
-        }
-
-        verify(arrangement.conversationRepository).suspendFunction(arrangement.conversationRepository::baseInfoById).with(any())
-            .wasInvoked(exactly = once)
-
-        verify(arrangement.conversationRepository).suspendFunction(arrangement.conversationRepository::updateAccessInfo)
-            .with(any(), any(), any()).wasNotInvoked()
     }
 
     @Test
@@ -251,13 +314,15 @@ class UpdateConversationAccessUseCaseTest {
         val (arrangement, updateConversationAccess) = Arrangement().withbaseInfoByIdReturning(Either.Right(conversation))
             .withUpdateAccessInfoRetuning(Either.Left(NetworkFailure.NoNetworkConnection(IOException()))).arrange()
 
-        updateConversationAccess(conversation.id, allowGuest = false, allowNonTeamMember = true, allowServices = true).also { result ->
+        // allowGuest = false, allowServices = true, allowNonTeamMember = true
+        updateConversationAccess(
+            conversationId = conversation.id,
+            accessRoles = Conversation.accessRolesFor(guestAllowed = false, servicesAllowed = true, nonTeamMembersAllowed = true),
+            access = Conversation.accessFor(guestsAllowed = false)
+        ).also { result ->
             assertIs<UpdateConversationAccessRoleUseCase.Result.Failure>(result)
             assertIs<NetworkFailure.NoNetworkConnection>(result.cause)
         }
-
-        verify(arrangement.conversationRepository).suspendFunction(arrangement.conversationRepository::baseInfoById).with(any())
-            .wasInvoked(exactly = once)
 
         verify(arrangement.conversationRepository).suspendFunction(arrangement.conversationRepository::updateAccessInfo)
             .with(any(), any(), any()).wasInvoked(exactly = once)
@@ -265,19 +330,26 @@ class UpdateConversationAccessUseCaseTest {
 
     companion object {
         val conversationStub = Conversation(
-            ConversationId(value = "1O1 ID", domain = "conv domain"),
-            "ONE_ON_ONE Name",
-            Conversation.Type.ONE_ON_ONE,
-            TeamId("cool_team_123"),
+            ConversationId(value = "someId", domain = "someDomain"),
+            "GROUP Conversation",
+            Conversation.Type.GROUP,
+            TeamId("someTeam"),
             ProtocolInfo.Proteus,
             MutedConversationStatus.AllAllowed,
             null,
             null,
             null,
-            access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
-            accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
+            access = listOf(
+                Conversation.Access.CODE,
+                Conversation.Access.INVITE
+            ),
+            accessRole = listOf(
+                Conversation.AccessRole.NON_TEAM_MEMBER,
+                Conversation.AccessRole.TEAM_MEMBER,
+                Conversation.AccessRole.GUEST
+            ),
             lastReadDate = "2022.01.02",
-            creatorId = null,
+            creatorId = "someCreatorId",
             receiptMode = Conversation.ReceiptMode.DISABLED
         )
     }
@@ -293,7 +365,9 @@ class UpdateConversationAccessUseCaseTest {
         }
 
         fun withUpdateAccessInfoRetuning(either: Either<CoreFailure, Unit>) = apply {
-            given(conversationRepository).suspendFunction(conversationRepository::updateAccessInfo).whenInvokedWith(any(), any(), any())
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::updateAccessInfo)
+                .whenInvokedWith(any(), any(), any())
                 .thenReturn(either)
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When creating or editing guest access, accessRole and access aren't always correct

### Solutions

- Refactor the code to have default values for accessRole and access
- Extract logic into 2 functions `accessRoleFor` and `accessFor`
- Don't hardcode Wire's logic into the SDK, let the caller decide


#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
