### PR TITLE
fix: [DEV] read receipts cancellation (AR-3169)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1015,7 +1015,8 @@ class UserSessionScope internal constructor(
             messages.sendConfirmation,
             renamedConversationHandler,
             qualifiedIdMapper,
-            team.isSelfATeamMember
+            team.isSelfATeamMember,
+            this
         )
 
     val migration get() = MigrationScope(userStorage.database)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -53,6 +53,7 @@ import com.wire.kalium.logic.feature.team.GetSelfTeamUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCase
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.sync.receiver.conversation.RenamedConversationEventHandler
+import kotlinx.coroutines.CoroutineScope
 
 @Suppress("LongParameterList")
 class ConversationScope internal constructor(
@@ -74,7 +75,8 @@ class ConversationScope internal constructor(
     private val sendConfirmation: SendConfirmationUseCase,
     private val renamedConversationHandler: RenamedConversationEventHandler,
     private val qualifiedIdMapper: QualifiedIdMapper,
-    private val isSelfATeamMember: IsSelfATeamMemberUseCase
+    private val isSelfATeamMember: IsSelfATeamMemberUseCase,
+    private val scope: CoroutineScope
 ) {
 
     val getSelfTeamUseCase: GetSelfTeamUseCase
@@ -149,7 +151,8 @@ class ConversationScope internal constructor(
             currentClientIdProvider,
             selfUserId,
             selfConversationIdProvider,
-            sendConfirmation
+            sendConfirmation,
+            scope
         )
 
     val updateConversationAccess: UpdateConversationAccessRoleUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -59,7 +59,7 @@ class UpdateConversationReadDateUseCase internal constructor(
      * @param conversationId The conversation id to update the last read date.
      * @param time The last read date to update.
      */
-    suspend operator fun invoke(conversationId: QualifiedID, time: Instant) {
+    operator fun invoke(conversationId: QualifiedID, time: Instant) {
         scope.launch {
             sendConfirmation(conversationId)
             conversationRepository.updateConversationReadDate(conversationId, time)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -44,6 +44,7 @@ import kotlinx.datetime.Instant
 
 // TODO: look into excluding self clients from sendConfirmation or run sendLastReadMessageToOtherClients if
 //  the conversation does not need to be notified
+@Suppress("LongParameterList")
 class UpdateConversationReadDateUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
     private val messageSender: MessageSender,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-3169 - Read receipts -> It takes some time to send read receipt when we open a conversation](https://wearezeta.atlassian.net/browse/AR-3169)

### Issues

Sending Read receipts confirmation were being cancelled.

### Causes (Optional)

Due to opening and closing a conversation very fast (with unread messages) it would cancel the scope (due to destroying the View and VM) and leading to Job Cancellation exception.

### Solutions

Add usage of User session scope instead of View/VM scope so even if the user closes the conversation screen, the process of read receipts confirmation is properly sent (as the user saw the messages).


### Testing

#### How to Test

- Run this branch on AR
- have a conversation with some unread messages
- open and close the conversation very fast
- job cancellation exceptions should not be happening anymore, and read receipts should be sent correctly.
