### PR TITLE
ci: use JDK 17 Temurin as it's bundled in CI machines

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: gradle
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/setup-java@v3
               with:
                 java-version: '17'
-                distribution: 'zulu'
+                distribution: 'temurin'
                 cache: gradle
 
             - name: Validate Gradle wrapper

--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -29,7 +29,7 @@ jobs:
               uses: actions/setup-java@v3
               with:
                   java-version: '17'
-                  distribution: 'zulu'
+                  distribution: 'temurin'
                   cache: gradle
 
             - name: Gradle Setup

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: gradle
 
       - name: Gradle Setup


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

CI takes some minutes to run the `Setup JDK` step as it downloads a JDK on every run, and sometimes gets stuck in the process, needing a rebuild.

### Solutions

Use JDK 17 Temurin as it's [bundled with the runners](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java).

### Testing

#### How to Test

Running this PR checks should do the trick.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
