### PR TITLE
fix: request content type and fix jackson self-reference cycle

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import javax.validation.Valid
+import javax.ws.rs.Consumes
 import javax.ws.rs.GET
 import javax.ws.rs.POST
 import javax.ws.rs.Path
@@ -46,6 +47,7 @@ class ClientResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/availability")
     @Operation(summary = "Set a user's availability")
+    @Consumes(MediaType.APPLICATION_JSON)
     @Suppress("MagicNumber")
     fun availability(@PathParam("id") id: String, @Valid request: AvailabilityRequest): Response {
         instanceService.getInstance(id) ?: throw WebApplicationException("No instance found with id $id")

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -38,6 +38,7 @@ import io.swagger.v3.oas.annotations.Operation
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import javax.validation.Valid
+import javax.ws.rs.Consumes
 import javax.ws.rs.POST
 import javax.ws.rs.Path
 import javax.ws.rs.PathParam
@@ -62,6 +63,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/clear")
     @Operation(summary = "Clear a conversation")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun clear(@PathParam("id") id: String, @Valid request: ClearConversationRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         with(request) {
@@ -75,6 +77,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/delete")
     @Operation(summary = "Delete a message locally")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun delete(@PathParam("id") id: String, @Valid deleteMessageRequest: DeleteMessageRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         with(deleteMessageRequest) {
@@ -93,6 +96,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/deleteEverywhere")
     @Operation(summary = "Delete a message for everyone")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun deleteEverywhere(@PathParam("id") id: String, @Valid deleteMessageRequest: DeleteMessageRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(deleteMessageRequest) {
@@ -110,6 +114,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/getMessages")
     @Operation(summary = "Get all messages")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun getMessages(@PathParam("id") id: String, @Valid getMessagesRequest: GetMessagesRequest): List<Message> {
         val instance = instanceService.getInstanceOrThrow(id)
         with(getMessagesRequest) {
@@ -128,6 +133,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendConfirmationDelivered")
     @Operation(summary = "Send a delivery confirmation for a message")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun sendConfirmationDelivered(
         @PathParam("id") id: String,
         @Valid sendConfirmationReadRequest: SendConfirmationReadRequest
@@ -148,6 +154,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendConfirmationRead")
     @Operation(summary = "Send a read confirmation for a message")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun sendConfirmationRead(
         @PathParam("id") id: String,
         @Valid sendConfirmationReadRequest: SendConfirmationReadRequest
@@ -174,6 +181,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendFile")
     @Operation(summary = "Send a file to a conversation")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun sendFile(@PathParam("id") id: String, @Valid sendFileRequest: SendFileRequest): Response {
         log.info("Instance $id: Send file with name ${sendFileRequest.fileName}")
         val instance = instanceService.getInstanceOrThrow(id)
@@ -196,6 +204,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendImage")
     @Operation(summary = "Send an image to a conversation")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun sendImage(@PathParam("id") id: String, @Valid sendImageRequest: SendImageRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendImageRequest) {
@@ -218,6 +227,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendPing")
     @Operation(summary = "Send a ping to a conversation")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun sendPing(@PathParam("id") id: String, @Valid sendPingRequest: SendPingRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendPingRequest) {
@@ -239,6 +249,7 @@ class ConversationResources(private val instanceService: InstanceService) {
     @POST
     @Path("/instance/{id}/sendReaction")
     @Operation(summary = "Send a reaction to a message")
+    @Consumes(MediaType.APPLICATION_JSON)
     fun sendReaction(@PathParam("id") id: String, @Valid sendReactionRequest: SendReactionRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         return with(sendReactionRequest) {
@@ -259,6 +270,7 @@ class ConversationResources(private val instanceService: InstanceService) {
         summary = "Send a text message to a conversation",
         description = "This can include mentions and reply (buttons and link previews not yet implemented)"
     )
+    @Consumes(MediaType.APPLICATION_JSON)
     fun sendText(@PathParam("id") id: String, @Valid sendTextRequest: SendTextRequest): Response {
         val instance = instanceService.getInstanceOrThrow(id)
         // TODO Implement buttons, link previews and ephemeral messages here

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/InstanceLifecycle.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/InstanceLifecycle.kt
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.validation.Valid
+import javax.ws.rs.Consumes
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
 import javax.ws.rs.PUT
@@ -59,6 +60,7 @@ class InstanceLifecycle(
     @PUT
     @Path("/instance")
     @Operation(summary = "Create a new instance")
+    @Consumes(MediaType.APPLICATION_JSON)
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     fun createInstance(@Valid instanceRequest: InstanceRequest, @Suspended ar: AsyncResponse) {
         val instanceId = UUID.randomUUID().toString()

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -114,7 +114,7 @@ class InstanceService(val metricRegistry: MetricRegistry) : Managed {
         val instancePath = System.getProperty("user.home") +
                 File.separator + ".testservice" + File.separator + instanceId
         log.info("Instance $instanceId: Creating $instancePath")
-        val kaliumConfigs = KaliumConfigs(developmentApiEnabled = true)
+        val kaliumConfigs = KaliumConfigs(developmentApiEnabled = false)
         val coreLogic = CoreLogic(instancePath, kaliumConfigs, userAgent)
         CoreLogger.setLoggingLevel(KaliumLogLevel.VERBOSE)
 

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/Instance.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/Instance.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.testservice.models
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.wire.kalium.logic.CoreLogic
 
 data class Instance(
@@ -25,6 +26,7 @@ data class Instance(
     val clientId: String?,
     val instanceId: String,
     val name: String?,
+    @JsonIgnore
     val coreLogic: CoreLogic,
     val instancePath: String?,
     val password: String,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Swagger was not usable because the content-type was not set correctly.
- There was a cycle when we tried to serialize CoreLogic object in instance model

### Solutions

Fixed it

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
