### PR TITLE
feat: Allow testservice to set device model name

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -52,7 +52,7 @@ class ClientMapper(
         deviceType = toDeviceTypeDTO(clientConfig.deviceType()),
         type = param.clientType?.let { toClientTypeDTO(param.clientType) } ?: toClientTypeDTO(clientConfig.clientType()),
         capabilities = param.capabilities?.let { capabilities -> capabilities.map { toClientCapabilityDTO(it) } },
-        model = clientConfig.deviceModelName(),
+        model = param.model?.let { param.model } ?: clientConfig.deviceModelName(),
         preKeys = param.preKeys.map { preyKeyMapper.toPreKeyDTO(it) },
         cookieLabel = param.cookieLabel,
         secondFactorVerificationCode = param.secondFactorVerificationCode,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -105,6 +105,7 @@ interface RegisterClientUseCase {
         val password: String?,
         val capabilities: List<ClientCapability>?,
         val clientType: ClientType? = null,
+        val model: String? = null,
         val preKeysToSend: Int = DEFAULT_PRE_KEYS_COUNT,
         val secondFactorVerificationCode: String? = null,
     )
@@ -137,7 +138,7 @@ class RegisterClientUseCaseImpl @OptIn(DelicateKaliumApi::class) internal constr
         val verificationCode = registerClientParam.secondFactorVerificationCode ?: currentlyStoredVerificationCode()
         sessionRepository.cookieLabel(selfUserId)
             .flatMap { cookieLabel ->
-                generateProteusPreKeys(preKeysToSend, password, capabilities, clientType, cookieLabel, verificationCode)
+                generateProteusPreKeys(preKeysToSend, password, capabilities, clientType, model, cookieLabel, verificationCode)
             }.fold({
                 RegisterClientResult.Failure.Generic(it)
             }, { registerClientParam ->
@@ -211,6 +212,7 @@ class RegisterClientUseCaseImpl @OptIn(DelicateKaliumApi::class) internal constr
         password: String?,
         capabilities: List<ClientCapability>?,
         clientType: ClientType? = null,
+        model: String? = null,
         cookieLabel: String?,
         secondFactorVerificationCode: String? = null,
     ) = withContext(dispatchers.io) {
@@ -224,7 +226,7 @@ class RegisterClientUseCaseImpl @OptIn(DelicateKaliumApi::class) internal constr
                         lastKey = lastKey,
                         deviceType = null,
                         label = null,
-                        model = null,
+                        model = model,
                         clientType = clientType,
                         cookieLabel = cookieLabel,
                         secondFactorVerificationCode = secondFactorVerificationCode,

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -213,7 +213,12 @@ class InstanceService(
             coreLogic.sessionScope(userId) {
                 if (client.needsToRegisterClient()) {
                     when (val result = client.getOrRegister(
-                        RegisterClientUseCase.RegisterClientParam(instanceRequest.password, emptyList(), ClientType.Permanent)
+                        RegisterClientUseCase.RegisterClientParam(
+                            password = instanceRequest.password,
+                            capabilities = emptyList(),
+                            clientType = ClientType.Permanent,
+                            model = instanceRequest.deviceName
+                        )
                     )) {
                         is RegisterClientResult.Failure ->
                             throw WebApplicationException("Instance $instanceId: Client registration failed")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

QA cannot distinguish between different devices in the automation because the current kalium implementation uses os.name for the devices. See:

![Screenshot 2023-06-13 at 14 33 02](https://github.com/wireapp/kalium/assets/1278296/72d63ad3-4be0-4056-92ed-990aac1f5d21)

### Solutions

In this PR I made the device model value configurable on client registration. If it is not set it will stay os.name.

Might be that this PR breaks android-reloaded? Maybe someone help me with that?

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
