### PR TITLE
feat: add self delete message type to notifications

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -174,6 +174,11 @@ class MessageMapperImpl(
             message.senderName.orEmpty(),
             message.senderImage?.toModel()
         )
+        if (message.isSelfDelete) {
+            return LocalNotificationMessage.SelfDeleteMessage(
+                message.date
+            )
+        }
         return when (message.contentType) {
             MessageEntity.ContentType.TEXT -> LocalNotificationMessage.Text(
                 author = sender,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
@@ -35,9 +35,13 @@ data class LocalNotificationConversation(
 )
 
 sealed class LocalNotificationMessage(
-    open val author: LocalNotificationMessageAuthor,
+    open val author: LocalNotificationMessageAuthor?,
     open val time: Instant
 ) {
+    data class SelfDeleteMessage(
+        override val time: Instant
+    ) : LocalNotificationMessage(null, time)
+
     data class Text(
         override val author: LocalNotificationMessageAuthor,
         override val time: Instant,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
@@ -5,6 +5,7 @@ SELECT
     Message.content_type AS contentType,
     Message.creation_date AS date,
     Message.sender_user_id AS senderUserId,
+    (Message.expire_after_millis IS NOT NULL) AS isSelfDelete,
     User.name AS senderName,
     User.preview_asset_id AS senderPreviewAssetId,
     Conversation.name AS conversationName,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -333,6 +333,7 @@ data class MessagePreviewEntity(
 data class NotificationMessageEntity(
     val id: String,
     val contentType: MessageEntity.ContentType,
+    val isSelfDelete: Boolean,
     val senderUserId: QualifiedIDEntity,
     val senderImage: UserAssetIdEntity?,
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -248,7 +248,8 @@ object MessageMapper {
         conversationId: QualifiedIDEntity,
         contentType: MessageEntity.ContentType,
         date: Instant,
-        senderUserId: UserIDEntity,
+        senderUserId: QualifiedIDEntity,
+        isSelfDelete: Boolean,
         senderName: String?,
         senderPreviewAssetId: QualifiedIDEntity?,
         conversationName: String?,
@@ -256,7 +257,7 @@ object MessageMapper {
         isQuotingSelf: Boolean?,
         assetMimeType: String?,
         mutedStatus: ConversationEntity.MutedStatus,
-        conversationType: ConversationEntity.Type,
+        conversationType: ConversationEntity.Type
     ): NotificationMessageEntity = NotificationMessageEntity(
         id = id,
         contentType = contentType,
@@ -270,7 +271,8 @@ object MessageMapper {
         conversationName = conversationName,
         mutedStatus = mutedStatus,
         conversationType = conversationType,
-        isQuotingSelf = isQuotingSelf == true
+        isQuotingSelf = isQuotingSelf == true,
+        isSelfDelete = isSelfDelete
     )
 
     private fun createMessageEntity(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

self delete messages content is visible in notifications 

### Solutions

hide content of self delete messages

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
