### PR TITLE
fix: failed field should be optional when listing users

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserProfileDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserProfileDTO.kt
@@ -46,6 +46,6 @@ data class UserProfileDTO(
 
 @Serializable
 data class ListUsersDTO(
-    @SerialName("failed") val usersFailed: List<UserId>,
+    @SerialName("failed") val usersFailed: List<UserId> = emptyList(),
     @SerialName("found") val usersFound: List<UserProfileDTO>
 )

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
@@ -39,7 +39,7 @@ import kotlin.test.assertTrue
 internal class UserDetailsApiV4Test : ApiTest() {
 
     @Test
-    fun givenListOfQualifiedIds_whenGettingListOfUsers_thenBodyShouldSerializeCorrectly() = runTest {
+    fun givenListOfQualifiedIds_whenGettingListOfUsersWithFailedUsers_thenBodyShouldSerializeCorrectly() = runTest {
         val params = ListUserRequest.qualifiedIds(
             listOf(QualifiedIDSamples.one, QualifiedIDSamples.two, QualifiedIDSamples.three)
         )
@@ -63,8 +63,34 @@ internal class UserDetailsApiV4Test : ApiTest() {
         assertEquals(response.value.usersFound, SUCCESS_RESPONSE_WITH_FAILED_TO_LIST.serializableData.usersFound)
     }
 
+    @Test
+    fun givenListOfQualifiedIds_whenGettingListOfUsers_thenBodyShouldSerializeCorrectly() = runTest {
+        val params = ListUserRequest.qualifiedIds(
+            listOf(QualifiedIDSamples.one, QualifiedIDSamples.two, QualifiedIDSamples.three)
+        )
+        val expectedRequestBody = KtxSerializer.json.encodeToString(params)
+        val networkClient = mockAuthenticatedNetworkClient(
+            SUCCESS_RESPONSE.rawJson,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertPost()
+                assertJson()
+                assertNoQueryParams()
+                assertPathEqual(PATH_LIST_USERS)
+                assertJsonBodyContent(expectedRequestBody)
+            }
+        )
+        val userDetailsApi: UserDetailsApiV4 = UserDetailsApiV4(networkClient)
+
+        val response: NetworkResponse<ListUsersDTO> = userDetailsApi.getMultipleUsers(params)
+        assertTrue(response.isSuccessful())
+        assertTrue(response.value.usersFailed.isEmpty())
+        assertEquals(response.value.usersFound, SUCCESS_RESPONSE.serializableData.usersFound)
+    }
+
     private companion object {
         const val PATH_LIST_USERS = "/list-users"
-        val SUCCESS_RESPONSE_WITH_FAILED_TO_LIST = ListUsersResponseJson.v4
+        val SUCCESS_RESPONSE_WITH_FAILED_TO_LIST = ListUsersResponseJson.v4_withFailedUsers
+        val SUCCESS_RESPONSE = ListUsersResponseJson.v4
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
@@ -100,7 +100,7 @@ object ListUsersResponseJson {
         validUserInfoProvider(it)
     }
 
-    val v4 = ValidJsonProvider(
+    val v4_withFailedUsers = ValidJsonProvider(
         ListUsersDTO(listOf(USER_3), expectedUsersResponse)
     ) {
         """
@@ -111,6 +111,16 @@ object ListUsersResponseJson {
         |        "id": "${it.usersFailed[0].value}"
         |      }
         |    ],
+        |    "found": ${validUserInfoProvider(it.usersFound)}
+        |}
+        """.trimMargin()
+    }
+
+    val v4 = ValidJsonProvider(
+        ListUsersDTO(listOf(USER_3), expectedUsersResponse)
+    ) {
+        """
+        |{
         |    "found": ${validUserInfoProvider(it.usersFound)}
         |}
         """.trimMargin()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Listing users fails on API V4

### Causes

The `failed` field is omitted when the are no failures when fetching users, but we expect it to always be there.

### Solutions

Make the `failed` field optional when decoding the response..


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
