### PR TITLE
fix: crash while initialising CoreCrypto WPB-1923

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
@@ -190,7 +190,7 @@ class ProteusClientCoreCryptoImpl internal constructor(
         try {
             return b()
         } catch (e: CryptoException) {
-            if (this::coreCrypto::isInitialized.get()) {
+            if (this::coreCrypto.isInitialized) {
                 throw ProteusException(e.message, ProteusException.fromProteusCode(coreCrypto.proteusLastErrorCode().toInt()), e)
             } else {
                 throw ProteusException(e.message, ProteusException.Code.UNKNOWN_ERROR, e)

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
@@ -44,9 +44,9 @@ class ProteusClientCoreCryptoImpl internal constructor(
     }
 
     override suspend fun openOrCreate() {
-        coreCrypto = wrapException {
+        wrapException {
             File(rootDir).mkdirs()
-            val coreCrypto = CoreCrypto.deferredInit(path, databaseKey.value, null)
+            coreCrypto = CoreCrypto.deferredInit(path, databaseKey.value, null)
             migrateFromCryptoBoxIfNecessary(coreCrypto)
             coreCrypto.proteusInit()
             coreCrypto
@@ -56,11 +56,10 @@ class ProteusClientCoreCryptoImpl internal constructor(
     override suspend fun openOrError() {
         val directory = File(rootDir)
         if (directory.exists()) {
-            coreCrypto = wrapException {
-                val coreCrypto = CoreCrypto.deferredInit(path, databaseKey.value, null)
+            wrapException {
+                coreCrypto = CoreCrypto.deferredInit(path, databaseKey.value, null)
                 migrateFromCryptoBoxIfNecessary(coreCrypto)
                 coreCrypto.proteusInit()
-                coreCrypto
             }
         } else {
             throw ProteusException(
@@ -186,14 +185,18 @@ class ProteusClientCoreCryptoImpl internal constructor(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "ThrowsCount")
     private fun <T> wrapException(b: () -> T): T {
         try {
             return b()
         } catch (e: CryptoException) {
-            throw ProteusException(e.message, ProteusException.fromProteusCode(coreCrypto.proteusLastErrorCode().toInt()), e.cause)
+            if (this::coreCrypto::isInitialized.get()) {
+                throw ProteusException(e.message, ProteusException.fromProteusCode(coreCrypto.proteusLastErrorCode().toInt()), e)
+            } else {
+                throw ProteusException(e.message, ProteusException.Code.UNKNOWN_ERROR, e)
+            }
         } catch (e: Exception) {
-            throw ProteusException(e.message, ProteusException.Code.UNKNOWN_ERROR, e.cause)
+            throw ProteusException(e.message, ProteusException.Code.UNKNOWN_ERROR, e)
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We crash / throw an unexpected exception when opening the core crypto proteus client.

### Causes (Optional)

If a CoreCrypto exception is thrown when initialising CoreCrypto attempt to figure out the root cause by calling `coreCrypto.proteusLastErrorCode()`. But the lateinit `coreCrypto` is not yet set and we crash.

### Solutions

Set `coreCrypto` before we call `proteusInit` and avoid calling `coreCrypto.proteusLastErrorCode()` if coreCrypto is not set.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
