### PR TITLE
fix: crash when deleting a self delete asset message

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -508,7 +508,10 @@ class MessageDataSource(
         }
     }
 
-    override suspend fun observeMessageVisibility(messageUuid: String, conversationId: ConversationId): Flow<Either<StorageFailure, MessageEntity.Visibility>> =
+    override suspend fun observeMessageVisibility(
+        messageUuid: String,
+        conversationId: ConversationId
+    ): Flow<Either<StorageFailure, MessageEntity.Visibility>> =
         wrapFlowStorageRequest {
             messageDAO.observeMessageVisibility(messageUuid, conversationId.toDao())
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.logic.wrapFlowStorageRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.api.base.authenticated.message.MessageApi
@@ -187,7 +188,7 @@ interface MessageRepository {
     suspend fun observeMessageVisibility(
         messageUuid: String,
         conversationId: ConversationId
-    ): Flow<MessageEntity.Visibility>
+    ): Flow<Either<StorageFailure, MessageEntity.Visibility>>
 
     val extensions: MessageRepositoryExtensions
 }
@@ -507,8 +508,9 @@ class MessageDataSource(
         }
     }
 
-    override suspend fun observeMessageVisibility(messageUuid: String, conversationId: ConversationId): Flow<MessageEntity.Visibility> {
-        return messageDAO.observeMessageVisibility(messageUuid, conversationId.toDao())
-    }
+    override suspend fun observeMessageVisibility(messageUuid: String, conversationId: ConversationId): Flow<Either<StorageFailure, MessageEntity.Visibility>> =
+        wrapFlowStorageRequest {
+            messageDAO.observeMessageVisibility(messageUuid, conversationId.toDao())
+        }
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
@@ -56,7 +56,6 @@ import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -164,12 +163,10 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
                             visibility.fold(
                                 {
                                     outGoingAssetUploadJob?.cancel()
-                                    this.cancel()
                                 },
                                 {
                                     if (it == MessageEntity.Visibility.DELETED) {
                                         outGoingAssetUploadJob?.cancel()
-                                        this.cancel()
                                     }
                                 }
                             )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
@@ -63,7 +63,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.IOException
@@ -663,7 +662,7 @@ class ScheduleNewAssetMessageUseCaseTest {
             given(messageRepository)
                 .suspendFunction(messageRepository::observeMessageVisibility)
                 .whenInvokedWith(any())
-                .thenReturn(flowOf(MessageEntity.Visibility.VISIBLE))
+                .thenReturn(flowOf(Either.Right(MessageEntity.Visibility.VISIBLE)))
         }
 
         fun withDeleteAssetLocally() = apply {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -87,7 +87,7 @@ interface MessageDAO {
         newMessageId: String
     )
 
-    suspend fun observeMessageVisibility(messageUuid: String, conversationId: QualifiedIDEntity): Flow<MessageEntity.Visibility>
+    suspend fun observeMessageVisibility(messageUuid: String, conversationId: QualifiedIDEntity): Flow<MessageEntity.Visibility?>
 
     suspend fun getConversationMessagesByContentType(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -32,7 +32,7 @@ import com.wire.kalium.persistence.dao.unread.ConversationUnreadEventEntity
 import com.wire.kalium.persistence.dao.unread.UnreadEventEntity
 import com.wire.kalium.persistence.dao.unread.UnreadEventMapper
 import com.wire.kalium.persistence.util.mapToList
-import com.wire.kalium.persistence.util.mapToOne
+import com.wire.kalium.persistence.util.mapToOneOrNull
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
@@ -367,10 +367,10 @@ class MessageDAOImpl(
     override suspend fun observeMessageVisibility(
         messageUuid: String,
         conversationId: QualifiedIDEntity
-    ): Flow<MessageEntity.Visibility> {
+    ): Flow<MessageEntity.Visibility?> {
         return queries.selectMessageVisibility(messageUuid, conversationId)
             .asFlow()
-            .mapToOne()
+            .mapToOneOrNull()
             .distinctUntilChanged()
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when deleting an asset message while being uploaded -> app crash

### Causes (Optional)

the asset message send use case is observing the message status to cancel the upload if the message is deleted and after delete the status is null and the mapper crashes (it expects non null values)

### Solutions

change the flow to emit null values when the data is not found

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
