### PR TITLE
fix: duplicated messages conversation creation (WPB-1916)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -300,6 +300,9 @@ internal class ConversationDataSource internal constructor(
                     selfTeamIdProvider().getOrNull(),
                 )
             )
+            conversationDAO.insertMembersWithQualifiedId(
+                memberMapper.fromApiModelToDaoModel(conversation.members), idMapper.fromApiToDao(conversation.id)
+            )
         }
         isNewConversation
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
-import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.event.Event
@@ -37,7 +36,7 @@ import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.util.DateTimeUtil
 
 interface NewConversationEventHandler {
-    suspend fun handle(event: Event.Conversation.NewConversation): Either<CoreFailure, Unit>
+    suspend fun handle(event: Event.Conversation.NewConversation)
 }
 
 internal class NewConversationEventHandlerImpl(
@@ -47,29 +46,42 @@ internal class NewConversationEventHandlerImpl(
     private val newGroupConversationSystemMessagesCreator: NewGroupConversationSystemMessagesCreator,
 ) : NewConversationEventHandler {
 
-    override suspend fun handle(event: Event.Conversation.NewConversation): Either<CoreFailure, Unit> = conversationRepository
-        .persistConversations(listOf(event.conversation), selfTeamIdProvider().getOrNull()?.value, originatedFromEvent = true)
-        .flatMap { conversationRepository.updateConversationModifiedDate(event.conversationId, DateTimeUtil.currentInstant()) }
-        .flatMap {
-            userRepository.fetchUsersIfUnknownByIds(event.conversation.members.otherMembers.map { it.id.toModel() }.toSet())
-        }.onSuccess {
-            createSystemMessagesForNewConversation(event)
-            kaliumLogger.logEventProcessing(EventLoggingStatus.SUCCESS, event)
-        }
-        .onFailure {
-            kaliumLogger.logEventProcessing(EventLoggingStatus.FAILURE, event, Pair("errorInfo", "$it"))
-        }
+    override suspend fun handle(event: Event.Conversation.NewConversation) {
+        conversationRepository
+            .persistConversationFromEvent(event.conversation, selfTeamIdProvider().getOrNull()?.value)
+            .flatMap { isNewUnhandledConversation ->
+                conversationRepository.updateConversationModifiedDate(event.conversationId, DateTimeUtil.currentInstant())
+                Either.Right(isNewUnhandledConversation)
+            }.flatMap { isNewUnhandledConversation ->
+                userRepository.fetchUsersIfUnknownByIds(event.conversation.members.otherMembers.map { it.id.toModel() }.toSet())
+                Either.Right(isNewUnhandledConversation)
+            }.onSuccess { isNewUnhandledConversation ->
+                createSystemMessagesForNewConversation(isNewUnhandledConversation, event)
+                kaliumLogger.logEventProcessing(EventLoggingStatus.SUCCESS, event)
+            }
+            .onFailure {
+                kaliumLogger.logEventProcessing(EventLoggingStatus.FAILURE, event, Pair("errorInfo", "$it"))
+            }
+    }
 
     /**
      * Creates system messages for new conversation.
      * Conversation started, members added and failed, read receipt status.
+     *
+     * @param isNewUnhandledConversation if true we need to generate system messages for new conversation
+     * @param event new conversation event
      */
-    private suspend fun createSystemMessagesForNewConversation(event: Event.Conversation.NewConversation) = run {
-        newGroupConversationSystemMessagesCreator.conversationStarted(event.senderUserId, event.conversation)
-        newGroupConversationSystemMessagesCreator.conversationResolvedMembersAddedAndFailed(
-            event.conversationId.toDao(),
-            event.conversation
-        )
-        newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(event.conversation)
+    private suspend fun createSystemMessagesForNewConversation(
+        isNewUnhandledConversation: Boolean,
+        event: Event.Conversation.NewConversation
+    ) {
+        if (isNewUnhandledConversation) {
+            newGroupConversationSystemMessagesCreator.conversationStarted(event.senderUserId, event.conversation)
+            newGroupConversationSystemMessagesCreator.conversationResolvedMembersAddedAndFailed(
+                event.conversationId.toDao(),
+                event.conversation
+            )
+            newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(event.conversation)
+        }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -48,7 +48,7 @@ internal class NewConversationEventHandlerImpl(
 
     override suspend fun handle(event: Event.Conversation.NewConversation) {
         conversationRepository
-            .persistConversationFromEvent(event.conversation, selfTeamIdProvider().getOrNull()?.value)
+            .persistConversation(event.conversation, selfTeamIdProvider().getOrNull()?.value, true)
             .flatMap { isNewUnhandledConversation ->
                 conversationRepository.updateConversationModifiedDate(event.conversationId, DateTimeUtil.currentInstant())
                 Either.Right(isNewUnhandledConversation)
@@ -58,8 +58,7 @@ internal class NewConversationEventHandlerImpl(
             }.onSuccess { isNewUnhandledConversation ->
                 createSystemMessagesForNewConversation(isNewUnhandledConversation, event)
                 kaliumLogger.logEventProcessing(EventLoggingStatus.SUCCESS, event)
-            }
-            .onFailure {
+            }.onFailure {
                 kaliumLogger.logEventProcessing(EventLoggingStatus.FAILURE, event, Pair("errorInfo", "$it"))
             }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -142,7 +142,7 @@ class ConversationRepositoryTest {
             .withExpectedConversationBase(null)
             .arrange()
 
-        conversationRepository.persistConversationFromEvent(event.conversation, "teamId")
+        conversationRepository.persistConversation(event.conversation, "teamId")
 
         with(arrangement) {
             verify(conversationDAO)
@@ -165,7 +165,7 @@ class ConversationRepositoryTest {
             .withExpectedConversationBase(TestConversation.ENTITY)
             .arrange()
 
-        conversationRepository.persistConversationFromEvent(event.conversation, "teamId")
+        conversationRepository.persistConversation(event.conversation, "teamId")
 
         with(arrangement) {
             verify(conversationDAO)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -134,6 +134,52 @@ class ConversationRepositoryTest {
     }
 
     @Test
+    fun givenNewConversationEvent_whenCallingPersistConversationFromEvent_thenConversationShouldBePersisted() = runTest {
+        val event = Event.Conversation.NewConversation("id", TestConversation.ID, false, TestUser.SELF.id, "time", CONVERSATION_RESPONSE)
+        val selfUserFlow = flowOf(TestUser.SELF)
+        val (arrangement, conversationRepository) = Arrangement()
+            .withSelfUserFlow(selfUserFlow)
+            .withExpectedConversationBase(null)
+            .arrange()
+
+        conversationRepository.persistConversationFromEvent(event.conversation, "teamId")
+
+        with(arrangement) {
+            verify(conversationDAO)
+                .suspendFunction(conversationDAO::insertConversation)
+                .with(
+                    matching { conversation ->
+                        conversation.id.value == CONVERSATION_RESPONSE.id.value
+                    }
+                )
+                .wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenNewConversationEvent_whenCallingPersistConversationFromEventAndExists_thenConversationPersistenceShouldBeSkipped() = runTest {
+        val event = Event.Conversation.NewConversation("id", TestConversation.ID, false, TestUser.SELF.id, "time", CONVERSATION_RESPONSE)
+        val selfUserFlow = flowOf(TestUser.SELF)
+        val (arrangement, conversationRepository) = Arrangement()
+            .withSelfUserFlow(selfUserFlow)
+            .withExpectedConversationBase(TestConversation.ENTITY)
+            .arrange()
+
+        conversationRepository.persistConversationFromEvent(event.conversation, "teamId")
+
+        with(arrangement) {
+            verify(conversationDAO)
+                .suspendFunction(conversationDAO::insertConversation)
+                .with(
+                    matching { conversation ->
+                        conversation.id.value == CONVERSATION_RESPONSE.id.value
+                    }
+                )
+                .wasNotInvoked()
+        }
+    }
+
+    @Test
     fun givenNewConversationEventWithMlsConversation_whenCallingInsertConversation_thenMlsGroupExistenceShouldBeQueried() = runTest {
         val event = Event.Conversation.NewConversation(
             "id",
@@ -1066,6 +1112,13 @@ class ConversationRepositoryTest {
         fun withExpectedConversation(conversationEntity: ConversationViewEntity?) = apply {
             given(conversationDAO)
                 .suspendFunction(conversationDAO::getConversationByQualifiedID)
+                .whenInvokedWith(any())
+                .thenReturn(conversationEntity)
+        }
+
+        fun withExpectedConversationBase(conversationEntity: ConversationEntity?) = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::getConversationBaseInfoByQualifiedID)
                 .whenInvokedWith(any())
                 .thenReturn(conversationEntity)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -88,7 +88,7 @@ class NewConversationEventHandlerTest {
         eventHandler.handle(event)
 
         verify(arrangement.conversationRepository)
-            .suspendFunction(arrangement.conversationRepository::persistConversationFromEvent)
+            .suspendFunction(arrangement.conversationRepository::persistConversation)
             .with(eq(event.conversation), eq(teamIdValue))
             .wasInvoked(exactly = once)
 
@@ -287,7 +287,7 @@ class NewConversationEventHandlerTest {
 
         fun withPersistingConversations(result: Either<StorageFailure, Boolean>) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::persistConversationFromEvent)
+                .suspendFunction(conversationRepository::persistConversation)
                 .whenInvokedWith(any(), any())
                 .thenReturn(result)
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometime user gets duplicated event when a conversation is created

### Causes (Optional)

They are two the same system messages about conversation message started

### Solutions

Check if the conversation received exists, and in that case we don't need to handle it again.