### PR TITLE
fix: service search by name is looking only exacg name and add unit test to ServiceRepository

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/service/ServiceRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/service/ServiceRepository.kt
@@ -21,15 +21,12 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
-import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.wrapFlowStorageRequest
 import com.wire.kalium.logic.wrapNullableFlowStorageRequest
 import com.wire.kalium.logic.wrapStorageNullableRequest
-import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.persistence.dao.ServiceDAO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -525,9 +525,7 @@ class UserSessionScope internal constructor(
 
     private val serviceRepository: ServiceRepository
         get() = ServiceDataSource(
-            serviceDAO = userStorage.database.serviceDAO,
-            userRepository = userRepository,
-            teamRepository = teamRepository
+            serviceDAO = userStorage.database.serviceDAO
         )
 
     private val connectionRepository: ConnectionRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCase.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.data.service.ServiceRepository
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.fold
 
 /**
  * This use case returns all services currently in the database.
@@ -38,11 +39,5 @@ class ObserveAllServicesUseCaseImpl internal constructor(
     private val serviceRepository: ServiceRepository
 ) : ObserveAllServicesUseCase {
 
-    override suspend fun invoke(): Flow<List<ServiceDetails>> =
-        serviceRepository.getAllServices()
-            .fold({
-                flowOf(listOf())
-            }, {
-                it
-            })
+    override suspend fun invoke(): Flow<List<ServiceDetails>> = TODO()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCase.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.map
 
 /**
  * This use case returns all services currently in the database.
@@ -39,5 +40,10 @@ class ObserveAllServicesUseCaseImpl internal constructor(
     private val serviceRepository: ServiceRepository
 ) : ObserveAllServicesUseCase {
 
-    override suspend fun invoke(): Flow<List<ServiceDetails>> = TODO()
+    override suspend fun invoke(): Flow<List<ServiceDetails>> = serviceRepository.observeAllServices().map {
+        it.fold(
+            { emptyList() },
+            { it }
+        )
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCase.kt
@@ -21,8 +21,6 @@ import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceRepository
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
 
 /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveIsServiceMemberUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveIsServiceMemberUseCase.kt
@@ -17,10 +17,13 @@
  */
 package com.wire.kalium.logic.feature.service
 
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.service.ServiceId
 import com.wire.kalium.logic.data.service.ServiceRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.Either
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -33,14 +36,14 @@ interface ObserveIsServiceMemberUseCase {
     suspend operator fun invoke(
         serviceId: ServiceId,
         conversationId: ConversationId
-    ): Flow<QualifiedID?>
+    ): Flow<Either<StorageFailure, UserId?>>
 }
 
 class ObserveIsServiceMemberUseCaseImpl internal constructor(
     private val serviceRepository: ServiceRepository
 ) : ObserveIsServiceMemberUseCase {
 
-    override suspend fun invoke(serviceId: ServiceId, conversationId: ConversationId): Flow<QualifiedID?> =
+    override suspend fun invoke(serviceId: ServiceId, conversationId: ConversationId): Flow<Either<StorageFailure, UserId?>> =
         serviceRepository.observeIsServiceMember(
             serviceId = serviceId,
             conversationId = conversationId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveIsServiceMemberUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveIsServiceMemberUseCase.kt
@@ -19,7 +19,6 @@ package com.wire.kalium.logic.feature.service
 
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.service.ServiceId
 import com.wire.kalium.logic.data.service.ServiceRepository
 import com.wire.kalium.logic.data.user.UserId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SearchServicesByNameUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SearchServicesByNameUseCase.kt
@@ -21,7 +21,6 @@ import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceRepository
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SearchServicesByNameUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SearchServicesByNameUseCase.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.data.service.ServiceRepository
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 /**
  * This use case searches for services based on given name string.
@@ -38,10 +39,11 @@ class SearchServicesByNameUseCaseImpl internal constructor(
 ) : SearchServicesByNameUseCase {
 
     override suspend fun invoke(search: String): Flow<List<ServiceDetails>> =
-        serviceRepository.searchServicesByName(name = search)
-            .fold({
-                flowOf(listOf())
+        serviceRepository.searchServicesByName(name = search).map {
+            it.fold({
+                listOf()
             }, {
                 it
             })
+        }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/service/ServiceRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/service/ServiceRepositoryTest.kt
@@ -1,0 +1,331 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.service
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.toModel
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.persistence.dao.BotIdEntity
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.ServiceDAO
+import com.wire.kalium.persistence.dao.ServiceEntity
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServiceRepositoryTest {
+
+    @Test
+    fun givenSuccess_whenReadingServiceInfoById_thenSuccessIsPropagated() = runTest {
+        val expected = serviceDetails
+
+        val (arrangement, serviceRepository) = Arrangement()
+            .withServiceByIdSuccess(serviceIdEntity, serviceEntity)
+            .arrange()
+
+        serviceRepository.getServiceById(serviceId).also {
+            it.shouldSucceed {
+                assertEquals(serviceDetails, it)
+            }
+        }
+
+        verify(arrangement.serviceDAO)
+            .suspendFunction(arrangement.serviceDAO::byId)
+            .with(any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenError_whenReadingServiceInfoById_thenErrorIsPropagated() = runTest {
+        val expected = StorageFailure.Generic(IllegalStateException())
+
+        val (arrangement, serviceRepository) = Arrangement()
+            .withServiceByIdFailure(serviceIdEntity, expected.rootCause)
+            .arrange()
+
+        serviceRepository.getServiceById(serviceId).also {
+            it.shouldFail {
+                assertEquals(expected, it)
+            }
+        }
+
+        verify(arrangement.serviceDAO)
+            .suspendFunction(arrangement.serviceDAO::byId)
+            .with(any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSuccess_whenObservingIfServiceIsMember_thenSuccessIsPropagated() = runTest {
+        val expected: List<QualifiedIDEntity?> = listOf(null, QualifiedIDEntity("id", "domain"), null)
+
+        val (arrangement, serviceRepository) = Arrangement()
+            .withObserveIsMemberSuccess(expected.asFlow())
+            .arrange()
+
+        serviceRepository.observeIsServiceMember(serviceId, ConversationId("id", "domain")).test {
+            expected.forEach { expectedEmit ->
+                val currentValue = awaitItem()
+                currentValue.shouldSucceed {
+                    assertEquals(expectedEmit?.toModel(), it)
+                }
+            }
+            awaitComplete()
+        }
+
+        verify(arrangement.serviceDAO)
+            .suspendFunction(arrangement.serviceDAO::observeIsServiceMember)
+            .with(any(), any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenError_whenObservingIfServiceIsMember_thenErrorIsPropagated() = runTest {
+        val expected = StorageFailure.Generic(IllegalStateException())
+
+        val (arrangement, serviceRepository) = Arrangement()
+            .withObserveIsMemberFailure(expected.rootCause)
+            .arrange()
+
+        serviceRepository.observeIsServiceMember(serviceId, ConversationId("id", "domain")).first().also {
+            it.shouldFail {
+                assertEquals(expected, it)
+            }
+        }
+
+        verify(arrangement.serviceDAO)
+            .suspendFunction(arrangement.serviceDAO::observeIsServiceMember)
+            .with(any(), any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSuccess_whenObservingAllServices_thenSuccessIsPropagated() = runTest {
+        val expectedEntity = listOf(
+            serviceEntity.copy(id = BotIdEntity("id1", "domain1")),
+            serviceEntity.copy(id = BotIdEntity("id2", "domain2"))
+        )
+
+        val expected = listOf(
+            serviceDetails.copy(id = ServiceId("id1", "domain1")),
+            serviceDetails.copy(id = ServiceId("id2", "domain2"))
+        )
+
+
+        val (arrangement, serviceRepository) = Arrangement()
+            .withGetAllServicesSuccess(flowOf(expectedEntity))
+            .arrange()
+
+        serviceRepository.observeAllServices().test {
+            val currentValue = awaitItem()
+            assertIs<Either.Right<List<ServiceDetails>>>(currentValue)
+            assertEquals(expected, currentValue.value)
+
+            awaitComplete()
+        }
+
+        verify(arrangement.serviceDAO)
+            .suspendFunction(arrangement.serviceDAO::getAllServices)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenError_whenObservingAllServices_thenErrorIsPropagated() = runTest {
+        val expected = StorageFailure.Generic(IllegalStateException())
+
+        val (arrangement, serviceRepository) = Arrangement()
+            .withGetAllServicesFailure(expected.rootCause)
+            .arrange()
+
+        serviceRepository.observeAllServices().test {
+            val currentValue = awaitItem()
+            assertIs<Either.Left<StorageFailure>>(currentValue)
+            assertEquals(expected, currentValue.value)
+
+            awaitComplete()
+        }
+
+        verify(arrangement.serviceDAO)
+            .suspendFunction(arrangement.serviceDAO::getAllServices)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSuccess_whenSearchingServicesByName_thenSearchResultIsPropagated() = runTest {
+        val expectedEntity = listOf(
+            serviceEntity.copy(id = BotIdEntity("id1", "domain1")),
+            serviceEntity.copy(id = BotIdEntity("id2", "domain2"))
+        )
+
+        val expected = listOf(
+            serviceDetails.copy(id = ServiceId("id1", "domain1")),
+            serviceDetails.copy(id = ServiceId("id2", "domain2"))
+        )
+
+        val (arrangement, serviceRepository) = Arrangement()
+            .withSearchServicesByNameSuccess(flowOf(expectedEntity))
+            .arrange()
+
+        serviceRepository.searchServicesByName("name").test {
+            val currentValue = awaitItem()
+            assertIs<Either.Right<List<ServiceDetails>>>(currentValue)
+            assertEquals(expected, currentValue.value)
+
+            awaitComplete()
+        }
+
+        verify(arrangement.serviceDAO)
+            .suspendFunction(arrangement.serviceDAO::searchServicesByName)
+            .with(any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenError_whenSearchingServicesByName_thenErrorIsPropagated() = runTest {
+        val expected = StorageFailure.Generic(IllegalStateException())
+
+        val (arrangement, serviceRepository) = Arrangement()
+            .withSearchServicesByNameFailure(expected.rootCause)
+            .arrange()
+
+        serviceRepository.searchServicesByName("name").test {
+            val currentValue = awaitItem()
+            assertIs<Either.Left<StorageFailure>>(currentValue)
+            assertEquals(expected, currentValue.value)
+
+            awaitComplete()
+        }
+
+        verify(arrangement.serviceDAO)
+            .suspendFunction(arrangement.serviceDAO::searchServicesByName)
+            .with(any())
+            .wasInvoked(exactly = once)
+    }
+
+    private companion object {
+        val serviceIdEntity = BotIdEntity("serviceId", "providerId")
+        val serviceId = ServiceId("serviceId", "providerId")
+
+        val serviceEntity = ServiceEntity(
+            id = serviceIdEntity,
+            name = "name",
+            description = "description",
+            completeAssetId = null,
+            previewAssetId = null,
+            enabled = true,
+            summary = "summary",
+            tags = emptyList()
+        )
+
+        val serviceDetails = ServiceDetails(
+            id = serviceId,
+            name = "name",
+            description = "description",
+            completeAssetId = null,
+            previewAssetId = null,
+            enabled = true,
+            summary = "summary",
+            tags = emptyList()
+        )
+    }
+
+
+    private class Arrangement {
+        @Mock
+        val serviceDAO: ServiceDAO = mock(ServiceDAO::class)
+
+        private val serviceRepository: ServiceRepository = ServiceDataSource(serviceDAO)
+
+        fun withServiceByIdSuccess(serviceId: BotIdEntity, result: ServiceEntity?) = apply {
+            given(serviceDAO)
+                .suspendFunction(serviceDAO::byId)
+                .whenInvokedWith(eq(serviceId))
+                .then { result }
+        }
+
+        fun withServiceByIdFailure(serviceId: BotIdEntity, error: Throwable) = apply {
+            given(serviceDAO)
+                .suspendFunction(serviceDAO::byId)
+                .whenInvokedWith(eq(serviceId))
+                .thenThrow(error)
+        }
+
+        fun withObserveIsMemberSuccess(result: Flow<QualifiedIDEntity?>) = apply {
+            given(serviceDAO)
+                .suspendFunction(serviceDAO::observeIsServiceMember)
+                .whenInvokedWith(any(), any())
+                .thenReturn(result)
+        }
+
+        fun withObserveIsMemberFailure(error: Throwable) = apply {
+            given(serviceDAO)
+                .suspendFunction(serviceDAO::observeIsServiceMember)
+                .whenInvokedWith(any(), any())
+                .thenThrow(error)
+        }
+
+        fun withGetAllServicesSuccess(result: Flow<List<ServiceEntity>>) = apply {
+            given(serviceDAO)
+                .suspendFunction(serviceDAO::getAllServices)
+                .whenInvoked()
+                .thenReturn(result)
+        }
+
+        fun withGetAllServicesFailure(error: Throwable) = apply {
+            given(serviceDAO)
+                .suspendFunction(serviceDAO::getAllServices)
+                .whenInvoked()
+                .thenThrow(error)
+        }
+
+        fun withSearchServicesByNameSuccess(result: Flow<List<ServiceEntity>>) = apply {
+            given(serviceDAO)
+                .suspendFunction(serviceDAO::searchServicesByName)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withSearchServicesByNameFailure(error: Throwable) = apply {
+            given(serviceDAO)
+                .suspendFunction(serviceDAO::searchServicesByName)
+                .whenInvokedWith(any())
+                .thenThrow(error)
+        }
+
+        fun arrange() = this to serviceRepository
+
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/ObserveIsServiceMemberUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/ObserveIsServiceMemberUseCaseTest.kt
@@ -22,6 +22,8 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceId
 import com.wire.kalium.logic.data.service.ServiceRepository
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.configure
@@ -50,14 +52,12 @@ class ObserveIsServiceMemberUseCaseTest {
             .arrange()
 
         // when
-        val result = observeServiceDetails.invoke(
+        observeServiceDetails.invoke(
             serviceId = Arrangement.serviceId,
             conversationId = Arrangement.conversationId
-        ).first()
-
-        // then
-        assertIs<QualifiedID>(result)
-        assertEquals(Arrangement.userId, result)
+        ).first().shouldSucceed { result ->
+            assertEquals(Arrangement.userId, result)
+        }
     }
 
     private class Arrangement {
@@ -80,7 +80,7 @@ class ObserveIsServiceMemberUseCaseTest {
             given(serviceRepository)
                 .suspendFunction(serviceRepository::observeIsServiceMember)
                 .whenInvokedWith(eq(serviceId), eq(conversationId))
-                .thenReturn(flowOf(userId))
+                .thenReturn(flowOf(Either.Right(userId)))
         }
 
         companion object {

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Service.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Service.sq
@@ -22,15 +22,7 @@ allServices:
 SELECT * FROM Service;
 
 byId:
-SELECT
-    Service.id,
-    Service.name,
-    Service.description,
-    Service.summary,
-    Service.tags,
-    Service.enabled,
-    Service.preview_asset_id,
-    Service.complete_asset_id
+SELECT *
 FROM Service
 WHERE Service.id = :id;
 
@@ -40,15 +32,7 @@ FROM User
 JOIN Member ON Member.user = User.qualified_id AND Member.conversation = :conversation
 WHERE User.bot_service = :id;
 
-getServicesByName:
-SELECT
-    Service.id,
-    Service.name,
-    Service.description,
-    Service.summary,
-    Service.tags,
-    Service.enabled,
-    Service.preview_asset_id,
-    Service.complete_asset_id
+searchByName:
+SELECT *
 FROM Service
-WHERE Service.name LIKE :query;
+WHERE Service.name LIKE ('%' || :query || '%');

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ServiceDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ServiceDAO.kt
@@ -90,7 +90,7 @@ internal class ServiceDAOImpl(
     override suspend fun searchServicesByName(
         query: String
     ): Flow<List<ServiceEntity>> =
-        serviceQueries.getServicesByName(query, mapper = ::mapToServiceEntity).asFlow().flowOn(context).mapToList()
+        serviceQueries.searchByName(query, mapper = ::mapToServiceEntity).asFlow().flowOn(context).mapToList()
 
     override suspend fun insert(service: ServiceEntity) = withContext(context) {
         serviceQueries.insert(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. search service by name is doing exact name lookup
2. missing unit test for ServiceRepository

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
