### PR TITLE
feat(mls-migration): add use case for updating self supported protocols #5

### DIFF
--- a/cli/src/appleMain/kotlin/main.kt
+++ b/cli/src/appleMain/kotlin/main.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.cli.commands.MarkAsReadCommand
 import com.wire.kalium.cli.commands.RefillKeyPackagesCommand
 import com.wire.kalium.cli.commands.RemoveMemberFromGroupCommand
 import com.wire.kalium.cli.commands.InteractiveCommand
+import com.wire.kalium.cli.commands.UpdateSupportedProtocolsCommand
 
 fun main(args: Array<String>) = CLIApplication().subcommands(
     LoginCommand().subcommands(
@@ -37,6 +38,7 @@ fun main(args: Array<String>) = CLIApplication().subcommands(
         RemoveMemberFromGroupCommand(),
         RefillKeyPackagesCommand(),
         MarkAsReadCommand(),
-        InteractiveCommand()
+        InteractiveCommand(),
+        UpdateSupportedProtocolsCommand()
     )
 ).main(args)

--- a/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/UpdateSupportedProtocolsCommand.kt
+++ b/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/UpdateSupportedProtocolsCommand.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.PrintMessage
+import com.github.ajalt.clikt.core.requireObject
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCase
+import kotlinx.coroutines.runBlocking
+
+class UpdateSupportedProtocolsCommand : CliktCommand(name = "update-supported-protocols") {
+
+    private val userSession by requireObject<UserSessionScope>()
+
+    override fun run() = runBlocking {
+        when (val result = userSession.users.updateSupportedProtocols()) {
+            is UpdateSupportedProtocolsUseCase.Result.Success ->
+                echo("supported protocols were updated")
+            is UpdateSupportedProtocolsUseCase.Result.Failure ->
+                throw PrintMessage("updating supported protocols failed: ${result.failure}")
+        }
+    }
+}

--- a/cli/src/jvmMain/kotlin/com/wire/kalium/cli/main.kt
+++ b/cli/src/jvmMain/kotlin/com/wire/kalium/cli/main.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.cli.commands.MarkAsReadCommand
 import com.wire.kalium.cli.commands.ConsoleCommand
 import com.wire.kalium.cli.commands.RefillKeyPackagesCommand
 import com.wire.kalium.cli.commands.RemoveMemberFromGroupCommand
+import com.wire.kalium.cli.commands.UpdateSupportedProtocolsCommand
 
 fun main(args: Array<String>) = CLIApplication().subcommands(
     LoginCommand().subcommands(
@@ -38,6 +39,7 @@ fun main(args: Array<String>) = CLIApplication().subcommands(
         RemoveMemberFromGroupCommand(),
         ConsoleCommand(),
         RefillKeyPackagesCommand(),
-        MarkAsReadCommand()
+        MarkAsReadCommand(),
+        UpdateSupportedProtocolsCommand()
     )
 ).main(args)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -81,7 +81,7 @@ class ClientMapper(
             model = model,
             isVerified = isVerified,
             isValid = isValid,
-            isMLSCapable = false // TODO jacob persist in db?
+            isMLSCapable = isMLSCapable
         )
     }
 
@@ -107,13 +107,14 @@ class ClientMapper(
                     clientType = null,
                     label = null,
                     model = null,
-                    registrationDate = null
+                    registrationDate = null,
+                    isMLSCapable = false
                 )
             }
         }
 
-    fun toInsertClientParam(simpleClientResponse: ClientResponse, userIdDTO: UserIdDTO): InsertClientParam =
-        with(simpleClientResponse) {
+    fun toInsertClientParam(clientResponse: ClientResponse, userIdDTO: UserIdDTO): InsertClientParam =
+        with(clientResponse) {
             InsertClientParam(
                 userId = userIdDTO.toDao(),
                 id = clientId,
@@ -121,7 +122,8 @@ class ClientMapper(
                 clientType = toClientTypeEntity(type),
                 label = label,
                 model = model,
-                registrationDate = Instant.parse(registrationTime)
+                registrationDate = Instant.parse(registrationTime),
+                isMLSCapable = mlsPublicKeys?.isNotEmpty() ?: false
             )
         }
 
@@ -134,7 +136,8 @@ class ClientMapper(
                 clientType = null,
                 label = null,
                 model = null,
-                registrationDate = null
+                registrationDate = null,
+                isMLSCapable = false
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -94,7 +94,7 @@ class ClientMapper(
         model = event.model,
         isVerified = false,
         isValid = true,
-        isMLSCapable = false // TODO jacob check if data is available on new client event
+        isMLSCapable = event.isMLSCapable
     )
 
     fun toInsertClientParam(simpleClientResponse: List<SimpleClientResponse>, userIdDTO: UserIdDTO): List<InsertClientParam> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -67,7 +67,8 @@ class ClientMapper(
         label = response.label,
         model = response.model,
         isVerified = false,
-        isValid = true
+        isValid = true,
+        isMLSCapable = response.mlsPublicKeys?.isNotEmpty() ?: false
     )
 
     fun fromClientEntity(clientEntity: ClientEntity): Client = with(clientEntity) {
@@ -79,7 +80,8 @@ class ClientMapper(
             label = label,
             model = model,
             isVerified = isVerified,
-            isValid = isValid
+            isValid = isValid,
+            isMLSCapable = false // TODO jacob persist in db?
         )
     }
 
@@ -91,7 +93,8 @@ class ClientMapper(
         label = event.label,
         model = event.model,
         isVerified = false,
-        isValid = true
+        isValid = true,
+        isMLSCapable = false // TODO jacob check if data is available on new client event
     )
 
     fun toInsertClientParam(simpleClientResponse: List<SimpleClientResponse>, userIdDTO: UserIdDTO): List<InsertClientParam> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
@@ -48,7 +48,8 @@ data class Client(
     val isValid: Boolean,
     val deviceType: DeviceType?,
     val label: String?,
-    val model: String?
+    val model: String?,
+    val isMLSCapable: Boolean
 )
 
 enum class ClientType {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.user.Connection
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
@@ -499,6 +500,7 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val email: String?,
             val previewAssetId: String?,
             val completeAssetId: String?,
+            val supportedProtocols: Set<SupportedProtocol>?
         ) : User(id, transient) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.Update",

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.Conversation.ReceiptMode
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
@@ -552,7 +553,8 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             val model: String?,
             val clientType: ClientTypeDTO,
             val deviceType: DeviceTypeDTO,
-            val label: String?
+            val label: String?,
+            val isMLSCapable: Boolean
         ) : User(id, transient) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.NewClient",

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -212,7 +212,8 @@ class EventMapper(
             model = eventNewClient.client.model,
             clientType = eventNewClient.client.clientType,
             deviceType = eventNewClient.client.deviceType,
-            label = eventNewClient.client.label
+            label = eventNewClient.client.label,
+            isMLSCapable = eventNewClient.client.mlsPublicKeys?.isNotEmpty() ?: false
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.event.Event.UserProperty.ReadReceiptModeSet
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapper
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toModel
+import com.wire.kalium.logic.data.user.toModel
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
@@ -433,7 +434,8 @@ class EventMapper(
         email = event.userData.email,
         previewAssetId = event.userData.assets?.getPreviewAssetOrNull()?.key,
         transient = transient,
-        completeAssetId = event.userData.assets?.getCompleteAssetOrNull()?.key
+        completeAssetId = event.userData.assets?.getCompleteAssetOrNull()?.key,
+        supportedProtocols = event.userData.supportedProtocols?.toModel()
     )
 
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -19,6 +19,8 @@
 package com.wire.kalium.logic.data.featureConfig
 
 import com.wire.kalium.logic.data.id.PlainId
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.data.user.toModel
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigResponse
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlagStatusDTO
@@ -74,10 +76,12 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
         data?.let {
             MLSModel(
                 it.config.protocolToggleUsers.map { userId -> PlainId(userId) },
+                it.config.supportedProtocols.map { it.toModel() }.toSet(),
                 fromDTO(it.status)
             )
         } ?: MLSModel(
             listOf(),
+            setOf(SupportedProtocol.PROTEUS),
             Status.DISABLED
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.data.featureConfig
 
 import com.wire.kalium.logic.data.id.PlainId
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import kotlinx.datetime.Instant
 
 data class FeatureConfigModel(
@@ -78,6 +79,7 @@ data class SelfDeletingMessagesConfigModel(
 
 data class MLSModel(
     val allowedUsers: List<PlainId>,
+    val supportedProtocols: Set<SupportedProtocol>,
     val status: Status
 )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -311,7 +311,8 @@ internal class UserMapperImpl(
                 previewAssetId = event.previewAssetId?.let { QualifiedIDEntity(it, persistedEntity.id.domain) }
                     ?: persistedEntity.previewAssetId,
                 completeAssetId = event.completeAssetId?.let { QualifiedIDEntity(it, persistedEntity.id.domain) }
-                    ?: persistedEntity.completeAssetId
+                    ?: persistedEntity.completeAssetId,
+                supportedProtocols = event.supportedProtocols?.toDao() ?: persistedEntity.supportedProtocols
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1215,7 +1215,6 @@ class UserSessionScope internal constructor(
             messages.messageSender,
             clientIdProvider,
             clientRepository,
-            mlsMigrationRepository,
             featureConfigRepository,
             slowSyncRepository,
             team.isSelfATeamMember,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1214,8 +1214,11 @@ class UserSessionScope internal constructor(
             userPropertyRepository,
             messages.messageSender,
             clientIdProvider,
-            conversationRepository,
-            team.isSelfATeamMember
+            clientRepository,
+            mlsMigrationRepository,
+            featureConfigRepository,
+            slowSyncRepository,
+            team.isSelfATeamMember,
         )
     private val clearUserData: ClearUserDataUseCase get() = ClearUserDataUseCaseImpl(userStorage)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCase.kt
@@ -86,13 +86,7 @@ internal class UpdateSupportedProtocolsUseCaseImpl(
         featureConfigRepository.getFeatureConfigs().flatMap { featureConfigs ->
             clientsRepository.selfListOfClients().map { selfClients ->
                 val mlsConfiguration = featureConfigs.mlsModel
-                val migrationConfiguration = featureConfigs.mlsMigrationModel ?: MLSMigrationModel(
-                    Instant.DISTANT_FUTURE,
-                    Instant.DISTANT_FUTURE,
-                    0,
-                    0,
-                    Status.DISABLED
-                )
+                val migrationConfiguration = featureConfigs.mlsMigrationModel ?: MIGRATION_CONFIGURATION_DISABLED
                 val supportedProtocols = mutableSetOf<SupportedProtocol>()
                 if (proteusIsSupported(mlsConfiguration, migrationConfiguration)) {
                     supportedProtocols.add(SupportedProtocol.PROTEUS)
@@ -123,5 +117,15 @@ internal class UpdateSupportedProtocolsUseCaseImpl(
         val proteusIsSupported = mlsConfiguration.supportedProtocols.contains(SupportedProtocol.PROTEUS)
         val mlsMigrationHasEnded = migrationConfiguration.hasMigrationEnded()
         return proteusIsSupported || !mlsMigrationHasEnded
+    }
+
+    companion object {
+        val MIGRATION_CONFIGURATION_DISABLED = MLSMigrationModel(
+            startTime = Instant.DISTANT_FUTURE,
+            endTime = Instant.DISTANT_FUTURE,
+            usersThreshold = 0,
+            clientsThreshold = 0,
+            status = Status.DISABLED
+        )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCase.kt
@@ -1,0 +1,129 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
+import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.mlsmigration.hasMigrationEnded
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.foldToEitherWhileRight
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCase.Result
+import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.flow.first
+
+/**
+ * Updates the supported protocols of the current user.
+ *
+ * @return [Result.Success] if the supported protocols were updated successfully, [Result.Failure] otherwise.
+ */
+interface UpdateSupportedProtocolsUseCase {
+    suspend operator fun invoke(): Result
+
+    sealed interface Result {
+        object Success : Result
+        data class Failure(val failure: CoreFailure) : Result
+    }
+}
+
+internal class UpdateSupportedProtocolsUseCaseImpl(
+    private val clientsRepository: ClientRepository,
+    private val userRepository: UserRepository,
+    private val mlsMigrationRepository: MLSMigrationRepository,
+    private val featureConfigRepository: FeatureConfigRepository,
+    private val slowSyncRepository: SlowSyncRepository
+) : UpdateSupportedProtocolsUseCase {
+
+    override suspend operator fun invoke(): Result {
+        kaliumLogger.d("Updating supported protocols")
+
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
+
+        return (userRepository.getSelfUser()?.let { selfUser ->
+            supportedProtocols().flatMap { newSupportedProtocols ->
+                kaliumLogger.d(
+                    "Updating supported protocols = $newSupportedProtocols previously = ${selfUser.supportedProtocols}"
+                )
+                if (newSupportedProtocols != selfUser.supportedProtocols) {
+                    userRepository.updateSupportedProtocols(newSupportedProtocols)
+                } else {
+                    Either.Right(Unit)
+                }
+            }
+        } ?: Either.Left(StorageFailure.DataNotFound))
+            .fold(Result::Failure) { Result.Success }
+    }
+
+    private suspend fun supportedProtocols(): Either<CoreFailure, Set<SupportedProtocol>> =
+        proteusIsSupported().flatMap { proteusIsSupported ->
+            mlsIsSupported().map { mlsIsSupported ->
+                val supportedProtocols = mutableSetOf<SupportedProtocol>()
+
+                if (proteusIsSupported) {
+                    supportedProtocols.add(SupportedProtocol.PROTEUS)
+                }
+
+                if (mlsIsSupported) {
+                    supportedProtocols.add(SupportedProtocol.MLS)
+                }
+
+                supportedProtocols
+            }
+        }
+
+    private suspend fun mlsIsSupported(): Either<CoreFailure, Boolean> =
+        listOf(
+            mlsMigrationDeadlineHasBeenReached(),
+            allActiveClientsAreMLSCapable()
+        ).foldToEitherWhileRight(false) { result, acc ->
+            result.flatMap { Either.Right(it || acc) }
+        }
+
+    private suspend fun proteusIsSupported(): Either<CoreFailure, Boolean> =
+        mlsMigrationRepository.fetchMigrationConfiguration().flatMap { // TODO jacob remove later
+            mlsMigrationRepository.getMigrationConfiguration().flatMap { migrationConfiguration ->
+                featureConfigRepository.getFeatureConfigs().map { it.mlsModel }.map { mlsConfiguration ->
+                    val proteusIsSupported = mlsConfiguration.supportedProtocols.contains(SupportedProtocol.PROTEUS)
+                    val mlsMigrationHasEnded = migrationConfiguration.hasMigrationEnded()
+                    proteusIsSupported || !mlsMigrationHasEnded
+                }
+            }
+        }
+
+    private suspend fun mlsMigrationDeadlineHasBeenReached(): Either<CoreFailure, Boolean> =
+        mlsMigrationRepository.getMigrationConfiguration().map { migrationConfiguration ->
+            migrationConfiguration.hasMigrationEnded()
+        }
+
+    private suspend fun allActiveClientsAreMLSCapable(): Either<CoreFailure, Boolean> =
+        clientsRepository.selfListOfClients()
+            .map { selfClients -> // TODO jacob filter out inactive clients
+                selfClients.all { it.isMLSCapable }
+            }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -76,7 +76,6 @@ class UserScope internal constructor(
     private val messageSender: MessageSender,
     private val clientIdProvider: CurrentClientIdProvider,
     private val clientRepository: ClientRepository,
-    private val mlsMigrationRepository: MLSMigrationRepository,
     private val featureConfigRepository: FeatureConfigRepository,
     private val slowSyncRepository: SlowSyncRepository,
     private val isSelfATeamMember: IsSelfATeamMemberUseCase
@@ -112,7 +111,6 @@ class UserScope internal constructor(
         get() = UpdateSupportedProtocolsUseCaseImpl(
             clientRepository,
             userRepository,
-            mlsMigrationRepository,
             featureConfigRepository,
             slowSyncRepository
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -24,7 +24,6 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
-import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.session.SessionRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -20,12 +20,15 @@ package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.asset.AssetRepository
+import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
-import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
@@ -72,7 +75,10 @@ class UserScope internal constructor(
     private val userPropertyRepository: UserPropertyRepository,
     private val messageSender: MessageSender,
     private val clientIdProvider: CurrentClientIdProvider,
-    private val conversationRepository: ConversationRepository,
+    private val clientRepository: ClientRepository,
+    private val mlsMigrationRepository: MLSMigrationRepository,
+    private val featureConfigRepository: FeatureConfigRepository,
+    private val slowSyncRepository: SlowSyncRepository,
     private val isSelfATeamMember: IsSelfATeamMemberUseCase
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
@@ -102,6 +108,14 @@ class UserScope internal constructor(
         get() = UpdateSelfAvailabilityStatusUseCase(userRepository, messageSender, clientIdProvider, selfUserId)
     val getAllContactsNotInConversation: GetAllContactsNotInConversationUseCase
         get() = GetAllContactsNotInConversationUseCase(userRepository)
+    val updateSupportedProtocols: UpdateSupportedProtocolsUseCase
+        get() = UpdateSupportedProtocolsUseCaseImpl(
+            clientRepository,
+            userRepository,
+            mlsMigrationRepository,
+            featureConfigRepository,
+            slowSyncRepository
+        )
 
     val isPasswordRequired
         get() = IsPasswordRequiredUseCase(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -354,6 +354,7 @@ class ClientRepositoryTest {
                 isVerified = false,
                 isValid = true,
                 userId = userId,
+                isMLSCapable = false
             )
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -280,7 +280,8 @@ class ClientRepositoryTest {
                 label = null,
                 model = "Mac ox",
                 isVerified = false,
-                isValid = true
+                isValid = true,
+                isMLSCapable = false
             ),
             Client(
                 id = PlainId(value = "client_id_2"),
@@ -290,7 +291,8 @@ class ClientRepositoryTest {
                 label = null,
                 model = "iphone 15",
                 isVerified = false,
-                isValid = true
+                isValid = true,
+                isMLSCapable = false
             ),
         )
 
@@ -364,7 +366,8 @@ class ClientRepositoryTest {
                 label = null,
                 model = null,
                 isVerified = false,
-                isValid = true
+                isValid = true,
+                isMLSCapable = false
             )
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProtocol
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -160,7 +160,7 @@ class FeatureConfigMapperTest {
                 MLSConfigDTO(
                     listOf("someId"),
                     ConvProtocol.MLS,
-                    listOf(UserProtocol.MLS),
+                    listOf(SupportedProtocolDTO.MLS),
                     emptyList(),
                     1
                 ),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
+import com.wire.kalium.network.api.base.authenticated.userDetails.UserProtocol
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -159,6 +160,7 @@ class FeatureConfigMapperTest {
                 MLSConfigDTO(
                     listOf("someId"),
                     ConvProtocol.MLS,
+                    listOf(UserProtocol.MLS),
                     emptyList(),
                     1
                 ),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProtocol
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import io.mockative.Mock
@@ -160,7 +160,7 @@ class FeatureConfigRepositoryTest {
                 MLSConfigDTO(
                     emptyList(),
                     ConvProtocol.MLS,
-                    listOf(UserProtocol.PROTEUS),
+                    listOf(SupportedProtocolDTO.PROTEUS),
                     emptyList(),
                 1
             ), FeatureFlagStatusDTO.ENABLED),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.data.featureConfig
 
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.shouldFail
@@ -32,6 +33,7 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
+import com.wire.kalium.network.api.base.authenticated.userDetails.UserProtocol
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import io.mockative.Mock
@@ -77,6 +79,7 @@ class FeatureConfigRepositoryTest {
             ConfigsStatusModel(Status.ENABLED),
             MLSModel(
                 emptyList(),
+                setOf(SupportedProtocol.PROTEUS),
                 Status.ENABLED
             ),
             MLSMigrationModel(
@@ -155,9 +158,10 @@ class FeatureConfigRepositoryTest {
             FeatureConfigData.ValidateSAMLEmails(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.MLS(
                 MLSConfigDTO(
-                emptyList(),
-                ConvProtocol.MLS,
-                emptyList(),
+                    emptyList(),
+                    ConvProtocol.MLS,
+                    listOf(UserProtocol.PROTEUS),
+                    emptyList(),
                 1
             ), FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.MLSMigration(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
@@ -43,7 +43,7 @@ object FeatureConfigTest {
         ssoModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         validateSAMLEmailsModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         mlsModel: MLSModel = MLSModel(listOf(), setOf(), Status.ENABLED),
-        mlsMigrationModel: MLSMigrationModel = MLSMigrationModel(
+        mlsMigrationModel: MLSMigrationModel? = MLSMigrationModel(
             Instant.DISTANT_FUTURE,
             Instant.DISTANT_FUTURE,
             100,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
@@ -42,7 +42,7 @@ object FeatureConfigTest {
         secondFactorPasswordChallengeModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         ssoModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         validateSAMLEmailsModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
-        mlsModel: MLSModel = MLSModel(listOf(), Status.ENABLED),
+        mlsModel: MLSModel = MLSModel(listOf(), setOf(), Status.ENABLED),
         mlsMigrationModel: MLSMigrationModel = MLSMigrationModel(
             Instant.DISTANT_FUTURE,
             Instant.DISTANT_FUTURE,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepositoryTest.kt
@@ -32,7 +32,7 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserProtocol
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.MetadataDAO
 import io.mockative.Mock
@@ -167,7 +167,7 @@ class MLSMigrationRepositoryTest {
                     MLSConfigDTO(
                         emptyList(),
                         ConvProtocol.MLS,
-                        listOf(UserProtocol.MLS),
+                        listOf(SupportedProtocolDTO.MLS),
                         emptyList(),
                         1
                     ), FeatureFlagStatusDTO.ENABLED),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepositoryTest.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
+import com.wire.kalium.network.api.base.authenticated.userDetails.UserProtocol
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.MetadataDAO
 import io.mockative.Mock
@@ -166,6 +167,7 @@ class MLSMigrationRepositoryTest {
                     MLSConfigDTO(
                         emptyList(),
                         ConvProtocol.MLS,
+                        listOf(UserProtocol.MLS),
                         emptyList(),
                         1
                     ), FeatureFlagStatusDTO.ENABLED),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCaseTest.kt
@@ -52,7 +52,7 @@ class GetOrRegisterClientUseCaseTest {
     @Test
     fun givenValidClientIsRetained_whenRegisteringAClient_thenDoNotRegisterNewAndReturnPersistedClient() = runTest {
         val clientId = ClientId("clientId")
-        val client = Client(clientId, ClientType.Permanent, Instant.DISTANT_FUTURE, isVerified = false, isValid = true, null, "label", null)
+        val client = Client(clientId, ClientType.Permanent, Instant.DISTANT_FUTURE, isVerified = false, isValid = true, null, "label", null, false)
         val (arrangement, useCase) = Arrangement()
             .withRetainedClientIdResult(Either.Right(clientId))
             .withVerifyExistingClientResult(VerifyExistingClientResult.Success(client))
@@ -81,7 +81,7 @@ class GetOrRegisterClientUseCaseTest {
     @Test
     fun givenInvalidClientIsRetained_whenRegisteringAClient_thenClearDataAndRegisterNewClient() = runTest {
         val clientId = ClientId("clientId")
-        val client = Client(clientId, ClientType.Permanent, Instant.DISTANT_FUTURE, isVerified = false, isValid = true, null, "label", null)
+        val client = Client(clientId, ClientType.Permanent, Instant.DISTANT_FUTURE, isVerified = false, isValid = true, null, "label", null, false)
         val (arrangement, useCase) = Arrangement()
             .withRetainedClientIdResult(Either.Right(clientId))
             .withVerifyExistingClientResult(VerifyExistingClientResult.Failure.ClientNotRegistered)
@@ -129,7 +129,7 @@ class GetOrRegisterClientUseCaseTest {
     @Test
     fun givenClientNotRetained_whenRegisteringAClient_thenRegisterNewClient() = runTest {
         val clientId = ClientId("clientId")
-        val client = Client(clientId, ClientType.Permanent, Instant.DISTANT_FUTURE, isVerified = false, isValid = true, null, "label", null)
+        val client = Client(clientId, ClientType.Permanent, Instant.DISTANT_FUTURE, isVerified = false, isValid = true, null, "label", null, false)
         val (arrangement, useCase) = Arrangement()
             .withRetainedClientIdResult(Either.Left(CoreFailure.MissingClientRegistration))
             .withRegisterClientResult(RegisterClientResult.Success(client))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOtherUserClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOtherUserClientsUseCaseTest.kt
@@ -56,7 +56,8 @@ class ObserveClientsByUserIdUseCaseTest {
                 label = null,
                 model = "Mac ox",
                 isVerified = false,
-                isValid = true
+                isValid = true,
+                isMLSCapable = false
             ),
             Client(
                 id = ClientId("2222"),
@@ -66,7 +67,8 @@ class ObserveClientsByUserIdUseCaseTest {
                 label = null,
                 model = "Mac ox",
                 isVerified = false,
-                isValid = true
+                isValid = true,
+                isMLSCapable = false
             )
         )
         val (arrangement, getOtherUsersClientsUseCase) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ObserveClientDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ObserveClientDetailsUseCaseTest.kt
@@ -103,7 +103,8 @@ class ObserveClientDetailsUseCaseTest {
             label = null,
             model = "Mac ox",
             isVerified = false,
-            isValid = true
+            isValid = true,
+            isMLSCapable = false
         )
         val CLIENT_RESULT = CLIENT.copy(id = PlainId(value = "client_id_1"))
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/SelfClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/SelfClientsUseCaseTest.kt
@@ -110,7 +110,8 @@ class SelfClientsUseCaseTest {
             label = null,
             model = "Mac ox",
             isVerified = false,
-            isValid = true
+            isValid = true,
+            isMLSCapable = false
         )
         val CLIENTS_LIST = listOf(
             CLIENT.copy(id = PlainId(value = "client_id_1")),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCaseTest.kt
@@ -44,7 +44,7 @@ class VerifyExistingClientUseCaseTest {
     @Test
     fun givenRegisteredClientId_whenInvoking_thenReturnSuccess() = runTest {
         val clientId = ClientId("clientId")
-        val client = Client(clientId, ClientType.Permanent, Instant.DISTANT_PAST, isVerified = false, isValid = false, null, null, "label")
+        val client = Client(clientId, ClientType.Permanent, Instant.DISTANT_PAST, isVerified = false, isValid = false, null, null, "label", false)
         val (_, useCase) = Arrangement()
             .withSelfClientsResult(Either.Right(listOf(client)))
             .arrange()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesConfigModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionMapper.toTeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.user.guestroomlink.GetGuestRoomLinkFeatureStatusUseCase
@@ -102,7 +103,7 @@ class SyncFeatureConfigsUseCaseTest {
     fun givenMlsIsEnabledAndSelfUserIsWhitelisted_whenSyncing_thenItShouldBeStoredAsEnabled() = runTest {
         val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
             .withRemoteFeatureConfigsSucceeding(
-                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(SELF_USER_ID.toPlainID()), Status.ENABLED))
+                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(SELF_USER_ID.toPlainID()), emptySet(), Status.ENABLED))
             ).arrange()
 
         syncFeatureConfigsUseCase()
@@ -116,7 +117,7 @@ class SyncFeatureConfigsUseCaseTest {
     fun givenMlsIsEnabledAndSelfUserIsNotWhitelisted_whenSyncing_thenItShouldBeStoredAsDisabled() = runTest {
         val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
             .withRemoteFeatureConfigsSucceeding(
-                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(), Status.ENABLED))
+                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(), emptySet(), Status.ENABLED))
             ).arrange()
 
         syncFeatureConfigsUseCase()
@@ -127,10 +128,10 @@ class SyncFeatureConfigsUseCaseTest {
     }
 
     @Test
-    fun givenMlsIsDisasbled_whenSyncing_thenItShouldBeStoredAsDisabled() = runTest {
+    fun givenMlsIsDisabled_whenSyncing_thenItShouldBeStoredAsDisabled() = runTest {
         val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
             .withRemoteFeatureConfigsSucceeding(
-                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(), Status.DISABLED))
+                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(), emptySet(), Status.DISABLED))
             ).arrange()
 
         syncFeatureConfigsUseCase()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
@@ -24,11 +24,13 @@ import com.wire.kalium.logic.data.featureConfig.FeatureConfigTest
 import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.Status
-import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCaseTest.Arrangement.Companion.COMPLETED_MIGRATION_CONFIGURATION
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCaseTest.Arrangement.Companion.DISABLED_MIGRATION_CONFIGURATION
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCaseTest.Arrangement.Companion.ONGOING_MIGRATION_CONFIGURATION
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
@@ -55,9 +57,10 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful()
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful()
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = emptySet())
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = emptySet(),
+                migrationConfiguration = ONGOING_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = emptyList())
             .withUpdateSupportedProtocolsSuccessful()
             .arrange()
@@ -74,9 +77,10 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful()
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.PROTEUS),
+                migrationConfiguration = ONGOING_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = emptyList())
             .withUpdateSupportedProtocolsSuccessful()
             .arrange()
@@ -94,9 +98,10 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful()
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful()
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.PROTEUS),
+                migrationConfiguration = ONGOING_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = emptyList())
             .withUpdateSupportedProtocolsSuccessful()
             .arrange()
@@ -114,9 +119,10 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful()
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful(configuration = Arrangement.ONGOING_MIGRATION_CONFIGURATION)
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.MLS),
+                migrationConfiguration = ONGOING_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = emptyList())
             .withUpdateSupportedProtocolsSuccessful()
             .arrange()
@@ -134,9 +140,10 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful()
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful(configuration = Arrangement.COMPLETED_MIGRATION_CONFIGURATION)
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.MLS),
+                migrationConfiguration = COMPLETED_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = emptyList())
             .withUpdateSupportedProtocolsSuccessful()
             .arrange()
@@ -154,9 +161,10 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful()
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful()
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.MLS),
+                migrationConfiguration = ONGOING_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = listOf(
                 TestClient.CLIENT.copy(isMLSCapable = true)
             ))
@@ -176,9 +184,10 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful()
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful()
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.MLS),
+                migrationConfiguration = ONGOING_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = listOf(
                 TestClient.CLIENT.copy(isMLSCapable = true),
                 TestClient.CLIENT.copy(isMLSCapable = false)
@@ -199,12 +208,36 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful()
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful(configuration = Arrangement.COMPLETED_MIGRATION_CONFIGURATION)
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.MLS),
+                migrationConfiguration = COMPLETED_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = listOf(
                 TestClient.CLIENT.copy(isMLSCapable = true),
                 TestClient.CLIENT.copy(isMLSCapable = false)
+            ))
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(matching { it.contains(SupportedProtocol.MLS) })
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenMigrationIsMissingAndAllClientsAreCapable_whenInvokingUseCase_thenMlsIsIncluded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS),
+                migrationConfiguration = null
+            )
+            .withGetSelfClientsSuccessful(clients = listOf(
+                TestClient.CLIENT.copy(isMLSCapable = true)
             ))
             .withUpdateSupportedProtocolsSuccessful()
             .arrange()
@@ -222,9 +255,10 @@ class UpdateSupportedProtocolsUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withSlowSyncStatusComplete()
             .withGetSelfUserSuccessful()
-            .withFetchMigrationConfigurationSuccessful()
-            .withGetMigrationConfigurationSuccessful(configuration = Arrangement.DISABLED_MIGRATION_CONFIGURATION)
-            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+            .withGetFeatureConfigurationSuccessful(
+                supportedProtocols = setOf(SupportedProtocol.PROTEUS),
+                migrationConfiguration = DISABLED_MIGRATION_CONFIGURATION
+            )
             .withGetSelfClientsSuccessful(clients = listOf(
                 TestClient.CLIENT.copy(isMLSCapable = true)
             ))
@@ -244,8 +278,6 @@ class UpdateSupportedProtocolsUseCaseTest {
         val clientRepository = mock(ClientRepository::class)
         @Mock
         val userRepository = mock(UserRepository::class)
-        @Mock
-        val mlsMigrationRepository = mock(MLSMigrationRepository::class)
         @Mock
         val featureConfigRepository = mock(FeatureConfigRepository::class)
         @Mock
@@ -275,29 +307,20 @@ class UpdateSupportedProtocolsUseCaseTest {
                 .thenReturn(Either.Right(Unit))
         }
 
-        fun withGetFeatureConfigurationSuccessful(supportedProtocols: Set<SupportedProtocol>) = apply {
+        fun withGetFeatureConfigurationSuccessful(
+            supportedProtocols: Set<SupportedProtocol>,
+            migrationConfiguration: MLSMigrationModel?) = apply {
             given(featureConfigRepository)
                 .suspendFunction(featureConfigRepository::getFeatureConfigs)
                 .whenInvoked()
-                .thenReturn(Either.Right(FeatureConfigTest.newModel(mlsModel = MLSModel(
-                    allowedUsers = emptyList(),
-                    supportedProtocols = supportedProtocols,
-                    status = Status.ENABLED
-                ))))
-        }
-
-        fun withGetMigrationConfigurationSuccessful(configuration: MLSMigrationModel = ONGOING_MIGRATION_CONFIGURATION) = apply {
-            given(mlsMigrationRepository)
-                .suspendFunction(mlsMigrationRepository::getMigrationConfiguration)
-                .whenInvoked()
-                .thenReturn(Either.Right(configuration))
-        }
-
-        fun withFetchMigrationConfigurationSuccessful() = apply {
-            given(mlsMigrationRepository)
-                .suspendFunction(mlsMigrationRepository::fetchMigrationConfiguration)
-                .whenInvoked()
-                .thenReturn(Either.Right(Unit))
+                .thenReturn(Either.Right(FeatureConfigTest.newModel(
+                    mlsModel = MLSModel(
+                        allowedUsers = emptyList(),
+                        supportedProtocols = supportedProtocols,
+                        status = Status.ENABLED
+                    ),
+                    mlsMigrationModel = migrationConfiguration
+                )))
         }
 
         fun withGetSelfClientsSuccessful(clients: List<Client>) = apply {
@@ -310,7 +333,6 @@ class UpdateSupportedProtocolsUseCaseTest {
         fun arrange() = this to UpdateSupportedProtocolsUseCaseImpl(
             clientRepository,
             userRepository,
-            mlsMigrationRepository,
             featureConfigRepository,
             slowSyncRepository
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
@@ -1,0 +1,332 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.data.client.Client
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigTest
+import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
+import com.wire.kalium.logic.data.featureConfig.MLSModel
+import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.mlsmigration.MLSMigrationRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.anything
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateSupportedProtocolsUseCaseTest {
+
+    @Test
+    fun givenSlowSyncIsCompleted_whenInvokingUseCase_thenContinueByFetchingSelfUser() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful()
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = emptySet())
+            .withGetSelfClientsSuccessful(clients = emptyList())
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::getSelfUser)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSupportedProtocolsHasNotChanged_whenInvokingUseCase_thenSupportedProtocolsAreNotUpdated() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful()
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+            .withGetSelfClientsSuccessful(clients = emptyList())
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(anything())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenProteusAsSupportedProtocol_whenInvokingUseCase_thenProteusIsIncluded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful()
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+            .withGetSelfClientsSuccessful(clients = emptyList())
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(matching { it.contains(SupportedProtocol.PROTEUS) })
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProteusIsNotSupportedButMigrationHasNotEnded_whenInvokingUseCase_thenProteusIsIncluded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful(configuration = Arrangement.ONGOING_MIGRATION_CONFIGURATION)
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetSelfClientsSuccessful(clients = emptyList())
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(matching { it.contains(SupportedProtocol.PROTEUS) })
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProteusIsNotSupported_whenInvokingUseCase_thenProteusIsNotIncluded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful(configuration = Arrangement.COMPLETED_MIGRATION_CONFIGURATION)
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetSelfClientsSuccessful(clients = emptyList())
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(matching { !it.contains(SupportedProtocol.PROTEUS) })
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenMlsIsSupportedAndAllClientsAreCapable_whenInvokingUseCase_thenMlsIsIncluded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful()
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetSelfClientsSuccessful(clients = listOf(
+                TestClient.CLIENT.copy(isMLSCapable = true)
+            ))
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(matching { it.contains(SupportedProtocol.MLS) })
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenMlsIsSupportedAndAllClientsAreNotCapable_whenInvokingUseCase_thenMlsIsNotIncluded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful()
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetSelfClientsSuccessful(clients = listOf(
+                TestClient.CLIENT.copy(isMLSCapable = true),
+                TestClient.CLIENT.copy(isMLSCapable = false)
+            ))
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(matching { !it.contains(SupportedProtocol.MLS) })
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenMlsIsSupportedAndMigrationHasEnded_whenInvokingUseCase_thenMlsIsIncluded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful(configuration = Arrangement.COMPLETED_MIGRATION_CONFIGURATION)
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.MLS))
+            .withGetSelfClientsSuccessful(clients = listOf(
+                TestClient.CLIENT.copy(isMLSCapable = true),
+                TestClient.CLIENT.copy(isMLSCapable = false)
+            ))
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(matching { it.contains(SupportedProtocol.MLS) })
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenMlsIsNotSupportedAndAllClientsAreCapable_whenInvokingUseCase_thenMlsIsNotIncluded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSlowSyncStatusComplete()
+            .withGetSelfUserSuccessful()
+            .withFetchMigrationConfigurationSuccessful()
+            .withGetMigrationConfigurationSuccessful(configuration = Arrangement.DISABLED_MIGRATION_CONFIGURATION)
+            .withGetFeatureConfigurationSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+            .withGetSelfClientsSuccessful(clients = listOf(
+                TestClient.CLIENT.copy(isMLSCapable = true)
+            ))
+            .withUpdateSupportedProtocolsSuccessful()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userRepository)
+            .suspendFunction(arrangement.userRepository::updateSupportedProtocols)
+            .with(matching { !it.contains(SupportedProtocol.MLS) })
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement {
+        @Mock
+        val clientRepository = mock(ClientRepository::class)
+        @Mock
+        val userRepository = mock(UserRepository::class)
+        @Mock
+        val mlsMigrationRepository = mock(MLSMigrationRepository::class)
+        @Mock
+        val featureConfigRepository = mock(FeatureConfigRepository::class)
+        @Mock
+        val slowSyncRepository = mock(SlowSyncRepository::class)
+
+        fun withSlowSyncStatusComplete() = apply {
+            val stateFlow = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
+            given(slowSyncRepository)
+                .getter(slowSyncRepository::slowSyncStatus)
+                .whenInvoked()
+                .thenReturn(stateFlow)
+        }
+
+        fun withGetSelfUserSuccessful(supportedProtocols: Set<SupportedProtocol>? = null) = apply {
+            given(userRepository)
+                .suspendFunction(userRepository::getSelfUser)
+                .whenInvoked()
+                .thenReturn(TestUser.SELF.copy(
+                    supportedProtocols = supportedProtocols
+                ))
+        }
+
+        fun withUpdateSupportedProtocolsSuccessful() = apply {
+            given(userRepository)
+                .suspendFunction(userRepository::updateSupportedProtocols)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withGetFeatureConfigurationSuccessful(supportedProtocols: Set<SupportedProtocol>) = apply {
+            given(featureConfigRepository)
+                .suspendFunction(featureConfigRepository::getFeatureConfigs)
+                .whenInvoked()
+                .thenReturn(Either.Right(FeatureConfigTest.newModel(mlsModel = MLSModel(
+                    allowedUsers = emptyList(),
+                    supportedProtocols = supportedProtocols,
+                    status = Status.ENABLED
+                ))))
+        }
+
+        fun withGetMigrationConfigurationSuccessful(configuration: MLSMigrationModel = ONGOING_MIGRATION_CONFIGURATION) = apply {
+            given(mlsMigrationRepository)
+                .suspendFunction(mlsMigrationRepository::getMigrationConfiguration)
+                .whenInvoked()
+                .thenReturn(Either.Right(configuration))
+        }
+
+        fun withFetchMigrationConfigurationSuccessful() = apply {
+            given(mlsMigrationRepository)
+                .suspendFunction(mlsMigrationRepository::fetchMigrationConfiguration)
+                .whenInvoked()
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withGetSelfClientsSuccessful(clients: List<Client>) = apply {
+            given(clientRepository)
+                .suspendFunction(clientRepository::selfListOfClients)
+                .whenInvoked()
+                .thenReturn(Either.Right(clients))
+        }
+
+        fun arrange() = this to UpdateSupportedProtocolsUseCaseImpl(
+            clientRepository,
+            userRepository,
+            mlsMigrationRepository,
+            featureConfigRepository,
+            slowSyncRepository
+        )
+
+        companion object {
+            val ONGOING_MIGRATION_CONFIGURATION = MLSMigrationModel(
+                Instant.DISTANT_PAST,
+                Instant.DISTANT_FUTURE,
+                0,
+                0,
+                Status.ENABLED
+            )
+            val COMPLETED_MIGRATION_CONFIGURATION = ONGOING_MIGRATION_CONFIGURATION
+                .copy(endTime = Instant.DISTANT_PAST)
+            val DISABLED_MIGRATION_CONFIGURATION = ONGOING_MIGRATION_CONFIGURATION
+                .copy(status = Status.DISABLED)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestClient.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestClient.kt
@@ -36,7 +36,8 @@ object TestClient {
         model = null,
         label = "label",
         isVerified = false,
-        isValid = true
+        isValid = true,
+        isMLSCapable = false
     )
 
     val SELF_USER_ID = UserId("self-user-id", "domain")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -74,7 +74,7 @@ object TestEvent {
     )
 
     fun newClient(eventId: String = "eventId", clientId: ClientId = ClientId("client")) = Event.User.NewClient(
-        false, eventId, clientId, "2022-04-30T15:36:00.000Z", "model", ClientTypeDTO.Permanent, DeviceTypeDTO.Phone, "label"
+        false, eventId, clientId, "2022-04-30T15:36:00.000Z", "model", ClientTypeDTO.Permanent, DeviceTypeDTO.Phone, "label", isMLSCapable = false
     )
 
     fun newConnection(eventId: String = "eventId") = Event.User.NewConnection(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -70,7 +70,7 @@ object TestEvent {
     fun userDelete(eventId: String = "eventId", userId: UserId) = Event.User.UserDelete(false, eventId, userId)
     fun updateUser(eventId: String = "eventId", userId: UserId) = Event.User.Update(
         eventId,
-        false, userId.toString(), null, false, "newName", null, null, null, null
+        false, userId.toString(), null, false, "newName", null, null, null, null, null
     )
 
     fun newClient(eventId: String = "eventId", clientId: ClientId = ClientId("client")) = Event.User.NewClient(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -58,7 +58,7 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            arrangement.newMLSUpdatedEvent(MLSModel(listOf(TestUser.SELF.id.toPlainID()), Status.ENABLED))
+            arrangement.newMLSUpdatedEvent(MLSModel(listOf(TestUser.SELF.id.toPlainID()), emptySet(), Status.ENABLED))
         )
 
         verify(arrangement.userConfigRepository)
@@ -73,7 +73,7 @@ class FeatureConfigEventReceiverTest {
             .withSettingMLSEnabledSuccessful()
             .arrange()
 
-        featureConfigEventReceiver.onEvent(arrangement.newMLSUpdatedEvent(MLSModel(emptyList(), Status.ENABLED)))
+        featureConfigEventReceiver.onEvent(arrangement.newMLSUpdatedEvent(MLSModel(emptyList(), emptySet(), Status.ENABLED)))
 
         verify(arrangement.userConfigRepository)
             .function(arrangement.userConfigRepository::setMLSEnabled)
@@ -89,7 +89,7 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            arrangement.newMLSUpdatedEvent(MLSModel(listOf(TestUser.SELF.id.toPlainID()), Status.DISABLED))
+            arrangement.newMLSUpdatedEvent(MLSModel(listOf(TestUser.SELF.id.toPlainID()), emptySet(), Status.DISABLED))
         )
 
         verify(arrangement.userConfigRepository)

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnCloseCallTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnCloseCallTest.kt
@@ -252,7 +252,7 @@ class OnCloseCallTest {
         val mlsCall = callMetadata.copy(
             protocol = Conversation.ProtocolInfo.MLS(
                 groupId = GroupID(""),
-                groupState = Conversation.ProtocolInfo.MLS.GroupState.ESTABLISHED,
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
                 epoch = ULong.MAX_VALUE,
                 keyingMaterialLastUpdate = Instant.DISTANT_FUTURE,
                 cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -19,7 +19,7 @@
 package com.wire.kalium.network.api.base.authenticated.featureConfigs
 
 import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
-import com.wire.kalium.network.api.base.authenticated.userDetails.SupportedProtocolDTO
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.network.api.base.authenticated.featureConfigs
 
 import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.base.authenticated.userDetails.SupportedProtocolDTO
 import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
@@ -86,6 +87,8 @@ data class MLSConfigDTO(
     val protocolToggleUsers: List<String>,
     @SerialName("defaultProtocol")
     val defaultProtocol: ConvProtocol,
+    @SerialName("supportedProtocols")
+    val supportedProtocols: List<SupportedProtocolDTO> = listOf(SupportedProtocolDTO.PROTEUS),
     @SerialName("allowedCipherSuites")
     val allowedCipherSuites: List<Int>,
     @SerialName("defaultCipherSuite")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/user/ClientEventsData.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/user/ClientEventsData.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.network.api.base.authenticated.notification.user
 import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.network.api.base.model.NonQualifiedUserId
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.api.base.model.UserAssetDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -49,5 +50,6 @@ data class UserUpdateEventData(
     @SerialName("handle") val handle: String?,
     @SerialName("email") val email: String?,
     @SerialName("sso_id_deleted") val ssoIdDeleted: Boolean?,
-    @SerialName("assets") val assets: List<UserAssetDTO>?
+    @SerialName("assets") val assets: List<UserAssetDTO>?,
+    @SerialName("supported_protocols")val supportedProtocols: List<SupportedProtocolDTO>?
 )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/user/ClientEventsData.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/user/ClientEventsData.kt
@@ -32,7 +32,8 @@ data class NewClientEventData(
     @SerialName("model") val model: String?,
     @SerialName("type") val clientType: ClientTypeDTO,
     @SerialName("class") val deviceType: DeviceTypeDTO,
-    @SerialName("label") val label: String?
+    @SerialName("label") val label: String?,
+    @SerialName("mls_public_keys") val mlsPublicKeys: Map<String, String>?
 )
 
 @Serializable

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/FeatureConfigJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/FeatureConfigJson.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDT
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
 import com.wire.kalium.network.api.base.model.ErrorResponse
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import kotlinx.datetime.Instant
 
 object FeatureConfigJson {
@@ -126,7 +127,7 @@ object FeatureConfigJson {
             SSO(FeatureFlagStatusDTO.ENABLED),
             ValidateSAMLEmails(FeatureFlagStatusDTO.ENABLED),
             MLS(
-                MLSConfigDTO(emptyList(), ConvProtocol.PROTEUS, listOf(1), 1),
+                MLSConfigDTO(emptyList(), ConvProtocol.PROTEUS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
                 FeatureFlagStatusDTO.ENABLED
             ),
             FeatureConfigData.MLSMigration(

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.network.api.base.authenticated.notification.EventContentD
 import com.wire.kalium.network.api.base.authenticated.notification.user.NewClientEventData
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.QualifiedID
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -183,7 +184,7 @@ object NotificationEventsResponseJson {
     private val newMlsFeatureConfigUpdate = ValidJsonProvider(
         EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO(
             MLS(
-                MLSConfigDTO(emptyList(), ConvProtocol.MLS, listOf(1), 1),
+                MLSConfigDTO(emptyList(), ConvProtocol.MLS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
                 FeatureFlagStatusDTO.ENABLED,
             )
         ),

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
@@ -57,7 +57,8 @@ object NotificationEventsResponseJson {
             |    "capabilities": {
             |      "capabilities": []
             |    },
-            |    "label": "${eventData.client.label}"
+            |    "label": "${eventData.client.label}",
+            |    "mls_public_keys": { "${eventData.client.mlsPublicKeys?.keys?.first()}": "${eventData.client.mlsPublicKeys?.values?.first()}" }
             |  }
             |}
         """.trimMargin()
@@ -66,7 +67,13 @@ object NotificationEventsResponseJson {
     private val clientAdd = ValidJsonProvider(
         EventContentDTO.User.NewClientDTO(
             NewClientEventData(
-                "id", "2022-02-15T12:54:30Z", "Firefox (Temporary)", ClientTypeDTO.Permanent, DeviceTypeDTO.Desktop, "OS X 10.15 10.15"
+                "id",
+                "2022-02-15T12:54:30Z",
+                "Firefox (Temporary)",
+                ClientTypeDTO.Permanent,
+                DeviceTypeDTO.Desktop,
+                "OS X 10.15 10.15",
+                mapOf(Pair("key_variant", "public_key"))
             )
         ),
         newClientSerializer

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -10,11 +10,11 @@ CREATE TABLE Client (
     device_type TEXT AS DeviceTypeEntity,
     is_valid INTEGER  AS Boolean NOT NULL DEFAULT 1,
     is_verified INTEGER  AS Boolean NOT NULL DEFAULT 0,
-    is_mls_capable INTEGER AS Boolean NOT NULL DEFAULT 0,
     client_type TEXT AS ClientTypeEntity DEFAULT NULL,
     registration_date INTEGER AS Instant DEFAULT NULL,
     label TEXT DEFAULT NULL,
     model TEXT DEFAULT NULL,
+    is_mls_capable INTEGER AS Boolean NOT NULL DEFAULT 0,
     FOREIGN KEY (user_id) REFERENCES User(qualified_id) ON DELETE CASCADE,
     PRIMARY KEY (user_id, id)
 );

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -10,6 +10,7 @@ CREATE TABLE Client (
     device_type TEXT AS DeviceTypeEntity,
     is_valid INTEGER  AS Boolean NOT NULL DEFAULT 1,
     is_verified INTEGER  AS Boolean NOT NULL DEFAULT 0,
+    is_mls_capable INTEGER AS Boolean NOT NULL DEFAULT 0,
     client_type TEXT AS ClientTypeEntity DEFAULT NULL,
     registration_date INTEGER AS Instant DEFAULT NULL,
     label TEXT DEFAULT NULL,
@@ -28,14 +29,15 @@ deleteClientsOfUser:
 DELETE FROM Client WHERE user_id = ?;
 
 insertClient:
-INSERT INTO Client(user_id, id,device_type, client_type, is_valid, registration_date, label, model)
-VALUES(?, ?,?, ?, ?,?, ?, ?)
+INSERT INTO Client(user_id, id,device_type, client_type, is_valid, is_mls_capable, registration_date, label, model)
+VALUES(?, ?,?, ?, ?,?,?, ?, ?)
 ON CONFLICT(id, user_id) DO UPDATE SET
 device_type = coalesce(excluded.device_type, device_type),
 registration_date = coalesce(excluded.registration_date, registration_date),
 label = coalesce(excluded.label, label),
 model = coalesce(excluded.model, model),
-is_valid = is_valid;
+is_valid = is_valid,
+is_mls_capable = is_mls_capable;
 
 selectAllClients:
 SELECT * FROM Client;

--- a/persistence/src/commonMain/db_user/migrations/43.sqm
+++ b/persistence/src/commonMain/db_user/migrations/43.sqm
@@ -1,3 +1,3 @@
 import kotlin.Boolean;
 
-ALTER TABLE Client ADD COLUMN is_mls_capable INTEGER AS Boolean NOT NULL DEFAULT 0 AFTER is_verified;
+ALTER TABLE Client ADD COLUMN is_mls_capable INTEGER AS Boolean NOT NULL DEFAULT 0;

--- a/persistence/src/commonMain/db_user/migrations/43.sqm
+++ b/persistence/src/commonMain/db_user/migrations/43.sqm
@@ -1,0 +1,3 @@
+import kotlin.Boolean;
+
+ALTER TABLE Client ADD COLUMN is_mls_capable INTEGER AS Boolean NOT NULL DEFAULT 0 AFTER is_verified;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
@@ -32,6 +32,7 @@ data class Client(
     val registrationDate: Instant?,
     val label: String?,
     val model: String?,
+    val isMLSCapable: Boolean
 )
 
 data class InsertClientParam(
@@ -41,7 +42,8 @@ data class InsertClientParam(
     val clientType: ClientTypeEntity?,
     val label: String?,
     val registrationDate: Instant?,
-    val model: String?
+    val model: String?,
+    val isMLSCapable: Boolean
 )
 
 enum class DeviceTypeEntity {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -37,11 +37,11 @@ internal object ClientMapper {
         device_type: DeviceTypeEntity?,
         is_valid: Boolean,
         is_verified: Boolean,
-        is_mls_capable: Boolean,
         client_type: ClientTypeEntity?,
         registration_date: Instant?,
         label: String?,
         model: String?,
+        is_mls_capable: Boolean
     ): Client = Client(
         userId = user_id,
         id = id,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -37,6 +37,7 @@ internal object ClientMapper {
         device_type: DeviceTypeEntity?,
         is_valid: Boolean,
         is_verified: Boolean,
+        is_mls_capable: Boolean,
         client_type: ClientTypeEntity?,
         registration_date: Instant?,
         label: String?,
@@ -48,6 +49,7 @@ internal object ClientMapper {
         clientType = client_type,
         isValid = is_valid,
         isVerified = is_verified,
+        isMLSCapable = is_mls_capable,
         registrationDate = registration_date,
         label = label,
         model = model
@@ -77,6 +79,7 @@ internal class ClientDAOImpl internal constructor(
             device_type = deviceType,
             client_type = clientType,
             is_valid = true,
+            is_mls_capable = isMLSCapable,
             registration_date = registrationDate,
             model = model,
             label = label

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserClientDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserClientDAOIntegrationTest.kt
@@ -75,7 +75,8 @@ class UserClientDAOIntegrationTest : BaseDatabaseTest() {
             registrationDate = null,
             label = null,
             clientType = null,
-            model = null
+            model = null,
+            isMLSCapable = false
         )
         val insertClientParam = InsertClientParam(
             client.userId,
@@ -84,7 +85,8 @@ class UserClientDAOIntegrationTest : BaseDatabaseTest() {
             client.clientType,
             client.label,
             client.registrationDate,
-            client.model
+            client.model,
+            client.isMLSCapable
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -63,8 +63,8 @@ class ClientDAOTest : BaseDatabaseTest() {
     @Test
     fun givenClientIsInserted_whenFetchingClientsByUserId_thenTheRelevantClientIsReturned() = runTest {
 
-        val insertedClient = insertedClient1.copy(user.id, "id1", deviceType = null)
-        val expected = client1.copy(user.id, "id1", deviceType = null, isValid = true, isVerified = false)
+        val insertedClient = insertedClient1.copy(user.id, "id1", deviceType = null, isMLSCapable = true)
+        val expected = client1.copy(user.id, "id1", deviceType = null, isValid = true, isVerified = false, isMLSCapable = true)
 
         userDAO.insertUser(user)
         clientDAO.insertClient(insertedClient)
@@ -285,7 +285,8 @@ class ClientDAOTest : BaseDatabaseTest() {
             clientType = null,
             label = null,
             model = null,
-            registrationDate = null
+            registrationDate = null,
+            isMLSCapable = false
         )
         val client = insertedClient.toClient()
 
@@ -324,6 +325,7 @@ private fun InsertClientParam.toClient(): Client =
             clientType = clientType,
             isValid = true,
             isVerified = false,
+            isMLSCapable = isMLSCapable,
             label = label,
             model = model,
             registrationDate = registrationDate


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds a use case which evaluates which protocols the self user (and its client) support. When the supported protocols change an API call is made to update them on the backend.

See: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/815693828/Use+case+updating+your+supported+protocols

### Dependencies

Needs releases with:

- [x] https://github.com/wireapp/kalium/pull/1786

### Testing

####

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
