### PR TITLE
fix(rc): remove devices remotely also delete locally (AR-3250)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -141,7 +141,7 @@ class ClientDataSource(
         }
 
     override suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit> {
-        return clientRemoteRepository.deleteClient(param).onSuccess { _ ->
+        return clientRemoteRepository.deleteClient(param).onSuccess {
             wrapStorageRequest { clientDAO.deleteClient(selfUserID.toDao(), param.clientId.value) }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.mapLeft
 import com.wire.kalium.logic.functional.onSuccess
@@ -140,7 +141,9 @@ class ClientDataSource(
         }
 
     override suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit> {
-        return clientRemoteRepository.deleteClient(param)
+        return clientRemoteRepository.deleteClient(param).onSuccess { _ ->
+            wrapStorageRequest { clientDAO.deleteClient(selfUserID.toDao(), param.clientId.value) }
+        }
     }
 
     /**


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When removing a device remotely, we were not deleting locally the storage

### Causes (Optional)

Observing to the list of local devices, was not consistent

### Solutions

When successfully removed a device, also delete it locally.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
