### PR TITLE
chore: improve generic failure logging

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -118,7 +118,7 @@ sealed class EncryptionFailure : CoreFailure.FeatureFailure() {
 
 sealed class StorageFailure : CoreFailure() {
     object DataNotFound : StorageFailure()
-    class Generic(val rootCause: Throwable) : StorageFailure()
+    data class Generic(val rootCause: Throwable) : StorageFailure()
 }
 
 private const val SOCKS_EXCEPTION = "socks"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
@@ -39,7 +39,7 @@ class AddAuthenticatedUserUseCase internal constructor(
         data class Success(val userId: UserId) : Result()
         sealed class Failure : Result() {
             object UserAlreadyExists : Failure()
-            class Generic(val genericFailure: CoreFailure) : Failure()
+            data class Generic(val genericFailure: CoreFailure) : Failure()
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -66,7 +66,7 @@ sealed class AuthenticationResult {
          * The user has entered a text that isn't considered a valid email or handle
          */
         object InvalidUserIdentifier : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/autoVersioningAuth/AutoVersionAuthScopeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/autoVersioningAuth/AutoVersionAuthScopeUseCase.kt
@@ -67,7 +67,7 @@ class AutoVersionAuthScopeUseCase(
         sealed class Failure : Result() {
             object UnknownServerVersion : Failure()
             object TooNewVersion : Failure()
-            class Generic(val genericFailure: CoreFailure) : Failure()
+            data class Generic(val genericFailure: CoreFailure) : Failure()
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/GetSSOLoginSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/GetSSOLoginSessionUseCase.kt
@@ -36,7 +36,7 @@ sealed class SSOLoginSessionResult {
 
     sealed class Failure : SSOLoginSessionResult() {
         object InvalidCookie : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOFinalizeLoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOFinalizeLoginUseCase.kt
@@ -30,7 +30,7 @@ sealed class SSOFinalizeLoginResult {
 
     sealed class Failure : SSOFinalizeLoginResult() {
         object InvalidCookie : SSOFinalizeLoginResult.Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCase.kt
@@ -34,7 +34,7 @@ sealed class SSOInitiateLoginResult {
         object InvalidCodeFormat : Failure()
         object InvalidCode : Failure()
         object InvalidRedirect : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOMetaDataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOMetaDataUseCase.kt
@@ -26,7 +26,7 @@ sealed class SSOMetaDataResult {
     data class Success(val metaData: String) : SSOMetaDataResult()
 
     sealed class Failure : SSOMetaDataResult() {
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOSettingsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOSettingsUseCase.kt
@@ -27,7 +27,7 @@ sealed class SSOSettingsResult {
     data class Success(val ssoSettings: SSOSettingsResponse) : SSOSettingsResult()
 
     sealed class Failure : SSOSettingsResult() {
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
@@ -64,6 +64,6 @@ sealed class DeleteClientResult {
     sealed class Failure : DeleteClientResult() {
         object InvalidCredentials : Failure()
         object PasswordAuthRequired : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/FetchSelfClientsFromRemoteUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/FetchSelfClientsFromRemoteUseCase.kt
@@ -57,6 +57,6 @@ sealed class SelfClientsResult {
     data class Success(val clients: List<Client>, val currentClientId: ClientId?) : SelfClientsResult()
 
     sealed class Failure : SelfClientsResult() {
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ObserveClientDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ObserveClientDetailsUseCase.kt
@@ -59,6 +59,6 @@ class ObserveClientDetailsUseCaseImpl(
         data class Success(val client: Client, val isCurrentClient: Boolean) : GetClientDetailsResult()
 
         sealed class Failure : GetClientDetailsResult() {
-            class Generic(val genericFailure: CoreFailure) : Failure()
+            data class Generic(val genericFailure: CoreFailure) : Failure()
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -71,7 +71,7 @@ sealed class RegisterClientResult {
 
         object TooManyClients : Failure()
         object PasswordAuthRequired : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCase.kt
@@ -60,6 +60,6 @@ sealed class VerifyExistingClientResult {
 
     sealed class Failure : VerifyExistingClientResult() {
         object ClientNotRegistered : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
@@ -70,6 +70,6 @@ sealed class MLSKeyPackageCountResult {
     sealed class Failure : MLSKeyPackageCountResult() {
         class NetworkCallFailure(val networkFailure: NetworkFailure) : Failure()
         class FetchClientIdFailure(val genericFailure: CoreFailure) : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchUsersResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchUsersResult.kt
@@ -26,6 +26,6 @@ sealed class SearchUsersResult {
     sealed class Failure : SearchUsersResult() {
         object InvalidQuery : Failure()
         object InvalidRequest : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/FetchApiVersionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/FetchApiVersionUseCase.kt
@@ -59,6 +59,6 @@ sealed class FetchApiVersionResult {
     sealed class Failure : FetchApiVersionResult() {
         object UnknownServerVersion : Failure()
         object TooNewVersion : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/GetServerConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/GetServerConfigUseCase.kt
@@ -43,6 +43,6 @@ sealed class GetServerConfigResult {
     class Success(val serverConfigLinks: ServerConfig.Links) : GetServerConfigResult()
 
     sealed class Failure : GetServerConfigResult() {
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/ObserveServerConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/ObserveServerConfigUseCase.kt
@@ -36,7 +36,7 @@ class ObserveServerConfigUseCase internal constructor(
     sealed class Result {
         data class Success(val value: Flow<List<ServerConfig>>) : Result()
         sealed class Failure : Result() {
-            class Generic(val genericFailure: CoreFailure) : Failure()
+            data class Generic(val genericFailure: CoreFailure) : Failure()
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/server/StoreServerConfigUseCase.kt
@@ -58,6 +58,6 @@ sealed class StoreServerConfigResult {
     class Success(val serverConfig: ServerConfig) : StoreServerConfigResult()
 
     sealed class Failure : StoreServerConfigResult() {
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/SessionResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/SessionResult.kt
@@ -26,6 +26,6 @@ sealed class GetAllSessionsResult {
 
     sealed class Failure : GetAllSessionsResult() {
         object NoSessionFound : Failure()
-        class Generic(val genericFailure: CoreFailure) : Failure()
+        data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCase.kt
@@ -64,7 +64,7 @@ internal class DeleteTeamConversationUseCaseImpl(
 sealed class Result {
     object Success : Result()
     sealed class Failure : Result() {
-        class GenericFailure(val coreFailure: CoreFailure) : Failure()
+        data class GenericFailure(val coreFailure: CoreFailure) : Failure()
         object NoTeamFailure : Result()
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/webSocketStatus/ObservePersistentWebSocketConnectionStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/webSocketStatus/ObservePersistentWebSocketConnectionStatusUseCase.kt
@@ -39,7 +39,7 @@ interface ObservePersistentWebSocketConnectionStatusUseCase {
         class Success(val persistentWebSocketStatusListFlow: Flow<List<PersistentWebSocketStatus>>) : Result()
         sealed class Failure : Result() {
             object StorageFailure : Failure()
-            class Generic(val genericFailure: CoreFailure) : Failure()
+            data class Generic(val genericFailure: CoreFailure) : Failure()
         }
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -53,36 +53,32 @@ import io.ktor.http.HttpStatusCode
 
 sealed class KaliumException : Exception() {
 
-    class Unauthorized(val errorCode: Int) : KaliumException()
+    data class Unauthorized(val errorCode: Int) : KaliumException()
 
     /**
      * http error 300 .. 399
      */
-    class RedirectError(val errorResponse: ErrorResponse) : KaliumException()
+    data class RedirectError(val errorResponse: ErrorResponse) : KaliumException()
 
     /**
      * http error 400 .. 499
      */
-    open class InvalidRequestError(val errorResponse: ErrorResponse) : KaliumException() {
-        override fun toString(): String {
-            return "InvalidRequestError(response = $errorResponse"
-        }
-    }
+    data class InvalidRequestError(val errorResponse: ErrorResponse) : KaliumException()
 
     /**
      * http error 500 .. 599
      */
-    class ServerError(val errorResponse: ErrorResponse) : KaliumException()
+    data class ServerError(val errorResponse: ErrorResponse) : KaliumException()
 
     /**
      * Generic errors e.g. Serialization errors
      */
-    class GenericError(override val cause: Throwable) : KaliumException()
+    data class GenericError(override val cause: Throwable) : KaliumException()
 
     /**
      * Federation errors types
      */
-    class FederationError(val errorResponse: ErrorResponse) : KaliumException()
+    data class FederationError(val errorResponse: ErrorResponse) : KaliumException()
 
     sealed class FeatureError : KaliumException()
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The log of some failures are unclear and kinda hard to understand, as they don't provide meaningful info when converted to string.

With things like this showing up:

```
"errorInfo" : "ServerMiscommunication(cause = KaliumException.GenericError@dbf12c)"
```

Especially bad when we have minified code on releases:

```
"errorInfo" : "ServerMiscommunication(cause = co.c$c)"
```

WTF is `co.c$c`, we need the mapping file to figure out.

### Causes

When converting a regular class to String, and the `toString()` is not overridden, the `[className]@[memoryAddress]` will be used, which doesn't provide enough info.

Again, even worse on minified builds, as the `className` will be replaced with shenanigans.

### Solutions

Convert the generic failure classes into Data classes, which will handle this better, and give us more information about the error.

The `GenericError` from the example above will _at least_ read like:

```
"errorInfo" : ServerMiscommunication(cause = KaliumException.GenericError(cause = NullPointerException@198ab))
```

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
