### PR TITLE
fix: trigger slow sync when it is needed after app update [AR-3424]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
@@ -39,6 +39,8 @@ internal interface SlowSyncRepository {
     suspend fun needsToPersistHistoryLostMessage(): Boolean
     suspend fun observeLastSlowSyncCompletionInstant(): Flow<Instant?>
     fun updateSlowSyncStatus(slowSyncStatus: SlowSyncStatus)
+    suspend fun setSlowSyncVersion(version: Int)
+    suspend fun getSlowSyncVersion(): Int
 }
 
 internal class SlowSyncRepositoryImpl(private val metadataDao: MetadataDAO) : SlowSyncRepository {
@@ -91,8 +93,17 @@ internal class SlowSyncRepositoryImpl(private val metadataDao: MetadataDAO) : Sl
         _slowSyncStatus.value = slowSyncStatus
     }
 
+    override suspend fun setSlowSyncVersion(version: Int) {
+        metadataDao.insertValue(value = version.toString(), key = SLOW_SYNC_VERSION_KEY)
+    }
+
+    override suspend fun getSlowSyncVersion(): Int {
+        return metadataDao.valueByKey(key = SLOW_SYNC_VERSION_KEY)?.toIntOrNull() ?: 0
+    }
+
     private companion object {
         const val LAST_SLOW_SYNC_INSTANT_KEY = "lastSlowSyncInstant"
+        const val SLOW_SYNC_VERSION_KEY = "slowSyncVersion"
         const val MLS_NEEDS_RECOVERY_KEY = "mlsNeedsRecovery"
         const val NEEDS_TO_PERSIST_HISTORY_LOST_MESSAGES_KEY = "needsToPersistHistoryLostMessages"
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -62,7 +62,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
 ) : SyncFeatureConfigsUseCase {
     override suspend operator fun invoke(): Either<CoreFailure, Unit> =
         featureConfigRepository.getFeatureConfigs().flatMap {
-            // TODO handle other feature flags
+            // TODO handle other feature flags and after it bump version in [SlowSyncManager.CURRENT_VERSION]
             handleGuestRoomLinkFeatureFlag(it.guestRoomLinkModel)
             handleFileSharingStatus(it.fileSharingModel)
             handleMLSStatus(it.mlsModel)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -155,6 +155,6 @@ internal class SlowSyncManager(
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
         val MIN_TIME_BETWEEN_SLOW_SYNCS = 7.days
-        const val CURRENT_VERSION = 3
+        const val CURRENT_VERSION = 1
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -155,6 +155,6 @@ internal class SlowSyncManager(
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
         val MIN_TIME_BETWEEN_SLOW_SYNCS = 7.days
-        const val CURRENT_VERSION = 1
+        const val CURRENT_VERSION = 1 // bump this version to perform slow sync when some new feature flag was added
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -103,7 +103,9 @@ internal class SlowSyncManager(
                 logger.i("Last SlowSync was performed on '$lastTimeSlowSyncWasPerformed'")
                 val nextSlowSyncDateTime = lastTimeSlowSyncWasPerformed + MIN_TIME_BETWEEN_SLOW_SYNCS
                 logger.i("Next SlowSync should be performed on '$nextSlowSyncDateTime'")
-                currentTime > nextSlowSyncDateTime
+                val lastVersion = slowSyncRepository.getSlowSyncVersion()
+                logger.i("Last saved SlowSync version is $lastVersion, current is $CURRENT_VERSION")
+                currentTime > nextSlowSyncDateTime || CURRENT_VERSION > lastVersion
             } ?: true
         }
 
@@ -128,6 +130,7 @@ internal class SlowSyncManager(
                 logger.i("Starting SlowSync as all criteria are met and it wasn't performed recently")
                 performSlowSync()
                 logger.i("SlowSync completed. Updating last completion instant")
+                slowSyncRepository.setSlowSyncVersion(CURRENT_VERSION)
                 slowSyncRepository.setLastSlowSyncCompletionInstant(DateTimeUtil.currentInstant())
             } else {
                 logger.i("No need to perform SlowSync. Marking as Complete")
@@ -152,5 +155,6 @@ internal class SlowSyncManager(
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
         val MIN_TIME_BETWEEN_SLOW_SYNCS = 7.days
+        const val CURRENT_VERSION = 3
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
@@ -51,6 +51,14 @@ class SlowSyncRepositoryTest {
         assertEquals(instant, slowSyncRepository.observeLastSlowSyncCompletionInstant().first())
     }
 
+    @Test
+    fun givenVersionIsUpdated_whenGettingTheLastSlowSyncVersion_thenShouldReturnTheNewState() = runTest(testDispatcher) {
+        val version = 2
+
+        slowSyncRepository.setSlowSyncVersion(version)
+        assertEquals(version, slowSyncRepository.getSlowSyncVersion())
+    }
+
     @IgnoreIOS // TODO investigate why test is failing
     @Test
     fun givenLastInstantWasNeverSet_whenGettingLastInstant_thenTheStateIsNull() = runTest(testDispatcher) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -465,14 +465,14 @@ class SlowSyncManagerTest {
                 .thenReturn(duration)
         }
 
-        fun withOldLastSlowSyncVersion() = apply {
+        fun withLastSlowSyncPerformedOnAnOldVersion() = apply {
             given(slowSyncRepository)
                 .suspendFunction(slowSyncRepository::getSlowSyncVersion)
                 .whenInvoked()
                 .thenReturn(0)
         }
 
-        fun withNewLastSlowSyncVersion() = apply {
+        fun withLastSlowSyncPerformedOnANewVersion() = apply {
             given(slowSyncRepository)
                 .suspendFunction(slowSyncRepository::getSlowSyncVersion)
                 .whenInvoked()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -80,6 +80,10 @@ class SlowSyncManagerTest {
         verify(arrangement.slowSyncWorker)
             .suspendFunction(arrangement.slowSyncWorker::performSlowSyncSteps)
             .wasInvoked(exactly = once)
+        verify(arrangement.slowSyncRepository)
+            .suspendFunction(arrangement.slowSyncRepository::setSlowSyncVersion)
+            .with(any())
+            .wasInvoked(exactly = once)
     }
 
     @Test
@@ -137,6 +141,11 @@ class SlowSyncManagerTest {
 
         advanceUntilIdle()
 
+        verify(arrangement.slowSyncRepository)
+            .suspendFunction(arrangement.slowSyncRepository::setSlowSyncVersion)
+            .with(any())
+            .wasInvoked(once)
+
         val completedTime = DateTimeUtil.currentInstant()
         verify(arrangement.slowSyncRepository)
             .function(arrangement.slowSyncRepository::setLastSlowSyncCompletionInstant)
@@ -164,6 +173,42 @@ class SlowSyncManagerTest {
             .with(any<Instant?>())
             .wasNotInvoked()
     }
+
+    @Test
+    fun givenItWasCompletedRecentlyAndVersionIsOutdated_whenCriteriaAreMet_thenShouldUpdateSlowSyncVersion() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, _) = Arrangement()
+                .withSatisfiedCriteria()
+                .withLastSlowSyncPerformedAt(flowOf(DateTimeUtil.currentInstant()))
+                .withSlowSyncWorkerReturning(emptyFlow())
+                .withOldLastSlowSyncVersion()
+                .arrange()
+
+            advanceUntilIdle()
+
+            verify(arrangement.slowSyncRepository)
+                .suspendFunction(arrangement.slowSyncRepository::setSlowSyncVersion)
+                .with(any())
+                .wasInvoked(once)
+        }
+
+    @Test
+    fun givenItWasCompletedRecentlyAndVersionIsUpToDate_whenCriteriaAreMet_thenShouldNotUpdateSlowSyncVersion() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, _) = Arrangement()
+                .withSatisfiedCriteria()
+                .withLastSlowSyncPerformedAt(flowOf(DateTimeUtil.currentInstant()))
+                .withSlowSyncWorkerReturning(emptyFlow())
+                .withNewLastSlowSyncVersion()
+                .arrange()
+
+            advanceUntilIdle()
+
+            verify(arrangement.slowSyncRepository)
+                .suspendFunction(arrangement.slowSyncRepository::setSlowSyncVersion)
+                .with(any())
+                .wasNotInvoked()
+        }
 
     @Test
     fun givenCriteriaAreMet_whenWorkerEmitsAStep_thenShouldUpdateStateInRepository() = runTest(TestKaliumDispatcher.default) {
@@ -325,6 +370,7 @@ class SlowSyncManagerTest {
             .function(arrangement.exponentialDurationHelper::reset)
             .wasInvoked(exactly = once)
     }
+
     @Test
     fun givenCriteriaAreMet_whenRecovers_thenShouldRetry() = runTest(TestKaliumDispatcher.default) {
         val (arrangement, _) = Arrangement()
@@ -366,6 +412,13 @@ class SlowSyncManagerTest {
             withLastSlowSyncPerformedAt(flowOf(null))
             withNetworkState(MutableStateFlow(NetworkState.ConnectedWithInternet))
             withNextExponentialDuration(1.seconds)
+            withNewLastSlowSyncVersion()
+            apply {
+                given(slowSyncRepository)
+                    .suspendFunction(slowSyncRepository::setSlowSyncVersion)
+                    .whenInvokedWith(any())
+                    .thenReturn(Unit)
+            }
         }
 
         fun withCriteriaProviderReturning(criteriaFlow: Flow<SyncCriteriaResolution>) = apply {
@@ -410,6 +463,20 @@ class SlowSyncManagerTest {
                 .function(exponentialDurationHelper::next)
                 .whenInvoked()
                 .thenReturn(duration)
+        }
+
+        fun withOldLastSlowSyncVersion() = apply {
+            given(slowSyncRepository)
+                .suspendFunction(slowSyncRepository::getSlowSyncVersion)
+                .whenInvoked()
+                .thenReturn(0)
+        }
+
+        fun withNewLastSlowSyncVersion() = apply {
+            given(slowSyncRepository)
+                .suspendFunction(slowSyncRepository::getSlowSyncVersion)
+                .whenInvoked()
+                .thenReturn(Int.MAX_VALUE)
         }
 
         private val slowSyncManager = SlowSyncManager(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -181,7 +181,7 @@ class SlowSyncManagerTest {
                 .withSatisfiedCriteria()
                 .withLastSlowSyncPerformedAt(flowOf(DateTimeUtil.currentInstant()))
                 .withSlowSyncWorkerReturning(emptyFlow())
-                .withOldLastSlowSyncVersion()
+                .withLastSlowSyncPerformedOnAnOldVersion()
                 .arrange()
 
             advanceUntilIdle()
@@ -199,7 +199,7 @@ class SlowSyncManagerTest {
                 .withSatisfiedCriteria()
                 .withLastSlowSyncPerformedAt(flowOf(DateTimeUtil.currentInstant()))
                 .withSlowSyncWorkerReturning(emptyFlow())
-                .withNewLastSlowSyncVersion()
+                .withLastSlowSyncPerformedOnANewVersion()
                 .arrange()
 
             advanceUntilIdle()
@@ -412,7 +412,7 @@ class SlowSyncManagerTest {
             withLastSlowSyncPerformedAt(flowOf(null))
             withNetworkState(MutableStateFlow(NetworkState.ConnectedWithInternet))
             withNextExponentialDuration(1.seconds)
-            withNewLastSlowSyncVersion()
+            withLastSlowSyncPerformedOnANewVersion()
             apply {
                 given(slowSyncRepository)
                     .suspendFunction(slowSyncRepository::setSlowSyncVersion)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
After adding some feature flags from AR kalium doesn't know to trigger slow sync

### Causes (Optional)
Some features can be disabled until app will perform slow sync (max 7 days delay)

### Solutions
Add manual trigger to perform slow sync when there is need.


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
