### PR TITLE
fix: save group message timer on sync

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -155,6 +155,6 @@ internal class SlowSyncManager(
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
         val MIN_TIME_BETWEEN_SLOW_SYNCS = 7.days
-        const val CURRENT_VERSION = 1 // bump this version to perform slow sync when some new feature flag was added
+        const val CURRENT_VERSION = 2 // bump this version to perform slow sync when some new feature flag was added
     }
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -68,7 +68,7 @@ last_read_date = last_read_date,
 mls_last_keying_material_update_date  = excluded.mls_last_keying_material_update_date,
 mls_cipher_suite = excluded.mls_cipher_suite,
 receipt_mode = excluded.receipt_mode,
-message_timer = message_timer;
+message_timer = excluded.message_timer;
 
 updateConversation:
 UPDATE Conversation

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -48,8 +48,8 @@ deleteConversation:
 DELETE FROM Conversation WHERE qualified_id = ?;
 
 insertConversation:
-INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
 type = excluded.type,
@@ -67,7 +67,8 @@ last_notified_date = last_notified_date,
 last_read_date = last_read_date,
 mls_last_keying_material_update_date  = excluded.mls_last_keying_material_update_date,
 mls_cipher_suite = excluded.mls_cipher_suite,
-receipt_mode = excluded.receipt_mode;
+receipt_mode = excluded.receipt_mode,
+message_timer = message_timer;
 
 updateConversation:
 UPDATE Conversation

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -268,7 +268,8 @@ class ConversationDAOImpl(
                 else Instant.fromEpochMilliseconds(MLS_DEFAULT_LAST_KEY_MATERIAL_UPDATE_MILLI),
                 if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.cipherSuite
                 else MLS_DEFAULT_CIPHER_SUITE,
-                receiptMode
+                receiptMode,
+                messageTimer
             )
         }
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -965,7 +965,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             creatorId = creatorId,
             selfRole = Member.Role.Member,
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
-            messageTimer = null
+            messageTimer = messageTimer
         )
     }
 
@@ -975,6 +975,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         val user1 = newUserEntity(id = "1").copy(team = teamId)
         val user2 = newUserEntity(id = "2").copy(team = teamId)
         val user3 = newUserEntity(id = "3").copy(team = teamId)
+        val messageTimer = 5000L
 
         val team = TeamEntity(teamId, "teamName", "")
 
@@ -992,7 +993,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             access = listOf(ConversationEntity.Access.LINK, ConversationEntity.Access.INVITE),
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
-            messageTimer = null
+            messageTimer = messageTimer
         )
         val conversationEntity2 = ConversationEntity(
             QualifiedIDEntity("2", "wire.com"),
@@ -1014,7 +1015,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             access = listOf(ConversationEntity.Access.LINK, ConversationEntity.Access.INVITE),
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
-            messageTimer = null
+            messageTimer = messageTimer
         )
 
         val conversationEntity3 = ConversationEntity(
@@ -1039,7 +1040,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             access = listOf(ConversationEntity.Access.LINK, ConversationEntity.Access.INVITE),
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
-            messageTimer = null
+            messageTimer = messageTimer
         )
 
         val conversationEntity4 = ConversationEntity(
@@ -1064,7 +1065,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             access = listOf(ConversationEntity.Access.LINK, ConversationEntity.Access.INVITE),
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
-            messageTimer = null
+            messageTimer = messageTimer
         )
 
         val member1 = Member(user1.id, Member.Role.Admin)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -819,6 +819,20 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenConversation_whenUpdatingMessageTimer_itReturnsCorrectTimer() = runTest {
+        // given
+        conversationDAO.insertConversation(conversationEntity3)
+        val messageTimer = 60000L
+        conversationDAO.updateMessageTimer(conversationEntity3.id, messageTimer)
+
+        // when
+        val result = conversationDAO.getConversationByQualifiedID(conversationEntity3.id)
+
+        // then
+        assertEquals(messageTimer, result?.messageTimer)
+    }
+
+    @Test
     fun givenSelfUserIsCreatorOfConversation_whenGettingConversationDetails_itReturnsCorrectDetails() = runTest {
         // given
         conversationDAO.insertConversation(conversationEntity3.copy(creatorId = selfUserId.value))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

I forgot to pass message timer when inserting conversation 😅 


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
