### PR TITLE
fix: other participant leaving an MLS conference call WPB-349

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -38,8 +38,10 @@ import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.combine
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
+import com.wire.kalium.logic.functional.flatten
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
@@ -63,6 +65,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlin.time.Duration
 
 data class ApplicationMessage(
@@ -92,8 +95,8 @@ interface MLSConversationRepository {
     suspend fun getMLSGroupsRequiringKeyingMaterialUpdate(threshold: Duration): Either<CoreFailure, List<GroupID>>
     suspend fun updateKeyingMaterial(groupID: GroupID): Either<CoreFailure, Unit>
     suspend fun commitPendingProposals(groupID: GroupID): Either<CoreFailure, Unit>
-    suspend fun setProposalTimer(timer: ProposalTimer)
-    suspend fun observeProposalTimers(): Flow<List<ProposalTimer>>
+    suspend fun setProposalTimer(timer: ProposalTimer, inMemory: Boolean = false)
+    suspend fun observeProposalTimers(): Flow<ProposalTimer>
     suspend fun observeEpochChanges(): Flow<GroupID>
 }
 
@@ -131,6 +134,7 @@ class MLSConversationDataSource(
     private val mlsPublicKeysRepository: MLSPublicKeysRepository,
     private val commitBundleEventReceiver: CommitBundleEventReceiver,
     private val epochsFlow: MutableSharedFlow<GroupID>,
+    private val proposalTimersFlow: MutableSharedFlow<ProposalTimer>,
     private val idMapper: IdMapper = MapperProvider.idMapper(),
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(),
     private val mlsPublicKeysMapper: MLSPublicKeysMapper = MapperProvider.mlsPublicKeyMapper(),
@@ -300,13 +304,19 @@ class MLSConversationDataSource(
                 }
             }
 
-    override suspend fun setProposalTimer(timer: ProposalTimer) {
-        conversationDAO.setProposalTimer(conversationMapper.toDAOProposalTimer(timer))
+    override suspend fun setProposalTimer(timer: ProposalTimer, inMemory: Boolean) {
+        if (inMemory) {
+            proposalTimersFlow.emit(timer)
+        } else {
+            conversationDAO.setProposalTimer(conversationMapper.toDAOProposalTimer(timer))
+        }
     }
 
-    override suspend fun observeProposalTimers(): Flow<List<ProposalTimer>> {
-        return conversationDAO.getProposalTimers().map { it.map(conversationMapper::fromDaoModel) }
-    }
+    override suspend fun observeProposalTimers(): Flow<ProposalTimer> =
+        merge(
+            proposalTimersFlow,
+            conversationDAO.getProposalTimers().map { it.map(conversationMapper::fromDaoModel) }.flatten()
+        )
 
     override suspend fun observeEpochChanges(): Flow<GroupID> {
         return epochsFlow

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -38,7 +38,6 @@ import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.combine
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.flatten

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubconversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubconversationRepository.kt
@@ -28,6 +28,7 @@ interface SubconversationRepository {
     suspend fun insertSubconversation(conversationId: ConversationId, subconversationId: SubconversationId, groupId: GroupID)
     suspend fun getSubconversationInfo(conversationId: ConversationId, subconversationId: SubconversationId): GroupID?
     suspend fun deleteSubconversation(conversationId: ConversationId, subconversationId: SubconversationId)
+    suspend fun containsSubconversation(groupId: GroupID): Boolean
 
 }
 
@@ -45,6 +46,12 @@ class SubconversationRepositoryImpl : SubconversationRepository {
     override suspend fun getSubconversationInfo(conversationId: ConversationId, subconversationId: SubconversationId): GroupID? {
         mutex.withLock {
             return subconversations[Pair(conversationId, subconversationId)]
+        }
+    }
+
+    override suspend fun containsSubconversation(groupId: GroupID): Boolean {
+        mutex.withLock {
+            return subconversations.containsValue(groupId)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -60,6 +60,7 @@ import com.wire.kalium.logic.data.conversation.NewConversationMembersRepository
 import com.wire.kalium.logic.data.conversation.NewConversationMembersRepositoryImpl
 import com.wire.kalium.logic.data.conversation.NewGroupConversationStartedMessageCreator
 import com.wire.kalium.logic.data.conversation.NewGroupConversationStartedMessageCreatorImpl
+import com.wire.kalium.logic.data.conversation.ProposalTimer
 import com.wire.kalium.logic.data.conversation.SubconversationRepositoryImpl
 import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProvider
 import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProviderImpl
@@ -382,6 +383,8 @@ class UserSessionScope internal constructor(
 
     private val epochsFlow = MutableSharedFlow<GroupID>()
 
+    private val proposalTimersFlow = MutableSharedFlow<ProposalTimer>()
+
     // TODO(refactor): Extract to Provider class and make atomic
     // val _teamId: Atomic<Either<CoreFailure, TeamId?>> = Atomic(Either.Left(CoreFailure.Unknown(Throwable("NotInitialized"))))
     private var _teamId: Either<CoreFailure, TeamId?> = Either.Left(CoreFailure.Unknown(Throwable("NotInitialized")))
@@ -463,7 +466,8 @@ class UserSessionScope internal constructor(
             syncManager,
             mlsPublicKeysRepository,
             commitBundleEventReceiver,
-            epochsFlow
+            epochsFlow,
+            proposalTimersFlow
         )
 
     private val notificationTokenRepository get() = NotificationTokenDataSource(globalPreferences.tokenStorage)
@@ -864,7 +868,12 @@ class UserSessionScope internal constructor(
     private val videoStateChecker: VideoStateChecker get() = VideoStateCheckerImpl()
 
     private val pendingProposalScheduler: PendingProposalScheduler =
-        PendingProposalSchedulerImpl(kaliumConfigs, incrementalSyncRepository, lazy { mlsConversationRepository })
+        PendingProposalSchedulerImpl(
+            kaliumConfigs,
+            incrementalSyncRepository,
+            lazy { mlsConversationRepository },
+            lazy { subconversationRepository }
+        )
 
     private val callManager: Lazy<CallManager> = lazy {
         globalCallManager.getCallManagerForClient(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -946,6 +946,8 @@ class MLSConversationRepositoryTest {
 
         val epochsFlow = MutableSharedFlow<GroupID>()
 
+        val proposalTimersFlow = MutableSharedFlow<ProposalTimer>()
+
         fun withGetConversationByGroupIdSuccessful() = apply {
             given(conversationDAO)
                 .suspendFunction(conversationDAO::getConversationByGroupID)
@@ -1113,7 +1115,8 @@ class MLSConversationRepositoryTest {
             syncManager,
             mlsPublicKeysRepository,
             commitBundleEventReceiver,
-            epochsFlow
+            epochsFlow,
+            proposalTimersFlow
         )
 
         internal companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When another participant leaves a MLS conference call he/she isn't immediately removed from the call.

### Causes

You leave an MLS conference by submitting a leave proposal to the "call" sub-conversation of the conversation where the call is happening. These leave proposals were never committed because we don't store sub-conversation in the database and the proposal timers rely on values being updated in the database.

### Solutions

Use an in memory timer when scheduling proposals from sub-conversations.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
