### PR TITLE
feat: testservice can break sessions on purpose (SQPIT-1606)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/BreakSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/BreakSessionUseCase.kt
@@ -1,0 +1,76 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.debug
+
+import com.wire.kalium.cryptography.CryptoClientId
+import com.wire.kalium.cryptography.CryptoSessionId
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.feature.ProteusClientProvider
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
+
+interface BreakSessionUseCase {
+    /**
+     * Function that can be used to create a broken session with another user on purpose. This debug function
+     * can be used to test correct client behaviour in case of broken sessions. It should not be used by
+     * clients itself.
+     *
+     * Only works for proteus protocol.
+     *
+     * @param userId the id of the user to whom the session should be broken
+     * @param clientId the id of the client of the user to whom the session should be broken
+     * @return an [BreakSessionResult] containing a [CoreFailure] in case anything goes wrong
+     * and [BreakSessionResult.Success] in case everything succeeds
+     */
+    suspend operator fun invoke(userId: UserId, clientId: ClientId): BreakSessionResult
+}
+
+internal class BreakSessionUseCaseImpl internal constructor(
+    private val proteusClientProvider: ProteusClientProvider,
+    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
+) : BreakSessionUseCase {
+    override suspend operator fun invoke(
+        userId: UserId,
+        clientId: ClientId
+    ): BreakSessionResult = withContext(dispatchers.io) {
+        return@withContext proteusClientProvider.getOrError().fold({
+            return@fold BreakSessionResult.Failure(it)
+        }, { proteusClient ->
+            val cryptoUserID = idMapper.toCryptoQualifiedIDId(userId)
+            val cryptoSessionId = CryptoSessionId(
+                userId = cryptoUserID,
+                cryptoClientId = CryptoClientId(clientId.value)
+            )
+            // create a new session with the same session id
+            proteusClient.createSession(proteusClient.newLastPreKey(), cryptoSessionId)
+            return@fold BreakSessionResult.Success
+        })
+    }
+}
+
+sealed class BreakSessionResult {
+    object Success : BreakSessionResult()
+    data class Failure(val coreFailure: CoreFailure) : BreakSessionResult()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -74,6 +74,9 @@ class DebugScope internal constructor(
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
+    val breakSession: BreakSessionUseCase
+        get() = BreakSessionUseCaseImpl(proteusClientProvider)
+
     val sendBrokenAssetMessage: SendBrokenAssetMessageUseCase
         get() = SendBrokenAssetMessageUseCaseImpl(
             currentClientIdProvider,

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -21,6 +21,8 @@ package com.wire.kalium.testservice.api.v1
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.testservice.managed.InstanceService
 import com.wire.kalium.testservice.models.AvailabilityRequest
+import com.wire.kalium.testservice.models.BreakSessionRequest
+import com.wire.kalium.testservice.models.SendSessionResetRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -95,9 +97,26 @@ class ClientResources(private val instanceService: InstanceService) {
         }
     }
 
-    // POST /api/v1/instance/{instanceId}/breakSession
-    // Break a session to a specific device of a remote user (on purpose).
+    @POST
+    @Path("/instance/{id}/breakSession")
+    @Operation(summary = "Break a session to a specific device of a remote user on purpose. Only for proteus sessions.")
+    @Consumes(MediaType.APPLICATION_JSON)
+    fun breakSession(@PathParam("id") id: String, @Valid request: BreakSessionRequest): Response {
+        instanceService.getInstance(id) ?: throw WebApplicationException("No instance found with id $id")
+        runBlocking {
+            with(request) {
+                instanceService.breakSession(id, clientId, userId, userDomain)
+            }
+        }
+        return Response.status(Response.Status.OK).build()
+    }
 
-    // POST /api/v1/instance/{instanceId}/sendSessionReset
-    // Reset session of a specific device
+    @POST
+    @Path("/instance/{id}/sendSessionReset")
+    @Operation(summary = "Reset session of a specific device")
+    @Consumes(MediaType.APPLICATION_JSON)
+    fun sendSessionReset(@PathParam("id") id: String, @Valid request: SendSessionResetRequest): Response {
+        instanceService.getInstance(id) ?: throw WebApplicationException("No instance found with id $id")
+        return Response.status(Response.Status.OK).build()
+    }
 }

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
@@ -37,6 +38,7 @@ import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.testservice.TestserviceConfiguration
 import com.wire.kalium.testservice.models.FingerprintResponse
 import com.wire.kalium.testservice.models.Instance
@@ -339,6 +341,30 @@ class InstanceService(
                 if (result is CurrentSessionResult.Success) {
                     instance.coreLogic.sessionScope(result.accountInfo.userId) {
                         users.updateSelfAvailabilityStatus(status)
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun breakSession(instanceId: String, clientId: String, userId: String, userDomain: String) {
+        val instance = getInstanceOrThrow(instanceId)
+        instance.coreLogic?.globalScope {
+            scope.async {
+                val result = session.currentSession()
+                if (result is CurrentSessionResult.Success) {
+                    instance.coreLogic.sessionScope(result.accountInfo.userId) {
+                        log.info("Instance ${instance.instanceId}: Wait until alive")
+                        if (syncManager.isSlowSyncOngoing()) {
+                            log.info("Instance ${instance.instanceId}: Slow sync is ongoing")
+                        }
+                        syncManager.waitUntilLiveOrFailure().onFailure {
+                            log.warn("Instance ${instance.instanceId}: Sync failed with $it")
+                        }
+                        log.info(
+                            "Instance ${instance.instanceId}: Break session with client $clientId of user $userId"
+                        )
+                        debug.breakSession(QualifiedID(userId, userDomain), ClientId(clientId))
                     }
                 }
             }

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/BreakSessionRequest.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/BreakSessionRequest.kt
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.testservice.models
+
+data class BreakSessionRequest(
+    val clientId: String = "",
+    val userId: String = "",
+    val userDomain: String = "staging.zinfra.io",
+)

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendSessionResetRequest.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendSessionResetRequest.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.testservice.models
+
+data class SendSessionResetRequest(
+    val conversationDomain: String = "staging.zinfra.io",
+    val conversationId: String = "",
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR provides a new function in the debug scope to break a session by creating a new session with a different prekey.

### Testing

#### How to Test

This functionality is tested by automation test C906622 of the QA.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
