### PR TITLE
chore: disable backup web assets

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
@@ -58,57 +58,6 @@ fun WebEventContent.toMigratedMessage(selfUserDomain: String): MigratedMessage? 
                 null
             )
         }
-        is WebEventContent.Conversation.AssetMessage -> {
-            val mimeType = data.contentType ?: ""
-            MigratedMessage(
-                conversationId = qualifiedConversation,
-                senderUserId = qualifiedFrom ?: QualifiedID(from, selfUserDomain),
-                senderClientId = ClientId(fromClientId),
-                timestamp = Instant.parse(time).toEpochMilliseconds(),
-                content = "",
-                unencryptedProto = ProtoContent.Readable(
-                    id,
-                    MessageContent.Asset(
-                        AssetContent(
-                            sizeInBytes = data.contentLength ?: 0,
-                            name = data.info?.name,
-                            mimeType = mimeType,
-                            remoteData = AssetContent.RemoteData(
-                                otrKey = data.otrKey?.toString()?.toByteArray() ?: ByteArray(0),
-                                sha256 = data.sha256?.toString()?.toByteArray() ?: ByteArray(0),
-                                assetId = data.key ?: "",
-                                assetToken = data.token,
-                                assetDomain = data.domain,
-                                encryptionAlgorithm = null
-                            ),
-                            metadata = when {
-                                mimeType.contains("image/") -> AssetContent.AssetMetadata.Image(
-                                    width = data.info!!.width!!,
-                                    height = data.info.height!!
-                                )
-                                mimeType.contains("video/") -> AssetContent.AssetMetadata.Video(
-                                    width = null,
-                                    height = null,
-                                    durationMs = null
-                                )
-                                mimeType.contains("audio/") -> AssetContent.AssetMetadata.Audio(
-                                    durationMs = data.meta?.duration,
-                                    normalizedLoudness = data.meta?.loudness?.toString()?.toByteArray() ?: ByteArray(0)
-                                )
-                                else -> null
-                            },
-                            uploadStatus = Message.UploadStatus.NOT_UPLOADED,
-                            downloadStatus = Message.DownloadStatus.NOT_DOWNLOADED
-                        ),
-                    ),
-                    data.expectsReadConfirmation
-                ),
-                encryptedProto = null,
-                null,
-                null,
-                null
-            )
-        }
         else -> null // TODO handle other cases
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is an issue with loading broken assets from web backup. They should be handled more properly but there is no priority for that.

### Causes (Optional)

App freezes when scrolling in conversation which contains a lot of broken assets because there is a loop trying to fetch those assets.

### Solutions

Skip restoring assets for web backup and get back to it when we will work more on performance for app with a lot of messages
