### PR TITLE
feat(mls-migration): fetch migration configuration every 24 hours #1

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -23,13 +23,12 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConf
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigResponse
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlagStatusDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
-import kotlinx.datetime.Instant
 
 interface FeatureConfigMapper {
     fun fromDTO(featureConfigResponse: FeatureConfigResponse): FeatureConfigModel
     fun fromDTO(status: FeatureFlagStatusDTO): Status
     fun fromDTO(data: FeatureConfigData.MLS?): MLSModel
-    fun fromDTO(data: FeatureConfigData.MLSMigration?): MLSMigrationModel
+    fun fromDTO(data: FeatureConfigData.MLSMigration): MLSMigrationModel
     fun fromDTO(data: FeatureConfigData.AppLock): AppLockModel
     fun fromDTO(data: FeatureConfigData.ClassifiedDomains): ClassifiedDomainsModel
     fun fromDTO(data: FeatureConfigData.SelfDeletingMessages): SelfDeletingMessagesModel
@@ -61,7 +60,7 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
                 ssoModel = ConfigsStatusModel(fromDTO(sso.status)),
                 validateSAMLEmailsModel = ConfigsStatusModel(fromDTO(validateSAMLEmails.status)),
                 mlsModel = fromDTO(mls),
-                mlsMigrationModel = fromDTO(mlsMigration)
+                mlsMigrationModel = mlsMigration?.let { fromDTO(it) }
             )
         }
 
@@ -83,21 +82,13 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
         )
 
     @Suppress("MagicNumber")
-    override fun fromDTO(data: FeatureConfigData.MLSMigration?): MLSMigrationModel =
-        data?.let {
-            MLSMigrationModel(
-                it.config.startTime,
-                it.config.finaliseRegardlessAfter,
-                it.config.usersThreshold,
-                it.config.clientsThreshold,
-                fromDTO(it.status)
-            )
-        } ?: MLSMigrationModel(
-            Instant.DISTANT_FUTURE,
-            Instant.DISTANT_FUTURE,
-            100,
-            100,
-            Status.DISABLED
+    override fun fromDTO(data: FeatureConfigData.MLSMigration): MLSMigrationModel =
+        MLSMigrationModel(
+            data.config.startTime,
+            data.config.finaliseRegardlessAfter,
+            data.config.usersThreshold,
+            data.config.clientsThreshold,
+            fromDTO(data.status)
         )
 
     override fun fromDTO(data: FeatureConfigData.AppLock): AppLockModel =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -82,6 +82,7 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
             Status.DISABLED
         )
 
+    @Suppress("MagicNumber")
     override fun fromDTO(data: FeatureConfigData.MLSMigration?): MLSMigrationModel =
         data?.let {
             MLSMigrationModel(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -22,17 +22,23 @@ import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigResponse
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlagStatusDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
+import kotlinx.datetime.Instant
 
 interface FeatureConfigMapper {
     fun fromDTO(featureConfigResponse: FeatureConfigResponse): FeatureConfigModel
     fun fromDTO(status: FeatureFlagStatusDTO): Status
     fun fromDTO(data: FeatureConfigData.MLS?): MLSModel
+    fun fromDTO(data: FeatureConfigData.MLSMigration?): MLSMigrationModel
     fun fromDTO(data: FeatureConfigData.AppLock): AppLockModel
     fun fromDTO(data: FeatureConfigData.ClassifiedDomains): ClassifiedDomainsModel
     fun fromDTO(data: FeatureConfigData.SelfDeletingMessages): SelfDeletingMessagesModel
     fun fromDTO(data: FeatureConfigData.FileSharing): ConfigsStatusModel
     fun fromDTO(data: FeatureConfigData.ConferenceCalling): ConferenceCallingModel
     fun fromDTO(data: FeatureConfigData.ConversationGuestLinks): ConfigsStatusModel
+
+    fun fromModel(status: Status): FeatureFlagStatusDTO
+    fun fromModel(model: MLSMigrationModel): FeatureConfigData.MLSMigration
 }
 
 class FeatureConfigMapperImpl : FeatureConfigMapper {
@@ -54,7 +60,8 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
                 ),
                 ssoModel = ConfigsStatusModel(fromDTO(sso.status)),
                 validateSAMLEmailsModel = ConfigsStatusModel(fromDTO(validateSAMLEmails.status)),
-                mlsModel = fromDTO(mls)
+                mlsModel = fromDTO(mls),
+                mlsMigrationModel = fromDTO(mlsMigration)
             )
         }
 
@@ -72,6 +79,23 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
             )
         } ?: MLSModel(
             listOf(),
+            Status.DISABLED
+        )
+
+    override fun fromDTO(data: FeatureConfigData.MLSMigration?): MLSMigrationModel =
+        data?.let {
+            MLSMigrationModel(
+                it.config.startTime,
+                it.config.finaliseRegardlessAfter,
+                it.config.usersThreshold,
+                it.config.clientsThreshold,
+                fromDTO(it.status)
+            )
+        } ?: MLSMigrationModel(
+            Instant.DISTANT_FUTURE,
+            Instant.DISTANT_FUTURE,
+            100,
+            100,
             Status.DISABLED
         )
 
@@ -106,5 +130,22 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
     override fun fromDTO(data: FeatureConfigData.ConferenceCalling): ConferenceCallingModel =
         ConferenceCallingModel(
             status = fromDTO(data.status)
+        )
+
+    override fun fromModel(status: Status): FeatureFlagStatusDTO =
+        when (status) {
+            Status.ENABLED -> FeatureFlagStatusDTO.ENABLED
+            Status.DISABLED -> FeatureFlagStatusDTO.DISABLED
+        }
+
+    override fun fromModel(model: MLSMigrationModel): FeatureConfigData.MLSMigration =
+        FeatureConfigData.MLSMigration(
+            MLSMigrationConfigDTO(
+                model.startTime,
+                model.endTime,
+                model.usersThreshold,
+                model.clientsThreshold
+            ),
+            fromModel(model.status)
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.data.featureConfig
 
 import com.wire.kalium.logic.data.id.PlainId
+import kotlinx.datetime.Instant
 
 data class FeatureConfigModel(
     val appLockModel: AppLockModel,
@@ -34,7 +35,8 @@ data class FeatureConfigModel(
     val secondFactorPasswordChallengeModel: ConfigsStatusModel,
     val ssoModel: ConfigsStatusModel,
     val validateSAMLEmailsModel: ConfigsStatusModel,
-    val mlsModel: MLSModel
+    val mlsModel: MLSModel,
+    val mlsMigrationModel: MLSMigrationModel
 )
 
 enum class Status {
@@ -76,6 +78,14 @@ data class SelfDeletingMessagesConfigModel(
 
 data class MLSModel(
     val allowedUsers: List<PlainId>,
+    val status: Status
+)
+
+data class MLSMigrationModel(
+    val startTime: Instant,
+    val endTime: Instant,
+    val usersThreshold: Int,
+    val clientsThreshold: Int,
     val status: Status
 )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -36,7 +36,7 @@ data class FeatureConfigModel(
     val ssoModel: ConfigsStatusModel,
     val validateSAMLEmailsModel: ConfigsStatusModel,
     val mlsModel: MLSModel,
-    val mlsMigrationModel: MLSMigrationModel
+    val mlsMigrationModel: MLSMigrationModel?
 )
 
 enum class Status {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepository.kt
@@ -1,0 +1,69 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.mlsmigration
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapper
+import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
+import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.logic.wrapStorageRequest
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
+import com.wire.kalium.persistence.dao.MetadataDAO
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+interface MLSMigrationRepository {
+    suspend fun fetchMigrationConfiguration(): Either<CoreFailure, Unit>
+    suspend fun setMigrationConfiguration(configuration: MLSMigrationModel): Either<StorageFailure, Unit>
+    suspend fun getMigrationConfiguration(): Either<StorageFailure, MLSMigrationModel>
+}
+
+internal class MLSMigrationRepositoryImpl(
+    private val featureConfigApi: FeatureConfigApi,
+    private val metadataDAO: MetadataDAO,
+    private val featureConfigMapper: FeatureConfigMapper = MapperProvider.featureConfigMapper()
+) : MLSMigrationRepository {
+
+    override suspend fun fetchMigrationConfiguration(): Either<CoreFailure, Unit> {
+        return wrapApiRequest { featureConfigApi.featureConfigs() }
+            .flatMap { it.mlsMigration?.let { setMigrationConfiguration(featureConfigMapper.fromDTO(it)) } ?: Either.Right(Unit) }
+    }
+
+    override suspend fun getMigrationConfiguration(): Either<StorageFailure, MLSMigrationModel> =
+        wrapStorageRequest {
+            metadataDAO.valueByKey(MLS_MIGRATION_CONFIGURATION_KEY)
+        }.map { encodedValue ->
+            featureConfigMapper.fromDTO(Json.decodeFromString<FeatureConfigData.MLSMigration>(encodedValue))
+        }
+
+    override suspend fun setMigrationConfiguration(configuration: MLSMigrationModel): Either<StorageFailure, Unit> =
+        wrapStorageRequest {
+            metadataDAO.insertValue(Json.encodeToString(featureConfigMapper.fromModel(configuration)), MLS_MIGRATION_CONFIGURATION_KEY)
+        }
+
+    companion object {
+        internal const val MLS_MIGRATION_CONFIGURATION_KEY = "mlsMigrationConfiguration"
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/TimestampKeyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/TimestampKeyRepository.kt
@@ -56,5 +56,6 @@ class TimestampKeyRepositoryImpl(
 
 enum class TimestampKeys {
     LAST_KEYING_MATERIAL_UPDATE_CHECK,
-    LAST_KEY_PACKAGE_COUNT_CHECK
+    LAST_KEY_PACKAGE_COUNT_CHECK,
+    LAST_MLS_MIGRATION_CHECK
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -85,7 +85,6 @@ import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.message.ProtoContentMapperImpl
 import com.wire.kalium.logic.data.message.reaction.ReactionRepositoryImpl
 import com.wire.kalium.logic.data.message.receipt.ReceiptRepositoryImpl
-import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
 import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepositoryImpl
 import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepositoryImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -85,6 +85,8 @@ import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.message.ProtoContentMapperImpl
 import com.wire.kalium.logic.data.message.reaction.ReactionRepositoryImpl
 import com.wire.kalium.logic.data.message.receipt.ReceiptRepositoryImpl
+import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
+import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepositoryImpl
 import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepositoryImpl
 import com.wire.kalium.logic.data.notification.PushTokenDataSource
@@ -832,6 +834,12 @@ class UserSessionScope internal constructor(
                 mlsClientProvider, clientRepository, keyPackageRepository, keyPackageLimitsProvider
             )
         })
+
+    internal val mlsMigrationRepository get() =
+        MLSMigrationRepositoryImpl(
+            authenticatedNetworkContainer.featureConfigApi,
+            userStorage.database.metadataDAO
+        )
 
     private val mlsPublicKeysRepository: MLSPublicKeysRepository
         get() = MLSPublicKeysRepositoryImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
@@ -1,0 +1,125 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.mlsmigration
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
+import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.feature.TimestampKeyRepository
+import com.wire.kalium.logic.feature.TimestampKeys
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.functional.getOrNull
+import com.wire.kalium.logic.functional.onSuccess
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Orchestrates the migration from proteus to MLS.
+ */
+internal interface MLSMigrationManager
+
+// The duration in hours after which we should re-check the MLS migration progress
+internal val MLS_MIGRATION_CHECK_DURATION = 24.hours
+
+internal class MLSMigrationManagerImpl(
+    private val featureSupport: FeatureSupport,
+    private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val clientRepository: Lazy<ClientRepository>,
+    private val timestampKeyRepository: Lazy<TimestampKeyRepository>,
+    private val mlsMigrationRepository: Lazy<MLSMigrationRepository>,
+    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
+) : MLSMigrationManager {
+    /**
+     * A dispatcher with limited parallelism of 1.
+     * This means using this dispatcher only a single coroutine will be processed at a time.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = kaliumDispatcher.default.limitedParallelism(1)
+
+    private val mlsMigrationScope = CoroutineScope(dispatcher)
+
+    private var mlsMigrationJob: Job? = null
+
+    init {
+        mlsMigrationJob = mlsMigrationScope.launch {
+            incrementalSyncRepository.incrementalSyncState.collect { syncState ->
+                ensureActive()
+                if (syncState is IncrementalSyncStatus.Live &&
+                    featureSupport.isMLSSupported &&
+                    clientRepository.value.hasRegisteredMLSClient().getOrElse(false)
+                ) {
+                    updateMigration()
+                }
+            }
+        }
+    }
+
+    private suspend fun updateMigration(): Either<CoreFailure, Unit> =
+        timestampKeyRepository.value.hasPassed(TimestampKeys.LAST_MLS_MIGRATION_CHECK, MLS_MIGRATION_CHECK_DURATION)
+            .flatMap { lastMlsMigrationCheckHasPassed ->
+                if (lastMlsMigrationCheckHasPassed) {
+                    mlsMigrationRepository.value.fetchMigrationConfiguration()
+                        .onSuccess { timestampKeyRepository.value.reset(TimestampKeys.LAST_MLS_MIGRATION_CHECK) }
+                        .flatMap {
+                            advanceMigration()
+                        }
+                }
+                Either.Right(Unit)
+            }
+
+    private suspend fun advanceMigration(): Either<CoreFailure, Unit> =
+        mlsMigrationRepository.value.getMigrationConfiguration().getOrNull()?.let { configuration ->
+            if (configuration.hasMigrationStarted()) {
+                initialiseMigration()
+            } else {
+                Either.Right(Unit)
+            }
+        } ?: Either.Right(Unit)
+
+    private suspend fun initialiseMigration(): Either<CoreFailure, Unit> {
+        // TODO initialise migration for all team owned conversations and 1:1 conversations
+        return Either.Right(Unit)
+    }
+
+    private suspend fun finaliseMigration(): Either<CoreFailure, Unit> {
+        // TODO finalise migration for all team owned conversations and 1:1 conversations
+        return Either.Right(Unit)
+    }
+}
+
+fun MLSMigrationModel.hasMigrationStarted(): Boolean {
+    return status == Status.ENABLED && Clock.System.now() > startTime
+}
+
+fun MLSMigrationModel.hasMigrationEnded(): Boolean {
+    return status == Status.ENABLED && Clock.System.now() > endTime
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -69,13 +69,13 @@ class FeatureConfigMapperTest {
     fun givenApiModelResponse_whenMappingMLSMigrationStatusToModel_thenShouldBeMappedCorrectly() {
         val (arrangement, mapper) = Arrangement().arrange()
 
-        val model = mapper.fromDTO(arrangement.featureConfigResponse.mlsMigration)
+        val model = arrangement.featureConfigResponse.mlsMigration?.let { mapper.fromDTO(it) }
 
-        assertEquals(Status.ENABLED, model.status)
-        assertEquals(Instant.DISTANT_FUTURE, model.startTime)
-        assertEquals(Instant.DISTANT_FUTURE, model.endTime)
-        assertEquals(100, model.usersThreshold)
-        assertEquals(80, model.clientsThreshold)
+        assertEquals(Status.ENABLED, model?.status)
+        assertEquals(Instant.DISTANT_FUTURE, model?.startTime)
+        assertEquals(Instant.DISTANT_FUTURE, model?.endTime)
+        assertEquals(100, model?.usersThreshold)
+        assertEquals(80, model?.clientsThreshold)
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -29,7 +29,9 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConf
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigResponse
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlagStatusDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -61,6 +63,19 @@ class FeatureConfigMapperTest {
 
         assertEquals(Status.ENABLED, model.status)
         assertEquals(listOf(PlainId("someId")), model.allowedUsers)
+    }
+
+    @Test
+    fun givenApiModelResponse_whenMappingMLSMigrationStatusToModel_thenShouldBeMappedCorrectly() {
+        val (arrangement, mapper) = Arrangement().arrange()
+
+        val model = mapper.fromDTO(arrangement.featureConfigResponse.mlsMigration)
+
+        assertEquals(Status.ENABLED, model.status)
+        assertEquals(Instant.DISTANT_FUTURE, model.startTime)
+        assertEquals(Instant.DISTANT_FUTURE, model.endTime)
+        assertEquals(100, model.usersThreshold)
+        assertEquals(80, model.clientsThreshold)
     }
 
     @Test
@@ -123,9 +138,13 @@ class FeatureConfigMapperTest {
     private class Arrangement {
         val featureConfigResponse = FeatureConfigResponse(
             FeatureConfigData.AppLock(
-                AppLockConfigDTO(true, 0), FeatureFlagStatusDTO.ENABLED
+                AppLockConfigDTO(true, 0),
+                FeatureFlagStatusDTO.ENABLED
             ),
-            FeatureConfigData.ClassifiedDomains(ClassifiedDomainsConfigDTO(listOf("wire.com")), FeatureFlagStatusDTO.ENABLED),
+            FeatureConfigData.ClassifiedDomains(
+                ClassifiedDomainsConfigDTO(listOf("wire.com")),
+                FeatureFlagStatusDTO.ENABLED
+            ),
             FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
@@ -142,7 +161,17 @@ class FeatureConfigMapperTest {
                     ConvProtocol.MLS,
                     emptyList(),
                     1
-                ), FeatureFlagStatusDTO.ENABLED
+                ),
+                FeatureFlagStatusDTO.ENABLED
+            ),
+            FeatureConfigData.MLSMigration(
+                MLSMigrationConfigDTO(
+                    Instant.DISTANT_FUTURE,
+                    Instant.DISTANT_FUTURE,
+                    100,
+                    80
+                ),
+                FeatureFlagStatusDTO.ENABLED
             )
         )
 
@@ -150,5 +179,4 @@ class FeatureConfigMapperTest {
 
         fun arrange() = this to mapper
     }
-
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConf
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigResponse
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlagStatusDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
@@ -41,6 +42,8 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -74,6 +77,13 @@ class FeatureConfigRepositoryTest {
             ConfigsStatusModel(Status.ENABLED),
             MLSModel(
                 emptyList(),
+                Status.ENABLED
+            ),
+            MLSMigrationModel(
+                Instant.DISTANT_FUTURE,
+                Instant.DISTANT_FUTURE,
+                100,
+                100,
                 Status.ENABLED
             )
         )
@@ -149,7 +159,11 @@ class FeatureConfigRepositoryTest {
                 ConvProtocol.MLS,
                 emptyList(),
                 1
-            ), FeatureFlagStatusDTO.ENABLED)
+            ), FeatureFlagStatusDTO.ENABLED),
+            FeatureConfigData.MLSMigration(
+                MLSMigrationConfigDTO(Instant.DISTANT_FUTURE, Instant.DISTANT_FUTURE, 100, 100),
+                FeatureFlagStatusDTO.ENABLED
+            )
         )
 
         @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
@@ -17,6 +17,8 @@
  */
 package com.wire.kalium.logic.data.featureConfig
 
+import kotlinx.datetime.Instant
+
 object FeatureConfigTest {
 
     @Suppress("LongParameterList")
@@ -40,7 +42,14 @@ object FeatureConfigTest {
         secondFactorPasswordChallengeModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         ssoModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         validateSAMLEmailsModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
-        mlsModel: MLSModel = MLSModel(listOf(), Status.ENABLED)
+        mlsModel: MLSModel = MLSModel(listOf(), Status.ENABLED),
+        mlsMigrationModel: MLSMigrationModel = MLSMigrationModel(
+            Instant.DISTANT_FUTURE,
+            Instant.DISTANT_FUTURE,
+            100,
+            100,
+            Status.ENABLED
+        )
     ): FeatureConfigModel = FeatureConfigModel(
         appLockModel,
         classifiedDomainsModel,
@@ -55,6 +64,7 @@ object FeatureConfigTest {
         secondFactorPasswordChallengeModel,
         ssoModel,
         validateSAMLEmailsModel,
-        mlsModel
+        mlsModel,
+        mlsMigrationModel
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepositoryTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.mlsmigration
+
+import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
+import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.functional.getOrNull
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.AppLockConfigDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigResponse
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlagStatusDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.persistence.dao.MetadataDAO
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MLSMigrationRepositoryTest {
+    @Test
+    fun givenExistingConfiguration_whenFetchingMigrationConfiguration_thenConfigurationIsPersisted() = runTest {
+        val (arrangement, mlsMigrationRepository) = Arrangement()
+            .withFeatureConfigApiRequestSucceeds()
+            .withMetaDataDaoInsertValue()
+            .arrange()
+
+        val result = mlsMigrationRepository.fetchMigrationConfiguration()
+
+        result.shouldSucceed()
+
+        verify(arrangement.metadataDAO)
+            .suspendFunction(arrangement.metadataDAO::insertValue)
+            .with(anything(), eq(MLSMigrationRepositoryImpl.MLS_MIGRATION_CONFIGURATION_KEY))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenMLSConfiguration_whenSettingMigrationConfiguration_thenValueIsEncodedCorrectly() = runTest {
+        val configuration = MLSMigrationModel(
+            Clock.System.now(),
+            Clock.System.now(),
+            75,
+            85,
+            Status.ENABLED
+        )
+        val encodedValue = Json.encodeToString(MapperProvider.featureConfigMapper().fromModel(configuration))
+
+        val (arrangement, mlsMigrationRepository) = Arrangement()
+            .withMetaDataDaoInsertValue()
+            .arrange()
+
+        val result = mlsMigrationRepository.setMigrationConfiguration(configuration)
+        result.shouldSucceed()
+
+        verify(arrangement.metadataDAO)
+            .suspendFunction(arrangement.metadataDAO::insertValue)
+            .with(eq(encodedValue), eq(MLSMigrationRepositoryImpl.MLS_MIGRATION_CONFIGURATION_KEY))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenMLSConfiguration_whenGettingMigrationConfiguration_thenValueIsDecodedCorrectly() = runTest {
+        val configuration = MLSMigrationModel(
+            Clock.System.now(),
+            Clock.System.now(),
+            75,
+            85,
+            Status.ENABLED
+        )
+        val encodedValue = Json.encodeToString(MapperProvider.featureConfigMapper().fromModel(configuration))
+
+        val (arrangement, mlsMigrationRepository) = Arrangement()
+            .withMetaDataDaoValueReturns(encodedValue)
+            .arrange()
+
+        val result = mlsMigrationRepository.getMigrationConfiguration()
+        result.shouldSucceed()
+
+        verify(arrangement.metadataDAO)
+            .suspendFunction(arrangement.metadataDAO::valueByKey)
+            .with(eq(MLSMigrationRepositoryImpl.MLS_MIGRATION_CONFIGURATION_KEY))
+            .wasInvoked(exactly = once)
+
+        assertEquals(configuration, result.getOrNull())
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val featureConfigApi = mock(classOf<FeatureConfigApi>())
+
+        @Mock
+        val metadataDAO = mock(classOf<MetadataDAO>())
+
+        fun withFeatureConfigApiRequestSucceeds() = apply {
+            given(featureConfigApi).suspendFunction(featureConfigApi::featureConfigs)
+                .whenInvoked()
+                .thenReturn(NetworkResponse.Success(featureConfigResponse,  emptyMap(),200))
+        }
+
+        fun withMetaDataDaoValueReturns(value: String?) = apply {
+            given(metadataDAO).suspendFunction(metadataDAO::valueByKey)
+                .whenInvokedWith(anything())
+                .thenReturn(value)
+        }
+
+        fun withMetaDataDaoInsertValue() = apply {
+            given(metadataDAO).suspendFunction(metadataDAO::insertValue)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(Unit)
+        }
+
+        fun arrange() = this to MLSMigrationRepositoryImpl(featureConfigApi, metadataDAO)
+
+        companion object {
+            val featureConfigResponse = FeatureConfigResponse(
+                FeatureConfigData.AppLock(
+                    AppLockConfigDTO(true, 0), FeatureFlagStatusDTO.ENABLED
+                ),
+                FeatureConfigData.ClassifiedDomains(ClassifiedDomainsConfigDTO(listOf()), FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.FileSharing(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.Legalhold(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.SearchVisibility(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.SelfDeletingMessages(SelfDeletingMessagesConfigDTO(0), FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.SecondFactorPasswordChallenge(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.SSO(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.ValidateSAMLEmails(FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.MLS(
+                    MLSConfigDTO(
+                        emptyList(),
+                        ConvProtocol.MLS,
+                        emptyList(),
+                        1
+                    ), FeatureFlagStatusDTO.ENABLED),
+                FeatureConfigData.MLSMigration(
+                    MLSMigrationConfigDTO(Instant.DISTANT_FUTURE, Instant.DISTANT_FUTURE, 100, 100),
+                    FeatureFlagStatusDTO.ENABLED
+                )
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManagerTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.mlsmigration
+
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
+import com.wire.kalium.logic.data.sync.InMemoryIncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.feature.TimestampKeyRepository
+import com.wire.kalium.logic.feature.TimestampKeys
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+
+class MLSMigrationManagerTest {
+
+    @Suppress("UnusedPrivateClass")
+    private class Arrangement {
+
+        val incrementalSyncRepository: IncrementalSyncRepository = InMemoryIncrementalSyncRepository()
+
+        @Mock
+        val clientRepository = mock(classOf<ClientRepository>())
+
+        @Mock
+        val featureSupport = mock(classOf<FeatureSupport>())
+
+        @Mock
+        val timestampKeyRepository = mock(classOf<TimestampKeyRepository>())
+
+        @Mock
+        val mlsMigrationRepository = mock(classOf<MLSMigrationRepository>())
+
+        fun withLastMLSMigrationCheck(hasPassed: Boolean) = apply {
+            given(timestampKeyRepository)
+                .suspendFunction(timestampKeyRepository::hasPassed)
+                .whenInvokedWith(eq(TimestampKeys.LAST_MLS_MIGRATION_CHECK), anything())
+                .thenReturn(Either.Right(hasPassed))
+        }
+
+        fun withIsMLSSupported(supported: Boolean) = apply {
+            given(featureSupport)
+                .invocation { featureSupport.isMLSSupported }
+                .thenReturn(supported)
+        }
+
+        fun withHasRegisteredMLSClient(result: Boolean) = apply {
+            given(clientRepository)
+                .suspendFunction(clientRepository::hasRegisteredMLSClient)
+                .whenInvoked()
+                .thenReturn(Either.Right(result))
+        }
+
+        fun arrange() = this to MLSMigrationManagerImpl(
+            featureSupport,
+            incrementalSyncRepository,
+            lazy { clientRepository },
+            lazy { timestampKeyRepository },
+            lazy { mlsMigrationRepository },
+            TestKaliumDispatcher
+        )
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.network.api.base.authenticated.featureConfigs
 
 import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -51,13 +52,16 @@ data class FeatureConfigResponse(
     @SerialName("validateSAMLemails")
     val validateSAMLEmails: FeatureConfigData.ValidateSAMLEmails,
     @SerialName("mls")
-    val mls: FeatureConfigData.MLS?
+    val mls: FeatureConfigData.MLS?,
+    @SerialName("mlsMigration")
+    val mlsMigration: FeatureConfigData.MLSMigration?
 )
 
 @Serializable
 enum class FeatureFlagStatusDTO {
     @SerialName("enabled")
     ENABLED,
+
     @SerialName("disabled")
     DISABLED;
 }
@@ -75,6 +79,7 @@ data class ClassifiedDomainsConfigDTO(
     @SerialName("domains")
     val domains: List<String>
 )
+
 @Serializable
 data class MLSConfigDTO(
     @SerialName("protocolToggleUsers")
@@ -85,6 +90,22 @@ data class MLSConfigDTO(
     val allowedCipherSuites: List<Int>,
     @SerialName("defaultCipherSuite")
     val defaultCipherSuite: Int
+)
+
+@Serializable
+data class MLSMigrationConfigDTO(
+    // migration start timestamp
+    @SerialName("startTime")
+    val startTime: Instant,
+    // timestamp of the date until the migration has to finalise
+    @SerialName("finaliseRegardlessAfter")
+    val finaliseRegardlessAfter: Instant,
+    // percentage of migrated users needed for migration to finalize (0-100)
+    @SerialName("usersThreshold")
+    val usersThreshold: Int,
+    // percentage of migrated clients needed for migration to finalize (0-100)
+    @SerialName("clientsThreshold")
+    val clientsThreshold: Int
 )
 
 @Serializable
@@ -199,6 +220,15 @@ sealed class FeatureConfigData {
     data class MLS(
         @SerialName("config")
         val config: MLSConfigDTO,
+        @SerialName("status")
+        val status: FeatureFlagStatusDTO
+    ) : FeatureConfigData()
+
+    @SerialName("mlsMigration")
+    @Serializable
+    data class MLSMigration(
+        @SerialName("config")
+        val config: MLSMigrationConfigDTO,
         @SerialName("status")
         val status: FeatureFlagStatusDTO
     ) : FeatureConfigData()

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/featureConfig/FeatureConfigApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/featureConfig/FeatureConfigApiV0Test.kt
@@ -32,7 +32,7 @@ import kotlin.test.assertTrue
 internal class FeatureConfigApiV0Test : ApiTest() {
 
     @Test
-    fun givenValidRequest_WhenCallingTheFileSharingApi_SuccessResponseExpected() = runTest {
+    fun givenValidRequest_WhenCallingTheFeatureConfigApi_SuccessResponseExpected() = runTest {
         // Given
         val apiPath = FEATURE_CONFIG
         val networkClient = mockAuthenticatedNetworkClient(
@@ -55,7 +55,7 @@ internal class FeatureConfigApiV0Test : ApiTest() {
     }
 
     @Test
-    fun givenInValidRequestWithInsufficientPermission_WhenCallingTheFileSharingApi_ErrorResponseExpected() = runTest {
+    fun givenInValidRequestWithInsufficientPermission_WhenCallingTheFeatureConfigApi_ErrorResponseExpected() = runTest {
         // Given
         val apiPath = FEATURE_CONFIG
         val networkClient = mockAuthenticatedNetworkClient(
@@ -79,7 +79,7 @@ internal class FeatureConfigApiV0Test : ApiTest() {
     }
 
     @Test
-    fun givenInValidRequestWithNoTeam_WhenCallingTheFileSharingApi_ErrorResponseExpected() = runTest {
+    fun givenInValidRequestWithNoTeam_WhenCallingFeatureConfigApi_ErrorResponseExpected() = runTest {
         // Given
         val apiPath = FEATURE_CONFIG
         val networkClient = mockAuthenticatedNetworkClient(

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/FeatureConfigJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/FeatureConfigJson.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.api.json.ValidJsonProvider
 import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData.AppLock
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData.ClassifiedDomains
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData.ConferenceCalling
@@ -38,8 +39,10 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConf
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigResponse
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlagStatusDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
 import com.wire.kalium.network.api.base.model.ErrorResponse
+import kotlinx.datetime.Instant
 
 object FeatureConfigJson {
     private val featureConfigResponseSerializer = { _: FeatureConfigResponse ->
@@ -124,6 +127,10 @@ object FeatureConfigJson {
             ValidateSAMLEmails(FeatureFlagStatusDTO.ENABLED),
             MLS(
                 MLSConfigDTO(emptyList(), ConvProtocol.PROTEUS, listOf(1), 1),
+                FeatureFlagStatusDTO.ENABLED
+            ),
+            FeatureConfigData.MLSMigration(
+                MLSMigrationConfigDTO(Instant.DISTANT_FUTURE, Instant.DISTANT_FUTURE, 100, 90),
                 FeatureFlagStatusDTO.ENABLED
             )
         ),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Implement: [Use case: client periodically check to start migration](https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/760086581/Use+case+client+periodically+check+to+start+migration+Proteus+to+MLS+migration)

Support MLS migration feature config and  a `MLSMigrationManager` which re-fetches the migration configuration and advances the proteus to MLS migration every 24 hours.

### Testing

#### Test Coverage

- [x] Add test scaffolding for MLSMigrationManager
- [x] Add tests for MLSMigrationRepository
- [x] Add tests for `mlsMigration` feature config

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
