### PR TITLE
fix: testservice did not start up anymore because of slf4j dependency

### DIFF
--- a/testservice/build.gradle.kts
+++ b/testservice/build.gradle.kts
@@ -62,7 +62,9 @@ dependencies {
     add("implementation", "io.prometheus:simpleclient_dropwizard:${Versions.prometheus_simpleclient}")
     add("implementation", "io.prometheus:simpleclient_servlet:${Versions.prometheus_simpleclient}")
 
-    add("implementation", project(":network"))
+    add("implementation", project(":network")) {
+        exclude("org.slf4j", "slf4j-api")
+    }
     add("implementation", project(":cryptography")) {
         exclude("org.slf4j", "slf4j-api")
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Testservice failed with an exception on startup:
```
Exception in thread "main" java.lang.IllegalStateException: Unable to acquire the logger context
        at io.dropwizard.logging.LoggingUtil.getLoggerContext(LoggingUtil.java:46)
        at io.dropwizard.logging.BootstrapLogging.bootstrap(BootstrapLogging.java:51)
        at io.dropwizard.logging.BootstrapLogging.bootstrap(BootstrapLogging.java:40)
        at io.dropwizard.Application.bootstrapLogging(Application.java:38)
        at io.dropwizard.Application.<init>(Application.java:26)
        at com.wire.kalium.testservice.TestserviceApplication.<init>(TestserviceApplication.kt:41)
        at com.wire.kalium.testservice.TestserviceApplication$Companion.main(TestserviceApplication.kt:48)
        at com.wire.kalium.testservice.TestserviceApplication.main(TestserviceApplication.kt)
```

### Causes (Optional)

dropwizard has problems loading slf4j logger contexts.

### Solutions

Exclude the slf4j dependency from testservice build configuration.

