### PR TITLE
chore: another try to run dokka

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -18,14 +18,6 @@ jobs:
           cache: gradle
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-
-      # temporary, remove later
-      -   name: Generate Dokka docs
-          run: make doc/generate-kdocs
-          env:
-              GITHUB_USER: ${{ github.actor }}
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run Detekt
         run: |
             make detekt/run-verify

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -18,6 +18,14 @@ jobs:
           cache: gradle
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+
+      # temporary, remove later
+      -   name: Generate Dokka docs
+          run: make doc/generate-kdocs
+          env:
+              GITHUB_USER: ${{ github.actor }}
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Detekt
         run: |
             make detekt/run-verify

--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
     publish:
-        runs-on: buildjet-4vcpu-ubuntu-2204
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout project
               uses: actions/checkout@v2 
               with:
                   fetch-depth: 0
 
-            - name: Set up JDK 11
+            - name: Set up JDK
               uses: actions/setup-java@v3
               with:
                 java-version: '17'

--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - develop # later on we should stick to main, since there will be the releases
   workflow_dispatch:
+      # deleteme. temp to test the workflow
+      inputs:
+          current-branch:
+              type: string
+              description: 'nothing to declare'
+              required: false
+              default: ''
 
 jobs:
     publish:
@@ -31,10 +38,10 @@ jobs:
                 GITHUB_USER: ${{ github.actor }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Deploy docs 🚀
-              uses: JamesIves/github-pages-deploy-action@v4.2.5
-              with:
-                  branch: gh-pages
-                  clean: false
-                  folder: build/dokka/htmlMultiModule
-                  target-folder: docs
+#            - name: Deploy docs 🚀
+#              uses: JamesIves/github-pages-deploy-action@v4.2.5
+#              with:
+#                  branch: gh-pages
+#                  clean: false
+#                  folder: build/dokka/htmlMultiModule
+#                  target-folder: docs

--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -5,13 +5,6 @@ on:
     branches:
       - develop # later on we should stick to main, since there will be the releases
   workflow_dispatch:
-      # deleteme. temp to test the workflow
-      inputs:
-          current-branch:
-              type: string
-              description: 'nothing to declare'
-              required: false
-              default: ''
 
 jobs:
     publish:
@@ -38,10 +31,10 @@ jobs:
                 GITHUB_USER: ${{ github.actor }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-#            - name: Deploy docs 🚀
-#              uses: JamesIves/github-pages-deploy-action@v4.2.5
-#              with:
-#                  branch: gh-pages
-#                  clean: false
-#                  folder: build/dokka/htmlMultiModule
-#                  target-folder: docs
+            - name: Deploy docs 🚀
+              uses: JamesIves/github-pages-deploy-action@v4.2.5
+              with:
+                  branch: gh-pages
+                  clean: false
+                  folder: build/dokka/htmlMultiModule
+                  target-folder: docs

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonDokkaConfig.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonDokkaConfig.kt
@@ -33,6 +33,8 @@ val documentedSubprojects = listOf(
     "protobuf"
 )
 
+private val DOKKA_CACHE_DIR = ".cache/dokka"
+
 /**
  * Adds a common Dokka configuration for the module, including:
  * - $MODULE_DIR$/module.md file
@@ -44,7 +46,12 @@ fun Project.commonDokkaConfig() {
 
     plugins.apply("org.jetbrains.dokka")
     val rootProject = rootProject
+    rootProject.mkdir("build/$DOKKA_CACHE_DIR") // creating cache dir
+
     tasks.withType(AbstractDokkaLeafTask::class.java).configureEach {
+        cacheRoot.set(rootProject.buildDir.resolve(DOKKA_CACHE_DIR))  // set cache config dir to rootProject/buildDir
+        offlineMode.set(true) // offline, since we don't do online package-list
+
         dokkaSourceSets.configureEach {
             file("module.md").takeIf { it.exists() }?.let {
                 includes.from(it)
@@ -53,6 +60,8 @@ fun Project.commonDokkaConfig() {
             samples.from(rootProject.file("samples"))
             includeNonPublic.set(true)
             documentedVisibilities.set(listOf(Visibility.PUBLIC, Visibility.INTERNAL))
+            classpath.setFrom("protobuf") // not sure... but why not?
         }
     }
 }
+


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Dokka was failing.

### Solutions

Brings dokka back as shown in prev execution, using a build cache, also setting up explicitly the protobuf project.

### Testing

Manually tested, execution logs on
https://pipelines.actions.githubusercontent.com/serviceHosts/34e009ab-724e-415a-b825-f651abb68c4f/_apis/pipelines/1/runs/56774/signedlogcontent/2?urlExpires=2023-06-05T16%3A07%3A22.3812312Z&urlSigningMethod=HMACV1&urlSignature=%2FxXD6NzZs23Ea3NBCLrtt15VHi5CrTcV35dvlFzrtYI%3D

[2023-06-05T16:00:55.4652656Z-logs.txt](https://github.com/wireapp/kalium/files/11654578/2023-06-05T16.00.55.4652656Z-logs.txt)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
