### PR TITLE
fix: stuck on connecting because of onBlockedStatusChanged [AR-3269]

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -40,11 +40,6 @@ actual class NetworkStateObserverImpl(appContext: Context) : NetworkStateObserve
                 networkStateFlow.tryEmit(networkCapabilities.toState())
             }
 
-            override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
-                super.onBlockedStatusChanged(network, blocked)
-                networkStateFlow.tryEmit(if (blocked) NetworkState.ConnectedWithoutInternet else NetworkState.ConnectedWithInternet)
-            }
-
             override fun onLost(network: Network) {
                 networkStateFlow.tryEmit(NetworkState.NotConnected)
                 super.onLost(network)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`onBlockedStatusChanged` was sending false positive state `NetworkState.ConnectedWithInternet` when user may not have internet connection yet. We should only depend on `onCapabilitiesChanged`

### Causes (Optional)

Sometimes after turning on internet user is stuck on connecting

### Solutions

Remove `onBlockedStatusChanged` to only depend on  `onCapabilitiesChanged`

