### PR TITLE
fix: remove unread events after message event [AR-3281]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -108,6 +108,9 @@ UPDATE Conversation
 SET last_modified_date = ?
 WHERE qualified_id = ?;
 
+getConversationReadDate:
+SELECT last_read_date FROM Conversation WHERE qualified_id = ?;
+
 updateConversationReadDate:
 UPDATE Conversation
 SET last_read_date = :last_read_date

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MigrationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MigrationDAO.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.persistence.dao
 
+import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.MigrationQueries
 import com.wire.kalium.persistence.UnreadEventsQueries
@@ -36,8 +37,14 @@ internal class MigrationDAOImpl(
     private val migrationQueries: MigrationQueries,
     messagesQueries: MessagesQueries,
     private val unreadEventsQueries: UnreadEventsQueries,
+    private val conversationsQueries: ConversationsQueries,
     selfUserIDEntity: UserIDEntity,
-) : MigrationDAO, MessageInsertExtension by MessageInsertExtensionImpl(messagesQueries, unreadEventsQueries, selfUserIDEntity) {
+) : MigrationDAO, MessageInsertExtension by MessageInsertExtensionImpl(
+    messagesQueries,
+    unreadEventsQueries,
+    conversationsQueries,
+    selfUserIDEntity
+) {
     override suspend fun insertConversation(conversationList: List<ConversationEntity>) {
         migrationQueries.transaction {
             conversationList.forEach {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -50,7 +50,7 @@ class MessageDAOImpl(
     private val selfUserId: UserIDEntity,
     private val reactionsQueries: ReactionsQueries,
     private val coroutineContext: CoroutineContext
-) : MessageDAO, MessageInsertExtension by MessageInsertExtensionImpl(queries, unreadEventsQueries, selfUserId) {
+) : MessageDAO, MessageInsertExtension by MessageInsertExtensionImpl(queries, unreadEventsQueries, conversationsQueries, selfUserId) {
     private val mapper = MessageMapper
     private val unreadEventMapper = UnreadEventMapper
 
@@ -76,6 +76,7 @@ class MessageDAOImpl(
             val messageCreationInstant = message.date
             if (updateConversationReadDate) {
                 conversationsQueries.updateConversationReadDate(messageCreationInstant, message.conversationId)
+                unreadEventsQueries.deleteUnreadEvents(message.date, message.conversationId)
             }
 
             insertInDB(message)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -200,7 +200,7 @@ class UserDatabaseBuilder internal constructor(
 
     val migrationDAO: MigrationDAO
         get() = MigrationDAOImpl(
-            database.migrationQueries, database.messagesQueries, database.unreadEventsQueries, userId
+            database.migrationQueries, database.messagesQueries, database.unreadEventsQueries, database.conversationsQueries, userId
         )
 
     /**


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Message events doesn't clear unread events.

### Causes (Optional)

When user send a message from another old client in conversation with unread events on new client messages are still marked as unread

### Solutions

- clear unread events after message event
- avoid saving unread event when message date is before conversation read date