### PR TITLE
fix: do not send 2fa code for login using username (AR-3232)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
@@ -42,8 +42,7 @@ internal interface LoginRepository {
         handle: String,
         password: String,
         label: String?,
-        shouldPersistClient: Boolean,
-        secondFactorVerificationCode: String? = null,
+        shouldPersistClient: Boolean
     ): Either<NetworkFailure, Pair<AuthTokens, SsoId?>>
 }
 
@@ -70,10 +69,9 @@ internal class LoginRepositoryImpl internal constructor(
         password: String,
         label: String?,
         shouldPersistClient: Boolean,
-        secondFactorVerificationCode: String?,
     ): Either<NetworkFailure, Pair<AuthTokens, SsoId?>> =
         login(
-            LoginApi.LoginParam.LoginWithHandle(handle, password, label, secondFactorVerificationCode),
+            LoginApi.LoginParam.LoginWithHandle(handle, password, label),
             shouldPersistClient
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -127,7 +127,6 @@ internal class LoginUseCaseImpl internal constructor(
                     password = password,
                     label = cookieLabel,
                     shouldPersistClient = shouldPersistClient,
-                    secondFactorVerificationCode = secondFactorVerificationCode,
                 )
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepositoryTest.kt
@@ -82,14 +82,12 @@ class LoginRepositoryTest {
             password = TEST_PASSWORD,
             label = TEST_LABEL,
             shouldPersistClient = TEST_PERSIST_CLIENT,
-            secondFactorVerificationCode = TEST_SECOND_FACTOR_CODE
         )
 
         val expectedParam = LoginApi.LoginParam.LoginWithHandle(
             handle = TEST_HANDLE,
             password = TEST_PASSWORD,
             label = TEST_LABEL,
-            verificationCode = TEST_SECOND_FACTOR_CODE
         )
         verify(arrangement.loginApi)
             .suspendFunction(arrangement.loginApi::login)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -77,7 +77,7 @@ class LoginUseCaseTest {
 
         verify(arrangement.loginRepository)
             .suspendFunction(arrangement.loginRepository::loginWithHandle)
-            .with(any(), any(), any(), any(), any())
+            .with(any(), any(), any(), any())
             .wasNotInvoked()
     }
 
@@ -104,7 +104,7 @@ class LoginUseCaseTest {
             .invocation { invoke(cleanHandle) }
             .wasInvoked(exactly = once)
         verify(arrangement.loginRepository)
-            .coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT, TEST_2FA_CODE) }
+            .coroutine { loginWithHandle(cleanHandle, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT) }
             .wasInvoked(exactly = once)
 
         verify(arrangement.loginRepository)
@@ -133,7 +133,7 @@ class LoginUseCaseTest {
             loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT, TEST_2FA_CODE)
         }.wasInvoked(exactly = once)
         verify(arrangement.loginRepository).suspendFunction(arrangement.loginRepository::loginWithHandle)
-            .with(any(), any(), any(), any(), any()).wasNotInvoked()
+            .with(any(), any(), any(), any()).wasNotInvoked()
     }
 
     @Test
@@ -156,7 +156,7 @@ class LoginUseCaseTest {
             .invocation { invoke(TEST_HANDLE) }
             .wasInvoked(exactly = once)
         verify(arrangement.loginRepository)
-            .coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, true, TEST_2FA_CODE) }
+            .coroutine { loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, true) }
             .wasInvoked(exactly = once)
         verify(arrangement.loginRepository)
             .suspendFunction(arrangement.loginRepository::loginWithEmail).with(any(), any(), any(), any(), any())
@@ -253,7 +253,7 @@ class LoginUseCaseTest {
         }.wasInvoked(exactly = once)
         verify(arrangement.loginRepository)
             .suspendFunction(arrangement.loginRepository::loginWithHandle)
-            .with(any(), any(), any(), any(), any())
+            .with(any(), any(), any(), any())
             .wasNotInvoked()
 
         // user handle
@@ -305,7 +305,7 @@ class LoginUseCaseTest {
         }.wasInvoked(exactly = once)
         verify(arrangement.loginRepository)
             .suspendFunction(arrangement.loginRepository::loginWithHandle)
-            .with(any(), any(), any(), any(), any())
+            .with(any(), any(), any(), any())
             .wasNotInvoked()
 
         // user handle
@@ -353,7 +353,7 @@ class LoginUseCaseTest {
         }.wasInvoked(exactly = once)
         verify(arrangement.loginRepository)
             .suspendFunction(arrangement.loginRepository::loginWithHandle)
-            .with(any(), any(), any(), any(), any())
+            .with(any(), any(), any(), any())
             .wasNotInvoked()
 
         // user handle
@@ -395,7 +395,7 @@ class LoginUseCaseTest {
         }.wasInvoked(exactly = once)
         verify(arrangement.loginRepository)
             .suspendFunction(arrangement.loginRepository::loginWithHandle)
-            .with(any(), any(), any(), any(), any())
+            .with(any(), any(), any(), any())
             .wasNotInvoked()
 
         // user handle
@@ -509,7 +509,7 @@ class LoginUseCaseTest {
         fun withLoginUsingHandleResulting(result: Either<NetworkFailure, Pair<AuthTokens, SsoId?>>) = apply {
             given(loginRepository)
                 .suspendFunction(loginRepository::loginWithHandle)
-                .whenInvokedWith(any(), any(), any(), any(), anything())
+                .whenInvokedWith(any(), any(), any(), any())
                 .thenReturn(result)
         }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/LoginApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/LoginApi.kt
@@ -25,13 +25,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 interface LoginApi {
     sealed class LoginParam(
         open val password: String,
-        open val label: String?,
-        /**
-         * Two-factor authentication code received in the user's email.
-         * Optional as it may or may not be required depending on team settings.
-         * @see VerificationCodeApi
-         */
-        open val verificationCode: String?
+        open val label: String?
     ) {
         data class LoginWithEmail(
             val email: String,
@@ -42,20 +36,14 @@ interface LoginApi {
              * Optional as it may or may not be required depending on team settings.
              * @see VerificationCodeApi
              */
-            override val verificationCode: String? = null,
-        ) : LoginParam(password, label, verificationCode)
+            val verificationCode: String? = null,
+        ) : LoginParam(password, label)
 
         data class LoginWithHandle(
             val handle: String,
             override val password: String,
             override val label: String?,
-            /**
-             * Two-factor authentication code received in the user's email.
-             * Optional as it may or may not be required depending on team settings.
-             * @see VerificationCodeApi
-             */
-            override val verificationCode: String? = null,
-        ) : LoginParam(password, label, verificationCode)
+        ) : LoginParam(password, label)
     }
 
     suspend fun login(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
@@ -65,7 +65,6 @@ internal open class LoginApiV0 internal constructor(
                 handle = handle,
                 password = password,
                 label = label,
-                verificationCode = verificationCode
             )
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users are failing to login using their handles

### Causes

Kalium sends `verification-code` even when logging in with handles, which is not supported.

Completely on me, as one of the first things I implemented was the serialisation and at that stage I didn't know it was only when logging in using email.

### Solutions

Completely remove the possibility to pass verification code when logging in using handle.

### Testing

#### Test Coverage

N/A: We removed the possibility to serialize it. It's impossible to pass a value. Won't compile.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
