### PR TITLE
fix: added isSelfMention field to MessageMention class

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMention.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMention.kt
@@ -23,5 +23,6 @@ import com.wire.kalium.logic.data.user.UserId
 data class MessageMention(
     val start: Int,
     val length: Int,
-    val userId: UserId
+    val userId: UserId,
+    val isSelfMention: Boolean
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMentionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMentionMapper.kt
@@ -41,7 +41,8 @@ class MessageMentionMapperImpl(
         return MessageMention(
             start = mention.start,
             length = mention.length,
-            userId = mention.userId.toModel()
+            userId = mention.userId.toModel(),
+            isSelfMention = mention.userId.toModel() == selfUserId
         )
     }
 
@@ -64,6 +65,7 @@ class MessageMentionMapperImpl(
             start = mention.start,
             length = mention.length,
             userId = userId,
+            isSelfMention = userId == selfUserId
         )
     }
 

--- a/samples/src/jvmMain/kotlin/samples/logic/MessageUseCases.kt
+++ b/samples/src/jvmMain/kotlin/samples/logic/MessageUseCases.kt
@@ -40,14 +40,16 @@ object MessageUseCases {
     suspend fun sendingTextMessageWithMentions(
         sendTextMessageUseCase: SendTextMessageUseCase,
         conversationId: ConversationId,
-        johnUserId: UserId
+        johnUserId: UserId,
+        selfUserId: UserId
     ) {
         // Sending a text message with mention
         val text = "Hello, @John"
         val johnMention = MessageMention(
             start = 8, // The index of the @ in the text above
             length = 5, // The length of the mention (including the @)
-            userId = johnUserId // ID of the user being mentioned
+            userId = johnUserId, // ID of the user being mentioned
+            isSelfMention = selfUserId == johnUserId // Whether the mention is for the current user
         )
         sendTextMessageUseCase.invoke(
             conversationId = conversationId,
@@ -60,13 +62,15 @@ object MessageUseCases {
         editTextMessageUseCase: SendEditTextMessageUseCase,
         conversationId: ConversationId,
         originalMessageId: String,
-        johnUserId: UserId
+        johnUserId: UserId,
+        selfUserId: UserId
     ) {
         // Editing a simple text message
         val johnMention = MessageMention(
             start = 8, // The index of the @ in the text above
             length = 5, // The length of the mention (including the @)
-            userId = johnUserId // ID of the user being mentioned
+            userId = johnUserId, // ID of the user being mentioned
+            isSelfMention = selfUserId == johnUserId // Whether the mention is for the current user
         )
         editTextMessageUseCase.invoke(
             conversationId = conversationId,

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -270,7 +270,8 @@ class ConversationResources(private val instanceService: InstanceService) {
                     MessageMention(
                         mention.start,
                         mention.length,
-                        UserId(mention.userId, mention.userDomain)
+                        UserId(mention.userId, mention.userDomain),
+                        false
                     )
                 }.toList()
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Mentions can't be distinguished between self mentions and other user mentions atm. And with this PR we will be able to do so.

Needs releases with:
This PR is raised to support  #AR-1582 one

- https://github.com/wireapp/wire-android-reloaded/pull/1582

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
