### PR TITLE
ci: escape environment variables in generate-changelog.yml (AR-2928)

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -19,18 +19,18 @@ jobs:
         run: echo "CURRENT_TAG=$(git tag --points-at ${{github.sha}})" >> "$GITHUB_ENV"
 
       - name: 'Set previous Git tag'
-        run: echo "PREVIOUS_TAG=$(git describe --tags --abbrev=0 --exclude ${{env.CURRENT_TAG}})" >> "$GITHUB_ENV"
+        run: echo "PREVIOUS_TAG=$(git describe --tags --abbrev=0 --exclude "$CURRENT_TAG")" >> "$GITHUB_ENV"
 
       - name: 'Print environment variables'
         run: |
-          echo -e "PREVIOUS_TAG = ${{env.PREVIOUS_TAG}}"
-          echo -e "CURRENT_TAG = ${{env.CURRENT_TAG}}"
+          echo -e "PREVIOUS_TAG = $PREVIOUS_TAG"
+          echo -e "CURRENT_TAG = $CURRENT_TAG"
           echo -e "Node.js version = $(node --version)"
 
       - name: 'Generate changelog'
         run: |
           echo "{}" > ./package.json
-          npx generate-changelog@1.8.0 -t ${{env.PREVIOUS_TAG}}...${{env.CURRENT_TAG}}
+          npx generate-changelog@1.8.0 -t "$PREVIOUS_TAG...$CURRENT_TAG"
 
       - name: 'Attach changelog to tag'
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Usage of workflow templating (e.g. `${{env....}}` could in theory lead to command injection.

### Solutions

Let the variables be handled by the shell environment to receive proper escaping.


### Testing

#### How to Test

Not really testable for this repository.
Needs to be reviewed and next run will show if it still works here, too.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
