### PR TITLE
refactor(rc): disable resending pending messages [AR-2693]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -92,7 +92,7 @@ class DebugScope internal constructor(
         )
 
     private val messageSendFailureHandler: MessageSendFailureHandler
-        get() = MessageSendFailureHandlerImpl(userRepository, clientRepository)
+        get() = MessageSendFailureHandlerImpl(userRepository, clientRepository, messageRepository)
 
     private val sessionEstablisher: SessionEstablisher
         get() = SessionEstablisherImpl(proteusClientProvider, preKeyRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -87,7 +87,7 @@ class MessageScope internal constructor(
 ) {
 
     private val messageSendFailureHandler: MessageSendFailureHandler
-        get() = MessageSendFailureHandlerImpl(userRepository, clientRepository)
+        get() = MessageSendFailureHandlerImpl(userRepository, clientRepository, messageRepository)
 
     private val sessionEstablisher: SessionEstablisher
         get() = SessionEstablisherImpl(proteusClientProvider, preKeyRepository)
@@ -133,11 +133,13 @@ class MessageScope internal constructor(
 
     val sendTextMessage: SendTextMessageUseCase
         get() = SendTextMessageUseCase(
+            messageRepository,
             persistMessage,
             selfUserId,
             currentClientIdProvider,
             slowSyncRepository,
             messageSender,
+            messageSendFailureHandler,
             userPropertyRepository
         )
 
@@ -147,7 +149,8 @@ class MessageScope internal constructor(
             selfUserId,
             currentClientIdProvider,
             slowSyncRepository,
-            messageSender
+            messageSender,
+            messageSendFailureHandler
         )
 
     val getMessageById: GetMessageByIdUseCase
@@ -214,11 +217,13 @@ class MessageScope internal constructor(
 
     val sendKnock: SendKnockUseCase
         get() = SendKnockUseCase(
+            messageRepository,
             persistMessage,
-            userRepository,
+            selfUserId,
             currentClientIdProvider,
             slowSyncRepository,
-            messageSender
+            messageSender,
+            messageSendFailureHandler
         )
 
     val markMessagesAsNotified: MarkMessagesAsNotifiedUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -70,6 +70,11 @@ interface MessageSender {
      * @param conversationId
      * @param messageUuid
      */
+    @Deprecated(
+        "For now we don't support re-sending pending messages, they should fail immediately when there's an error, " +
+                "even if it's no network",
+        ReplaceWith("sendMessage")
+    )
     suspend fun sendPendingMessage(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit>
 
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
@@ -33,7 +33,6 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
-import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
@@ -54,6 +53,7 @@ class SendEditTextMessageUseCase internal constructor(
     private val provideClientId: CurrentClientIdProvider,
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSender: MessageSender,
+    private val messageSendFailureHandler: MessageSendFailureHandler,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
@@ -122,14 +122,10 @@ class SendEditTextMessageUseCase internal constructor(
                             }
                         }
                 }
-        }.onFailure {
-            messageRepository.updateMessageStatus(MessageEntity.Status.FAILED, conversationId, originalMessageId)
-            if (it is CoreFailure.Unknown) {
-                kaliumLogger.e("There was an unknown error trying to send the edit message $it", it.rootCause)
-                it.rootCause?.printStackTrace()
-            } else {
-                kaliumLogger.e("There was an error trying to send the edit message $it")
-            }
-        }
+        }.onFailure { messageSendFailureHandler.handleFailureUpdateMessageStatus(it, conversationId, originalMessageId, TYPE) }
+    }
+
+    companion object {
+        const val TYPE = "edit text"
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
@@ -18,28 +18,31 @@
 
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
-import com.wire.kalium.logic.data.user.ConnectionState
-import com.wire.kalium.logic.data.user.SelfUser
-import com.wire.kalium.logic.data.user.UserAssetId
-import com.wire.kalium.logic.data.user.UserAvailabilityStatus
-import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.persistence.dao.message.MessageEntity
 import io.mockative.Mock
 import io.mockative.any
+import io.mockative.anything
 import io.mockative.classOf
+import io.mockative.configure
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -51,25 +54,67 @@ class SendKnockUserCaseTest {
     fun givenAValidSendKnockRequest_whenSendingKnock_thenShouldReturnASuccessResult() = runTest {
         // Given
         val conversationId = ConversationId("some-convo-id", "some-domain-id")
-        val (_, sendKnockUseCase) = Arrangement()
-            .withSuccessfulResponse(false)
+        val (arrangement, sendKnockUseCase) = Arrangement()
+            .withCurrentClientProviderSuccess()
+            .withPersistMessageSuccess()
+            .withSlowSyncStatusComplete()
+            .withSendMessageSuccess()
+            .withUpdateMessageStatusSuccess()
             .arrange()
 
         // When
-        val result =
-            sendKnockUseCase.invoke(conversationId, false)
+        val result = sendKnockUseCase.invoke(conversationId, false)
 
         // Then
         assertTrue(result is Either.Right)
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(any(), any())
+            .wasInvoked(once)
+        verify(arrangement.messageRepository)
+            .suspendFunction(arrangement.messageRepository::updateMessageStatus)
+            .with(eq(MessageEntity.Status.SENT), any(), any())
+            .wasInvoked(once)
+        verify(arrangement.messageSendFailureHandler)
+            .suspendFunction(arrangement.messageSendFailureHandler::handleFailureUpdateMessageStatus)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenNoNetwork_whenSendingKnock_thenShouldReturnAFailure() = runTest {
+        // Given
+        val conversationId = ConversationId("some-convo-id", "some-domain-id")
+        val (arrangement, sendKnockUseCase) = Arrangement()
+            .withCurrentClientProviderSuccess()
+            .withPersistMessageSuccess()
+            .withSlowSyncStatusComplete()
+            .withSendMessageFailure()
+            .withUpdateMessageStatusSuccess()
+            .arrange()
+
+        // When
+        val result = sendKnockUseCase.invoke(conversationId, false)
+
+        // Then
+        assertTrue(result is Either.Left)
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(any(), any())
+            .wasInvoked(once)
+        verify(arrangement.messageSendFailureHandler)
+            .suspendFunction(arrangement.messageSendFailureHandler::handleFailureUpdateMessageStatus)
+            .with(any(), any(), any(), any())
+            .wasInvoked(once)
     }
 
     private class Arrangement {
 
         @Mock
-        private val persistMessage = mock(classOf<PersistMessageUseCase>())
+        val messageRepository = mock(classOf<MessageRepository>())
 
         @Mock
-        private val userRepository = mock(classOf<UserRepository>())
+        private val persistMessage = mock(classOf<PersistMessageUseCase>())
 
         @Mock
         val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
@@ -78,56 +123,57 @@ class SendKnockUserCaseTest {
         private val slowSyncRepository = mock(classOf<SlowSyncRepository>())
 
         @Mock
-        private val messageSender = mock(classOf<MessageSender>())
+        val messageSender = mock(classOf<MessageSender>())
 
-        val someClientId = ClientId("some-client-id")
+        @Mock
+        val messageSendFailureHandler = configure(mock(classOf<MessageSendFailureHandler>())) { stubsUnitByDefault = true }
 
-        val completeStateFlow = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
-
-        private fun fakeSelfUser() = SelfUser(
-            UserId("some_id", "some_domain"),
-            "some_name",
-            "some_handle",
-            "some_email",
-            null,
-            1,
-            null,
-            ConnectionState.ACCEPTED,
-            previewPicture = UserAssetId("value1", "domain"),
-            completePicture = UserAssetId("value2", "domain"),
-            UserAvailabilityStatus.NONE
-        )
-
-        fun withSuccessfulResponse(hotKnock: Boolean): Arrangement {
-            given(userRepository)
-                .suspendFunction(userRepository::observeSelfUser)
-                .whenInvoked()
-                .thenReturn(flowOf(fakeSelfUser()))
+        fun withSendMessageSuccess() = apply {
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Right(Unit))
+        }
+        fun withSendMessageFailure() = apply {
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Left(NetworkFailure.NoNetworkConnection(null)))
+        }
+        fun withCurrentClientProviderSuccess(clientId: ClientId = TestClient.CLIENT_ID) = apply {
             given(currentClientIdProvider)
                 .suspendFunction(currentClientIdProvider::invoke)
                 .whenInvoked()
-                .thenReturn(Either.Right(someClientId))
+                .thenReturn(Either.Right(clientId))
+        }
+        fun withPersistMessageSuccess() = apply {
             given(persistMessage)
                 .suspendFunction(persistMessage::invoke)
                 .whenInvokedWith(any())
                 .thenReturn(Either.Right(Unit))
+        }
+        fun withSlowSyncStatusComplete() = apply {
+            val stateFlow = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
             given(slowSyncRepository)
                 .getter(slowSyncRepository::slowSyncStatus)
                 .whenInvoked()
-                .thenReturn(completeStateFlow)
-            given(messageSender)
-                .suspendFunction(messageSender::sendPendingMessage)
-                .whenInvokedWith(any(), any())
+                .thenReturn(stateFlow)
+        }
+        fun withUpdateMessageStatusSuccess() = apply {
+            given(messageRepository)
+                .suspendFunction(messageRepository::updateMessageStatus)
+                .whenInvokedWith(anything(), anything(), anything())
                 .thenReturn(Either.Right(Unit))
-            return this
         }
 
         fun arrange() = this to SendKnockUseCase(
+            messageRepository,
             persistMessage,
-            userRepository,
+            TestUser.SELF.id,
             currentClientIdProvider,
             slowSyncRepository,
-            messageSender
+            messageSender,
+            messageSendFailureHandler
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
@@ -18,19 +18,25 @@
 
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.persistence.dao.message.MessageEntity
 import io.mockative.Mock
 import io.mockative.any
+import io.mockative.anything
 import io.mockative.classOf
+import io.mockative.configure
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
@@ -38,10 +44,8 @@ import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -51,7 +55,12 @@ class SendTextMessageCaseTest {
     fun givenAValidMessage_whenSendingSomeText_thenShouldReturnASuccessResult() = runTest {
         // Given
         val (arrangement, sendTextMessage) = Arrangement()
-            .withSuccessfulResponse()
+            .withToggleReadReceiptsStatus()
+            .withCurrentClientProviderSuccess()
+            .withPersistMessageSuccess()
+            .withSlowSyncStatusComplete()
+            .withSendMessageSuccess()
+            .withUpdateMessageStatusSuccess()
             .arrange()
 
         // When
@@ -59,7 +68,6 @@ class SendTextMessageCaseTest {
 
         // Then
         assertTrue(result is Either.Right)
-        assertEquals(SlowSyncStatus.Complete, arrangement.completeStateFlow.value)
 
         verify(arrangement.userPropertyRepository)
             .suspendFunction(arrangement.userPropertyRepository::getReadReceiptsStatus)
@@ -69,19 +77,61 @@ class SendTextMessageCaseTest {
             .with(any())
             .wasInvoked(once)
         verify(arrangement.messageSender)
-            .suspendFunction(arrangement.messageSender::sendPendingMessage)
+            .suspendFunction(arrangement.messageSender::sendMessage)
             .with(any(), any())
             .wasInvoked(once)
+        verify(arrangement.messageRepository)
+            .suspendFunction(arrangement.messageRepository::updateMessageStatus)
+            .with(eq(MessageEntity.Status.SENT), any(), any())
+            .wasInvoked(once)
+        verify(arrangement.messageSendFailureHandler)
+            .suspendFunction(arrangement.messageSendFailureHandler::handleFailureUpdateMessageStatus)
+            .with(any(), any(), any(), any())
+            .wasNotInvoked()
+    }
 
+    @Test
+    fun givenNoNetwork_whenSendingSomeText_thenShouldReturnAFailure() = runTest {
+        // Given
+        val (arrangement, sendTextMessage) = Arrangement()
+            .withToggleReadReceiptsStatus()
+            .withCurrentClientProviderSuccess()
+            .withPersistMessageSuccess()
+            .withSlowSyncStatusComplete()
+            .withSendMessageFailure()
+            .withUpdateMessageStatusSuccess()
+            .arrange()
+
+        // When
+        val result = sendTextMessage(TestConversation.ID, "some-text")
+
+        // Then
+        assertTrue(result is Either.Left)
+
+        verify(arrangement.userPropertyRepository)
+            .suspendFunction(arrangement.userPropertyRepository::getReadReceiptsStatus)
+            .wasInvoked(once)
+        verify(arrangement.persistMessage)
+            .suspendFunction(arrangement.persistMessage::invoke)
+            .with(any())
+            .wasInvoked(once)
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(any(), any())
+            .wasInvoked(once)
+        verify(arrangement.messageSendFailureHandler)
+            .suspendFunction(arrangement.messageSendFailureHandler::handleFailureUpdateMessageStatus)
+            .with(any(), any(), any(), any())
+            .wasInvoked(once)
     }
 
     private class Arrangement {
 
         @Mock
-        val persistMessage = mock(classOf<PersistMessageUseCase>())
+        val messageRepository = mock(classOf<MessageRepository>())
 
         @Mock
-        private val userRepository = mock(classOf<UserRepository>())
+        val persistMessage = mock(classOf<PersistMessageUseCase>())
 
         @Mock
         val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
@@ -95,34 +145,46 @@ class SendTextMessageCaseTest {
         @Mock
         val userPropertyRepository = mock(classOf<UserPropertyRepository>())
 
-        val completeStateFlow = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
+        @Mock
+        val messageSendFailureHandler = configure(mock(classOf<MessageSendFailureHandler>())) { stubsUnitByDefault = true }
 
-        fun withSuccessfulResponse(): Arrangement {
-            given(userRepository)
-                .suspendFunction(userRepository::observeSelfUser)
-                .whenInvoked()
-                .thenReturn(flowOf())
+        fun withSendMessageSuccess() = apply {
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Right(Unit))
+        }
+        fun withSendMessageFailure() = apply {
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Left(NetworkFailure.NoNetworkConnection(null)))
+        }
+        fun withCurrentClientProviderSuccess(clientId: ClientId = TestClient.CLIENT_ID) = apply {
             given(currentClientIdProvider)
                 .suspendFunction(currentClientIdProvider::invoke)
                 .whenInvoked()
-                .thenReturn(Either.Right(TestClient.CLIENT_ID))
+                .thenReturn(Either.Right(clientId))
+        }
+        fun withPersistMessageSuccess() = apply {
             given(persistMessage)
                 .suspendFunction(persistMessage::invoke)
                 .whenInvokedWith(any())
                 .thenReturn(Either.Right(Unit))
+        }
+        fun withSlowSyncStatusComplete() = apply {
+            val stateFlow = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
             given(slowSyncRepository)
                 .getter(slowSyncRepository::slowSyncStatus)
                 .whenInvoked()
-                .thenReturn(completeStateFlow)
-            given(messageSender)
-                .suspendFunction(messageSender::sendPendingMessage)
-                .whenInvokedWith(any(), any())
-                .thenReturn(Either.Right(Unit))
-
-            withToggleReadReceiptsStatus()
-            return this
+                .thenReturn(stateFlow)
         }
-
+        fun withUpdateMessageStatusSuccess() = apply {
+            given(messageRepository)
+                .suspendFunction(messageRepository::updateMessageStatus)
+                .whenInvokedWith(anything(), anything(), anything())
+                .thenReturn(Either.Right(Unit))
+        }
         fun withToggleReadReceiptsStatus(enabled: Boolean = false) = apply {
             given(userPropertyRepository)
                 .suspendFunction(userPropertyRepository::getReadReceiptsStatus)
@@ -131,11 +193,13 @@ class SendTextMessageCaseTest {
         }
 
         fun arrange() = this to SendTextMessageUseCase(
+            messageRepository,
             persistMessage,
             TestUser.SELF.id,
             currentClientIdProvider,
             slowSyncRepository,
             messageSender,
+            messageSendFailureHandler,
             userPropertyRepository
         )
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Copy of https://github.com/wireapp/kalium/pull/1591

### Issues

Currently, if the message send fails, we schedule a worker to retry sending after some time or when the connection is back. At the current stage, we don't want to deal with such complex logic and just mark every message as failed to send when there's an error.

### Solutions

Refactor two use cases responsible for sending text and knock messages, which were using `sendPendingMessage` and scheduling the worker in case of failure. Now they try to send immediately and if it fails, the message is marked as failed. In the near future, we will implement the manual retry mechanism for the user to send such message again.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
