### PR TITLE
chore(rc): adjustment to not trust by default same domain (AR-3215)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1148,9 +1148,10 @@ class UserSessionScope internal constructor(
     val connection: ConnectionScope get() = ConnectionScope(connectionRepository, conversationRepository)
 
     val observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase
-        get() = ObserveSecurityClassificationLabelUseCaseImpl(userId, conversationRepository, userConfigRepository)
+        get() = ObserveSecurityClassificationLabelUseCaseImpl(conversationRepository, userConfigRepository)
+
     val getOtherUserSecurityClassificationLabel: GetOtherUserSecurityClassificationLabelUseCase
-        get() = GetOtherUserSecurityClassificationLabelUseCaseImpl(userId, userConfigRepository)
+        get() = GetOtherUserSecurityClassificationLabelUseCaseImpl(userConfigRepository)
 
     val kaliumFileSystem: KaliumFileSystem by lazy {
         // Create the cache and asset storage directories

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCase.kt
@@ -37,19 +37,12 @@ interface GetOtherUserSecurityClassificationLabelUseCase {
 }
 
 internal class GetOtherUserSecurityClassificationLabelUseCaseImpl(
-    private val selfUserId: UserId,
     private val userConfigRepository: UserConfigRepository,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) : GetOtherUserSecurityClassificationLabelUseCase {
 
     override suspend fun invoke(otherUserId: UserId): SecurityClassificationType = withContext(dispatchers.io) {
-        val trustedDomains = getClassifiedDomainsStatus()
-        val computedStatus = if (trustedDomains == null) {
-            null
-        } else {
-            otherUserId.domain == selfUserId.domain || trustedDomains.contains(otherUserId.domain)
-        }
-        return@withContext when (computedStatus) {
+        return@withContext when (getClassifiedDomainsStatus()?.contains(otherUserId.domain)) {
             true -> SecurityClassificationType.CLASSIFIED
             false -> SecurityClassificationType.NOT_CLASSIFIED
             null -> SecurityClassificationType.NONE

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCase.kt
@@ -39,7 +39,6 @@ interface ObserveSecurityClassificationLabelUseCase {
 }
 
 internal class ObserveSecurityClassificationLabelUseCaseImpl(
-    private val selfUserId: UserId,
     private val conversationRepository: ConversationRepository,
     private val userConfigRepository: UserConfigRepository
 ) : ObserveSecurityClassificationLabelUseCase {
@@ -51,9 +50,7 @@ internal class ObserveSecurityClassificationLabelUseCaseImpl(
                 if (trustedDomains == null) {
                     null
                 } else {
-                    participantsIds.map { it.id.domain }.all { participantDomain ->
-                        participantDomain == selfUserId.domain || trustedDomains.contains(participantDomain)
-                    }
+                    participantsIds.map { it.id.domain }.all { participantDomain -> trustedDomains.contains(participantDomain) }
                 }
             }.map { isClassified ->
                 when (isClassified) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOtherUserSecurityClassificationLabelUseCaseTest.kt
@@ -92,7 +92,7 @@ class GetOtherUserSecurityClassificationLabelUseCaseTest {
         }
 
         fun arrange() = this to GetOtherUserSecurityClassificationLabelUseCaseImpl(
-            selfUserId, userConfigRepository, dispatcher
+            userConfigRepository, dispatcher
         )
 
         companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCaseTest.kt
@@ -88,7 +88,7 @@ class ObserveSecurityClassificationLabelUseCaseTest {
         val userConfigRepository = mock(classOf<UserConfigRepository>())
 
         private val getSecurityClassificationType = ObserveSecurityClassificationLabelUseCaseImpl(
-            selfUserId, conversationRepository, userConfigRepository
+            conversationRepository, userConfigRepository
         )
 
         fun withGettingClassifiedDomainsDisabled() = apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The logic for classifications labels needed to be adjusted to not trust by default the own domain. 
More context of this on: https://wearezeta.atlassian.net/wiki/spaces/~444846844/pages/770441447/2023-03-15+Playtest+result+classified+conversations+behavior

### Solutions

Adjust the logic to consider the list of trusted domains only for computing the label.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
