### PR TITLE
fix: re-using previous proteus client after it has been deleted WPB-2289

### DIFF
--- a/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
+++ b/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
@@ -46,7 +46,9 @@ class ProteusClientCryptoBoxImpl constructor(
     }
 
     override fun clearLocalFiles(): Boolean {
-        box.close()
+        if (::box.isInitialized) {
+            box.close()
+        }
         return File(path).deleteRecursively()
     }
 

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
@@ -36,6 +36,9 @@ class ProteusClientCoreCryptoImpl internal constructor(
     private lateinit var coreCrypto: CoreCrypto
 
     override fun clearLocalFiles(): Boolean {
+        if (::coreCrypto.isInitialized) {
+            coreCrypto.close()
+        }
         return File(path).deleteRecursively()
     }
 

--- a/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
+++ b/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
@@ -44,7 +44,9 @@ class ProteusClientCryptoBoxImpl constructor(
     }
 
     override fun clearLocalFiles(): Boolean {
-        box.close()
+        if (::box.isInitialized) {
+            box.close()
+        }
         return File(path).deleteRecursively()
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/ProteusClientProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/ProteusClientProvider.kt
@@ -63,7 +63,7 @@ class ProteusClientProviderImpl(
     override suspend fun clearLocalFiles() {
         mutex.withLock {
             withContext(dispatcher.io) {
-                _proteusClient?.clearLocalFiles()
+                (_proteusClient ?: createProteusClient()).clearLocalFiles()
                 _proteusClient = null
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCase.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -64,11 +65,10 @@ internal class ClearClientDataUseCaseImpl internal constructor(
         wrapCryptoRequest {
             proteusClientProvider.clearLocalFiles()
         }.flatMap {
-            mlsClientProvider.getMLSClient()
-                .flatMap { mlsClient ->
-                    wrapMLSRequest {
-                        mlsClient.clearLocalFiles()
-                    }
+            mlsClientProvider.getMLSClient().getOrNull()?.let { mlsClient ->
+                wrapMLSRequest {
+                    mlsClient.clearLocalFiles()
                 }
+            } ?: Either.Right(false)
         }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logging again after your device has been deleted remotely will cause decryption errors

### Causes

The previous proteus client is re-used when registering the new device on the backend. When any message is encrypted using a pre-existing session, decryption errors generated on the receiving side because it would expect a new session to initiated for this new device.

The proteus client re-used because when `_proteusClient?.clearLocalFiles()` is executed `_proteusClient` is null so the proteus data files are never removed.

### Solutions

- Instantiate a ProteusClient if it doesn't already exist
- Make it safe to call `clearLocalFiles` before opening the proteus client.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
