### PR TITLE
refactor: User DTOs

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
@@ -35,7 +35,7 @@ import com.wire.kalium.logic.data.user.type.DomainUserTypeMapper
 import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.api.base.model.getCompleteAssetOrNull
 import com.wire.kalium.network.api.base.model.getPreviewAssetOrNull
 import com.wire.kalium.persistence.dao.BotIdEntity

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -29,13 +29,13 @@ import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
 import com.wire.kalium.network.api.base.authenticated.self.UserUpdateRequest
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.AssetSizeDTO
 import com.wire.kalium.network.api.base.model.NonQualifiedUserId
 import com.wire.kalium.network.api.base.model.QualifiedID
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.UserAssetDTO
 import com.wire.kalium.network.api.base.model.UserAssetTypeDTO
-import com.wire.kalium.network.api.base.model.UserDTO
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.api.base.model.getCompleteAssetOrNull
 import com.wire.kalium.network.api.base.model.getPreviewAssetOrNull
 import com.wire.kalium.persistence.dao.BotIdEntity
@@ -48,13 +48,13 @@ import com.wire.kalium.persistence.dao.client.Client
 import com.wire.kalium.persistence.dao.UserIDEntity as UserIdEntity
 
 interface UserMapper {
-    fun fromDtoToSelfUser(userDTO: UserDTO): SelfUser
+    fun fromDtoToSelfUser(userDTO: SelfUserDTO): SelfUser
     fun fromApiModelWithUserTypeEntityToDaoModel(
         userProfileDTO: UserProfileDTO,
         userTypeEntity: UserTypeEntity?
     ): UserEntity
 
-    fun fromApiSelfModelToDaoModel(userDTO: UserDTO): UserEntity
+    fun fromApiSelfModelToDaoModel(userDTO: SelfUserDTO): UserEntity
     fun fromDaoModelToSelfUser(userEntity: UserEntity): SelfUser
     fun fromSelfUserToDaoModel(selfUser: SelfUser): UserEntity
 
@@ -98,7 +98,7 @@ internal class UserMapperImpl(
     private val userEntityTypeMapper: UserEntityTypeMapper = MapperProvider.userTypeEntityMapper()
 ) : UserMapper {
 
-    override fun fromDtoToSelfUser(userDTO: UserDTO): SelfUser = with(userDTO) {
+    override fun fromDtoToSelfUser(userDTO: SelfUserDTO): SelfUser = with(userDTO) {
         SelfUser(
             id = id.toModel(),
             name = name,
@@ -210,7 +210,7 @@ internal class UserMapperImpl(
         )
     }
 
-    override fun fromApiSelfModelToDaoModel(userDTO: UserDTO): UserEntity = with(userDTO) {
+    override fun fromApiSelfModelToDaoModel(userDTO: SelfUserDTO): UserEntity = with(userDTO) {
         return UserEntity(
             id = idMapper.fromApiToDao(id),
             name = name,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -54,9 +54,9 @@ import com.wire.kalium.network.api.base.authenticated.self.SelfApi
 import com.wire.kalium.network.api.base.authenticated.self.UserUpdateRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
-import com.wire.kalium.network.api.base.model.UserDTO
+import com.wire.kalium.network.api.base.model.SelfUserDTO
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -164,7 +164,7 @@ internal class UserDataSource internal constructor(
             }
         }
 
-    private suspend fun updateSelfUserProviderAccountInfo(userDTO: UserDTO): Either<StorageFailure, Unit> =
+    private suspend fun updateSelfUserProviderAccountInfo(userDTO: SelfUserDTO): Either<StorageFailure, Unit> =
         sessionRepository.updateSsoIdAndScimInfo(userDTO.id.toModel(), idMapper.toSsoId(userDTO.ssoID), userDTO.managedByDTO)
 
     override suspend fun getKnownUser(userId: UserId): Flow<OtherUser?> =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepositoryTest.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.data.auth.login
 
 import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
 import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.api.base.unauthenticated.LoginApi
@@ -102,11 +103,11 @@ class LoginRepositoryTest {
 
         init {
             withLoginReturning(
-                NetworkResponse.Success(value = SESSION_DTO to USER_DTO, mapOf(), HttpStatusCode.OK.value)
+                NetworkResponse.Success(value = SESSION_DTO to TestUser.SELF_USER_DTO, mapOf(), HttpStatusCode.OK.value)
             )
         }
 
-        fun withLoginReturning(response: NetworkResponse<Pair<SessionDTO, UserDTO>>) = apply {
+        fun withLoginReturning(response: NetworkResponse<Pair<SessionDTO, SelfUserDTO>>) = apply {
             given(loginApi)
                 .suspendFunction(loginApi::login)
                 .whenInvokedWith(any(), any())
@@ -124,9 +125,9 @@ class LoginRepositoryTest {
         const val TEST_SECOND_FACTOR_CODE = "123456"
         const val TEST_PASSWORD = "123456"
         const val TEST_PERSIST_CLIENT = false
-        val USER_DTO: UserDTO = TestUser.USER_DTO
+        val SELF_USER_DTO: UserDTO = TestUser.SELF_USER_DTO
         val SESSION_DTO: SessionDTO = SessionDTO(
-            userId = USER_DTO.id,
+            userId = SELF_USER_DTO.id,
             tokenType = "tokenType",
             accessToken = "access_token",
             refreshToken = "refresh_token",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -34,10 +34,10 @@ import com.wire.kalium.network.api.base.authenticated.connection.ConnectionDTO
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionResponse
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionStateDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
 import com.wire.kalium.network.api.base.model.QualifiedID
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConnectionDAO

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -38,8 +38,8 @@ import com.wire.kalium.network.api.base.authenticated.search.SearchPolicyDTO
 import com.wire.kalium.network.api.base.authenticated.search.UserSearchResponse
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.MetadataDAO

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepositoryTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AuthTokens
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
 import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
@@ -323,7 +324,7 @@ class RegisterAccountRepositoryTest {
         const val TEAM_ICON = "teamIcon"
         val USERID_DTO = UserIdDTO("user_id", "domain.com")
         val SESSION: SessionDTO = SessionDTO(USERID_DTO, "tokenType", "access_token", "refresh_token", "cookieLabel")
-        val TEST_USER: UserDTO = UserDTO(
+        val TEST_USER: SelfUserDTO = SelfUserDTO(
             id = USERID_DTO,
             name = NAME,
             email = EMAIL,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -522,7 +522,7 @@ class UserRepositoryTest {
             given(selfApi)
                 .suspendFunction(selfApi::getSelfInfo)
                 .whenInvoked()
-                .thenReturn(NetworkResponse.Success(TestUser.USER_DTO.copy(deleted = true), mapOf(), 200))
+                .thenReturn(NetworkResponse.Success(TestUser.SELF_USER_DTO.copy(deleted = true), mapOf(), 200))
         }
 
         fun withSuccessfulGetMultipleUsersApiRequest(result: ListUsersDTO) = apply {
@@ -550,6 +550,6 @@ class UserRepositoryTest {
     }
 
     private companion object {
-        val SELF_USER = TestUser.USER_DTO
+        val SELF_USER = TestUser.SELF_USER_DTO
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -26,12 +26,12 @@ import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.AssetSizeDTO
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.UserAssetDTO
 import com.wire.kalium.network.api.base.model.UserAssetTypeDTO
-import com.wire.kalium.network.api.base.model.UserDTO
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
@@ -118,7 +118,7 @@ object TestUser {
         service = null
     )
 
-    val USER_DTO = UserDTO(
+    val SELF_USER_DTO = SelfUserDTO(
         id = NETWORK_ID,
         name = "user_name_123",
         accentId = 2,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/self/SelfApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/self/SelfApi.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.network.api.base.authenticated.self
 
-import com.wire.kalium.network.api.base.model.UserDTO
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import kotlinx.serialization.SerialName
 
@@ -28,7 +28,7 @@ data class ChangeHandleRequest(
 )
 
 interface SelfApi {
-    suspend fun getSelfInfo(): NetworkResponse<UserDTO>
+    suspend fun getSelfInfo(): NetworkResponse<SelfUserDTO>
     suspend fun updateSelf(userUpdateRequest: UserUpdateRequest): NetworkResponse<Unit>
     suspend fun changeHandle(request: ChangeHandleRequest): NetworkResponse<Unit>
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/ListUsersDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/ListUsersDTO.kt
@@ -18,31 +18,10 @@
 
 package com.wire.kalium.network.api.base.authenticated.userDetails
 
-import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
-import com.wire.kalium.network.api.base.model.NonQualifiedUserId
-import com.wire.kalium.network.api.base.model.ServiceDTO
-import com.wire.kalium.network.api.base.model.TeamId
-import com.wire.kalium.network.api.base.model.UserAssetDTO
 import com.wire.kalium.network.api.base.model.UserId
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-
-@Serializable
-data class UserProfileDTO(
-    @SerialName("qualified_id") val id: UserId,
-    @SerialName("name") val name: String,
-    @SerialName("handle") val handle: String?,
-    @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatusResponse,
-    @SerialName("team") val teamId: TeamId?,
-    @SerialName("accent_id") val accentId: Int,
-    @SerialName("assets") val assets: List<UserAssetDTO>,
-    @SerialName("deleted") val deleted: Boolean?,
-    @SerialName("email") val email: String?,
-    @SerialName("expires_at") val expiresAt: String?,
-    @Deprecated("use id instead", replaceWith = ReplaceWith("this.id"))
-    @SerialName("id") val nonQualifiedId: NonQualifiedUserId,
-    @SerialName("service") val service: ServiceDTO?
-)
 
 @Serializable
 data class ListUsersDTO(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserDetailsApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/userDetails/UserDetailsApi.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.network.api.base.authenticated.userDetails
 
 import com.wire.kalium.network.api.base.model.UserId
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface UserDetailsApi {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/SessionDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/SessionDTO.kt
@@ -26,4 +26,4 @@ data class SessionDTO(
     val cookieLabel: String?
 )
 
-data class AuthenticationResultDTO(val sessionDTO: SessionDTO, val userDTO: UserDTO)
+data class AuthenticationResultDTO(val sessionDTO: SessionDTO, val userDTO: SelfUserDTO)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/UserDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/UserDTO.kt
@@ -23,24 +23,54 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class UserDTO(
-    @SerialName("accent_id") val accentId: Int,
-    @SerialName("assets") val assets: List<UserAssetDTO>,
-    @SerialName("deleted") val deleted: Boolean?,
-    @SerialName("email") val email: String?,
-    @SerialName("expires_at") val expiresAt: String?,
-    @SerialName("handle") val handle: String?,
-    @Deprecated("use id instead", replaceWith = ReplaceWith("this.id"))
-    @SerialName("id") val nonQualifiedId: NonQualifiedUserId,
-    @SerialName("name") val name: String,
+sealed class UserDTO {
+    abstract val id: UserId
+    abstract val name: String
+    abstract val handle: String?
+    abstract val teamId: TeamId?
+    abstract val accentId: Int
+    abstract val assets: List<UserAssetDTO>
+    abstract val deleted: Boolean?
+    abstract val email: String?
+    abstract val expiresAt: String?
+    abstract val nonQualifiedId: NonQualifiedUserId
+    abstract val service: ServiceDTO?
+}
+
+@Serializable
+data class UserProfileDTO(
+    @SerialName("qualified_id") override val id: UserId,
+    @SerialName("name") override val name: String,
+    @SerialName("handle") override val handle: String?,
+    @SerialName("team") override val teamId: TeamId?,
+    @SerialName("accent_id") override val accentId: Int,
+    @SerialName("assets") override val assets: List<UserAssetDTO>,
+    @SerialName("deleted") override val deleted: Boolean?,
+    @SerialName("email") override val email: String?,
+    @SerialName("expires_at") override val expiresAt: String?,
+    @SerialName("id") override val nonQualifiedId: NonQualifiedUserId,
+    @SerialName("service") override val service: ServiceDTO?,
+    @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatusResponse,
+) : UserDTO()
+
+@Serializable
+data class SelfUserDTO(
+    @SerialName("qualified_id") override val id: UserId,
+    @SerialName("name") override val name: String,
+    @SerialName("handle") override val handle: String?,
+    @SerialName("team") override val teamId: TeamId?,
+    @SerialName("accent_id") override val accentId: Int,
+    @SerialName("assets") override val assets: List<UserAssetDTO>,
+    @SerialName("deleted") override val deleted: Boolean?,
+    @SerialName("email") override val email: String?,
+    @SerialName("expires_at") override val expiresAt: String?,
+    @SerialName("id") override val nonQualifiedId: NonQualifiedUserId,
+    @SerialName("service") override val service: ServiceDTO?,
     @SerialName("locale") val locale: String,
     @SerialName("managed_by") val managedByDTO: ManagedByDTO?,
     @SerialName("phone") val phone: String?,
-    @SerialName("qualified_id") val id: UserId,
-    @SerialName("service") val service: ServiceDTO?,
     @SerialName("sso_id") val ssoID: UserSsoIdDTO?,
-    @SerialName("team") val teamId: TeamId?
-)
+) : UserDTO()
 
 @Serializable
 internal data class NewUserDTO(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/LoginApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/LoginApi.kt
@@ -18,8 +18,8 @@
 
 package com.wire.kalium.network.api.base.unauthenticated
 
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
-import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface LoginApi {
@@ -49,5 +49,5 @@ interface LoginApi {
     suspend fun login(
         param: LoginParam,
         persist: Boolean
-    ): NetworkResponse<Pair<SessionDTO, UserDTO>>
+    ): NetworkResponse<Pair<SessionDTO, SelfUserDTO>>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/register/RegisterApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/register/RegisterApi.kt
@@ -19,8 +19,8 @@
 package com.wire.kalium.network.api.base.unauthenticated.register
 
 import com.wire.kalium.network.api.base.model.NewUserDTO
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
-import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface RegisterApi {
@@ -118,7 +118,7 @@ interface RegisterApi {
 
     suspend fun register(
         param: RegisterParam
-    ): NetworkResponse<Pair<UserDTO, SessionDTO>>
+    ): NetworkResponse<Pair<SelfUserDTO, SessionDTO>>
 
     suspend fun requestActivationCode(
         param: RequestActivationCodeParam

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/SelfApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/SelfApiV0.kt
@@ -23,8 +23,8 @@ import com.wire.kalium.network.api.base.authenticated.self.ChangeHandleRequest
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
 import com.wire.kalium.network.api.base.authenticated.self.UserUpdateRequest
 import com.wire.kalium.network.api.base.model.RefreshTokenProperties
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.UpdateEmailRequest
-import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.utils.NetworkResponse
@@ -44,7 +44,7 @@ internal open class SelfApiV0 internal constructor(
 
     private val httpClient get() = authenticatedNetworkClient.httpClient
 
-    override suspend fun getSelfInfo(): NetworkResponse<UserDTO> = wrapKaliumResponse {
+    override suspend fun getSelfInfo(): NetworkResponse<SelfUserDTO> = wrapKaliumResponse {
         httpClient.get(PATH_SELF)
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/UserDetailsApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/UserDetailsApiV0.kt
@@ -22,8 +22,8 @@ import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.UserId
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
@@ -21,8 +21,8 @@ package com.wire.kalium.network.api.v0.unauthenticated
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.RefreshTokenProperties
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
-import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.api.base.model.toSessionDto
 import com.wire.kalium.network.api.base.unauthenticated.LoginApi
 import com.wire.kalium.network.utils.CustomErrors
@@ -72,7 +72,7 @@ internal open class LoginApiV0 internal constructor(
     override suspend fun login(
         param: LoginApi.LoginParam,
         persist: Boolean
-    ): NetworkResponse<Pair<SessionDTO, UserDTO>> = wrapKaliumResponse<AccessTokenDTO> {
+    ): NetworkResponse<Pair<SessionDTO, SelfUserDTO>> = wrapKaliumResponse<AccessTokenDTO> {
         httpClient.post(PATH_LOGIN) {
             parameter(QUERY_PERSIST, persist)
             setBody(param.toRequestBody())
@@ -85,7 +85,7 @@ internal open class LoginApiV0 internal constructor(
         }.mapSuccess { Pair(accessTokenDTOResponse.value, it) }
     }.flatMap { tokensPairResponse ->
         // this is a hack to get the user QualifiedUserId on login
-        wrapKaliumResponse<UserDTO> {
+        wrapKaliumResponse<SelfUserDTO> {
             httpClient.get(PATH_SELF) {
                 bearerAuth(tokensPairResponse.value.first.value)
             }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/RegisterApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/RegisterApiV0.kt
@@ -21,8 +21,8 @@ package com.wire.kalium.network.api.v0.unauthenticated
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.RefreshTokenProperties
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
-import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.utils.CustomErrors
 import com.wire.kalium.network.utils.NetworkResponse
@@ -48,7 +48,7 @@ internal open class RegisterApiV0 internal constructor(
 
     override suspend fun register(
         param: RegisterApi.RegisterParam
-    ): NetworkResponse<Pair<UserDTO, SessionDTO>> = wrapKaliumResponse<UserDTO> {
+    ): NetworkResponse<Pair<SelfUserDTO, SessionDTO>> = wrapKaliumResponse<SelfUserDTO> {
         httpClient.post(REGISTER_PATH) {
             setBody(param.toBody())
         }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/SSOLoginApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/SSOLoginApiV0.kt
@@ -22,7 +22,7 @@ import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.AuthenticationResultDTO
 import com.wire.kalium.network.api.base.model.RefreshTokenProperties
-import com.wire.kalium.network.api.base.model.UserDTO
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.toSessionDto
 import com.wire.kalium.network.api.base.unauthenticated.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.SSOSettingsResponse
@@ -87,7 +87,7 @@ internal open class SSOLoginApiV0 internal constructor(
                 NetworkResponse.Success(refreshToken, headers, httpCode)
             }.mapSuccess { Pair(accessTokenDTOResponse.value, it) }
         }.flatMap { tokensPairResponse ->
-            wrapKaliumResponse<UserDTO> {
+            wrapKaliumResponse<SelfUserDTO> {
                 httpClient.get(PATH_SELF) {
                     bearerAuth(tokensPairResponse.value.first.value)
                 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/login/LoginApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/login/LoginApiV0Test.kt
@@ -25,8 +25,8 @@ import com.wire.kalium.model.LoginWithEmailRequestJson
 import com.wire.kalium.model.UserDTOJson
 import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.QualifiedID
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
-import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.api.base.unauthenticated.LoginApi
 import com.wire.kalium.network.api.v0.unauthenticated.LoginApiV0
 import com.wire.kalium.network.exceptions.KaliumException
@@ -139,7 +139,7 @@ internal class LoginApiV0Test : ApiTest() {
             expiresIn = 900,
             tokenType = "Bearer"
         )
-        val userDTO = UserDTO(
+        val userDTO = SelfUserDTO(
             id = userID,
             name = "user_name_123",
             accentId = 2,

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/UserDetailsApiV4Test.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.model.ListUsersResponseJson
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
+import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v4.authenticated.UserDetailsApiV4
 import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.NetworkResponse
@@ -31,6 +32,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
@@ -20,9 +20,9 @@ package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProfileDTO
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
 import com.wire.kalium.network.api.base.model.UserId
+import com.wire.kalium.network.api.base.model.UserProfileDTO
 
 object ListUsersResponseJson {
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/UserDTOJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/UserDTOJson.kt
@@ -19,7 +19,7 @@
 package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
-import com.wire.kalium.network.api.base.model.UserDTO
+import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.UserId
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -29,7 +29,7 @@ import kotlinx.serialization.json.putJsonObject
 
 object UserDTOJson {
 
-    private val jsonProvider = { serializable: UserDTO ->
+    private val jsonProvider = { serializable: SelfUserDTO ->
         buildJsonObject {
             put("accent_id", serializable.accentId)
             put("id", serializable.nonQualifiedId)
@@ -73,10 +73,10 @@ object UserDTOJson {
         }.toString()
     }
 
-    fun createValid(userDTO: UserDTO) = ValidJsonProvider(userDTO, jsonProvider)
+    fun createValid(userDTO: SelfUserDTO) = ValidJsonProvider(userDTO, jsonProvider)
 
     val valid = ValidJsonProvider(
-        UserDTO(
+        SelfUserDTO(
             id = UserId("user_id", "domain.com"),
             name = "user_name_123",
             accentId = 2,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

I implemented a new field for users but I forgot to implement for both the self user DTO and the other user DTO.

### Causes (Optional)

They are completely separate DTOs even though they share many fields.

### Solutions

Introduce a base class which both DTOs inherit from.

### Testing

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
