### PR TITLE
fix: message timer not started when message is sent

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -189,6 +189,11 @@ interface MessageRepository {
         conversationId: ConversationId
     ): Flow<MessageEntity.Visibility>
 
+    suspend fun observeMessageStatus(
+        messageUuid: String,
+        conversationId: ConversationId
+    ) : Flow<MessageEntity.Status>
+
     val extensions: MessageRepositoryExtensions
 }
 
@@ -509,6 +514,10 @@ class MessageDataSource(
 
     override suspend fun observeMessageVisibility(messageUuid: String, conversationId: ConversationId): Flow<MessageEntity.Visibility> {
         return messageDAO.observeMessageVisibility(messageUuid, conversationId.toDao())
+    }
+
+    override suspend fun observeMessageStatus(messageUuid: String, conversationId: ConversationId): Flow<MessageEntity.Status> {
+        return messageDAO.observeMessageStatus(messageUuid,conversationId.toDao())
     }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -138,7 +138,7 @@ class DebugScope internal constructor(
             mlsMessageCreator,
             messageSendingInterceptor,
             userRepository,
-            { message, expirationData -> ephemeralMessageDeletionHandler.enqueueSelfDeletion(message, expirationData) },
+            { conversationId, messageId -> ephemeralMessageDeletionHandler.startSelfDeletion(conversationId, messageId) },
             scope
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -140,7 +140,7 @@ class MessageScope internal constructor(
             mlsMessageCreator,
             messageSendingInterceptor,
             userRepository,
-            { message, expirationData -> ephemeralMessageDeletionHandler.enqueueSelfDeletion(message, expirationData) },
+            { conversationId, messageId -> ephemeralMessageDeletionHandler.startSelfDeletion(conversationId, messageId) },
             scope
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -190,7 +190,6 @@ internal class MessageSenderImpl internal constructor(
                         serverDate = if (!isEditMessage) serverDate else null,
                         millis = millis
                     )
-                    startSelfDeletionIfNeeded(message)
 
                     Unit
                 }
@@ -225,6 +224,8 @@ internal class MessageSenderImpl internal constructor(
                         attemptToSendWithProteus(message, messageTarget)
                     }
                 }
+            }.onSuccess {
+                startSelfDeletionIfNeeded(message)
             }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -190,10 +190,8 @@ internal class MessageSenderImpl internal constructor(
                         serverDate = if (!isEditMessage) serverDate else null,
                         millis = millis
                     )
+                    startSelfDeletionIfNeeded(message)
 
-                    if (message is Message.Regular && message.expirationData != null) {
-                        enqueueSelfDeletion(message.conversationId, message.id)
-                    }
                     Unit
                 }
             }
@@ -368,8 +366,8 @@ internal class MessageSenderImpl internal constructor(
                     }
                     .onFailure {
                         val logLine = "Fatal Proteus $action Failure: { \"message\" : \"${messageLogString}\"" +
-                            " , " +
-                            "\"errorInfo\" : \"${it}\"}"
+                                " , " +
+                                "\"errorInfo\" : \"${it}\"}"
                         logger.e(logLine)
                     }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
@@ -61,6 +61,7 @@ internal class EphemeralMessageDeletionHandlerImpl(
             Message.Status.FAILED,
             Message.Status.FAILED_REMOTELY -> true
         }
+        kaliumLogger.i("deleting the message with status ${message.status}")
         if (!canBeDeleted) {
             SelfDeletionEventLogger.log(
                 LoggingSelfDeletionEvent.InvalidMessageStatus(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -777,11 +777,8 @@ class MessageSenderTest {
             mlsMessageCreator = mlsMessageCreator,
             messageSendingInterceptor = messageSendingInterceptor,
             userRepository = userRepository,
-            enqueueSelfDeletion = { message, expirationData ->
-                selfDeleteMessageSenderHandler.enqueueSelfDeletion(
-                    message,
-                    expirationData
-                )
+            enqueueSelfDeletion = { conversationId, messageId ->
+                selfDeleteMessageSenderHandler.startSelfDeletion(conversationId, messageId)
             },
             scope = testScope
         )

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -534,6 +534,9 @@ WHERE message_id = ? AND conversation_id = ?;
 selectMessageVisibility:
 SELECT visibility FROM Message WHERE id = ? AND conversation_id = ?;
 
+selectMessageStatus:
+SELECT status FROM Message WHERE id = ? AND conversation_id = ?;
+
 updateAssetDownloadStatus:
 UPDATE MessageAssetContent
 SET asset_download_status = ?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -88,7 +88,7 @@ interface MessageDAO {
     )
 
     suspend fun observeMessageVisibility(messageUuid: String, conversationId: QualifiedIDEntity): Flow<MessageEntity.Visibility>
-
+    suspend fun observeMessageStatus(messageUuid: String, conversationId: QualifiedIDEntity) : Flow<MessageEntity.Status>
     suspend fun getConversationMessagesByContentType(
         conversationId: QualifiedIDEntity,
         contentType: MessageEntity.ContentType

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -374,6 +374,13 @@ class MessageDAOImpl(
             .distinctUntilChanged()
     }
 
+    override suspend fun observeMessageStatus(messageUuid: String, conversationId: QualifiedIDEntity): Flow<MessageEntity.Status> {
+        return queries.selectMessageStatus(messageUuid, conversationId)
+            .asFlow()
+            .mapToOne()
+            .distinctUntilChanged()
+    }
+
     override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, mapper, coroutineContext)
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

 - Once the message is sent, we were passing old instance of the message that has not updated status.
 - Also in some cases even though the functions are executed sequentially, before we do a check again after invoking enqueue method to enqueue self deletion, the database returns still old status of the message, which is weird but perhaps invalidating database takes some time ?

### Solutions

- Pass conversation id and message id instead so that the self deletion handler, retrieves the state of the message as it is inside the deletion handler.
- Instead of relaying on exact correct timing if the status is set to SENT, we observe the status instead to make it more reliable. 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
