### PR TITLE
fix: replace @Syncronized annotation with synchronized block and wrap the shared pref builder function in object

### DIFF
--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -30,7 +30,6 @@ private fun SettingOptions.keyAlias(): String = when (this) {
 }
 
 internal actual object EncryptedSettingsBuilder {
-    @Synchronized
     private fun getOrCreateMasterKey(context: Context, keyAlias: String = MasterKey.DEFAULT_MASTER_KEY_ALIAS): MasterKey =
         MasterKey
             .Builder(context, keyAlias)
@@ -38,12 +37,11 @@ internal actual object EncryptedSettingsBuilder {
             .setRequestStrongBoxBacked(true)
             .build()
 
-    @Synchronized
     actual fun build(
         options: SettingOptions,
         param: EncryptedSettingsPlatformParam
-    ): Settings {
-        return SharedPreferencesSettings(
+    ): Settings = synchronized(this) {
+        SharedPreferencesSettings(
             if (options.shouldEncryptData) {
                 EncryptedSharedPreferences.create(
                     param.appContext,
@@ -57,7 +55,6 @@ internal actual object EncryptedSettingsBuilder {
             }, false
         )
     }
-
 }
 
 internal actual class EncryptedSettingsPlatformParam(val appContext: Context)

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -39,7 +39,7 @@ internal actual object EncryptedSettingsBuilder {
             .build()
 
     @Synchronized
-    fun build(
+    actual fun build(
         options: SettingOptions,
         param: EncryptedSettingsPlatformParam
     ): Settings {

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -29,32 +29,35 @@ private fun SettingOptions.keyAlias(): String = when (this) {
     is SettingOptions.UserSettings -> "_${this.fileName}_master_key_"
 }
 
-@Synchronized
-private fun getOrCreateMasterKey(context: Context, keyAlias: String = MasterKey.DEFAULT_MASTER_KEY_ALIAS): MasterKey =
-    MasterKey
-        .Builder(context, keyAlias)
-        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-        .setRequestStrongBoxBacked(true)
-        .build()
+internal actual object EncryptedSettingsBuilder {
+    @Synchronized
+    private fun getOrCreateMasterKey(context: Context, keyAlias: String = MasterKey.DEFAULT_MASTER_KEY_ALIAS): MasterKey =
+        MasterKey
+            .Builder(context, keyAlias)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .setRequestStrongBoxBacked(true)
+            .build()
 
-@Synchronized
-internal actual fun encryptedSettingsBuilder(
-    options: SettingOptions,
-    param: EncryptedSettingsPlatformParam
-): Settings {
-    return SharedPreferencesSettings(
-        if (options.shouldEncryptData) {
-            EncryptedSharedPreferences.create(
-                param.appContext,
-                options.fileName,
-                getOrCreateMasterKey(param.appContext, options.keyAlias()),
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-            )
-        } else {
-            param.appContext.getSharedPreferences(options.fileName, Context.MODE_PRIVATE)
-        }, false
-    )
+    @Synchronized
+    fun build(
+        options: SettingOptions,
+        param: EncryptedSettingsPlatformParam
+    ): Settings {
+        return SharedPreferencesSettings(
+            if (options.shouldEncryptData) {
+                EncryptedSharedPreferences.create(
+                    param.appContext,
+                    options.fileName,
+                    getOrCreateMasterKey(param.appContext, options.keyAlias()),
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+                )
+            } else {
+                param.appContext.getSharedPreferences(options.fileName, Context.MODE_PRIVATE)
+            }, false
+        )
+    }
+
 }
 
 internal actual class EncryptedSettingsPlatformParam(val appContext: Context)

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -28,7 +28,7 @@ import com.wire.kalium.persistence.dbPassphrase.PassphraseStorageImpl
 actual class GlobalPrefProvider(context: Context, shouldEncryptData: Boolean = true) {
 
     private val encryptedSettingsHolder: KaliumPreferences = KaliumPreferencesSettings(
-        encryptedSettingsBuilder(SettingOptions.AppSettings(shouldEncryptData), EncryptedSettingsPlatformParam(context))
+        EncryptedSettingsBuilder.build(SettingOptions.AppSettings(shouldEncryptData), EncryptedSettingsPlatformParam(context))
     )
 
     actual val authTokenStorage: AuthTokenStorage

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
@@ -32,7 +32,7 @@ actual class UserPrefBuilder(
 ) {
     private val encryptedSettingsHolder =
         KaliumPreferencesSettings(
-            encryptedSettingsBuilder(
+            EncryptedSettingsBuilder.build(
                 SettingOptions.UserSettings(shouldEncryptData = shouldEncryptData, userIDEntity = userId),
                 EncryptedSettingsPlatformParam(context)
             )

--- a/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -23,9 +23,11 @@ import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
 
 @OptIn(ExperimentalSettingsImplementation::class)
-internal actual fun encryptedSettingsBuilder(
-    options: SettingOptions,
-    param: EncryptedSettingsPlatformParam
-): Settings = KeychainSettings(param.serviceName)
+internal actual object EncryptedSettingsBuilder {
+    actual fun build(
+        options: SettingOptions,
+        param: EncryptedSettingsPlatformParam
+    ): Settings = KeychainSettings(param.serviceName)
+}
 
 internal actual class EncryptedSettingsPlatformParam(val serviceName: String)

--- a/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -30,7 +30,7 @@ actual class GlobalPrefProvider(
 ) {
     private val kaliumPref =
         KaliumPreferencesSettings(
-            encryptedSettingsBuilder(
+            EncryptedSettingsBuilder.build(
                 SettingOptions.AppSettings(shouldEncryptData),
                 EncryptedSettingsPlatformParam(rootPath)
             )

--- a/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
+++ b/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
@@ -32,7 +32,7 @@ actual class UserPrefBuilder(
 
     private val kaliumPreferences =
         KaliumPreferencesSettings(
-            encryptedSettingsBuilder(SettingOptions.UserSettings(shouldEncryptData, userId), EncryptedSettingsPlatformParam(rootPath))
+            EncryptedSettingsBuilder.build(SettingOptions.UserSettings(shouldEncryptData, userId), EncryptedSettingsPlatformParam(rootPath))
         )
 
     actual val lastRetrievedNotificationEventStorage: LastRetrievedNotificationEventStorage

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -35,6 +35,7 @@ internal sealed class SettingOptions {
     }
 }
 
-internal expect fun encryptedSettingsBuilder(options: SettingOptions, param: EncryptedSettingsPlatformParam): Settings
-
+internal expect object EncryptedSettingsBuilder {
+    fun build(options: SettingOptions, param: EncryptedSettingsPlatformParam): Settings
+}
 internal expect class EncryptedSettingsPlatformParam

--- a/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -22,9 +22,11 @@ import com.russhwolf.settings.Settings
 import com.russhwolf.settings.StorageSettings
 import org.w3c.dom.Storage
 
-internal actual fun encryptedSettingsBuilder(
-    options: SettingOptions,
-    param: EncryptedSettingsPlatformParam
-): Settings = StorageSettings(param.storage)
+internal actual object EncryptedSettingsBuilder {
+    actual fun build(
+        options: SettingOptions,
+        param: EncryptedSettingsPlatformParam
+    ): Settings = StorageSettings(param.storage)
+}
 
 internal actual class EncryptedSettingsPlatformParam(val storage: Storage)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -47,14 +47,16 @@ private fun createOrLoad(rootPath: String, file: File): Properties {
 /**
  * the java implementation is not yet encrypted
  */
-internal actual fun encryptedSettingsBuilder(
-    options: SettingOptions,
-    param: EncryptedSettingsPlatformParam
-): Settings {
-    val file: File = File(Paths.get(param.rootPath, options.fileName).toString())
-    val properties = createOrLoad(param.rootPath, file)
+internal actual object EncryptedSettingsBuilder {
+    actual fun build(
+        options: SettingOptions,
+        param: EncryptedSettingsPlatformParam
+    ): Settings {
+        val file: File = File(Paths.get(param.rootPath, options.fileName).toString())
+        val properties = createOrLoad(param.rootPath, file)
 
-    return PropertiesSettings(properties) { onModify(it, file) }
+        return PropertiesSettings(properties) { onModify(it, file) }
+    }
 }
 
 internal actual class EncryptedSettingsPlatformParam(val rootPath: String)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -30,7 +30,7 @@ actual class GlobalPrefProvider(
 ) {
     private val kaliumPref =
         KaliumPreferencesSettings(
-            encryptedSettingsBuilder(
+            EncryptedSettingsBuilder.build(
                 SettingOptions.AppSettings(shouldEncryptData),
                 EncryptedSettingsPlatformParam(rootPath)
             )

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
@@ -32,7 +32,10 @@ actual class UserPrefBuilder(
 
     private val kaliumPref =
         KaliumPreferencesSettings(
-            encryptedSettingsBuilder(SettingOptions.UserSettings(shouldEncryptData, userId), EncryptedSettingsPlatformParam(rootPath))
+            EncryptedSettingsBuilder.build(
+                SettingOptions.UserSettings(shouldEncryptData, userId),
+                EncryptedSettingsPlatformParam(rootPath)
+            )
         )
 
     actual val lastRetrievedNotificationEventStorage: LastRetrievedNotificationEventStorage

--- a/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/EncryptedSettingsBuilderTest.kt
+++ b/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/EncryptedSettingsBuilderTest.kt
@@ -19,9 +19,9 @@
 package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.kmmSettings.EncryptedSettingsBuilder
 import com.wire.kalium.persistence.kmmSettings.EncryptedSettingsPlatformParam
 import com.wire.kalium.persistence.kmmSettings.SettingOptions
-import com.wire.kalium.persistence.kmmSettings.encryptedSettingsBuilder
 import org.junit.Test
 import java.io.FileInputStream
 import java.nio.file.Files
@@ -37,7 +37,7 @@ class EncryptedSettingsBuilderTest {
         val rootPath = Files.createTempDirectory("test-rootPath").toString()
         val userIDEntity = QualifiedIDEntity("user", "domain")
 
-        val encryptedSettings = encryptedSettingsBuilder(
+        val encryptedSettings = EncryptedSettingsBuilder.build(
             SettingOptions.UserSettings(
                 shouldEncryptData = false,
                 userIDEntity
@@ -57,7 +57,7 @@ class EncryptedSettingsBuilderTest {
     fun givenJvmPropertiesSettings_WhenAppSettingsAreChanged_ThenItIsStoredInFile() {
         val rootPath = Files.createTempDirectory("test-rootPath").toString()
 
-        val encryptedSettings = encryptedSettingsBuilder(
+        val encryptedSettings = EncryptedSettingsBuilder.build(
             SettingOptions.AppSettings(
                 shouldEncryptData = false
             ),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

rare crash because of encrypted shared pref creation

### Solutions

Wrapping the build function in an object should resolve any issues with concurrency issues  

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
