### PR TITLE
chore: add outcome to event logging

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.data.event
 
 import com.wire.kalium.cryptography.utils.EncryptedData
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -35,10 +36,9 @@ import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
-import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
-import com.wire.kalium.util.serialization.toJsonElement
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.serialization.json.JsonNull
 
 sealed class Event(open val id: String, open val transient: Boolean) {
@@ -575,13 +575,30 @@ internal fun KaliumLogger.logEventProcessing(
     vararg extraInfo: Pair<String, Any>
 ) {
     val logMap = mapOf("event" to event.toLogMap()) + extraInfo.toMap()
-    val logJson = logMap.toJsonElement()
 
     when (status) {
-        EventLoggingStatus.SUCCESS -> i("Success handling event: $logJson")
-        EventLoggingStatus.FAILURE -> e("Failure handling event: $logJson")
-        EventLoggingStatus.SKIPPED -> w("Skipped handling event: $logJson")
+        EventLoggingStatus.SUCCESS -> {
+            val finalMap = logMap.toMutableMap()
+            finalMap["outcome"] = "success"
+            val logJson = finalMap.toJsonElement()
+            i("Success handling event: $logJson")
+        }
+        EventLoggingStatus.FAILURE -> {
+            val finalMap = logMap.toMutableMap()
+            finalMap["outcome"] = "failure"
+            val logJson = finalMap.toJsonElement()
+            e("Failure handling event: $logJson")
+        }
+        EventLoggingStatus.SKIPPED -> {
+            val finalMap = logMap.toMutableMap()
+            finalMap["outcome"] = "skipped"
+            val logJson = finalMap.toJsonElement()
+            w("Skipped handling event: $logJson")
+        }
         else -> {
+            val finalMap = logMap.toMutableMap()
+            finalMap["outcome"] = "unknown"
+            val logJson = finalMap.toJsonElement()
             w("Unknown outcome of event handling: $logJson")
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In the logs for event handling there is not outcome reported in the json representation


### Solutions

Add "outcome" to the json representation

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
