### PR TITLE
feat(darwin): chunked AES encryption methods for better memory usage 

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/CryptoUtils.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/CryptoUtils.kt
@@ -24,12 +24,12 @@ import okio.Source
 
 actual fun encryptDataWithAES256(data: PlainData, key: AES256Key): EncryptedData = AESEncrypt().encryptData(data, key)
 
-actual fun encryptFileWithAES256(assetDataSource: Source, key: AES256Key, outputSink: Sink) =
-    AESEncrypt().encryptFile(assetDataSource, key, outputSink)
+actual fun encryptFileWithAES256(source: Source, key: AES256Key, sink: Sink) =
+    AESEncrypt().encryptFile(source, key, sink)
 
 actual fun decryptDataWithAES256(data: EncryptedData, secretKey: AES256Key): PlainData = AESDecrypt(secretKey).decryptData(data)
 
-actual fun decryptFileWithAES256(encryptedDataSource: Source, decryptedDataSink: Sink, secretKey: AES256Key) =
-    AESDecrypt(secretKey).decryptFile(encryptedDataSource, decryptedDataSink)
+actual fun decryptFileWithAES256(source: Source, sink: Sink, secretKey: AES256Key) =
+    AESDecrypt(secretKey).decryptFile(source, sink)
 
 actual fun generateRandomAES256Key(): AES256Key = AESEncrypt().generateRandomAES256Key()

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
@@ -33,6 +33,7 @@ fun calcMd5(bytes: ByteArray): String =
 
 /**
  * Method used to calculate the digested MD5 hash of a relatively small byte array
+ *
  * @param bytes the data to be hashed
  * @return the digested md5 hash of the input [bytes] data
  * @see calcFileMd5
@@ -56,6 +57,7 @@ fun calcSHA256(bytes: ByteArray): ByteArray =
 
 /**
  * Method used to calculate the digested SHA256 hash of a relatively small byte array
+ *
  * @param bytes the data to be hashed
  * @return the digested SHA256 hash of the input [bytes] data
  * @see calcFileSHA256
@@ -76,6 +78,7 @@ fun calcFileSHA256(dataSource: Source): ByteArray? =
 
 /**
  * Method used to encrypt a relatively small array of bytes using the AES256 encryption algorithm
+ *
  * @param data the [PlainData] that needs to be encrypted
  * @param key the symmetric secret [AES256Key] that will be used for the encryption
  * @return the final [EncryptedData], on which the first 16 bytes belong to the initialisation vector
@@ -88,6 +91,7 @@ expect fun encryptDataWithAES256(
 
 /**
  * Method used to decrypt a relatively small array of bytes using the AES256 decryption algorithm
+ *
  * @param data the [EncryptedData] that needs to be decrypted
  * @return the decrypted data as a byte array encapsulated in a [PlainData] object
  * @see decryptFileWithAES256
@@ -95,24 +99,26 @@ expect fun encryptDataWithAES256(
 expect fun decryptDataWithAES256(data: EncryptedData, secretKey: AES256Key): PlainData
 
 /**
- * Method used to encrypt some data stored on the file system using the AES256 encryption algorithm
- * @param assetDataSource the path to the data that needs to be encrypted
+ * Method used to encrypt binary data using the AES256 encryption algorithm
+ *
+ * @param source the [Source] of the plain text data that needs to be encrypted
  * @param key the symmetric secret [AES256Key] that will be used for the encryption
- * @param outputSink the path where the encrypted data will be saved
+ * @param sink the [Sink] which the encrypted data will be written to
  * @return the size of the encrypted data in bytes if the encryption succeeded and 0 otherwise
  * @see encryptDataWithAES256
  */
-expect fun encryptFileWithAES256(assetDataSource: Source, key: AES256Key, outputSink: Sink): Long
+expect fun encryptFileWithAES256(source: Source, key: AES256Key, sink: Sink): Long
 
 /**
  * Method used to decrypt some binary data using the AES256 encryption algorithm
- * @param encryptedDataSource the [Source] of the encrypted data that needs to be decrypted
- * @param decryptedDataSink the output stream data sink invoked to write the decrypted data
+ *
+ * @param source the [Source] of the encrypted data that needs to be decrypted
+ * @param sink the [Sink] to which the plain text data will be written to
  * @param secretKey the key used for the decryption
  * @return the size of the decrypted data in bytes if the decryption succeeded -1L otherwise
  * @see decryptDataWithAES256
  */
-expect fun decryptFileWithAES256(encryptedDataSource: Source, decryptedDataSink: Sink, secretKey: AES256Key): Long
+expect fun decryptFileWithAES256(source: Source, sink: Sink, secretKey: AES256Key): Long
 
 /**
  * Method to generate a random Secret Key via the AES256 ciphering Algorithm

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/CryptoUtilsTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/CryptoUtilsTest.kt
@@ -34,6 +34,7 @@ import okio.buffer
 import okio.fakefilesystem.FakeFileSystem
 import okio.use
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -82,7 +83,7 @@ class CryptoUtilsTest {
 
         // Then
         assertNotNull(digest)
-        assertTrue(digest.contentEquals(expectedValue))
+        assertContentEquals(expectedValue, digest)
     }
 
     @Test
@@ -120,7 +121,7 @@ class CryptoUtilsTest {
         // Then
         assertTrue(input.size % 16 == 0)
         assertEquals(decryptedDataSize, input.size.toLong())
-        assertTrue(input.contentEquals(decryptedData))
+        assertContentEquals(decryptedData, input)
     }
 
     @Test
@@ -157,7 +158,7 @@ class CryptoUtilsTest {
         assertTrue(encryptedDataSize % 16 == 0)
         assertEquals(decryptedData.size, input.size)
         assertEquals(decryptedDataSize, input.size.toLong())
-        assertTrue(input.contentEquals(decryptedData))
+        assertContentEquals(decryptedData, input)
     }
 
     @Test
@@ -189,8 +190,8 @@ class CryptoUtilsTest {
 
         // Then
         assertTrue(input.size % 16 == 0)
-        assertEquals(decryptedData.data.size, input.size)
-        assertTrue(input.contentEquals(decryptedData.data))
+        assertEquals(input.size, decryptedData.data.size)
+        assertContentEquals(input, decryptedData.data)
     }
 
     @Test

--- a/cryptography/src/darwinMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
+++ b/cryptography/src/darwinMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
@@ -31,7 +31,11 @@ import okio.Sink
 import okio.Source
 import okio.buffer
 import okio.use
-import platform.CoreCrypto.CCCrypt
+import platform.CoreCrypto.CCCryptorCreate
+import platform.CoreCrypto.CCCryptorFinal
+import platform.CoreCrypto.CCCryptorRefVar
+import platform.CoreCrypto.CCCryptorRelease
+import platform.CoreCrypto.CCCryptorUpdate
 import platform.CoreCrypto.kCCAlgorithmAES
 import platform.CoreCrypto.kCCBlockSizeAES128
 import platform.CoreCrypto.kCCDecrypt
@@ -70,100 +74,176 @@ actual fun decryptDataWithAES256(data: EncryptedData, secretKey: AES256Key): Pla
 }
 
 actual fun encryptFileWithAES256(assetDataSource: Source, key: AES256Key, outputSink: Sink): Long {
-    try {
-        val iv = generateRandomData(kCCBlockSizeAES128.toInt())
-        val plainData = assetDataSource.buffer().readByteArray()
-        val encryptedBuffer = ByteArray(plainData.size + kCCBlockSizeAES128.toInt())
+    val iv = generateRandomData(kCCBlockSizeAES128.toInt())
+    val encryptedBuffer = ByteArray(BUFFER_SIZE + kCCBlockSizeAES128.toInt())
 
-        // TODO avoid read whole file into memory by using streaming or block based API
-        return memScoped {
-            val bytesCopied = alloc<ULongVar>()
-            val status = key.data.usePinned { key ->
+    return memScoped {
+        val cryptor = alloc<CCCryptorRefVar>()
+        val bytesCopied = alloc<ULongVar>()
+        var bytesCopiedTotal: ULong = 0u
+
+        try {
+            key.data.usePinned { key ->
                 iv.usePinned { iv ->
-                    plainData.usePinned { plainData ->
-                        encryptedBuffer.usePinned { encryptedBuffer ->
-                            CCCrypt(
-                                kCCEncrypt,
-                                kCCAlgorithmAES,
-                                kCCOptionPKCS7Padding,
-                                key.addressOf(0),
-                                kCCKeySizeAES256.toULong(),
-                                iv.addressOf(0),
-                                plainData.addressOf(0),
-                                plainData.get().size.toULong(),
-                                encryptedBuffer.addressOf(0),
-                                encryptedBuffer.get().size.toULong(),
-                                bytesCopied.ptr
-                            )
-                        }
+                    val status = CCCryptorCreate(
+                        kCCEncrypt,
+                        kCCAlgorithmAES,
+                        kCCOptionPKCS7Padding,
+                        key.addressOf(0),
+                        kCCKeySizeAES256.toULong(),
+                        iv.addressOf(0),
+                        cryptor.ptr
+                    )
+
+                    if (status != kCCSuccess) {
+                        throw CryptographyException("Failure on CCCryptorCreate, status = $status")
                     }
                 }
-            }
-
-            if (status != kCCSuccess) {
-                throw CryptographyException("Failure while encrypting data using AES256")
             }
 
             Buffer().use {
                 outputSink.write(it.write(iv), iv.size.toLong())
             }
+
+            val inputBuffer = assetDataSource.buffer()
+            val unencryptedBuffer = ByteArray(BUFFER_SIZE)
+            var bytesRead: Int
+
+            while (inputBuffer.read(unencryptedBuffer, 0, BUFFER_SIZE).also { bytesRead = it } > 0) {
+                unencryptedBuffer.usePinned { unencryptedBuffer ->
+                    encryptedBuffer.usePinned { encryptedBuffer ->
+                        val status = CCCryptorUpdate(
+                            cryptor.value,
+                            unencryptedBuffer.addressOf(0),
+                            bytesRead.toULong(),
+                            encryptedBuffer.addressOf(0),
+                            encryptedBuffer.get().size.toULong(),
+                            bytesCopied.ptr
+                        )
+
+                        if (status != kCCSuccess) {
+                            throw CryptographyException("Failure on CCCryptorUpdate, status = $status")
+                        }
+                    }
+                }
+
+                Buffer().use {
+                    outputSink.write(it.write(encryptedBuffer), bytesCopied.value.toLong())
+                }
+                bytesCopiedTotal += bytesCopied.value
+            }
+
+            encryptedBuffer.usePinned { encryptedBuffer ->
+                val status = CCCryptorFinal(
+                    cryptor.value,
+                    encryptedBuffer.addressOf(0),
+                    encryptedBuffer.get().size.toULong(),
+                    bytesCopied.ptr
+                )
+
+                if (status != kCCSuccess) {
+                    throw CryptographyException("Failure on CCCryptorFinal, status = $status")
+                }
+            }
+
             Buffer().use {
                 outputSink.write(it.write(encryptedBuffer), bytesCopied.value.toLong())
             }
-            bytesCopied.value.toLong()
+            bytesCopiedTotal += bytesCopied.value
+        } finally {
+            CCCryptorRelease(cryptor.value)
+            assetDataSource.close()
+            outputSink.close()
         }
-    } finally {
-        assetDataSource.close()
-        outputSink.close()
+
+        bytesCopiedTotal.toLong()
     }
 }
 
 actual fun decryptFileWithAES256(encryptedDataSource: Source, decryptedDataSink: Sink, secretKey: AES256Key): Long {
-    try {
-        val iv = Buffer().use {
-            encryptedDataSource.read(it, kCCBlockSizeAES128.toLong())
-            it.readByteArray()
-        }
-        val encryptedData = encryptedDataSource.buffer().readByteArray()
-        val decryptedBuffer = ByteArray(encryptedData.size + kCCBlockSizeAES128.toInt())
+    val decryptedBuffer = ByteArray(BUFFER_SIZE + kCCBlockSizeAES128.toInt())
 
-        // TODO avoid read whole file into memory by using streaming or block based API
-        return memScoped {
-            val bytesCopied = alloc<ULongVar>()
-            val status = secretKey.data.usePinned { key ->
+    return memScoped {
+        val cryptor = alloc<CCCryptorRefVar>()
+        val bytesCopied = alloc<ULongVar>()
+        var bytesCopiedTotal: ULong = 0u
+
+        try {
+            val iv = Buffer().use {
+                encryptedDataSource.read(it, kCCBlockSizeAES128.toLong())
+                it.readByteArray()
+            }
+
+            secretKey.data.usePinned { key ->
                 iv.usePinned { iv ->
-                    encryptedData.usePinned { encryptedData ->
-                        decryptedBuffer.usePinned { decryptedBuffer ->
-                            CCCrypt(
-                                kCCDecrypt,
-                                kCCAlgorithmAES,
-                                kCCOptionPKCS7Padding,
-                                key.addressOf(0),
-                                kCCKeySizeAES256.toULong(),
-                                iv.addressOf(0),
-                                encryptedData.addressOf(0),
-                                encryptedData.get().size.toULong(),
-                                decryptedBuffer.addressOf(0),
-                                decryptedBuffer.get().size.toULong(),
-                                bytesCopied.ptr
-                            )
-                        }
+                    val status = CCCryptorCreate(
+                        kCCDecrypt,
+                        kCCAlgorithmAES,
+                        kCCOptionPKCS7Padding,
+                        key.addressOf(0),
+                        kCCKeySizeAES256.toULong(),
+                        iv.addressOf(0),
+                        cryptor.ptr
+                    )
+
+                    if (status != kCCSuccess) {
+                        throw CryptographyException("Failure on CCCryptorCreate, status = $status")
                     }
                 }
             }
 
-            if (status != kCCSuccess) {
-                throw CryptographyException("Failure while decrypting data using AES256")
+            val inputBuffer = encryptedDataSource.buffer()
+            val encryptedBuffer = ByteArray(BUFFER_SIZE)
+            var bytesRead: Int
+
+            while (inputBuffer.read(encryptedBuffer, 0, BUFFER_SIZE).also { bytesRead = it } > 0) {
+                decryptedBuffer.usePinned { decryptedBuffer ->
+                    encryptedBuffer.usePinned { encryptedDataBlock ->
+                        val status = CCCryptorUpdate(
+                            cryptor.value,
+                            encryptedDataBlock.addressOf(0),
+                            bytesRead.toULong(),
+                            decryptedBuffer.addressOf(0),
+                            decryptedBuffer.get().size.toULong(),
+                            bytesCopied.ptr
+                        )
+
+                        if (status != kCCSuccess) {
+                            throw CryptographyException("Failure on CCCryptorUpdate, status = $status")
+                        }
+                    }
+                }
+
+                Buffer().use {
+                    decryptedDataSink.write(it.write(decryptedBuffer), bytesCopied.value.toLong())
+                }
+                bytesCopiedTotal += bytesCopied.value
+            }
+
+            decryptedBuffer.usePinned { decryptedBuffer ->
+                val status = CCCryptorFinal(
+                    cryptor.value,
+                    decryptedBuffer.addressOf(0),
+                    decryptedBuffer.get().size.toULong(),
+                    bytesCopied.ptr
+                )
+
+                if (status != kCCSuccess) {
+                    throw CryptographyException("Failure on CCCryptorFinal, status = $status")
+                }
             }
 
             Buffer().use {
                 decryptedDataSink.write(it.write(decryptedBuffer), bytesCopied.value.toLong())
             }
-             bytesCopied.value.toLong()
+            bytesCopiedTotal += bytesCopied.value
+        } finally {
+            CCCryptorRelease(cryptor.value)
+            encryptedDataSource.close()
+            decryptedDataSink.close()
         }
-    } finally {
-        encryptedDataSource.close()
-        decryptedDataSink.close()
+
+        bytesCopiedTotal.toLong()
     }
 }
 
@@ -184,3 +264,5 @@ private fun generateRandomData(size: Int): ByteArray {
 
     return keyMaterial
 }
+
+private const val BUFFER_SIZE = 1024 * 8

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/utils/CryptoUtils.kt
@@ -29,11 +29,11 @@ actual fun decryptDataWithAES256(data: EncryptedData, secretKey: AES256Key): Pla
     TODO("Not yet implemented")
 }
 
-actual fun encryptFileWithAES256(assetDataSource: Source, key: AES256Key, outputSink: Sink): Long {
+actual fun encryptFileWithAES256(source: Source, key: AES256Key, sink: Sink): Long {
     TODO("Not yet implemented")
 }
 
-actual fun decryptFileWithAES256(encryptedDataSource: Source, decryptedDataSink: Sink, secretKey: AES256Key): Long =
+actual fun decryptFileWithAES256(source: Source, sink: Sink, secretKey: AES256Key): Long =
     TODO("Not yet implemented")
 
 actual fun generateRandomAES256Key(): AES256Key {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The Darwin methods for encrypting using AES is done in memory which can lead to out memory scenarios when encrypting/decrypting large files.

### Solutions

Perform encryption in chunks.

### Notes

I also improved the documentation a bit since it was inconsistent with what the methods actually do.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
