### PR TITLE
chore: automatically fetch self user if null

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -58,13 +58,13 @@ import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.client.ClientDAO
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -218,10 +218,18 @@ internal class UserDataSource internal constructor(
         else fetchUsersByIds(missingIds.map { it.toModel() }.toSet())
     }
 
-    @OptIn(FlowPreview::class)
     override suspend fun observeSelfUser(): Flow<SelfUser> {
-        // TODO: handle storage error
-        return metadataDAO.valueByKeyFlow(SELF_USER_ID_KEY).filterNotNull().flatMapMerge { encodedValue ->
+        return metadataDAO.valueByKeyFlow(SELF_USER_ID_KEY).onEach {
+            // If the self user is not in the database, proactively fetch it.
+            if (it == null) {
+                kaliumLogger.w("Observing self user before it's inserted into the DB. Triggering a fetch.")
+                fetchSelfUser().fold({ failure ->
+                    kaliumLogger.e("Fetching of self user failed, caused by $failure")
+                }, {
+                    kaliumLogger.i("Fetching of self user succeeded")
+                })
+            }
+        }.filterNotNull().flatMapMerge { encodedValue ->
             val selfUserID: QualifiedIDEntity = Json.decodeFromString(encodedValue)
             userDAO.getUserByQualifiedID(selfUserID)
                 .filterNotNull()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -222,11 +222,12 @@ internal class UserDataSource internal constructor(
         return metadataDAO.valueByKeyFlow(SELF_USER_ID_KEY).onEach {
             // If the self user is not in the database, proactively fetch it.
             if (it == null) {
-                kaliumLogger.w("Observing self user before it's inserted into the DB. Triggering a fetch.")
+                val logPrefix = "Observing self user before insertion"
+                kaliumLogger.w("$logPrefix: Triggering a fetch.")
                 fetchSelfUser().fold({ failure ->
-                    kaliumLogger.e("Fetching of self user failed, caused by $failure")
+                    kaliumLogger.e("""$logPrefix failed: {"failure":"$failure"}""")
                 }, {
-                    kaliumLogger.i("Fetching of self user succeeded")
+                    kaliumLogger.i("$logPrefix: Succeeded")
                 })
             }
         }.filterNotNull().flatMapMerge { encodedValue ->


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After creating `UserSessionScope` for the first time, there is no information about `SelfUser` and it's easy to make mistakes and assume that user data is known when `observeSelfUser` is available.

This is extremely annoying as `observeSelfUser` has a `filterNotNull()`, which makes Kalium hang forever.

### Solutions

Add an automatic retrieval of self user:
If self user is unknown, fetch it from remote and insert locally.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
