### PR TITLE
fix(rc): federated user data is not refreshed (AR-3249)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/type/UserType.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/type/UserType.kt
@@ -60,3 +60,7 @@ enum class UserType {
 
 fun UserType.isTeammate(): Boolean =
     this in listOf(UserType.INTERNAL, UserType.ADMIN, UserType.OWNER, UserType.EXTERNAL, UserType.SERVICE)
+
+fun UserType.isFederated(): Boolean =
+    this == UserType.FEDERATED
+

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/type/UserType.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/type/UserType.kt
@@ -63,4 +63,3 @@ fun UserType.isTeammate(): Boolean =
 
 fun UserType.isFederated(): Boolean =
     this == UserType.FEDERATED
-

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -437,17 +437,16 @@ class UserSessionScope internal constructor(
             selfUserId = userId
         )
 
-    private val userRepository: UserRepository
-        get() = UserDataSource(
-            userStorage.database.userDAO,
-            userStorage.database.metadataDAO,
-            userStorage.database.clientDAO,
-            authenticatedDataSourceSet.authenticatedNetworkContainer.selfApi,
-            authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi,
-            globalScope.sessionRepository,
-            userId,
-            qualifiedIdMapper
-        )
+    private val userRepository: UserRepository = UserDataSource(
+        userStorage.database.userDAO,
+        userStorage.database.metadataDAO,
+        userStorage.database.clientDAO,
+        authenticatedDataSourceSet.authenticatedNetworkContainer.selfApi,
+        authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi,
+        globalScope.sessionRepository,
+        userId,
+        qualifiedIdMapper
+    )
 
     internal val pushTokenRepository: PushTokenRepository
         get() = PushTokenDataSource(userStorage.database.metadataDAO)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -445,7 +445,8 @@ class UserSessionScope internal constructor(
         authenticatedDataSourceSet.authenticatedNetworkContainer.userDetailsApi,
         globalScope.sessionRepository,
         userId,
-        qualifiedIdMapper
+        qualifiedIdMapper,
+        selfTeamId,
     )
 
     internal val pushTokenRepository: PushTokenRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
@@ -26,24 +26,16 @@ import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.logic.data.user.type.isFederated
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMapRightWithEither
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.mapRight
 import com.wire.kalium.logic.functional.mapToRightOr
-import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapStorageRequest
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
-import kotlinx.datetime.Instant
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Use case that allows observing the user details of a user locally,
@@ -63,35 +55,14 @@ internal class ObserveUserInfoUseCaseImpl(
     private val userRepository: UserRepository,
     private val teamRepository: TeamRepository
 ) : ObserveUserInfoUseCase {
-
-    private val poorManFederatedUsersCache = mutableMapOf<UserId, Instant>()
-
+    
     override suspend fun invoke(userId: UserId): Flow<GetUserInfoResult> {
-        val getUserInfoResultFlow = observeOtherUser(userId)
+        return observeOtherUser(userId)
             .flatMapRightWithEither { otherUser ->
                 observeOtherUserTeam(otherUser)
                     .mapRight { team -> GetUserInfoResult.Success(otherUser, team) }
             }
             .mapToRightOr(GetUserInfoResult.Failure)
-
-        return getUserInfoResultFlow
-            .onStart { emitAll(getUserInfoResultFlow) }
-            .onEach { userInfoResult: GetUserInfoResult ->
-                if (shouldRefreshFederatedUser(userId, userInfoResult))
-                    userRepository.fetchUserInfo(userId).also {
-                        kaliumLogger.d("Federated user, refreshing user info from API...")
-                        poorManFederatedUsersCache[userId] = DateTimeUtil.currentInstant().plus(15.seconds)
-                    }
-            }
-    }
-
-    /**
-     * In case of federated users, we need to refresh their info every 5 minutes.
-     * Since the current backend implementation at wire does not emit this user event across backends.
-     */
-    private fun shouldRefreshFederatedUser(userId: UserId, userInfoResult: GetUserInfoResult): Boolean {
-        return userInfoResult is GetUserInfoResult.Success && userInfoResult.otherUser.userType.isFederated()
-                && poorManFederatedUsersCache[userId]?.let { DateTimeUtil.currentInstant() > it } ?: true
     }
 
     private suspend fun observeOtherUser(userId: UserId): Flow<Either<CoreFailure, OtherUser>> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
@@ -55,7 +55,7 @@ internal class ObserveUserInfoUseCaseImpl(
     private val userRepository: UserRepository,
     private val teamRepository: TeamRepository
 ) : ObserveUserInfoUseCase {
-    
+
     override suspend fun invoke(userId: UserId): Flow<GetUserInfoResult> {
         return observeOtherUser(userId)
             .flatMapRightWithEither { otherUser ->


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In federated environments data for users is not refreshed

### Causes (Optional)

We are not getting updates for names, and in case a backend is down, that info is never refreshed.

### Solutions

When requesting the stored user info —only in case of a federated user— we fetch and store the data. 
This also adds an in-memory cache to avoid excessive requests.

### Testing

#### Test Coverage (Optional) 

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
