### PR TITLE
feat(mls-migration): update self supported protocols during slow sync #9

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -22,6 +22,7 @@ import com.wire.crypto.CryptoException
 import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import io.ktor.utils.io.errors.IOException
@@ -100,6 +101,11 @@ sealed class NetworkFailure : CoreFailure {
      * Failure due to a federated backend context
      */
     object FederatedBackendFailure : NetworkFailure()
+
+    /**
+     * Failure due to a feature not supported by the current client/backend.
+     */
+    object FeatureNotSupported : NetworkFailure()
 }
 
 interface MLSFailure : CoreFailure {
@@ -143,6 +149,10 @@ internal inline fun <T : Any> wrapApiRequest(networkCall: () -> NetworkResponse<
                 // todo SocketException is platform specific so need to wrap it in our own exceptions
                 exception.cause?.message?.contains(SOCKS_EXCEPTION, true) == true -> {
                     Either.Left(NetworkFailure.ProxyError(exception.cause))
+                }
+
+                exception is APINotSupported -> {
+                    Either.Left(NetworkFailure.FeatureNotSupported)
                 }
 
                 else -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
@@ -34,6 +34,7 @@ sealed interface SlowSyncStatus {
 enum class SlowSyncStep {
     SELF_USER,
     FEATURE_FLAGS,
+    UPDATE_SUPPORTED_PROTOCOLS,
     CONVERSATIONS,
     CONNECTIONS,
     SELF_TEAM,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -759,6 +759,7 @@ class UserSessionScope internal constructor(
         SlowSyncWorkerImpl(
             syncSelfUser,
             syncFeatureConfigsUseCase,
+            users.updateSupportedProtocols,
             syncConversations,
             syncConnections,
             syncSelfTeamUseCase,
@@ -871,13 +872,21 @@ class UserSessionScope internal constructor(
                 mlsClientProvider, clientRepository, keyPackageRepository, keyPackageLimitsProvider
             )
         })
+
+    internal val mlsMigrationWorker get() =
+        MLSMigrationWorkerImpl(
+            mlsMigrationRepository,
+            mlsMigrator,
+            users.updateSupportedProtocols
+        )
+
     internal val mlsMigrationManager: MLSMigrationManager = MLSMigrationManagerImpl(
             kaliumConfigs,
             featureSupport,
             incrementalSyncRepository,
             lazy { clientRepository },
             lazy { users.timestampKeyRepository },
-            lazy { MLSMigrationWorkerImpl(mlsMigrationRepository, mlsMigrator) },
+            lazy { mlsMigrationWorker },
             lazy { mlsMigrationRepository }
     )
 
@@ -1219,7 +1228,6 @@ class UserSessionScope internal constructor(
             clientIdProvider,
             clientRepository,
             featureConfigRepository,
-            slowSyncRepository,
             team.isSelfATeamMember,
         )
     private val clearUserData: ClearUserDataUseCase get() = ClearUserDataUseCaseImpl(userStorage)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -136,7 +136,7 @@ internal class LoginUseCaseImpl internal constructor(
                 when (it) {
                     is NetworkFailure.ProxyError -> AuthenticationResult.Failure.SocketError
                     is NetworkFailure.ServerMiscommunication -> handleServerMiscommunication(it, isEmail, cleanUserIdentifier)
-                    is NetworkFailure.NoNetworkConnection, NetworkFailure.FederatedBackendFailure ->
+                    is NetworkFailure.NoNetworkConnection, NetworkFailure.FederatedBackendFailure, NetworkFailure.FeatureNotSupported ->
                         AuthenticationResult.Failure.Generic(it)
                 }
             }, {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCase.kt
@@ -52,6 +52,7 @@ class CheckConversationInviteCodeUseCase internal constructor(
                 when (failure) {
                     is NetworkFailure.NoNetworkConnection,
                     is NetworkFailure.FederatedBackendFailure,
+                    is NetworkFailure.FeatureNotSupported,
                     is NetworkFailure.ProxyError -> Result.Failure.Generic(failure)
 
                     is NetworkFailure.ServerMiscommunication -> handleServerMissCommunicationError(failure)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -27,7 +27,6 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.session.SessionRepository
-import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
@@ -76,7 +75,6 @@ class UserScope internal constructor(
     private val clientIdProvider: CurrentClientIdProvider,
     private val clientRepository: ClientRepository,
     private val featureConfigRepository: FeatureConfigRepository,
-    private val slowSyncRepository: SlowSyncRepository,
     private val isSelfATeamMember: IsSelfATeamMemberUseCase
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
@@ -110,8 +108,7 @@ class UserScope internal constructor(
         get() = UpdateSupportedProtocolsUseCaseImpl(
             clientRepository,
             userRepository,
-            featureConfigRepository,
-            slowSyncRepository
+            featureConfigRepository
         )
 
     val isPasswordRequired

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -115,6 +115,7 @@ class SessionManagerImpl internal constructor(
                     is NetworkFailure.NoNetworkConnection -> null
                     is NetworkFailure.ProxyError -> null
                     is NetworkFailure.FederatedBackendFailure -> null
+                    is NetworkFailure.FeatureNotSupported -> null
                     is NetworkFailure.ServerMiscommunication -> {
                         onServerMissCommunication(it)
                         null

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.SyncContactsUseCase
 import com.wire.kalium.logic.feature.user.SyncSelfUserUseCase
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
@@ -53,6 +54,7 @@ internal interface SlowSyncWorker {
 internal class SlowSyncWorkerImpl(
     private val syncSelfUser: SyncSelfUserUseCase,
     private val syncFeatureConfigs: SyncFeatureConfigsUseCase,
+    private val updateSupportedProtocols: UpdateSupportedProtocolsUseCase,
     private val syncConversations: SyncConversationsUseCase,
     private val syncConnections: SyncConnectionsUseCase,
     private val syncSelfTeam: SyncSelfTeamUseCase,
@@ -73,6 +75,7 @@ internal class SlowSyncWorkerImpl(
 
         performStep(SlowSyncStep.SELF_USER, syncSelfUser::invoke)
             .continueWithStep(SlowSyncStep.FEATURE_FLAGS, syncFeatureConfigs::invoke)
+            .continueWithStep(SlowSyncStep.UPDATE_SUPPORTED_PROTOCOLS, updateSupportedProtocols::invoke)
             .continueWithStep(SlowSyncStep.CONVERSATIONS, syncConversations::invoke)
             .continueWithStep(SlowSyncStep.CONNECTIONS, syncConnections::invoke)
             .continueWithStep(SlowSyncStep.SELF_TEAM, syncSelfTeam::invoke)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Invoke the `UpdateSupportedProtocols` use case during the slow sync and every 24 hours when the migration feature is enabled.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
