### PR TITLE
fix(RC): deciding if time passed to send the delete message is not accura…

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -20,11 +20,11 @@ package com.wire.kalium.logic.data.message
 
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
-import com.wire.kalium.util.serialization.toJsonElement
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
-import kotlinx.datetime.Clock
+import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Instant
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -274,6 +274,7 @@ sealed interface Message {
                 MessageContent.HistoryLost -> mutableMapOf(
                     typeKey to "conversationMightLostHistory"
                 )
+
                 is MessageContent.ConversationMessageTimerChanged -> mutableMapOf(
                     typeKey to "conversationMessageTimerChanged"
                 )
@@ -338,7 +339,8 @@ sealed interface Message {
 
         fun timeLeftForDeletion(): Duration {
             return if (selfDeletionStatus is SelfDeletionStatus.Started) {
-                val timeElapsedSinceSelfDeletionStartDate = Clock.System.now() - selfDeletionStatus.selfDeletionStartDate
+                val timeElapsedSinceSelfDeletionStartDate =
+                    DateTimeUtil.currentInstant() - selfDeletionStatus.selfDeletionStartDate
 
                 // time left for deletion it can be a negative value if the time difference between the self deletion start date and
                 // now is greater then expire after millis, we normalize it to 0 seconds

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCase.kt
@@ -118,6 +118,7 @@ class JoinSubconversationUseCaseImpl(
     }
 
 }
+// TODO(MO): should we user DateTimeUtil instead os Clock.System.now()?
 private fun Instant.timeElapsedUntilNow(): Duration =
     Clock.System.now().minus(this)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
@@ -60,7 +60,7 @@ class SendConfirmationUseCase internal constructor(
         val selfUser = userRepository.observeSelfUser().first()
 
         val generatedMessageUuid = uuid4().toString()
-
+        // TODO(MO): should we user DateTimeUtil instead os Clock.System.now()?
         return currentClientIdProvider().flatMap { currentClientId ->
             val message = Message.Signaling(
                 id = generatedMessageUuid,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -14,7 +15,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.datetime.Clock
 import kotlin.coroutines.CoroutineContext
 
 internal interface EphemeralMessageDeletionHandler {
@@ -167,7 +167,7 @@ internal class EphemeralMessageDeletionHandlerImpl(
                     )
                 )
 
-                val deletionStartMark = Clock.System.now()
+                val deletionStartMark = DateTimeUtil.currentInstant()
 
                 messageRepository.markSelfDeletionStartDate(
                     conversationId = message.conversationId,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -343,6 +343,7 @@ class MessageNotificationsTest : BaseMessageTest() {
         userDAO.updateUserAvailabilityStatus(SELF_USER_ID, status)
     }
 
+    // TODO(MO): should we user DateTimeUtil instead os Clock.System.now()?
     private suspend fun setConversationMutedStatus(conversationId: QualifiedIDEntity, mutedStatus: ConversationEntity.MutedStatus) {
         conversationDAO.updateConversationMutedStatus(conversationId, mutedStatus, Clock.System.now().toEpochMilliseconds())
     }


### PR DESCRIPTION
…te enough

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

delete message is sent before its time

### Solutions

use date time util to get current time

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

Untestable with unit test atm

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
