### PR TITLE
feat(mls-migration): support the mixed protocol #3

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -628,7 +628,8 @@ internal class CallDataSource(
                         ).flattenConcat()
                     }
                 } ?: Either.Left(CoreFailure.NotSupportedByProteus)
-                is Conversation.ProtocolInfo.Proteus -> Either.Left(CoreFailure.NotSupportedByProteus)
+                is Conversation.ProtocolInfo.Proteus,
+                is Conversation.ProtocolInfo.Mixed -> Either.Left(CoreFailure.NotSupportedByProteus)
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/CallMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/CallMapper.kt
@@ -125,7 +125,8 @@ class CallMapperImpl(
             Conversation.Type.GROUP -> {
                 when (conversation.protocol) {
                     is Conversation.ProtocolInfo.MLS -> ConversationType.ConferenceMls
-                    is Conversation.ProtocolInfo.Proteus -> ConversationType.Conference
+                    is Conversation.ProtocolInfo.Proteus,
+                    is Conversation.ProtocolInfo.Mixed -> ConversationType.Conference
                 }
             }
             Conversation.Type.ONE_ON_ONE -> ConversationType.OneOnOne

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -200,7 +200,7 @@ data class Conversation(
             override fun name() = "Mixed"
         }
 
-        sealed interface MLSCapable: ProtocolInfo {
+        sealed interface MLSCapable : ProtocolInfo {
             val groupId: GroupID
             val groupState: GroupState
             val epoch: ULong
@@ -210,8 +210,7 @@ data class Conversation(
             enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
         }
 
-
-        abstract fun name(): String
+        fun name(): String
     }
 
     data class Member(val id: UserId, val role: Role) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -175,22 +175,41 @@ data class Conversation(
     val supportsUnreadMessageCount
         get() = type in setOf(Type.ONE_ON_ONE, Type.GROUP)
 
-    sealed class ProtocolInfo {
-        object Proteus : ProtocolInfo() {
+    sealed interface ProtocolInfo {
+        object Proteus : ProtocolInfo {
             override fun name() = "Proteus"
         }
 
         data class MLS(
-            val groupId: GroupID,
-            val groupState: GroupState,
-            val epoch: ULong,
-            val keyingMaterialLastUpdate: Instant,
-            val cipherSuite: CipherSuite
-        ) : ProtocolInfo() {
-            enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
-
+            override val groupId: GroupID,
+            override val groupState: MLSCapable.GroupState,
+            override val epoch: ULong,
+            override val keyingMaterialLastUpdate: Instant,
+            override val cipherSuite: CipherSuite
+        ) : MLSCapable {
             override fun name() = "MLS"
         }
+
+        data class Mixed(
+            override val groupId: GroupID,
+            override val groupState: MLSCapable.GroupState,
+            override val epoch: ULong,
+            override val keyingMaterialLastUpdate: Instant,
+            override val cipherSuite: CipherSuite
+        ) : MLSCapable {
+            override fun name() = "Mixed"
+        }
+
+        sealed interface MLSCapable: ProtocolInfo {
+            val groupId: GroupID
+            val groupState: GroupState
+            val epoch: ULong
+            val keyingMaterialLastUpdate: Instant
+            val cipherSuite: CipherSuite
+
+            enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
+        }
+
 
         abstract fun name(): String
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -250,7 +250,11 @@ internal class ConversationGroupRepositoryImpl(
     override suspend fun fetchLimitedInfoViaInviteCode(code: String, key: String): Either<NetworkFailure, LimitedConversationInfo> =
         wrapApiRequest { conversationApi.fetchLimitedInformationViaCode(code, key) }
 
-    private suspend fun deleteMemberFromMlsGroup(userId: UserId, conversationId: ConversationId, protocol: ConversationEntity.ProtocolInfo.MLSCapable) =
+    private suspend fun deleteMemberFromMlsGroup(
+        userId: UserId,
+        conversationId: ConversationId,
+        protocol: ConversationEntity.ProtocolInfo.MLSCapable
+    ) =
         if (userId == selfUserId) {
             deleteMemberFromCloudAndStorage(userId, conversationId).flatMap {
                 mlsConversationRepository.leaveGroup(GroupID(protocol.groupId))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -113,7 +113,7 @@ internal class ConversationGroupRepositoryImpl(
                             is Conversation.ProtocolInfo.Proteus ->
                                 persistMembersFromConversationResponse(conversationResponse)
 
-                            is Conversation.ProtocolInfo.MLS ->
+                            is Conversation.ProtocolInfo.MLSCapable ->
                                 persistMembersFromConversationResponse(conversationResponse)
                                     .flatMap { mlsConversationRepository.establishMLSGroup(protocol.groupId, usersList + selfUserId) }
                         }
@@ -149,6 +149,12 @@ internal class ConversationGroupRepositoryImpl(
                     is ConversationEntity.ProtocolInfo.Proteus ->
                         addMembersToCloudAndStorage(userIdList, conversationId)
 
+                    is ConversationEntity.ProtocolInfo.Mixed ->
+                        addMembersToCloudAndStorage(userIdList, conversationId)
+                            .flatMap {
+                                mlsConversationRepository.addMemberToMLSGroup(GroupID(protocol.groupId), userIdList)
+                            }
+
                     is ConversationEntity.ProtocolInfo.MLS -> {
                         mlsConversationRepository.addMemberToMLSGroup(GroupID(protocol.groupId), userIdList)
                     }
@@ -159,7 +165,7 @@ internal class ConversationGroupRepositoryImpl(
         wrapStorageRequest { conversationDAO.getConversationProtocolInfo(conversationId.toDao()) }
             .flatMap { protocol ->
                 when (protocol) {
-                    is ConversationEntity.ProtocolInfo.Proteus -> {
+                    is ConversationEntity.ProtocolInfo.Proteus, is ConversationEntity.ProtocolInfo.Mixed -> {
                         wrapApiRequest {
                             conversationApi.addService(
                                 AddServiceRequest(id = serviceId.id, provider = serviceId.provider),
@@ -202,15 +208,12 @@ internal class ConversationGroupRepositoryImpl(
                     is ConversationEntity.ProtocolInfo.Proteus ->
                         deleteMemberFromCloudAndStorage(userId, conversationId)
 
+                    is ConversationEntity.ProtocolInfo.Mixed ->
+                        deleteMemberFromCloudAndStorage(userId, conversationId)
+                            .flatMap { deleteMemberFromMlsGroup(userId, conversationId, protocol) }
+
                     is ConversationEntity.ProtocolInfo.MLS -> {
-                        if (userId == selfUserId) {
-                            deleteMemberFromCloudAndStorage(userId, conversationId).flatMap {
-                                mlsConversationRepository.leaveGroup(GroupID(protocol.groupId))
-                            }
-                        } else {
-                            // when removing a member from an MLS group, don't need to call the api
-                            mlsConversationRepository.removeMembersFromMLSGroup(GroupID(protocol.groupId), listOf(userId))
-                        }
+                        deleteMemberFromMlsGroup(userId, conversationId, protocol)
                     }
                 }
             }
@@ -233,7 +236,7 @@ internal class ConversationGroupRepositoryImpl(
                                 is ConversationEntity.ProtocolInfo.Proteus ->
                                     Either.Right(Unit)
 
-                                is ConversationEntity.ProtocolInfo.MLS -> {
+                                is ConversationEntity.ProtocolInfo.MLSCapable -> {
                                     joinExistingMLSConversation(conversationId).flatMap {
                                         addMembers(listOf(selfUserId), conversationId)
                                     }
@@ -246,6 +249,16 @@ internal class ConversationGroupRepositoryImpl(
 
     override suspend fun fetchLimitedInfoViaInviteCode(code: String, key: String): Either<NetworkFailure, LimitedConversationInfo> =
         wrapApiRequest { conversationApi.fetchLimitedInformationViaCode(code, key) }
+
+    private suspend fun deleteMemberFromMlsGroup(userId: UserId, conversationId: ConversationId, protocol: ConversationEntity.ProtocolInfo.MLSCapable) =
+        if (userId == selfUserId) {
+            deleteMemberFromCloudAndStorage(userId, conversationId).flatMap {
+                mlsConversationRepository.leaveGroup(GroupID(protocol.groupId))
+            }
+        } else {
+            // when removing a member from an MLS group, don't need to call the api
+            mlsConversationRepository.removeMembersFromMLSGroup(GroupID(protocol.groupId), listOf(userId))
+        }
 
     private suspend fun deleteMemberFromCloudAndStorage(userId: UserId, conversationId: ConversationId) =
         wrapApiRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -231,14 +231,14 @@ internal class ConversationGroupRepositoryImpl(
             memberJoinEventHandler.handle(eventMapper.conversationMemberJoin(LocalId.generate(), response.event, true))
                 .flatMap {
                     wrapStorageRequest { conversationDAO.getConversationProtocolInfo(conversationId.toDao()) }
-                        .flatMap {
-                            when (it) {
+                        .flatMap { protocol ->
+                            when (protocol) {
                                 is ConversationEntity.ProtocolInfo.Proteus ->
                                     Either.Right(Unit)
 
                                 is ConversationEntity.ProtocolInfo.MLSCapable -> {
                                     joinExistingMLSConversation(conversationId).flatMap {
-                                        addMembers(listOf(selfUserId), conversationId)
+                                        mlsConversationRepository.addMemberToMLSGroup(GroupID(protocol.groupId), listOf(selfUserId))
                                     }
                                 }
                             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -69,7 +69,7 @@ interface ConversationMapper {
     fun fromDaoModel(daoModel: ProposalTimerEntity): ProposalTimer
     fun toDAOAccess(accessList: Set<ConversationAccessDTO>): List<ConversationEntity.Access>
     fun toDAOAccessRole(accessRoleList: Set<ConversationAccessRoleDTO>): List<ConversationEntity.AccessRole>
-    fun toDAOGroupState(groupState: Conversation.ProtocolInfo.MLS.GroupState): GroupState
+    fun toDAOGroupState(groupState: Conversation.ProtocolInfo.MLSCapable.GroupState): GroupState
     fun toDAOProposalTimer(proposalTimer: ProposalTimer): ProposalTimerEntity
     fun toApiModel(access: Conversation.Access): ConversationAccessDTO
     fun toApiModel(accessRole: Conversation.AccessRole): ConversationAccessRoleDTO
@@ -117,7 +117,7 @@ internal class ConversationMapperImpl(
     override fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol = when (apiModel) {
         ConvProtocol.PROTEUS -> Protocol.PROTEUS
         ConvProtocol.MLS -> Protocol.MLS
-        ConvProtocol.MIXED -> Protocol.MLS // TODO jacob create separate case for mixed
+        ConvProtocol.MIXED -> Protocol.MIXED
     }
 
     override fun fromDaoModel(daoModel: ConversationViewEntity): Conversation = with(daoModel) {
@@ -280,12 +280,12 @@ internal class ConversationMapperImpl(
             }
         }
 
-    override fun toDAOGroupState(groupState: Conversation.ProtocolInfo.MLS.GroupState): GroupState =
+    override fun toDAOGroupState(groupState: Conversation.ProtocolInfo.MLSCapable.GroupState): GroupState =
         when (groupState) {
-            Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED -> GroupState.ESTABLISHED
-            Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN -> GroupState.PENDING_JOIN
-            Conversation.ProtocolInfo.MLS.GroupState.PENDING_WELCOME_MESSAGE -> GroupState.PENDING_WELCOME_MESSAGE
-            Conversation.ProtocolInfo.MLS.GroupState.PENDING_CREATION -> GroupState.PENDING_CREATION
+            Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED -> GroupState.ESTABLISHED
+            Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN -> GroupState.PENDING_JOIN
+            Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_WELCOME_MESSAGE -> GroupState.PENDING_WELCOME_MESSAGE
+            Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION -> GroupState.PENDING_CREATION
         }
 
     override fun toDAOProposalTimer(proposalTimer: ProposalTimer): ProposalTimerEntity =
@@ -356,7 +356,15 @@ internal class ConversationMapperImpl(
 
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {
         return when (protocol) {
-            ConvProtocol.MLS, ConvProtocol.MIXED -> ProtocolInfo.MLS( // TODO jacob create separate case for the MIXED case
+            ConvProtocol.MLS -> ProtocolInfo.MLS(
+                groupId ?: "",
+                mlsGroupState ?: GroupState.PENDING_JOIN,
+                epoch ?: 0UL,
+                keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                ConversationEntity.CipherSuite.fromTag(mlsCipherSuiteTag)
+            )
+
+            ConvProtocol.MIXED -> ProtocolInfo.Mixed(
                 groupId ?: "",
                 mlsGroupState ?: GroupState.PENDING_JOIN,
                 epoch ?: 0UL,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -143,7 +143,7 @@ interface ConversationRepository {
     ): Either<NetworkFailure, Unit>
 
     suspend fun getConversationsByGroupState(
-        groupState: Conversation.ProtocolInfo.MLS.GroupState
+        groupState: Conversation.ProtocolInfo.MLSCapable.GroupState
     ): Either<StorageFailure, List<Conversation>>
 
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedID): Either<StorageFailure, Unit>
@@ -466,7 +466,7 @@ internal class ConversationDataSource internal constructor(
         }
 
     override suspend fun getConversationsByGroupState(
-        groupState: Conversation.ProtocolInfo.MLS.GroupState
+        groupState: Conversation.ProtocolInfo.MLSCapable.GroupState
     ): Either<StorageFailure, List<Conversation>> =
         wrapStorageRequest {
             conversationDAO.getConversationsByGroupState(conversationMapper.toDAOGroupState(groupState))
@@ -599,7 +599,7 @@ internal class ConversationDataSource internal constructor(
     override suspend fun deleteConversation(conversationId: ConversationId) =
         getConversationProtocolInfo(conversationId).flatMap {
             when (it) {
-                is Conversation.ProtocolInfo.MLS ->
+                is Conversation.ProtocolInfo.MLSCapable ->
                     mlsClientProvider.getMLSClient().flatMap { mlsClient ->
                         wrapCryptoRequest {
                             mlsClient.wipeConversation(it.groupId.toCrypto())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapper.kt
@@ -35,7 +35,14 @@ class ProtocolInfoMapperImpl(
             is ConversationEntity.ProtocolInfo.Proteus -> Conversation.ProtocolInfo.Proteus
             is ConversationEntity.ProtocolInfo.MLS -> Conversation.ProtocolInfo.MLS(
                 idMapper.fromGroupIDEntity(protocolInfo.groupId),
-                Conversation.ProtocolInfo.MLS.GroupState.valueOf(protocolInfo.groupState.name),
+                Conversation.ProtocolInfo.MLSCapable.GroupState.valueOf(protocolInfo.groupState.name),
+                protocolInfo.epoch,
+                protocolInfo.keyingMaterialLastUpdate,
+                Conversation.CipherSuite.fromTag(protocolInfo.cipherSuite.cipherSuiteTag)
+            )
+            is ConversationEntity.ProtocolInfo.Mixed -> Conversation.ProtocolInfo.Mixed(
+                idMapper.fromGroupIDEntity(protocolInfo.groupId),
+                Conversation.ProtocolInfo.MLSCapable.GroupState.valueOf(protocolInfo.groupState.name),
                 protocolInfo.epoch,
                 protocolInfo.keyingMaterialLastUpdate,
                 Conversation.CipherSuite.fromTag(protocolInfo.cipherSuite.cipherSuiteTag)
@@ -46,6 +53,13 @@ class ProtocolInfoMapperImpl(
         when (protocolInfo) {
             is Conversation.ProtocolInfo.Proteus -> ConversationEntity.ProtocolInfo.Proteus
             is Conversation.ProtocolInfo.MLS -> ConversationEntity.ProtocolInfo.MLS(
+                idMapper.toGroupIDEntity(protocolInfo.groupId),
+                ConversationEntity.GroupState.valueOf(protocolInfo.groupState.name),
+                protocolInfo.epoch,
+                protocolInfo.keyingMaterialLastUpdate,
+                ConversationEntity.CipherSuite.fromTag(protocolInfo.cipherSuite.tag)
+            )
+            is Conversation.ProtocolInfo.Mixed -> ConversationEntity.ProtocolInfo.Mixed(
                 idMapper.toGroupIDEntity(protocolInfo.groupId),
                 ConversationEntity.GroupState.valueOf(protocolInfo.groupState.name),
                 protocolInfo.epoch,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -82,7 +82,7 @@ class JoinExistingMLSConversationUseCaseImpl(
         }
 
     private suspend fun joinOrEstablishMLSGroup(conversation: Conversation): Either<CoreFailure, Unit> {
-        return if (conversation.protocol is Conversation.ProtocolInfo.MLS) {
+        return if (conversation.protocol is Conversation.ProtocolInfo.MLSCapable) {
             if (conversation.protocol.epoch == 0UL) {
                 if (
                     conversation.type == Conversation.Type.GLOBAL_TEAM ||

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLS.GroupState
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLSCapable.GroupState
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt
@@ -21,7 +21,7 @@ package com.wire.kalium.logic.feature.conversation
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLS.GroupState
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLSCapable.GroupState
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.featureFlags.FeatureSupport

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -206,7 +206,7 @@ internal class MessageSenderImpl internal constructor(
                         attemptToSendWithMLS(protocolInfo.groupId, message)
                     }
 
-                    is Conversation.ProtocolInfo.Proteus -> {
+                    is Conversation.ProtocolInfo.Proteus, is Conversation.ProtocolInfo.Mixed -> {
                         // TODO(messaging): make this thread safe (per user)
                         attemptToSendWithProteus(message, messageTarget)
                     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -84,7 +84,7 @@ class MLSMigratorImpl(
         conversationRepository.getConversationProtocolInfo(conversationId)
             .flatMap { protocolInfo ->
                 when (protocolInfo) {
-                    is Conversation.ProtocolInfo.MLS -> { // TODO jacob should be MIXED
+                    is Conversation.ProtocolInfo.Mixed -> {
                         mlsConversationRepository.establishMLSGroup(protocolInfo.groupId, emptyList())
                             .flatMap {
                                 conversationRepository.getConversationMembers(conversationId).flatMap { members ->
@@ -92,7 +92,7 @@ class MLSMigratorImpl(
                                 }
                             }
                     }
-                    is Conversation.ProtocolInfo.Proteus -> Either.Right(Unit)
+                    else -> Either.Right(Unit)
                 }
             }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpacker.kt
@@ -120,7 +120,7 @@ internal class MLSMessageUnpackerImpl(
                         "groupID = ${protocolInfo.groupId.value.obfuscateId()}")
                 decryptMessageContent(messageEvent.content.decodeBase64Bytes(), protocolInfo.groupId)
             } else {
-                Either.Right(null)
+                Either.Left(CoreFailure.NotSupportedByProteus)
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpacker.kt
@@ -114,7 +114,7 @@ internal class MLSMessageUnpackerImpl(
                 decryptMessageContent(messageEvent.content.decodeBase64Bytes(), groupID)
             }
         } ?: conversationRepository.getConversationProtocolInfo(messageEvent.conversationId).flatMap { protocolInfo ->
-            if (protocolInfo is Conversation.ProtocolInfo.MLS) {
+            if (protocolInfo is Conversation.ProtocolInfo.MLSCapable) {
                 logger.d("Decrypting MLS for " +
                         "converationId = ${messageEvent.conversationId.value.obfuscateId()} " +
                         "groupID = ${protocolInfo.groupId.value.obfuscateId()}")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -1751,7 +1751,7 @@ class CallRepositoryTest {
 
             val mlsProtocolInfo = Conversation.ProtocolInfo.MLS(
                 groupId,
-                Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED,
+                Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
                 1UL,
                 Clock.System.now(),
                 Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -253,7 +253,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenProteusConversationAndAPICallFails_whenAddingMembersToConversation_thenShouldNotSucceed() = runTest {
+    fun givenProteusConversationAndAPICallFails_whenAddingMembersToConversation_thenShouldFail() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
             .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
@@ -270,7 +270,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenMLSConversation_whenAddingServiceToConversation_theReturnError() = runTest {
+    fun givenMLSConversation_whenAddingServiceToConversation_thenReturnError() = runTest {
         val serviceID = ServiceId("service-id", "service-provider")
 
         val (arrangement, conversationGroupRepository) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -196,6 +196,11 @@ class ConversationGroupRepositoryTest {
         conversationGroupRepository.addMembers(listOf(TestConversation.USER_1), TestConversation.ID)
             .shouldSucceed()
 
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::addMember)
+            .with(anything(), eq(TestConversation.ID.toApi()))
+            .wasInvoked(exactly = once)
+
         verify(arrangement.memberJoinEventHandler)
             .suspendFunction(arrangement.memberJoinEventHandler::handle)
             .with(anything())
@@ -315,6 +320,35 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
+    fun givenMixedConversation_whenAddMemberFromConversation_thenShouldSucceed() = runTest {
+        val (arrangement, conversationGroupRepository) = Arrangement()
+            .withConversationDetailsById(TestConversation.MIXED_CONVERSATION)
+            .withProtocolInfoById(MIXED_PROTOCOL_INFO)
+            .withAddMemberAPISucceedChanged()
+            .withSuccessfulAddMemberToMLSGroup()
+            .withSuccessfulHandleMemberJoinEvent()
+            .arrange()
+
+        conversationGroupRepository.addMembers(listOf(TestConversation.USER_1), TestConversation.ID)
+            .shouldSucceed()
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::addMember)
+            .with(anything(), eq(TestConversation.ID.toApi()))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.memberJoinEventHandler)
+            .suspendFunction(arrangement.memberJoinEventHandler::handle)
+            .with(anything())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::addMemberToMLSGroup)
+            .with(eq(GROUP_ID), eq(listOf(TestConversation.USER_1)))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
     fun givenProteusConversation_whenRemovingMemberFromConversation_thenShouldSucceed() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
@@ -325,6 +359,11 @@ class ConversationGroupRepositoryTest {
 
         conversationGroupRepository.deleteMember(TestConversation.USER_1, TestConversation.ID)
             .shouldSucceed()
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::removeMember)
+            .with(eq(TestConversation.USER_1.toApi()), eq(TestConversation.ID.toApi()))
+            .wasInvoked(exactly = once)
 
         verify(arrangement.memberLeaveEventHandler)
             .suspendFunction(arrangement.memberLeaveEventHandler::handle)
@@ -423,6 +462,36 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
+    fun givenMixedConversation_whenRemoveMemberFromConversation_thenShouldSucceed() = runTest {
+        val (arrangement, conversationGroupRepository) = Arrangement()
+            .withConversationDetailsById(TestConversation.MIXED_CONVERSATION)
+            .withProtocolInfoById(MIXED_PROTOCOL_INFO)
+            .withDeleteMemberAPISucceedChanged()
+            .withSuccessfulMemberDeletion()
+            .withSuccessfulRemoveMemberFromMLSGroup()
+            .withSuccessfulHandleMemberLeaveEvent()
+            .arrange()
+
+        conversationGroupRepository.deleteMember(TestConversation.USER_1, TestConversation.ID)
+            .shouldSucceed()
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::removeMember)
+            .with(eq(TestConversation.USER_1.toApi()), eq(TestConversation.ID.toApi()))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.memberLeaveEventHandler)
+            .suspendFunction(arrangement.memberLeaveEventHandler::handle)
+            .with(anything())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::removeMembersFromMLSGroup)
+            .with(eq(GROUP_ID), eq(listOf(TestConversation.USER_1)))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
     fun givenProteusConversation_whenJoiningConversationSuccessWithChanged_thenResponseIsHandled() = runTest {
         val (code, key, uri) = Triple("code", "key", null)
 
@@ -453,7 +522,37 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenMlsConversation_whenJoiningConversationSuccessWithChanged_thenAddSelfClientsToMlsGroup() = runTest {
+    fun givenProteusConversation_whenJoiningConversationSuccessWithUnchanged_thenMemberJoinEventHandlerIsNotInvoked() = runTest {
+        val (code, key, uri) = Triple("code", "key", null)
+
+        val (arrangement, conversationGroupRepository) = Arrangement()
+            .withConversationDetailsById(TestConversation.CONVERSATION)
+            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withJoinConversationAPIResponse(
+                code,
+                key,
+                uri,
+                NetworkResponse.Success(ConversationMemberAddedResponse.Unchanged, emptyMap(), 204)
+            )
+            .withSuccessfulHandleMemberJoinEvent()
+            .arrange()
+
+        conversationGroupRepository.joinViaInviteCode(code, key, uri)
+            .shouldSucceed()
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::joinConversation)
+            .with(eq(code), eq(key), eq(uri))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.memberJoinEventHandler)
+            .suspendFunction(arrangement.memberJoinEventHandler::handle)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenMLSConversation_whenJoiningConversationSuccessWithChanged_thenAddSelfClientsToMlsGroup() = runTest {
         val (code, key, uri) = Triple("code", "key", null)
 
         val (arrangement, conversationGroupRepository) = Arrangement()
@@ -495,19 +594,21 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenProteusConversation_whenJoiningConversationSuccessWithUnchanged_thenMemberJoinEventHandlerIsNotInvoked() = runTest {
+    fun givenMixedConversation_whenJoiningConversationSuccessWithChanged_thenAddSelfClientsToMlsGroup() = runTest {
         val (code, key, uri) = Triple("code", "key", null)
 
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
-            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withProtocolInfoById(MIXED_PROTOCOL_INFO)
             .withJoinConversationAPIResponse(
                 code,
                 key,
                 uri,
-                NetworkResponse.Success(ConversationMemberAddedResponse.Unchanged, emptyMap(), 204)
+                NetworkResponse.Success(ADD_MEMBER_TO_CONVERSATION_SUCCESSFUL_RESPONSE, emptyMap(), 200)
             )
             .withSuccessfulHandleMemberJoinEvent()
+            .withJoinExistingMlsConversationSucceeds()
+            .withSuccessfulAddMemberToMLSGroup()
             .arrange()
 
         conversationGroupRepository.joinViaInviteCode(code, key, uri)
@@ -521,7 +622,17 @@ class ConversationGroupRepositoryTest {
         verify(arrangement.memberJoinEventHandler)
             .suspendFunction(arrangement.memberJoinEventHandler::handle)
             .with(any())
-            .wasNotInvoked()
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.joinExistingMLSConversation)
+            .suspendFunction(arrangement.joinExistingMLSConversation::invoke)
+            .with(eq(ADD_MEMBER_TO_CONVERSATION_SUCCESSFUL_RESPONSE.event.qualifiedConversation.toModel()))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::addMemberToMLSGroup)
+            .with(eq(GroupID(MIXED_PROTOCOL_INFO.groupId)), eq(listOf(TestUser.SELF.id)))
+            .wasInvoked(exactly = once)
     }
 
     @Test
@@ -991,6 +1102,14 @@ class ConversationGroupRepositoryTest {
         val PROTEUS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo.Proteus
         val MLS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo
             .MLS(
+                RAW_GROUP_ID,
+                groupState = ConversationEntity.GroupState.ESTABLISHED,
+                0UL,
+                Instant.parse("2021-03-30T15:36:00.000Z"),
+                cipherSuite = ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            )
+        val MIXED_PROTOCOL_INFO = ConversationEntity.ProtocolInfo
+            .Mixed(
                 RAW_GROUP_ID,
                 groupState = ConversationEntity.GroupState.ESTABLISHED,
                 0UL,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -184,7 +184,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenAConversationAndAPISucceedsWithChange_whenAddingMembersToConversation_thenShouldSucceed() = runTest {
+    fun givenProteusConversation_whenAddingMembersToConversation_thenShouldSucceed() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
             .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
@@ -203,7 +203,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenAConversationAndAPISucceedsWithChange_whenAddingServiceToConversation_thenShouldSucceed() = runTest {
+    fun givenProteusConversation_whenAddingServiceToConversation_thenShouldSucceed() = runTest {
         val serviceID = ServiceId("service-id", "service-provider")
         val addServiceRequest = AddServiceRequest(id = serviceID.id, provider = serviceID.provider)
 
@@ -227,6 +227,41 @@ class ConversationGroupRepositoryTest {
             .suspendFunction(arrangement.memberJoinEventHandler::handle)
             .with(anything())
             .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProteusConversationAndUserIsAlreadyAMember_whenAddingMembersToConversation_thenShouldSucceed() = runTest {
+        val (arrangement, conversationGroupRepository) = Arrangement()
+            .withConversationDetailsById(TestConversation.CONVERSATION)
+            .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
+            .withFetchUsersIfUnknownByIdsSuccessful()
+            .withAddMemberAPISucceedUnchanged()
+            .arrange()
+
+        conversationGroupRepository.addMembers(listOf(TestConversation.USER_1), TestConversation.ID)
+            .shouldSucceed()
+
+        verify(arrangement.memberJoinEventHandler)
+            .suspendFunction(arrangement.memberJoinEventHandler::handle)
+            .with(anything())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenProteusConversationAndAPICallFails_whenAddingMembersToConversation_thenShouldNotSucceed() = runTest {
+        val (arrangement, conversationGroupRepository) = Arrangement()
+            .withConversationDetailsById(TestConversation.CONVERSATION)
+            .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
+            .withAddMemberAPIFailed()
+            .arrange()
+
+        conversationGroupRepository.addMembers(listOf(TestConversation.USER_1), TestConversation.ID)
+            .shouldFail()
+
+        verify(arrangement.memberJoinEventHandler)
+            .suspendFunction(arrangement.memberJoinEventHandler::handle)
+            .with(anything())
+            .wasNotInvoked()
     }
 
     @Test
@@ -256,42 +291,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenAConversationAndAPISucceedsWithoutChange_whenAddingMembersToConversation_thenShouldSucceed() = runTest {
-        val (arrangement, conversationGroupRepository) = Arrangement()
-            .withConversationDetailsById(TestConversation.CONVERSATION)
-            .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
-            .withFetchUsersIfUnknownByIdsSuccessful()
-            .withAddMemberAPISucceedUnchanged()
-            .arrange()
-
-        conversationGroupRepository.addMembers(listOf(TestConversation.USER_1), TestConversation.ID)
-            .shouldSucceed()
-
-        verify(arrangement.memberJoinEventHandler)
-            .suspendFunction(arrangement.memberJoinEventHandler::handle)
-            .with(anything())
-            .wasNotInvoked()
-    }
-
-    @Test
-    fun givenAConversationAndAPIFailed_whenAddingMembersToConversation_thenShouldNotSucceed() = runTest {
-        val (arrangement, conversationGroupRepository) = Arrangement()
-            .withConversationDetailsById(TestConversation.CONVERSATION)
-            .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
-            .withAddMemberAPIFailed()
-            .arrange()
-
-        conversationGroupRepository.addMembers(listOf(TestConversation.USER_1), TestConversation.ID)
-            .shouldFail()
-
-        verify(arrangement.memberJoinEventHandler)
-            .suspendFunction(arrangement.memberJoinEventHandler::handle)
-            .with(anything())
-            .wasNotInvoked()
-    }
-
-    @Test
-    fun givenAnMLSConversationAndAPISucceeds_whenAddMemberFromConversation_thenShouldSucceed() = runTest {
+    fun givenMLSConversation_whenAddMemberFromConversation_thenShouldSucceed() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.MLS_CONVERSATION)
             .withProtocolInfoById(MLS_PROTOCOL_INFO)
@@ -315,7 +315,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenAConversationAndAPISucceedsWithChange_whenRemovingMemberFromConversation_thenShouldSucceed() = runTest {
+    fun givenProteusConversation_whenRemovingMemberFromConversation_thenShouldSucceed() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
             .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
@@ -333,7 +333,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenAConversationAndAPISucceedsWithoutChange_whenRemovingMemberFromConversation_thenShouldSucceed() = runTest {
+    fun givenProteusConversationAndUserIsNotAMember_whenRemovingMemberFromConversation_thenShouldSucceed() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
             .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
@@ -350,7 +350,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenAConversationAndAPIFailed_whenRemovingMemberFromConversation_thenShouldFail() = runTest {
+    fun givenProteusConversationAndAPICallFails_whenRemovingMemberFromConversation_thenShouldFail() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
             .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
@@ -367,7 +367,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenAnMLSConversationAndAPISucceeds_whenRemovingLeavingConversation_thenShouldSucceed() = runTest {
+    fun givenMLSConversation_whenRemovingLeavingConversation_thenShouldSucceed() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.MLS_CONVERSATION)
             .withProtocolInfoById(MLS_PROTOCOL_INFO)
@@ -395,7 +395,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenAnMLSConversationAndAPISucceeds_whenRemoveMemberFromConversation_thenShouldSucceed() = runTest {
+    fun givenMLSConversation_whenRemoveMemberFromConversation_thenShouldSucceed() = runTest {
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.MLS_CONVERSATION)
             .withProtocolInfoById(MLS_PROTOCOL_INFO)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
@@ -30,6 +30,13 @@ class ProtocolInfoMapperTest {
     private val protocolInfoMapper = ProtocolInfoMapperImpl()
 
     @Test
+    fun givenConversationMixedProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
+        val mappedValue = protocolInfoMapper.toEntity(CONVERSATION_MIXED_PROTOCOL_INFO)
+        assertIs<ConversationEntity.ProtocolInfo>(mappedValue)
+        assertEquals(mappedValue, CONV_ENTITY_MIXED_PROTOCOL_INFO)
+    }
+
+    @Test
     fun givenConversationMLSProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
         val mappedValue = protocolInfoMapper.toEntity(CONVERSATION_MLS_PROTOCOL_INFO)
         assertIs<ConversationEntity.ProtocolInfo>(mappedValue)
@@ -41,6 +48,13 @@ class ProtocolInfoMapperTest {
         val mappedValue = protocolInfoMapper.toEntity(CONVERSATION_PROTEUS_PROTOCOL_INFO)
         assertIs<ConversationEntity.ProtocolInfo>(mappedValue)
         assertEquals(mappedValue, CONV_ENTITY_PROTEUS_PROTOCOL_INFO)
+    }
+
+    @Test
+    fun givenEntityMixedProtocolInfo_WhenMapToConversationProtocolInfo_ResultShouldBeEqual() = runTest {
+        val mappedValue = protocolInfoMapper.fromEntity(CONV_ENTITY_MIXED_PROTOCOL_INFO)
+        assertIs<Conversation.ProtocolInfo>(mappedValue)
+        assertEquals(mappedValue, CONVERSATION_MIXED_PROTOCOL_INFO)
     }
 
     @Test
@@ -58,6 +72,13 @@ class ProtocolInfoMapperTest {
     }
 
     companion object {
+        val CONVERSATION_MIXED_PROTOCOL_INFO = Conversation.ProtocolInfo.Mixed(
+            GroupID("GROUP_ID"),
+            Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+            5UL,
+            Instant.parse("2021-03-30T15:36:00.000Z"),
+            cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        )
         val CONVERSATION_MLS_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
             GroupID("GROUP_ID"),
             Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
@@ -67,6 +88,14 @@ class ProtocolInfoMapperTest {
         )
         val CONVERSATION_PROTEUS_PROTOCOL_INFO = Conversation.ProtocolInfo.Proteus
 
+        val CONV_ENTITY_MIXED_PROTOCOL_INFO =
+            ConversationEntity.ProtocolInfo.Mixed(
+                "GROUP_ID",
+                groupState = ConversationEntity.GroupState.ESTABLISHED,
+                5UL,
+                Instant.parse("2021-03-30T15:36:00.000Z"),
+                cipherSuite = ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            )
         val CONV_ENTITY_MLS_PROTOCOL_INFO =
             ConversationEntity.ProtocolInfo.MLS(
                 "GROUP_ID",
@@ -76,6 +105,5 @@ class ProtocolInfoMapperTest {
                 cipherSuite = ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             )
         val CONV_ENTITY_PROTEUS_PROTOCOL_INFO = ConversationEntity.ProtocolInfo.Proteus
-
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ProtocolInfoMapperTest.kt
@@ -60,7 +60,7 @@ class ProtocolInfoMapperTest {
     companion object {
         val CONVERSATION_MLS_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
             GroupID("GROUP_ID"),
-            Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED,
+            Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
             5UL,
             Instant.parse("2021-03-30T15:36:00.000Z"),
             cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -296,7 +296,7 @@ class JoinExistingMLSConversationUseCaseTest {
             val MLS_CONVERSATION1 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID1,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 1UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
@@ -306,7 +306,7 @@ class JoinExistingMLSConversationUseCaseTest {
             val MLS_CONVERSATION2 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID2,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 1UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
@@ -316,7 +316,7 @@ class JoinExistingMLSConversationUseCaseTest {
             val MLS_UNESTABLISHED_GROUP_CONVERSATION = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID3,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 0UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
@@ -326,7 +326,7 @@ class JoinExistingMLSConversationUseCaseTest {
             val MLS_UNESTABLISHED_SELF_CONVERSATION = TestConversation.SELF(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID_SELF,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 0UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
@@ -336,7 +336,7 @@ class JoinExistingMLSConversationUseCaseTest {
             val MLS_UNESTABLISHED_GLOBAL_TEAM_CONVERSATION = TestConversation.GLOBAL_TEAM(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID_TEAM,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 0UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -167,7 +167,7 @@ class JoinExistingMLSConversationsUseCaseTest {
             val MLS_CONVERSATION1 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID1,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 1UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
@@ -177,7 +177,7 @@ class JoinExistingMLSConversationsUseCaseTest {
             val MLS_CONVERSATION2 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID2,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 1UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCaseTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCaseTests.kt
@@ -260,7 +260,7 @@ class RecoverMLSConversationsUseCaseTests {
             val MLS_CONVERSATION1 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID1,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 1UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
@@ -270,7 +270,7 @@ class RecoverMLSConversationsUseCaseTests {
             val MLS_CONVERSATION2 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
                     GROUP_ID2,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 1UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -865,7 +865,7 @@ class MessageSenderTest {
             val GROUP_ID = GroupID("groupId")
             val MLS_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
                 GROUP_ID,
-                Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED,
+                Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
                 0UL,
                 Instant.DISTANT_PAST,
                 Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -224,15 +224,17 @@ class MLSMigratorTest {
         }
 
         companion object {
-            val MLS_STALE_MESSAGE_ERROR = KaliumException.InvalidRequestError(ErrorResponse(409, "", "mls-stale-message"))
+            val MLS_STALE_MESSAGE_ERROR = KaliumException.InvalidRequestError(
+                ErrorResponse(409, "", "mls-stale-message")
+            )
             val MEMBERS = listOf(TestUser.USER_ID)
-            val MIXED_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
+            val MIXED_PROTOCOL_INFO = Conversation.ProtocolInfo.Mixed(
                 TestConversation.GROUP_ID,
-                Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+                Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                 0UL,
                 Instant.parse("2021-03-30T15:36:00.000Z"),
                 cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-            ) // TODO jacob should be mixed
+            )
             val UPDATE_PROTOCOL_SUCCESS = NetworkResponse.Success(
                 UpdateConversationProtocolResponse.ProtocolUpdated(
                     EventContentDTO.Conversation.ProtocolUpdate(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -332,7 +332,7 @@ object TestConversation {
         TestTeam.TEAM_ID,
         ProtocolInfo.MLS(
             GROUP_ID,
-            ProtocolInfo.MLS.GroupState.PENDING_JOIN,
+            ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
             0UL,
             Instant.parse("2021-03-30T15:36:00.000Z"),
             cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -307,6 +307,24 @@ object TestConversation {
         messageTimer = null
     )
 
+    val MLS_PROTOCOL_INFO = ProtocolInfo.MLS(
+        GROUP_ID,
+        ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
+        0UL,
+        Instant.parse("2021-03-30T15:36:00.000Z"),
+        cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+    )
+
+    val PROTEUS_PROTOCOL_INFO = ProtocolInfo.Proteus
+
+    val MIXED_PROTOCOL_INFO = ProtocolInfo.Mixed(
+        GROUP_ID,
+        ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
+        0UL,
+        Instant.parse("2021-03-30T15:36:00.000Z"),
+        cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+    )
+
     val CONVERSATION = Conversation(
         ConversationId("conv_id", "domain"),
         "ONE_ON_ONE Name",
@@ -330,13 +348,7 @@ object TestConversation {
         "MLS Name",
         Conversation.Type.ONE_ON_ONE,
         TestTeam.TEAM_ID,
-        ProtocolInfo.MLS(
-            GROUP_ID,
-            ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
-            0UL,
-            Instant.parse("2021-03-30T15:36:00.000Z"),
-            cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-        ),
+        MLS_PROTOCOL_INFO,
         MutedConversationStatus.AllAllowed,
         null,
         null,
@@ -347,6 +359,10 @@ object TestConversation {
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null
+    )
+
+    val MIXED_CONVERSATION = MLS_CONVERSATION.copy(
+        protocol = MIXED_PROTOCOL_INFO
     )
 
     val LIMITED_CONVERSATION_INFO: LimitedConversationInfo = LimitedConversationInfo("conv_id_value", "name")

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -206,7 +206,7 @@ SELECT * FROM ConversationDetails
 WHERE type IS NOT "SELF" AND
 (type IS "GROUP" AND (name IS NOT NULL OR otherUserId IS NOT NULL) --filter deleted groups after first sync
 OR (type IS NOT "GROUP" AND otherUserId IS NOT NULL)) -- show other conversation- todo: problem here! if the sync wasn't succesful the the user seems to be null!
-AND (protocol IS "PROTEUS" OR (protocol IS "MLS" AND mls_group_state IS "ESTABLISHED"))
+AND (protocol IS "PROTEUS" OR protocol IS "MIXED" OR (protocol IS "MLS" AND mls_group_state IS "ESTABLISHED"))
 ORDER BY lastModifiedDate DESC, name COLLATE NOCASE ASC;
 
 selectAllConversations:
@@ -232,7 +232,7 @@ selectByGroupId:
 SELECT * FROM ConversationDetails WHERE mls_group_id = ?;
 
 selectByGroupState:
-SELECT * FROM ConversationDetails WHERE mls_group_state = ? AND protocol = ?;
+SELECT * FROM ConversationDetails WHERE mls_group_state = ? AND (protocol IS "MLS" OR protocol IS "MIXED");
 
 getConversationIdByGroupId:
 SELECT qualified_id FROM Conversation WHERE mls_group_id = ?;
@@ -249,7 +249,7 @@ updateKeyingMaterialDate:
 UPDATE Conversation SET mls_last_keying_material_update_date= ? WHERE mls_group_id = ?;
 
 selectByKeyingMaterialUpdate:
-SELECT mls_group_id FROM Conversation WHERE mls_group_state = ? AND protocol = ? AND mls_last_keying_material_update_date - ? <0 AND mls_group_id IS NOT NULL;
+SELECT mls_group_id FROM Conversation WHERE mls_group_state = ? AND (protocol IS "MLS" OR protocol IS "MIXED") AND mls_last_keying_material_update_date - ? <0 AND mls_group_id IS NOT NULL;
 
 updateProposalTimer:
 UPDATE Conversation SET mls_proposal_timer = COALESCE(mls_proposal_timer, ?) WHERE mls_group_id = ?;
@@ -258,7 +258,7 @@ clearProposalTimer:
 UPDATE Conversation SET mls_proposal_timer = NULL WHERE mls_group_id = ?;
 
 selectProposalTimers:
-SELECT mls_group_id, mls_proposal_timer FROM Conversation WHERE protocol = ? AND mls_group_id IS NOT NULL AND mls_proposal_timer IS NOT NULL;
+SELECT mls_group_id, mls_proposal_timer FROM Conversation WHERE (protocol IS "MLS" OR protocol IS "MIXED") AND mls_group_id IS NOT NULL AND mls_proposal_timer IS NOT NULL;
 
 isUserMember:
 SELECT user FROM Member WHERE conversation = ? AND user = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -51,7 +51,7 @@ data class ConversationEntity(
 
     enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
 
-    enum class Protocol { PROTEUS, MLS }
+    enum class Protocol { PROTEUS, MLS, MIXED }
     enum class ReceiptMode { DISABLED, ENABLED }
 
     @Suppress("MagicNumber")
@@ -73,15 +73,30 @@ data class ConversationEntity(
 
     enum class MutedStatus { ALL_ALLOWED, ONLY_MENTIONS_AND_REPLIES_ALLOWED, MENTIONS_MUTED, ALL_MUTED }
 
-    sealed class ProtocolInfo {
-        object Proteus : ProtocolInfo()
+    sealed interface ProtocolInfo {
+        object Proteus : ProtocolInfo
         data class MLS(
-            val groupId: String,
-            val groupState: GroupState,
-            val epoch: ULong,
-            val keyingMaterialLastUpdate: Instant,
+            override val groupId: String,
+            override val groupState: GroupState,
+            override val epoch: ULong,
+            override val keyingMaterialLastUpdate: Instant,
+            override val cipherSuite: CipherSuite
+        ) : MLSCapable
+        data class Mixed(
+            override val groupId: String,
+            override val groupState: GroupState,
+            override val epoch: ULong,
+            override val keyingMaterialLastUpdate: Instant,
+            override val cipherSuite: CipherSuite
+        ) : MLSCapable
+
+        sealed interface MLSCapable : ProtocolInfo {
+            val groupId: String
+            val groupState: GroupState
+            val epoch: ULong
+            val keyingMaterialLastUpdate: Instant
             val cipherSuite: CipherSuite
-        ) : ProtocolInfo()
+        }
     }
 }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -389,7 +389,7 @@ class ConversationDAOImpl(
 
     override suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationViewEntity> =
         withContext(coroutineContext) {
-            conversationQueries.selectByGroupState(groupState, ConversationEntity.Protocol.MLS)
+            conversationQueries.selectByGroupState(groupState)
                 .executeAsList()
                 .map(conversationMapper::toModel)
         }
@@ -512,7 +512,6 @@ class ConversationDAOImpl(
     override suspend fun getConversationsByKeyingMaterialUpdate(threshold: Duration): List<String> = withContext(coroutineContext) {
         conversationQueries.selectByKeyingMaterialUpdate(
             ConversationEntity.GroupState.ESTABLISHED,
-            ConversationEntity.Protocol.MLS,
             DateTimeUtil.currentInstant().minus(threshold)
         ).executeAsList()
     }
@@ -526,7 +525,7 @@ class ConversationDAOImpl(
     }
 
     override suspend fun getProposalTimers(): Flow<List<ProposalTimerEntity>> {
-        return conversationQueries.selectProposalTimers(ConversationEntity.Protocol.MLS)
+        return conversationQueries.selectProposalTimers()
             .asFlow()
             .flowOn(coroutineContext)
             .mapToList()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -196,6 +196,14 @@ private class ConversationMapper {
                 mlsCipherSuite
             )
 
+            ConversationEntity.Protocol.MIXED -> ConversationEntity.ProtocolInfo.Mixed(
+                mlsGroupId ?: "",
+                mlsGroupState,
+                mlsEpoch.toULong(),
+                mlsLastKeyingMaterialUpdate,
+                mlsCipherSuite
+            )
+
             ConversationEntity.Protocol.PROTEUS -> ConversationEntity.ProtocolInfo.Proteus
         }
     }
@@ -248,14 +256,17 @@ class ConversationDAOImpl(
                 name,
                 type,
                 teamId,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.groupId
+                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.groupId
                 else null,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.groupState
+                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.groupState
                 else ConversationEntity.GroupState.ESTABLISHED,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.epoch.toLong()
+                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.epoch.toLong()
                 else MLS_DEFAULT_EPOCH,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) ConversationEntity.Protocol.MLS
-                else ConversationEntity.Protocol.PROTEUS,
+                when (protocolInfo) {
+                    is ConversationEntity.ProtocolInfo.MLS -> ConversationEntity.Protocol.MLS
+                    is ConversationEntity.ProtocolInfo.Mixed -> ConversationEntity.Protocol.MIXED
+                    is ConversationEntity.ProtocolInfo.Proteus -> ConversationEntity.Protocol.PROTEUS
+                },
                 mutedStatus,
                 mutedTime,
                 creatorId,
@@ -264,9 +275,9 @@ class ConversationDAOImpl(
                 access,
                 accessRole,
                 lastReadDate,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.keyingMaterialLastUpdate
+                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.keyingMaterialLastUpdate
                 else Instant.fromEpochMilliseconds(MLS_DEFAULT_LAST_KEY_MATERIAL_UPDATE_MILLI),
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLS) protocolInfo.cipherSuite
+                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.cipherSuite
                 else MLS_DEFAULT_CIPHER_SUITE,
                 receiptMode
             )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -120,11 +120,11 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenExistingMixedConversation_ThenConversationIdCanBeRetrievedByGroupID() = runTest {
-        conversationDAO.insertConversation(conversationEntity5)
-        insertTeamUserAndMember(team, user2, conversationEntity5.id)
+        conversationDAO.insertConversation(conversationEntity6)
+        insertTeamUserAndMember(team, user2, conversationEntity6.id)
         val result =
-            conversationDAO.getConversationIdByGroupID((conversationEntity5.protocolInfo as ConversationEntity.ProtocolInfo.Mixed).groupId)
-        assertEquals(conversationEntity5.id, result)
+            conversationDAO.getConversationIdByGroupID((conversationEntity6.protocolInfo as ConversationEntity.ProtocolInfo.Mixed).groupId)
+        assertEquals(conversationEntity6.id, result)
     }
     @Test
     fun givenExistingMLSConversation_ThenConversationIdCanBeRetrievedByGroupID() = runTest {
@@ -137,12 +137,12 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenExistingMixedConversation_ThenConversationCanBeRetrievedByGroupState() = runTest {
-        conversationDAO.insertConversation(conversationEntity5)
+        conversationDAO.insertConversation(conversationEntity6)
         conversationDAO.insertConversation(conversationEntity3)
-        insertTeamUserAndMember(team, user2, conversationEntity5.id)
+        insertTeamUserAndMember(team, user2, conversationEntity6.id)
         val result =
             conversationDAO.getConversationsByGroupState(ConversationEntity.GroupState.ESTABLISHED)
-        assertEquals(listOf(conversationEntity5.toViewEntity(user2)), result)
+        assertEquals(listOf(conversationEntity6.toViewEntity(user2)), result)
     }
 
     @Test
@@ -228,13 +228,13 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenExistingMixedConversation_whenAddingMembersByGroupId_ThenAllMembersCanBeRetrieved() = runTest {
-        conversationDAO.insertConversation(conversationEntity5)
+        conversationDAO.insertConversation(conversationEntity6)
         conversationDAO.insertMembers(
             listOf(member1, member2),
-            (conversationEntity5.protocolInfo as ConversationEntity.ProtocolInfo.Mixed).groupId
+            (conversationEntity6.protocolInfo as ConversationEntity.ProtocolInfo.Mixed).groupId
         )
 
-        assertEquals(setOf(member1, member2), conversationDAO.getAllMembers(conversationEntity5.id).first().toSet())
+        assertEquals(setOf(member1, member2), conversationDAO.getAllMembers(conversationEntity6.id).first().toSet())
     }
 
     @Test
@@ -878,13 +878,13 @@ class ConversationDAOTest : BaseDatabaseTest() {
     @Test
     fun givenMixedConversation_whenGettingConversationProtocolInfo_itReturnsCorrectInfo() = runTest {
         // given
-        conversationDAO.insertConversation(conversationEntity5)
+        conversationDAO.insertConversation(conversationEntity6)
 
         // when
-        val result = conversationDAO.getConversationProtocolInfo(conversationEntity5.id)
+        val result = conversationDAO.getConversationProtocolInfo(conversationEntity6.id)
 
         // then
-        assertEquals(conversationEntity5.protocolInfo, result)
+        assertEquals(conversationEntity6.protocolInfo, result)
     }
 
     @Test
@@ -1141,7 +1141,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = null
         )
 
-        val conversationEntity5 = ConversationEntity(
+        val conversationEntity6 = ConversationEntity(
             QualifiedIDEntity("5", "wire.com"),
             "conversation5",
             ConversationEntity.Type.GROUP,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Support the "mixed" protocol on conversations, which means it's a proteus conversation which also has a mls group. During migration mls clients will be added the mls group until every client has joined, at which the conversation transitions to the mls protocol.

- Support persisting the mixed protocol with associated MLS fields
- Support MLS operations on "mixed" conversations
- Perform proteus & MLS operations when adding, removing users to "mixed" conversations.

Use case: [Maintaining the client list in "mixed" mode](https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/759169316/Use+case+Maintaining+the+client+list+in+mixed+mode+Proteus+to+MLS+migration)

### Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/1729

### Testing

#### Test Coverage

- [x] Test mapping of mixed conversations
- [x] Test that "mixed" conversations perform proteus & mls operations 
- [x] Test that MLS messages are processed for "mixed" conversations
- [x] Test that proteus messages are processed for "mixed" conversations

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
