### PR TITLE
fix(dev): remove devices remotely also delete locally (AR-3250)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -140,7 +140,9 @@ class ClientDataSource(
         }
 
     override suspend fun deleteClient(param: DeleteClientParam): Either<NetworkFailure, Unit> {
-        return clientRemoteRepository.deleteClient(param)
+        return clientRemoteRepository.deleteClient(param).onSuccess {
+            wrapStorageRequest { clientDAO.deleteClient(selfUserID.toDao(), param.clientId.value) }
+        }
     }
 
     /**


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When removing a device remotely, we were not deleting locally from the storage

### Causes (Optional)

Observing to the list of local devices, was not consistent

### Solutions

When successfully removed a device, also delete it locally.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
