### PR TITLE
feat: add support for v4 list-prekeys endpoint new contract

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyListMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyListMapper.kt
@@ -20,7 +20,9 @@ package com.wire.kalium.logic.data.prekey
 
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyDTO
 
 class PreKeyListMapper(private val preKeyMapper: PreKeyMapper) {
@@ -51,4 +53,9 @@ class PreKeyListMapper(private val preKeyMapper: PreKeyMapper) {
                 QualifiedUserPreKeyInfo(entry.key, clientsInfo)
             }
         }
+
+    fun fromListPrekeyResponseToUsersWithoutSessions(listPrekeysResponse: ListPrekeysResponse) =
+        UsersWithoutSessions(listPrekeysResponse.failedToList
+            ?.map { it.toModel() }
+            ?: listOf())
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/UsersWithoutSessions.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/UsersWithoutSessions.kt
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.prekey
+
+import com.wire.kalium.logic.data.user.UserId
+
+/**
+ * Holder class for an optional list of users ids whose sessions are missing.
+ */
+data class UsersWithoutSessions(val users: List<UserId>) {
+    fun areMissingSessions() = users.isNotEmpty()
+
+    companion object {
+        val EMPTY = UsersWithoutSessions(emptyList())
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientFingerprintUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientFingerprintUseCase.kt
@@ -69,7 +69,7 @@ class ClientFingerprintUseCase internal constructor(
     private suspend fun onSessionNotFound(userId: UserId, clientId: ClientId): Either<CoreFailure, ByteArray> {
         return prekeyRepository.establishSessions(mapOf(userId to listOf(clientId))).fold(
             { error -> Either.Left(error) },
-            {
+            { _ ->
                 proteusClientProvider.getOrError().flatMap { proteusClient ->
                     wrapCryptoRequest {
                         proteusClient.remoteFingerPrint(CryptoSessionId(userId.toCrypto(), CryptoClientId(clientId.value)))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -253,7 +253,7 @@ internal class MessageSenderImpl internal constructor(
 
             sessionEstablisher
                 .prepareRecipientsForNewOutgoingMessage(recipients)
-                .flatMap {
+                .flatMap { _ ->
                     messageEnvelopeCreator
                         .createOutgoingBroadcastEnvelope(recipients, message)
                         .flatMap { envelope -> tryBroadcastProteusEnvelope(envelope, message, option, target) }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
+import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyDTO
 import com.wire.kalium.network.exceptions.KaliumException
@@ -134,12 +135,15 @@ class PreKeyRepositoryTest {
         val prekeyCrypto = PreKeyCrypto(preKey.id, preKey.key)
 
         val userPreKeysResult = NetworkResponse.Success(
-            mapOf(
-                TEST_USER_ID_1.domain to mapOf(
-                    TEST_USER_ID_1.value to mapOf(
-                        TEST_CLIENT_ID_1.value to preKey,
-                        "invalidClient" to null,
+
+            ListPrekeysResponse(
+                qualifiedUserClientPrekeys = mapOf(
+                    TEST_USER_ID_1.domain to mapOf(
+                        TEST_USER_ID_1.value to mapOf(
+                            TEST_CLIENT_ID_1.value to preKey,
+                            "invalidClient" to null,
                         )
+                    )
                 )
             ),
             emptyMap(),
@@ -284,7 +288,7 @@ class PreKeyRepositoryTest {
             given(preKeyApi)
                 .suspendFunction(preKeyApi::getUsersPreKey)
                 .whenInvokedWith(any())
-                .then { NetworkResponse.Success(preKeyMap, emptyMap(), 200) }
+                .then { NetworkResponse.Success(ListPrekeysResponse(qualifiedUserClientPrekeys = preKeyMap), emptyMap(), 200) }
         }
 
         fun withGetRemoteUsersPreKeyFail(error: NetworkResponse.Error? = null) = apply {
@@ -328,7 +332,7 @@ class PreKeyRepositoryTest {
         }
 
         fun withPreKeysOfClientsByQualifiedUsersSuccess(
-            preKeyMap: NetworkResponse<Map<String, Map<String, Map<String, PreKeyDTO?>>>>
+            preKeyMap: NetworkResponse<ListPrekeysResponse>
         ) = apply {
             given(preKeyApi)
                 .suspendFunction(preKeyApi::getUsersPreKey)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ClientFingerprintUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ClientFingerprintUseCaseTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
+import com.wire.kalium.logic.data.prekey.UsersWithoutSessions
 import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
@@ -71,7 +72,7 @@ class ClientFingerprintUseCaseTest {
     }
 
     @Test
-    fun givenClientHaveNoSession_thenEstaqablishANewSession() = runTest {
+    fun givenClientHaveNoSession_thenEstablishANewSession() = runTest {
         val fingerprint = byteArrayOf(1, 2, 3, 4, 5)
 
         val userId = TestUser.USER_ID
@@ -79,7 +80,7 @@ class ClientFingerprintUseCaseTest {
 
         val (arrange, userCase) = Arrangement()
             .withSessionNotFound(fingerprint)
-            .withEstablishSession(Either.Right(Unit))
+            .withEstablishSession(Either.Right(UsersWithoutSessions.EMPTY))
             .arrange()
 
         userCase(userId, clientId).also { result ->
@@ -180,7 +181,7 @@ class ClientFingerprintUseCaseTest {
                 .thenReturn(result)
         }
 
-        fun withEstablishSession(result: Either<CoreFailure, Unit>) = apply {
+        fun withEstablishSession(result: Either<CoreFailure, UsersWithoutSessions>) = apply {
             given(preKeyRepository)
                 .suspendFunction(preKeyRepository::establishSessions)
                 .whenInvokedWith(any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageEnvelope
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.prekey.UsersWithoutSessions
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSenderTest.Arrangement.Companion.FEDERATION_MESSAGE_FAILURE
@@ -734,7 +735,7 @@ class MessageSenderTest {
             given(sessionEstablisher)
                 .suspendFunction(sessionEstablisher::prepareRecipientsForNewOutgoingMessage)
                 .whenInvokedWith(anything())
-                .thenReturn(if (failing) TEST_CORE_FAILURE else Either.Right(Unit))
+                .thenReturn(if (failing) TEST_CORE_FAILURE else Either.Right(UsersWithoutSessions.EMPTY))
         }
 
         fun withCommitPendingProposals(failing: Boolean = false) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SessionEstablisherTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SessionEstablisherTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
+import com.wire.kalium.logic.data.prekey.UsersWithoutSessions
 import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
@@ -112,7 +113,7 @@ class SessionEstablisherTest {
 
         val (_, sessionEstablisher) = Arrangement()
             .withDoesSessionExist(false)
-            .withEstablishSessions(Either.Right(Unit))
+            .withEstablishSessions(Either.Right(UsersWithoutSessions.EMPTY))
             .arrange()
 
         sessionEstablisher.prepareRecipientsForNewOutgoingMessage(listOf(TEST_RECIPIENT_1))
@@ -160,7 +161,7 @@ class SessionEstablisherTest {
 
         }
 
-        fun withEstablishSessions(result: Either<CoreFailure, Unit>) = apply {
+        fun withEstablishSessions(result: Either<CoreFailure, UsersWithoutSessions>) = apply {
             given(preKeyRepository)
                 .suspendFunction(preKeyRepository::establishSessions)
                 .whenInvokedWith(any())

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/prekey/PreKeyApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/prekey/PreKeyApi.kt
@@ -18,7 +18,10 @@
 
 package com.wire.kalium.network.api.base.authenticated.prekey
 
+import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.utils.NetworkResponse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 interface PreKeyApi {
     /**
@@ -27,11 +30,22 @@ interface PreKeyApi {
      */
     suspend fun getUsersPreKey(
         users: Map<String, Map<String, List<String>>>
-    ): NetworkResponse<Map<String, Map<String, Map<String, PreKeyDTO?>>>>
+    ): NetworkResponse<ListPrekeysResponse>
 
     suspend fun getClientAvailablePrekeys(clientId: String): NetworkResponse<List<Int>>
-
 }
 
 typealias DomainToUserIdToClientsToPreKeyMap = Map<String, Map<String, Map<String, PreKeyDTO?>>>
 typealias DomainToUserIdToClientsMap = Map<String, Map<String, List<String>>>
+
+/**
+ * v4 API response type for prekeys
+ * Will extend to older versions of the API, to support backwards compatibility plus versioning
+ */
+@Serializable
+data class ListPrekeysResponse(
+    @SerialName("failed_to_list")
+    val failedToList: List<UserId>? = listOf(),
+    @SerialName("qualified_user_client_prekeys")
+    val qualifiedUserClientPrekeys: DomainToUserIdToClientsToPreKeyMap
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/PreKeyApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/PreKeyApiV0.kt
@@ -19,33 +19,38 @@
 package com.wire.kalium.network.api.v0.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
+import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
-import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyDTO
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 
-internal open class PreKeyApiV0 internal constructor(private val authenticatedNetworkClient: AuthenticatedNetworkClient) : PreKeyApi {
+internal open class PreKeyApiV0 internal constructor(
+    private val authenticatedNetworkClient: AuthenticatedNetworkClient
+) : PreKeyApi {
 
-    private val httpClient get() = authenticatedNetworkClient.httpClient
+    protected val httpClient get() = authenticatedNetworkClient.httpClient
 
     override suspend fun getUsersPreKey(
         users: Map<String, Map<String, List<String>>>
-    ): NetworkResponse<Map<String, Map<String, Map<String, PreKeyDTO?>>>
-            > =
-        wrapKaliumResponse {
+    ): NetworkResponse<ListPrekeysResponse> =
+        wrapKaliumResponse<DomainToUserIdToClientsToPreKeyMap> {
             httpClient.post("$PATH_USERS/$PATH_List_PREKEYS") {
                 setBody(users)
             }
+        }.mapSuccess {
+            ListPrekeysResponse(failedToList = emptyList(), qualifiedUserClientPrekeys = it)
         }
 
     override suspend fun getClientAvailablePrekeys(clientId: String): NetworkResponse<List<Int>> = wrapKaliumResponse {
         httpClient.get("$PATH_CLIENTS/$clientId/$PATH_PRE_KEY")
     }
 
-    private companion object {
+    protected companion object {
         const val PATH_USERS = "users"
         const val PATH_CLIENTS = "clients"
         const val PATH_PRE_KEY = "prekeys"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/PreKeyApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/PreKeyApiV4.kt
@@ -19,8 +19,19 @@
 package com.wire.kalium.network.api.v4.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.v3.authenticated.PreKeyApiV3
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 
 internal open class PreKeyApiV4 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient
-) : PreKeyApiV3(authenticatedNetworkClient)
+) : PreKeyApiV3(authenticatedNetworkClient) {
+    override suspend fun getUsersPreKey(users: Map<String, Map<String, List<String>>>) =
+        wrapKaliumResponse<ListPrekeysResponse> {
+            httpClient.post("$PATH_USERS/$PATH_List_PREKEYS") {
+                setBody(users)
+            }
+        }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/json/model/DomainToUserIdToClientToPreKeyMapJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/json/model/DomainToUserIdToClientToPreKeyMapJson.kt
@@ -20,7 +20,9 @@ package com.wire.kalium.api.json.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
 import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
+import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyDTO
+import com.wire.kalium.network.api.base.model.UserId
 
 object DomainToUserIdToClientToPreKeyMapJson {
 
@@ -35,8 +37,10 @@ object DomainToUserIdToClientToPreKeyMapJson {
     private const val USER_2_CLIENT = "32233lj33j3dfh7u"
     private val USER_2_CLIENT_PREYKEY = PreKeyDTO(key = "preKey2ANWARqEvoQI6l9hw0D", id = 2)
 
+    private val USER_3 = UserId("user300d0-000b-9c1a-000d-a4130002c121", "domain3.example.com")
+
     private val jsonProvider = { _: DomainToUserIdToClientsToPreKeyMap ->
-            """
+        """
             |{
             |  "$DOMAIN_1": {
             |    "$USER_1": {
@@ -55,7 +59,7 @@ object DomainToUserIdToClientToPreKeyMapJson {
             |    }
             |  }
             |}
-            """.trimMargin()
+        """.trimMargin()
     }
 
     val valid = ValidJsonProvider(
@@ -73,4 +77,51 @@ object DomainToUserIdToClientToPreKeyMapJson {
         ),
         jsonProvider
     )
+
+    val validV4 = ValidJsonProvider(
+        ListPrekeysResponse(
+            listOf(USER_3),
+            mapOf(
+                DOMAIN_1 to
+                        mapOf(
+                            USER_1 to
+                                    mapOf(USER_1_CLIENT to USER_1_CLIENT_PREYKEY)
+                        ),
+                DOMAIN_2 to
+                        mapOf(
+                            USER_2 to
+                                    mapOf(USER_2_CLIENT to USER_2_CLIENT_PREYKEY)
+                        )
+            )
+        )
+    ) {
+        """
+            |{
+            |   "failed_to_list": [
+            |       {
+            |           "domain": "${it.failedToList?.first()?.domain}",
+            |           "id": "${it.failedToList?.first()?.value}"
+            |       }
+            |   ],
+            |   "qualified_user_client_prekeys": {
+            |       "$DOMAIN_1": {
+            |           "$USER_1": {
+            |               "$USER_1_CLIENT": {
+            |                   "key": "${USER_1_CLIENT_PREYKEY.key}",
+            |                   "id": ${USER_1_CLIENT_PREYKEY.id}
+            |               }
+            |           }
+            |       },
+            |       "$DOMAIN_2": {
+            |           "$USER_2": {
+            |               "$USER_2_CLIENT": {
+            |                   "key": "${USER_2_CLIENT_PREYKEY.key}",
+            |                   "id": "${USER_2_CLIENT_PREYKEY.id}"
+            |               }
+            |           }
+            |       }
+            |  }
+            |}  
+        """.trimMargin()
+    }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/PrekeyApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/PrekeyApiV4Test.kt
@@ -16,7 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.api.v0.prekey
+package com.wire.kalium.api.v4
 
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.json.model.DomainToUserIdToClientToPreKeyMapJson
@@ -24,7 +24,7 @@ import com.wire.kalium.api.json.model.DomainToUserIdToClientsMapJson
 import com.wire.kalium.api.json.model.ErrorResponseJson
 import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
-import com.wire.kalium.network.api.v0.authenticated.PreKeyApiV0
+import com.wire.kalium.network.api.v4.authenticated.PreKeyApiV4
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
@@ -37,8 +37,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
-class PrekeyApiV0Test : ApiTest {
-
+class PrekeyApiV4Test : ApiTest {
     @Test
     fun givenAValidDomainToUserIdToClientsMap_whenCallingGetUsersPrekeyEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
@@ -50,11 +49,11 @@ class PrekeyApiV0Test : ApiTest {
                 assertPathEqual(PATH_PREKEYS)
             }
         )
-        val preKeyApi: PreKeyApi = PreKeyApiV0(networkClient)
+        val preKeyApi = PreKeyApiV4(networkClient)
 
         val response: NetworkResponse<ListPrekeysResponse> = preKeyApi.getUsersPreKey(VALID_GET_USERS_PREKEY_REQUEST.serializableData)
         assertTrue(response.isSuccessful())
-        assertEquals(response.value.qualifiedUserClientPrekeys, VALID_GET_USERS_PREKEY_RESPONSE.serializableData)
+        assertEquals(response.value, VALID_GET_USERS_PREKEY_RESPONSE.serializableData)
     }
 
     @Test
@@ -63,7 +62,7 @@ class PrekeyApiV0Test : ApiTest {
             ErrorResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.Forbidden,
         )
-        val preKeyApi: PreKeyApi = PreKeyApiV0(networkClient)
+        val preKeyApi: PreKeyApi = PreKeyApiV4(networkClient)
         val errorResponse = preKeyApi.getUsersPreKey(VALID_GET_USERS_PREKEY_REQUEST.serializableData)
         assertFalse(errorResponse.isSuccessful())
         assertTrue(errorResponse.kException is KaliumException.InvalidRequestError)
@@ -72,7 +71,7 @@ class PrekeyApiV0Test : ApiTest {
 
     private companion object {
         val VALID_GET_USERS_PREKEY_REQUEST = DomainToUserIdToClientsMapJson.valid
-        val VALID_GET_USERS_PREKEY_RESPONSE = DomainToUserIdToClientToPreKeyMapJson.valid
+        val VALID_GET_USERS_PREKEY_RESPONSE = DomainToUserIdToClientToPreKeyMapJson.validV4
         val ERROR_RESPONSE = ErrorResponseJson.valid.serializableData
         const val PATH_PREKEYS = "/users/list-prekeys"
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since api v4, `/users/list-prekeys` endpoint will return a different response. This is changed to:

```
{
  "failed_to_list": [
    {
      "domain": "example.com",
      "id": "99db9768-04e3-4b5d-9268-831b6a25c4ab"
    }
  ],
  "qualified_user_client_prekeys": {
    "additionalProp1": {
      "000600d0-000b-9c1a-000d-a4130002c221": {
        "44901fb0712e588f": {
          "id": 1,
          "key": "pQABAQECoQBYIOjl7hw0D8YRNq..."
        }
      }
    },
    "additionalProp2": {
      "000600d0-000b-9c1a-000d-a4130002c221": {
        "44901fb0712e588f": {
          "id": 1,
          "key": "pQABAQECoQBYIOjl7hw0D8YRNq..."
        }
      }
    },
    "additionalProp3": {
      "000600d0-000b-9c1a-000d-a4130002c221": {
        "44901fb0712e588f": {
          "id": 1,
          "key": "pQABAQECoQBYIOjl7hw0D8YRNq..."
        }
      }
    }
  }
}
```

### Causes (Optional)

Breaks the retrocompatibility and api versioning we have on the project, since the old response until v3 is contained in this new json object.

### Solutions

- Change the return type from old `v0 -> v3` of the endpoint and only map what we need ignoring the new optional field, using `.mapSuccess` to maintain retrocompatibility.
- For v4 and up, we don't perform any transformation to handle the optional field `failed_to_list` we just delegate to ktor the mapping.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
