### PR TITLE
fix: issue with circular dependency in MessageScope

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -138,7 +138,7 @@ class DebugScope internal constructor(
             mlsMessageCreator,
             messageSendingInterceptor,
             userRepository,
-            ephemeralMessageDeletionHandler,
+            { ephemeralMessageDeletionHandler.enqueueSelfDeletion(it) },
             scope
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -133,7 +133,7 @@ internal class MessageSenderImpl internal constructor(
     private val mlsMessageCreator: MLSMessageCreator,
     private val messageSendingInterceptor: MessageSendingInterceptor,
     private val userRepository: UserRepository,
-    private val selfDeleteMessageSenderHandler: EphemeralMessageDeletionHandler,
+    private val enqueueSelfDeletion: (Message.Regular) -> Unit,
     private val scope: CoroutineScope
 ) : MessageSender {
 
@@ -225,7 +225,7 @@ internal class MessageSenderImpl internal constructor(
 
     private fun startSelfDeletionIfNeeded(message: Message.Sendable) {
         if (message is Message.Regular && message.expirationData?.expireAfter.isPositiveNotNull()) {
-            selfDeleteMessageSenderHandler.enqueueSelfDeletion(message)
+            enqueueSelfDeletion(message)
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Circular dependency with initialisation of `ephemeralMessageDeletionHandler` inside `MessageScope` class.

### Solutions

Pass a lambda method instead of whole `MessageSender` class.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
