### PR TITLE
fix: protect sync from freezing due to overflown buffer (AR-3167) (AR-3181)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepository.kt
@@ -57,7 +57,6 @@ internal interface IncrementalSyncRepository {
     suspend fun updateIncrementalSyncState(newState: IncrementalSyncStatus)
     suspend fun setConnectionPolicy(connectionPolicy: ConnectionPolicy)
 
-
     companion object {
         // The same default buffer size used by Coroutines channels
         const val BUFFER_SIZE = 64

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
@@ -25,7 +25,16 @@ import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.sync.SyncState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 
+/**
+ * Allows observing of [SyncState].
+ * A value is always available immediately for new observers, so calling [Flow.first] is safe.
+ * Assumes that old SyncStates are not relevant anymore, so the available [Flow]
+ * has a limited buffer size and will drop the oldest values as there's no point
+ * in waiting for slow collectors.
+ * In case a slow collector is interested in receiving all values, it should add a buffer of its own.
+ */
 class ObserveSyncStateUseCase internal constructor(
     private val slowSyncRepository: SlowSyncRepository,
     private val incrementalSyncRepository: IncrementalSyncRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ObserveSyncStateUseCase.kt
@@ -25,11 +25,10 @@ import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.sync.SyncState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 
 /**
  * Allows observing of [SyncState].
- * A value is always available immediately for new observers, so calling [Flow.first] is safe.
+ * A value is always available immediately for new observers.
  * Assumes that old SyncStates are not relevant anymore, so the available [Flow]
  * has a limited buffer size and will drop the oldest values as there's no point
  * in waiting for slow collectors.

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepositoryTest.kt
@@ -26,6 +26,9 @@ import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
@@ -33,10 +36,14 @@ import kotlinx.coroutines.flow.toCollection
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
 
 class IncrementalSyncRepositoryTest {
 
@@ -197,4 +204,57 @@ class IncrementalSyncRepositoryTest {
         assertEquals(initialValue, state)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun givenASlowStateCollector_whenStateIsUpdatedManyTimes_thenUpdateEmissionShouldNotBeBlockedByOverflownBuffer() = runTest {
+        val updateCount = 10_000
+        withContext(Dispatchers.Default) {
+            val slowCollectionJob = launch {
+                incrementalSyncRepository.incrementalSyncState.collect {
+                    delay(1.days)
+                }
+            }
+            val updateStateJob = launch {
+                repeat(updateCount) {
+                    incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+                }
+            }
+            withTimeout(10.seconds) {
+                // The update job shouldn't take more than a few milliseconds.
+                // If it ever waits for more than 10 seconds, something is definitely wrong,
+                // and it's probably blocked by the slow collection, which is the whole point of this test NOT happen.
+                // So we fail the test if it takes too long (10 seconds).
+                updateStateJob.join()
+            }
+            // Cancel the slow collector as we already know we're able to emit all updates without being blocked.
+            slowCollectionJob.cancel()
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun givenASlowPolicyCollector_whenPolicyIsUpdatedManyTimes_thenUpdateEmissionShouldNotBeBlockedByOverflownBuffer() = runTest {
+        val updateCount = 10_000
+        withContext(Dispatchers.Default) {
+            val slowCollectionJob = launch {
+                incrementalSyncRepository.connectionPolicyState.collect {
+                    delay(1.days)
+                }
+            }
+            val updatePolicyJob = launch {
+                repeat(updateCount) {
+                    incrementalSyncRepository.setConnectionPolicy(ConnectionPolicy.KEEP_ALIVE)
+                }
+            }
+            withTimeout(10.seconds) {
+                // The update job shouldn't take more than a few milliseconds.
+                // If it ever waits for more than 10 seconds, something is definitely wrong,
+                // and it's probably blocked by the slow collection, which is the whole point of this test NOT happen.
+                // So we fail the test if it takes too long (10 seconds).
+                updatePolicyJob.join()
+            }
+            // Cancel the slow collector as we already know we're able to emit all updates without being blocked.
+            slowCollectionJob.cancel()
+        }
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If `incrementalSyncState` has a slow collector, after it being updated some times, it can cause the emitter suspended indefinitely.

### Causes

`incrementalSyncState` has a limited buffer size of 64, and once it is full it will suspend the emitters and wait for collectors to catch up.
On Reloaded, there was a bug making this happen very early:
- https://github.com/wireapp/wire-android-reloaded/pull/1544

### Solutions

To make sure small bugs on the client-side cause the whole Sync mechanism to freeze, adopt a different Buffer Overflow policy for this flow: drop the oldest values.

Add documentation describing this behaviour.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
