### PR TITLE
refactor: replace NewClientEventData with ClientDTO

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -20,12 +20,11 @@ package com.wire.kalium.logic.data.client
 
 import com.wire.kalium.logic.configuration.ClientConfig
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.prekey.PreKeyMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.base.authenticated.client.ClientCapabilityDTO
-import com.wire.kalium.network.api.base.authenticated.client.ClientResponse
+import com.wire.kalium.network.api.base.authenticated.client.ClientDTO
 import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.RegisterClientRequest
@@ -59,13 +58,13 @@ class ClientMapper(
     )
 
     // TODO: mapping directly form DTO to domain object is not ideal since we lose verification information
-    fun fromClientResponse(response: ClientResponse): Client = Client(
-        id = ClientId(response.clientId),
-        type = fromClientTypeDTO(response.type),
-        registrationTime = Instant.parse(response.registrationTime),
-        deviceType = fromDeviceTypeDTO(response.deviceType),
-        label = response.label,
-        model = response.model,
+    fun fromClientDto(client: ClientDTO): Client = Client(
+        id = ClientId(client.clientId),
+        type = fromClientTypeDTO(client.type),
+        registrationTime = Instant.parse(client.registrationTime),
+        deviceType = fromDeviceTypeDTO(client.deviceType),
+        label = client.label,
+        model = client.model,
         isVerified = false,
         isValid = true
     )
@@ -83,17 +82,6 @@ class ClientMapper(
         )
     }
 
-    fun fromNewClientEvent(event: Event.User.NewClient): Client = Client(
-        id = event.clientId,
-        type = fromClientTypeDTO(event.clientType),
-        registrationTime = Instant.parse(event.registrationTime),
-        deviceType = fromDeviceTypeDTO(event.deviceType),
-        label = event.label,
-        model = event.model,
-        isVerified = false,
-        isValid = true
-    )
-
     fun toInsertClientParam(simpleClientResponse: List<SimpleClientResponse>, userIdDTO: UserIdDTO): List<InsertClientParam> =
         simpleClientResponse.map {
             with(it) {
@@ -109,8 +97,8 @@ class ClientMapper(
             }
         }
 
-    fun toInsertClientParam(simpleClientResponse: ClientResponse, userIdDTO: UserIdDTO): InsertClientParam =
-        with(simpleClientResponse) {
+    fun toInsertClientParam(client: ClientDTO, userIdDTO: UserIdDTO): InsertClientParam =
+        with(client) {
             InsertClientParam(
                 userId = userIdDTO.toDao(),
                 id = clientId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -160,7 +160,7 @@ class ClientDataSource(
             }.map {
                 // TODO: mapping directly from the api to the domain model is not ideal,
                 //  and the verification status is not correctly reflected
-                it.map { clientMapper.fromClientResponse(it) }
+                it.map { clientMapper.fromClientDto(it) }
             }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/remote/ClientRemoteRepository.kt
@@ -58,7 +58,7 @@ class ClientRemoteDataSource(
 
     override suspend fun registerClient(param: RegisterClientParam): Either<NetworkFailure, Client> =
         wrapApiRequest { clientApi.registerClient(clientMapper.toRegisterClientRequest(clientConfig, param)) }
-            .map { clientResponse -> clientMapper.fromClientResponse(clientResponse) }
+            .map { clientResponse -> clientMapper.fromClientDto(clientResponse) }
 
     override suspend fun registerMLSClient(clientId: ClientId, publicKey: String): Either<NetworkFailure, Unit> =
         wrapApiRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.cryptography.utils.EncryptedData
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
+import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.Conversation.ReceiptMode
@@ -35,8 +36,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
-import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.serialization.toJsonElement
@@ -547,22 +546,17 @@ sealed class Event(open val id: String, open val transient: Boolean) {
         data class NewClient(
             override val transient: Boolean,
             override val id: String,
-            val clientId: ClientId,
-            val registrationTime: String,
-            val model: String?,
-            val clientType: ClientTypeDTO,
-            val deviceType: DeviceTypeDTO,
-            val label: String?
+            val client: Client,
         ) : User(id, transient) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.NewClient",
                 idKey to id.obfuscateId(),
-                clientIdKey to clientId.value.obfuscateId(),
-                "registrationTime" to registrationTime,
-                "model" to (model ?: ""),
-                "clientType" to clientType,
-                "deviceType" to deviceType,
-                "label" to (label ?: "")
+                clientIdKey to client.id.value.obfuscateId(),
+                "registrationTime" to client.registrationTime,
+                "model" to (client.model ?: ""),
+                "clientType" to client.type,
+                "deviceType" to client.deviceType,
+                "label" to (client.label ?: "")
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.data.event
 
 import com.wire.kalium.cryptography.utils.EncryptedData
+import com.wire.kalium.logic.data.client.ClientMapper
 import com.wire.kalium.logic.data.connection.ConnectionMapper
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -47,7 +48,8 @@ class EventMapper(
     private val connectionMapper: ConnectionMapper,
     private val featureConfigMapper: FeatureConfigMapper,
     private val roleMapper: ConversationRoleMapper,
-    private val receiptModeMapper: ReceiptModeMapper = MapperProvider.receiptModeMapper()
+    private val receiptModeMapper: ReceiptModeMapper = MapperProvider.receiptModeMapper(),
+    private val clientMapper: ClientMapper = MapperProvider.clientMapper()
 ) {
     fun fromDTO(eventResponse: EventResponse): List<Event> {
         // TODO(edge-case): Multiple payloads in the same event have the same ID, is this an issue when marking lastProcessedEventId?
@@ -207,12 +209,7 @@ class EventMapper(
         return Event.User.NewClient(
             transient = transient,
             id = id,
-            clientId = ClientId(eventNewClient.client.id),
-            registrationTime = eventNewClient.client.registrationTime,
-            model = eventNewClient.client.model,
-            clientType = eventNewClient.client.clientType,
-            deviceType = eventNewClient.client.deviceType,
-            label = eventNewClient.client.label
+            client = clientMapper.fromClientDto(eventNewClient.client)
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/NewClientManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/NewClientManager.kt
@@ -52,7 +52,7 @@ internal object NewClientManagerImpl : NewClientManager {
      * Use this method in [com.wire.kalium.logic.sync.receiver.UserEventReceiver] or where ever [Event.User.NewClient] come into.
      */
     override suspend fun scheduleNewClientEvent(newClientEvent: Event.User.NewClient, userId: UserId) {
-        newClients.send(mapper.fromNewClientEvent(newClientEvent) to userId)
+        newClients.send(newClientEvent.client to userId)
     }
 
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -32,7 +32,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
-import com.wire.kalium.network.api.base.authenticated.client.ClientResponse
+import com.wire.kalium.network.api.base.authenticated.client.ClientDTO
 import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.SimpleClientResponse
@@ -242,7 +242,7 @@ class ClientRepositoryTest {
     fun whenSelfListOfClientsIsReturnSuccess_thenTheSuccessIsPropagated() = runTest {
         val result = NetworkResponse.Success(
             listOf(
-                ClientResponse(
+                ClientDTO(
                     clientId = "client_id_1",
                     type = ClientTypeDTO.Permanent,
                     registrationTime = "1969-05-12T10:52:02.671Z",
@@ -254,7 +254,7 @@ class ClientRepositoryTest {
                     cookie = null,
                     location = null
                 ),
-                ClientResponse(
+                ClientDTO(
                     clientId = "client_id_2",
                     type = ClientTypeDTO.Permanent,
                     registrationTime = "2021-05-12T10:52:02.671Z",
@@ -440,7 +440,7 @@ class ClientRepositoryTest {
                 .thenReturn(values)
         }
 
-        fun withFetchSelfUserClient(result: NetworkResponse<List<ClientResponse>>) = apply {
+        fun withFetchSelfUserClient(result: NetworkResponse<List<ClientDTO>>) = apply {
             given(clientApi)
                 .suspendFunction(clientApi::fetchSelfUserClient)
                 .whenInvoked()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NewClientManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NewClientManagerTest.kt
@@ -31,7 +31,7 @@ class NewClientManagerTest {
     fun testIfProperDataIsPassedForward() = runTest {
         val newClientManager = NewClientManagerImpl
         val event = TestEvent.newClient()
-        val expectedClient = MapperProvider.clientMapper().fromNewClientEvent(event)
+        val expectedClient = event.client
         newClientManager.observeNewClients().test {
             newClientManager.scheduleNewClientEvent(event, TestUser.USER_ID)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -74,7 +74,7 @@ object TestEvent {
     )
 
     fun newClient(eventId: String = "eventId", clientId: ClientId = ClientId("client")) = Event.User.NewClient(
-        false, eventId, clientId, "2022-04-30T15:36:00.000Z", "model", ClientTypeDTO.Permanent, DeviceTypeDTO.Phone, "label"
+        false, eventId, TestClient.CLIENT
     )
 
     fun newConnection(eventId: String = "eventId") = Event.User.NewConnection(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/client/ClientApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/client/ClientApi.kt
@@ -24,15 +24,15 @@ import com.wire.kalium.network.utils.NetworkResponse
 
 interface ClientApi {
 
-    suspend fun registerClient(registerClientRequest: RegisterClientRequest): NetworkResponse<ClientResponse>
+    suspend fun registerClient(registerClientRequest: RegisterClientRequest): NetworkResponse<ClientDTO>
 
     suspend fun listClientsOfUsers(userIds: List<UserId>): NetworkResponse<Map<UserId, List<SimpleClientResponse>>>
 
-    suspend fun fetchSelfUserClient(): NetworkResponse<List<ClientResponse>>
+    suspend fun fetchSelfUserClient(): NetworkResponse<List<ClientDTO>>
 
     suspend fun deleteClient(password: String?, clientID: String): NetworkResponse<Unit>
 
-    suspend fun fetchClientInfo(clientID: String): NetworkResponse<ClientResponse>
+    suspend fun fetchClientInfo(clientID: String): NetworkResponse<ClientDTO>
 
     suspend fun updateClient(updateClientRequest: UpdateClientRequest, clientID: String): NetworkResponse<Unit>
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/client/ClientDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/client/ClientDTO.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ClientResponse(
+data class ClientDTO(
     @SerialName("cookie") val cookie: String?,
     @SerialName("time") val registrationTime: String, // yyyy-mm-ddThh:MM:ss.qqq
     @SerialName("location") val location: LocationResponse?,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.network.api.base.authenticated.notification
 
+import com.wire.kalium.network.api.base.authenticated.client.ClientDTO
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMembers
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationNameUpdateEvent
@@ -33,7 +34,6 @@ import com.wire.kalium.network.api.base.authenticated.notification.conversation.
 import com.wire.kalium.network.api.base.authenticated.notification.team.PermissionsData
 import com.wire.kalium.network.api.base.authenticated.notification.team.TeamMemberIdData
 import com.wire.kalium.network.api.base.authenticated.notification.team.TeamUpdateData
-import com.wire.kalium.network.api.base.authenticated.notification.user.NewClientEventData
 import com.wire.kalium.network.api.base.authenticated.notification.user.RemoveClientEventData
 import com.wire.kalium.network.api.base.authenticated.notification.user.UserUpdateEventData
 import com.wire.kalium.network.api.base.model.ConversationId
@@ -289,7 +289,7 @@ sealed class EventContentDTO {
         @Serializable
         @SerialName("user.client-add")
         data class NewClientDTO(
-            @SerialName("client") val client: NewClientEventData,
+            @SerialName("client") val client: ClientDTO,
         ) : User()
 
         @Serializable

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/user/ClientEventsData.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/user/ClientEventsData.kt
@@ -18,22 +18,10 @@
 
 package com.wire.kalium.network.api.base.authenticated.notification.user
 
-import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
-import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.network.api.base.model.NonQualifiedUserId
 import com.wire.kalium.network.api.base.model.UserAssetDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-
-@Serializable
-data class NewClientEventData(
-    @SerialName("id") val id: String,
-    @SerialName("time") val registrationTime: String,
-    @SerialName("model") val model: String?,
-    @SerialName("type") val clientType: ClientTypeDTO,
-    @SerialName("class") val deviceType: DeviceTypeDTO,
-    @SerialName("label") val label: String?
-)
 
 @Serializable
 data class RemoveClientEventData(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ClientApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ClientApiV0.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.network.api.v0.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
-import com.wire.kalium.network.api.base.authenticated.client.ClientResponse
+import com.wire.kalium.network.api.base.authenticated.client.ClientDTO
 import com.wire.kalium.network.api.base.authenticated.client.ClientsOfUsersResponse
 import com.wire.kalium.network.api.base.authenticated.client.ListClientsOfUsersRequest
 import com.wire.kalium.network.api.base.authenticated.client.PasswordRequest
@@ -45,7 +45,7 @@ internal open class ClientApiV0 internal constructor(
 
     protected val httpClient get() = authenticatedNetworkClient.httpClient
 
-    override suspend fun registerClient(registerClientRequest: RegisterClientRequest): NetworkResponse<ClientResponse> =
+    override suspend fun registerClient(registerClientRequest: RegisterClientRequest): NetworkResponse<ClientDTO> =
         wrapKaliumResponse {
             httpClient.post(PATH_CLIENTS) {
                 setBody(registerClientRequest)
@@ -67,7 +67,7 @@ internal open class ClientApiV0 internal constructor(
             }.toMap()
         }
 
-    override suspend fun fetchSelfUserClient(): NetworkResponse<List<ClientResponse>> =
+    override suspend fun fetchSelfUserClient(): NetworkResponse<List<ClientDTO>> =
         wrapKaliumResponse { httpClient.get(PATH_CLIENTS) }
 
     override suspend fun deleteClient(password: String?, clientID: String) =
@@ -77,7 +77,7 @@ internal open class ClientApiV0 internal constructor(
             }
         }
 
-    override suspend fun fetchClientInfo(clientID: String): NetworkResponse<ClientResponse> =
+    override suspend fun fetchClientInfo(clientID: String): NetworkResponse<ClientDTO> =
         wrapKaliumResponse { httpClient.get("$PATH_CLIENTS/$clientID") }
 
     override suspend fun updateClient(updateClientRequest: UpdateClientRequest, clientID: String): NetworkResponse<Unit> =

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/ClientResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/ClientResponseJson.kt
@@ -21,13 +21,13 @@ package com.wire.kalium.model
 import com.wire.kalium.api.json.ValidJsonProvider
 import com.wire.kalium.network.api.base.authenticated.client.Capabilities
 import com.wire.kalium.network.api.base.authenticated.client.ClientCapabilityDTO
-import com.wire.kalium.network.api.base.authenticated.client.ClientResponse
+import com.wire.kalium.network.api.base.authenticated.client.ClientDTO
 import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.network.api.base.model.LocationResponse
 
 object ClientResponseJson {
-    private val jsonProvider = { serializable: ClientResponse ->
+    private val jsonProvider = { serializable: ClientDTO ->
         """
         |{
         |   "id": "${serializable.clientId}",
@@ -51,7 +51,7 @@ object ClientResponseJson {
     }
 
     val valid = ValidJsonProvider(
-        ClientResponse(
+        ClientDTO(
             clientId = "defkrr8e7grgsoufhg8",
             type = ClientTypeDTO.Permanent,
             deviceType = DeviceTypeDTO.Phone,
@@ -66,5 +66,5 @@ object ClientResponseJson {
         jsonProvider
     )
 
-    fun createValid(clientResponse: ClientResponse) = ValidJsonProvider(clientResponse, jsonProvider)
+    fun createValid(client: ClientDTO) = ValidJsonProvider(client, jsonProvider)
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
 import com.wire.kalium.model.conversation.ConversationResponseJson
+import com.wire.kalium.network.api.base.authenticated.client.ClientDTO
 import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
 import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
@@ -34,8 +35,8 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
-import com.wire.kalium.network.api.base.authenticated.notification.user.NewClientEventData
 import com.wire.kalium.network.api.base.model.ConversationId
+import com.wire.kalium.network.api.base.model.LocationResponse
 import com.wire.kalium.network.api.base.model.QualifiedID
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.encodeToString
@@ -51,12 +52,13 @@ object NotificationEventsResponseJson {
             |    "time": "${eventData.client.registrationTime}",
             |    "model": "${eventData.client.model}",
             |    "id": "71ff8872e468a970",
-            |    "type": "${eventData.client.clientType}",
+            |    "type": "${eventData.client.type}",
             |    "class": "desktop",
             |    "capabilities": {
             |      "capabilities": []
             |    },
-            |    "label": "${eventData.client.label}"
+            |    "label": "${eventData.client.label}",
+            |    "mls_public_keys": { "${eventData.client.mlsPublicKeys?.keys?.first()}": "${eventData.client.mlsPublicKeys?.values?.first()}" }
             |  }
             |}
         """.trimMargin()
@@ -64,8 +66,17 @@ object NotificationEventsResponseJson {
 
     private val clientAdd = ValidJsonProvider(
         EventContentDTO.User.NewClientDTO(
-            NewClientEventData(
-                "id", "2022-02-15T12:54:30Z", "Firefox (Temporary)", ClientTypeDTO.Permanent, DeviceTypeDTO.Desktop, "OS X 10.15 10.15"
+            ClientDTO(
+                cookie = null,
+                clientId = "id",
+                location = LocationResponse("23.2", "43.2"),
+                registrationTime = "2022-02-15T12:54:30Z",
+                model = "Firefox (Temporary)",
+                type = ClientTypeDTO.Permanent,
+                deviceType = DeviceTypeDTO.Desktop,
+                label = "OS X 10.15 10.15",
+                capabilities = null,
+                mlsPublicKeys = mapOf(Pair("key_variant", "public_key")),
             )
         ),
         newClientSerializer


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`NewClientEventData` duplicates `ClientResponse` since they are represented by same underlaying type.

### Solutions

Delete `NewClientEventData` and replace it with `ClientDTO` (renamed from ClientResponse) and we can also remove some repeating mapping code due to this.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
