### PR TITLE
fix: crash during root verification

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/rootDetection/RootDetectorImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/rootDetection/RootDetectorImpl.kt
@@ -4,21 +4,31 @@ import android.annotation.SuppressLint
 import java.io.File
 
 actual class RootDetectorImpl actual constructor() : RootDetector {
-    override fun isSystemRooted(): Boolean {
-        val releaseTagsExist = getSystemProperty("ro.build.tags").contains("release-keys")
-        val otacertsExist = File("/etc/security/otacerts.zip").exists()
-        val canRunSu = runCommand("su")
 
-        return !releaseTagsExist || !otacertsExist || canRunSu
+    override fun isSystemRooted(): Boolean {
+        // Lambdas so they can be executed lazily
+        val releaseTagsExist = {
+            // Fallback to true in case of failure
+            getSystemProperty("ro.build.tags")?.contains("release-keys") ?: true
+        }
+        val otacertsExist = { File("/etc/security/otacerts.zip").exists() }
+        val canRunSu = { runCommand("su") }
+
+        // Return eagerly on the first root detection
+        return !releaseTagsExist() || !otacertsExist() || canRunSu()
     }
 
     @SuppressLint("PrivateApi")
-    private fun getSystemProperty(key: String): List<String> {
-        val result = Class.forName("android.os.SystemProperties")
-            .getMethod("get", List::class.java as Class<out List<String>>)
-            .invoke(null, key) as? List<String>
-
-        return result ?: emptyList()
+    /**
+     * Attempts to read a system property based on the provided [key].
+     * @return The property's value, or null if it wasn't possible to read it.
+     */
+    private fun getSystemProperty(key: String): String? = try {
+        Class.forName("android.os.SystemProperties")
+            .getMethod("get", String::class.java)
+            .invoke(null, key) as? String
+    } catch (nsm: NoSuchMethodException) {
+        null
     }
 
     @Suppress("SwallowedException", "TooGenericExceptionCaught")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When running the RootDetector, the app crashes.

### Causes

It uses reflection to invoke a private function ([`SystemProperties$get()`](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/os/SystemProperties.java)). 

Our code wants a `get` function that takes in a `List<String>`, and expects a `List<String>` as return type.

The function actually takes in a `String`, not a `List<String>`, and returns a single `String` as well.

### Solutions

Change our code to find the correct method. Also handle `NoSuchMethod` case as a fallback.

Tiny improvement: make the root detections execute lazily. If any results in a detection, the `||` operator will short-circuit and do not invoke the rest.

### Testing

#### How to Test

Using Reloaded on a rooted device and it was properly detected:

![Screenshot_1682517952](https://user-images.githubusercontent.com/9389043/234602176-4c9e34ff-d121-47fe-a1b5-1fb554e265fb.png)

Also doesn't crash when executing on non-rooted devices.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
