### PR TITLE
fix: handle insertion of user with incomplete metadata at query level (WPB-411)

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -75,8 +75,8 @@ SET team = NULL , preview_asset_id = NULL, complete_asset_id = NULL, user_type =
 WHERE qualified_id = ?;
 
 insertOrIgnoreUserId:
-INSERT OR IGNORE INTO User(qualified_id)
-VALUES(?);
+INSERT OR IGNORE INTO User(qualified_id, incomplete_metadata)
+VALUES(?, 1);
 
 updateSelfUser:
 UPDATE User

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -1144,10 +1144,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         // when
         conversationDAO.insertMembersWithQualifiedId(
-            listOf(
-                Member(user1.id, Member.Role.Member),
-                Member(selfUserId, Member.Role.Member) // adding SelfUser as a member too
-            ),
+            listOf(Member(user1.id, Member.Role.Member)),
             conversationEntity1.id
         )
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -1136,4 +1136,23 @@ class ConversationDAOTest : BaseDatabaseTest() {
                 assertEquals(conversationEntity2.id, it.first())
             }
         }
+
+    @Test
+    fun givenConversation_whenPersistingMembersWithoutMetadata_ThenUsersShouldBeMarkedWithIncompleteMetadataTrue() = runTest(dispatcher) {
+        // given
+        conversationDAO.insertConversation(conversationEntity1)
+
+        // when
+        conversationDAO.insertMembersWithQualifiedId(
+            listOf(
+                Member(user1.id, Member.Role.Member),
+                Member(selfUserId, Member.Role.Member) // adding SelfUser as a member too
+            ),
+            conversationEntity1.id
+        )
+
+        // then
+        val member = userDAO.getUserByQualifiedID(user1.id).first()
+        assertEquals(true, member?.hasIncompleteMetadata)
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When fetching failed conversations, the participants with whom I'm not connected with, are showing as "username not available"

### Causes (Optional)

This users are not refreshed, because when inserting ids, we assume we have the metadata.

### Solutions

When persisting only id's of users, mark them as incomplete metadata, so we can refetch them later.

### Attachments (Optional)

**Before**
<img src="https://github.com/wireapp/kalium/assets/5806454/61e198cc-a34f-4359-a176-1bd469352393" width="300"/>

**After**
<img src="https://github.com/wireapp/kalium/assets/5806454/76492946-c5f7-419f-98c6-04dda7fccde5" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
