### PR TITLE
chore: improve IDE support for composite builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,6 @@ kotlin.js.compiler=ir
 kotlin.native.binary.freezing=disabled
 
 org.gradle.parallel=true
+
+# Support KMP Gradle Composite Builds - See https://youtrack.jetbrains.com/issue/KT-52172/
+kotlin.mpp.import.enableKgpDependencyResolution=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,10 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-rootProject.name = "Kalium"
+// Work-around to make dependency resolution work with Multiplatform Composite Builds
+// We can uncomment the project name once the issue is fixed.
+// See: https://youtrack.jetbrains.com/issue/KT-56536
+// rootProject.name = "Kalium"
 
 // Assume that all folders that contain a build.gradle.kts and are not buildSrc should be included
 rootDir


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

IDE support sucks at the moment when looking at Kalium:logic files inside Reloaded.

### Causes

Our structure (using Gradle Composite builds) wasn't officially supported by KMP.
It kinda is now on Kotlin 1.8.20, but it's behind a feature flag.
It should become the standard in Kotlin 1.9.0.

### Solutions

Enable the KGP Dependency resolution flag, as seen [here](https://youtrack.jetbrains.com/issue/KT-52172/Multiplatform-Support-composite-builds).

A bug was let-through that (at least on IntelliJ 2023.1.1 EAP) requires us to not customize the Kalium's root project name, as seen [here](https://youtrack.jetbrains.com/issue/KT-56536). So that's also disabled.

### Attachments

Using IntelliJ 2023.1.1 RC.

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/9389043/235164491-052c4a54-3daa-4e87-b60b-a395813ec273.png) | ![image](https://user-images.githubusercontent.com/9389043/235164547-c93b2511-bfae-4f06-bb8d-579b9db7b852.png) |

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
