### PR TITLE
fix: add extension to assets without it [AR-3261, AR-2929, AR-3482]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ carthage = "0.0.1"
 libsodiumBindings = "0.8.6"
 protobufCodegen = "0.9.1"
 annotation = "1.2.0"
+apache-tika = "2.8.0"
 
 [plugins]
 # Home-made convention plugins
@@ -167,6 +168,7 @@ pbandk-runtime-macX64 = { module = "pro.streem.pbandk:pbandk-runtime-macosx64", 
 pbandk-runtime-macArm64 = { module = "pro.streem.pbandk:pbandk-runtime-macosarm64", version.ref = "pbandk" }
 pbandk-runtime-common = { module = "pro.streem.pbandk:pbandk-runtime", version.ref = "pbandk" }
 benAsherUUID = { module = "com.benasher44:uuid", version.ref = "benasher-uuid" }
+apacheTika = { module = "org.apache.tika:tika-core", version.ref = "apache-tika" }
 
 # avs
 avs = { module = "com.wire:avs", version.ref = "avs" }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
@@ -71,25 +71,3 @@ fun isVideoMimeType(mimeType: String): Boolean = mimeType in setOf(
     "video/mp4", "video/webm", "video/3gpp", "video/mkv"
 )
 
-fun getExtensionFromMimeType(mimeType: String?): String? {
-    return mimeType?.let { mimeTypeToExtensionMap[it.lowercase()] }
-}
-
-private val mimeTypeToExtensionMap = mapOf(
-    "image/jpg" to "jpg",
-    "image/jpeg" to "jpeg",
-    "image/png" to "png",
-    "image/heic" to "heic",
-    "image/gif" to "gif",
-    "image/webp" to "webp",
-    "audio/mp3" to "mp3",
-    "audio/mpeg" to "mpeg",
-    "audio/ogg" to "ogg",
-    "audio/wav" to "wav",
-    "audio/x-wav" to "wav",
-    "audio/x-pn-wav" to "wav",
-    "video/mp4" to "mp4",
-    "video/webm" to "webm",
-    "video/3gpp" to "3gpp",
-    "video/mkv" to "mkv"
-)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
@@ -70,4 +70,3 @@ fun isAudioMimeType(mimeType: String): Boolean = mimeType in setOf(
 fun isVideoMimeType(mimeType: String): Boolean = mimeType in setOf(
     "video/mp4", "video/webm", "video/3gpp", "video/mkv"
 )
-

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
@@ -46,6 +46,19 @@ enum class RetentionType {
     EXPIRING
 }
 
+enum class AttachmentType {
+    IMAGE, GENERIC_FILE, AUDIO, VIDEO;
+
+    companion object {
+        fun fromMimeTypeString(mimeType: String): AttachmentType = when {
+            isDisplayableImageMimeType(mimeType) -> IMAGE
+            isAudioMimeType(mimeType) -> AUDIO
+            isVideoMimeType(mimeType) -> VIDEO
+            else -> GENERIC_FILE
+        }
+    }
+}
+
 fun isDisplayableImageMimeType(mimeType: String): Boolean = mimeType in setOf(
     "image/jpg", "image/jpeg", "image/png", "image/heic", "image/gif", "image/webp"
 )
@@ -56,4 +69,27 @@ fun isAudioMimeType(mimeType: String): Boolean = mimeType in setOf(
 
 fun isVideoMimeType(mimeType: String): Boolean = mimeType in setOf(
     "video/mp4", "video/webm", "video/3gpp", "video/mkv"
+)
+
+fun getExtensionFromMimeType(mimeType: String?): String? {
+    return mimeType?.let { mimeTypeToExtensionMap[it.lowercase()] }
+}
+
+private val mimeTypeToExtensionMap = mapOf(
+    "image/jpg" to "jpg",
+    "image/jpeg" to "jpeg",
+    "image/png" to "png",
+    "image/heic" to "heic",
+    "image/gif" to "gif",
+    "image/webp" to "webp",
+    "audio/mp3" to "mp3",
+    "audio/mpeg" to "mpeg",
+    "audio/ogg" to "ogg",
+    "audio/wav" to "wav",
+    "audio/x-wav" to "wav",
+    "audio/x-pn-wav" to "wav",
+    "video/mp4" to "mp4",
+    "video/webm" to "webm",
+    "video/3gpp" to "3gpp",
+    "video/mkv" to "mkv"
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.persistence.dao.asset.AssetDAO
+import com.wire.kalium.util.getExtensionFromMimeType
 import kotlinx.coroutines.flow.firstOrNull
 import okio.IOException
 import okio.Path

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -280,7 +280,6 @@ internal class AssetDataSource(
                                     ?: getExtensionFromMimeType(mimeType)
                             )
                         )
-                    kaliumLogger.d("KBX repo ${decodedAssetPath.name}")
 
                     val decodedAssetSink = kaliumFileSystem.sink(decodedAssetPath)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
@@ -80,7 +80,7 @@ internal class GetMessageAssetUseCaseImpl(
                     val wasDownloaded: Boolean = assetDownloadStatus == SAVED_INTERNALLY || assetDownloadStatus == SAVED_EXTERNALLY
                     // assets uploaded by other clients have upload status NOT_UPLOADED
                     val alreadyUploaded: Boolean = (assetUploadStatus == NOT_UPLOADED && content.value.shouldBeDisplayed)
-                                || assetUploadStatus == UPLOADED
+                            || assetUploadStatus == UPLOADED
                     val assetMetadata = with(content.value.remoteData) {
                         DownloadAssetMessageMetadata(
                             content.value.name ?: "",
@@ -102,6 +102,7 @@ internal class GetMessageAssetUseCaseImpl(
                             assetId = assetMetadata.assetKey,
                             assetDomain = assetMetadata.assetKeyDomain,
                             assetName = assetMetadata.assetName,
+                            mimeType = content.value.mimeType,
                             assetToken = assetMetadata.assetToken,
                             encryptionKey = assetMetadata.encryptionKey,
                             assetSHA256Key = assetMetadata.assetSHA256Key,
@@ -132,6 +133,11 @@ internal class GetMessageAssetUseCaseImpl(
 }
 
 sealed class MessageAssetResult {
-    class Success(val decodedAssetPath: Path, val assetSize: Long, val assetName: String) : MessageAssetResult()
+    class Success(
+        val decodedAssetPath: Path,
+        val assetSize: Long,
+        val assetName: String
+    ) : MessageAssetResult()
+
     class Failure(val coreFailure: CoreFailure) : MessageAssetResult()
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -248,7 +248,8 @@ class AssetRepositoryTest {
             assetToken = assetToken,
             encryptionKey = assetEncryptionKey,
             assetSHA256Key = SHA256Key(assetSha256!!),
-            downloadIfNeeded = true
+            downloadIfNeeded = true,
+            mimeType = null
         )
 
         // Then
@@ -294,7 +295,8 @@ class AssetRepositoryTest {
                 assetToken = assetToken,
                 encryptionKey = assetEncryptionKey,
                 assetSHA256Key = SHA256Key(assetSha256!!),
-                downloadIfNeeded = false
+                downloadIfNeeded = false,
+                mimeType = null
             )
 
             // Then
@@ -339,7 +341,8 @@ class AssetRepositoryTest {
                 assetToken = assetToken,
                 encryptionKey = assetEncryptionKey,
                 assetSHA256Key = SHA256Key(assetSha256!!),
-                downloadIfNeeded = false
+                downloadIfNeeded = false,
+                mimeType = null
             )
 
             // Then
@@ -387,6 +390,7 @@ class AssetRepositoryTest {
                 assetKey.value,
                 assetKey.domain,
                 assetName,
+                null,
                 assetToken,
                 assetEncryptionKey,
                 SHA256Key(wrongAssetSha256!!)
@@ -450,6 +454,7 @@ class AssetRepositoryTest {
             assetId = assetKey.value,
             assetDomain = assetKey.domain,
             assetName,
+            null,
             null,
             encryptionKey,
             assetSha256

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
@@ -147,7 +147,7 @@ class GetMessageAssetUseCaseTest {
         // Then
         verify(arrangement.assetDataSource)
             .suspendFunction(arrangement.assetDataSource::fetchPrivateDecodedAsset)
-            .with(eq(arrangement.mockedImageContent.remoteData.assetId), any(), any(), any(), any(), any(), eq(true))
+            .with(eq(arrangement.mockedImageContent.remoteData.assetId), any(), any(), any(), any(), any(), any(), eq(true))
             .wasInvoked(once)
         verify(arrangement.updateAssetMessageDownloadStatus)
             .suspendFunction(arrangement.updateAssetMessageDownloadStatus::invoke)
@@ -170,7 +170,7 @@ class GetMessageAssetUseCaseTest {
         // Then
         verify(arrangement.assetDataSource)
             .suspendFunction(arrangement.assetDataSource::fetchPrivateDecodedAsset)
-            .with(eq(arrangement.mockedImageContent.remoteData.assetId), any(), any(), any(), any(), any(), eq(false))
+            .with(eq(arrangement.mockedImageContent.remoteData.assetId), any(), any(), any(), any(), any(), any(), eq(false))
             .wasInvoked(once)
         verify(arrangement.updateAssetMessageDownloadStatus)
             .suspendFunction(arrangement.updateAssetMessageDownloadStatus::invoke)
@@ -262,6 +262,7 @@ class GetMessageAssetUseCaseTest {
             given(assetDataSource)
                 .suspendFunction(assetDataSource::fetchPrivateDecodedAsset)
                 .whenInvokedWith(
+                    anything(),
                     anything(),
                     anything(),
                     anything(),

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -48,5 +48,10 @@ kotlin {
                 implementation(libs.annotation)
             }
         }
+        val jvmMain by getting {
+            dependencies {
+                implementation(libs.apacheTika)
+            }
+        }
     }
 }

--- a/util/src/androidMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
+++ b/util/src/androidMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.util
+
+import android.webkit.MimeTypeMap
+
+actual fun getExtensionFromMimeType(mimeType: String?): String? =
+    MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)?.removePrefix(".")

--- a/util/src/appleMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
+++ b/util/src/appleMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.util
 actual fun getExtensionFromMimeType(mimeType: String?): String? =
     mimeType?.let { mimeTypeToExtensionMap[it.lowercase()] } // TODO: replace with a proper platform implementation
 
-private val mimeTypeToExtensionMap: Map<String, String> =  // TODO: remove after all platforms have their own proper implementations
+private val mimeTypeToExtensionMap: Map<String, String> = // TODO: remove after all platforms have their own proper implementations
     mapOf(
         "image/jpg" to "jpg",
         "image/jpeg" to "jpeg",

--- a/util/src/appleMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
+++ b/util/src/appleMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.util
+
+actual fun getExtensionFromMimeType(mimeType: String?): String? =
+    mimeType?.let { mimeTypeToExtensionMap[it.lowercase()] } // TODO: replace with a proper platform implementation
+
+private val mimeTypeToExtensionMap: Map<String, String> =  // TODO: remove after all platforms have their own proper implementations
+    mapOf(
+        "image/jpg" to "jpg",
+        "image/jpeg" to "jpeg",
+        "image/png" to "png",
+        "image/heic" to "heic",
+        "image/gif" to "gif",
+        "image/webp" to "webp",
+        "audio/mpeg" to "mp3",
+        "audio/ogg" to "ogg",
+        "audio/wav" to "wav",
+        "audio/x-wav" to "wav",
+        "audio/x-pn-wav" to "wav",
+        "video/mp4" to "mp4",
+        "video/webm" to "webm",
+        "video/3gpp" to "3gpp",
+        "video/mkv" to "mkv",
+        "application/zip" to "zip",
+        "application/pdf" to "pdf"
+    )

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.util
+
+expect fun getExtensionFromMimeType(mimeType: String?): String?

--- a/util/src/jsMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
+++ b/util/src/jsMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.util
 actual fun getExtensionFromMimeType(mimeType: String?): String? =
     mimeType?.let { mimeTypeToExtensionMap[it.lowercase()] } // TODO: replace with a proper platform implementation
 
-private val mimeTypeToExtensionMap: Map<String, String> =  // TODO: remove after all platforms have their own proper implementations
+private val mimeTypeToExtensionMap: Map<String, String> = // TODO: remove after all platforms have their own proper implementations
     mapOf(
         "image/jpg" to "jpg",
         "image/jpeg" to "jpeg",

--- a/util/src/jsMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
+++ b/util/src/jsMain/kotlin/com.wire.kalium.util/MimeTypeUtil.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.util
+
+actual fun getExtensionFromMimeType(mimeType: String?): String? =
+    mimeType?.let { mimeTypeToExtensionMap[it.lowercase()] } // TODO: replace with a proper platform implementation
+
+private val mimeTypeToExtensionMap: Map<String, String> =  // TODO: remove after all platforms have their own proper implementations
+    mapOf(
+        "image/jpg" to "jpg",
+        "image/jpeg" to "jpeg",
+        "image/png" to "png",
+        "image/heic" to "heic",
+        "image/gif" to "gif",
+        "image/webp" to "webp",
+        "audio/mpeg" to "mp3",
+        "audio/ogg" to "ogg",
+        "audio/wav" to "wav",
+        "audio/x-wav" to "wav",
+        "audio/x-pn-wav" to "wav",
+        "video/mp4" to "mp4",
+        "video/webm" to "webm",
+        "video/3gpp" to "3gpp",
+        "video/mkv" to "mkv"
+    )

--- a/util/src/jvmMain/kotlin/com/wire/kalium/util/MimeTypeUtil.kt
+++ b/util/src/jvmMain/kotlin/com/wire/kalium/util/MimeTypeUtil.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.util
+
+import org.apache.tika.mime.MimeTypes
+
+actual fun getExtensionFromMimeType(mimeType: String?): String? =
+    mimeType?.let { MimeTypes.getDefaultMimeTypes().forName(it).extension.removePrefix(".") }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some assets uploaded from iOS or web doesn't have extension in file name.

### Causes (Optional)

Sharing those assets by share intent makes them files with unknown type

### Solutions

Get mime type from asset which doesn't have extension and map it to extension suffix to the file 


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
