### PR TITLE
fix(RC): delete message is sent to everyone in the conversation

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -530,7 +530,7 @@ internal class ConversationDataSource internal constructor(
     override suspend fun getConversationRecipients(conversationId: ConversationId): Either<CoreFailure, List<Recipient>> =
         wrapStorageRequest {
             clientDAO.conversationRecipient(conversationId.toDao())
-        }.map (memberMapper::fromMapOfClientsEntityToRecipients)
+        }.map(memberMapper::fromMapOfClientsEntityToRecipients)
 
     /**
      * Fetches a list of all recipients for a given conversation including this very client

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -529,10 +529,8 @@ internal class ConversationDataSource internal constructor(
      */
     override suspend fun getConversationRecipients(conversationId: ConversationId): Either<CoreFailure, List<Recipient>> =
         wrapStorageRequest {
-            memberMapper.fromMapOfClientsEntityToRecipients(
-                clientDAO.conversationRecipient(conversationId.toDao())
-            )
-        }
+            clientDAO.conversationRecipient(conversationId.toDao())
+        }.map (memberMapper::fromMapOfClientsEntityToRecipients)
 
     /**
      * Fetches a list of all recipients for a given conversation including this very client

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/EphemeralMessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/EphemeralMessageRepository.kt
@@ -46,5 +46,5 @@ internal class EphemeralMessageDataSource internal constructor(
     ): Either<StorageFailure, List<Recipient>> = wrapStorageRequest {
         val recipientId = setOf(senderId.toDao())
         clientDAO.recipientsIfTHeyArePartOfConversation(conversationId.toDao(), recipientId)
-    }.map (memberMapper::fromMapOfClientsEntityToRecipients)
+    }.map(memberMapper::fromMapOfClientsEntityToRecipients)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/EphemeralMessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/EphemeralMessageRepository.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.MemberMapper
+import com.wire.kalium.logic.data.conversation.Recipient
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.toDao
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.wrapStorageRequest
+import com.wire.kalium.persistence.dao.client.ClientDAO
+
+internal interface EphemeralMessageRepository {
+    suspend fun recipientsForDeletedEphemeral(
+        senderId: UserId,
+        conversationId: ConversationId
+    ): Either<StorageFailure, List<Recipient>>
+}
+
+internal class EphemeralMessageDataSource internal constructor(
+    private val clientDAO: ClientDAO,
+    private val selfUserId: UserId,
+    private val memberMapper: MemberMapper = MapperProvider.memberMapper()
+) : EphemeralMessageRepository {
+    override suspend fun recipientsForDeletedEphemeral(
+        senderId: UserId,
+        conversationId: ConversationId
+    ): Either<StorageFailure, List<Recipient>> = wrapStorageRequest {
+        val recipientId = listOf(senderId, selfUserId).map(UserId::toDao).toSet()
+
+        clientDAO.recipientOfUsers(conversationId.toDao(), recipientId)
+    }.map (memberMapper::fromMapOfClientsEntityToRecipients)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/EphemeralMessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/EphemeralMessageRepository.kt
@@ -38,15 +38,13 @@ internal interface EphemeralMessageRepository {
 
 internal class EphemeralMessageDataSource internal constructor(
     private val clientDAO: ClientDAO,
-    private val selfUserId: UserId,
     private val memberMapper: MemberMapper = MapperProvider.memberMapper()
 ) : EphemeralMessageRepository {
     override suspend fun recipientsForDeletedEphemeral(
         senderId: UserId,
         conversationId: ConversationId
     ): Either<StorageFailure, List<Recipient>> = wrapStorageRequest {
-        val recipientId = listOf(senderId, selfUserId).map(UserId::toDao).toSet()
-
-        clientDAO.recipientOfUsers(conversationId.toDao(), recipientId)
+        val recipientId = setOf(senderId.toDao())
+        clientDAO.recipientsIfTHeyArePartOfConversation(conversationId.toDao(), recipientId)
     }.map (memberMapper::fromMapOfClientsEntityToRecipients)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -78,6 +78,8 @@ import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProviderImpl
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.logout.LogoutDataSource
 import com.wire.kalium.logic.data.logout.LogoutRepository
+import com.wire.kalium.logic.data.message.EphemeralMessageDataSource
+import com.wire.kalium.logic.data.message.EphemeralMessageRepository
 import com.wire.kalium.logic.data.message.IsMessageSentInSelfConversationUseCase
 import com.wire.kalium.logic.data.message.IsMessageSentInSelfConversationUseCaseImpl
 import com.wire.kalium.logic.data.message.MessageDataSource
@@ -1060,6 +1062,12 @@ class UserSessionScope internal constructor(
         userStorage.database.metadataDAO
     )
 
+    private val ephemeralMessageRepository: EphemeralMessageRepository
+        get() = EphemeralMessageDataSource(
+            clientDAO = userStorage.database.clientDAO,
+            selfUserId = userId
+        )
+
     val observeSyncState: ObserveSyncStateUseCase
         get() = ObserveSyncStateUseCase(slowSyncRepository, incrementalSyncRepository)
 
@@ -1140,8 +1148,8 @@ class UserSessionScope internal constructor(
             syncManager,
             slowSyncRepository,
             messageSendingScheduler,
-            selfConversationIdProvider,
-            this
+            this,
+            ephemeralMessageRepository
         )
     val messages: MessageScope
         get() = MessageScope(
@@ -1164,6 +1172,7 @@ class UserSessionScope internal constructor(
             slowSyncRepository,
             messageSendingScheduler,
             userPropertyRepository,
+            ephemeralMessageRepository,
             incrementalSyncRepository,
             protoContentMapper,
             observeSelfDeletingMessages,
@@ -1261,7 +1270,7 @@ class UserSessionScope internal constructor(
     val service: ServiceScope
         get() = ServiceScope(
             serviceRepository,
-        teamRepository,
+            teamRepository,
             selfTeamId
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1064,8 +1064,7 @@ class UserSessionScope internal constructor(
 
     private val ephemeralMessageRepository: EphemeralMessageRepository
         get() = EphemeralMessageDataSource(
-            clientDAO = userStorage.database.clientDAO,
-            selfUserId = userId
+            clientDAO = userStorage.database.clientDAO
         )
 
     val observeSyncState: ObserveSyncStateUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1148,6 +1148,7 @@ class UserSessionScope internal constructor(
             syncManager,
             slowSyncRepository,
             messageSendingScheduler,
+            selfConversationIdProvider,
             this,
             ephemeralMessageRepository
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.debug
 
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
@@ -74,6 +75,7 @@ class DebugScope internal constructor(
     private val syncManager: SyncManager,
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
+    private val selfConversationIdProvider: SelfConversationIdProvider,
     private val scope: CoroutineScope,
     private val ephemeralMessageRepository: EphemeralMessageRepository,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
@@ -149,7 +151,8 @@ class DebugScope internal constructor(
             currentClientIdProvider = currentClientIdProvider,
             messageSender = messageSender,
             selfUserId = userId,
-            ephemeralMessageRepository = ephemeralMessageRepository
+            ephemeralMessageRepository = ephemeralMessageRepository,
+            selfConversationIdProvider = selfConversationIdProvider
         )
 
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -18,12 +18,12 @@
 
 package com.wire.kalium.logic.feature.debug
 
-import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.message.EphemeralMessageRepository
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.message.ProtoContentMapperImpl
@@ -74,8 +74,8 @@ class DebugScope internal constructor(
     private val syncManager: SyncManager,
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
-    private val selfConversationIdProvider: SelfConversationIdProvider,
     private val scope: CoroutineScope,
+    private val ephemeralMessageRepository: EphemeralMessageRepository,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
@@ -149,7 +149,7 @@ class DebugScope internal constructor(
             currentClientIdProvider = currentClientIdProvider,
             messageSender = messageSender,
             selfUserId = userId,
-            selfConversationIdProvider = selfConversationIdProvider
+            ephemeralMessageRepository = ephemeralMessageRepository
         )
 
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -303,6 +303,7 @@ class MessageScope internal constructor(
             currentClientIdProvider = currentClientIdProvider,
             messageSender = messageSender,
             selfUserId = selfUserId,
+            selfConversationIdProvider = selfConversationIdProvider,
             ephemeralMessageRepository = ephemeralMessageRepository
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.EphemeralMessageRepository
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.message.PersistMessageUseCaseImpl
@@ -82,6 +83,7 @@ class MessageScope internal constructor(
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
     private val userPropertyRepository: UserPropertyRepository,
+    private val ephemeralMessageRepository: EphemeralMessageRepository,
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val protoContentMapper: ProtoContentMapper,
     private val observeSelfDeletingMessages: ObserveSelfDeletionTimerSettingsForConversationUseCase,
@@ -301,6 +303,6 @@ class MessageScope internal constructor(
             currentClientIdProvider = currentClientIdProvider,
             messageSender = messageSender,
             selfUserId = selfUserId,
-            selfConversationIdProvider = selfConversationIdProvider
+            ephemeralMessageRepository = ephemeralMessageRepository
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
@@ -54,6 +54,7 @@ internal interface DeleteEphemeralMessageForSelfUserAsReceiverUseCase {
     suspend operator fun invoke(conversationId: ConversationId, messageId: String): Either<CoreFailure, Unit>
 }
 
+@Suppress("LongParameterList")
 internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
     private val messageRepository: MessageRepository,
     private val assetRepository: AssetRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.feature.message.ephemeral
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.ASSETS
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
@@ -33,6 +34,7 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -44,7 +46,7 @@ import com.wire.kalium.util.DateTimeUtil
  * for the self-deleting message, before the receiver does it on the sender side, the message is simply marked as deleted
  * see [com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl]
  **/
-interface DeleteEphemeralMessageForSelfUserAsReceiverUseCase {
+internal interface DeleteEphemeralMessageForSelfUserAsReceiverUseCase {
     /**
      * @param conversationId the conversation id that contains the self-deleting message
      * @param messageId the id of the self-deleting message
@@ -59,29 +61,61 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val messageSender: MessageSender,
     private val selfUserId: UserId,
+    private val selfConversationIdProvider: SelfConversationIdProvider
 ) : DeleteEphemeralMessageForSelfUserAsReceiverUseCase {
     override suspend fun invoke(conversationId: ConversationId, messageId: String): Either<CoreFailure, Unit> =
-        messageRepository.getMessageById(conversationId, messageId).flatMap { message ->
-            currentClientIdProvider().flatMap { currentClientId ->
-                sendDeleteSignalFrSelfAndSender(
-                    messageId,
-                    conversationId,
-                    message.senderUserId,
-                    currentClientId
-                )
-            }.onSuccess { deleteMessageAssetIfExists(message) }
-                .flatMap { messageRepository.deleteMessage(messageId, conversationId) }
+        currentClientIdProvider().flatMap { currentClientId ->
+            messageRepository.getMessageById(conversationId, messageId).flatMap { message ->
+                currentClientIdProvider().flatMap { currentClientId ->
+                    sendDeleteMessageToSelf(
+                        message.id,
+                        currentClientId
+                    )
+                }.flatMap {
+                    sendDeleteMessageToOriginalSender(
+                        message.id,
+                        message.conversationId,
+                        message.senderUserId,
+                        currentClientId
+                    )
+                }.onSuccess {
+                    deleteMessageAssetIfExists(message)
+                }.flatMap {
+                    messageRepository.deleteMessage(messageId, conversationId)
+                }
+            }
         }
 
-    private suspend fun sendDeleteSignalFrSelfAndSender(
-        messageId: String,
-        originalMessageSender: UserId,
-        conversationId: ConversationId,
+    private suspend fun sendDeleteMessageToSelf(
+        messageToDelete: String,
         currentClientId: ClientId
-    ): Either<CoreFailure, Unit> =
+    ): Either<CoreFailure, Unit> = selfConversationIdProvider().flatMap { selfConversaionIdList ->
+        selfConversaionIdList.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
+            Message.Signaling(
+                id = uuid4().toString(),
+                content = MessageContent.DeleteMessage(messageToDelete),
+                conversationId = selfConversationId,
+                date = DateTimeUtil.currentIsoDateTimeString(),
+                senderUserId = selfUserId,
+                senderClientId = currentClientId,
+                status = Message.Status.PENDING,
+                isSelfMessage = false
+            ).let { deleteSinglingMessage ->
+                messageSender.sendMessage(deleteSinglingMessage, MessageTarget.Conversation)
+            }
+        }
+    }
+
+    private suspend fun sendDeleteMessageToOriginalSender(
+        messageToDelete: String,
+        conversationId: ConversationId,
+        originalMessageSender: UserId,
+        currentClientId: ClientId
+    ) = ephemeralMessageRepository.recipientsForDeletedEphemeral(conversationId, originalMessageSender).flatMap { recipients ->
+        if (recipients.isEmpty()) return@flatMap Either.Right(Unit)
         Message.Signaling(
             id = uuid4().toString(),
-            content = MessageContent.DeleteMessage(messageId),
+            content = MessageContent.DeleteMessage(messageToDelete),
             conversationId = conversationId,
             date = DateTimeUtil.currentIsoDateTimeString(),
             senderUserId = selfUserId,
@@ -89,23 +123,22 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
             status = Message.Status.PENDING,
             isSelfMessage = false
         ).let { deleteSinglingMessage ->
-            ephemeralMessageRepository.recipientsForDeletedEphemeral(conversationId, originalMessageSender).flatMap { recipients ->
-                messageSender.sendMessage(deleteSinglingMessage, MessageTarget.Client(recipients))
-            }
+            messageSender.sendMessage(
+                deleteSinglingMessage,
+                MessageTarget.Client(recipients)
+            )
         }
-
+    }
 
     private suspend fun deleteMessageAssetIfExists(message: Message) {
         (message.content as? MessageContent.Asset)?.value?.remoteData?.let { assetToRemove ->
-
             assetRepository.deleteAsset(
                 assetToRemove.assetId,
                 assetToRemove.assetDomain,
                 assetToRemove.assetToken
-            )
-                .onFailure {
-                    kaliumLogger.withFeatureId(ASSETS).w("delete message asset failure: $it")
-                }
+            ).onFailure {
+                kaliumLogger.withFeatureId(ASSETS).w("delete message asset failure: $it")
+            }
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/EphemeralRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/EphemeralRepositoryTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Recipient
+import com.wire.kalium.logic.data.id.toModel
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.client.ClientDAO
+import com.wire.kalium.persistence.dao.client.ClientTypeEntity
+import com.wire.kalium.persistence.dao.client.DeviceTypeEntity
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import com.wire.kalium.persistence.dao.client.Client as ClientEntity
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EphemeralRepositoryTest {
+
+    @Test
+    fun givenSuccess_whenGettingDeleteMessageRecipients_thenSuccessIsPropagated() = runTest {
+        val user = QualifiedIDEntity("userId", "domain.com")
+        val conversationId = QualifiedIDEntity("conversationId", "domain.com")
+        val clients = listOf(
+            ClientEntity(
+                user,
+                "clientId",
+                DeviceTypeEntity.Desktop,
+                ClientTypeEntity.Permanent,
+                true,
+                true,
+                null,
+                null,
+                null
+            )
+        )
+
+        val expected = Recipient(
+            user.toModel(),
+            clients.map { ClientId(it.id) }
+        )
+
+        val (arrangement, repo) = Arrangement()
+            .withDeleteMessageRecipientSuccess(mapOf(user to clients))
+            .arrange()
+
+        repo.recipientsForDeletedEphemeral(user.toModel(), conversationId.toModel()).shouldSucceed {
+            assertEquals(listOf(expected), it)
+        }
+
+        verify(arrangement.clientDAO)
+            .suspendFunction(arrangement.clientDAO::recipientsIfTHeyArePartOfConversation)
+            .with(eq(conversationId), eq(setOf(user)))
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement {
+        @Mock
+        val clientDAO: ClientDAO = mock(ClientDAO::class)
+        private val repo = EphemeralMessageDataSource(clientDAO)
+
+        fun withDeleteMessageRecipientSuccess(result: Map<QualifiedIDEntity, List<ClientEntity>>) = apply {
+            given(clientDAO)
+                .suspendFunction(clientDAO::recipientsIfTHeyArePartOfConversation)
+                .whenInvokedWith(any(), any())
+                .thenReturn(result)
+        }
+
+        fun arrange() = this to repo
+    }
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -63,3 +63,10 @@ SELECT * FROM Client WHERE user_id IN (SELECT user FROM Member WHERE conversatio
 
 updateClientVerificatioStatus:
 UPDATE Client SET is_verified = :is_verified WHERE user_id = :user_id AND id = :client_id;
+
+selectRecipientsByConversationAndUserId:
+SELECT *
+ FROM Client
+  WHERE user_id IN
+  (SELECT user FROM Member WHERE conversation = :conversation_id AND user_id IN :userIdList)
+  AND is_valid = 1;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.persistence.dao.client
 
+import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
@@ -74,5 +75,18 @@ interface ClientDAO {
     suspend fun tryMarkInvalid(invalidClientsList: List<Pair<QualifiedIDEntity, List<String>>>)
     suspend fun updateClientVerificationStatus(userId: QualifiedIDEntity, clientId: String, verified: Boolean)
     suspend fun observeClient(userId: QualifiedIDEntity, clientId: String): Flow<Client?>
+
+    /**
+     * Returns a map of users and their clients.
+     * the result include only users that are in the conversation
+     * @param conversationId the conversation id
+     * @param userIds the set of users
+     * @return a map of users and their clients
+     */
+    suspend fun recipientOfUsers(
+        conversationId: ConversationIDEntity,
+        userIds: Set<QualifiedIDEntity>
+    ): Map<QualifiedIDEntity, List<Client>>
+
     suspend fun selectAllClients(): Map<QualifiedIDEntity, List<Client>>
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
@@ -83,7 +83,7 @@ interface ClientDAO {
      * @param userIds the set of users
      * @return a map of users and their clients
      */
-    suspend fun recipientOfUsers(
+    suspend fun recipientsIfTHeyArePartOfConversation(
         conversationId: ConversationIDEntity,
         userIds: Set<QualifiedIDEntity>
     ): Map<QualifiedIDEntity, List<Client>>

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.dao.client
 
 import app.cash.sqldelight.coroutines.asFlow
 import com.wire.kalium.persistence.ClientsQueries
+import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneNotNull
@@ -116,6 +117,15 @@ internal class ClientDAOImpl internal constructor(
             .asFlow()
             .mapToOneNotNull()
             .flowOn(queriesContext)
+
+    override suspend fun recipientOfUsers(
+        conversationId: ConversationIDEntity,
+        userIds: Set<QualifiedIDEntity>
+    ): Map<QualifiedIDEntity, List<Client>> = withContext(queriesContext) {
+        clientsQueries.selectRecipientsByConversationAndUserId(conversationId, userIds, mapper::fromClient)
+            .executeAsList()
+            .groupBy { it.userId }
+    }
 
     override suspend fun selectAllClients(): Map<QualifiedIDEntity, List<Client>> =
         clientsQueries.selectAllClients(mapper::fromClient)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -118,7 +118,7 @@ internal class ClientDAOImpl internal constructor(
             .mapToOneNotNull()
             .flowOn(queriesContext)
 
-    override suspend fun recipientOfUsers(
+    override suspend fun recipientsIfTHeyArePartOfConversation(
         conversationId: ConversationIDEntity,
         userIds: Set<QualifiedIDEntity>
     ): Map<QualifiedIDEntity, List<Client>> = withContext(queriesContext) {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -35,6 +35,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
@@ -275,6 +276,53 @@ class ClientDAOTest : BaseDatabaseTest() {
         assertTrue { clientDAO.getClientsOfUserByQualifiedID(userId).first().isVerified }
     }
 
+    @Test
+    fun givenUserIsPartOfConversation_whenGettingRecipient_thenOnlyValidUserClientsAreReturned() = runTest {
+        val user = user
+        userDAO.insertUser(user)
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertMember(Member(user.id, Member.Role.Admin), conversationEntity1.id)
+
+        clientDAO.insertClient(insertedClient)
+        val invalidClient = insertedClient.copy(id = "id2")
+        clientDAO.insertClient(invalidClient)
+        clientDAO.tryMarkInvalid(listOf(invalidClient.userId to listOf(invalidClient.id)))
+
+        clientDAO.recipientsIfTHeyArePartOfConversation(conversationEntity1.id, setOf(user.id)).also {
+            assertEquals(1, it.size)
+            assertEquals(listOf(client), it[user.id])
+        }
+    }
+
+    @Test
+    fun givenUserIsNotPartOfConversation_whenGettingRecipient_thenTheyAreNotIncludedInTheResult() = runTest {
+        val user = user
+        userDAO.insertUser(user)
+        clientDAO.insertClient(insertedClient)
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertMember(Member(user.id, Member.Role.Admin), conversationEntity1.id)
+
+        val user2 = newUserEntity(QualifiedIDEntity("test2", "domain"))
+        userDAO.insertUser(user2)
+        val insertedClient2 = InsertClientParam(
+            userId = user2.id,
+            id = "id01",
+            deviceType = null,
+            clientType = null,
+            label = null,
+            model = null,
+            registrationDate = null
+        )
+        clientDAO.insertClient(insertedClient2)
+
+
+        clientDAO.recipientsIfTHeyArePartOfConversation(conversationEntity1.id, setOf(user.id, user2.id)).also {
+            assertEquals(1, it.size)
+            assertEquals(listOf(client), it[user.id])
+            assertNull(it[user2.id])
+        }
+    }
+
     private companion object {
         val userId = QualifiedIDEntity("test", "domain")
         val user = newUserEntity(userId)
@@ -317,14 +365,14 @@ class ClientDAOTest : BaseDatabaseTest() {
 }
 
 private fun InsertClientParam.toClient(): Client =
-        Client(
-            userId,
-            id,
-            deviceType = deviceType,
-            clientType = clientType,
-            isValid = true,
-            isVerified = false,
-            label = label,
-            model = model,
-            registrationDate = registrationDate
-        )
+    Client(
+        userId,
+        id,
+        deviceType = deviceType,
+        clientType = clientType,
+        isValid = true,
+        isVerified = false,
+        label = label,
+        model = model,
+        registrationDate = registrationDate
+    )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

self deleting messages delete message is sent to all of the conversation members

### Solutions

Send 2 delete messages:
1. for the original message sender if they are still a member.
2. send a message, a delete message to the user self conversation

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
