### PR TITLE
fix: register MLS device when enabled & supported by BE

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1188,7 +1188,7 @@ class UserSessionScope internal constructor(
 
     @OptIn(DelicateKaliumApi::class)
     private val isAllowedToRegisterMLSClient: IsAllowedToRegisterMLSClientUseCase
-        get() = IsAllowedToRegisterMLSClientUseCaseImpl(featureSupport, featureConfigRepository, userId)
+        get() = IsAllowedToRegisterMLSClientUseCaseImpl(featureSupport, mlsPublicKeysRepository)
 
     private val syncFeatureConfigsUseCase: SyncFeatureConfigsUseCase
         get() = SyncFeatureConfigsUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
@@ -18,16 +18,17 @@
 
 package com.wire.kalium.logic.feature.client
 
-import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
-import com.wire.kalium.logic.data.featureConfig.Status
-import com.wire.kalium.logic.data.id.PlainId
-import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.featureFlags.FeatureSupport
-import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.util.DelicateKaliumApi
 
 /**
- * Answers the question if the backend has MLS support enabled, is the self user allowed to register an MLS client?
+ * Answers the question if the self user allowed to register an MLS client
+ *
+ * Which we are allowed to do if:
+ * - MLS support is enabled.
+ * - MLS supported is configured on the backend, which can be verified by looking for the existence of MLS public keys.
  */
 @DelicateKaliumApi("This use case performs network calls, consider using IsMLSEnabledUseCase.")
 interface IsAllowedToRegisterMLSClientUseCase {
@@ -37,16 +38,9 @@ interface IsAllowedToRegisterMLSClientUseCase {
 @OptIn(DelicateKaliumApi::class)
 class IsAllowedToRegisterMLSClientUseCaseImpl(
     private val featureSupport: FeatureSupport,
-    private val featureConfigRepository: FeatureConfigRepository,
-    private val selfUserId: UserId
+    private val mlsPublicKeysRepository: MLSPublicKeysRepository,
 ) : IsAllowedToRegisterMLSClientUseCase {
 
     override suspend operator fun invoke(): Boolean =
-        featureConfigRepository.getFeatureConfigs().fold({
-            false
-        }, {
-            featureSupport.isMLSSupported &&
-                    it.mlsModel.status == Status.ENABLED &&
-                    it.mlsModel.allowedUsers.contains(PlainId(selfUserId.value))
-        })
+        featureSupport.isMLSSupported && mlsPublicKeysRepository.getKeys().isRight()
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are incorrectly only registering an MLS client if the the user has been whitelisted for creating MLS conversations.

### Solutions

Register an MLS client if it's enabled locally and on the backend.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
