### PR TITLE
fix: mark asset messages with no content as deleted

### DIFF
--- a/persistence/src/commonMain/db_user/migrations/40.sq
+++ b/persistence/src/commonMain/db_user/migrations/40.sq
@@ -1,0 +1,5 @@
+UPDATE Message
+SET visibility = 'DELETED'
+WHERE Message.content_type = 'ASSET' AND
+        Message.visibility IS NOT 'DELETED' AND
+ (SELECT message_id FROM MessageAssetContent WHERE Message.id = MessageAssetContent.message_id AND Message.conversation_id = MessageAssetContent.conversation_id) IS NULL;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the issue from https://github.com/wireapp/kalium/pull/1756 can lead to crash loop in effected conversations

### Solutions

#1756 fixes the core issue but we still need to fix the issue for user who already had it happen

this DB migration will mark Asset messages with no content as DELETED

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
