### PR TITLE
fix: not all events are emitted [AR-3310]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
@@ -38,8 +38,8 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -387,7 +387,7 @@ class EventGathererTest {
                 .thenReturn(either)
         }
 
-        fun withConnectionPolicyReturning(policyStateFlow: StateFlow<ConnectionPolicy>) = apply {
+        fun withConnectionPolicyReturning(policyStateFlow: MutableSharedFlow<ConnectionPolicy>) = apply {
             given(incrementalSyncRepository)
                 .getter(incrementalSyncRepository::connectionPolicyState)
                 .whenInvoked()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -138,6 +139,31 @@ class EventGathererTest {
     }
 
     @Test
+    fun givenWebsocketThousandsEventsAndKeepAlivePolicy_whenGathering_thenShouldEmitAllEvents() = runTest {
+        val repeatValue = 10_000
+        val liveEventsChannel = flow<WebSocketEvent<Event>> {
+            emit(WebSocketEvent.Open())
+            repeat(repeatValue) { value ->
+                emit(WebSocketEvent.BinaryPayloadReceived(TestEvent.newConnection(eventId = "event_$value")))
+
+            }
+        }
+
+        val (arrangement, eventGatherer) = Arrangement()
+            .withLastEventIdReturning(Either.Right("lastEventId"))
+            .withPendingEventsReturning(emptyFlow())
+            .withConnectionPolicyReturning(MutableStateFlow(ConnectionPolicy.KEEP_ALIVE))
+            .withLiveEventsReturning(Either.Right(liveEventsChannel))
+            .arrange()
+
+        eventGatherer.gatherEvents().test {
+            repeat(repeatValue) { value ->
+                assertEquals("event_$value", awaitItem().id)
+            }
+        }
+
+    }
+    @Test
     fun givenWebsocketEventAndDisconnectPolicy_whenGathering_thenShouldCompleteFlow() = runTest {
         val liveEventsChannel = Channel<WebSocketEvent<Event>>(capacity = Channel.UNLIMITED)
 
@@ -155,10 +181,6 @@ class EventGathererTest {
         advanceUntilIdle()
 
         eventGatherer.gatherEvents().test {
-            verify(arrangement.eventRepository)
-                .suspendFunction(arrangement.eventRepository::pendingEvents)
-                .wasNotInvoked()
-
             awaitComplete()
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`combine` function is skipping some events from websocket due to Batch-receive optimization inside this function

### Causes (Optional)

When revoking guest access in conversation some member leave events are skipped which leaves some guest in conversation.

### Solutions

Added buffer to not skip any emitted events