### PR TITLE
feat: testservice can send and receive ephemeral messages (SQPIT-1807)

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
@@ -43,6 +43,8 @@ import java.util.Base64
 import java.util.Collections
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 sealed class ConversationRepository {
 
@@ -143,11 +145,13 @@ sealed class ConversationRepository {
             }
         }
 
+        @Suppress("LongParameterList")
         suspend fun sendTextMessage(
             instance: Instance,
             conversationId: ConversationId,
             text: String?,
             mentions: List<MessageMention>,
+            messageTimer: Int?,
             quotedMessageId: String?
         ): Response = instance.coreLogic.globalScope {
             return when (val session = session.currentSession()) {
@@ -155,8 +159,9 @@ sealed class ConversationRepository {
                     instance.coreLogic.sessionScope(session.accountInfo.userId) {
                         if (text != null) {
                             log.info("Instance ${instance.instanceId}: Send text message '$text'")
+                            val expireAfter = messageTimer?.toDuration(DurationUnit.MILLISECONDS)
                             messages.sendTextMessage(
-                                conversationId, text, mentions, null, quotedMessageId
+                                conversationId, text, mentions, expireAfter, quotedMessageId
                             ).fold({
                                 Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(it).build()
                             }, {

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendEphemeralConfirmationDeliveredRequest.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendEphemeralConfirmationDeliveredRequest.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.testservice.models
+
+data class SendEphemeralConfirmationDeliveredRequest(
+    val conversationDomain: String = "staging.zinfra.io",
+    val conversationId: String = "",
+    val firstMessageId: String = "",
+    val moreMessageIds: List<String>? = null
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR adds the ability to send timed messages via testservice and also to mark them as delivered and remove them from conversations. The functionality to mark ephemeral messages as read was not used in the automation so it does not need to be implemented.

Additionally it cleans a bit the structure of ConversationResources class.

### Testing

This was tested through running automatic test cases C318633 and C434930 which deal with ephemeral messaging.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
