### PR TITLE
chore: handle different core crypto exceptions [WBP-1803]

### DIFF
--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -54,6 +54,9 @@ kotlin {
 
                 // Okio
                 implementation(libs.okio.core)
+
+                // CoreCrypto
+                implementation(libs.coreCrypto)
             }
         }
         val commonTest by getting {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -29,28 +29,28 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
-sealed class CoreFailure {
+sealed interface CoreFailure {
 
     /**
      * The attempted operation requires that this client is registered.
      */
-    object MissingClientRegistration : CoreFailure()
+    object MissingClientRegistration : CoreFailure
 
     /**
      * A user has no key packages available which prevents him/her from being added
      * to an existing or new conversation.
      */
-    data class NoKeyPackagesAvailable(val userId: UserId) : CoreFailure()
+    data class NoKeyPackagesAvailable(val userId: UserId) : CoreFailure
 
     /**
      * It's not allowed to run the application with development API enabled when
      * connecting to the production environment.
      */
-    object DevelopmentAPINotAllowedOnProduction : CoreFailure()
+    object DevelopmentAPINotAllowedOnProduction : CoreFailure
 
-    data class Unknown(val rootCause: Throwable?) : CoreFailure()
+    data class Unknown(val rootCause: Throwable?) : CoreFailure
 
-    abstract class FeatureFailure : CoreFailure()
+    abstract class FeatureFailure : CoreFailure
 
     /**
      * It's only allowed to insert system messages as bulk for all conversations.
@@ -63,7 +63,7 @@ sealed class CoreFailure {
     object NotSupportedByProteus : FeatureFailure()
 }
 
-sealed class NetworkFailure : CoreFailure() {
+sealed class NetworkFailure : CoreFailure {
     /**
      * Failed to establish a connection with the necessary servers in order to pull/push data.
      *
@@ -101,12 +101,12 @@ sealed class NetworkFailure : CoreFailure() {
     object FederatedBackendFailure : NetworkFailure()
 }
 
-class MLSFailure(internal val exception: Exception) : CoreFailure() {
+class MLSFailure(internal val exception: Exception) : CoreFailure {
 
     val rootCause: Throwable get() = exception
 }
 
-class ProteusFailure(internal val proteusException: ProteusException) : CoreFailure() {
+class ProteusFailure(internal val proteusException: ProteusException) : CoreFailure {
 
     val rootCause: Throwable get() = proteusException
 }
@@ -117,7 +117,7 @@ sealed class EncryptionFailure : CoreFailure.FeatureFailure() {
     object WrongAssetHash : EncryptionFailure()
 }
 
-sealed class StorageFailure : CoreFailure() {
+sealed class StorageFailure : CoreFailure {
     object DataNotFound : StorageFailure()
     data class Generic(val rootCause: Throwable) : StorageFailure()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -163,8 +163,12 @@ internal class ConversationGroupRepositoryImpl(
                         }.map { Unit }
                     }
 
-                    is ConversationEntity.ProtocolInfo.MLS ->
-                        Either.Left(MLSFailure(UnsupportedOperationException("Adding service to MLS conversation is not supported")))
+                    is ConversationEntity.ProtocolInfo.MLS -> {
+                        val failure = MLSFailure.Generic(
+                            UnsupportedOperationException("Adding service to MLS conversation is not supported")
+                        )
+                        Either.Left(failure)
+                    }
                 }
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/corefailure/WrapMLSRequestTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/corefailure/WrapMLSRequestTest.kt
@@ -18,6 +18,8 @@
 
 package com.wire.kalium.logic.corefailure
 
+import com.wire.crypto.CryptoException
+import com.wire.kalium.logic.MLSFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.wrapMLSRequest
@@ -45,7 +47,21 @@ class WrapMLSRequestTest {
         }
 
         result.shouldFail {
+            assertIs<MLSFailure.Generic>(it)
             assertEquals(exception, it.rootCause)
+        }
+    }
+
+    @Test
+    fun givenWrongEpochExceptionIsThrown_whenWrappingMLSRequest_thenShouldMapToWrongEpochFailure() {
+        val exception = CryptoException.WrongEpoch("SomeMessage")
+
+        val result = wrapMLSRequest {
+            throw exception
+        }
+
+        result.shouldFail {
+            assertIs<MLSFailure.WrongEpoch>(it)
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -246,7 +246,7 @@ class ConversationGroupRepositoryTest {
 
         conversationGroupRepository.addService(serviceID, TestConversation.ID)
             .shouldFail {
-                assertIs<MLSFailure>(it)
+                assertIs<MLSFailure.Generic>(it)
                 assertIs<UnsupportedOperationException>(it.exception)
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddServiceToConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddServiceToConversationUseCaseTest.kt
@@ -61,12 +61,12 @@ class AddServiceToConversationUseCaseTest {
         val serviceId = ServiceId("serviceId", "provider")
 
         val (arrangement, addService) = Arrangement()
-            .withAddService(Either.Left(MLSFailure(UnsupportedOperationException())))
+            .withAddService(Either.Left(MLSFailure.Generic(UnsupportedOperationException())))
             .arrange()
 
         val result = addService(TestConversation.ID, serviceId)
         assertIs<AddServiceToConversationUseCase.Result.Failure>(result)
-        assertIs<MLSFailure>(result.cause)
+        assertIs<MLSFailure.Generic>(result.cause)
 
         verify(arrangement.conversationGroupRepository)
             .suspendFunction(arrangement.conversationGroupRepository::addService)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We do not handle MLS-specific exceptions on the business logic level at the moment.
And this is needed for things like `WrongEpoch`.

### Solutions

As a proof of concept, make `MLSFailure` a sealed interface, and branch it into `WrongEpoch` and `Generic(exception)`.

Based on this, we can expand later.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
