### PR TITLE
feat: use case for user domain lookup

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -72,8 +72,7 @@ abstract class CoreLogicCommon internal constructor(
         serverConfig: ServerConfig,
         proxyCredentials: ProxyCredentials? = null
     ): AuthenticationScope =
-        // TODO(logic): make it lazier
-        authenticationScopeProvider.provide(serverConfig, proxyCredentials)
+        authenticationScopeProvider.provide(serverConfig, proxyCredentials, getGlobalScope().serverConfigRepository)
 
     @Suppress("MemberVisibilityCanBePrivate") // Can be used by other targets like iOS and JS
     abstract fun getSessionScope(userId: UserId): UserSessionScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/DomainLookupResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/DomainLookupResult.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.auth.login
+
+data class DomainLookupResult (
+    val configJsonUrl: String,
+    val webappWelcomeUrl: String
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/DomainLookupResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/DomainLookupResult.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.data.auth.login
 
-data class DomainLookupResult (
+data class DomainLookupResult(
     val configJsonUrl: String,
     val webappWelcomeUrl: String
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/SSOLoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/SSOLoginRepository.kt
@@ -20,8 +20,10 @@ package com.wire.kalium.logic.data.auth.login
 
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.base.model.AuthenticationResultDTO
+import com.wire.kalium.network.api.base.unauthenticated.DomainLookupApi
 import com.wire.kalium.network.api.base.unauthenticated.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.SSOSettingsResponse
 
@@ -42,10 +44,12 @@ interface SSOLoginRepository {
     suspend fun metaData(): Either<NetworkFailure, String>
 
     suspend fun settings(): Either<NetworkFailure, SSOSettingsResponse>
+    suspend fun domainLookup(domain: String): Either<NetworkFailure, DomainLookupResult>
 }
 
 class SSOLoginRepositoryImpl(
-    private val ssoLogin: SSOLoginApi
+    private val ssoLogin: SSOLoginApi,
+    private val domainLookup: DomainLookupApi
 ) : SSOLoginRepository {
 
     override suspend fun initiate(
@@ -74,5 +78,11 @@ class SSOLoginRepositoryImpl(
 
     override suspend fun settings(): Either<NetworkFailure, SSOSettingsResponse> = wrapApiRequest {
         ssoLogin.settings()
+    }
+
+     override suspend fun domainLookup(domain: String): Either<NetworkFailure, DomainLookupResult> = wrapApiRequest {
+        domainLookup.lookup(domain)
+    }.map {
+        DomainLookupResult(it.configJsonUrl, it.webappWelcomeUrl)
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -415,7 +415,8 @@ class UserSessionScope internal constructor(
     )
     val authenticationScope: AuthenticationScope = authenticationScopeProvider.provide(
         sessionManager.getServerConfig(),
-        sessionManager.getProxyCredentials()
+        sessionManager.getProxyCredentials(),
+         globalScope.serverConfigRepository
     )
 
     private val userConfigRepository: UserConfigRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/appVersioning/ObserveIfAppUpdateRequiredUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/appVersioning/ObserveIfAppUpdateRequiredUseCase.kt
@@ -96,7 +96,7 @@ class ObserveIfAppUpdateRequiredUseCaseImpl internal constructor(
                         withContext(coroutineContext) {
                             async {
                                 val isUpdateRequired = authenticationScopeProvider
-                                    .provide(serverConfig, proxyCredentials)
+                                    .provide(serverConfig, proxyCredentials, serverConfigRepository)
                                     .checkIfUpdateRequired(currentAppVersion, serverConfig.links.blackList)
                                 serverConfig.id to isUpdateRequired
                             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -39,7 +39,7 @@ import com.wire.kalium.logic.feature.register.RegisterScope
 import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkContainer
 import io.ktor.util.collections.ConcurrentMap
 
-class AuthenticationScopeProvider(
+class AuthenticationScopeProvider internal constructor(
     private val userAgent: String
 ) {
 
@@ -48,7 +48,7 @@ class AuthenticationScopeProvider(
         ConcurrentMap()
     }
 
-    fun provide(
+    internal fun provide(
         serverConfig: ServerConfig,
         proxyCredentials: ProxyCredentials?
     ): AuthenticationScope =
@@ -61,12 +61,11 @@ class AuthenticationScopeProvider(
         }
 }
 
-class AuthenticationScope(
+class AuthenticationScope internal constructor (
     private val userAgent: String,
     private val serverConfig: ServerConfig,
     private val proxyCredentials: ProxyCredentials?
 ) {
-
     private val unauthenticatedNetworkContainer: UnauthenticatedNetworkContainer by lazy {
         UnauthenticatedNetworkContainer.create(
             MapperProvider.serverConfigMapper().toDTO(serverConfig),
@@ -81,8 +80,8 @@ class AuthenticationScope(
         get() = RegisterAccountDataSource(
             unauthenticatedNetworkContainer.registerApi
         )
-    private val ssoLoginRepository: SSOLoginRepository
-        get() = SSOLoginRepositoryImpl(unauthenticatedNetworkContainer.sso)
+    internal val ssoLoginRepository: SSOLoginRepository
+        get() = SSOLoginRepositoryImpl(unauthenticatedNetworkContainer.sso, unauthenticatedNetworkContainer.domainLookupApi)
 
     internal val secondFactorVerificationRepository: SecondFactorVerificationRepository =
         SecondFactorVerificationRepositoryImpl(unauthenticatedNetworkContainer.verificationCodeApi)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/DomainLookupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/DomainLookupUseCase.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.auth
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.configuration.server.ServerConfigRepository
+import com.wire.kalium.logic.data.auth.login.SSOLoginRepository
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
+
+/**
+ * Use case for domain lookup.
+ * will return the server config for the domain.
+ * if the domain is not found then it will return a failure.
+ * @param email the email to lookup
+ */
+class DomainLookupUseCase internal constructor(
+    private val serverConfigRepository: ServerConfigRepository,
+    private val ssoLoginRepository: SSOLoginRepository
+) {
+    suspend operator fun invoke(email: String): Result {
+        val domain = email.substringAfterLast('@').ifBlank {
+            // if the text is not an email then use the text as domain
+            email
+        }
+
+        return ssoLoginRepository.domainLookup(domain).flatMap {
+            serverConfigRepository.fetchRemoteConfig(it.configJsonUrl)
+        }.fold(Result::Failure, Result::Success)
+    }
+
+    sealed interface Result {
+        data class Success(val serverLinks: ServerConfig.Links) : Result
+        data class Failure(val coreFailure: CoreFailure) : Result
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/autoVersioningAuth/AutoVersionAuthScopeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/autoVersioningAuth/AutoVersionAuthScopeUseCase.kt
@@ -37,6 +37,7 @@ class AutoVersionAuthScopeUseCase(
     private val serverLinks: ServerConfig.Links,
     private val coreLogic: CoreLogicCommon,
 ) {
+    
     suspend operator fun invoke(
         proxyAuthentication: ProxyAuthentication = ProxyAuthentication.None
     ): Result =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/autoVersioningAuth/AutoVersionAuthScopeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/autoVersioningAuth/AutoVersionAuthScopeUseCase.kt
@@ -37,7 +37,7 @@ class AutoVersionAuthScopeUseCase(
     private val serverLinks: ServerConfig.Links,
     private val coreLogic: CoreLogicCommon,
 ) {
-    
+
     suspend operator fun invoke(
         proxyAuthentication: ProxyAuthentication = ProxyAuthentication.None
     ): Result =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/DomainLookupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/DomainLookupUseCaseTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.auth
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.configuration.server.ServerConfigRepository
+import com.wire.kalium.logic.data.auth.login.DomainLookupResult
+import com.wire.kalium.logic.data.auth.login.SSOLoginRepository
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.stubs.newServerConfig
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okio.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DomainLookupUseCaseTest {
+
+    @Test
+    fun givenEmail_whenInvoked_thenLookupForTheEmailDomainOnly() = runTest {
+        val userEmail = "cool-person@wire.com"
+        val (arrangement, useCases) = Arrangement()
+            .withDomainLookupResult(Either.Left(NetworkFailure.NoNetworkConnection(IOException())))
+            .arrange()
+        useCases(userEmail)
+
+        verify(arrangement.ssoLoginRepository)
+            .suspendFunction(arrangement.ssoLoginRepository::domainLookup)
+            .with(eq("wire.com"))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenDomain_whenInvoked_thenUserInputIsNotChangedForLookup() = runTest {
+        val userEmail = "wire.com"
+        val (arrangement, useCases) = Arrangement()
+            .withDomainLookupResult(Either.Left(NetworkFailure.NoNetworkConnection(IOException())))
+            .arrange()
+        useCases(userEmail)
+
+        verify(arrangement.ssoLoginRepository)
+            .suspendFunction(arrangement.ssoLoginRepository::domainLookup)
+            .with(eq("wire.com"))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSuccessForDomainLookup_whenLookup_thenFetchServerConfigUsingTheServerConfigUrl() = runTest {
+        val userEmail = "cool-person@wire.com"
+
+        val (arrangement, useCases) = Arrangement()
+            .withDomainLookupResult(Either.Right(DomainLookupResult("https://wire.com", "https://wire.com")))
+            .withFetchServerConfigResult(Either.Left(NetworkFailure.NoNetworkConnection(IOException())))
+            .arrange()
+        useCases(userEmail)
+
+        verify(arrangement.serverConfigRepository)
+            .suspendFunction(arrangement.serverConfigRepository::fetchRemoteConfig)
+            .with(eq("https://wire.com"))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSuccess_whenLookup_thenSuccessIsPropagated() = runTest {
+        val userEmail = "cool-person@wire.com"
+        val expectedServerLinks = newServerConfig(1).links
+        val (arrangement, useCases) = Arrangement()
+            .withDomainLookupResult(Either.Right(DomainLookupResult("https://wire.com", "https://wire.com")))
+            .withFetchServerConfigResult(Either.Right(expectedServerLinks))
+            .arrange()
+
+        useCases(userEmail).also {
+            assertIs<DomainLookupUseCase.Result.Success>(it)
+            assertEquals(expectedServerLinks, it.serverLinks)
+        }
+
+        verify(arrangement.ssoLoginRepository)
+            .suspendFunction(arrangement.ssoLoginRepository::domainLookup)
+            .with(eq("wire.com"))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.serverConfigRepository)
+            .suspendFunction(arrangement.serverConfigRepository::fetchRemoteConfig)
+            .with(eq("https://wire.com"))
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val ssoLoginRepository: SSOLoginRepository = mock(SSOLoginRepository::class)
+
+        @Mock
+        val serverConfigRepository: ServerConfigRepository = mock(ServerConfigRepository::class)
+
+        private val useCases = DomainLookupUseCase(
+            serverConfigRepository,
+            ssoLoginRepository
+        )
+
+        fun withDomainLookupResult(result: Either<NetworkFailure, DomainLookupResult>) = apply {
+            given(ssoLoginRepository)
+                .suspendFunction(ssoLoginRepository::domainLookup)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withFetchServerConfigResult(result: Either<NetworkFailure, ServerConfig.Links>) = apply {
+            given(serverConfigRepository)
+                .suspendFunction(serverConfigRepository::fetchRemoteConfig)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun arrange() = this to useCases
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/DomainLookupApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/DomainLookupApi.kt
@@ -1,0 +1,32 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.base.unauthenticated
+
+import com.wire.kalium.network.utils.NetworkResponse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+interface DomainLookupApi {
+    suspend fun lookup(domain: String): NetworkResponse<DomainLookupResponse>
+}
+
+@Serializable
+data class DomainLookupResponse(
+    @SerialName("config_json_url") val configJsonUrl: String,
+    @SerialName("webapp_welcome_url") val webappWelcomeUrl: String
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/DomainLookupApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/DomainLookupApiV0.kt
@@ -26,7 +26,7 @@ import io.ktor.client.request.get
 
 internal open class DomainLookupApiV0 internal constructor(
     private val unauthenticatedNetworkClient: UnauthenticatedNetworkClient
-): DomainLookupApi {
+) : DomainLookupApi {
     private val httpClient get() = unauthenticatedNetworkClient.httpClient
 
     override suspend fun lookup(domain: String): NetworkResponse<DomainLookupResponse> = wrapKaliumResponse {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/DomainLookupApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/DomainLookupApiV0.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v0.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.base.unauthenticated.DomainLookupApi
+import com.wire.kalium.network.api.base.unauthenticated.DomainLookupResponse
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.get
+
+internal open class DomainLookupApiV0 internal constructor(
+    private val unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+): DomainLookupApi {
+    private val httpClient get() = unauthenticatedNetworkClient.httpClient
+
+    override suspend fun lookup(domain: String): NetworkResponse<DomainLookupResponse> = wrapKaliumResponse {
+        httpClient.get("$CUSTOM_BACKEND_PATH/$BY_DOMAIN_PATH/$domain")
+    }
+
+    private companion object {
+        const val CUSTOM_BACKEND_PATH = "custom-backend"
+        const val BY_DOMAIN_PATH = "by-domain"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV0.kt
@@ -19,12 +19,14 @@
 package com.wire.kalium.network.api.v0.unauthenticated.networkContainer
 
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.base.unauthenticated.DomainLookupApi
 import com.wire.kalium.network.api.base.unauthenticated.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
+import com.wire.kalium.network.api.v0.unauthenticated.DomainLookupApiV0
 import com.wire.kalium.network.api.v0.unauthenticated.LoginApiV0
 import com.wire.kalium.network.api.v0.unauthenticated.RegisterApiV0
 import com.wire.kalium.network.api.v0.unauthenticated.SSOLoginApiV0
@@ -36,7 +38,7 @@ import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkContainer
 import com.wire.kalium.network.tools.ServerConfigDTO
 import io.ktor.client.engine.HttpClientEngine
 
-class UnauthenticatedNetworkContainerV0 constructor(
+class UnauthenticatedNetworkContainerV0 internal constructor(
     backendLinks: ServerConfigDTO,
     proxyCredentials: ProxyCredentialsDTO?,
     engine: HttpClientEngine = defaultHttpEngine(backendLinks.links.apiProxy, proxyCredentials)
@@ -48,6 +50,7 @@ class UnauthenticatedNetworkContainerV0 constructor(
     ) {
     override val loginApi: LoginApi get() = LoginApiV0(unauthenticatedNetworkClient)
     override val verificationCodeApi: VerificationCodeApi get() = VerificationCodeApiV0(unauthenticatedNetworkClient)
+    override val domainLookupApi: DomainLookupApi get() = DomainLookupApiV0(unauthenticatedNetworkClient)
     override val registerApi: RegisterApi get() = RegisterApiV0(unauthenticatedNetworkClient)
     override val sso: SSOLoginApi get() = SSOLoginApiV0(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/DomainLookupApiV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/DomainLookupApiV2.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v2.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v0.unauthenticated.DomainLookupApiV0
+
+internal open class DomainLookupApiV2 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+): DomainLookupApiV0(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/DomainLookupApiV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/DomainLookupApiV2.kt
@@ -22,4 +22,4 @@ import com.wire.kalium.network.api.v0.unauthenticated.DomainLookupApiV0
 
 internal open class DomainLookupApiV2 internal constructor(
     unauthenticatedNetworkClient: UnauthenticatedNetworkClient
-): DomainLookupApiV0(unauthenticatedNetworkClient)
+) : DomainLookupApiV0(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV2.kt
@@ -19,12 +19,14 @@
 package com.wire.kalium.network.api.v2.unauthenticated.networkContainer
 
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.base.unauthenticated.DomainLookupApi
 import com.wire.kalium.network.api.base.unauthenticated.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
+import com.wire.kalium.network.api.v2.unauthenticated.DomainLookupApiV2
 import com.wire.kalium.network.api.v2.unauthenticated.LoginApiV2
 import com.wire.kalium.network.api.v2.unauthenticated.RegisterApiV2
 import com.wire.kalium.network.api.v2.unauthenticated.SSOLoginApiV2
@@ -36,7 +38,7 @@ import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkContainer
 import com.wire.kalium.network.tools.ServerConfigDTO
 import io.ktor.client.engine.HttpClientEngine
 
-class UnauthenticatedNetworkContainerV2 constructor(
+class UnauthenticatedNetworkContainerV2 internal constructor(
     backendLinks: ServerConfigDTO,
     proxyCredentials: ProxyCredentialsDTO?,
     engine: HttpClientEngine = defaultHttpEngine(backendLinks.links.apiProxy, proxyCredentials)
@@ -48,6 +50,7 @@ class UnauthenticatedNetworkContainerV2 constructor(
     ) {
     override val loginApi: LoginApi get() = LoginApiV2(unauthenticatedNetworkClient)
     override val verificationCodeApi: VerificationCodeApi get() = VerificationCodeApiV2(unauthenticatedNetworkClient)
+    override val domainLookupApi: DomainLookupApi get() = DomainLookupApiV2(unauthenticatedNetworkClient)
     override val registerApi: RegisterApi get() = RegisterApiV2(unauthenticatedNetworkClient)
     override val sso: SSOLoginApi get() = SSOLoginApiV2(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/DomainLookupApiV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/DomainLookupApiV3.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v3.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v2.unauthenticated.DomainLookupApiV2
+
+internal open class DomainLookupApiV3 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+): DomainLookupApiV2(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/DomainLookupApiV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/DomainLookupApiV3.kt
@@ -22,4 +22,4 @@ import com.wire.kalium.network.api.v2.unauthenticated.DomainLookupApiV2
 
 internal open class DomainLookupApiV3 internal constructor(
     unauthenticatedNetworkClient: UnauthenticatedNetworkClient
-): DomainLookupApiV2(unauthenticatedNetworkClient)
+) : DomainLookupApiV2(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV3.kt
@@ -19,12 +19,14 @@
 package com.wire.kalium.network.api.v3.unauthenticated.networkContainer
 
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.base.unauthenticated.DomainLookupApi
 import com.wire.kalium.network.api.base.unauthenticated.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
+import com.wire.kalium.network.api.v3.unauthenticated.DomainLookupApiV3
 import com.wire.kalium.network.api.v3.unauthenticated.LoginApiV3
 import com.wire.kalium.network.api.v3.unauthenticated.RegisterApiV3
 import com.wire.kalium.network.api.v3.unauthenticated.SSOLoginApiV3
@@ -36,7 +38,7 @@ import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkContainer
 import com.wire.kalium.network.tools.ServerConfigDTO
 import io.ktor.client.engine.HttpClientEngine
 
-class UnauthenticatedNetworkContainerV3 constructor(
+class UnauthenticatedNetworkContainerV3 internal constructor(
     backendLinks: ServerConfigDTO,
     proxyCredentials: ProxyCredentialsDTO?,
     engine: HttpClientEngine = defaultHttpEngine(backendLinks.links.apiProxy, proxyCredentials),
@@ -48,6 +50,7 @@ class UnauthenticatedNetworkContainerV3 constructor(
     ) {
     override val loginApi: LoginApi get() = LoginApiV3(unauthenticatedNetworkClient)
     override val verificationCodeApi: VerificationCodeApi get() = VerificationCodeApiV3(unauthenticatedNetworkClient)
+    override val domainLookupApi: DomainLookupApi get() = DomainLookupApiV3(unauthenticatedNetworkClient)
     override val registerApi: RegisterApi get() = RegisterApiV3(unauthenticatedNetworkClient)
     override val sso: SSOLoginApi get() = SSOLoginApiV3(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/DomainLookupApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/DomainLookupApiV4.kt
@@ -22,4 +22,4 @@ import com.wire.kalium.network.api.v3.unauthenticated.DomainLookupApiV3
 
 internal open class DomainLookupApiV4 internal constructor(
     unauthenticatedNetworkClient: UnauthenticatedNetworkClient
-): DomainLookupApiV3(unauthenticatedNetworkClient)
+) : DomainLookupApiV3(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/DomainLookupApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/DomainLookupApiV4.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v4.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v3.unauthenticated.DomainLookupApiV3
+
+internal open class DomainLookupApiV4 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+): DomainLookupApiV3(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV4.kt
@@ -19,12 +19,14 @@
 package com.wire.kalium.network.api.v4.unauthenticated.networkContainer
 
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.base.unauthenticated.DomainLookupApi
 import com.wire.kalium.network.api.base.unauthenticated.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
+import com.wire.kalium.network.api.v4.unauthenticated.DomainLookupApiV4
 import com.wire.kalium.network.api.v4.unauthenticated.LoginApiV4
 import com.wire.kalium.network.api.v4.unauthenticated.RegisterApiV4
 import com.wire.kalium.network.api.v4.unauthenticated.SSOLoginApiV4
@@ -36,7 +38,7 @@ import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkContainer
 import com.wire.kalium.network.tools.ServerConfigDTO
 import io.ktor.client.engine.HttpClientEngine
 
-class UnauthenticatedNetworkContainerV4 constructor(
+class UnauthenticatedNetworkContainerV4 internal constructor(
     backendLinks: ServerConfigDTO,
     proxyCredentials: ProxyCredentialsDTO?,
     engine: HttpClientEngine = defaultHttpEngine(backendLinks.links.apiProxy, proxyCredentials),
@@ -48,6 +50,7 @@ class UnauthenticatedNetworkContainerV4 constructor(
     ) {
     override val loginApi: LoginApi get() = LoginApiV4(unauthenticatedNetworkClient)
     override val verificationCodeApi: VerificationCodeApi get() = VerificationCodeApiV4(unauthenticatedNetworkClient)
+    override val domainLookupApi: DomainLookupApi get() = DomainLookupApiV4(unauthenticatedNetworkClient)
     override val registerApi: RegisterApi get() = RegisterApiV4(unauthenticatedNetworkClient)
     override val sso: SSOLoginApi get() = SSOLoginApiV4(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/UnauthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/UnauthenticatedNetworkContainer.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.network.networkContainer
 
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.base.unauthenticated.DomainLookupApi
 import com.wire.kalium.network.api.base.unauthenticated.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.VerificationCodeApi
@@ -40,6 +41,7 @@ interface UnauthenticatedNetworkContainer {
     val sso: SSOLoginApi
     val appVersioningApi: AppVersioningApi
     val verificationCodeApi: VerificationCodeApi
+    val domainLookupApi: DomainLookupApi
 
     companion object {
         fun create(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

[WPB-255](https://wearezeta.atlassian.net/browse/WPB-255)

### Solutions

implement Use Case to do Domain lookup and return the Server links associated with the user domain 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[WPB-255]: https://wearezeta.atlassian.net/browse/WPB-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ