### PR TITLE
fix: missing 2fa code on login (AR-3088)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -108,16 +108,16 @@ internal class LoginUseCaseImpl internal constructor(
     ): AuthenticationResult {
         // remove White Spaces around userIdentifier
         val cleanUserIdentifier = userIdentifier.trim()
-        var isEmail = false
+        val isEmail = validateEmailUseCase(cleanUserIdentifier)
+        val clean2FACode = secondFactorVerificationCode?.trim()?.takeIf { it.isNotBlank() }
         return when {
-            validateEmailUseCase(cleanUserIdentifier) -> {
-                isEmail = true
+            isEmail -> {
                 loginRepository.loginWithEmail(
                     email = cleanUserIdentifier,
                     password = password,
                     label = cookieLabel,
                     shouldPersistClient = shouldPersistClient,
-                    secondFactorVerificationCode = secondFactorVerificationCode?.trim()?.takeIf { it.isNotBlank() }
+                    secondFactorVerificationCode = clean2FACode
                 )
             }
 
@@ -141,8 +141,8 @@ internal class LoginUseCaseImpl internal constructor(
                         AuthenticationResult.Failure.Generic(it)
                 }
             }, {
-                if (isEmail && secondFactorVerificationCode != null) {
-                    secondFactorVerificationRepository.storeVerificationCode(cleanUserIdentifier, secondFactorVerificationCode)
+                if (isEmail && clean2FACode != null) {
+                    secondFactorVerificationRepository.storeVerificationCode(cleanUserIdentifier, clean2FACode)
                 }
                 it
             })

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -117,7 +117,7 @@ internal class LoginUseCaseImpl internal constructor(
                     password = password,
                     label = cookieLabel,
                     shouldPersistClient = shouldPersistClient,
-                    secondFactorVerificationCode = secondFactorVerificationCode,
+                    secondFactorVerificationCode = secondFactorVerificationCode?.trim()?.takeIf { it.isNotBlank() }
                 )
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -56,7 +56,7 @@ class LoginUseCaseTest {
             .withEmailValidationSucceeding(true, cleanEmail)
             .arrange()
 
-        val loginUserCaseResult = loginUseCase(dirtyEmail, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        val loginUserCaseResult = loginUseCase(dirtyEmail, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL, TEST_2FA_CODE)
 
         assertEquals(
             loginUserCaseResult,
@@ -72,7 +72,7 @@ class LoginUseCaseTest {
             .wasNotInvoked()
 
         verify(arrangement.loginRepository)
-            .coroutine { loginWithEmail(cleanEmail, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT) }
+            .coroutine { loginWithEmail(cleanEmail, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT, TEST_2FA_CODE) }
             .wasInvoked(exactly = once)
 
         verify(arrangement.loginRepository)
@@ -90,7 +90,7 @@ class LoginUseCaseTest {
             .withHandleValidationReturning(ValidateUserHandleResult.Valid(cleanHandle), dirtyHandle)
             .arrange()
 
-        val loginUserCaseResult = loginUseCase(dirtyHandle, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        val loginUserCaseResult = loginUseCase(dirtyHandle, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL, TEST_2FA_CODE)
 
         assertEquals(
             loginUserCaseResult,
@@ -104,7 +104,7 @@ class LoginUseCaseTest {
             .invocation { invoke(cleanHandle) }
             .wasInvoked(exactly = once)
         verify(arrangement.loginRepository)
-            .coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT) }
+            .coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT, TEST_2FA_CODE) }
             .wasInvoked(exactly = once)
 
         verify(arrangement.loginRepository)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
@@ -55,8 +55,18 @@ internal open class LoginApiV0 internal constructor(
 
     private fun LoginApi.LoginParam.toRequestBody(): LoginRequest {
         return when (this) {
-            is LoginApi.LoginParam.LoginWithEmail -> LoginRequest(email = email, password = password, label = label)
-            is LoginApi.LoginParam.LoginWithHandle -> LoginRequest(handle = handle, password = password, label = label)
+            is LoginApi.LoginParam.LoginWithEmail -> LoginRequest(
+                email = email,
+                password = password,
+                label = label,
+                verificationCode = verificationCode
+            )
+            is LoginApi.LoginParam.LoginWithHandle -> LoginRequest(
+                handle = handle,
+                password = password,
+                label = label,
+                verificationCode = verificationCode
+            )
         }
     }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/login/LoginApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/login/LoginApiV0Test.kt
@@ -31,9 +31,12 @@ import com.wire.kalium.network.api.base.unauthenticated.LoginApi
 import com.wire.kalium.network.api.v0.unauthenticated.LoginApiV0
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.isSuccessful
+import com.wire.kalium.util.serialization.toJsonElement
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -53,6 +56,8 @@ class LoginApiV0Test : ApiTest {
                 assertQueryExist(QUERY_PERSIST)
                 assertHttps()
                 assertJson()
+                val verificationCode = this.body.toJsonElement().jsonObject["verification_code"]?.jsonPrimitive?.content
+                assertEquals(LOGIN_WITH_EMAIL_REQUEST.serializableData.verificationCode, verificationCode)
             },
             headers = mapOf("set-cookie" to "zuid=$refreshToken")
         )

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/LoginWithEmailRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/LoginWithEmailRequestJson.kt
@@ -40,6 +40,7 @@ object LoginWithEmailRequestJson {
             email = "user@email.de",
             label = "label",
             password = "password",
+            verificationCode = "verificationCode"
         ), jsonProvider
     )
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

No `verification-code` is actually being added to the serialised request body.

### Causes

Oversight during the first PR + I really thought we had tests for this serialisation 😅 

### Solutions

Correctly pass the arguments and add tests to make sure it doesn't break.

> **Note**: Also made a small refactoring to the `LoginUseCase` that removes the unnecessary mutability for `isEmail`.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
