### PR TITLE
feat: unread events table for performance purposes [AR-3111]

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
@@ -121,6 +121,7 @@ internal class OnHttpRequest(
             senderUserId = userId,
             senderClientId = clientId,
             status = Message.Status.SENT,
+            isSelfMessage = true
         )
 
         return messageSender.sendMessage(message, messageTarget)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -68,6 +68,7 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.util.DelicateKaliumApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -339,13 +340,21 @@ internal class ConversationDataSource internal constructor(
         combine(
             conversationDAO.getAllConversationDetails(),
             messageDAO.observeLastMessages(),
-            messageDAO.observeUnreadMessageCounter(),
-        ) { conversationList, lastMessageList, unreadMessageCount ->
+            messageDAO.observeUnreadEvents(),
+        ) { conversationList, lastMessageList, unreadEvents ->
             val lastMessageMap = lastMessageList.associateBy { it.conversationId }
             conversationList.map { conversation ->
                 conversationMapper.fromDaoModelToDetails(conversation,
                     lastMessageMap[conversation.id]?.let { messageMapper.fromEntityToMessagePreview(it) },
-                    unreadMessageCount[conversation.id]?.let { mapOf(UnreadEventType.MESSAGE to it) }
+                    unreadEvents[conversation.id]?.map {
+                        when (it.type) {
+                            UnreadEventTypeEntity.KNOCK -> UnreadEventType.KNOCK
+                            UnreadEventTypeEntity.MISSED_CALL -> UnreadEventType.MISSED_CALL
+                            UnreadEventTypeEntity.MENTION -> UnreadEventType.MENTION
+                            UnreadEventTypeEntity.REPLY -> UnreadEventType.REPLY
+                            UnreadEventTypeEntity.MESSAGE -> UnreadEventType.MESSAGE
+                        }
+                    }?.groupingBy { it }?.eachCount()
                 )
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -72,7 +72,7 @@ sealed interface Message {
         override val status: Status,
         override val visibility: Visibility = Visibility.VISIBLE,
         override val senderUserName: String? = null,
-        override val isSelfMessage: Boolean = false,
+        override val isSelfMessage: Boolean,
         override val senderClientId: ClientId,
         val editStatus: EditStatus,
         val reactions: Reactions = Reactions.EMPTY,
@@ -146,7 +146,7 @@ sealed interface Message {
         override val senderClientId: ClientId,
         override val status: Status,
         override val senderUserName: String? = null,
-        override val isSelfMessage: Boolean = false,
+        override val isSelfMessage: Boolean,
     ) : Sendable {
         override fun toLogString(): String {
             val typeKey = "type"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -841,7 +841,8 @@ class UserSessionScope internal constructor(
             ),
             DeleteForMeHandlerImpl(messageRepository, isMessageSentInSelfConversation),
             messageEncoder,
-            receiptMessageHandler
+            receiptMessageHandler,
+            userId
         )
 
     private val newMessageHandler: NewMessageEventHandlerImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
@@ -142,7 +142,8 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
                 editStatus = Message.EditStatus.NotEdited,
-                expectsReadConfirmation = expectsReadConfirmation
+                expectsReadConfirmation = expectsReadConfirmation,
+                isSelfMessage = true
             )
 
             // We persist the asset message right away so that it can be displayed on the conversation screen loading

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.backup.RestoreBackupResult.BackupRestoreFai
 import com.wire.kalium.logic.feature.message.PersistMigratedMessagesUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.incremental.RestartSlowSyncProcessForRecoveryUseCase
 import com.wire.kalium.logic.util.decodeBufferSequence
@@ -44,8 +45,6 @@ import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.MissingFieldException
 import okio.Path
 import okio.buffer
 import okio.use
@@ -86,11 +85,10 @@ internal class RestoreWebBackupUseCaseImpl(
         filePath: Path,
         coroutineScope: CoroutineScope
     ): Either<RestoreBackupResult.BackupRestoreFailure, Unit> {
-        tryImportConversations(filePath)
         return importMessages(filePath, coroutineScope)
+            .map { tryImportConversations(filePath) }
     }
 
-    @OptIn(ExperimentalSerializationApi::class)
     private suspend fun tryImportConversations(filePath: Path) =
         kaliumFileSystem.listDirectories(filePath).firstOrNull { it.name == BACKUP_WEB_CONVERSATIONS_FILE_NAME }?.let { path ->
             kaliumFileSystem.source(path).buffer()
@@ -105,7 +103,7 @@ internal class RestoreWebBackupUseCaseImpl(
                             if (migratedConversation != null) {
                                 migratedConversations.add(migratedConversation)
                             }
-                        } catch (exception: MissingFieldException) {
+                        } catch (exception: Exception) {
                             kaliumLogger.e("$TAG ${exception.message}")
                         }
                     }
@@ -117,7 +115,6 @@ internal class RestoreWebBackupUseCaseImpl(
                 }
         }
 
-    @OptIn(ExperimentalSerializationApi::class)
     private suspend fun importMessages(filePath: Path, coroutineScope: CoroutineScope) = kaliumFileSystem.listDirectories(filePath)
         .firstOrNull { it.name == BACKUP_WEB_EVENTS_FILE_NAME }?.let { path ->
             kaliumFileSystem.source(path).buffer()
@@ -133,7 +130,7 @@ internal class RestoreWebBackupUseCaseImpl(
                             if (migratedMessage != null) {
                                 migratedMessagesBatch.add(migratedMessage)
                             }
-                        } catch (exception: MissingFieldException) {
+                        } catch (exception: Exception) {
                             kaliumLogger.e("$TAG ${exception.message}")
                         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContent.kt
@@ -101,7 +101,8 @@ internal class ClearConversationContentUseCaseImpl(
                             date = DateTimeUtil.currentIsoDateTimeString(),
                             senderUserId = selfUserId,
                             senderClientId = currentClientId,
-                            status = Message.Status.PENDING
+                            status = Message.Status.PENDING,
+                            isSelfMessage = true
                         )
                         messageSender.sendMessage(regularMessage)
                     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -84,7 +84,8 @@ class UpdateConversationReadDateUseCase internal constructor(
                 date = DateTimeUtil.currentIsoDateTimeString(),
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
-                status = Message.Status.PENDING
+                status = Message.Status.PENDING,
+                isSelfMessage = true
             )
             messageSender.sendMessage(regularMessage)
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendBrokenAssetMessageUseCaseImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendBrokenAssetMessageUseCaseImpl.kt
@@ -129,7 +129,8 @@ internal class SendBrokenAssetMessageUseCaseImpl(
                 senderUserId = userId,
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
-                editStatus = Message.EditStatus.NotEdited
+                editStatus = Message.EditStatus.NotEdited,
+                isSelfMessage = true
             )
 
             uploadAssetAndUpdateMessage(message, brokenState)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
@@ -69,7 +69,8 @@ class SendConfirmationUseCase internal constructor(
                 date = Clock.System.now().toString(),
                 senderUserId = selfUser.id,
                 senderClientId = currentClientId,
-                status = Message.Status.PENDING
+                status = Message.Status.PENDING,
+                isSelfMessage = true
             )
             messageSender.sendMessage(message)
         }.onFailure {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -90,6 +90,7 @@ class DeleteMessageUseCase internal constructor(
                                     senderUserId = selfUserId,
                                     senderClientId = currentClientId,
                                     status = Message.Status.PENDING,
+                                    isSelfMessage = true
                                 )
                                 messageSender.sendMessage(regularMessage)
                             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCase.kt
@@ -88,6 +88,7 @@ internal class SendConfirmationUseCase internal constructor(
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
+                isSelfMessage = true
             )
 
             messageSender.sendMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -71,7 +71,8 @@ class SendKnockUseCase internal constructor(
                 senderUserId = selfUser.id,
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
-                editStatus = Message.EditStatus.NotEdited
+                editStatus = Message.EditStatus.NotEdited,
+                isSelfMessage = true
             )
             persistMessage(message)
         }.flatMap {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -89,6 +89,7 @@ class SendTextMessageUseCase internal constructor(
                 senderClientId = clientId,
                 status = Message.Status.PENDING,
                 editStatus = Message.EditStatus.NotEdited,
+                isSelfMessage = true
             )
             persistMessage(message)
         }.flatMap {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionResetSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionResetSender.kt
@@ -67,7 +67,8 @@ class SessionResetSenderImpl internal constructor(
                 date = DateTimeUtil.currentIsoDateTimeString(),
                 senderUserId = selfUserId,
                 senderClientId = selfClientId,
-                status = Message.Status.SENT
+                status = Message.Status.SENT,
+                isSelfMessage = true
             )
             val recipient = Recipient(userId, listOf(clientId))
             messageSender.sendMessage(message, MessageTarget.Client(listOf(recipient)))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
@@ -114,6 +114,7 @@ class ToggleReactionUseCase internal constructor(
                     senderUserId = userId,
                     senderClientId = clientId,
                     status = Message.Status.PENDING,
+                    isSelfMessage = true
                 )
                 messageSender.sendMessage(regularMessage)
             }
@@ -140,6 +141,7 @@ class ToggleReactionUseCase internal constructor(
                     senderUserId = userId,
                     senderClientId = clientId,
                     status = Message.Status.PENDING,
+                    isSelfMessage = true
                 )
                 messageSender.sendMessage(regularMessage)
             }.flatMapLeft {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -81,7 +81,8 @@ internal class ApplicationMessageHandlerImpl(
     private val clearConversationContentHandler: ClearConversationContentHandler,
     private val deleteForMeHandler: DeleteForMeHandler,
     private val messageEncoder: MessageContentEncoder,
-    private val receiptMessageHandler: ReceiptMessageHandler
+    private val receiptMessageHandler: ReceiptMessageHandler,
+    private val selfUserId: UserId
 ) : ApplicationMessageHandler {
 
     private val logger by lazy { kaliumLogger.withFeatureId(ApplicationFlow.EVENT_RECEIVER) }
@@ -120,7 +121,8 @@ internal class ApplicationMessageHandlerImpl(
                     status = Message.Status.SENT,
                     editStatus = Message.EditStatus.NotEdited,
                     visibility = visibility,
-                    expectsReadConfirmation = content.expectsReadConfirmation
+                    expectsReadConfirmation = content.expectsReadConfirmation,
+                    isSelfMessage = senderUserId == selfUserId
                 )
                 processMessage(message)
             }
@@ -133,7 +135,8 @@ internal class ApplicationMessageHandlerImpl(
                     timestampIso,
                     senderUserId,
                     senderClientId,
-                    status = Message.Status.SENT
+                    status = Message.Status.SENT,
+                    isSelfMessage = senderUserId == selfUserId
                 )
                 processSignaling(signalingMessage)
             }
@@ -301,7 +304,8 @@ internal class ApplicationMessageHandlerImpl(
             senderClientId = senderClientId,
             status = Message.Status.SENT,
             editStatus = Message.EditStatus.NotEdited,
-            visibility = Message.Visibility.VISIBLE
+            visibility = Message.Visibility.VISIBLE,
+            isSelfMessage = senderUserId == selfUserId
         )
         processMessage(message)
     }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
@@ -1,0 +1,29 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity;
+import kotlinx.datetime.Instant;
+
+CREATE TABLE UnreadEvent (
+      id TEXT NOT NULL,
+      type TEXT AS UnreadEventTypeEntity NOT NULL,
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      creation_date INTEGER AS Instant NOT NULL,
+
+    FOREIGN KEY (id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY (id, conversation_id)
+);
+
+deleteReadedEvents:
+DELETE FROM UnreadEvent WHERE creation_date <= ? AND conversation_id = ?;
+
+insertEvent:
+INSERT INTO UnreadEvent(id, type, conversation_id, creation_date)
+VALUES(?, ?, ?, ?);
+
+getUnreadEvents:
+SELECT * FROM UnreadEvent;
+
+getPaginatedUnreadEvents:
+SELECT * FROM UnreadEvent LIMIT ? OFFSET ?;
+
+getUnreadEventsCount:
+SELECT COUNT(*) FROM UnreadEvent;

--- a/persistence/src/commonMain/db_user/migrations/30.sqm
+++ b/persistence/src/commonMain/db_user/migrations/30.sqm
@@ -1,0 +1,13 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity;
+import kotlinx.datetime.Instant;
+
+CREATE TABLE UnreadEvent (
+      id TEXT NOT NULL,
+      type TEXT AS UnreadEventTypeEntity NOT NULL,
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      creation_date INTEGER AS Instant NOT NULL,
+
+    FOREIGN KEY (id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY (id, conversation_id)
+);

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -22,6 +22,7 @@ import app.cash.sqldelight.coroutines.asFlow
 import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MembersQueries
 import com.wire.kalium.persistence.SelectConversationByMember
+import com.wire.kalium.persistence.UnreadEventsQueries
 import com.wire.kalium.persistence.UsersQueries
 import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneOrNull
@@ -214,6 +215,7 @@ class ConversationDAOImpl(
     private val conversationQueries: ConversationsQueries,
     private val userQueries: UsersQueries,
     private val memberQueries: MembersQueries,
+    private val unreadEventsQueries: UnreadEventsQueries,
     private val coroutineContext: CoroutineContext
 ) : ConversationDAO {
 
@@ -471,6 +473,7 @@ class ConversationDAOImpl(
     }
 
     override suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: Instant) = withContext(coroutineContext) {
+        unreadEventsQueries.deleteReadedEvents(date, conversationID)
         conversationQueries.updateConversationReadDate(date, conversationID)
     }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MigrationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MigrationDAO.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.dao
 
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.MigrationQueries
+import com.wire.kalium.persistence.UnreadEventsQueries
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageInsertExtension
 import com.wire.kalium.persistence.dao.message.MessageInsertExtensionImpl
@@ -33,12 +34,15 @@ interface MigrationDAO {
 
 internal class MigrationDAOImpl(
     private val migrationQueries: MigrationQueries,
-    messagesQueries: MessagesQueries
-) : MigrationDAO, MessageInsertExtension by MessageInsertExtensionImpl(messagesQueries) {
+    messagesQueries: MessagesQueries,
+    private val unreadEventsQueries: UnreadEventsQueries,
+    selfUserIDEntity: UserIDEntity,
+) : MigrationDAO, MessageInsertExtension by MessageInsertExtensionImpl(messagesQueries, unreadEventsQueries, selfUserIDEntity) {
     override suspend fun insertConversation(conversationList: List<ConversationEntity>) {
         migrationQueries.transaction {
             conversationList.forEach {
                 with(it) {
+                    unreadEventsQueries.deleteReadedEvents(lastReadDate, id)
                     migrationQueries.insertConversation(
                         id,
                         name,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.dao.unread.UnreadEventEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
 
@@ -95,7 +96,7 @@ interface MessageDAO {
 
     suspend fun observeLastMessages(): Flow<List<MessagePreviewEntity>>
 
-    suspend fun observeUnreadMessages(): Flow<List<MessagePreviewEntity>>
+    suspend fun observeUnreadEvents(): Flow<Map<ConversationIDEntity, List<UnreadEventEntity>>>
     suspend fun observeUnreadMessageCounter(): Flow<Map<ConversationIDEntity, Int>>
 
     suspend fun resetAssetUploadStatus()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -27,6 +27,8 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.UserTypeEntity
 import com.wire.kalium.persistence.dao.reaction.ReactionMapper
 import com.wire.kalium.persistence.dao.reaction.ReactionsEntity
+import com.wire.kalium.persistence.dao.unread.UnreadEventEntity
+import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.persistence.util.JsonSerializer
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Instant
@@ -184,6 +186,19 @@ object MessageMapper {
             senderUserId = senderUserId
         )
 
+    }
+
+    fun toUnreadEntity(
+        id: String,
+        type: UnreadEventTypeEntity,
+        conversation_id: QualifiedIDEntity,
+        creation_date: Instant,
+    ): UnreadEventEntity {
+        return UnreadEventEntity(
+            id = id,
+            type = type,
+            conversationId = conversation_id,
+        )
     }
 
     @Suppress("ComplexMethod", "UNUSED_PARAMETER")

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/unread/UnreadEventEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/unread/UnreadEventEntity.kt
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.persistence.dao.unread
+
+import com.wire.kalium.persistence.dao.ConversationIDEntity
+
+data class UnreadEventEntity(
+    val id: String,
+    val type: UnreadEventTypeEntity,
+    val conversationId: ConversationIDEntity
+)
+
+enum class UnreadEventTypeEntity {
+    KNOCK,
+    MISSED_CALL,
+    MENTION,
+    REPLY,
+    MESSAGE
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.persistence.MessageUnknownContent
 import com.wire.kalium.persistence.Reaction
 import com.wire.kalium.persistence.Receipt
 import com.wire.kalium.persistence.SelfUser
+import com.wire.kalium.persistence.UnreadEvent
 import com.wire.kalium.persistence.User
 import com.wire.kalium.persistence.adapter.BotServiceAdapter
 import com.wire.kalium.persistence.adapter.ContentTypeAdapter
@@ -160,5 +161,11 @@ internal object TableMapper {
     )
     val messageConversationReceiptModeChangedContentAdapter = MessageConversationReceiptModeChangedContent.Adapter(
         conversation_idAdapter = QualifiedIDAdapter
+    )
+
+    val unreadEventAdapter = UnreadEvent.Adapter(
+        conversation_idAdapter = QualifiedIDAdapter,
+        typeAdapter = EnumColumnAdapter(),
+        creation_dateAdapter = InstantTypeAdapter,
     )
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -123,6 +123,7 @@ class UserDatabaseBuilder internal constructor(
         UserAdapter = TableMapper.userAdapter,
         MessageConversationReceiptModeChangedContentAdapter = TableMapper.messageConversationReceiptModeChangedContentAdapter,
         MessageNewConversationReceiptModeContentAdapter = TableMapper.messageNewConversationReceiptModeContentAdapter,
+        UnreadEventAdapter = TableMapper.unreadEventAdapter
     )
 
     init {
@@ -139,7 +140,13 @@ class UserDatabaseBuilder internal constructor(
         get() = ConnectionDAOImpl(database.connectionsQueries, database.conversationsQueries, queriesContext)
 
     val conversationDAO: ConversationDAO
-        get() = ConversationDAOImpl(database.conversationsQueries, database.usersQueries, database.membersQueries, queriesContext)
+        get() = ConversationDAOImpl(
+            database.conversationsQueries,
+            database.usersQueries,
+            database.membersQueries,
+            database.unreadEventsQueries,
+            queriesContext
+        )
 
     private val metadataCache = LRUCache<String, Flow<String?>>(METADATA_CACHE_SIZE)
     val metadataDAO: MetadataDAO
@@ -162,6 +169,7 @@ class UserDatabaseBuilder internal constructor(
             database.messagesQueries,
             database.notificationQueries,
             database.conversationsQueries,
+            database.unreadEventsQueries,
             userId,
             database.reactionsQueries,
             queriesContext
@@ -182,7 +190,10 @@ class UserDatabaseBuilder internal constructor(
     val prekeyDAO: PrekeyDAO
         get() = PrekeyDAOImpl(database.metadataQueries, queriesContext)
 
-    val migrationDAO: MigrationDAO get() = MigrationDAOImpl(database.migrationQueries, database.messagesQueries)
+    val migrationDAO: MigrationDAO
+        get() = MigrationDAOImpl(
+            database.migrationQueries, database.messagesQueries, database.unreadEventsQueries, userId
+        )
 
     /**
      * @return the absolute path of the DB file or null if the DB file does not exist

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.persistence.dao.ConversationEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.persistence.utils.IgnoreIOS
 import com.wire.kalium.persistence.utils.stubs.newConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
@@ -423,11 +424,11 @@ class MessageDAOTest : BaseDatabaseTest() {
         )
 
         // when
-        val messageIds = messageDAO.observeUnreadMessages()
-            .map { it.filter { previewEntity -> previewEntity.conversationId == conversationId }.map { message -> message.id } }
+        val messageTypes = messageDAO.observeUnreadEvents()
+            .map { it[conversationId]!!.map { event -> event.type } }
             .first()
         // then
-        assertContains(messageIds, messageId)
+        assertContains(messageTypes, UnreadEventTypeEntity.MESSAGE)
     }
 
     @Test
@@ -458,11 +459,11 @@ class MessageDAOTest : BaseDatabaseTest() {
         )
 
         // when
-        val messageIds = messageDAO.observeUnreadMessages()
-            .map { it.filter { previewEntity -> previewEntity.conversationId == conversationId }.map { message -> message.id } }
+        val messageTypes = messageDAO.observeUnreadEvents()
+            .map { it[conversationId]!!.map { event -> event.type } }
             .first()
         // then
-        assertContains(messageIds, messageId)
+        assertContains(messageTypes, UnreadEventTypeEntity.MISSED_CALL)
     }
 
     @Test
@@ -496,11 +497,11 @@ class MessageDAOTest : BaseDatabaseTest() {
         messageDAO.insertOrIgnoreMessages(message)
 
         // when
-        val messages = messageDAO.observeUnreadMessages()
-            .map { it.filter { previewEntity -> previewEntity.conversationId == conversationId } }
+        val messageTypes = messageDAO.observeUnreadEvents()
+            .map { it[conversationId]!!.map { event -> event.type } }
             .first()
         // then
-        assertEquals(0, messages.size)
+        assertEquals(0, messageTypes.size)
     }
 
     @Test
@@ -547,11 +548,11 @@ class MessageDAOTest : BaseDatabaseTest() {
         messageDAO.insertOrIgnoreMessages(message)
 
         // when
-        val messages = messageDAO.observeUnreadMessages()
-            .map { it.filter { previewEntity -> previewEntity.conversationId == conversationId } }
+        val messageTypes = messageDAO.observeUnreadEvents()
+            .map { it[conversationId]!!.map { event -> event.type } }
             .first()
         // then
-        assertEquals(unreadMessagesCount, messages.size)
+        assertEquals(unreadMessagesCount, messageTypes.size)
     }
 
     @Test
@@ -598,13 +599,12 @@ class MessageDAOTest : BaseDatabaseTest() {
         messageDAO.insertOrIgnoreMessages(message)
 
         // when
-        val messages = messageDAO.observeUnreadMessages()
-            .map { it.filter { previewEntity -> previewEntity.conversationId == conversationId } }
+        val messageTypes = messageDAO.observeUnreadEvents()
+            .map { it[conversationId]!!.map { event -> event.type } }
             .first()
 
-        assertNotNull(messages)
         // then
-        assertEquals(unreadMessagesCount, messages.size)
+        assertEquals(unreadMessagesCount, messageTypes.size)
     }
 
     @Test
@@ -635,11 +635,11 @@ class MessageDAOTest : BaseDatabaseTest() {
         )
 
         // when
-        val messageIds = messageDAO.observeUnreadMessages()
-            .map { it.filter { previewEntity -> previewEntity.conversationId == conversationId }.map { message -> message.id } }
+        val messageTypes = messageDAO.observeUnreadEvents()
+            .map { it[conversationId]!!.map { event -> event.type } }
             .first()
         // then
-        assertContains(messageIds, messageId)
+        assertContains(messageTypes, UnreadEventTypeEntity.MESSAGE)
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
- To not have too much join tables for unread events I created another table to fetch unread events in more performant way.
- Also fixed issue that sometimes `isSelfMessage` was not passed to `Message` object
- Changed try catch error for restore web backup use case

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
