### PR TITLE
fix: [DEV] accept Text/Plain content type for custom server config

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/configuration/ServerConfigApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/configuration/ServerConfigApi.kt
@@ -31,6 +31,7 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.http.ContentType
 import io.ktor.http.Url
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 
 interface ServerConfigApi {
@@ -53,10 +54,14 @@ class ServerConfigApiImpl internal constructor(
                 accept(ContentType.Text.Plain)
                 setUrl(Url(serverConfigUrl))
             }
-        }.flatMap{
+        }.flatMap {
             try {
-                NetworkResponse.Success(KtxSerializer.json.decodeFromString<ServerConfigResponse>(it.value), mapOf(), 200)
-            } catch (e: Exception) {
+                NetworkResponse.Success(
+                    KtxSerializer.json.decodeFromString<ServerConfigResponse>(it.value),
+                    it.headers,
+                    it.httpCode
+                )
+            } catch (e: SerializationException) {
                 NetworkResponse.Error(KaliumException.GenericError(e))
             }
         }.mapSuccess {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

custom server deep links for testing are not working because of incorrect content type

### Solutions

accept Text/Plain content type


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
