### PR TITLE
fix: timer start when self delete message failed to send

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.network.exceptions.KaliumException
@@ -190,7 +191,7 @@ internal class MessageSenderImpl internal constructor(
                         millis = millis
                     )
                     Unit
-                }.also {
+                }.onSuccess {
                     startSelfDeletionIfNeeded(message)
                 }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -727,6 +727,33 @@ class MessageSenderTest {
         }
     }
 
+    @Test
+    fun givenError_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldStart() {
+        val duration = Duration.parse("PT1M")
+        val message = TestMessage.TEXT_MESSAGE.copy(
+            expirationData = Message.ExpirationData(duration)
+        )
+
+        // given
+        val (arrangement, messageSender) = Arrangement()
+            .withSendProteusMessage(true, true)
+            .withPromoteMessageToSentUpdatingServerTime()
+            .arrange()
+
+        arrangement.testScope.runTest {
+            // when
+            val result = messageSender.sendMessage(message)
+
+            // then
+            result.shouldFail()
+            verify(arrangement.selfDeleteMessageSenderHandler)
+                .function(arrangement.selfDeleteMessageSenderHandler::enqueueSelfDeletion)
+                .with(eq(message))
+                .wasNotInvoked()
+        }
+    }
+
+
     private class Arrangement {
         @Mock
         val messageRepository: MessageRepository = mock(MessageRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -728,7 +728,7 @@ class MessageSenderTest {
     }
 
     @Test
-    fun givenError_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldStart() {
+fun givenError_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldNotStart() {
         val duration = Duration.parse("PT1M")
         val message = TestMessage.TEXT_MESSAGE.copy(
             expirationData = Message.ExpirationData(duration)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

timer starts for self delete messages even when they fail to send

### Solutions

do not start timer on failure

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
