### PR TITLE
fix: add proper scope instead of view model scope

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCaseTest.kt
@@ -27,12 +27,10 @@ import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.feature.SelfTeamIdProvider
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.given
 import io.mockative.mock
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -51,15 +49,13 @@ class ObserveAllServicesUseCaseTest {
             serviceDetails.copy(id = ServiceId("id2", "providerId"))
         )
 
-        val scope = CoroutineScope(TestKaliumDispatcher.main)
-
         val (_, observeAllServicesUseCase) = Arrangement()
             .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
             .withSyncingServices()
             .withObserveAllServices(flowOf(Either.Right(expected)))
             .arrange()
 
-        observeAllServicesUseCase(scope).first().also {
+        observeAllServicesUseCase().first().also {
             assertEquals(expected, it)
         }
     }
@@ -74,9 +70,7 @@ class ObserveAllServicesUseCaseTest {
             .withObserveAllServices(flowOf(Either.Left(error)))
             .arrange()
 
-        val scope = CoroutineScope(TestKaliumDispatcher.main)
-
-        observeAllServicesUseCase(scope).first().also {
+        observeAllServicesUseCase().first().also {
             assertEquals(emptyList<ServiceDetails>(), it)
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were using the scope from the view model to launch syncing of services when collecting all services from DB

### Solutions

Use proper usecase scope

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
