### PR TITLE
refactor: rename `wrapCryptoRequest` to be proteus specific

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -151,9 +151,9 @@ internal inline fun <T : Any> wrapApiRequest(networkCall: () -> NetworkResponse<
         }
     }
 
-internal inline fun <T : Any> wrapCryptoRequest(cryptoRequest: () -> T): Either<ProteusFailure, T> {
+internal inline fun <T : Any> wrapProteusRequest(proteusRequest: () -> T): Either<ProteusFailure, T> {
     return try {
-        Either.Right(cryptoRequest())
+        Either.Right(proteusRequest())
     } catch (e: ProteusException) {
         kaliumLogger.e(
             """{ "ProteusException": "${e.message},"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -29,28 +29,28 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
-sealed class CoreFailure {
+sealed interface CoreFailure {
 
     /**
      * The attempted operation requires that this client is registered.
      */
-    object MissingClientRegistration : CoreFailure()
+    object MissingClientRegistration : CoreFailure
 
     /**
      * A user has no key packages available which prevents him/her from being added
      * to an existing or new conversation.
      */
-    data class NoKeyPackagesAvailable(val userId: UserId) : CoreFailure()
+    data class NoKeyPackagesAvailable(val userId: UserId) : CoreFailure
 
     /**
      * It's not allowed to run the application with development API enabled when
      * connecting to the production environment.
      */
-    object DevelopmentAPINotAllowedOnProduction : CoreFailure()
+    object DevelopmentAPINotAllowedOnProduction : CoreFailure
 
-    data class Unknown(val rootCause: Throwable?) : CoreFailure()
+    data class Unknown(val rootCause: Throwable?) : CoreFailure
 
-    abstract class FeatureFailure : CoreFailure()
+    abstract class FeatureFailure : CoreFailure
 
     /**
      * It's only allowed to insert system messages as bulk for all conversations.
@@ -63,7 +63,7 @@ sealed class CoreFailure {
     object NotSupportedByProteus : FeatureFailure()
 }
 
-sealed class NetworkFailure : CoreFailure() {
+sealed class NetworkFailure : CoreFailure {
     /**
      * Failed to establish a connection with the necessary servers in order to pull/push data.
      *
@@ -101,12 +101,12 @@ sealed class NetworkFailure : CoreFailure() {
     object FederatedBackendFailure : NetworkFailure()
 }
 
-class MLSFailure(internal val exception: Exception) : CoreFailure() {
+class MLSFailure(internal val exception: Exception) : CoreFailure {
 
     val rootCause: Throwable get() = exception
 }
 
-class ProteusFailure(internal val proteusException: ProteusException) : CoreFailure() {
+class ProteusFailure(internal val proteusException: ProteusException) : CoreFailure {
 
     val rootCause: Throwable get() = proteusException
 }
@@ -117,7 +117,7 @@ sealed class EncryptionFailure : CoreFailure.FeatureFailure() {
     object WrongAssetHash : EncryptionFailure()
 }
 
-sealed class StorageFailure : CoreFailure() {
+sealed class StorageFailure : CoreFailure {
     object DataNotFound : StorageFailure()
     data class Generic(val rootCause: Throwable) : StorageFailure()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -59,7 +59,7 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.logic.wrapApiRequest
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.persistence.dao.ConversationEntity
@@ -593,7 +593,7 @@ internal class CallDataSource(
 
     private suspend fun createEpochInfo(parentGroupID: GroupID, subconversationGroupID: GroupID): Either<CoreFailure, EpochInfo> =
         mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-            wrapCryptoRequest {
+            wrapMLSRequest {
                 val epoch = mlsClient.conversationEpoch(subconversationGroupID.toCrypto())
                 val secret = mlsClient.deriveSecret(subconversationGroupID.toCrypto(), 32u)
                 val conversationMembers = mlsClient.members(parentGroupID.toCrypto())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -50,7 +50,7 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -599,7 +599,7 @@ internal class ConversationDataSource internal constructor(
             when (it) {
                 is Conversation.ProtocolInfo.MLS ->
                     mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-                        wrapCryptoRequest {
+                        wrapProteusRequest {
                             mlsClient.wipeConversation(it.groupId.toCrypto())
                         }
                     }.flatMap {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.feature.message.CryptoSessionMapperImpl
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.wrapApiRequest
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
 import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
@@ -64,16 +64,16 @@ class PreKeyDataSource(
         firstKeyId: Int,
         keysCount: Int
     ): Either<ProteusFailure, List<PreKeyCrypto>> =
-        wrapCryptoRequest { proteusClientProvider.getOrCreate().newPreKeys(firstKeyId, keysCount) }
+        wrapProteusRequest { proteusClientProvider.getOrCreate().newPreKeys(firstKeyId, keysCount) }
 
     override suspend fun generateNewLastKey(): Either<ProteusFailure, PreKeyCrypto> =
-        wrapCryptoRequest {
+        wrapProteusRequest {
             proteusClientProvider.getOrCreate().newLastPreKey()
         }
 
     override suspend fun getLocalFingerprint(): Either<CoreFailure, ByteArray> =
         proteusClientProvider.getOrError().flatMap { proteusClient ->
-            wrapCryptoRequest {
+            wrapProteusRequest {
                 proteusClient.getLocalFingerprint()
             }
         }
@@ -118,7 +118,7 @@ class PreKeyDataSource(
         proteusClientProvider.getOrError()
             .flatMap { proteusClient ->
                 val (valid, invalid) = getMapOfSessionIdsToPreKeysAndMarkNullClientsAsInvalid(preKeyInfoList)
-                wrapCryptoRequest {
+                wrapProteusRequest {
                     proteusClient.createSessions(valid)
                 }.also {
                     wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/ProteusClientProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/ProteusClientProvider.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.mapLeft
 import com.wire.kalium.logic.util.SecurityHelperImpl
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorage
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
@@ -81,7 +81,7 @@ class ProteusClientProviderImpl(
     override suspend fun getOrError(): Either<CoreFailure, ProteusClient> {
         return mutex.withLock {
             _proteusClient?.let { Either.Right(it) } ?: run {
-                wrapCryptoRequest {
+                wrapProteusRequest {
                     createProteusClient().also {
                         it.openOrError()
                         _proteusClient = it

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCase.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
@@ -62,7 +62,7 @@ internal class ClearClientDataUseCaseImpl internal constructor(
     }
 
     private suspend fun clearCrypto(): Either<CoreFailure, Boolean> =
-        wrapCryptoRequest {
+        wrapProteusRequest {
             proteusClientProvider.clearLocalFiles()
         }.flatMap {
             mlsClientProvider.getMLSClient().getOrNull()?.let { mlsClient ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientFingerprintUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientFingerprintUseCase.kt
@@ -30,10 +30,10 @@ import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 
 /**
- * Retrieves the fingerprint of a client.
+ * Retrieves the Proteus-specific fingerprint of a client.
  * If no session exists for the client, a new session is established.
  * @param userId The user id of the client.
  * @param clientId The client id of the client.
@@ -47,7 +47,7 @@ class ClientFingerprintUseCase internal constructor(
 ) {
     suspend operator fun invoke(userId: UserId, clientId: ClientId): Result =
         proteusClientProvider.getOrError().flatMap { proteusClient ->
-            wrapCryptoRequest {
+            wrapProteusRequest {
                 proteusClient.remoteFingerPrint(CryptoSessionId(userId.toCrypto(), CryptoClientId(clientId.value)))
             }
         }.fold(
@@ -71,7 +71,7 @@ class ClientFingerprintUseCase internal constructor(
             { error -> Either.Left(error) },
             { _ ->
                 proteusClientProvider.getOrError().flatMap { proteusClient ->
-                    wrapCryptoRequest {
+                    wrapProteusRequest {
                         proteusClient.remoteFingerPrint(CryptoSessionId(userId.toCrypto(), CryptoClientId(clientId.value)))
                     }
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/LeaveSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/LeaveSubconversationUseCase.kt
@@ -30,7 +30,8 @@ import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.wrapApiRequest
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapMLSRequest
+import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationMember
 
@@ -56,7 +57,7 @@ class LeaveSubconversationUseCaseImpl(
                 }.flatMap {
                     subconversationRepository.deleteSubconversation(conversationId, subconversationId)
                     mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-                        wrapCryptoRequest {
+                        wrapMLSRequest {
                             mlsClient.wipeConversation(groupId.toCrypto())
                         }
                     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/LeaveSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/LeaveSubconversationUseCase.kt
@@ -31,7 +31,6 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapMLSRequest
-import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationMember
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
@@ -46,7 +46,7 @@ import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 
 interface MessageEnvelopeCreator {
 
@@ -115,7 +115,7 @@ class MessageEnvelopeCreatorImpl(
         }
 
         return proteusClientProvider.getOrError().flatMap { proteusClient ->
-            wrapCryptoRequest {
+            wrapProteusRequest {
                 proteusClient.encryptBatched(encodedContent.data, sessions)
             }
         }.flatMap {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionEstablisher.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionEstablisher.kt
@@ -35,7 +35,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyDTO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 
@@ -99,7 +99,7 @@ internal class SessionEstablisherImpl internal constructor(
         proteusClientProvider.getOrError()
             .flatMap { proteusClient ->
                 val cryptoSessionID = CryptoSessionId(idMapper.toCryptoQualifiedIDId(recipientUserId), CryptoClientId(client.value))
-                wrapCryptoRequest {
+                wrapProteusRequest {
                     proteusClient.doesSessionExist(cryptoSessionID)
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
@@ -40,7 +40,7 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.Base64
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 import io.ktor.utils.io.core.toByteArray
 
 internal interface ProteusMessageUnpacker {
@@ -66,7 +66,7 @@ internal class ProteusMessageUnpackerImpl(
         )
         return proteusClientProvider.getOrError()
             .flatMap {
-                wrapCryptoRequest {
+                wrapProteusRequest {
                     it.decrypt(decodedContentBytes, cryptoSessionId)
                 }
             }
@@ -106,7 +106,7 @@ internal class ProteusMessageUnpackerImpl(
     private fun solveExternalContentForProteusMessage(
         externalInstructions: ProtoContent.ExternalMessageInstructions,
         externalData: EncryptedData
-    ): Either<CoreFailure, ProtoContent.Readable> = wrapCryptoRequest {
+    ): Either<CoreFailure, ProtoContent.Readable> = wrapProteusRequest {
         val decryptedExternalMessage = decryptDataWithAES256(externalData, AES256Key(externalInstructions.otrKey)).data
         logger.d("ExternalMessage - Decrypted external message content: '$decryptedExternalMessage'")
         PlainMessageBlob(decryptedExternalMessage)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/corefailure/WrapProteusRequestTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/corefailure/WrapProteusRequestTest.kt
@@ -22,17 +22,17 @@ import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.wrapCryptoRequest
+import com.wire.kalium.logic.wrapProteusRequest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
-class WrapCryptoRequestTest {
+class WrapProteusRequestTest {
 
     @Test
     fun whenACryptoRequestReturnValue_thenSuccessIsPropagated() {
         val expected = listOf(PreKeyCrypto(1, "key 1"), PreKeyCrypto(2, "key 2"))
-        val actual = wrapCryptoRequest { expected }
+        val actual = wrapProteusRequest { expected }
 
         assertIs<Either.Right<List<PreKeyCrypto>>>(actual)
         assertEquals(expected, actual.value)
@@ -41,7 +41,7 @@ class WrapCryptoRequestTest {
     @Test
     fun whenApiRequestReturnNoInternetConnection_thenCorrectErrorIsPropagated() {
         val expected = ProteusException(null, ProteusException.Code.PANIC, RuntimeException())
-        val actual = wrapCryptoRequest { throw expected }
+        val actual = wrapProteusRequest { throw expected }
 
         assertIs<Either.Left<ProteusFailure>>(actual)
         assertEquals(expected, actual.value.proteusException)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`wrapCryptoRequest` has a generic name, although it only handles Proteus exceptions.

This can lead to confusion, and misusage of the function.

### Solutions

1. Rename it to `wrapProteusRequest`
2. Replace wrong `wrapCryptoRequest` with `wrapMLSRequest` where needed.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
