### PR TITLE
fix: file sharing dialog is displayed after first install (AR-3150)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -104,9 +104,9 @@ class UserConfigDataSource(
         serverSideConfig: Either<StorageFailure, IsFileSharingEnabledEntity>,
         buildConfig: BuildFileRestrictionState
     ): Either<StorageFailure, FileSharingStatus> = when {
-        serverSideConfig.isLeft() -> Either.Left(serverSideConfig.value)
+        serverSideConfig.isLeft() -> serverSideConfig
 
-        !serverSideConfig.value.status -> Either.Right(
+        serverSideConfig.value.status.not() -> Either.Right(
             FileSharingStatus(
                 isStatusChanged = serverSideConfig.value.isStatusChanged,
                 state = FileSharingStatus.Value.Disabled

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1222,7 +1222,7 @@ class UserSessionScope internal constructor(
 
     private val syncFeatureConfigsUseCase: SyncFeatureConfigsUseCase
         get() = SyncFeatureConfigsUseCaseImpl(
-            userConfigRepository, featureConfigRepository, isFileSharingEnabled, getGuestRoomLinkFeature, kaliumConfigs, userId
+            userConfigRepository, featureConfigRepository, getGuestRoomLinkFeature, kaliumConfigs, userId
         )
 
     val team: TeamScope get() = TeamScope(userRepository, teamRepository, conversationRepository, selfTeamId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.selfdeletingMessages.SelfDeletionTimer
 import com.wire.kalium.logic.feature.selfdeletingMessages.TeamSettingsSelfDeletionStatus
-import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.feature.user.guestroomlink.GetGuestRoomLinkFeatureStatusUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
@@ -56,7 +55,6 @@ internal interface SyncFeatureConfigsUseCase {
 internal class SyncFeatureConfigsUseCaseImpl(
     private val userConfigRepository: UserConfigRepository,
     private val featureConfigRepository: FeatureConfigRepository,
-    // private val isFileSharingEnabledUseCase: IsFileSharingEnabledUseCase,
     private val getGuestRoomLinkFeatureStatus: GetGuestRoomLinkFeatureStatusUseCase,
     private val kaliumConfigs: KaliumConfigs,
     private val selfUserId: UserId
@@ -108,7 +106,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
         val isStatusChanged: Boolean = when (currentStatus) {
             is Either.Left -> false
             is Either.Right -> {
-                when(currentStatus.value.state) {
+                when (currentStatus.value.state) {
                     FileSharingStatus.Value.Disabled -> newStatus
                     FileSharingStatus.Value.EnabledAll -> !newStatus
                     // EnabledSome is a build time flag, so we don't need to check if the server side status have been changed


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

file sharing dialog is displayed after a fresh install

### Cause

the sync was getting its initial value from the IsFileSharingEnabledUseCase which in its part is adding a default value of disabled when no value is stored yet

### Solutions

if file sharing status is missing (fresh install) consider it as not changed

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
