### PR TITLE
fix: immediately retry sync on connection policy upgrade

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -35,10 +35,19 @@ import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -76,7 +85,10 @@ internal class IncrementalSyncManager(
     private val incrementalSyncRecoveryHandler: IncrementalSyncRecoveryHandler,
     private val networkStateObserver: NetworkStateObserver,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl,
-    private val exponentialDurationHelper: ExponentialDurationHelper = ExponentialDurationHelperImpl(MIN_RETRY_DELAY, MAX_RETRY_DELAY)
+    private val exponentialDurationHelper: ExponentialDurationHelper = ExponentialDurationHelperImpl(
+        MIN_RETRY_DELAY,
+        MAX_RETRY_DELAY
+    )
 ) {
 
     /**
@@ -101,13 +113,34 @@ internal class IncrementalSyncManager(
                 incrementalSyncRecoveryHandler.recover(failure = failure) {
                     val delay = exponentialDurationHelper.next()
                     kaliumLogger.i("$TAG Triggering delay($delay) and waiting for reconnection")
-                    networkStateObserver.delayUntilConnectedWithInternetAgain(delay)
+                    delayUntilConnectedOrPolicyUpgrade(delay)
                     kaliumLogger.i("$TAG Delay and waiting for connection finished - retrying")
                     startMonitoringForSync()
                 }
             }
         }
     )
+
+    private suspend fun delayUntilConnectedOrPolicyUpgrade(delay: Duration): Unit = coroutineScope {
+        select {
+            async {
+                incrementalSyncRepository
+                    .connectionPolicyState
+                    .onEach {
+                        println(it)
+                    }
+                    .drop(1)
+                    .first { it == KEEP_ALIVE }
+            }.onAwait {
+                kaliumLogger.i("$TAG backoff timer short-circuited as Policy was upgraded")
+            }
+            async {
+                networkStateObserver.delayUntilConnectedWithInternetAgain(delay)
+            }.onAwait {
+                kaliumLogger.i("$TAG wait whole timer, as there was no policy upgrade until now")
+            }
+        }.also { coroutineContext.cancelChildren() }
+    }
 
     private val syncScope = CoroutineScope(SupervisorJob() + eventProcessingDispatcher)
 
@@ -136,6 +169,7 @@ internal class IncrementalSyncManager(
             .filter { it == KEEP_ALIVE }
             .cancellable()
             .collect {
+                exponentialDurationHelper.reset()
                 kaliumLogger.i("$TAG Re-starting IncrementalSync, as ConnectionPolicy was upgraded to KEEP_ALIVE")
                 doIncrementalSyncWhilePolicyAllows()
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlin.time.Duration

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -125,9 +125,6 @@ internal class IncrementalSyncManager(
             async {
                 incrementalSyncRepository
                     .connectionPolicyState
-                    .onEach {
-                        println(it)
-                    }
                     .drop(1)
                     .first { it == KEEP_ALIVE }
             }.onAwait {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -341,7 +342,7 @@ class IncrementalSyncManagerTest {
                 .withWorkerReturning(flowThatFailsOnFirstTime())
                 .withNextExponentialDuration(retryDelay)
                 .withRecoveringFromFailure()
-                .withConnectionPolicyReturning(policyFlow.consumeAsFlow())
+                .withConnectionPolicyReturning(policyFlow.receiveAsFlow())
                 .arrange()
 
             arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -19,10 +19,10 @@
 package com.wire.kalium.logic.sync.incremental
 
 import com.wire.kalium.logic.data.sync.ConnectionPolicy
-import com.wire.kalium.logic.data.sync.SlowSyncRepositoryImpl
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepositoryImpl
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.network.NetworkState
 import com.wire.kalium.logic.network.NetworkStateObserver
@@ -40,6 +40,7 @@ import io.mockative.given
 import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
+import io.mockative.times
 import io.mockative.twice
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,6 +51,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.cancellation.CancellationException
@@ -296,10 +298,61 @@ class IncrementalSyncManagerTest {
         arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
         advanceUntilIdle()
 
-        verify(arrangement.exponentialDurationHelper)
-            .function(arrangement.exponentialDurationHelper::next)
-            .wasInvoked(exactly = once)
-    }
+            verify(arrangement.exponentialDurationHelper)
+                .function(arrangement.exponentialDurationHelper::next)
+                .wasInvoked(exactly = once)
+        }
+
+    @Test
+    fun givenSlowSyncIsCompletedAndWorkerFails_whenPolicyIsUpgraded_thenShouldResetExponentialDuration() =
+        runTest(TestKaliumDispatcher.default) {
+            val policyFlow = MutableStateFlow(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+
+            val (arrangement, _) = Arrangement()
+                .withWorkerReturning(emptyFlow())
+                .withRecoveringFromFailure()
+                .withConnectionPolicyReturning(policyFlow)
+                .arrange()
+
+            arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+            verify(arrangement.exponentialDurationHelper)
+                .function(arrangement.exponentialDurationHelper::reset)
+                .wasNotInvoked()
+
+            policyFlow.emit(ConnectionPolicy.KEEP_ALIVE)
+            advanceUntilIdle()
+
+            verify(arrangement.exponentialDurationHelper)
+                .function(arrangement.exponentialDurationHelper::reset)
+                .wasInvoked(exactly = once)
+        }
+
+    @Test
+    fun givenWorkerFailsAndDelayUntilRetry_whenPolicyIsUpgraded_thenShouldRetryImmediately() =
+        runTest(TestKaliumDispatcher.default) {
+            val policyFlow = Channel<ConnectionPolicy>(capacity = Channel.UNLIMITED)
+            policyFlow.send(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+            policyFlow.send(ConnectionPolicy.KEEP_ALIVE)
+
+            val retryDelay = 10.seconds
+
+            val (arrangement, _) = Arrangement()
+                .withWorkerReturning(flowThatFailsOnFirstTime())
+                .withNextExponentialDuration(retryDelay)
+                .withRecoveringFromFailure()
+                .withConnectionPolicyReturning(policyFlow.consumeAsFlow())
+                .arrange()
+
+            arrangement.slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
+
+            // Should ignore the rest of the timer and immediately retry
+            advanceTimeBy(retryDelay.inWholeMilliseconds / 2)
+            verify(arrangement.incrementalSyncWorker)
+                .suspendFunction(arrangement.incrementalSyncWorker::processEventsWhilePolicyAllowsFlow)
+                .wasInvoked(exactly = 2.times)
+        }
+
     private class Arrangement {
 
         val database = TestUserDatabase(UserIDEntity("SELF_USER", "DOMAIN"))
@@ -345,7 +398,7 @@ class IncrementalSyncManagerTest {
                 .thenReturn(sourceFlow)
         }
 
-        fun withConnectionPolicyReturning(connectionPolicyFlow: StateFlow<ConnectionPolicy>) = apply {
+        fun withConnectionPolicyReturning(connectionPolicyFlow: Flow<ConnectionPolicy>) = apply {
             given(incrementalSyncRepository)
                 .getter(incrementalSyncRepository::connectionPolicyState)
                 .whenInvoked()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes users on Reloaded are "stuck on connecting"

### Causes

1. The OS can block the app from connecting to the network when the app isn't visible after a while. And we do not handle the "unblocking" on Kalium's `NetworkStateObserver`.
2. Given the current backoff policy can make it grow to up to 10 minutes while on the background, even if the app is reopened, the retry counter will stay counting.

### Solutions

The first "cause" isn't handled on this PR. As Android's ConnectivityManager calls need some testing to make sure it works well and it would be safer to improve after the next code freeze.

About the second one. It's two-fold:
1. Whenever there's a policy upgrade: reset the backoff timer.
2. Whenever there's a policy upgrade: cancel the timer that is currently running.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
