### PR TITLE
fix(rc): added isSelfMention field to MessageMention class

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMention.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMention.kt
@@ -23,5 +23,6 @@ import com.wire.kalium.logic.data.user.UserId
 data class MessageMention(
     val start: Int,
     val length: Int,
-    val userId: UserId
+    val userId: UserId,
+    val isSelfMention: Boolean
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMentionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMentionMapper.kt
@@ -41,7 +41,8 @@ class MessageMentionMapperImpl(
         return MessageMention(
             start = mention.start,
             length = mention.length,
-            userId = mention.userId.toModel()
+            userId = mention.userId.toModel(),
+            isSelfMention = mention.userId.toModel() == selfUserId
         )
     }
 
@@ -64,6 +65,7 @@ class MessageMentionMapperImpl(
             start = mention.start,
             length = mention.length,
             userId = userId,
+            isSelfMention = userId == selfUserId
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageMentionMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageMentionMapperTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.id.IdMapperImpl
+import com.wire.kalium.logic.data.id.toDao
+import com.wire.kalium.logic.data.message.mention.MessageMention
+import com.wire.kalium.logic.data.message.mention.MessageMentionMapper
+import com.wire.kalium.logic.data.message.mention.MessageMentionMapperImpl
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.protobuf.messages.Mention
+import com.wire.kalium.protobuf.messages.QualifiedUserId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MessageMentionMapperTest {
+
+    val selfUserId = UserId("user-id", "domain")
+    val idMapper: IdMapper = IdMapperImpl()
+    private val messageMentionMapper: MessageMentionMapper = MessageMentionMapperImpl(idMapper, selfUserId)
+
+    @Test
+    fun givenASelfMentionEntity_whenMappingFromDaoToModel_thenMessageMentionIsMappedAsASelfMention() {
+        val mention = MessageEntity.Mention(
+            start = 0,
+            length = 1,
+            userId = selfUserId.toDao()
+        )
+        val result = messageMentionMapper.fromDaoToModel(mention)
+        assertEquals(result.start, mention.start)
+        assertEquals(result.length, mention.length)
+        assertEquals(result.userId.value, mention.userId.value)
+        assertEquals(result.userId.domain, mention.userId.domain)
+        assertTrue(result.isSelfMention)
+    }
+
+    @Test
+    fun givenAnotherUsersMentionEntity_whenMappingFromDaoToModel_thenMessageMentionIsNotMappedAsASelfMention() {
+        val otherUser = UserId("other-user-id", "domain")
+        val mention = MessageEntity.Mention(
+            start = 0,
+            length = 1,
+            userId = otherUser.toDao()
+        )
+        val result = messageMentionMapper.fromDaoToModel(mention)
+        assertEquals(result.start, mention.start)
+        assertEquals(result.length, mention.length)
+        assertEquals(result.userId.value, mention.userId.value)
+        assertEquals(result.userId.domain, mention.userId.domain)
+        assertFalse(result.isSelfMention)
+    }
+
+    @Test
+    fun givenAModelSelfMention_whenMappingFromModelToDao_thenMessageMentionIsMappedAsASelfMentionEntity() {
+        val mention = MessageMention(
+            start = 0,
+            length = 1,
+            userId = selfUserId,
+            isSelfMention = true
+        )
+        val result = messageMentionMapper.fromModelToDao(mention)
+        assertEquals(result.start, mention.start)
+        assertEquals(result.length, mention.length)
+        assertEquals(result.userId.value, mention.userId.value)
+        assertEquals(result.userId.domain, mention.userId.domain)
+    }
+
+    @Test
+    fun givenAnotherUsersMention_whenMappingFromDaoToModel_thenMessageMentionIsNotMappedAsASelfMentionEntity() {
+        val otherUser = UserId("other-user-id", "domain")
+        val mention = MessageMention(
+            start = 0,
+            length = 1,
+            userId = otherUser,
+            isSelfMention = false
+        )
+        val result = messageMentionMapper.fromModelToDao(mention)
+        assertEquals(result.start, mention.start)
+        assertEquals(result.length, mention.length)
+        assertEquals(result.userId.value, mention.userId.value)
+        assertEquals(result.userId.domain, mention.userId.domain)
+    }
+
+    @Test
+    fun givenAProtoSelfMention_whenMappingFromProtoToModel_thenMessageMentionIsMappedAsASelfMention() {
+        val mention = Mention(
+            start = 0,
+            length = 1,
+            qualifiedUserId = QualifiedUserId(selfUserId.value, selfUserId.domain),
+            mentionType = Mention.MentionType.UserId(selfUserId.value)
+        )
+        val result = messageMentionMapper.fromProtoToModel(mention)
+        assertEquals(result.start, mention.start)
+        assertEquals(result.length, mention.length)
+        assertEquals(result.userId.value, mention.qualifiedUserId?.id)
+        assertEquals(result.userId.domain, mention.qualifiedUserId?.domain)
+        assertTrue(result.isSelfMention)
+    }
+
+    @Test
+    fun givenAProtoUserMention_whenMappingFromProtoToModel_thenMessageMentionIsNotMappedAsASelfMention() {
+        val otherUser = UserId("other-user-id", "domain")
+        val mention = Mention(
+            start = 0,
+            length = 1,
+            qualifiedUserId = QualifiedUserId(otherUser.value, otherUser.domain),
+            mentionType = Mention.MentionType.UserId(otherUser.value)
+        )
+        val result = messageMentionMapper.fromProtoToModel(mention)
+        assertEquals(result.start, mention.start)
+        assertEquals(result.length, mention.length)
+        assertEquals(result.userId.value, mention.qualifiedUserId?.id)
+        assertEquals(result.userId.domain, mention.qualifiedUserId?.domain)
+        assertFalse(result.isSelfMention)
+    }
+
+    @Test
+    fun givenAModelSelfMention_whenMappingFromModelToProto_thenMessageMentionIsMappedAsASelfMention() {
+        val mention = MessageMention(
+            start = 0,
+            length = 1,
+            userId = selfUserId,
+            isSelfMention = true
+        )
+        val result = messageMentionMapper.fromModelToProto(mention)
+        assertEquals(result.start, mention.start)
+        assertEquals(result.length, mention.length)
+        assertEquals(result.qualifiedUserId?.id, mention.userId.value)
+        assertEquals(result.qualifiedUserId?.domain, mention.userId.domain)
+        assertEquals(result.userId, mention.userId.value)
+    }
+
+    @Test
+    fun givenAModelUserMention_whenMappingFromModelToProto_thenMessageMentionIsNotMappedAsASelfMention() {
+        val otherUser = UserId("other-user-id", "domain")
+        val mention = MessageMention(
+            start = 0,
+            length = 1,
+            userId = otherUser,
+            isSelfMention = true
+        )
+        val result = messageMentionMapper.fromModelToProto(mention)
+        assertEquals(result.start, mention.start)
+        assertEquals(result.length, mention.length)
+        assertEquals(result.qualifiedUserId?.id, mention.userId.value)
+        assertEquals(result.qualifiedUserId?.domain, mention.userId.domain)
+        assertEquals(result.userId, mention.userId.value)
+    }
+}

--- a/samples/src/jvmMain/kotlin/samples/logic/MessageUseCases.kt
+++ b/samples/src/jvmMain/kotlin/samples/logic/MessageUseCases.kt
@@ -40,14 +40,16 @@ object MessageUseCases {
     suspend fun sendingTextMessageWithMentions(
         sendTextMessageUseCase: SendTextMessageUseCase,
         conversationId: ConversationId,
-        johnUserId: UserId
+        johnUserId: UserId,
+        selfUserId: UserId
     ) {
         // Sending a text message with mention
         val text = "Hello, @John"
         val johnMention = MessageMention(
             start = 8, // The index of the @ in the text above
             length = 5, // The length of the mention (including the @)
-            userId = johnUserId // ID of the user being mentioned
+            userId = johnUserId, // ID of the user being mentioned
+            isSelfMention = selfUserId == johnUserId // Whether the mention is for the current user
         )
         sendTextMessageUseCase.invoke(
             conversationId = conversationId,
@@ -60,13 +62,15 @@ object MessageUseCases {
         editTextMessageUseCase: SendEditTextMessageUseCase,
         conversationId: ConversationId,
         originalMessageId: String,
-        johnUserId: UserId
+        johnUserId: UserId,
+        selfUserId: UserId
     ) {
         // Editing a simple text message
         val johnMention = MessageMention(
             start = 8, // The index of the @ in the text above
             length = 5, // The length of the mention (including the @)
-            userId = johnUserId // ID of the user being mentioned
+            userId = johnUserId, // ID of the user being mentioned
+            isSelfMention = selfUserId == johnUserId // Whether the mention is for the current user
         )
         editTextMessageUseCase.invoke(
             conversationId = conversationId,

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -270,7 +270,8 @@ class ConversationResources(private val instanceService: InstanceService) {
                     MessageMention(
                         mention.start,
                         mention.length,
-                        UserId(mention.userId, mention.userDomain)
+                        UserId(mention.userId, mention.userDomain),
+                        false
                     )
                 }.toList()
             }


### PR DESCRIPTION
* fix: added isSelfMention field to MessageMention class

* feat: added MessageMentionMapperTest class

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Counterpart PR of https://github.com/wireapp/kalium/pull/1594 but this time against RC branch 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
