### PR TITLE
chore: upgrade kotlin to 1.8.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-kotlin = "1.7.20"
+kotlin = "1.8.10"
 activity-compose = "1.3.1"
 app-compat = "1.1.0"
 android-paging3 = "3.1.1"
 cli-kt = "3.5.0"
 coroutines = "1.6.4"
-compose-compiler = "1.3.2"
+compose-compiler = "1.4.3"
 compose-ui = "1.3.2"
 compose-material = "1.3.1"
 cryptobox4j = "1.3.0"
@@ -41,7 +41,7 @@ desugar-jdk = "1.1.5"
 kermit = "1.2.2"
 detekt = "1.19.0"
 agp = "7.3.1"
-dokka = "1.7.20"
+dokka = "1.8.10"
 carthage = "0.0.1"
 libsodiumBindings = "0.8.6"
 protobufCodegen = "0.9.1"
@@ -56,7 +56,7 @@ completeKotlin = { id = "com.louiscad.complete-kotlin", version.ref = "completeK
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version = "1.7.20-1.0.8" }
+ksp = { id = "com.google.devtools.ksp", version = "1.8.10-1.0.9" }
 carthage = { id = "com.wire.carthage-gradle-plugin", version.ref = "carthage" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufCodegen" }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

A newer version of Kotlin is available and the upgrade comes for free.
We should upgrade before the Reloaded code freeze so we don't differ much between `develop` and `release` and make our lives easier in the future.
A new version will be required for some features we're cooking and experimentation with new libraries.

### Solutions

Upgrade Kotlin to 1.8.10 (1.8.20 is still RC but should be coming out soon without breaking changes).

Change KSP to support 1.8.10;
Change the compose compiler to support 1.8.10;
Upgrade Dokka to support 1.8.10;

### Testing

All tests seem to pass on my machine.
Reloaded using 1.8.10 was also working.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
