### PR TITLE
fix: improve TooManyRequests failure result on 2FA code request  (AR-3365)

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -139,6 +139,10 @@ fun KaliumException.InvalidRequestError.isInvalidHandle(): Boolean {
     return errorResponse.label == INVALID_HANDLE
 }
 
+fun KaliumException.InvalidRequestError.isTooManyRequests(): Boolean {
+    return errorResponse.code == HttpStatusCode.TooManyRequests.value
+}
+
 fun KaliumException.InvalidRequestError.isHandleExists(): Boolean {
     return errorResponse.label == HANDLE_EXISTS
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users on Reloaded are greeted with generic error when attempting to login frequently using 2FA.

### Causes

Backend is very harsh and limits to around 1 request per every couple of minutes for each email.

### Solutions

Return a more specific failure in the UseCase. So the UI can better handle it.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
