### PR TITLE
fix: pass quoted message id even if it's not in db [AR-3238]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.notification.LocalNotificationMessage
 import com.wire.kalium.logic.data.notification.LocalNotificationMessageAuthor
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.persistence.dao.message.AssetTypeEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
@@ -329,11 +330,11 @@ class MessageMapperImpl(
             MessageContent.Text(
                 value = this.messageBody,
                 mentions = this.mentions.map { messageMentionMapper.fromDaoToModel(it) },
-                quotedMessageReference = quotedMessageDetails?.let {
+                quotedMessageReference = quotedMessageId?.let {
                     MessageContent.QuoteReference(
-                        quotedMessageId = it.messageId,
+                        quotedMessageId = it,
                         quotedMessageSha256 = null,
-                        isVerified = it.isVerified
+                        isVerified = quotedMessageDetails?.isVerified ?: false
                     )
                 },
                 quotedMessageDetails = quotedMessageDetails

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.logic.data.notification.LocalNotificationMessage
 import com.wire.kalium.logic.data.notification.LocalNotificationMessageAuthor
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.persistence.dao.message.AssetTypeEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -259,7 +259,7 @@ IFNULL(
     ),
     '[]'
 ) AS mentions,
-QuotedMessage.id AS quotedMessageId,
+TextContent.quoted_message_id AS quotedMessageId,
 QuotedMessage.sender_user_id AS quotedSenderId,
 TextContent.is_quote_verified AS isQuoteVerified,
 QuotedSender.name AS quotedSenderName,

--- a/persistence/src/commonMain/db_user/migrations/32.sqm
+++ b/persistence/src/commonMain/db_user/migrations/32.sqm
@@ -1,0 +1,124 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+
+DROP VIEW IF EXISTS MessageDetailsView;
+
+CREATE VIEW IF NOT EXISTS MessageDetailsView
+AS SELECT
+Message.id AS id,
+Message.conversation_id AS conversationId,
+Message.content_type AS contentType,
+Message.creation_date AS date,
+Message.sender_user_id AS senderUserId,
+Message.sender_client_id AS senderClientId,
+Message.status AS status,
+Message.last_edit_date AS lastEditTimestamp,
+Message.visibility AS visibility,
+Message.expects_read_confirmation AS expectsReadConfirmation,
+User.name AS senderName,
+User.handle AS senderHandle,
+User.email AS senderEmail,
+User.phone AS senderPhone,
+User.accent_id AS senderAccentId,
+User.team AS senderTeamId,
+User.connection_status AS senderConnectionStatus,
+User.preview_asset_id AS senderPreviewAssetId,
+User.complete_asset_id AS senderCompleteAssetId,
+User.user_availability_status AS senderAvailabilityStatus,
+User.user_type AS senderUserType,
+User.bot_service AS senderBotService,
+User.deleted AS senderIsDeleted,
+(Message.sender_user_id == SelfUser.id) AS isSelfMessage,
+TextContent.text_body AS text,
+TextContent.is_quoting_self AS isQuotingSelfUser,
+AssetContent.asset_size AS assetSize,
+AssetContent.asset_name AS assetName,
+AssetContent.asset_mime_type AS assetMimeType,
+AssetContent.asset_upload_status AS assetUploadStatus,
+AssetContent.asset_download_status AS assetDownloadStatus,
+AssetContent.asset_otr_key AS assetOtrKey,
+AssetContent.asset_sha256 AS assetSha256,
+AssetContent.asset_id AS assetId,
+AssetContent.asset_token AS assetToken,
+AssetContent.asset_domain AS assetDomain,
+AssetContent.asset_encryption_algorithm AS assetEncryptionAlgorithm,
+AssetContent.asset_width AS assetWidth,
+AssetContent.asset_height AS assetHeight,
+AssetContent.asset_duration_ms AS assetDuration,
+AssetContent.asset_normalized_loudness AS assetNormalizedLoudness,
+MissedCallContent.caller_id AS callerId,
+MemberChangeContent.member_change_list AS memberChangeList,
+MemberChangeContent.member_change_type AS memberChangeType,
+UnknownContent.unknown_type_name AS unknownContentTypeName,
+UnknownContent.unknown_encoded_data AS unknownContentData,
+RestrictedAssetContent.asset_mime_type AS restrictedAssetMimeType,
+RestrictedAssetContent.asset_size AS restrictedAssetSize,
+RestrictedAssetContent.asset_name AS restrictedAssetName,
+FailedToDecryptContent.unknown_encoded_data AS failedToDecryptData,
+FailedToDecryptContent.is_decryption_resolved AS isDecryptionResolved,
+ConversationNameChangedContent.conversation_name AS conversationName,
+'{' || IFNULL(
+    (SELECT GROUP_CONCAT('"' || emoji || '":' || count)
+    FROM (
+        SELECT COUNT(*) count, Reaction.emoji emoji
+        FROM Reaction
+        WHERE Reaction.message_id = Message.id
+        AND Reaction.conversation_id = Message.conversation_id
+        GROUP BY Reaction.emoji
+    )),
+    '')
+|| '}' AS allReactionsJson,
+IFNULL(
+    (SELECT '[' || GROUP_CONCAT('"' || Reaction.emoji || '"') || ']'
+    FROM Reaction
+    WHERE Reaction.message_id = Message.id
+        AND Reaction.conversation_id = Message.conversation_id
+        AND Reaction.sender_id = SelfUser.id
+    ),
+    '[]'
+) AS selfReactionsJson,
+IFNULL(
+    (SELECT '[' || GROUP_CONCAT(
+        '{"start":' || start || ', "length":' || length ||
+        ', "userId":{"value":"' || replace(substr(user_id, 0, instr(user_id, '@')), '@', '') || '"' ||
+        ',"domain":"' || replace(substr(user_id, instr(user_id, '@')+1, length(user_id)), '@', '') || '"' ||
+        '}' || '}') || ']'
+    FROM MessageMention
+    WHERE MessageMention.message_id = Message.id
+        AND MessageMention.conversation_id = Message.conversation_id
+    ),
+    '[]'
+) AS mentions,
+TextContent.quoted_message_id AS quotedMessageId,
+QuotedMessage.sender_user_id AS quotedSenderId,
+TextContent.is_quote_verified AS isQuoteVerified,
+QuotedSender.name AS quotedSenderName,
+QuotedMessage.creation_date AS quotedMessageDateTime,
+QuotedMessage.last_edit_date AS quotedMessageEditTimestamp,
+QuotedMessage.visibility AS quotedMessageVisibility,
+QuotedMessage.content_type AS quotedMessageContentType,
+QuotedTextContent.text_body AS quotedTextBody,
+QuotedAssetContent.asset_mime_type AS quotedAssetMimeType,
+QuotedAssetContent.asset_name AS quotedAssetName,
+NewConversationReceiptMode.receipt_mode AS newConversationReceiptMode,
+ConversationReceiptModeChanged.receipt_mode AS conversationReceiptModeChanged
+FROM Message
+JOIN User ON Message.sender_user_id = User.qualified_id
+LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
+LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
+LEFT JOIN MessageMissedCallContent AS MissedCallContent ON Message.id = MissedCallContent.message_id AND Message.conversation_id = MissedCallContent.conversation_id
+LEFT JOIN MessageMemberChangeContent AS MemberChangeContent ON Message.id = MemberChangeContent.message_id AND Message.conversation_id = MemberChangeContent.conversation_id
+LEFT JOIN MessageUnknownContent AS UnknownContent ON Message.id = UnknownContent.message_id AND Message.conversation_id = UnknownContent.conversation_id
+LEFT JOIN MessageRestrictedAssetContent AS RestrictedAssetContent ON Message.id = RestrictedAssetContent.message_id AND RestrictedAssetContent.conversation_id = RestrictedAssetContent.conversation_id
+LEFT JOIN MessageFailedToDecryptContent AS FailedToDecryptContent ON Message.id = FailedToDecryptContent.message_id AND Message.conversation_id = FailedToDecryptContent.conversation_id
+LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
+
+-- joins for quoted messages
+LEFT JOIN Message AS QuotedMessage ON QuotedMessage.id = TextContent.quoted_message_id AND QuotedMessage.conversation_id = TextContent.conversation_id
+LEFT JOIN User AS QuotedSender ON QuotedMessage.sender_user_id = QuotedSender.qualified_id
+LEFT JOIN MessageTextContent AS QuotedTextContent ON QuotedTextContent.message_id = QuotedMessage.id AND QuotedMessage.conversation_id = TextContent.conversation_id
+LEFT JOIN MessageAssetContent AS QuotedAssetContent ON QuotedAssetContent.message_id = QuotedMessage.id AND QuotedMessage.conversation_id = TextContent.conversation_id
+-- end joins for quoted messages
+LEFT JOIN MessageNewConversationReceiptModeContent AS NewConversationReceiptMode ON Message.id = NewConversationReceiptMode.message_id AND Message.conversation_id = NewConversationReceiptMode.conversation_id
+LEFT JOIN MessageConversationReceiptModeChangedContent AS ConversationReceiptModeChanged ON Message.id = ConversationReceiptModeChanged.message_id AND Message.conversation_id = ConversationReceiptModeChanged.conversation_id
+LEFT JOIN SelfUser;
+-- TODO: Remove IFNULL functions above if we can force SQLDelight to not unpack as notnull

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -348,9 +348,9 @@ object MessageMapper {
                 messageBody = text ?: "",
                 mentions = messageMentionsFromJsonString(mentions),
                 quotedMessageId = quotedMessageId,
-                quotedMessage = quotedMessageId?.let {
+                quotedMessage = quotedMessageContentType?.let {
                     MessageEntityContent.Text.QuotedMessage(
-                        id = it,
+                        id = quotedMessageId.requireField("quotedMessageId"),
                         senderId = quotedSenderId.requireField("quotedSenderId"),
                         isQuotingSelfUser = isQuotingSelfUser.requireField("isQuotingSelfUser"),
                         isVerified = isQuoteVerified ?: false,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -1332,6 +1332,68 @@ class MessageDAOTest : BaseDatabaseTest() {
         }
     }
 
+    @Test
+    fun givenReplyMessage_WhenQuotedMessageExist_MessageShouldContainQuotedDetails() = runTest {
+        insertInitialData()
+        val quotedUser = userEntity1
+        val otherUser = userEntity2
+        val conversationId = conversationEntity1.id
+
+        val quotedMessageId = "quotedId"
+        val replyMessageId = "replyId"
+
+        val allMessages = listOf(
+            newRegularMessageEntity(
+                id = quotedMessageId,
+                conversationId = conversationId,
+                senderUserId = quotedUser.id,
+            ),
+            newRegularMessageEntity(
+                id = replyMessageId,
+                senderUserId = otherUser.id,
+                conversationId = conversationId,
+                content = MessageEntityContent.Text(quotedMessageId = quotedMessageId, messageBody = "Sure")
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(allMessages)
+
+        val replyMessage = messageDAO.getMessageById(replyMessageId, conversationId)
+        assertTrue {
+            replyMessage != null
+                    && replyMessage.content is MessageEntityContent.Text
+                    && (replyMessage.content as MessageEntityContent.Text).quotedMessage?.id == quotedMessageId
+        }
+    }
+
+    @Test
+    fun givenReplyMessage_WhenQuotedMessageNotExist_MessageShouldContainOnlyQuotedMessageId() = runTest {
+        insertInitialData()
+        val otherUser = userEntity2
+        val conversationId = conversationEntity1.id
+
+        val quotedMessageId = "quotedId"
+        val replyMessageId = "replyId"
+
+        val allMessages = listOf(
+            newRegularMessageEntity(
+                id = replyMessageId,
+                senderUserId = otherUser.id,
+                conversationId = conversationId,
+                content = MessageEntityContent.Text(quotedMessageId = quotedMessageId, messageBody = "Sure")
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(allMessages)
+
+        val replyMessage = messageDAO.getMessageById(replyMessageId, conversationId)
+        assertTrue {
+            replyMessage != null
+                    && replyMessage.content is MessageEntityContent.Text
+                    && (replyMessage.content as MessageEntityContent.Text).quotedMessageId == quotedMessageId
+                    && (replyMessage.content as MessageEntityContent.Text).quotedMessage == null
+        }
+    }
+
+
     private suspend fun insertInitialData() {
         userDAO.upsertUsers(listOf(userEntity1, userEntity2))
         conversationDAO.insertConversation(conversationEntity1)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Quoted messages are ignored if they are not in user db.

### Causes (Optional)

Quoted messages are showed as normal text messages.

### Solutions

Pass quoted messages if they contain at least quotedMessageId to show that it's a reply with unknown quoted message
