### PR TITLE
feat: handle creation of conversation initial system message (AR-910)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -79,6 +79,7 @@ internal class ConversationGroupRepositoryImpl(
     private val conversationDAO: ConversationDAO,
     private val conversationApi: ConversationApi,
     private val newConversationMemberHandler: NewConversationMemberHandler,
+    private val newConversationGroupStartedHandler: NewConversationGroupStartedHandler,
     private val selfUserId: UserId,
     private val teamIdProvider: SelfTeamIdProvider,
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(),
@@ -105,6 +106,8 @@ internal class ConversationGroupRepositoryImpl(
 
                     wrapStorageRequest {
                         conversationDAO.insertConversation(conversationEntity)
+                    }.flatMap {
+                        newConversationGroupStartedHandler.handle(conversationEntity)
                     }.flatMap {
                         newConversationMemberHandler.handleMembersJoinedFromResponse(
                             conversationEntity.id, conversationResponse, usersList

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewConversationGroupStartedHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewConversationGroupStartedHandler.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.id.toModel
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.persistence.dao.ConversationEntity
+import com.wire.kalium.util.DateTimeUtil
+
+/**
+ * Handles the creation started message for a group conversation.
+ */
+internal interface NewConversationGroupStartedHandler {
+    suspend fun handle(conversation: ConversationEntity): Either<CoreFailure, Unit>
+}
+
+internal class NewConversationGroupStartedHandlerImpl(
+    private val persistMessage: PersistMessageUseCase,
+    private val selfUserId: UserId,
+) : NewConversationGroupStartedHandler {
+
+    override suspend fun handle(conversation: ConversationEntity): Either<CoreFailure, Unit> = run {
+        if (conversation.type != ConversationEntity.Type.GROUP) {
+            return Either.Right(Unit)
+        }
+
+        persistMessage(
+            Message.System(
+                uuid4().toString(),
+                MessageContent.ConversationCreated,
+                conversation.id.toModel(),
+                DateTimeUtil.currentIsoDateTimeString(),
+                selfUserId,
+                Message.Status.SENT,
+                Message.Visibility.VISIBLE
+            )
+        )
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -277,6 +277,10 @@ sealed interface Message {
                 is MessageContent.ConversationMessageTimerChanged -> mutableMapOf(
                     typeKey to "conversationMessageTimerChanged"
                 )
+
+                is MessageContent.ConversationCreated -> mutableMapOf(
+                    typeKey to "conversationCreated"
+                )
             }
 
             val standardProperties = mapOf(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -237,6 +237,7 @@ sealed class MessageContent {
     object CryptoSessionReset : System()
 
     object HistoryLost : System()
+    object ConversationCreated : System()
 }
 
 sealed class MessagePreviewContent {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -216,6 +216,7 @@ class MessageMapperImpl(
             MessageEntity.ContentType.CONVERSATION_RECEIPT_MODE_CHANGED -> null
             MessageEntity.ContentType.HISTORY_LOST -> null
             MessageEntity.ContentType.CONVERSATION_MESSAGE_TIMER_CHANGED -> null
+            MessageEntity.ContentType.CONVERSATION_CREATED -> null
         }
     }
 
@@ -285,6 +286,7 @@ class MessageMapperImpl(
         is MessageContent.Knock -> MessageEntityContent.Knock(hotKnock = regularMessage.hotKnock)
     }
 
+    @Suppress("ComplexMethod")
     private fun MessageContent.System.toMessageEntityContent(): MessageEntityContent.System = when (this) {
         is MessageContent.MemberChange -> {
             val memberUserIdList = this.members.map { it.toDao() }
@@ -311,6 +313,7 @@ class MessageMapperImpl(
         is MessageContent.ConversationReceiptModeChanged -> MessageEntityContent.ConversationReceiptModeChanged(receiptMode)
         is MessageContent.HistoryLost -> MessageEntityContent.HistoryLost
         is MessageContent.ConversationMessageTimerChanged -> MessageEntityContent.ConversationMessageTimerChanged(messageTimer)
+        is MessageContent.ConversationCreated -> MessageEntityContent.ConversationCreated
     }
 
     private fun MessageEntityContent.Regular.toMessageContent(hidden: Boolean): MessageContent.Regular = when (this) {
@@ -376,6 +379,7 @@ class MessageMapperImpl(
         else -> MessageContent.QuotedMessageDetails.Invalid
     }
 
+    @Suppress("ComplexMethod")
     private fun MessageEntityContent.System.toMessageContent(): MessageContent.System = when (this) {
         is MessageEntityContent.MemberChange -> {
             val memberList = this.memberUserIdList.map { it.toModel() }
@@ -395,6 +399,7 @@ class MessageMapperImpl(
         is MessageEntityContent.ConversationReceiptModeChanged -> MessageContent.ConversationReceiptModeChanged(receiptMode)
         is MessageEntityContent.HistoryLost -> MessageContent.HistoryLost
         is MessageEntityContent.ConversationMessageTimerChanged -> MessageContent.ConversationMessageTimerChanged(messageTimer)
+        is MessageEntityContent.ConversationCreated -> MessageContent.ConversationCreated
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -95,5 +95,6 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.ConversationMessageTimerChanged -> false
             is MessageContent.MemberChange.CreationAdded -> false
             is MessageContent.MemberChange.FailedToAdd -> false
+            is MessageContent.ConversationCreated -> false
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -56,6 +56,8 @@ import com.wire.kalium.logic.data.conversation.ConversationGroupRepositoryImpl
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationDataSource
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.NewConversationGroupStartedHandler
+import com.wire.kalium.logic.data.conversation.NewConversationGroupStartedHandlerImpl
 import com.wire.kalium.logic.data.conversation.NewConversationMemberHandler
 import com.wire.kalium.logic.data.conversation.NewConversationMemberHandlerImpl
 import com.wire.kalium.logic.data.conversation.SubconversationRepositoryImpl
@@ -489,8 +491,15 @@ class UserSessionScope internal constructor(
             userStorage.database.conversationDAO,
             authenticatedNetworkContainer.conversationApi,
             newConversationMemberHandler,
+            newConversationGroupStartedHandler,
             userId,
             selfTeamId
+        )
+
+    private val newConversationGroupStartedHandler: NewConversationGroupStartedHandler
+        get() = NewConversationGroupStartedHandlerImpl(
+            persistMessage,
+            userId
         )
 
     private val newConversationMemberHandler: NewConversationMemberHandler

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -91,6 +91,7 @@ class ConversationGroupRepositoryTest {
             .withInsertConversationSuccess()
             .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
             .withInsertMembersWithQualifiedIdSucceeds()
+            .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .arrange()
 
@@ -123,6 +124,7 @@ class ConversationGroupRepositoryTest {
             .withInsertConversationSuccess()
             .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
             .withInsertMembersWithQualifiedIdSucceeds()
+            .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .arrange()
 
@@ -156,6 +158,7 @@ class ConversationGroupRepositoryTest {
             .withInsertConversationSuccess()
             .withMlsConversationEstablished()
             .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .arrange()
 
@@ -685,6 +688,9 @@ class ConversationGroupRepositoryTest {
         val newConversationMemberHandler = mock(NewConversationMemberHandler::class)
 
         @Mock
+        val newConversationGroupStartedHandler = mock(NewConversationGroupStartedHandler::class)
+
+        @Mock
         val joinExistingMLSConversation: JoinExistingMLSConversationUseCase = mock(JoinExistingMLSConversationUseCase::class)
 
         val conversationGroupRepository =
@@ -696,6 +702,7 @@ class ConversationGroupRepositoryTest {
                 conversationDAO,
                 conversationApi,
                 newConversationMemberHandler,
+                newConversationGroupStartedHandler,
                 TestUser.SELF.id,
                 selfTeamIdProvider
             )
@@ -984,6 +991,13 @@ class ConversationGroupRepositoryTest {
                 .suspendFunction(conversationDAO::observeGuestRoomLinkByConversationId)
                 .whenInvokedWith(any())
                 .thenReturn(GUEST_ROOM_LINK_FLOW)
+        }
+
+        fun withSuccessfulNewConversationGroupStartedHandled() = apply {
+            given(newConversationGroupStartedHandler)
+                .suspendFunction(newConversationGroupStartedHandler::handle)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
         }
 
         fun withSuccessfulNewConversationMemberHandled() = apply {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -188,7 +188,8 @@ sealed class MessageEntity(
     enum class ContentType {
         TEXT, ASSET, KNOCK, MEMBER_CHANGE, MISSED_CALL, RESTRICTED_ASSET,
         CONVERSATION_RENAMED, UNKNOWN, FAILED_DECRYPTION, REMOVED_FROM_TEAM, CRYPTO_SESSION_RESET,
-        NEW_CONVERSATION_RECEIPT_MODE, CONVERSATION_RECEIPT_MODE_CHANGED, HISTORY_LOST, CONVERSATION_MESSAGE_TIMER_CHANGED
+        NEW_CONVERSATION_RECEIPT_MODE, CONVERSATION_RECEIPT_MODE_CHANGED, HISTORY_LOST, CONVERSATION_MESSAGE_TIMER_CHANGED,
+        CONVERSATION_CREATED
     }
 
     enum class MemberChangeType {
@@ -311,6 +312,7 @@ sealed class MessageEntityContent {
     data class ConversationReceiptModeChanged(val receiptMode: Boolean) : System()
     data class ConversationMessageTimerChanged(val messageTimer: Long?) : System()
     object HistoryLost : System()
+    object ConversationCreated : System()
 }
 
 /**

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageInsertExtension.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageInsertExtension.kt
@@ -218,6 +218,10 @@ internal class MessageInsertExtensionImpl(
                 conversation_id = message.conversationId,
                 message_timer = content.messageTimer
             )
+
+            is MessageEntityContent.ConversationCreated -> {
+                /* no-op */
+            }
         }
     }
 
@@ -312,5 +316,6 @@ internal class MessageInsertExtensionImpl(
         is MessageEntityContent.ConversationReceiptModeChanged -> MessageEntity.ContentType.CONVERSATION_RECEIPT_MODE_CHANGED
         is MessageEntityContent.HistoryLost -> MessageEntity.ContentType.HISTORY_LOST
         is MessageEntityContent.ConversationMessageTimerChanged -> MessageEntity.ContentType.CONVERSATION_MESSAGE_TIMER_CHANGED
+        is MessageEntityContent.ConversationCreated -> MessageEntity.ContentType.CONVERSATION_CREATED
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -184,6 +184,7 @@ object MessageMapper {
             MessageEntity.ContentType.CONVERSATION_RECEIPT_MODE_CHANGED -> MessagePreviewEntityContent.Unknown
             MessageEntity.ContentType.HISTORY_LOST -> MessagePreviewEntityContent.Unknown
             MessageEntity.ContentType.CONVERSATION_MESSAGE_TIMER_CHANGED -> MessagePreviewEntityContent.Unknown
+            MessageEntity.ContentType.CONVERSATION_CREATED -> MessagePreviewEntityContent.Unknown
         }
     }
 
@@ -488,6 +489,8 @@ object MessageMapper {
             MessageEntity.ContentType.CONVERSATION_MESSAGE_TIMER_CHANGED -> MessageEntityContent.ConversationMessageTimerChanged(
                 messageTimer = conversationMessageTimerChanged
             )
+
+            MessageEntity.ContentType.CONVERSATION_CREATED -> MessageEntityContent.ConversationCreated
         }
 
         return createMessageEntity(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we don't show a system message when starting a group conversation.

### Solutions

This PR:
- Add the system message into the creation conversation flow about when the conversation was created/started date.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
