### PR TITLE
fix: increase socket timeout (AR-3344) (develop) 

### DIFF
--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -34,6 +34,13 @@ actual fun defaultHttpEngine(
     serverConfigDTOApiProxy: ServerConfigDTO.ApiProxy?,
     proxyCredentials: ProxyCredentialsDTO?
 ): HttpClientEngine = OkHttp.create {
+
+    val okHttpClient = OkHttpClient.Builder()
+        .pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS)
+        .connectTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+        .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+        .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+
     // OkHttp doesn't support configuring ping intervals dynamically,
     // so they must be set when creating the Engine
     // See https://youtrack.jetbrains.com/issue/KTOR-4752
@@ -54,13 +61,12 @@ actual fun defaultHttpEngine(
             InetSocketAddress.createUnresolved(serverConfigDTOApiProxy?.host, serverConfigDTOApiProxy!!.port)
         )
 
-        val client = OkHttpClient.Builder().pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS).proxy(proxy)
-            .build()
-        preconfigured = client
-        webSocketFactory = KaliumWebSocketFactory(client)
+        val clientWithProxy = okHttpClient.proxy(proxy).build()
+        preconfigured = clientWithProxy
+        webSocketFactory = KaliumWebSocketFactory(clientWithProxy)
 
     } else {
-        val client = OkHttpClient.Builder().pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS).build()
+        val client = okHttpClient.build()
         preconfigured = client
         webSocketFactory = KaliumWebSocketFactory(client)
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/NetworkClient.kt
@@ -143,3 +143,4 @@ internal fun provideBaseHttpClient(
 internal fun shouldAddApiVersion(apiVersion: Int): Boolean = apiVersion >= MINIMUM_API_VERSION_TO_ADD
 private const val MINIMUM_API_VERSION_TO_ADD = 1
 internal const val WEBSOCKET_PING_INTERVAL_MILLIS = 20_000L
+internal const val WEBSOCKET_TIMEOUT = 30_000L


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`SocketTimeoutException` thrown when we try to upload multiple files

```
GenericError(cause=io.ktor.client.network.sockets.SocketTimeoutException: Socket timeout has expired [url=***/v2/assets, socket_timeout=unknown] ms)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at com.wire.kalium.network.api.v2.authenticated.AssetApiV2.uploadAsset$suspendImpl(AssetApiV2.kt:106)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at com.wire.kalium.network.api.v2.authenticated.AssetApiV2$uploadAsset$1.invokeSuspend(Unknown Source:18)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: Caused by: io.ktor.client.network.sockets.SocketTimeoutException: Socket timeout has expired [url=***/v2/assets, socket_timeout=unknown] ms
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at io.ktor.client.plugins.HttpTimeoutKt.SocketTimeoutException(HttpTimeout.kt:235)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at io.ktor.client.engine.okhttp.OkUtilsKt.mapOkHttpException(OkUtils.kt:79)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at io.ktor.client.engine.okhttp.OkUtilsKt.access$mapOkHttpException(OkUtils.kt:1)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at io.ktor.client.engine.okhttp.OkHttpCallback.onFailure(OkUtils.kt:39)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:525)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
04-25 17:05:47.398 31889 10293 I com.wire.internal.debug: 	at java.util.concurrent.ThreadPoolExecutor$Worke
```

### Solutions

Default timeout is 10s for OkhttpClient, increasing it to 30s

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
