### PR TITLE
feat(mls): handle wrong epoch error [WPB-1803]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -106,6 +106,8 @@ interface MLSFailure : CoreFailure {
 
     object WrongEpoch : MLSFailure
 
+    object ConversationDoesNotSupportMLS : MLSFailure
+
     class Generic(internal val exception: Exception) : MLSFailure {
         val rootCause: Throwable get() = exception
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -281,6 +281,10 @@ sealed interface Message {
                 is MessageContent.ConversationCreated -> mutableMapOf(
                     typeKey to "conversationCreated"
                 )
+
+                is MessageContent.MLSWrongEpochWarning -> mutableMapOf(
+                    typeKey to "mlsWrongEpochWarning"
+                )
             }
 
             val standardProperties = mapOf(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -232,6 +232,8 @@ sealed class MessageContent {
         val clientId: ClientId? = null
     ) : Regular()
 
+    object MLSWrongEpochWarning : System()
+
     object ClientAction : Signaling()
 
     object CryptoSessionReset : System()
@@ -276,6 +278,7 @@ fun MessageContent?.getType() = when (this) {
     is MessageContent.ConversationCreated -> "ConversationCreated"
     is MessageContent.MemberChange.CreationAdded -> "MemberChange.CreationAdded"
     is MessageContent.MemberChange.FailedToAdd -> "MemberChange.FailedToAdd"
+    is MessageContent.MLSWrongEpochWarning -> "MLSWrongEpochWarning"
     null -> "Unknown"
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -222,6 +222,7 @@ class MessageMapperImpl(
             MessageEntity.ContentType.HISTORY_LOST -> null
             MessageEntity.ContentType.CONVERSATION_MESSAGE_TIMER_CHANGED -> null
             MessageEntity.ContentType.CONVERSATION_CREATED -> null
+            MessageEntity.ContentType.MLS_WRONG_EPOCH_WARNING -> null
         }
     }
 
@@ -319,6 +320,7 @@ class MessageMapperImpl(
         is MessageContent.HistoryLost -> MessageEntityContent.HistoryLost
         is MessageContent.ConversationMessageTimerChanged -> MessageEntityContent.ConversationMessageTimerChanged(messageTimer)
         is MessageContent.ConversationCreated -> MessageEntityContent.ConversationCreated
+        is MessageContent.MLSWrongEpochWarning -> MessageEntityContent.MLSWrongEpochWarning
     }
 
     private fun MessageEntityContent.Regular.toMessageContent(hidden: Boolean): MessageContent.Regular = when (this) {
@@ -405,6 +407,7 @@ class MessageMapperImpl(
         is MessageEntityContent.HistoryLost -> MessageContent.HistoryLost
         is MessageEntityContent.ConversationMessageTimerChanged -> MessageContent.ConversationMessageTimerChanged(messageTimer)
         is MessageEntityContent.ConversationCreated -> MessageContent.ConversationCreated
+        is MessageEntityContent.MLSWrongEpochWarning -> MessageContent.MLSWrongEpochWarning
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -96,5 +96,6 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.MemberChange.CreationAdded -> false
             is MessageContent.MemberChange.FailedToAdd -> false
             is MessageContent.ConversationCreated -> false
+            is MessageContent.MLSWrongEpochWarning -> false
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -275,6 +275,8 @@ import com.wire.kalium.logic.sync.receiver.conversation.ReceiptModeUpdateEventHa
 import com.wire.kalium.logic.sync.receiver.conversation.ReceiptModeUpdateEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.RenamedConversationEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.RenamedConversationEventHandlerImpl
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSWrongEpochHandler
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSWrongEpochHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
@@ -953,9 +955,17 @@ class UserSessionScope internal constructor(
             userId
         )
 
+    private val mlsWrongEpochHandler: MLSWrongEpochHandler
+        get() = MLSWrongEpochHandlerImpl(
+                selfUserId = userId,
+                persistMessage = persistMessage,
+                conversationRepository = conversationRepository,
+                joinExistingMLSConversation = joinExistingMLSConversationUseCase
+        )
+
     private val newMessageHandler: NewMessageEventHandlerImpl
         get() = NewMessageEventHandlerImpl(
-            proteusUnpacker, mlsUnpacker, applicationMessageHandler
+            proteusUnpacker, mlsUnpacker, applicationMessageHandler, mlsWrongEpochHandler
         )
 
     private val newConversationHandler: NewConversationEventHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandler.kt
@@ -55,8 +55,7 @@ internal class MLSWrongEpochHandlerImpl(
         dateIso: String,
     ) {
         logger.i("Handling MLS WrongEpoch result")
-        conversationRepository.baseInfoById(conversationId).flatMap {
-            val protocol = it.protocol
+        conversationRepository.getConversationProtocolInfo(conversationId).flatMap { protocol ->
             if (protocol is Conversation.ProtocolInfo.MLS) {
                 Either.Right(protocol)
             } else {
@@ -77,9 +76,8 @@ internal class MLSWrongEpochHandlerImpl(
 
     private suspend fun getUpdatedConversationEpoch(conversationId: ConversationId): Either<CoreFailure, ULong?> {
         return conversationRepository.fetchConversation(conversationId).flatMap {
-            conversationRepository.baseInfoById(conversationId)
-        }.map { updatedConversation ->
-            val updatedProtocol = updatedConversation.protocol
+            conversationRepository.getConversationProtocolInfo(conversationId)
+        }.map { updatedProtocol ->
             (updatedProtocol as? Conversation.ProtocolInfo.MLS)?.epoch
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandler.kt
@@ -1,0 +1,100 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation.message
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.MLSFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.kaliumLogger
+
+interface MLSWrongEpochHandler {
+    suspend fun onMLSWrongEpoch(
+        conversationId: ConversationId,
+        dateIso: String,
+    )
+}
+
+internal class MLSWrongEpochHandlerImpl(
+    private val selfUserId: UserId,
+    private val persistMessage: PersistMessageUseCase,
+    private val conversationRepository: ConversationRepository,
+    private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase
+) : MLSWrongEpochHandler {
+
+    private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
+
+    override suspend fun onMLSWrongEpoch(
+        conversationId: ConversationId,
+        dateIso: String,
+    ) {
+        logger.i("Handling MLS WrongEpoch result")
+        conversationRepository.baseInfoById(conversationId).flatMap {
+            val protocol = it.protocol
+            if (protocol is Conversation.ProtocolInfo.MLS) {
+                Either.Right(protocol)
+            } else {
+                Either.Left(MLSFailure.ConversationDoesNotSupportMLS)
+            }
+        }.flatMap { currentProtocol ->
+            getUpdatedConversationEpoch(conversationId).map { updatedEpoch ->
+                updatedEpoch != null && updatedEpoch != currentProtocol.epoch
+            }
+        }.flatMap { isRejoinNeeded ->
+            if (isRejoinNeeded) {
+                joinExistingMLSConversation(conversationId)
+            } else Either.Right(Unit)
+        }.flatMap {
+            insertInfoMessage(conversationId, dateIso)
+        }
+    }
+
+    private suspend fun getUpdatedConversationEpoch(conversationId: ConversationId): Either<CoreFailure, ULong?> {
+        return conversationRepository.fetchConversation(conversationId).flatMap {
+            conversationRepository.baseInfoById(conversationId)
+        }.map { updatedConversation ->
+            val updatedProtocol = updatedConversation.protocol
+            (updatedProtocol as? Conversation.ProtocolInfo.MLS)?.epoch
+        }
+    }
+
+    private suspend fun insertInfoMessage(conversationId: ConversationId, dateIso: String): Either<CoreFailure, Unit> {
+        val mlsEpochWarningMessage = Message.System(
+            id = uuid4().toString(),
+            content = MessageContent.MLSWrongEpochWarning,
+            conversationId = conversationId,
+            date = dateIso,
+            senderUserId = selfUserId,
+            status = Message.Status.READ,
+            visibility = Message.Visibility.VISIBLE,
+            senderUserName = null
+        )
+        return persistMessage(mlsEpochWarningMessage)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandlerTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation.message
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.feature.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class MLSWrongEpochHandlerTest {
+
+    @Test
+    fun givenConversationIsNotMLS_whenHandlingEpochFailure_thenShouldNotInsertWarning() = runTest {
+        val (arrangement, mlsWrongEpochHandler) = Arrangement()
+            .withConversationByIdReturning { Either.Right(conversation.copy(protocol = Conversation.ProtocolInfo.Proteus)) }
+            .arrange()
+
+        mlsWrongEpochHandler.onMLSWrongEpoch(conversation.id, "date")
+
+        verify(arrangement.persistMessageUseCase)
+            .suspendFunction(arrangement.persistMessageUseCase::invoke)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenConversationIsNotMLS_whenHandlingEpochFailure_thenShouldNotFetchConversationAgain() = runTest {
+        val (arrangement, mlsWrongEpochHandler) = Arrangement()
+            .withConversationByIdReturning { Either.Right(conversation.copy(protocol = Conversation.ProtocolInfo.Proteus)) }
+            .arrange()
+
+        mlsWrongEpochHandler.onMLSWrongEpoch(conversation.id, "date")
+
+        verify(arrangement.persistMessageUseCase)
+            .suspendFunction(arrangement.persistMessageUseCase::invoke)
+            .with(any())
+            .wasNotInvoked()
+    }
+    private class Arrangement {
+
+        @Mock
+        val persistMessageUseCase = mock(classOf<PersistMessageUseCase>())
+
+        @Mock
+        val conversationRepository = mock(classOf<ConversationRepository>())
+
+        @Mock
+        val joinExistingMLSConversationUseCase = mock(classOf<JoinExistingMLSConversationUseCase>())
+
+        init {
+            withFetchByIdSucceeding()
+        }
+
+        fun withFetchByIdReturning(result: Either<CoreFailure, Unit>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::fetchConversation)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withFetchByIdSucceeding() = withFetchByIdReturning(Either.Right(Unit))
+
+        fun withConversationByIdReturning(resultProvider: () -> Either<StorageFailure, Conversation>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::baseInfoById)
+                .whenInvokedWith(any())
+                .thenInvoke(resultProvider)
+        }
+
+        fun arrange() = this to MLSWrongEpochHandlerImpl(
+            TestUser.SELF.id,
+            persistMessageUseCase,
+            conversationRepository,
+            joinExistingMLSConversationUseCase
+        )
+    }
+
+    private companion object {
+        val conversation = TestConversation.CONVERSATION
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandlerTest.kt
@@ -21,29 +21,36 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.feature.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.thenReturnSequentially
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
+import io.mockative.eq
 import io.mockative.given
+import io.mockative.matching
 import io.mockative.mock
+import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MLSWrongEpochHandlerTest {
 
     @Test
     fun givenConversationIsNotMLS_whenHandlingEpochFailure_thenShouldNotInsertWarning() = runTest {
         val (arrangement, mlsWrongEpochHandler) = Arrangement()
-            .withConversationByIdReturning { Either.Right(conversation.copy(protocol = Conversation.ProtocolInfo.Proteus)) }
+            .withConversationByIdReturningSequence(Either.Right(proteusConversation))
             .arrange()
 
-        mlsWrongEpochHandler.onMLSWrongEpoch(conversation.id, "date")
+        mlsWrongEpochHandler.onMLSWrongEpoch(mlsConversation.id, "date")
 
         verify(arrangement.persistMessageUseCase)
             .suspendFunction(arrangement.persistMessageUseCase::invoke)
@@ -54,16 +61,109 @@ class MLSWrongEpochHandlerTest {
     @Test
     fun givenConversationIsNotMLS_whenHandlingEpochFailure_thenShouldNotFetchConversationAgain() = runTest {
         val (arrangement, mlsWrongEpochHandler) = Arrangement()
-            .withConversationByIdReturning { Either.Right(conversation.copy(protocol = Conversation.ProtocolInfo.Proteus)) }
+            .withConversationByIdReturningSequence(Either.Right(proteusConversation))
             .arrange()
 
-        mlsWrongEpochHandler.onMLSWrongEpoch(conversation.id, "date")
+        mlsWrongEpochHandler.onMLSWrongEpoch(mlsConversation.id, "date")
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::fetchConversation)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenMLSConversation_whenHandlingEpochFailure_thenShouldFetchConversationAgain() = runTest {
+        val conversationId = mlsConversation.id
+        val (arrangement, mlsWrongEpochHandler) = Arrangement()
+            .withConversationByIdReturning(Either.Right(mlsConversation))
+            .arrange()
+
+        mlsWrongEpochHandler.onMLSWrongEpoch(conversationId, "date")
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::fetchConversation)
+            .with(eq(conversationId))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenUpdatedMLSConversationHasDifferentEpoch_whenHandlingEpochFailure_thenShouldRejoinTheConversation() = runTest {
+        val conversationId = mlsConversation.id
+        val (arrangement, mlsWrongEpochHandler) = Arrangement()
+            .withConversationByIdReturningSequence(
+                Either.Right(mlsConversation),
+                Either.Right(mlsConversationWithUpdatedEpoch)
+            )
+            .arrange()
+
+        mlsWrongEpochHandler.onMLSWrongEpoch(conversationId, "date")
+
+        verify(arrangement.joinExistingMLSConversationUseCase)
+            .suspendFunction(arrangement.joinExistingMLSConversationUseCase::invoke)
+            .with(eq(conversationId))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenUpdatedMLSConversationHasSameEpoch_whenHandlingEpochFailure_thenShouldRejoinTheConversation() = runTest {
+        val conversationId = mlsConversation.id
+        val (arrangement, mlsWrongEpochHandler) = Arrangement()
+            .withConversationByIdReturning(Either.Right(mlsConversation))
+            .arrange()
+
+        mlsWrongEpochHandler.onMLSWrongEpoch(conversationId, "date")
+
+        verify(arrangement.joinExistingMLSConversationUseCase)
+            .suspendFunction(arrangement.joinExistingMLSConversationUseCase::invoke)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenRejoiningFails_whenHandlingEpochFailure_thenShouldNotPersistAnyMessage() = runTest {
+        val conversationId = mlsConversation.id
+        val (arrangement, mlsWrongEpochHandler) = Arrangement()
+            .withConversationByIdReturningSequence(
+                Either.Right(mlsConversation),
+                Either.Right(mlsConversationWithUpdatedEpoch)
+            )
+            .withJoinExistingConversationReturning(Either.Left(CoreFailure.Unknown(null)))
+            .arrange()
+
+        mlsWrongEpochHandler.onMLSWrongEpoch(conversationId, "date")
 
         verify(arrangement.persistMessageUseCase)
             .suspendFunction(arrangement.persistMessageUseCase::invoke)
             .with(any())
             .wasNotInvoked()
     }
+
+    @Test
+    fun givenConversationIsRejoined_whenHandlingEpochFailure_thenShouldInsertMLSWarningWithCorrectDateAndConversation() = runTest {
+        val conversationId = mlsConversation.id
+        val date = "date"
+        val (arrangement, mlsWrongEpochHandler) = Arrangement()
+            .withConversationByIdReturningSequence(
+                Either.Right(mlsConversation),
+                Either.Right(mlsConversationWithUpdatedEpoch)
+            )
+            .arrange()
+
+        mlsWrongEpochHandler.onMLSWrongEpoch(conversationId, date)
+
+        verify(arrangement.persistMessageUseCase)
+            .suspendFunction(arrangement.persistMessageUseCase::invoke)
+            .with(
+                matching {
+                    it.conversationId == conversationId &&
+                    it.content == MessageContent.MLSWrongEpochWarning &&
+                    it.date == date
+                }
+            )
+            .wasInvoked(exactly = once)
+    }
+
     private class Arrangement {
 
         @Mock
@@ -77,6 +177,8 @@ class MLSWrongEpochHandlerTest {
 
         init {
             withFetchByIdSucceeding()
+            withPersistMessageSucceeding()
+            withJoinExistingConversationSucceeding()
         }
 
         fun withFetchByIdReturning(result: Either<CoreFailure, Unit>) = apply {
@@ -88,12 +190,37 @@ class MLSWrongEpochHandlerTest {
 
         fun withFetchByIdSucceeding() = withFetchByIdReturning(Either.Right(Unit))
 
-        fun withConversationByIdReturning(resultProvider: () -> Either<StorageFailure, Conversation>) = apply {
+        fun withConversationByIdReturning(result: Either<StorageFailure, Conversation>) = apply {
+            given(conversationRepository)
+                    .suspendFunction(conversationRepository::baseInfoById)
+                    .whenInvokedWith(any())
+                    .thenReturn(result)
+        }
+
+        fun withConversationByIdReturningSequence(vararg results: Either<StorageFailure, Conversation>) = apply {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::baseInfoById)
                 .whenInvokedWith(any())
-                .thenInvoke(resultProvider)
+                .thenReturnSequentially(*results)
         }
+
+        fun withPersistMessageReturning(result: Either<CoreFailure, Unit>) = apply {
+            given(persistMessageUseCase)
+                .suspendFunction(persistMessageUseCase::invoke)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withPersistMessageSucceeding() = withPersistMessageReturning(Either.Right(Unit))
+
+        fun withJoinExistingConversationReturning(result: Either<CoreFailure, Unit>) = apply {
+            given(joinExistingMLSConversationUseCase)
+                .suspendFunction(joinExistingMLSConversationUseCase::invoke)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withJoinExistingConversationSucceeding() = withJoinExistingConversationReturning(Either.Right(Unit))
 
         fun arrange() = this to MLSWrongEpochHandlerImpl(
             TestUser.SELF.id,
@@ -104,6 +231,11 @@ class MLSWrongEpochHandlerTest {
     }
 
     private companion object {
-        val conversation = TestConversation.CONVERSATION
+        val mlsConversation = TestConversation.MLS_CONVERSATION
+        val proteusConversation = mlsConversation.copy(protocol = Conversation.ProtocolInfo.Proteus)
+
+        val originalProtocolInfo = mlsConversation.protocol as Conversation.ProtocolInfo.MLS
+        val protocolWithUpdatedEpoch = originalProtocolInfo.copy(epoch = originalProtocolInfo.epoch + 1U)
+        val mlsConversationWithUpdatedEpoch = mlsConversation.copy(protocol = protocolWithUpdatedEpoch)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSWrongEpochHandlerTest.kt
@@ -106,7 +106,7 @@ class MLSWrongEpochHandlerTest {
     }
 
     @Test
-    fun givenUpdatedMLSConversationHasSameEpoch_whenHandlingEpochFailure_thenShouldRejoinTheConversation() = runTest {
+    fun givenUpdatedMLSConversationHasSameEpoch_whenHandlingEpochFailure_thenShouldNotRejoinTheConversation() = runTest {
         val conversationId = mlsConversation.id
         val (arrangement, mlsWrongEpochHandler) = Arrangement()
             .withConversationByIdReturning(Either.Right(mlsConversation))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/MockativeExt.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/MockativeExt.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util
+
+import io.mockative.AnyResultBuilder
+import io.mockative.AnySuspendResultBuilder
+
+/**
+ * Sets up the mock to return the given results sequentially. That is,
+ * the first call to the mock will return the first value provided in [results], the second
+ * call will return the second value, and so on.
+ */
+fun <R> AnyResultBuilder<R>.thenReturnSequentially(vararg results: R) {
+    var index = -1
+    return thenInvoke {
+        index += 1
+        require(index <= results.lastIndex) {
+            "Function called more times than expected. No result set for index $index"
+        }
+        results[index++]
+    }
+}
+
+/**
+ * Sets up the mock to return the given results sequentially. That is,
+ * the first call to the mock will return the first value provided in [results], the second
+ * call will return the second value, and so on.
+ */
+fun <R> AnySuspendResultBuilder<R>.thenReturnSequentially(vararg results: R) {
+    var index = -1
+    return thenInvoke {
+        index += 1
+        require(index <= results.lastIndex) {
+            "Function called more times than expected. No result set for index $index"
+        }
+        results[index]
+    }
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -189,7 +189,7 @@ sealed class MessageEntity(
         TEXT, ASSET, KNOCK, MEMBER_CHANGE, MISSED_CALL, RESTRICTED_ASSET,
         CONVERSATION_RENAMED, UNKNOWN, FAILED_DECRYPTION, REMOVED_FROM_TEAM, CRYPTO_SESSION_RESET,
         NEW_CONVERSATION_RECEIPT_MODE, CONVERSATION_RECEIPT_MODE_CHANGED, HISTORY_LOST, CONVERSATION_MESSAGE_TIMER_CHANGED,
-        CONVERSATION_CREATED
+        CONVERSATION_CREATED, MLS_WRONG_EPOCH_WARNING
     }
 
     enum class MemberChangeType {
@@ -292,6 +292,8 @@ sealed class MessageEntityContent {
         val senderUserId: QualifiedIDEntity,
         val senderClientId: String?,
     ) : Regular()
+
+    object MLSWrongEpochWarning : System()
 
     data class MemberChange(
         val memberUserIdList: List<QualifiedIDEntity>,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageInsertExtension.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageInsertExtension.kt
@@ -222,6 +222,10 @@ internal class MessageInsertExtensionImpl(
             is MessageEntityContent.ConversationCreated -> {
                 /* no-op */
             }
+
+            is MessageEntityContent.MLSWrongEpochWarning -> {
+                /* no-op */
+            }
         }
     }
 
@@ -317,5 +321,6 @@ internal class MessageInsertExtensionImpl(
         is MessageEntityContent.HistoryLost -> MessageEntity.ContentType.HISTORY_LOST
         is MessageEntityContent.ConversationMessageTimerChanged -> MessageEntity.ContentType.CONVERSATION_MESSAGE_TIMER_CHANGED
         is MessageEntityContent.ConversationCreated -> MessageEntity.ContentType.CONVERSATION_CREATED
+        is MessageEntityContent.MLSWrongEpochWarning -> MessageEntity.ContentType.MLS_WRONG_EPOCH_WARNING
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -185,6 +185,7 @@ object MessageMapper {
             MessageEntity.ContentType.HISTORY_LOST -> MessagePreviewEntityContent.Unknown
             MessageEntity.ContentType.CONVERSATION_MESSAGE_TIMER_CHANGED -> MessagePreviewEntityContent.Unknown
             MessageEntity.ContentType.CONVERSATION_CREATED -> MessagePreviewEntityContent.Unknown
+            MessageEntity.ContentType.MLS_WRONG_EPOCH_WARNING -> MessagePreviewEntityContent.Unknown
         }
     }
 
@@ -493,6 +494,7 @@ object MessageMapper {
             )
 
             MessageEntity.ContentType.CONVERSATION_CREATED -> MessageEntityContent.ConversationCreated
+            MessageEntity.ContentType.MLS_WRONG_EPOCH_WARNING -> MessageEntityContent.MLSWrongEpochWarning
         }
 
         return createMessageEntity(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If there's any race condition on the backend, or the device becomes offline for too long, we might lose some MLS messages, resulting in `WRONG_EPOCH`.

### Solutions

Handle the case, by creating a `MLSWrongEpochHandler`, that will be called when there's a failure to unpack MLS conversations.
This will:
1. Fetch the conversation from the backend
2. Compare the `epoch` and see if it is different from the local version
3. In case of a difference, rejoin the existing MLS conversation to match the epoch
4. In case of a rejoin, insert a MLS warning system message for the affected conversation

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
