### PR TITLE
feat(mls-migration): migrate proteus conversations to "mixed" protocol  #2

### DIFF
--- a/cli/src/commonMain/kotlin/com/wire/kalium/cli/CLIApplication.kt
+++ b/cli/src/commonMain/kotlin/com/wire/kalium/cli/CLIApplication.kt
@@ -30,13 +30,25 @@ import com.wire.kalium.logic.CoreLogger
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import kotlinx.coroutines.runBlocking
+import kotlin.time.Duration
 
 class CLIApplication : CliktCommand(allowMultipleSubcommands = true) {
 
-    private val logLevel by option(help = "log level").enum<KaliumLogLevel>().default(KaliumLogLevel.WARN)
-    private val logOutputFile by option(help = "output file for logs")
-    private val developmentApiEnabled by option(help = "use development API if supported by backend").flag(default = false)
-    private val encryptProteusStorage by option(help = "use encrypted storage for proteus sessions and identity").flag(default = false)
+    private val logLevel by option(
+        help = "log level"
+    ).enum<KaliumLogLevel>().default(KaliumLogLevel.WARN)
+    private val logOutputFile by option(
+        help = "output file for logs"
+    )
+    private val developmentApiEnabled by option(
+        help = "use development API if supported by backend"
+    ).flag(default = false)
+    private val encryptProteusStorage by option(
+        help = "use encrypted storage for proteus sessions and identity"
+    ).flag(default = false)
+    private val mlsMigrationInterval by option(
+        help = "interval at which mls migration is updated"
+    ).default("24h")
     private val fileLogger: LogWriter by lazy { fileLogger(logOutputFile ?: "kalium.log") }
 
     override fun run() = runBlocking {
@@ -45,7 +57,8 @@ class CLIApplication : CliktCommand(allowMultipleSubcommands = true) {
                 rootPath = "$HOME_DIRECTORY/.kalium/accounts",
                 kaliumConfigs = KaliumConfigs(
                     developmentApiEnabled = developmentApiEnabled,
-                    encryptProteusStorage = encryptProteusStorage
+                    encryptProteusStorage = encryptProteusStorage,
+                    mlsMigrationInterval = Duration.parse(mlsMigrationInterval)
                 )
             )
         }
@@ -63,7 +76,6 @@ class CLIApplication : CliktCommand(allowMultipleSubcommands = true) {
     companion object {
         val HOME_DIRECTORY: String = homeDirectory()
     }
-
 }
 
 expect fun fileLogger(filePath: String): LogWriter

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -117,6 +117,7 @@ internal class ConversationMapperImpl(
     override fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol = when (apiModel) {
         ConvProtocol.PROTEUS -> Protocol.PROTEUS
         ConvProtocol.MLS -> Protocol.MLS
+        ConvProtocol.MIXED -> Protocol.MLS // TODO jacob create separate case for mixed
     }
 
     override fun fromDaoModel(daoModel: ConversationViewEntity): Conversation = with(daoModel) {
@@ -355,7 +356,7 @@ internal class ConversationMapperImpl(
 
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {
         return when (protocol) {
-            ConvProtocol.MLS -> ProtocolInfo.MLS(
+            ConvProtocol.MLS, ConvProtocol.MIXED -> ProtocolInfo.MLS( // TODO jacob create separate case for the MIXED case
                 groupId ?: "",
                 mlsGroupState ?: GroupState.PENDING_JOIN,
                 epoch ?: 0UL,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toCrypto
 import com.wire.kalium.logic.data.id.toDao
@@ -98,6 +99,7 @@ interface ConversationRepository {
 
     suspend fun getConversationList(): Either<StorageFailure, Flow<List<Conversation>>>
     suspend fun observeConversationList(): Flow<List<Conversation>>
+    suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, Flow<List<Conversation>>>
     suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>>
     suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
@@ -337,6 +339,12 @@ internal class ConversationDataSource internal constructor(
     override suspend fun observeConversationList(): Flow<List<Conversation>> {
         return conversationDAO.getAllConversations().map { it.map(conversationMapper::fromDaoModel) }
     }
+
+    override suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, Flow<List<Conversation>>> =
+        wrapStorageRequest {
+            conversationDAO.getAllProteusTeamConversations(teamId.value)
+                .map { it.map(conversationMapper::fromDaoModel) }
+        }
 
     override suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>> =
         combine(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -318,7 +318,11 @@ class MLSConversationDataSource(
     override suspend fun addMemberToMLSGroup(groupID: GroupID, userIdList: List<UserId>): Either<CoreFailure, Unit> =
         internalAddMemberToMLSGroup(groupID, userIdList, retryOnStaleMessage = true)
 
-    suspend fun internalAddMemberToMLSGroup(groupID: GroupID, userIdList: List<UserId>, retryOnStaleMessage: Boolean): Either<CoreFailure, Unit> =
+    suspend fun internalAddMemberToMLSGroup(
+        groupID: GroupID,
+        userIdList: List<UserId>,
+        retryOnStaleMessage: Boolean
+    ): Either<CoreFailure, Unit> =
         commitPendingProposals(groupID).flatMap {
             retryOnCommitFailure(groupID, retryOnStaleMessage = retryOnStaleMessage) {
                 keyPackageRepository.claimKeyPackages(userIdList).flatMap { keyPackages ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncManager
@@ -103,12 +104,15 @@ private enum class CommitStrategy {
     ABORT
 }
 
-private fun CoreFailure.getStrategy(retryOnClientMismatch: Boolean = true): CommitStrategy {
+private fun CoreFailure.getStrategy(
+    retryOnClientMismatch: Boolean = true,
+    retryOnStaleMessage: Boolean = true
+): CommitStrategy {
     return if (this is NetworkFailure.ServerMiscommunication && this.kaliumException is KaliumException.InvalidRequestError) {
         if (this.kaliumException.isMlsClientMismatch() && retryOnClientMismatch) {
             CommitStrategy.DISCARD_AND_RETRY
         } else if (
-            this.kaliumException.isMlsStaleMessage() ||
+            this.kaliumException.isMlsStaleMessage() && retryOnStaleMessage ||
             this.kaliumException.isMlsCommitMissingReferences()
         ) {
             CommitStrategy.KEEP_AND_RETRY
@@ -197,7 +201,6 @@ class MLSConversationDataSource(
                     idMapper.toCryptoModel(groupID)
                 )
             }
-
         }
     }
 
@@ -313,8 +316,11 @@ class MLSConversationDataSource(
     }
 
     override suspend fun addMemberToMLSGroup(groupID: GroupID, userIdList: List<UserId>): Either<CoreFailure, Unit> =
+        internalAddMemberToMLSGroup(groupID, userIdList, retryOnStaleMessage = true)
+
+    suspend fun internalAddMemberToMLSGroup(groupID: GroupID, userIdList: List<UserId>, retryOnStaleMessage: Boolean): Either<CoreFailure, Unit> =
         commitPendingProposals(groupID).flatMap {
-            retryOnCommitFailure(groupID) {
+            retryOnCommitFailure(groupID, retryOnStaleMessage = retryOnStaleMessage) {
                 keyPackageRepository.claimKeyPackages(userIdList).flatMap { keyPackages ->
                     mlsClientProvider.getMLSClient().flatMap { mlsClient ->
                         val clientKeyPackageList = keyPackages
@@ -403,7 +409,11 @@ class MLSConversationDataSource(
                     )
                 }
             }.flatMap {
-                addMemberToMLSGroup(groupID, members)
+                internalAddMemberToMLSGroup(groupID, members, retryOnStaleMessage = false).onFailure {
+                    wrapMLSRequest {
+                        mlsClient.wipeConversation(groupID.toCrypto())
+                    }
+                }
             }.flatMap {
                 wrapStorageRequest {
                     conversationDAO.updateConversationGroupState(
@@ -417,25 +427,32 @@ class MLSConversationDataSource(
     private suspend fun retryOnCommitFailure(
         groupID: GroupID,
         retryOnClientMismatch: Boolean = true,
+        retryOnStaleMessage: Boolean = true,
         operation: suspend () -> Either<CoreFailure, Unit>
     ) =
         operation()
             .flatMapLeft {
-                handleCommitFailure(it, groupID, retryOnClientMismatch, operation)
+                handleCommitFailure(it, groupID, retryOnClientMismatch, retryOnStaleMessage, operation)
             }
 
     private suspend fun handleCommitFailure(
         failure: CoreFailure,
         groupID: GroupID,
         retryOnClientMismatch: Boolean,
+        retryOnStaleMessage: Boolean,
         retryOperation: suspend () -> Either<CoreFailure, Unit>
     ): Either<CoreFailure, Unit> {
-        return when (failure.getStrategy(retryOnClientMismatch)) {
+        return when (
+            failure.getStrategy(
+                retryOnClientMismatch = retryOnClientMismatch,
+                retryOnStaleMessage = retryOnStaleMessage
+            )
+        ) {
             CommitStrategy.KEEP_AND_RETRY -> keepCommitAndRetry(groupID)
             CommitStrategy.DISCARD_AND_RETRY -> discardCommitAndRetry(groupID, retryOperation)
             CommitStrategy.ABORT -> return discardCommit(groupID).flatMap { Either.Left(failure) }
         }.flatMapLeft {
-            handleCommitFailure(it, groupID, retryOnClientMismatch, retryOperation)
+            handleCommitFailure(it, groupID, retryOnClientMismatch, retryOnStaleMessage, retryOperation)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -318,7 +318,7 @@ class MLSConversationDataSource(
     override suspend fun addMemberToMLSGroup(groupID: GroupID, userIdList: List<UserId>): Either<CoreFailure, Unit> =
         internalAddMemberToMLSGroup(groupID, userIdList, retryOnStaleMessage = true)
 
-    suspend fun internalAddMemberToMLSGroup(
+    private suspend fun internalAddMemberToMLSGroup(
         groupID: GroupID,
         userIdList: List<UserId>,
         retryOnStaleMessage: Boolean

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -61,13 +61,6 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
                 validateSAMLEmailsModel = ConfigsStatusModel(fromDTO(validateSAMLEmails.status)),
                 mlsModel = fromDTO(mls),
                 mlsMigrationModel = mlsMigration?.let { fromDTO(it) }
-                    ?: MLSMigrationModel( // TODO jacob debugging values while not implemented on BE
-                        Instant.DISTANT_PAST,
-                        Instant.DISTANT_PAST,
-                        100,
-                        100,
-                        Status.ENABLED
-                    )
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -61,6 +61,13 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
                 validateSAMLEmailsModel = ConfigsStatusModel(fromDTO(validateSAMLEmails.status)),
                 mlsModel = fromDTO(mls),
                 mlsMigrationModel = mlsMigration?.let { fromDTO(it) }
+                    ?: MLSMigrationModel( // TODO jacob debugging values while not implemented on BE
+                        Instant.DISTANT_PAST,
+                        Instant.DISTANT_PAST,
+                        100,
+                        100,
+                        Status.ENABLED
+                    )
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepository.kt
@@ -48,7 +48,7 @@ internal class MLSMigrationRepositoryImpl(
 
     override suspend fun fetchMigrationConfiguration(): Either<CoreFailure, Unit> {
         return wrapApiRequest { featureConfigApi.featureConfigs() }
-            .flatMap { it.mlsMigration?.let { setMigrationConfiguration(featureConfigMapper.fromDTO(it)) } ?: Either.Right(Unit) }
+            .flatMap { setMigrationConfiguration(featureConfigMapper.fromDTO(it.mlsMigration)) }
     }
 
     override suspend fun getMigrationConfiguration(): Either<StorageFailure, MLSMigrationModel> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepository.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapper
 import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
+import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
@@ -30,6 +31,7 @@ import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.persistence.dao.MetadataDAO
+import kotlinx.datetime.Instant
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -46,9 +48,24 @@ internal class MLSMigrationRepositoryImpl(
     private val featureConfigMapper: FeatureConfigMapper = MapperProvider.featureConfigMapper()
 ) : MLSMigrationRepository {
 
+    @Suppress("MagicNumber")
     override suspend fun fetchMigrationConfiguration(): Either<CoreFailure, Unit> {
         return wrapApiRequest { featureConfigApi.featureConfigs() }
-            .flatMap { setMigrationConfiguration(featureConfigMapper.fromDTO(it.mlsMigration)) }
+            .flatMap {
+                it.mlsMigration?.let { mlsMigration ->
+                    setMigrationConfiguration(featureConfigMapper.fromDTO(mlsMigration))
+                } ?: run {
+                    setMigrationConfiguration(
+                        MLSMigrationModel( // TODO jacob debugging values while not implemented on BE
+                            Instant.DISTANT_PAST,
+                            Instant.DISTANT_PAST,
+                            100,
+                            100,
+                            Status.ENABLED
+                        )
+                    )
+                }
+            }
     }
 
     override suspend fun getMigrationConfiguration(): Either<StorageFailure, MLSMigrationModel> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -816,6 +816,14 @@ class UserSessionScope internal constructor(
             authenticatedNetworkContainer.notificationApi, userStorage.database.metadataDAO, clientIdProvider
         )
 
+    private val mlsMigrator: MLSMigrator
+        get() = MLSMigratorImpl(
+            selfTeamId,
+            conversationRepository,
+            mlsConversationRepository,
+            authenticatedNetworkContainer.conversationApi
+        )
+
     internal val keyPackageManager: KeyPackageManager = KeyPackageManagerImpl(featureSupport,
         incrementalSyncRepository,
         lazy { clientRepository },
@@ -844,7 +852,7 @@ class UserSessionScope internal constructor(
             incrementalSyncRepository,
             lazy { clientRepository },
             lazy { users.timestampKeyRepository },
-            lazy { MLSMigrationWorkerImpl(mlsMigrationRepository, MLSMigratorImpl(selfTeamId, conversationRepository, mlsConversationRepository, authenticatedNetworkContainer.conversationApi)) },
+            lazy { MLSMigrationWorkerImpl(mlsMigrationRepository, mlsMigrator) },
             lazy { mlsMigrationRepository }
     )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -181,6 +181,11 @@ import com.wire.kalium.logic.feature.message.PersistMigratedMessagesUseCaseImpl
 import com.wire.kalium.logic.feature.message.SessionEstablisher
 import com.wire.kalium.logic.feature.message.SessionEstablisherImpl
 import com.wire.kalium.logic.feature.migration.MigrationScope
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationManager
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationManagerImpl
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationWorkerImpl
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrator
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigratorImpl
 import com.wire.kalium.logic.feature.notificationToken.PushTokenUpdater
 import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfdeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCaseImpl
@@ -824,7 +829,7 @@ class UserSessionScope internal constructor(
         lazy { users.timestampKeyRepository })
 
     internal val mlsClientManager: MLSClientManager = MLSClientManagerImpl(clientIdProvider,
-        isMLSEnabled,
+        isAllowedToRegisterMLSClient,
         incrementalSyncRepository,
         lazy { slowSyncRepository },
         lazy { clientRepository },
@@ -833,6 +838,15 @@ class UserSessionScope internal constructor(
                 mlsClientProvider, clientRepository, keyPackageRepository, keyPackageLimitsProvider
             )
         })
+    internal val mlsMigrationManager: MLSMigrationManager = MLSMigrationManagerImpl(
+            kaliumConfigs,
+            featureSupport,
+            incrementalSyncRepository,
+            lazy { clientRepository },
+            lazy { users.timestampKeyRepository },
+            lazy { MLSMigrationWorkerImpl(mlsMigrationRepository, MLSMigratorImpl(conversationRepository, mlsConversationRepository, authenticatedNetworkContainer.conversationApi)) },
+            lazy { mlsMigrationRepository }
+    )
 
     internal val mlsMigrationRepository get() =
         MLSMigrationRepositoryImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -844,7 +844,7 @@ class UserSessionScope internal constructor(
             incrementalSyncRepository,
             lazy { clientRepository },
             lazy { users.timestampKeyRepository },
-            lazy { MLSMigrationWorkerImpl(mlsMigrationRepository, MLSMigratorImpl(conversationRepository, mlsConversationRepository, authenticatedNetworkContainer.conversationApi)) },
+            lazy { MLSMigrationWorkerImpl(mlsMigrationRepository, MLSMigratorImpl(selfTeamId, conversationRepository, mlsConversationRepository, authenticatedNetworkContainer.conversationApi)) },
             lazy { mlsMigrationRepository }
     )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/MLSClientManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/MLSClientManager.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
-import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onSuccess

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/MLSClientManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/MLSClientManager.kt
@@ -45,7 +45,7 @@ interface MLSClientManager
 @Suppress("LongParameterList")
 internal class MLSClientManagerImpl(
     private val currentClientIdProvider: CurrentClientIdProvider,
-    private val isMLSEnabled: IsMLSEnabledUseCase,
+    private val isAllowedToRegisterMLSClient: IsAllowedToRegisterMLSClientUseCase,
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val slowSyncRepository: Lazy<SlowSyncRepository>,
     private val clientRepository: Lazy<ClientRepository>,
@@ -68,7 +68,7 @@ internal class MLSClientManagerImpl(
             incrementalSyncRepository.incrementalSyncState.collect { syncState ->
                 ensureActive()
                 if (syncState is IncrementalSyncStatus.Live &&
-                    isMLSEnabled()
+                    isAllowedToRegisterMLSClient()
                 ) {
                     registerMLSClientIfNeeded()
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
@@ -27,11 +27,12 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.feature.TimestampKeyRepository
 import com.wire.kalium.logic.feature.TimestampKeys
 import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.getOrElse
-import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.onSuccess
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -40,21 +41,19 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
-import kotlin.time.Duration.Companion.hours
 
 /**
  * Orchestrates the migration from proteus to MLS.
  */
 internal interface MLSMigrationManager
 
-// The duration in hours after which we should re-check the MLS migration progress
-internal val MLS_MIGRATION_CHECK_DURATION = 24.hours
-
 internal class MLSMigrationManagerImpl(
+    private val kaliumConfigs: KaliumConfigs,
     private val featureSupport: FeatureSupport,
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val clientRepository: Lazy<ClientRepository>,
     private val timestampKeyRepository: Lazy<TimestampKeyRepository>,
+    private val mlsMigrationWorker: Lazy<MLSMigrationWorker>,
     private val mlsMigrationRepository: Lazy<MLSMigrationRepository>,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : MLSMigrationManager {
@@ -84,36 +83,20 @@ internal class MLSMigrationManagerImpl(
     }
 
     private suspend fun updateMigration(): Either<CoreFailure, Unit> =
-        timestampKeyRepository.value.hasPassed(TimestampKeys.LAST_MLS_MIGRATION_CHECK, MLS_MIGRATION_CHECK_DURATION)
+        timestampKeyRepository.value.hasPassed(TimestampKeys.LAST_MLS_MIGRATION_CHECK, kaliumConfigs.mlsMigrationInterval)
             .flatMap { lastMlsMigrationCheckHasPassed ->
+                kaliumLogger.d("Migration needs to be updated: $lastMlsMigrationCheckHasPassed")
                 if (lastMlsMigrationCheckHasPassed) {
+                    kaliumLogger.d("Updating migration config")
                     mlsMigrationRepository.value.fetchMigrationConfiguration()
                         .onSuccess { timestampKeyRepository.value.reset(TimestampKeys.LAST_MLS_MIGRATION_CHECK) }
                         .flatMap {
-                            advanceMigration()
+                            mlsMigrationWorker.value.runMigration()
+                            Either.Right(Unit)
                         }
                 }
                 Either.Right(Unit)
             }
-
-    private suspend fun advanceMigration(): Either<CoreFailure, Unit> =
-        mlsMigrationRepository.value.getMigrationConfiguration().getOrNull()?.let { configuration ->
-            if (configuration.hasMigrationStarted()) {
-                initialiseMigration()
-            } else {
-                Either.Right(Unit)
-            }
-        } ?: Either.Right(Unit)
-
-    private suspend fun initialiseMigration(): Either<CoreFailure, Unit> {
-        // TODO initialise migration for all team owned conversations and 1:1 conversations
-        return Either.Right(Unit)
-    }
-
-    private suspend fun finaliseMigration(): Either<CoreFailure, Unit> {
-        // TODO finalise migration for all team owned conversations and 1:1 conversations
-        return Either.Right(Unit)
-    }
 }
 
 fun MLSMigrationModel.hasMigrationStarted(): Boolean {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
@@ -47,6 +47,7 @@ import kotlinx.datetime.Clock
  */
 internal interface MLSMigrationManager
 
+@Suppress("LongParameterList")
 internal class MLSMigrationManagerImpl(
     private val kaliumConfigs: KaliumConfigs,
     private val featureSupport: FeatureSupport,
@@ -83,20 +84,22 @@ internal class MLSMigrationManagerImpl(
     }
 
     private suspend fun updateMigration(): Either<CoreFailure, Unit> =
-        timestampKeyRepository.value.hasPassed(TimestampKeys.LAST_MLS_MIGRATION_CHECK, kaliumConfigs.mlsMigrationInterval)
-            .flatMap { lastMlsMigrationCheckHasPassed ->
-                kaliumLogger.d("Migration needs to be updated: $lastMlsMigrationCheckHasPassed")
-                if (lastMlsMigrationCheckHasPassed) {
-                    kaliumLogger.d("Updating migration config")
-                    mlsMigrationRepository.value.fetchMigrationConfiguration()
-                        .onSuccess { timestampKeyRepository.value.reset(TimestampKeys.LAST_MLS_MIGRATION_CHECK) }
-                        .flatMap {
-                            mlsMigrationWorker.value.runMigration()
-                            Either.Right(Unit)
-                        }
-                }
-                Either.Right(Unit)
+        timestampKeyRepository.value.hasPassed(
+            TimestampKeys.LAST_MLS_MIGRATION_CHECK,
+            kaliumConfigs.mlsMigrationInterval
+        ).flatMap { lastMlsMigrationCheckHasPassed ->
+            kaliumLogger.d("Migration needs to be updated: $lastMlsMigrationCheckHasPassed")
+            if (lastMlsMigrationCheckHasPassed) {
+                kaliumLogger.d("Updating migration config")
+                mlsMigrationRepository.value.fetchMigrationConfiguration()
+                    .onSuccess { timestampKeyRepository.value.reset(TimestampKeys.LAST_MLS_MIGRATION_CHECK) }
+                    .flatMap {
+                        mlsMigrationWorker.value.runMigration()
+                        Either.Right(Unit)
+                    }
             }
+            Either.Right(Unit)
+        }
 }
 
 fun MLSMigrationModel.hasMigrationStarted(): Boolean {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorker.kt
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.mlsmigration
+
+import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.getOrNull
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.kaliumLogger
+
+interface MLSMigrationWorker {
+    suspend fun runMigration()
+}
+
+class MLSMigrationWorkerImpl(
+    private val mlsMigrationRepository: MLSMigrationRepository,
+    private val mlsMigrator: MLSMigrator
+) : MLSMigrationWorker {
+
+    override suspend fun runMigration() {
+        advanceMigration().onFailure {
+            kaliumLogger.e("Failed to advance migration: $it")
+        }
+    }
+
+    suspend fun advanceMigration() =
+        mlsMigrationRepository.getMigrationConfiguration().getOrNull()?.let { configuration ->
+            if (configuration.hasMigrationStarted()) {
+                kaliumLogger.i("Running proteus to MLS migration")
+                mlsMigrator.migrateProteusConversations()
+            } else {
+                kaliumLogger.i("MLS migration is not enabled")
+                Either.Right(Unit)
+            }
+        } ?: Either.Right(Unit)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -1,0 +1,98 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.mlsmigration
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.feature.SelfTeamIdProvider
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.flatMapLeft
+import com.wire.kalium.logic.functional.foldToEitherWhileRight
+import com.wire.kalium.logic.functional.getOrNull
+import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolResponse
+import kotlinx.coroutines.flow.first
+
+interface MLSMigrator {
+    suspend fun migrateProteusConversations(): Either<CoreFailure, Unit>
+}
+
+class MLSMigratorImpl(
+    private val selfTeamIdProvider: SelfTeamIdProvider,
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val conversationApi: ConversationApi
+) : MLSMigrator {
+
+    override suspend fun migrateProteusConversations(): Either<CoreFailure, Unit> =
+        conversationRepository.getConversationList().flatMap {
+            it.first().filter { conversation ->
+                conversation.protocol is Conversation.ProtocolInfo.Proteus &&
+                    conversation.type == Conversation.Type.GROUP &&
+                    conversation.isTeamGroup() &&
+                    conversation.teamId == selfTeamIdProvider().getOrNull()
+            }.foldToEitherWhileRight(Unit) { conversation, _ ->
+                migrate(conversation.id)
+            }
+        }
+
+    private suspend fun migrate(conversationId: ConversationId): Either<CoreFailure, Unit> {
+        kaliumLogger.i("migrating ${conversationId.toLogString()} to mixed")
+        return updateProtocolToMixed(conversationId)
+            .flatMap {
+                establishConversation(conversationId)
+            }.flatMapLeft {
+                kaliumLogger.w("failed to migrate ${conversationId.toLogString()} to mixed: $it")
+                Either.Right(Unit)
+            }
+    }
+
+    private suspend fun updateProtocolToMixed(conversationId: ConversationId) =
+        wrapApiRequest { conversationApi.updateProtocol(conversationId.toApi(), ConvProtocol.MIXED) }
+            .flatMap {
+                if (it is UpdateConversationProtocolResponse.ProtocolUpdated) {
+                    conversationRepository.fetchConversation(conversationId)
+                } else {
+                    Either.Right(Unit)
+                }
+            }
+
+    private suspend fun establishConversation(conversationId: ConversationId) =
+        conversationRepository.getConversationProtocolInfo(conversationId)
+            .flatMap { protocolInfo ->
+                when (protocolInfo) {
+                    is Conversation.ProtocolInfo.MLS -> { // TODO jacob should be MIXED
+                        mlsConversationRepository.establishMLSGroup(protocolInfo.groupId, emptyList())
+                            .flatMap {
+                                conversationRepository.getConversationMembers(conversationId).flatMap { members ->
+                                    mlsConversationRepository.addMemberToMLSGroup(protocolInfo.groupId, members)
+                                }
+                            }
+                    }
+                    is Conversation.ProtocolInfo.Proteus -> Either.Right(Unit)
+                }
+            }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -18,6 +18,9 @@
 
 package com.wire.kalium.logic.featureFlags
 
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+
 data class KaliumConfigs(
     val isChangeEmailEnabled: Boolean = false,
     val forceConstantBitrateCalls: Boolean = false,
@@ -39,5 +42,7 @@ data class KaliumConfigs(
     val selfDeletingMessages: Boolean = true,
     val wipeOnCookieInvalid: Boolean = false,
     val wipeOnDeviceRemoval: Boolean = false,
-    val wipeOnRootedDevice: Boolean = false
+    val wipeOnRootedDevice: Boolean = false,
+    // Interval between attempts to advance the proteus to MLS migration
+    val mlsMigrationInterval: Duration = 24.hours
 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/MLSClientManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/MLSClientManagerTest.kt
@@ -48,7 +48,7 @@ class MLSClientManagerTest {
     fun givenMLSSupportIsDisabled_whenObservingSyncFinishes_thenMLSClientIsNotRegistered() =
         runTest(TestKaliumDispatcher.default) {
             val (arrangement, _) = Arrangement()
-                .withIsMLSEnabled(false)
+                .withIsAllowedToRegisterMLSClient(false)
                 .arrange()
 
             arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
@@ -64,7 +64,7 @@ class MLSClientManagerTest {
     fun givenMLSClientIsNotRegistered_whenObservingSyncFinishes_thenMLSClientIsRegistered() =
         runTest(TestKaliumDispatcher.default) {
             val (arrangement, _) = Arrangement()
-                .withIsMLSEnabled(true)
+                .withIsAllowedToRegisterMLSClient(true)
                 .withHasRegisteredMLSClient(Either.Right(false))
                 .withCurrentClientId(Either.Right(TestClient.CLIENT_ID))
                 .withRegisterMLSClientSuccessful()
@@ -87,7 +87,7 @@ class MLSClientManagerTest {
     fun givenMLSClientIsRegistered_whenObservingSyncFinishes_thenMLSClientIsNotRegistered() =
         runTest(TestKaliumDispatcher.default) {
             val (arrangement, _) = Arrangement()
-                .withIsMLSEnabled(true)
+                .withIsAllowedToRegisterMLSClient(true)
                 .withHasRegisteredMLSClient(Either.Right(true))
                 .arrange()
 
@@ -114,7 +114,7 @@ class MLSClientManagerTest {
         val clientRepository = mock(classOf<ClientRepository>())
 
         @Mock
-        val isMLSEnabled = mock(classOf<IsMLSEnabledUseCase>())
+        val isAllowedToRegisterMLSClient = mock(classOf<IsAllowedToRegisterMLSClientUseCase>())
 
         @Mock
         val registerMLSClient = mock(classOf<RegisterMLSClientUseCase>())
@@ -140,16 +140,16 @@ class MLSClientManagerTest {
                 .thenReturn(Either.Right(Unit))
         }
 
-        fun withIsMLSEnabled(enabled: Boolean) = apply {
-            given(isMLSEnabled)
-                .function(isMLSEnabled::invoke)
+        fun withIsAllowedToRegisterMLSClient(enabled: Boolean) = apply {
+            given(isAllowedToRegisterMLSClient)
+                .suspendFunction(isAllowedToRegisterMLSClient::invoke)
                 .whenInvoked()
                 .thenReturn(enabled)
         }
 
         fun arrange() = this to MLSClientManagerImpl(
             clientIdProvider,
-            isMLSEnabled,
+            isAllowedToRegisterMLSClient,
             incrementalSyncRepository,
             lazy { slowSyncRepository },
             lazy { clientRepository },

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManagerTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.feature.TimestampKeyRepository
 import com.wire.kalium.logic.feature.TimestampKeys
 import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import io.mockative.Mock
@@ -40,6 +41,8 @@ class MLSMigrationManagerTest {
 
         val incrementalSyncRepository: IncrementalSyncRepository = InMemoryIncrementalSyncRepository()
 
+        val kaliumConfigs = KaliumConfigs()
+
         @Mock
         val clientRepository = mock(classOf<ClientRepository>())
 
@@ -51,6 +54,9 @@ class MLSMigrationManagerTest {
 
         @Mock
         val mlsMigrationRepository = mock(classOf<MLSMigrationRepository>())
+
+        @Mock
+        val mlsMigrationWorker = mock(classOf<MLSMigrationWorker>())
 
         fun withLastMLSMigrationCheck(hasPassed: Boolean) = apply {
             given(timestampKeyRepository)
@@ -73,10 +79,12 @@ class MLSMigrationManagerTest {
         }
 
         fun arrange() = this to MLSMigrationManagerImpl(
+            kaliumConfigs,
             featureSupport,
             incrementalSyncRepository,
             lazy { clientRepository },
             lazy { timestampKeyRepository },
+            lazy { mlsMigrationWorker },
             lazy { mlsMigrationRepository },
             TestKaliumDispatcher
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -1,0 +1,287 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.mlsmigration
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.SelfTeamIdProvider
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestTeam
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolResponse
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationProtocolDTO
+import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.model.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.NetworkResponse
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MLSMigratorTest {
+
+    @Test
+    fun givenTeamConversation_whenMigrating_thenProtocolIsUpdatedToMixedAndGroupIsEstablished() = runTest {
+        val conversation = TestConversation.CONVERSATION.copy(
+            type = Conversation.Type.GROUP,
+            teamId = TestTeam.TEAM_ID
+        )
+
+        val (arrangement, migrator) = Arrangement()
+            .withGetConversationListReturning(listOf(conversation))
+            .withUpdateProtocolReturns(Arrangement.UPDATE_PROTOCOL_SUCCESS)
+            .withFetchConversationSucceeding()
+            .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
+            .withEstablishGroupSucceeds()
+            .withGetConversationMembersReturning(Arrangement.MEMBERS)
+            .withAddMembersSucceeds()
+            .arrange()
+
+        migrator.migrateProteusConversations()
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::updateProtocol)
+            .with(eq(conversation.id.toApi()), eq(ConvProtocol.MIXED))
+            .wasInvoked(once)
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::establishMLSGroup)
+            .with(eq(Arrangement.MIXED_PROTOCOL_INFO.groupId), eq(emptyList()))
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::addMemberToMLSGroup)
+            .with(eq(Arrangement.MIXED_PROTOCOL_INFO.groupId), eq(Arrangement.MEMBERS))
+    }
+
+    @Test
+    fun givenProtocolIsUnchanged_whenMigrating_thenGroupIsEstablished() = runTest {
+        val conversation = TestConversation.CONVERSATION.copy(
+            type = Conversation.Type.GROUP,
+            teamId = TestTeam.TEAM_ID
+        )
+
+        val (arrangement, migrator) = Arrangement()
+            .withGetConversationListReturning(listOf(conversation))
+            .withUpdateProtocolReturns(Arrangement.UPDATE_PROTOCOL_UNCHANGED)
+            .withFetchConversationSucceeding()
+            .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
+            .withEstablishGroupSucceeds()
+            .withGetConversationMembersReturning(Arrangement.MEMBERS)
+            .withAddMembersSucceeds()
+            .arrange()
+
+        migrator.migrateProteusConversations()
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::updateProtocol)
+            .with(eq(conversation.id.toApi()), eq(ConvProtocol.MIXED))
+            .wasInvoked(once)
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::establishMLSGroup)
+            .with(eq(Arrangement.MIXED_PROTOCOL_INFO.groupId), eq(emptyList()))
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::addMemberToMLSGroup)
+            .with(eq(Arrangement.MIXED_PROTOCOL_INFO.groupId), eq(Arrangement.MEMBERS))
+    }
+
+    @Test
+    fun givenAnError_whenMigrating_thenStillConsiderItASuccess() = runTest {
+        val conversation = TestConversation.CONVERSATION.copy(
+            type = Conversation.Type.GROUP,
+            teamId = TestTeam.TEAM_ID
+        )
+
+        val (arrangement, migrator) = Arrangement()
+            .withGetConversationListReturning(listOf(conversation))
+            .withUpdateProtocolReturns(Arrangement.UPDATE_PROTOCOL_UNCHANGED)
+            .withFetchConversationSucceeding()
+            .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
+            .withEstablishGroupFails()
+            .arrange()
+
+        val result = migrator.migrateProteusConversations()
+        result.shouldSucceed()
+    }
+
+    @Test
+    fun givenNonTeamConversation_whenMigrating_thenConversationIsIgnored() = runTest {
+        val conversation = TestConversation.CONVERSATION.copy(
+            type = Conversation.Type.GROUP,
+            teamId = null
+        )
+
+        val (arrangement, migrator) = Arrangement()
+            .withGetConversationListReturning(listOf(conversation))
+            .arrange()
+
+        migrator.migrateProteusConversations()
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::updateProtocol)
+            .with(eq(conversation.id.toApi()), eq(ConvProtocol.MIXED))
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenOneToOneConversation_whenMigrating_thenConversationIsIgnored() = runTest {
+        val conversation = TestConversation.CONVERSATION.copy(
+            type = Conversation.Type.ONE_ON_ONE
+        )
+
+        val (arrangement, migrator) = Arrangement()
+            .withGetConversationListReturning(listOf(conversation))
+            .arrange()
+
+        migrator.migrateProteusConversations()
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::updateProtocol)
+            .with(eq(conversation.id.toApi()), eq(ConvProtocol.MIXED))
+            .wasNotInvoked()
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val conversationRepository = mock(classOf<ConversationRepository>())
+
+        @Mock
+        val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
+
+        @Mock
+        val conversationApi = mock(classOf<ConversationApi>())
+
+        @Mock
+        val selfTeamIdProvider = mock(classOf<SelfTeamIdProvider>())
+
+        fun withGetConversationListReturning(conversations: List<Conversation>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::getConversationList)
+                .whenInvoked()
+                .thenReturn(Either.Right(flowOf(conversations)))
+        }
+
+        fun withGetConversationProtocolInfoReturning(protocolInfo: Conversation.ProtocolInfo) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::getConversationProtocolInfo)
+                .whenInvokedWith(anything())
+                .thenReturn(Either.Right(protocolInfo))
+        }
+
+        fun withGetConversationMembersReturning(members: List<UserId>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::getConversationMembers)
+                .whenInvokedWith(anything())
+                .thenReturn(Either.Right(members))
+        }
+
+        fun withFetchConversationSucceeding() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::fetchConversation)
+                .whenInvokedWith(anything())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withUpdateProtocolReturns(response: NetworkResponse<UpdateConversationProtocolResponse>) = apply {
+            given(conversationApi)
+                .suspendFunction(conversationApi::updateProtocol)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(response)
+        }
+
+        fun withEstablishGroupSucceeds() = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::establishMLSGroup)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withEstablishGroupFails() = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::establishMLSGroup)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(Either.Left(NetworkFailure.ServerMiscommunication(MLS_STALE_MESSAGE_ERROR)))
+        }
+
+        fun withAddMembersSucceeds() = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::addMemberToMLSGroup)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun arrange() = this to MLSMigratorImpl(
+            selfTeamIdProvider,
+            conversationRepository,
+            mlsConversationRepository,
+            conversationApi
+        )
+
+        init {
+            given(selfTeamIdProvider)
+                .suspendFunction(selfTeamIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(Either.Right(TestTeam.TEAM_ID))
+        }
+
+        companion object {
+            val MLS_STALE_MESSAGE_ERROR = KaliumException.InvalidRequestError(ErrorResponse(409, "", "mls-stale-message"))
+            val MEMBERS = listOf(TestUser.USER_ID)
+            val MIXED_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
+                TestConversation.GROUP_ID,
+                Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                0UL,
+                Instant.parse("2021-03-30T15:36:00.000Z"),
+                cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            ) // TODO jacob should be mixed
+            val UPDATE_PROTOCOL_SUCCESS = NetworkResponse.Success(
+                UpdateConversationProtocolResponse.ProtocolUpdated(
+                    EventContentDTO.Conversation.ProtocolUpdate(
+                        TestConversation.NETWORK_ID,
+                        ConversationProtocolDTO(ConvProtocol.MIXED),
+                        TestUser.NETWORK_ID
+                    )
+                ), emptyMap(), 200
+            )
+            val UPDATE_PROTOCOL_UNCHANGED = NetworkResponse.Success(
+                UpdateConversationProtocolResponse.ProtocolUnchanged,
+                emptyMap(), 204)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -62,7 +62,7 @@ class MLSMigratorTest {
         )
 
         val (arrangement, migrator) = Arrangement()
-            .withGetConversationListReturning(listOf(conversation))
+            .withGetProteusTeamConversationsReturning(listOf(conversation))
             .withUpdateProtocolReturns(Arrangement.UPDATE_PROTOCOL_SUCCESS)
             .withFetchConversationSucceeding()
             .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
@@ -95,7 +95,7 @@ class MLSMigratorTest {
         )
 
         val (arrangement, migrator) = Arrangement()
-            .withGetConversationListReturning(listOf(conversation))
+            .withGetProteusTeamConversationsReturning(listOf(conversation))
             .withUpdateProtocolReturns(Arrangement.UPDATE_PROTOCOL_UNCHANGED)
             .withFetchConversationSucceeding()
             .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
@@ -128,7 +128,7 @@ class MLSMigratorTest {
         )
 
         val (arrangement, migrator) = Arrangement()
-            .withGetConversationListReturning(listOf(conversation))
+            .withGetProteusTeamConversationsReturning(listOf(conversation))
             .withUpdateProtocolReturns(Arrangement.UPDATE_PROTOCOL_UNCHANGED)
             .withFetchConversationSucceeding()
             .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
@@ -137,43 +137,6 @@ class MLSMigratorTest {
 
         val result = migrator.migrateProteusConversations()
         result.shouldSucceed()
-    }
-
-    @Test
-    fun givenNonTeamConversation_whenMigrating_thenConversationIsIgnored() = runTest {
-        val conversation = TestConversation.CONVERSATION.copy(
-            type = Conversation.Type.GROUP,
-            teamId = null
-        )
-
-        val (arrangement, migrator) = Arrangement()
-            .withGetConversationListReturning(listOf(conversation))
-            .arrange()
-
-        migrator.migrateProteusConversations()
-
-        verify(arrangement.conversationApi)
-            .suspendFunction(arrangement.conversationApi::updateProtocol)
-            .with(eq(conversation.id.toApi()), eq(ConvProtocol.MIXED))
-            .wasNotInvoked()
-    }
-
-    @Test
-    fun givenOneToOneConversation_whenMigrating_thenConversationIsIgnored() = runTest {
-        val conversation = TestConversation.CONVERSATION.copy(
-            type = Conversation.Type.ONE_ON_ONE
-        )
-
-        val (arrangement, migrator) = Arrangement()
-            .withGetConversationListReturning(listOf(conversation))
-            .arrange()
-
-        migrator.migrateProteusConversations()
-
-        verify(arrangement.conversationApi)
-            .suspendFunction(arrangement.conversationApi::updateProtocol)
-            .with(eq(conversation.id.toApi()), eq(ConvProtocol.MIXED))
-            .wasNotInvoked()
     }
 
     private class Arrangement {
@@ -190,10 +153,10 @@ class MLSMigratorTest {
         @Mock
         val selfTeamIdProvider = mock(classOf<SelfTeamIdProvider>())
 
-        fun withGetConversationListReturning(conversations: List<Conversation>) = apply {
+        fun withGetProteusTeamConversationsReturning(conversations: List<Conversation>) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::getConversationList)
-                .whenInvoked()
+                .suspendFunction(conversationRepository::getProteusTeamConversations)
+                .whenInvokedWith(anything())
                 .thenReturn(Either.Right(flowOf(conversations)))
         }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.network.api.base.model.ServiceAddedResponse
 import com.wire.kalium.network.api.base.model.SubconversationId
 import com.wire.kalium.network.api.base.model.TeamId
 import com.wire.kalium.network.api.base.model.UserId
+import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.utils.NetworkResponse
 
 @Suppress("TooManyFunctions")
@@ -146,4 +147,15 @@ interface ConversationApi {
     suspend fun revokeGuestRoomLink(conversationId: ConversationId): NetworkResponse<Unit>
 
     suspend fun updateMessageTimer(conversationId: ConversationId, messageTimer: Long?): NetworkResponse<Unit>
+
+    suspend fun updateProtocol(
+        conversationId: ConversationId,
+        protocol: ConvProtocol
+    ): NetworkResponse<UpdateConversationProtocolResponse>
+
+    companion object {
+        fun getApiNotSupportError(apiName: String, apiVersion: String = "4") = NetworkResponse.Error(
+            APINotSupported("${this::class.simpleName}: $apiName api is only available on API V$apiVersion")
+        )
+    }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/CreateConversationRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/CreateConversationRequest.kt
@@ -89,7 +89,10 @@ enum class ConvProtocol {
     PROTEUS,
 
     @SerialName("mls")
-    MLS;
+    MLS,
+
+    @SerialName("mixed")
+    MIXED;
 
     override fun toString(): String {
         return this.name.lowercase()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/UpdateConversationProtocolRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/UpdateConversationProtocolRequest.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.base.authenticated.conversation
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateConversationProtocolRequest(
+    @SerialName("protocol")
+    val protocol: ConvProtocol
+) {
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/UpdateConversationProtocolRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/UpdateConversationProtocolRequest.kt
@@ -24,5 +24,4 @@ import kotlinx.serialization.Serializable
 data class UpdateConversationProtocolRequest(
     @SerialName("protocol")
     val protocol: ConvProtocol
-) {
-}
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/UpdateConversationProtocolResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/UpdateConversationProtocolResponse.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.base.authenticated.conversation
+
+import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
+
+sealed class UpdateConversationProtocolResponse {
+    object ProtocolUnchanged : UpdateConversationProtocolResponse()
+    data class ProtocolUpdated(val event: EventContentDTO.Conversation.ProtocolUpdate) : UpdateConversationProtocolResponse()
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationProtocolDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationProtocolDTO.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.base.authenticated.conversation.model
+
+import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConversationProtocolDTO constructor(
+    @SerialName("protocol")
+    val protocol: ConvProtocol
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ConversationR
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationUsers
 import com.wire.kalium.network.api.base.authenticated.conversation.messagetimer.ConversationMessageTimerDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationAccessInfoDTO
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationProtocolDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationReceiptModeDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlagStatusDTO
@@ -245,6 +246,14 @@ sealed class EventContentDTO {
             @SerialName("data") val message: String,
             @SerialName("from") val from: String
         ) : Conversation()
+
+        @Serializable
+        @SerialName("conversation.protocol-update")
+        data class ProtocolUpdate(
+            @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
+            @SerialName("data") val data: ConversationProtocolDTO,
+            @SerialName("qualified_from") val qualifiedFrom: UserId,
+        )
 
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.network.api.v0.authenticated
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.conversation.AddConversationMembersRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.AddServiceRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberAddedResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberRemovedResponse
@@ -36,6 +37,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.Subconversati
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessResponse
+import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationReceiptModeResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.guestroomlink.GenerateGuestRoomLinkResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.messagetimer.ConversationMessageTimerDTO
@@ -272,14 +274,6 @@ internal open class ConversationApiV0 internal constructor(
             APINotSupported("MLS: fetchSubconversationDetails api is only available on API V3")
         )
 
-    override suspend fun fetchSubconversationGroupInfo(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId
-    ): NetworkResponse<ByteArray> =
-        NetworkResponse.Error(
-            APINotSupported("MLS: fetchSubconversationGroupInfo api is only available on API V3")
-        )
-
     override suspend fun deleteSubconversation(
         conversationId: ConversationId,
         subconversationId: SubconversationId,
@@ -287,6 +281,14 @@ internal open class ConversationApiV0 internal constructor(
     ): NetworkResponse<Unit> =
         NetworkResponse.Error(
             APINotSupported("MLS: deleteSubconversation api is only available on API V3")
+        )
+
+    override suspend fun fetchSubconversationGroupInfo(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<ByteArray> =
+        NetworkResponse.Error(
+            APINotSupported("MLS: fetchSubconversationGroupInfo api is only available on API V3")
         )
 
     override suspend fun leaveSubconversation(
@@ -371,6 +373,12 @@ internal open class ConversationApiV0 internal constructor(
                 setBody(ConversationMessageTimerDTO(messageTimer))
             }
         }
+
+    override suspend fun updateProtocol(
+        conversationId: ConversationId,
+        protocol: ConvProtocol
+    ): NetworkResponse<UpdateConversationProtocolResponse> =
+        ConversationApi.getApiNotSupportError("updateProtocol")
 
     protected companion object {
         const val PATH_CONVERSATIONS = "conversations"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
@@ -45,7 +45,7 @@ internal open class ConversationApiV4 internal constructor(
         httpClient.put("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_PROTOCOL") {
             setBody(UpdateConversationProtocolRequest(protocol))
         }.let { httpResponse ->
-            when(httpResponse.status) {
+            when (httpResponse.status) {
                 HttpStatusCode.NoContent -> NetworkResponse.Success(
                     UpdateConversationProtocolResponse.ProtocolUnchanged, httpResponse
                 )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
@@ -19,8 +19,49 @@
 package com.wire.kalium.network.api.v4.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolResponse
+import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.v3.authenticated.ConversationApiV3
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.mapSuccess
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpStatusCode
+import okio.IOException
 
 internal open class ConversationApiV4 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient
-) : ConversationApiV3(authenticatedNetworkClient)
+) : ConversationApiV3(authenticatedNetworkClient) {
+
+    override suspend fun updateProtocol(
+        conversationId: ConversationId,
+        protocol: ConvProtocol
+    ): NetworkResponse<UpdateConversationProtocolResponse> = try {
+        httpClient.put("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_PROTOCOL") {
+            setBody(UpdateConversationProtocolRequest(protocol))
+        }.let { httpResponse ->
+            when(httpResponse.status) {
+                HttpStatusCode.NoContent -> NetworkResponse.Success(
+                    UpdateConversationProtocolResponse.ProtocolUnchanged, httpResponse
+                )
+                else -> {
+                    wrapKaliumResponse<EventContentDTO.Conversation.ProtocolUpdate> { httpResponse }
+                        .mapSuccess {
+                            UpdateConversationProtocolResponse.ProtocolUpdated(it)
+                        }
+                }
+            }
+        }
+    } catch (e: IOException) {
+        NetworkResponse.Error(KaliumException.GenericError(e))
+    }
+
+    companion object {
+        const val PATH_PROTOCOL = "protocol"
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
@@ -1,0 +1,83 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.api.v4
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.model.EventContentDTOJson
+import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolResponse
+import com.wire.kalium.network.api.base.model.ConversationId
+import com.wire.kalium.network.api.v4.authenticated.ConversationApiV4
+import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ConversationApiV4Test : ApiTest() {
+
+    @Test
+    fun given200Response_whenUpdatingConversationProtocol_thenEventIsParsedCorrectly() = runTest {
+        val conversationId = ConversationId("conversationId", "conversationDomain")
+
+        val networkClient = mockAuthenticatedNetworkClient(
+            EventContentDTOJson.validUpdateProtocol.rawJson,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertPut()
+                assertPathEqual("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_PROTOCOL")
+            }
+        )
+        val conversationApi = ConversationApiV4(networkClient)
+        val response = conversationApi.updateProtocol(conversationId, ConvProtocol.MIXED)
+
+        assertIs<NetworkResponse.Success<UpdateConversationProtocolResponse>>(response)
+        assertIs<UpdateConversationProtocolResponse.ProtocolUpdated>(response.value)
+        assertEquals(
+            EventContentDTOJson.validUpdateProtocol.serializableData,
+            (response.value as UpdateConversationProtocolResponse.ProtocolUpdated).event
+        )
+    }
+
+    @Test
+    fun given204Response_whenUpdatingConversationProtocol_thenEventIsParsedCorrectly() = runTest {
+        val conversationId = ConversationId("conversationId", "conversationDomain")
+
+        val networkClient = mockAuthenticatedNetworkClient(
+            "",
+            statusCode = HttpStatusCode.NoContent,
+            assertion = {
+                assertPut()
+                assertPathEqual("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_PROTOCOL")
+            }
+        )
+        val conversationApi = ConversationApiV4(networkClient)
+        val response = conversationApi.updateProtocol(conversationId, ConvProtocol.MIXED)
+
+        assertIs<NetworkResponse.Success<UpdateConversationProtocolResponse>>(response)
+        assertIs<UpdateConversationProtocolResponse.ProtocolUnchanged>(response.value)
+    }
+
+    private companion object {
+        const val PATH_CONVERSATIONS = "/conversations"
+        const val PATH_PROTOCOL = "protocol"
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
@@ -19,10 +19,12 @@
 package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
+import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMembers
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationUsers
 import com.wire.kalium.network.api.base.authenticated.conversation.ReceiptMode
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationAccessInfoDTO
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationProtocolDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationReceiptModeDTO
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
@@ -136,6 +138,28 @@ object EventContentDTOJson {
         """.trimMargin()
     }
 
+    private val jsonProviderUpdateConversationProtocol = { serializable: EventContentDTO.Conversation.ProtocolUpdate ->
+        """
+        |{
+        |  "conversation":"${serializable.qualifiedConversation.value}",
+        |  "data":{
+        |    "protocol": "mixed"
+        |  },
+        |  "from":"${serializable.qualifiedFrom.value}",
+        |  "qualified_conversation": {
+        |    "id": "${serializable.qualifiedConversation.value}",
+        |    "domain": "${serializable.qualifiedConversation.domain}"
+        |  },
+        |  "qualified_from" : {
+        |     "id" : "${serializable.qualifiedFrom.value}",
+        |     "domain" : "${serializable.qualifiedFrom.domain}"
+        |  },
+        |  "time":"2023-01-27T10:35:10.146Z",
+        |  "type":"conversation.protocol-update"
+        |}
+        """.trimMargin()
+    }
+
     val validAccessUpdate = ValidJsonProvider(
         EventContentDTO.Conversation.AccessUpdate(
             qualifiedConversation = ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
@@ -211,6 +235,21 @@ object EventContentDTOJson {
             data = ConversationReceiptModeDTO(receiptMode = ReceiptMode.ENABLED)
         ),
         jsonProviderUpdateConversationReceiptMode
+    )
+
+    val validUpdateProtocol = ValidJsonProvider(
+        EventContentDTO.Conversation.ProtocolUpdate(
+            qualifiedConversation = QualifiedID(
+                value = "conversationId",
+                domain = "conversationDomain"
+            ),
+            qualifiedFrom = QualifiedID(
+                value = "qualifiedFromId",
+                domain = "qualifiedFromDomain"
+            ),
+            data = ConversationProtocolDTO(ConvProtocol.MIXED)
+        ),
+        jsonProviderUpdateConversationProtocol
     )
 
     val validGenerateGuestRoomLink = """

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -212,6 +212,9 @@ ORDER BY lastModifiedDate DESC, name COLLATE NOCASE ASC;
 selectAllConversations:
 SELECT * FROM ConversationDetails WHERE type IS NOT 'CONNECTION_PENDING' ORDER BY last_modified_date DESC, name ASC;
 
+selectAllTeamProteusConversations:
+SELECT * FROM ConversationDetails WHERE type IS 'GROUP' AND protocol IS 'PROTEUS' AND teamId = ?;
+
 selectByQualifiedId:
 SELECT * FROM ConversationDetails WHERE qualifiedId = ?;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -154,6 +154,7 @@ interface ConversationDAO {
     suspend fun updateAllConversationsNotificationDate()
     suspend fun getAllConversations(): Flow<List<ConversationViewEntity>>
     suspend fun getAllConversationDetails(): Flow<List<ConversationViewEntity>>
+    suspend fun getAllProteusTeamConversations(teamId: String): Flow<List<ConversationViewEntity>>
     suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?>
     suspend fun observeGetConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
     suspend fun getConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -315,6 +315,14 @@ class ConversationDAOImpl(
             .map { list -> list.map { it.let { conversationMapper.toModel(it) } } }
     }
 
+    override suspend fun getAllProteusTeamConversations(teamId: String): Flow<List<ConversationViewEntity>> {
+        return conversationQueries.selectAllTeamProteusConversations(teamId)
+            .asFlow()
+            .mapToList()
+            .flowOn(coroutineContext)
+            .map { it.map(conversationMapper::toModel) }
+    }
+
     override suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?> {
         return conversationQueries.selectByQualifiedId(qualifiedID)
             .asFlow()

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -138,6 +138,19 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenExistingConversations_ThenAllProteusTeamConversationsCanBeRetrieved() = runTest {
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity4)
+        conversationDAO.insertConversation(conversationEntity5)
+        insertTeamUserAndMember(team, user2, conversationEntity5.id)
+
+        val result =
+            conversationDAO.getAllProteusTeamConversations(teamId)
+
+        assertEquals(listOf(conversationEntity5.toViewEntity()), result.first())
+    }
+
+    @Test
     fun givenExistingConversation_ThenConversationGroupStateCanBeUpdated() = runTest {
         conversationDAO.insertConversation(conversationEntity2)
         conversationDAO.updateConversationGroupState(
@@ -1061,6 +1074,22 @@ class ConversationDAOTest : BaseDatabaseTest() {
             lastReadDate = "2000-01-01T12:00:00.000Z".toInstant(),
             // and it's status is set to be only notified if there is a mention for the user
             mutedStatus = ConversationEntity.MutedStatus.ONLY_MENTIONS_AND_REPLIES_ALLOWED,
+            access = listOf(ConversationEntity.Access.LINK, ConversationEntity.Access.INVITE),
+            accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
+            receiptMode = ConversationEntity.ReceiptMode.DISABLED,
+            messageTimer = null
+        )
+        val conversationEntity5 = ConversationEntity(
+            QualifiedIDEntity("5", "wire.com"),
+            "conversation1",
+            ConversationEntity.Type.GROUP,
+            teamId,
+            ConversationEntity.ProtocolInfo.Proteus,
+            creatorId = "someValue",
+            lastNotificationDate = null,
+            lastModifiedDate = "2022-03-30T15:36:00.000Z".toInstant(),
+            lastReadDate = "2000-01-01T12:00:00.000Z".toInstant(),
+            mutedStatus = ConversationEntity.MutedStatus.ALL_ALLOWED,
             access = listOf(ConversationEntity.Access.LINK, ConversationEntity.Access.INVITE),
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Implements: [Use case: client initialises migration on conversations](https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/760217617/Use+case+client+initialises+migration+on+conversations+Proteus+to+MLS+migration)

When MLS migration is active regularly upgrade "proteus" conversations to "mixed" and establish the associated MLS group.

### Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/1728

### Testing

#### Test Coverage

- [x] Add test for rollback when loosing the race establish an MLS group
- [x] Add tests for MLSMigrator
- [x] Add tests for MLSMigrationManager
- [x] Add tests for updateProtocol API call

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
