### PR TITLE
chore: reduce sync min retry to 1s

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -160,7 +160,7 @@ internal class IncrementalSyncManager(
     }
 
     private companion object {
-        val MIN_RETRY_DELAY = 10.seconds
+        val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
         private const val TAG = "IncrementalSyncManager"
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -149,7 +149,7 @@ internal class SlowSyncManager(
     }
 
     private companion object {
-        val MIN_RETRY_DELAY = 10.seconds
+        val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
         val MIN_TIME_BETWEEN_SLOW_SYNCS = 7.days
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -290,7 +290,7 @@ class IncrementalSyncManagerTest {
             .withWorkerReturning(flowThatFailsOnFirstTime())
             .withDisconnectConnectionPolicy()
             .withRecoveringFromFailure()
-            .withNextExponentialDuration(10.seconds)
+            .withNextExponentialDuration(1.seconds)
             .arrange()
 
         arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
@@ -335,7 +335,7 @@ class IncrementalSyncManagerTest {
 
         init {
             withNetworkState(MutableStateFlow(NetworkState.ConnectedWithInternet))
-            withNextExponentialDuration(10.seconds)
+            withNextExponentialDuration(1.seconds)
         }
 
         fun withWorkerReturning(sourceFlow: Flow<EventSource>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -331,7 +331,7 @@ class SlowSyncManagerTest {
             .withSatisfiedCriteria()
             .withSlowSyncWorkerReturning(flowThatFailsOnFirstTime())
             .withRecoveringFromFailure()
-            .withNextExponentialDuration(10.seconds)
+            .withNextExponentialDuration(1.seconds)
             .arrange()
 
         advanceUntilIdle()
@@ -365,7 +365,7 @@ class SlowSyncManagerTest {
         init {
             withLastSlowSyncPerformedAt(flowOf(null))
             withNetworkState(MutableStateFlow(NetworkState.ConnectedWithInternet))
-            withNextExponentialDuration(10.seconds)
+            withNextExponentialDuration(1.seconds)
         }
 
         fun withCriteriaProviderReturning(criteriaFlow: Flow<SyncCriteriaResolution>) = apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When users are on flaky internet connections (_e.g._ mobile data), the 10s min retry is _too_ much and leads to people thinking the app died or something. According to [Nah, 2014](https://www.researchgate.net/publication/220893869_A_Study_on_Tolerable_Waiting_Time_How_Long_Are_Web_Users_Willing_to_Wait): 2 seconds is enough to get users losing patience.

### Solutions

Replace the min retry interval so it is just 1 second.

For example, comparing `minInterval = 1s` and `minInterval = 10s`:

![image](https://user-images.githubusercontent.com/9389043/237052989-4d44847d-1139-415a-b6a8-dc091a0b10f2.png)

During the first 10 seconds, when the user can lose their patience, being a bit more agressive can be provide a better experience. 
After the first 30 seconds, they behave very similarly.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
