### PR TITLE
feat: start self delete after the message is sent

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1131,7 +1131,8 @@ class UserSessionScope internal constructor(
             syncManager,
             slowSyncRepository,
             messageSendingScheduler,
-            this,
+            selfConversationIdProvider,
+            this
         )
     val messages: MessageScope
         get() = MessageScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.debug
 
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
@@ -45,6 +46,9 @@ import com.wire.kalium.logic.feature.message.MessageSendingInterceptorImpl
 import com.wire.kalium.logic.feature.message.MessageSendingScheduler
 import com.wire.kalium.logic.feature.message.SessionEstablisher
 import com.wire.kalium.logic.feature.message.SessionEstablisherImpl
+import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl
+import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.util.MessageContentEncoder
 import com.wire.kalium.util.KaliumDispatcher
@@ -70,6 +74,7 @@ class DebugScope internal constructor(
     private val syncManager: SyncManager,
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
+    private val selfConversationIdProvider: SelfConversationIdProvider,
     private val scope: CoroutineScope,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
@@ -133,6 +138,28 @@ class DebugScope internal constructor(
             mlsMessageCreator,
             messageSendingInterceptor,
             userRepository,
+            ephemeralMessageDeletionHandler,
             scope
+        )
+
+    private val deleteEphemeralMessageForSelfUserAsReceiver: DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl
+        get() = DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
+            messageRepository = messageRepository,
+            assetRepository = assetRepository,
+            currentClientIdProvider = currentClientIdProvider,
+            messageSender = messageSender,
+            selfUserId = userId,
+            selfConversationIdProvider = selfConversationIdProvider
+        )
+
+    private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
+        get() = DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl(messageRepository)
+
+    private val ephemeralMessageDeletionHandler =
+        EphemeralMessageDeletionHandlerImpl(
+            userSessionCoroutineScope = scope,
+            messageRepository = messageRepository,
+            deleteEphemeralMessageForSelfUserAsReceiver = deleteEphemeralMessageForSelfUserAsReceiver,
+            deleteEphemeralMessageForSelfUserAsSender = deleteEphemeralMessageForSelfUserAsSender,
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -125,6 +125,7 @@ class MessageScope internal constructor(
             mlsMessageCreator,
             messageSendingInterceptor,
             userRepository,
+            ephemeralMessageDeletionHandler,
             scope
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -38,7 +38,7 @@ import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.failure.ProteusSendMessageFailure
-import com.wire.kalium.logic.feature.message.ephemeral.SelfDeleteMessageSenderHandler
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
@@ -132,7 +132,7 @@ internal class MessageSenderImpl internal constructor(
     private val mlsMessageCreator: MLSMessageCreator,
     private val messageSendingInterceptor: MessageSendingInterceptor,
     private val userRepository: UserRepository,
-    private val selfDeleteMessageSenderHandler: SelfDeleteMessageSenderHandler,
+    private val selfDeleteMessageSenderHandler: EphemeralMessageDeletionHandler,
     private val scope: CoroutineScope
 ) : MessageSender {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -120,7 +120,7 @@ interface MessageSender {
     suspend fun sendClientDiscoveryMessage(message: Message.Regular): Either<CoreFailure, String>
 }
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 internal class MessageSenderImpl internal constructor(
     private val messageRepository: MessageRepository,
     private val conversationRepository: ConversationRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -35,17 +35,19 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageEnvelope
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.logic.data.message.getType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.failure.ProteusSendMessageFailure
+import com.wire.kalium.logic.feature.message.ephemeral.SelfDeleteMessageSenderHandler
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.logic.util.isPositiveNotNull
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isMlsStaleMessage
 import com.wire.kalium.util.DateTimeUtil
@@ -130,6 +132,7 @@ internal class MessageSenderImpl internal constructor(
     private val mlsMessageCreator: MLSMessageCreator,
     private val messageSendingInterceptor: MessageSendingInterceptor,
     private val userRepository: UserRepository,
+    private val selfDeleteMessageSenderHandler: SelfDeleteMessageSenderHandler,
     private val scope: CoroutineScope
 ) : MessageSender {
 
@@ -144,7 +147,7 @@ internal class MessageSenderImpl internal constructor(
                     else Either.Left(StorageFailure.Generic(IllegalArgumentException("Client cannot send server messages")))
                 result
                     .onFailure {
-                        val type = message.content.getType()
+                        val type = getType(message.content) ?: "Unknown"
                         logger.i("Failed to send message of type $type. Failure = $it")
                         messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
                             failure = it,
@@ -216,7 +219,15 @@ internal class MessageSenderImpl internal constructor(
                         attemptToSendWithProteus(message, messageTarget)
                     }
                 }
+            }.onSuccess {
+                startSelfDeletionIfNeeded(message)
             }
+    }
+
+    private fun startSelfDeletionIfNeeded(message: Message.Sendable) {
+        if (message is Message.Regular && message.expirationData?.expireAfter.isPositiveNotNull()) {
+            selfDeleteMessageSenderHandler.enqueueSelfDeletion(message)
+        }
     }
 
     private suspend fun attemptToSendWithProteus(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageEnvelope
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.getType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.failure.ProteusSendMessageFailure
@@ -147,7 +148,7 @@ internal class MessageSenderImpl internal constructor(
                     else Either.Left(StorageFailure.Generic(IllegalArgumentException("Client cannot send server messages")))
                 result
                     .onFailure {
-                        val type = getType(message.content) ?: "Unknown"
+                        val type = message.content.getType()
                         logger.i("Failed to send message of type $type. Failure = $it")
                         messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
                             failure = it,
@@ -160,8 +161,6 @@ internal class MessageSenderImpl internal constructor(
             }
         }
     }
-
-    private fun getType(messageContent: MessageContent?) = messageContent?.let { it::class.simpleName }
 
     override suspend fun sendMessage(message: Message.Sendable, messageTarget: MessageTarget): Either<CoreFailure, Unit> =
         messageSendingInterceptor

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
@@ -14,10 +14,14 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.CoroutineContext
 
-interface EphemeralMessageDeletionHandler {
+internal interface EphemeralMessageDeletionHandler {
 
     fun startSelfDeletion(conversationId: ConversationId, messageId: String)
     fun enqueuePendingSelfDeletionMessages()
+}
+
+internal interface SelfDeleteMessageSenderHandler {
+    fun enqueueSelfDeletion(message: Message.Regular)
 }
 
 internal class EphemeralMessageDeletionHandlerImpl(
@@ -26,7 +30,7 @@ internal class EphemeralMessageDeletionHandlerImpl(
     private val deleteEphemeralMessageForSelfUserAsReceiver: DeleteEphemeralMessageForSelfUserAsReceiverUseCase,
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCase,
     userSessionCoroutineScope: CoroutineScope
-) : EphemeralMessageDeletionHandler, CoroutineScope by userSessionCoroutineScope {
+) : EphemeralMessageDeletionHandler, SelfDeleteMessageSenderHandler, CoroutineScope by userSessionCoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = kaliumDispatcher.default
 
@@ -40,7 +44,15 @@ internal class EphemeralMessageDeletionHandlerImpl(
         }
     }
 
-    private suspend fun enqueueSelfDeletion(message: Message.Regular) {
+    override fun enqueueSelfDeletion(message: Message.Regular) {
+        val canBeDeleted = when(message.status) {
+            Message.Status.PENDING -> false
+            Message.Status.SENT,
+            Message.Status.READ,
+            Message.Status.FAILED,
+            Message.Status.FAILED_REMOTELY -> true
+        }
+        if (!canBeDeleted) return
         launch {
             ongoingSelfDeletionMessagesMutex.withLock {
                 val isSelfDeletionOutgoing = ongoingSelfDeletionMessages[message.conversationId to message.id] != null

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
@@ -42,7 +42,7 @@ internal class EphemeralMessageDeletionHandlerImpl(
     }
 
     override fun enqueueSelfDeletion(message: Message.Regular) {
-        val canBeDeleted = when(message.status) {
+        val canBeDeleted = when (message.status) {
             Message.Status.PENDING -> false
             Message.Status.SENT,
             Message.Status.READ,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
@@ -17,11 +17,8 @@ import kotlin.coroutines.CoroutineContext
 internal interface EphemeralMessageDeletionHandler {
 
     fun startSelfDeletion(conversationId: ConversationId, messageId: String)
-    fun enqueuePendingSelfDeletionMessages()
-}
-
-internal interface SelfDeleteMessageSenderHandler {
     fun enqueueSelfDeletion(message: Message.Regular)
+    fun enqueuePendingSelfDeletionMessages()
 }
 
 internal class EphemeralMessageDeletionHandlerImpl(
@@ -30,7 +27,7 @@ internal class EphemeralMessageDeletionHandlerImpl(
     private val deleteEphemeralMessageForSelfUserAsReceiver: DeleteEphemeralMessageForSelfUserAsReceiverUseCase,
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCase,
     userSessionCoroutineScope: CoroutineScope
-) : EphemeralMessageDeletionHandler, SelfDeleteMessageSenderHandler, CoroutineScope by userSessionCoroutineScope {
+) : EphemeralMessageDeletionHandler, CoroutineScope by userSessionCoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = kaliumDispatcher.default
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.MessageSenderTest.Arrangement.Companion.FEDERATION_MESSAGE_FAILURE
 import com.wire.kalium.logic.feature.message.MessageSenderTest.Arrangement.Companion.TEST_PROTOCOL_INFO_FAILURE
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.functional.Either
@@ -65,6 +66,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MessageSenderTest {
@@ -699,6 +701,32 @@ class MessageSenderTest {
         }
     }
 
+    @Test
+    fun givenAllStepsSucceed_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldStart() {
+        val duration = Duration.parse("PT1M")
+        val message = TestMessage.TEXT_MESSAGE.copy(
+            expirationData = Message.ExpirationData(duration)
+        )
+
+        // given
+        val (arrangement, messageSender) = Arrangement()
+            .withSendProteusMessage()
+            .withPromoteMessageToSentUpdatingServerTime()
+            .arrange()
+
+        arrangement.testScope.runTest {
+            // when
+            val result = messageSender.sendMessage(message)
+
+            // then
+            result.shouldSucceed()
+            verify(arrangement.selfDeleteMessageSenderHandler)
+                .function(arrangement.selfDeleteMessageSenderHandler::enqueueSelfDeletion)
+                .with(eq(message))
+                .wasInvoked(exactly = once)
+        }
+    }
+
     private class Arrangement {
         @Mock
         val messageRepository: MessageRepository = mock(MessageRepository::class)
@@ -727,6 +755,9 @@ class MessageSenderTest {
         @Mock
         val userRepository = configure(mock(UserRepository::class)) { stubsUnitByDefault = true }
 
+        @Mock
+        val selfDeleteMessageSenderHandler = mock(EphemeralMessageDeletionHandler::class)
+
         val testScope = TestScope()
 
         private val messageSendingInterceptor = object : MessageSendingInterceptor {
@@ -746,6 +777,7 @@ class MessageSenderTest {
             mlsMessageCreator = mlsMessageCreator,
             messageSendingInterceptor = messageSendingInterceptor,
             userRepository = userRepository,
+            selfDeleteMessageSenderHandler = selfDeleteMessageSenderHandler,
             scope = testScope
         )
 
@@ -880,16 +912,22 @@ class MessageSenderTest {
             createOutgoingEnvelopeFailing: Boolean = false,
             sendEnvelopeWithResult: Either<CoreFailure, String>? = null,
             updateMessageStatusFailing: Boolean = false
-        ) =
-            apply {
-                withGetMessageById()
-                if (getConversationProtocolFailing) withGetProtocolInfoFailing() else withGetProtocolInfo()
-                withGetConversationRecipients(getConversationsRecipientFailing)
-                withPrepareRecipientsForNewOutgoingMessage(prepareRecipientsForNewOutGoingMessageFailing)
-                withCreateOutgoingEnvelope(createOutgoingEnvelopeFailing)
-                if (sendEnvelopeWithResult != null) withSendEnvelope(sendEnvelopeWithResult) else withSendEnvelope()
-                withUpdateMessageStatus(updateMessageStatusFailing)
-            }
+        ) = apply {
+            withGetMessageById()
+            if (getConversationProtocolFailing) withGetProtocolInfoFailing() else withGetProtocolInfo()
+            withGetConversationRecipients(getConversationsRecipientFailing)
+            withPrepareRecipientsForNewOutgoingMessage(prepareRecipientsForNewOutGoingMessageFailing)
+            withCreateOutgoingEnvelope(createOutgoingEnvelopeFailing)
+            if (sendEnvelopeWithResult != null) withSendEnvelope(sendEnvelopeWithResult) else withSendEnvelope()
+            withUpdateMessageStatus(updateMessageStatusFailing)
+        }
+
+        fun withEnqueueSelfDeleteMessage() = apply {
+            given(selfDeleteMessageSenderHandler)
+                .function(selfDeleteMessageSenderHandler::enqueueSelfDeletion)
+                .whenInvokedWith(anything())
+                .thenReturn(Unit)
+        }
 
         fun withSendMlsMessage(
             sendMlsMessageWithResult: Either<CoreFailure, String>? = null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandlerTest.kt
@@ -42,7 +42,8 @@ class EphemeralMessageDeletionHandlerTest {
                 expireAfter = 1.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
             ),
-            isSelfMessage = false
+            isSelfMessage = false,
+            status = Message.Status.SENT
         )
 
         val (arrangement, ephemeralMessageDeletionHandler) = Arrangement(
@@ -82,7 +83,8 @@ class EphemeralMessageDeletionHandlerTest {
                 expireAfter = 1.seconds,
                 selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
             ),
-            isSelfMessage = false
+            isSelfMessage = false,
+            status = Message.Status.SENT
         )
 
         val (arrangement, ephemeralMessageDeletionHandler) = Arrangement(this, testDispatcher)
@@ -141,7 +143,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = timeUntilExpiration,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val (arrangement, ephemeralMessageDeletionHandler) = Arrangement(
@@ -178,7 +181,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = timeUntilExpiration,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = true
+                isSelfMessage = true,
+                status = Message.Status.SENT
             )
 
             val (arrangement, ephemeralMessageDeletionHandler) = Arrangement(
@@ -215,7 +219,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = timeUntilExpiration,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val (arrangement, ephemeralMessageDeletionHandler) = Arrangement(this, testDispatcher)
@@ -285,7 +290,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = timeUntilExpiration,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val pendingMessagesToDelete = listOf(
@@ -331,7 +337,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = timeUntilExpiration,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = true
+                isSelfMessage = true,
+                status = Message.Status.SENT
             )
 
             val pendingMessagesToDelete = listOf(
@@ -376,7 +383,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 1.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val twoSecondEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
@@ -385,7 +393,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 2.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val threeSecondsEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
@@ -394,7 +403,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 3.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val fourSecondsEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
@@ -403,7 +413,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 4.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val pendingMessagesToDelete = listOf(
@@ -464,7 +475,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 1.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = true
+                isSelfMessage = true,
+                status = Message.Status.SENT
             )
 
             val twoSecondEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
@@ -473,7 +485,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 2.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = true
+                isSelfMessage = true,
+                status = Message.Status.SENT
             )
 
             val threeSecondsEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
@@ -482,7 +495,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 3.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = true
+                isSelfMessage = true,
+                status = Message.Status.SENT
             )
 
             val fourSecondsEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
@@ -491,7 +505,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 4.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = true
+                isSelfMessage = true,
+                status = Message.Status.SENT
             )
 
             val pendingMessagesToDelete = listOf(
@@ -551,7 +566,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 1.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val twoSecondsEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
@@ -559,7 +575,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 2.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = false
+                isSelfMessage = false,
+                status = Message.Status.SENT
             )
 
             val pendingMessagesToDeletePastTheTime = listOf(
@@ -599,7 +616,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 1.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = true
+                isSelfMessage = true,
+                status = Message.Status.SENT
             )
 
             val twoSecondsEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
@@ -607,7 +625,8 @@ class EphemeralMessageDeletionHandlerTest {
                     expireAfter = 2.seconds,
                     selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
                 ),
-                isSelfMessage = true
+                isSelfMessage = true,
+                status = Message.Status.SENT
             )
 
             val pendingMessagesToDeletePastTheTime = listOf(
@@ -638,6 +657,49 @@ class EphemeralMessageDeletionHandlerTest {
                 .wasInvoked(Times(pendingMessagesToDeletePastTheTime.size))
 
         }
+
+    @Test
+    fun givenPendingMessage_whenEnqueuingMessageForSelfDelete_thenDoNothing() = runTest(
+        testDispatcher.default
+    ) {
+        // given
+        val oneSecondEphemeralMessage = TestMessage.TEXT_MESSAGE.copy(
+            id = "1",
+            expirationData = Message.ExpirationData(
+                expireAfter = 1.seconds,
+                selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
+            ),
+            isSelfMessage = false,
+            status = Message.Status.PENDING
+        )
+
+        val (arrangement, ephemeralMessageDeletionHandler) = Arrangement(
+            coroutineScope = this,
+            dispatcher = testDispatcher
+        ).withMessageRepositoryReturningMessage(oneSecondEphemeralMessage)
+            .withMessageRepositoryMarkingSelfDeletionStartDate()
+            .withDeletingMessage()
+            .arrange()
+
+        // when
+        ephemeralMessageDeletionHandler.startSelfDeletion(
+            conversationId = oneSecondEphemeralMessage.conversationId,
+            messageId = oneSecondEphemeralMessage.id
+        )
+
+        advanceUntilIdle()
+
+        // then
+        verify(arrangement.messageRepository)
+            .suspendFunction(arrangement.messageRepository::markSelfDeletionStartDate)
+            .with(any())
+            .wasNotInvoked()
+
+        verify(arrangement.messageRepository)
+            .suspendFunction(arrangement.messageRepository::getMessageById)
+            .with(eq(oneSecondEphemeralMessage.conversationId), eq(oneSecondEphemeralMessage.id))
+            .wasInvoked(exactly = once)
+    }
 
     private fun TestScope.advanceTimeBy(duration: Duration) = advanceTimeBy(duration.inWholeMilliseconds)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

self delete timer is started even when the message is not yet sent

### Solutions

start the timer after the message is sent

### Need to be released with
- [x] https://github.com/wireapp/kalium/pull/1765

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
