### PR TITLE
fix: duplicated conversation timer change event [WPB-286]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandler.kt
@@ -44,20 +44,22 @@ internal class ConversationMessageTimerEventHandlerImpl(
 
     override suspend fun handle(event: Event.Conversation.ConversationMessageTimer) {
         updateMessageTimer(event)
-            .onSuccess {
-                val message = Message.System(
-                    uuid4().toString(),
-                    MessageContent.ConversationMessageTimerChanged(
-                        messageTimer = event.messageTimer
-                    ),
-                    event.conversationId,
-                    DateTimeUtil.currentIsoDateTimeString(),
-                    event.senderUserId,
-                    Message.Status.SENT,
-                    Message.Visibility.VISIBLE
-                )
+            .onSuccess { updated ->
+                if (updated) {
+                    val message = Message.System(
+                        uuid4().toString(),
+                        MessageContent.ConversationMessageTimerChanged(
+                            messageTimer = event.messageTimer
+                        ),
+                        event.conversationId,
+                        DateTimeUtil.currentIsoDateTimeString(),
+                        event.senderUserId,
+                        Message.Status.SENT,
+                        Message.Visibility.VISIBLE
+                    )
 
-                persistMessage(message)
+                    persistMessage(message)
+                }
                 kaliumLogger
                     .logEventProcessing(
                         EventLoggingStatus.SUCCESS,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -147,6 +147,14 @@ object TestEvent {
         transient = false
     )
 
+    fun timerChanged(eventId: String = "eventId") = Event.Conversation.ConversationMessageTimer(
+        id = eventId,
+        conversationId = TestConversation.ID,
+        transient = false,
+        messageTimer = 3000,
+        senderUserId = TestUser.USER_ID
+    )
+
     fun userPropertyReadReceiptMode(eventId: String = "eventId") = Event.UserProperty.ReadReceiptModeSet(
         id = eventId,
         transient = false,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandlerTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.sync.receiver.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.framework.TestEvent
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.persistence.dao.ConversationDAO
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConversationMessageTimerEventHandlerTest {
+
+    @Test
+    fun givenAConversationMessageTimerEvent_whenItGetsUpdated_thenShouldPersistSystemMessage() = runTest {
+        val event = TestEvent.timerChanged()
+        val (arrangement, eventHandler) = Arrangement()
+            .withConversationUpdateMessageTimer(true)
+            .withPersistMessage(Either.Right(Unit))
+            .arrange()
+
+        eventHandler.handle(event)
+
+        with(arrangement) {
+            verify(persistMessageUseCase)
+                .suspendFunction(persistMessageUseCase::invoke)
+                .with(any())
+                .wasInvoked(once)
+        }
+    }
+
+    @Test
+    fun givenAConversationMessageTimerEvent_whenIsNotUpdated_thenShouldNotPersistSystemMessage() = runTest {
+        val event = TestEvent.timerChanged()
+        val (arrangement, eventHandler) = Arrangement()
+            .withConversationUpdateMessageTimer(false)
+            .withPersistMessage(Either.Right(Unit))
+            .arrange()
+
+        eventHandler.handle(event)
+
+        with(arrangement) {
+            verify(persistMessageUseCase)
+                .suspendFunction(persistMessageUseCase::invoke)
+                .with(any())
+                .wasNotInvoked()
+        }
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val conversationDAO = mock(classOf<ConversationDAO>())
+
+        @Mock
+        val persistMessageUseCase = mock(classOf<PersistMessageUseCase>())
+
+        private val conversationMessageTimerEventHandler: ConversationMessageTimerEventHandler = ConversationMessageTimerEventHandlerImpl(
+            conversationDAO,
+            persistMessageUseCase
+        )
+
+        fun withConversationUpdateMessageTimer(updated: Boolean) = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::updateMessageTimer)
+                .whenInvokedWith(any())
+                .thenReturn(updated)
+        }
+
+        fun withPersistMessage(result: Either<CoreFailure, Unit>) = apply {
+            given(persistMessageUseCase)
+                .suspendFunction(persistMessageUseCase::invoke)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun arrange() = this to conversationMessageTimerEventHandler
+    }
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -298,6 +298,9 @@ UPDATE Conversation
 SET message_timer = ?
 WHERE qualified_id = ?;
 
+getMessageTimer:
+SELECT message_timer FROM Conversation WHERE qualified_id = ?;
+
 updateUserMessageTimer:
 UPDATE Conversation
 SET user_message_timer = ?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -207,6 +207,6 @@ interface ConversationDAO {
     suspend fun updateConversationReceiptMode(conversationID: QualifiedIDEntity, receiptMode: ConversationEntity.ReceiptMode)
     suspend fun updateGuestRoomLink(conversationId: QualifiedIDEntity, link: String?)
     suspend fun observeGuestRoomLinkByConversationId(conversationId: QualifiedIDEntity): Flow<String?>
-    suspend fun updateMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?) : Boolean
+    suspend fun updateMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?): Boolean
     suspend fun updateUserMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -207,6 +207,6 @@ interface ConversationDAO {
     suspend fun updateConversationReceiptMode(conversationID: QualifiedIDEntity, receiptMode: ConversationEntity.ReceiptMode)
     suspend fun updateGuestRoomLink(conversationId: QualifiedIDEntity, link: String?)
     suspend fun observeGuestRoomLinkByConversationId(conversationId: QualifiedIDEntity): Flow<String?>
-    suspend fun updateMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?)
+    suspend fun updateMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?) : Boolean
     suspend fun updateUserMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -567,7 +567,7 @@ class ConversationDAOImpl(
     override suspend fun updateMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?) = withContext(coroutineContext) {
         val previousTimer = conversationQueries.getMessageTimer(conversationId).executeAsOneOrNull()?.message_timer
         val updated = previousTimer != messageTimer
-        if(updated) {
+        if (updated) {
             conversationQueries.updateMessageTimer(messageTimer, conversationId)
         }
         updated

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -565,7 +565,12 @@ class ConversationDAOImpl(
         }.flowOn(coroutineContext)
 
     override suspend fun updateMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?) = withContext(coroutineContext) {
-        conversationQueries.updateMessageTimer(messageTimer, conversationId)
+        val previousTimer = conversationQueries.getMessageTimer(conversationId).executeAsOneOrNull()?.message_timer
+        val updated = previousTimer != messageTimer
+        if(updated) {
+            conversationQueries.updateMessageTimer(messageTimer, conversationId)
+        }
+        updated
     }
 
     override suspend fun updateUserMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?) = withContext(coroutineContext) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometime user gets duplicated event when he changes conversation message timer

### Causes (Optional)

They are two the same system messages about conversation message timer change

### Solutions

Check if current message timer is different than timer received from event, if yes then send system message