### PR TITLE
feat: add support for v4 list-users endpoint new contract (AR-3322)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
@@ -157,7 +157,7 @@ internal class SearchUserRepositoryImpl(
                 if (qualifiedIdList.isEmpty()) Either.Right(listOf())
                 else wrapApiRequest {
                     userDetailsApi.getMultipleUsers(ListUserRequest.qualifiedIds(qualifiedIdList))
-                }
+                }.map { listUsersDTO -> listUsersDTO.usersFound }
             response.map { userProfileDTOList ->
                 val otherUserList = if (userProfileDTOList.isEmpty()) emptyList() else {
                     val selfUser = getSelfUser()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -221,7 +221,7 @@ internal class UserDataSource internal constructor(
         userDetailsApi.getMultipleUsers(
             ListUserRequest.qualifiedIds(qualifiedUsersOnSameDomainList.map { userId -> userId.toApi() })
         )
-    }.flatMap { listUserProfileDTO -> persistUsers(listUserProfileDTO) }
+    }.flatMap { listUserProfileDTO -> persistUsers(listUserProfileDTO.usersFound) }
 
     override suspend fun fetchUserInfo(userId: UserId) =
         wrapApiRequest { userDetailsApi.getUserInfo(userId.toApi()) }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.test_util.TestNetworkResponseError
 import com.wire.kalium.network.api.base.authenticated.search.ContactDTO
 import com.wire.kalium.network.api.base.authenticated.search.SearchPolicyDTO
 import com.wire.kalium.network.api.base.authenticated.search.UserSearchResponse
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
@@ -360,7 +361,7 @@ class SearchUserRepositoryTest {
             given(userDetailsApi)
                 .suspendFunction(userDetailsApi::getMultipleUsers)
                 .whenInvokedWith(any())
-                .then { NetworkResponse.Success(emptyList(), mapOf(), 200) }
+                .then { NetworkResponse.Success(USER_RESPONSE.copy(usersFound = emptyList()), mapOf(), 200) }
 
             given(metadataDAO)
                 .suspendFunction(metadataDAO::valueByKeyFlow)
@@ -534,20 +535,23 @@ class SearchUserRepositoryTest {
             took = 0,
         )
 
-        val USER_RESPONSE = listOf(
-            UserProfileDTO(
-                accentId = 1,
-                handle = "handle",
-                id = UserIdDTO(value = "value", domain = "domain"),
-                name = "name",
-                legalHoldStatus = LegalHoldStatusResponse.ENABLED,
-                teamId = "team",
-                assets = emptyList(),
-                deleted = null,
-                email = null,
-                expiresAt = null,
-                nonQualifiedId = "value",
-                service = null
+        val USER_RESPONSE = ListUsersDTO(
+            usersFailed = emptyList(),
+            usersFound = listOf(
+                UserProfileDTO(
+                    accentId = 1,
+                    handle = "handle",
+                    id = UserIdDTO(value = "value", domain = "domain"),
+                    name = "name",
+                    legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+                    teamId = "team",
+                    assets = emptyList(),
+                    deleted = null,
+                    email = null,
+                    expiresAt = null,
+                    nonQualifiedId = "value",
+                    service = null
+                )
             )
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -32,8 +32,8 @@ import com.wire.kalium.logic.test_util.TestNetworkResponseError
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
@@ -108,7 +108,7 @@ class UserRepositoryTest {
             .withGetSelfUserId()
             .withSuccessfulGetUsersInfo()
             .withSuccessfulGetUsersByQualifiedIdList(knownUserEntities)
-            .withSuccessfulGetMultipleUsersApiRequest(listOf(TestUser.USER_PROFILE_DTO))
+            .withSuccessfulGetMultipleUsersApiRequest(ListUsersDTO(usersFailed = emptyList(), listOf(TestUser.USER_PROFILE_DTO)))
             .arrange()
 
         userRepository.fetchUsersIfUnknownByIds(requestedUserIds).shouldSucceed()
@@ -525,7 +525,7 @@ class UserRepositoryTest {
                 .thenReturn(NetworkResponse.Success(TestUser.USER_DTO.copy(deleted = true), mapOf(), 200))
         }
 
-        fun withSuccessfulGetMultipleUsersApiRequest(result: List<UserProfileDTO>) = apply {
+        fun withSuccessfulGetMultipleUsersApiRequest(result: ListUsersDTO) = apply {
             given(userDetailsApi)
                 .suspendFunction(userDetailsApi::getMultipleUsers)
                 .whenInvokedWith(any())

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserDetailsApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserDetailsApi.kt
@@ -22,6 +22,6 @@ import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface UserDetailsApi {
-    suspend fun getMultipleUsers(users: ListUserRequest): NetworkResponse<List<UserProfileDTO>>
+    suspend fun getMultipleUsers(users: ListUserRequest): NetworkResponse<ListUsersDTO>
     suspend fun getUserInfo(userId: UserId): NetworkResponse<UserProfileDTO>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserProfileDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserProfileDTO.kt
@@ -18,12 +18,12 @@
 
 package com.wire.kalium.network.api.base.authenticated.userDetails
 
-import com.wire.kalium.network.api.base.model.NonQualifiedUserId
-import com.wire.kalium.network.api.base.model.TeamId
-import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.NonQualifiedUserId
 import com.wire.kalium.network.api.base.model.ServiceDTO
+import com.wire.kalium.network.api.base.model.TeamId
 import com.wire.kalium.network.api.base.model.UserAssetDTO
+import com.wire.kalium.network.api.base.model.UserId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -42,4 +42,9 @@ data class UserProfileDTO(
     @Deprecated("use id instead", replaceWith = ReplaceWith("this.id"))
     @SerialName("id") val nonQualifiedId: NonQualifiedUserId,
     @SerialName("service") val service: ServiceDTO?
+)
+
+data class ListUsersDTO(
+    @SerialName("failed") val usersFailed: List<UserId>,
+    @SerialName("found") val usersFound: List<UserProfileDTO>
 )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserProfileDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserProfileDTO.kt
@@ -44,6 +44,7 @@ data class UserProfileDTO(
     @SerialName("service") val service: ServiceDTO?
 )
 
+@Serializable
 data class ListUsersDTO(
     @SerialName("failed") val usersFailed: List<UserId>,
     @SerialName("found") val usersFound: List<UserProfileDTO>

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/UserDetailsApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/UserDetailsApiV0.kt
@@ -20,10 +20,12 @@ package com.wire.kalium.network.api.v0.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.get
 import io.ktor.client.request.post
@@ -35,11 +37,13 @@ internal open class UserDetailsApiV0 internal constructor(
 
     private val httpClient get() = authenticatedNetworkClient.httpClient
 
-    override suspend fun getMultipleUsers(users: ListUserRequest): NetworkResponse<List<UserProfileDTO>> {
-        return wrapKaliumResponse {
+    override suspend fun getMultipleUsers(users: ListUserRequest): NetworkResponse<ListUsersDTO> {
+        return wrapKaliumResponse<List<UserProfileDTO>> {
             httpClient.post(PATH_LIST_USERS) {
                 setBody(users)
             }
+        }.mapSuccess {
+            ListUsersDTO(usersFailed = emptyList(), usersFound = it)
         }
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/UserDetailsApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/UserDetailsApiV0.kt
@@ -35,7 +35,7 @@ internal open class UserDetailsApiV0 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient
 ) : UserDetailsApi {
 
-    private val httpClient get() = authenticatedNetworkClient.httpClient
+    protected val httpClient get() = authenticatedNetworkClient.httpClient
 
     override suspend fun getMultipleUsers(users: ListUserRequest): NetworkResponse<ListUsersDTO> {
         return wrapKaliumResponse<List<UserProfileDTO>> {
@@ -53,7 +53,7 @@ internal open class UserDetailsApiV0 internal constructor(
         }
     }
 
-    private companion object {
+    protected companion object {
         const val PATH_LIST_USERS = "list-users"
         const val PATH_USERS = "users"
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/UserDetailsApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/UserDetailsApiV4.kt
@@ -19,8 +19,21 @@
 package com.wire.kalium.network.api.v4.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.v3.authenticated.UserDetailsApiV3
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 
 internal open class UserDetailsApiV4 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient
-) : UserDetailsApiV3(authenticatedNetworkClient)
+) : UserDetailsApiV3(authenticatedNetworkClient) {
+    override suspend fun getMultipleUsers(users: ListUserRequest): NetworkResponse<ListUsersDTO> =
+        wrapKaliumResponse<ListUsersDTO> {
+            httpClient.post(PATH_LIST_USERS) {
+                setBody(users)
+            }
+        }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/json/model/QualifiedIDSamples.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/json/model/QualifiedIDSamples.kt
@@ -23,4 +23,5 @@ import com.wire.kalium.network.api.base.model.QualifiedID
 object QualifiedIDSamples {
     val one = QualifiedID("someValue", "someDomain")
     val two = QualifiedID("anotherValue", "anotherDomain")
+    val three = QualifiedID("anotherValue3", "anotherDomain3")
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/details/UserDetailsApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/details/UserDetailsApiV0Test.kt
@@ -21,19 +21,23 @@ package com.wire.kalium.api.v0.user.details
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.json.model.QualifiedHandleSample
 import com.wire.kalium.api.json.model.QualifiedIDSamples
-import com.wire.kalium.model.ListUsersRequestJson
+import com.wire.kalium.model.ListUsersResponseJson
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedHandles
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
 import com.wire.kalium.network.api.v0.authenticated.UserDetailsApiV0
 import com.wire.kalium.network.tools.KtxSerializer
+import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class UserDetailsApiV0Test : ApiTest {
@@ -43,7 +47,7 @@ class UserDetailsApiV0Test : ApiTest {
         val params = ListUserRequest.qualifiedIds(listOf(QualifiedIDSamples.one, QualifiedIDSamples.two))
         val expectedRequestBody = KtxSerializer.json.encodeToString(params)
         val networkClient = mockAuthenticatedNetworkClient(
-            ListUsersRequestJson.validIdsJsonProvider.rawJson,
+            ListUsersResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.Created,
             assertion = {
                 assertPost()
@@ -55,7 +59,10 @@ class UserDetailsApiV0Test : ApiTest {
         )
         val userDetailsApi: UserDetailsApi = UserDetailsApiV0(networkClient)
 
-        userDetailsApi.getMultipleUsers(params)
+        val response: NetworkResponse<ListUsersDTO> = userDetailsApi.getMultipleUsers(params)
+        assertTrue(response.isSuccessful())
+        assertTrue(response.value.usersFailed.isEmpty())
+        assertEquals(response.value.usersFound, ListUsersResponseJson.valid.serializableData)
     }
 
     @Test
@@ -63,7 +70,7 @@ class UserDetailsApiV0Test : ApiTest {
         val params = ListUserRequest.qualifiedHandles(listOf(QualifiedHandleSample.one, QualifiedHandleSample.two))
         val expectedRequestBody = KtxSerializer.json.encodeToString(params)
         val networkClient = mockAuthenticatedNetworkClient(
-            ListUsersRequestJson.validIdsJsonProvider.rawJson,
+            ListUsersResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.Created,
             assertion = {
                 assertJsonBodyContent(expectedRequestBody)
@@ -77,7 +84,7 @@ class UserDetailsApiV0Test : ApiTest {
     @Test
     fun givenAValidRequest_whenGettingListOfUsers_thenCorrectHttpHeadersAndMethodShouldBeUsed() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
-            ListUsersRequestJson.validIdsJsonProvider.rawJson,
+            ListUsersResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.Created,
             assertion = {
                 assertPost()
@@ -94,7 +101,7 @@ class UserDetailsApiV0Test : ApiTest {
     @Test
     fun givenAUserId_whenInvokingUserInfo_thenShouldConfigureTheRequestOkAndReturnAResultWithData() = runTest {
         val httpClient = mockAuthenticatedNetworkClient(
-            ListUsersRequestJson.validIdsJsonProvider.rawJson,
+            ListUsersResponseJson.valid.rawJson,
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertGet()

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/details/UserDetailsApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/details/UserDetailsApiV0Test.kt
@@ -47,7 +47,7 @@ class UserDetailsApiV0Test : ApiTest {
         val params = ListUserRequest.qualifiedIds(listOf(QualifiedIDSamples.one, QualifiedIDSamples.two))
         val expectedRequestBody = KtxSerializer.json.encodeToString(params)
         val networkClient = mockAuthenticatedNetworkClient(
-            ListUsersResponseJson.valid.rawJson,
+            SUCCESS_RESPONSE.rawJson,
             statusCode = HttpStatusCode.Created,
             assertion = {
                 assertPost()
@@ -62,7 +62,7 @@ class UserDetailsApiV0Test : ApiTest {
         val response: NetworkResponse<ListUsersDTO> = userDetailsApi.getMultipleUsers(params)
         assertTrue(response.isSuccessful())
         assertTrue(response.value.usersFailed.isEmpty())
-        assertEquals(response.value.usersFound, ListUsersResponseJson.valid.serializableData)
+        assertEquals(response.value.usersFound, SUCCESS_RESPONSE.serializableData)
     }
 
     @Test
@@ -70,7 +70,7 @@ class UserDetailsApiV0Test : ApiTest {
         val params = ListUserRequest.qualifiedHandles(listOf(QualifiedHandleSample.one, QualifiedHandleSample.two))
         val expectedRequestBody = KtxSerializer.json.encodeToString(params)
         val networkClient = mockAuthenticatedNetworkClient(
-            ListUsersResponseJson.valid.rawJson,
+            SUCCESS_RESPONSE.rawJson,
             statusCode = HttpStatusCode.Created,
             assertion = {
                 assertJsonBodyContent(expectedRequestBody)
@@ -84,7 +84,7 @@ class UserDetailsApiV0Test : ApiTest {
     @Test
     fun givenAValidRequest_whenGettingListOfUsers_thenCorrectHttpHeadersAndMethodShouldBeUsed() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
-            ListUsersResponseJson.valid.rawJson,
+            SUCCESS_RESPONSE.rawJson,
             statusCode = HttpStatusCode.Created,
             assertion = {
                 assertPost()
@@ -101,7 +101,7 @@ class UserDetailsApiV0Test : ApiTest {
     @Test
     fun givenAUserId_whenInvokingUserInfo_thenShouldConfigureTheRequestOkAndReturnAResultWithData() = runTest {
         val httpClient = mockAuthenticatedNetworkClient(
-            ListUsersResponseJson.valid.rawJson,
+            SUCCESS_RESPONSE.rawJson,
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertGet()
@@ -118,5 +118,6 @@ class UserDetailsApiV0Test : ApiTest {
     private companion object {
         const val PATH_LIST_USERS = "/list-users"
         const val PATH_USERS = "/users"
+        private val SUCCESS_RESPONSE = ListUsersResponseJson.v0
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
@@ -1,0 +1,70 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.api.v4
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.api.json.model.QualifiedIDSamples
+import com.wire.kalium.model.ListUsersResponseJson
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
+import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
+import com.wire.kalium.network.api.v4.authenticated.UserDetailsApiV4
+import com.wire.kalium.network.tools.KtxSerializer
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.isSuccessful
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class UserDetailsApiV4Test : ApiTest {
+
+    @Test
+    fun givenListOfQualifiedIds_whenGettingListOfUsers_thenBodyShouldSerializeCorrectly() = runTest {
+        val params = ListUserRequest.qualifiedIds(
+            listOf(QualifiedIDSamples.one, QualifiedIDSamples.two, QualifiedIDSamples.three)
+        )
+        val expectedRequestBody = KtxSerializer.json.encodeToString(params)
+        val networkClient = mockAuthenticatedNetworkClient(
+            SUCCESS_RESPONSE.rawJson,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertPost()
+                assertJson()
+                assertNoQueryParams()
+                assertPathEqual(PATH_LIST_USERS)
+                assertJsonBodyContent(expectedRequestBody)
+            }
+        )
+        val userDetailsApi: UserDetailsApiV4 = UserDetailsApiV4(networkClient)
+
+        val response: NetworkResponse<ListUsersDTO> = userDetailsApi.getMultipleUsers(params)
+        assertTrue(response.isSuccessful())
+        assertTrue(response.value.usersFailed.isNotEmpty())
+        assertEquals(response.value.usersFound, SUCCESS_RESPONSE.serializableData.usersFound)
+    }
+
+    private companion object {
+        const val PATH_LIST_USERS = "/list-users"
+        val SUCCESS_RESPONSE = ListUsersResponseJson.valid4
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
@@ -65,6 +65,6 @@ class UserDetailsApiV4Test : ApiTest {
 
     private companion object {
         const val PATH_LIST_USERS = "/list-users"
-        val SUCCESS_RESPONSE = ListUsersResponseJson.valid4
+        val SUCCESS_RESPONSE = ListUsersResponseJson.v4
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
@@ -45,7 +45,7 @@ class UserDetailsApiV4Test : ApiTest {
         )
         val expectedRequestBody = KtxSerializer.json.encodeToString(params)
         val networkClient = mockAuthenticatedNetworkClient(
-            SUCCESS_RESPONSE.rawJson,
+            SUCCESS_RESPONSE_WITH_FAILED_TO_LIST.rawJson,
             statusCode = HttpStatusCode.Created,
             assertion = {
                 assertPost()
@@ -60,11 +60,11 @@ class UserDetailsApiV4Test : ApiTest {
         val response: NetworkResponse<ListUsersDTO> = userDetailsApi.getMultipleUsers(params)
         assertTrue(response.isSuccessful())
         assertTrue(response.value.usersFailed.isNotEmpty())
-        assertEquals(response.value.usersFound, SUCCESS_RESPONSE.serializableData.usersFound)
+        assertEquals(response.value.usersFound, SUCCESS_RESPONSE_WITH_FAILED_TO_LIST.serializableData.usersFound)
     }
 
     private companion object {
         const val PATH_LIST_USERS = "/list-users"
-        val SUCCESS_RESPONSE = ListUsersResponseJson.v4
+        val SUCCESS_RESPONSE_WITH_FAILED_TO_LIST = ListUsersResponseJson.v4
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersRequestJson.kt
@@ -27,9 +27,20 @@ object ListUsersRequestJson {
 
     private val qualifiedIdsProvider = { serializable: QualifiedUserIdListRequest ->
         val idsArrayContent = serializable.qualifiedIds.joinToString(",") {
-            """{"domain": "${it.domain}", "id":"${it.value}""""
+            """
+                {
+                    "domain": "${it.domain}",
+                    "id": "${it.value}"
+                }
+            """.trimIndent()
         }
-        """{"qualified_ids": [$idsArrayContent]}"""
+        """
+            {
+                "qualified_ids": [
+                    $idsArrayContent
+                ]
+            }
+        """.trimIndent()
     }
     private val qualifiedHandlesProvider = { serializable: QualifiedHandleListRequest ->
         val handlesArrayContent = serializable.qualifiedHandles.joinToString(",") {

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
@@ -28,6 +28,7 @@ object ListUsersResponseJson {
 
     private val USER_1 = UserId("user10d0-000b-9c1a-000d-a4130002c221", "domain1.example.com")
     private val USER_2 = UserId("user20d0-000b-9c1a-000d-a4130002c221", "domain2.example.com")
+    private val USER_3 = UserId("user30d0-000b-9c1a-000d-a4130002c220", "domain3.example.com")
 
     private val expectedUsersResponse = listOf(
         UserProfileDTO(
@@ -93,21 +94,21 @@ object ListUsersResponseJson {
         """.trimMargin()
     }
 
-    val valid = ValidJsonProvider(
+    val v0 = ValidJsonProvider(
         expectedUsersResponse
     ) {
         validUserInfoProvider(it)
     }
 
-    val valid4 = ValidJsonProvider(
-        ListUsersDTO(emptyList(), expectedUsersResponse)
+    val v4 = ValidJsonProvider(
+        ListUsersDTO(listOf(USER_3), expectedUsersResponse)
     ) {
         """
         |{
         |    "failed": [
         |      {
-        |        "domain": "domain3.example.com",
-        |        "id": "99db9768-04e3-4b5d-9268-831b6a25c4ab"
+        |        "domain": "${it.usersFailed[0].domain}",
+        |        "id": "${it.usersFailed[0].value}"
         |      }
         |    ],
         |    "found": ${validUserInfoProvider(it.usersFound)}

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
@@ -1,0 +1,95 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.model
+
+import com.wire.kalium.api.json.ValidJsonProvider
+import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
+import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.UserId
+
+object ListUsersResponseJson {
+
+    private val USER_1 = UserId("user10d0-000b-9c1a-000d-a4130002c221", "domain1.example.com")
+    private val USER_2 = UserId("user20d0-000b-9c1a-000d-a4130002c221", "domain2.example.com")
+    private val expectedUsersResponse = listOf(
+        UserProfileDTO(
+            id = USER_1,
+            name = "usera",
+            handle = "user_a",
+            accentId = 2147483647,
+            legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+            teamId = null,
+            assets = emptyList(),
+            deleted = false,
+            email = null,
+            expiresAt = null,
+            nonQualifiedId = USER_1.value,
+            service = null
+        ),
+        UserProfileDTO(
+            id = USER_2,
+            name = "userb",
+            handle = "user_b",
+            accentId = 2147483647,
+            legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+            teamId = null,
+            assets = emptyList(),
+            deleted = false,
+            email = null,
+            expiresAt = null,
+            nonQualifiedId = USER_2.value,
+            service = null
+        ),
+    )
+
+    val valid = ValidJsonProvider(
+        expectedUsersResponse
+    ) {
+        """
+            |[
+            |   {
+            |    "accent_id": ${it[0].accentId},
+            |    "handle": "${it[0].handle}",
+            |    "legalhold_status": "enabled",
+            |    "name": "${it[0].name}",
+            |    "assets": ${it[0].assets},
+            |    "id": "${it[0].id.value}",
+            |    "deleted": "false",
+            |    "qualified_id": {
+            |      "domain": "${it[0].id.domain}",
+            |      "id": "${it[0].id.value}"
+            |    }
+            |   },
+            |   {
+            |    "accent_id": ${it[1].accentId},
+            |    "handle": "${it[1].handle}",
+            |    "legalhold_status": "enabled",
+            |    "name": "${it[1].name}",
+            |    "assets": ${it[1].assets},
+            |    "id": "${it[1].id.value}",
+            |    "deleted": "false",
+            |    "qualified_id": {
+            |      "domain": "${it[1].id.domain}",
+            |      "id": "${it[1].id.value}"
+            |    }
+            |   }
+            |]
+        """.trimMargin()
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
 import com.wire.kalium.network.api.base.model.UserId
@@ -27,6 +28,7 @@ object ListUsersResponseJson {
 
     private val USER_1 = UserId("user10d0-000b-9c1a-000d-a4130002c221", "domain1.example.com")
     private val USER_2 = UserId("user20d0-000b-9c1a-000d-a4130002c221", "domain2.example.com")
+
     private val expectedUsersResponse = listOf(
         UserProfileDTO(
             id = USER_1,
@@ -58,38 +60,58 @@ object ListUsersResponseJson {
         ),
     )
 
+    private val validUserInfoProvider = { userInfo: List<UserProfileDTO> ->
+        """
+        |[
+        |   {
+        |    "accent_id": ${userInfo[0].accentId},
+        |    "handle": "${userInfo[0].handle}",
+        |    "legalhold_status": "enabled",
+        |    "name": "${userInfo[0].name}",
+        |    "assets": ${userInfo[0].assets},
+        |    "id": "${userInfo[0].id.value}",
+        |    "deleted": "false",
+        |    "qualified_id": {
+        |      "domain": "${userInfo[0].id.domain}",
+        |      "id": "${userInfo[0].id.value}"
+        |    }
+        |   },
+        |   {
+        |    "accent_id": ${userInfo[1].accentId},
+        |    "handle": "${userInfo[1].handle}",
+        |    "legalhold_status": "enabled",
+        |    "name": "${userInfo[1].name}",
+        |    "assets": ${userInfo[1].assets},
+        |    "id": "${userInfo[1].id.value}",
+        |    "deleted": "false",
+        |    "qualified_id": {
+        |      "domain": "${userInfo[1].id.domain}",
+        |      "id": "${userInfo[1].id.value}"
+        |    }
+        |   }
+        |]
+        """.trimMargin()
+    }
+
     val valid = ValidJsonProvider(
         expectedUsersResponse
     ) {
+        validUserInfoProvider(it)
+    }
+
+    val valid4 = ValidJsonProvider(
+        ListUsersDTO(emptyList(), expectedUsersResponse)
+    ) {
         """
-            |[
-            |   {
-            |    "accent_id": ${it[0].accentId},
-            |    "handle": "${it[0].handle}",
-            |    "legalhold_status": "enabled",
-            |    "name": "${it[0].name}",
-            |    "assets": ${it[0].assets},
-            |    "id": "${it[0].id.value}",
-            |    "deleted": "false",
-            |    "qualified_id": {
-            |      "domain": "${it[0].id.domain}",
-            |      "id": "${it[0].id.value}"
-            |    }
-            |   },
-            |   {
-            |    "accent_id": ${it[1].accentId},
-            |    "handle": "${it[1].handle}",
-            |    "legalhold_status": "enabled",
-            |    "name": "${it[1].name}",
-            |    "assets": ${it[1].assets},
-            |    "id": "${it[1].id.value}",
-            |    "deleted": "false",
-            |    "qualified_id": {
-            |      "domain": "${it[1].id.domain}",
-            |      "id": "${it[1].id.value}"
-            |    }
-            |   }
-            |]
+        |{
+        |    "failed": [
+        |      {
+        |        "domain": "domain3.example.com",
+        |        "id": "99db9768-04e3-4b5d-9268-831b6a25c4ab"
+        |      }
+        |    ],
+        |    "found": ${validUserInfoProvider(it.usersFound)}
+        |}
         """.trimMargin()
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Since api v4, `/users/list-users` endpoint will return a different response. This is changed to:

```
{
  "failed": [
    {
      "domain": "example.com",
      "id": "99db9768-04e3-4b5d-9268-831b6a25c4ab"
    }
  ],
  "found": [
    {
      "accent_id": 2147483647,
      "assets": [
        {
          "key": "3-1-47de4580-ae51-4650-acbb-d10c028cb0ac",
          "size": "preview",
          "type": "image"
        }
      ],
      "deleted": true,
      "email": "string",
      "expires_at": "2021-05-12T10:52:02.671Z",
      "handle": "string",
      "id": "99db9768-04e3-4b5d-9268-831b6a25c4ab",
      "legalhold_status": "enabled",
      "name": "string",
      "picture": [
        "string"
      ],
      "qualified_id": {
        "domain": "example.com",
        "id": "99db9768-04e3-4b5d-9268-831b6a25c4ab"
      },
      "service": {
        "id": "99db9768-04e3-4b5d-9268-831b6a25c4ab",
        "provider": "99db9768-04e3-4b5d-9268-831b6a25c4ab"
      },
      "team": "99db9768-04e3-4b5d-9268-831b6a25c4ab"
    }
  ]
}
```

### Causes (Optional)

Breaks the retrocompatibility and api versioning we have on the project, since the old response until v3 is contained in this new json object.

### Solutions

- Change the return type from old `v0 -> v3` of the endpoint and only map what we need ignoring the new optional field, using `.mapSuccess` to maintain retrocompatibility.
- For v4 and up, we don't perform any transformation we just delegate to ktor the mapping.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
