### PR TITLE
feat(mls-migration): update conversation protocol to MLS when every member supports MLS #6

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -174,6 +174,12 @@ data class Conversation(
         CODE;
     }
 
+    enum class Protocol {
+        PROTEUS,
+        MIXED,
+        MLS
+    }
+
     enum class ReceiptMode { DISABLED, ENABLED }
 
     @Suppress("MagicNumber")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -478,6 +478,6 @@ internal fun Conversation.Protocol.toApi(): ConvProtocol = when (this) {
 
 internal fun Conversation.Protocol.toDao(): Protocol = when (this) {
     Conversation.Protocol.PROTEUS -> Protocol.PROTEUS
-    Conversation.Protocol.MIXED -> Protocol.PROTEUS
-    Conversation.Protocol.MLS -> Protocol.PROTEUS
+    Conversation.Protocol.MIXED -> Protocol.MIXED
+    Conversation.Protocol.MLS -> Protocol.MLS
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -469,3 +469,15 @@ private fun Conversation.Access.toDAO(): ConversationEntity.Access = when (this)
     Conversation.Access.LINK -> ConversationEntity.Access.LINK
     Conversation.Access.CODE -> ConversationEntity.Access.CODE
 }
+
+internal fun Conversation.Protocol.toApi(): ConvProtocol = when (this) {
+    Conversation.Protocol.PROTEUS -> ConvProtocol.PROTEUS
+    Conversation.Protocol.MIXED -> ConvProtocol.MIXED
+    Conversation.Protocol.MLS -> ConvProtocol.MLS
+}
+
+internal fun Conversation.Protocol.toDao(): Protocol = when (this) {
+    Conversation.Protocol.PROTEUS -> Protocol.PROTEUS
+    Conversation.Protocol.MIXED -> Protocol.PROTEUS
+    Conversation.Protocol.MLS -> Protocol.PROTEUS
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -104,8 +104,8 @@ interface ConversationRepository {
 
     suspend fun getConversationList(): Either<StorageFailure, Flow<List<Conversation>>>
     suspend fun observeConversationList(): Flow<List<Conversation>>
-    suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, Flow<List<Conversation>>>
-    suspend fun getProteusTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, Flow<List<QualifiedID>>>
+    suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
+    suspend fun getProteusTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
     suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>>
     suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
@@ -349,16 +349,16 @@ internal class ConversationDataSource internal constructor(
         return conversationDAO.getAllConversations().map { it.map(conversationMapper::fromDaoModel) }
     }
 
-    override suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, Flow<List<Conversation>>> =
+    override suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
         wrapStorageRequest {
             conversationDAO.getAllProteusTeamConversations(teamId.value)
-                .map { it.map(conversationMapper::fromDaoModel) }
+                .map { it.toModel() }
         }
 
-    override suspend fun getProteusTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, Flow<List<QualifiedID>>> =
+    override suspend fun getProteusTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
         wrapStorageRequest {
             conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId.value)
-                .map { it.map(QualifiedIDEntity::toModel) }
+                .map { it.toModel() }
         }
 
     override suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -104,6 +104,7 @@ interface ConversationRepository {
     suspend fun getConversationList(): Either<StorageFailure, Flow<List<Conversation>>>
     suspend fun observeConversationList(): Flow<List<Conversation>>
     suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, Flow<List<Conversation>>>
+    suspend fun getProteusTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, Flow<List<QualifiedID>>>
     suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>>
     suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
@@ -350,6 +351,12 @@ internal class ConversationDataSource internal constructor(
         wrapStorageRequest {
             conversationDAO.getAllProteusTeamConversations(teamId.value)
                 .map { it.map(conversationMapper::fromDaoModel) }
+        }
+
+    override suspend fun getProteusTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, Flow<List<QualifiedID>>> =
+        wrapStorageRequest {
+            conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId.value)
+                .map { it.map(QualifiedIDEntity::toModel) }
         }
 
     override suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -274,4 +274,3 @@ fun List<SupportedProtocolDTO>.toDao() = this.map { it.toDao() }.toSet()
 fun List<SupportedProtocolDTO>.toModel() = this.map { it.toModel() }.toSet()
 fun Set<SupportedProtocol>.toDao() = this.map { it.toDao() }.toSet()
 fun Set<SupportedProtocolEntity>.toModel() = this.map { it.toModel() }.toSet()
-

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -838,8 +838,7 @@ class UserSessionScope internal constructor(
             selfTeamId,
             userRepository,
             conversationRepository,
-            mlsConversationRepository,
-            authenticatedNetworkContainer.conversationApi
+            mlsConversationRepository
         )
 
     internal val keyPackageManager: KeyPackageManager = KeyPackageManagerImpl(featureSupport,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -836,6 +836,7 @@ class UserSessionScope internal constructor(
     private val mlsMigrator: MLSMigrator
         get() = MLSMigratorImpl(
             selfTeamId,
+            userRepository,
             conversationRepository,
             mlsConversationRepository,
             authenticatedNetworkContainer.conversationApi

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorker.kt
@@ -43,6 +43,7 @@ class MLSMigrationWorkerImpl(
             if (configuration.hasMigrationStarted()) {
                 kaliumLogger.i("Running proteus to MLS migration")
                 mlsMigrator.migrateProteusConversations()
+                mlsMigrator.finaliseProteusConversations()
             } else {
                 kaliumLogger.i("MLS migration is not enabled")
                 Either.Right(Unit)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.kaliumLogger
-import kotlinx.coroutines.flow.first
 
 interface MLSMigrator {
     suspend fun migrateProteusConversations(): Either<CoreFailure, Unit>

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -50,8 +50,8 @@ internal class MLSMigratorImpl(
         }.flatMap { teamId ->
             conversationRepository.getProteusTeamConversations(teamId)
                 .flatMap {
-                    it.first().foldToEitherWhileRight(Unit) { conversation, _ ->
-                        migrate(conversation.id)
+                    it.foldToEitherWhileRight(Unit) { conversationId, _ ->
+                        migrate(conversationId)
                     }
                 }
         }
@@ -64,7 +64,7 @@ internal class MLSMigratorImpl(
                 .flatMap {
                     conversationRepository.getProteusTeamConversationsReadyForFinalisation(teamId)
                         .flatMap {
-                            it.first().foldToEitherWhileRight(Unit) { conversationId, _ ->
+                            it.foldToEitherWhileRight(Unit) { conversationId, _ ->
                                 finalise(conversationId)
                             }
                         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -57,9 +57,11 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ConversationR
 import com.wire.kalium.network.api.base.authenticated.conversation.ReceiptMode
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessResponse
+import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationReceiptModeResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationAccessInfoDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationMemberRoleDTO
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationProtocolDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationReceiptModeDTO
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
@@ -842,6 +844,78 @@ class ConversationRepositoryTest {
         }
     }
 
+    @Test
+    fun givenConversation_whenUpdatingProtocolToMls_thenShouldUpdateLocally() = runTest {
+        // given
+        val protocol = Conversation.Protocol.MLS
+
+        val (arrange, conversationRepository) = Arrangement()
+            .withUpdateProtocolResponse(UPDATE_PROTOCOL_SUCCESS)
+            .arrange()
+
+        // when
+        val result = conversationRepository.updateProtocol(CONVERSATION_ID, protocol)
+
+        // then
+        with(result) {
+            shouldSucceed()
+            verify(arrange.conversationDAO)
+                .suspendFunction(arrange.conversationDAO::updateConversationProtocol)
+                .with(eq(CONVERSATION_ID.toDao()), eq(protocol.toDao()))
+                .wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenNoChange_whenUpdatingProtocolToMls_thenShouldNotUpdateLocally() = runTest {
+        // given
+        val protocol = Conversation.Protocol.MLS
+
+        val (arrange, conversationRepository) = Arrangement()
+            .withUpdateProtocolResponse(UPDATE_PROTOCOL_UNCHANGED)
+            .arrange()
+
+        // when
+        val result = conversationRepository.updateProtocol(CONVERSATION_ID, protocol)
+
+        // then
+        with(result) {
+            shouldSucceed()
+            verify(arrange.conversationDAO)
+                .suspendFunction(arrange.conversationDAO::updateConversationProtocol)
+                .with(eq(CONVERSATION_ID.toDao()), eq(protocol.toDao()))
+                .wasNotInvoked()
+        }
+    }
+
+    @Test
+    fun givenConversation_whenUpdatingProtocolToMixed_thenShouldFetchConversation() = runTest {
+        // given
+        val protocol = Conversation.Protocol.MIXED
+        val conversationResponse = NetworkResponse.Success(
+            TestConversation.CONVERSATION_RESPONSE,
+            emptyMap(),
+            HttpStatusCode.OK.value
+        )
+
+        val (arrangement, conversationRepository) = Arrangement()
+            .withUpdateProtocolResponse(UPDATE_PROTOCOL_SUCCESS)
+            .withFetchConversationsDetails(conversationResponse)
+            .arrange()
+
+        // when
+        val result = conversationRepository.updateProtocol(CONVERSATION_ID, protocol)
+
+        // then
+        with(result) {
+            shouldSucceed()
+            verify(arrangement.conversationApi)
+                .suspendFunction(arrangement.conversationApi::fetchConversationDetails)
+                .with(eq(CONVERSATION_ID.toApi()))
+                .wasInvoked(exactly = once)
+        }
+    }
+
     private class Arrangement {
         @Mock
         val userRepository: UserRepository = mock(UserRepository::class)
@@ -938,6 +1012,13 @@ class ConversationRepositoryTest {
                 .suspendFunction(userRepository::getSelfUser)
                 .whenInvoked()
                 .thenReturn(selfUser)
+        }
+
+        fun withFetchConversationsDetails(response: NetworkResponse<ConversationResponse>) = apply {
+            given(conversationApi)
+                .suspendFunction(conversationApi::fetchConversationDetails)
+                .whenInvokedWith(any())
+                .thenReturn(response)
         }
 
         fun withFetchConversationsIds(response: NetworkResponse<ConversationPagingResponse>) = apply {
@@ -1136,6 +1217,13 @@ class ConversationRepositoryTest {
                 )
         }
 
+        fun withUpdateProtocolResponse(response: NetworkResponse<UpdateConversationProtocolResponse>) = apply {
+            given(conversationApi)
+                .suspendFunction(conversationApi::updateProtocol)
+                .whenInvokedWith(any(), any())
+                .thenReturn(response)
+        }
+
         fun arrange() = this to conversationRepository
     }
 
@@ -1208,6 +1296,19 @@ class ConversationRepositoryTest {
                 ConversationNameUpdateEvent("newName")
             )
         )
+
+        val UPDATE_PROTOCOL_SUCCESS = NetworkResponse.Success(
+            UpdateConversationProtocolResponse.ProtocolUpdated(
+                EventContentDTO.Conversation.ProtocolUpdate(
+                    TestConversation.NETWORK_ID,
+                    ConversationProtocolDTO(ConvProtocol.MIXED),
+                    TestUser.NETWORK_ID
+                )
+            ), emptyMap(), 200
+        )
+        val UPDATE_PROTOCOL_UNCHANGED = NetworkResponse.Success(
+            UpdateConversationProtocolResponse.ProtocolUnchanged,
+            emptyMap(), 204)
 
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -65,7 +65,7 @@ class MLSMigratorTest {
         )
 
         val (arrangement, migrator) = Arrangement()
-            .withGetProteusTeamConversationsReturning(listOf(conversation))
+            .withGetProteusTeamConversationsReturning(listOf(conversation.id))
             .withUpdateProtocolReturns()
             .withFetchConversationSucceeding()
             .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
@@ -98,7 +98,7 @@ class MLSMigratorTest {
         )
 
         val (_, migrator) = Arrangement()
-            .withGetProteusTeamConversationsReturning(listOf(conversation))
+            .withGetProteusTeamConversationsReturning(listOf(conversation.id))
             .withUpdateProtocolReturns()
             .withFetchConversationSucceeding()
             .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
@@ -144,11 +144,12 @@ class MLSMigratorTest {
         )
 
         val (_, migrator) = Arrangement()
-            .withGetProteusTeamConversationsReturning(listOf(conversation))
+            .withFetchKnownUsersSucceeding()
+            .withGetProteusTeamConversationsReadyForFinalisationReturning(listOf(conversation.id))
             .withUpdateProtocolReturns(Either.Left(TestNetworkResponseError.noNetworkConnection()))
             .arrange()
 
-        val result = migrator.migrateProteusConversations()
+        val result = migrator.finaliseProteusConversations()
         result.shouldSucceed()
     }
 
@@ -173,18 +174,18 @@ class MLSMigratorTest {
                 .thenReturn(Either.Right(Unit))
         }
 
-        fun withGetProteusTeamConversationsReturning(conversations: List<Conversation>) = apply {
+        fun withGetProteusTeamConversationsReturning(conversationsIds: List<ConversationId>) = apply {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::getProteusTeamConversations)
                 .whenInvokedWith(anything())
-                .thenReturn(Either.Right(flowOf(conversations)))
+                .thenReturn(Either.Right(conversationsIds))
         }
 
-        fun withGetProteusTeamConversationsReadyForFinalisationReturning(conversationsIs: List<ConversationId>) = apply {
+        fun withGetProteusTeamConversationsReadyForFinalisationReturning(conversationsIds: List<ConversationId>) = apply {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::getProteusTeamConversationsReadyForFinalisation)
                 .whenInvokedWith(anything())
-                .thenReturn(Either.Right(flowOf(conversationsIs)))
+                .thenReturn(Either.Right(conversationsIds))
         }
 
         fun withGetConversationProtocolInfoReturning(protocolInfo: Conversation.ProtocolInfo) = apply {

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -223,6 +223,14 @@ SELECT * FROM ConversationDetails WHERE type IS NOT 'CONNECTION_PENDING' ORDER B
 selectAllTeamProteusConversations:
 SELECT * FROM ConversationDetails WHERE type IS 'GROUP' AND protocol IS 'PROTEUS' AND teamId = ?;
 
+selectAllTeamProteusConversationsReadyForMigration:
+SELECT
+qualified_id,
+(SELECT count(*) FROM Member WHERE conversation = qualified_id) AS memberCount,
+(SELECT count(*) FROM Member LEFT JOIN User ON User.qualified_id = Member.user WHERE Member.conversation = Conversation.qualified_id AND User.supported_protocols LIKE '%mls%') AS mlsCapableMemberCount
+FROM Conversation
+WHERE type IS 'GROUP' AND protocol IS 'PROTEUS' AND team_id = ? AND memberCount = mlsCapableMemberCount;
+
 selectByQualifiedId:
 SELECT * FROM ConversationDetails WHERE qualifiedId = ?;
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -292,6 +292,11 @@ UPDATE Conversation
 SET type = ?
 WHERE qualified_id = ?;
 
+updateConversationProtocol:
+UPDATE Conversation
+SET protocol = ?
+WHERE qualified_id = ?;
+
 selfConversationId:
 SELECT qualified_id FROM Conversation WHERE type = 'SELF' AND protocol = ? LIMIT 1;
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -227,7 +227,7 @@ selectAllTeamProteusConversationsReadyForMigration:
 SELECT
 qualified_id,
 (SELECT count(*) FROM Member WHERE conversation = qualified_id) AS memberCount,
-(SELECT count(*) FROM Member LEFT JOIN User ON User.qualified_id = Member.user WHERE Member.conversation = Conversation.qualified_id AND User.supported_protocols LIKE '%mls%') AS mlsCapableMemberCount
+(SELECT count(*) FROM Member LEFT JOIN User ON User.qualified_id = Member.user WHERE Member.conversation = Conversation.qualified_id AND (User.supported_protocols = 'MLS' OR User.supported_protocols = 'MLS,PROTEUS' OR User.supported_protocols = 'PROTEUS,MLS')) AS mlsCapableMemberCount
 FROM Conversation
 WHERE type IS 'GROUP' AND protocol IS 'PROTEUS' AND team_id = ? AND memberCount = mlsCapableMemberCount;
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -221,7 +221,7 @@ selectAllConversations:
 SELECT * FROM ConversationDetails WHERE type IS NOT 'CONNECTION_PENDING' ORDER BY last_modified_date DESC, name ASC;
 
 selectAllTeamProteusConversations:
-SELECT * FROM ConversationDetails WHERE type IS 'GROUP' AND protocol IS 'PROTEUS' AND teamId = ?;
+SELECT qualified_id FROM Conversation WHERE type IS 'GROUP' AND protocol IS 'PROTEUS' AND team_id = ?;
 
 selectAllTeamProteusConversationsReadyForMigration:
 SELECT

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -173,6 +173,7 @@ interface ConversationDAO {
     suspend fun getAllConversations(): Flow<List<ConversationViewEntity>>
     suspend fun getAllConversationDetails(): Flow<List<ConversationViewEntity>>
     suspend fun getAllProteusTeamConversations(teamId: String): Flow<List<ConversationViewEntity>>
+    suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): Flow<List<QualifiedIDEntity>>
     suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?>
     suspend fun observeGetConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
     suspend fun getConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -220,6 +220,7 @@ interface ConversationDAO {
     suspend fun whoDeletedMeInConversation(conversationId: QualifiedIDEntity, selfUserIdString: String): UserIDEntity?
     suspend fun updateConversationName(conversationId: QualifiedIDEntity, conversationName: String, timestamp: String)
     suspend fun updateConversationType(conversationID: QualifiedIDEntity, type: ConversationEntity.Type)
+    suspend fun updateConversationProtocol(conversationId: QualifiedIDEntity, protocol: ConversationEntity.Protocol)
     suspend fun revokeOneOnOneConversationsWithDeletedUser(userId: UserIDEntity)
     suspend fun getConversationIdsByUserId(userId: UserIDEntity): List<QualifiedIDEntity>
     suspend fun updateConversationReceiptMode(conversationID: QualifiedIDEntity, receiptMode: ConversationEntity.ReceiptMode)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -172,8 +172,8 @@ interface ConversationDAO {
     suspend fun updateAllConversationsNotificationDate()
     suspend fun getAllConversations(): Flow<List<ConversationViewEntity>>
     suspend fun getAllConversationDetails(): Flow<List<ConversationViewEntity>>
-    suspend fun getAllProteusTeamConversations(teamId: String): Flow<List<ConversationViewEntity>>
-    suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): Flow<List<QualifiedIDEntity>>
+    suspend fun getAllProteusTeamConversations(teamId: String): List<QualifiedIDEntity>
+    suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity>
     suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?>
     suspend fun observeGetConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
     suspend fun getConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -334,20 +334,19 @@ class ConversationDAOImpl(
             .map { list -> list.map { it.let { conversationMapper.toModel(it) } } }
     }
 
-    override suspend fun getAllProteusTeamConversations(teamId: String): Flow<List<ConversationViewEntity>> {
-        return conversationQueries.selectAllTeamProteusConversations(teamId)
-            .asFlow()
-            .mapToList()
-            .flowOn(coroutineContext)
-            .map { it.map(conversationMapper::toModel) }
+    override suspend fun getAllProteusTeamConversations(teamId: String): List<QualifiedIDEntity> {
+        return withContext(coroutineContext) {
+            conversationQueries.selectAllTeamProteusConversations(teamId)
+                .executeAsList()
+        }
     }
 
-    override suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): Flow<List<QualifiedIDEntity>> {
-        return conversationQueries.selectAllTeamProteusConversationsReadyForMigration(teamId)
-            .asFlow()
-            .mapToList()
-            .flowOn(coroutineContext)
-            .map { it.also { println(it) }.map { it.qualified_id } }
+    override suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity> {
+        return withContext(coroutineContext) {
+            conversationQueries.selectAllTeamProteusConversationsReadyForMigration(teamId)
+                .executeAsList()
+                .map { it.qualified_id }
+        }
     }
 
     override suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?> {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -570,6 +570,12 @@ class ConversationDAOImpl(
             conversationQueries.updateConversationType(type, conversationID)
         }
 
+    override suspend fun updateConversationProtocol(conversationId: QualifiedIDEntity, protocol: ConversationEntity.Protocol) {
+        withContext(coroutineContext) {
+            conversationQueries.updateConversationProtocol(protocol, conversationId)
+        }
+    }
+
     override suspend fun revokeOneOnOneConversationsWithDeletedUser(userId: UserIDEntity) = withContext(coroutineContext) {
         memberQueries.deleteUserFromGroupConversations(userId, userId)
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -342,6 +342,14 @@ class ConversationDAOImpl(
             .map { it.map(conversationMapper::toModel) }
     }
 
+    override suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): Flow<List<QualifiedIDEntity>> {
+        return conversationQueries.selectAllTeamProteusConversationsReadyForMigration(teamId)
+            .asFlow()
+            .mapToList()
+            .flowOn(coroutineContext)
+            .map { it.also { println(it) }.map { it.qualified_id } }
+    }
+
     override suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?> {
         return conversationQueries.selectByQualifiedId(qualifiedID)
             .asFlow()

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -169,6 +169,36 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenAllMembersAreMlsCapable_WhenGetAllProteusTeamConversationsReadyToBeFinalised_ThenConversationIsReturned() = runTest {
+        val allProtocols = setOf(SupportedProtocolEntity.PROTEUS, SupportedProtocolEntity.MLS)
+        val selfUser = user1.copy(id = selfUserId, supportedProtocols = allProtocols)
+        userDAO.insertUser(selfUser)
+
+        conversationDAO.insertConversation(conversationEntity5)
+        insertTeamUserAndMember(team, user2.copy(supportedProtocols = allProtocols), conversationEntity5.id)
+        insertTeamUserAndMember(team, user3.copy(supportedProtocols = allProtocols), conversationEntity5.id)
+
+        val result = conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId)
+
+        assertEquals(listOf(conversationEntity5.id), result.first())
+    }
+
+    @Test
+    fun givenOnlySomeMembersAreMlsCapable_WhenGetAllProteusTeamConversationsReadyToBeFinalised_ThenConversationIsNotReturned() = runTest {
+        val allProtocols = setOf(SupportedProtocolEntity.PROTEUS, SupportedProtocolEntity.MLS)
+        val selfUser = user1.copy(id = selfUserId, supportedProtocols = allProtocols)
+        userDAO.insertUser(selfUser)
+
+        conversationDAO.insertConversation(conversationEntity5)
+        insertTeamUserAndMember(team, user2.copy(supportedProtocols = allProtocols), conversationEntity5.id)
+        insertTeamUserAndMember(team, user3.copy(supportedProtocols = setOf(SupportedProtocolEntity.PROTEUS)), conversationEntity5.id)
+
+        val result = conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId)
+
+        assertTrue(result.first().isEmpty())
+    }
+
+    @Test
     fun givenExistingConversation_ThenConversationGroupStateCanBeUpdated() = runTest {
         conversationDAO.insertConversation(conversationEntity2)
         conversationDAO.updateConversationGroupState(

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -165,7 +165,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         val result =
             conversationDAO.getAllProteusTeamConversations(teamId)
 
-        assertEquals(listOf(conversationEntity5.toViewEntity()), result.first())
+        assertEquals(listOf(conversationEntity5.id), result)
     }
 
     @Test
@@ -180,7 +180,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         val result = conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId)
 
-        assertEquals(listOf(conversationEntity5.id), result.first())
+        assertEquals(listOf(conversationEntity5.id), result)
     }
 
     @Test
@@ -195,7 +195,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         val result = conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId)
 
-        assertTrue(result.first().isEmpty())
+        assertTrue(result.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

After the migration has started for conversation we should periodically monitor when all members of the groups have announced that they support MLS. When all members support MLS we should make an request to update the protocol to MLS so that future messages are sent via the MLS protocol.

### Dependencies

Needs releases with:

- [x] https://github.com/wireapp/kalium/pull/1797

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
