### PR TITLE
fix: remove the usage of atomic fu form SessionManager

### DIFF
--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -48,7 +48,6 @@ kotlin {
                 implementation(libs.ktxSerialization)
                 implementation(libs.ktxDateTime)
                 implementation(libs.benAsherUUID)
-                implementation(libs.ktx.atomicfu)
 
                 // the Dependency is duplicated between here and persistence build.gradle.kts
                 implementation(libs.settings.kmp)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -47,10 +47,6 @@ import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.persistence.client.AuthTokenStorage
 import com.wire.kalium.util.KaliumDispatcherImpl
 import io.ktor.http.HttpStatusCode
-import kotlinx.atomicfu.AtomicRef
-import kotlinx.atomicfu.atomic
-import kotlinx.atomicfu.update
-import kotlinx.atomicfu.updateAndGet
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
@@ -67,7 +63,7 @@ class SessionManagerImpl internal constructor(
     private val serverConfigMapper: ServerConfigMapper = MapperProvider.serverConfigMapper()
 ) : SessionManager {
 
-    private val session: SessionDTO? = null
+    private var session: SessionDTO? = null
     private var serverConfig: ServerConfigDTO? = null
 
     override suspend fun session(): SessionDTO? = withContext(coroutineContext) {
@@ -86,11 +82,11 @@ class SessionManagerImpl internal constructor(
         }
     }
 
-    override fun serverConfig(): ServerConfigDTO = serverConfig?: run {
-            sessionRepository.fullAccountInfo(userId)
-                .map { serverConfigMapper.toDTO(it.serverConfig) }
-                .onSuccess { serverConfig = it }
-                .fold({ error("use serverConfig is missing or an error while reading local storage") }, { it })
+    override fun serverConfig(): ServerConfigDTO = serverConfig ?: run {
+        sessionRepository.fullAccountInfo(userId)
+            .map { serverConfigMapper.toDTO(it.serverConfig) }
+            .onSuccess { serverConfig = it }
+            .fold({ error("use serverConfig is missing or an error while reading local storage") }, { it })
         serverConfig!!
     }!!
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the recent usage of atomic fu in `SessionManagerImpl` had errors

### Solutions

after closer look it is not needed to use atomic ref since the cached session can be accessed only by one thread at a time

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
