### PR TITLE
feat(mls-migration): force migration when migration deadline arrives #10

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -474,7 +474,7 @@ private fun ConversationEntity.AccessRole.toDAO(): Conversation.AccessRole = whe
     ConversationEntity.AccessRole.EXTERNAL -> Conversation.AccessRole.EXTERNAL
 }
 
-private fun Conversation.Type.toDAO(): ConversationEntity.Type = when (this) {
+internal fun Conversation.Type.toDAO(): ConversationEntity.Type = when (this) {
     Conversation.Type.SELF -> ConversationEntity.Type.SELF
     Conversation.Type.ONE_ON_ONE -> ConversationEntity.Type.ONE_ON_ONE
     Conversation.Type.GROUP -> ConversationEntity.Type.GROUP

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -118,8 +118,8 @@ interface ConversationRepository {
 
     suspend fun getConversationList(): Either<StorageFailure, Flow<List<Conversation>>>
     suspend fun observeConversationList(): Flow<List<Conversation>>
-    suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
-    suspend fun getProteusTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
+    suspend fun getTeamConversations(teamId: TeamId, protocol: Conversation.Protocol): Either<StorageFailure, List<QualifiedID>>
+    suspend fun getTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
     suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>>
     suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
@@ -393,13 +393,13 @@ internal class ConversationDataSource internal constructor(
         return conversationDAO.getAllConversations().map { it.map(conversationMapper::fromDaoModel) }
     }
 
-    override suspend fun getProteusTeamConversations(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
+    override suspend fun getTeamConversations(teamId: TeamId, protocol: Conversation.Protocol): Either<StorageFailure, List<QualifiedID>> =
         wrapStorageRequest {
-            conversationDAO.getAllProteusTeamConversations(teamId.value)
+            conversationDAO.getAllTeamConversations(teamId.value, protocol.toDao())
                 .map { it.toModel() }
         }
 
-    override suspend fun getProteusTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
+    override suspend fun getTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
         wrapStorageRequest {
             conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId.value)
                 .map { it.toModel() }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -118,8 +118,12 @@ interface ConversationRepository {
 
     suspend fun getConversationList(): Either<StorageFailure, Flow<List<Conversation>>>
     suspend fun observeConversationList(): Flow<List<Conversation>>
-    suspend fun getTeamConversations(teamId: TeamId, protocol: Conversation.Protocol): Either<StorageFailure, List<QualifiedID>>
-    suspend fun getTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
+    suspend fun getConversationIds(
+        type: Conversation.Type,
+        protocol: Conversation.Protocol,
+        teamId: TeamId? = null
+    ): Either<StorageFailure, List<QualifiedID>>
+    suspend fun getTeamConversationIdsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
     suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>>
     suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
@@ -131,7 +135,6 @@ interface ConversationRepository {
     suspend fun getConversationRecipients(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
     suspend fun getConversationRecipientsForCalling(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
     suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, Conversation.ProtocolInfo>
-    suspend fun getGroupConversationIdsByProtocol(protocol: Conversation.Protocol): Either<StorageFailure, List<ConversationId>>
     suspend fun observeConversationMembers(conversationID: ConversationId): Flow<List<Conversation.Member>>
 
     /**
@@ -393,15 +396,18 @@ internal class ConversationDataSource internal constructor(
         return conversationDAO.getAllConversations().map { it.map(conversationMapper::fromDaoModel) }
     }
 
-    override suspend fun getTeamConversations(teamId: TeamId, protocol: Conversation.Protocol): Either<StorageFailure, List<QualifiedID>> =
+    override suspend fun getConversationIds(
+        type: Conversation.Type,
+        protocol: Conversation.Protocol,
+        teamId: TeamId?
+    ): Either<StorageFailure, List<QualifiedID>> =
         wrapStorageRequest {
-            conversationDAO.getAllTeamConversations(teamId.value, protocol.toDao())
+            conversationDAO.getConversationIds(type.toDAO(), protocol.toDao(), teamId?.value)
                 .map { it.toModel() }
         }
-
-    override suspend fun getTeamConversationsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
+    override suspend fun getTeamConversationIdsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
         wrapStorageRequest {
-            conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId.value)
+            conversationDAO.getTeamConversationIdsReadyToBeFinalised(teamId.value)
                 .map { it.toModel() }
         }
 
@@ -488,11 +494,6 @@ internal class ConversationDataSource internal constructor(
             conversationDAO.getConversationProtocolInfo(conversationId.toDao())?.let {
                 protocolInfoMapper.fromEntity(it)
             }
-        }
-
-    override suspend fun getGroupConversationIdsByProtocol(protocol: Conversation.Protocol): Either<StorageFailure, List<ConversationId>> =
-        wrapStorageRequest {
-            conversationDAO.getGroupConversationIdsByProtocol(protocol.toDao()).map(QualifiedIDEntity::toModel)
         }
 
     override suspend fun observeConversationMembers(conversationID: ConversationId): Flow<List<Conversation.Member>> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -123,7 +123,7 @@ interface ConversationRepository {
         protocol: Conversation.Protocol,
         teamId: TeamId? = null
     ): Either<StorageFailure, List<QualifiedID>>
-    suspend fun getTeamConversationIdsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
+    suspend fun getTeamConversationIdsReadyToCompleteMigration(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
     suspend fun observeConversationListDetails(): Flow<List<ConversationDetails>>
     suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
@@ -405,9 +405,9 @@ internal class ConversationDataSource internal constructor(
             conversationDAO.getConversationIds(type.toDAO(), protocol.toDao(), teamId?.value)
                 .map { it.toModel() }
         }
-    override suspend fun getTeamConversationIdsReadyForFinalisation(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
+    override suspend fun getTeamConversationIdsReadyToCompleteMigration(teamId: TeamId): Either<StorageFailure, List<QualifiedID>> =
         wrapStorageRequest {
-            conversationDAO.getTeamConversationIdsReadyToBeFinalised(teamId.value)
+            conversationDAO.getTeamConversationIdsReadyToCompleteMigration(teamId.value)
                 .map { it.toModel() }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/SyncConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/SyncConversationsUseCase.kt
@@ -35,7 +35,7 @@ internal class SyncConversationsUseCase(
     private val systemMessageInserter: SystemMessageInserter
 ) {
     suspend operator fun invoke(): Either<CoreFailure, Unit> =
-        conversationRepository.getGroupConversationIdsByProtocol(Conversation.Protocol.PROTEUS)
+        conversationRepository.getConversationIds(Conversation.Type.GROUP, Conversation.Protocol.PROTEUS)
             .flatMap { proteusConversationIds ->
                 conversationRepository.fetchConversations()
                     .flatMap {
@@ -46,7 +46,7 @@ internal class SyncConversationsUseCase(
     private suspend fun reportConversationsWithPotentialHistoryLoss(
         proteusConversationIds: List<ConversationId>
     ): Either<StorageFailure, Unit> =
-        conversationRepository.getGroupConversationIdsByProtocol(Conversation.Protocol.MLS)
+        conversationRepository.getConversationIds(Conversation.Type.GROUP, Conversation.Protocol.MLS)
             .flatMap { mlsConversationIds ->
                 val conversationsWithUpgradedProtocol = mlsConversationIds.intersect(proteusConversationIds)
                 for (conversationId in conversationsWithUpgradedProtocol) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorker.kt
@@ -47,8 +47,12 @@ class MLSMigrationWorkerImpl(
                 kaliumLogger.i("Running proteus to MLS migration")
                 updateSupportedProtocols().flatMap {
                     mlsMigrator.migrateProteusConversations().flatMap {
+                        if (configuration.hasMigrationEnded()) {
+                            mlsMigrator.finaliseAllProteusConversations()
+                        } else {
                             mlsMigrator.finaliseProteusConversations()
                         }
+                    }
                 }
             } else {
                 kaliumLogger.i("MLS migration is not enabled")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -53,7 +53,7 @@ internal class MLSMigratorImpl(
         selfTeamIdProvider().flatMap {
             it?.let { Either.Right(it) } ?: Either.Left(StorageFailure.DataNotFound)
         }.flatMap { teamId ->
-            conversationRepository.getTeamConversations(teamId, Protocol.PROTEUS)
+            conversationRepository.getConversationIds(Conversation.Type.GROUP, Protocol.PROTEUS, teamId)
                 .flatMap {
                     it.foldToEitherWhileRight(Unit) { conversationId, _ ->
                         migrate(conversationId)
@@ -65,7 +65,7 @@ internal class MLSMigratorImpl(
         selfTeamIdProvider().flatMap {
             it?.let { Either.Right(it) } ?: Either.Left(StorageFailure.DataNotFound)
         }.flatMap { teamId ->
-            conversationRepository.getTeamConversations(teamId, Protocol.MIXED)
+            conversationRepository.getConversationIds(Conversation.Type.GROUP, Protocol.MIXED, teamId)
                 .flatMap {
                     it.foldToEitherWhileRight(Unit) { conversationId, _ ->
                         finalise(conversationId)
@@ -79,7 +79,7 @@ internal class MLSMigratorImpl(
         }.flatMap { teamId ->
             userRepository.fetchKnownUsers()
                 .flatMap {
-                    conversationRepository.getTeamConversationsReadyForFinalisation(teamId)
+                    conversationRepository.getTeamConversationIdsReadyForFinalisation(teamId)
                         .flatMap {
                             it.foldToEitherWhileRight(Unit) { conversationId, _ ->
                                 finalise(conversationId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.kaliumLogger
 interface MLSMigrator {
     suspend fun migrateProteusConversations(): Either<CoreFailure, Unit>
     suspend fun finaliseProteusConversations(): Either<CoreFailure, Unit>
+    suspend fun finaliseAllProteusConversations(): Either<CoreFailure, Unit>
 }
 internal class MLSMigratorImpl(
     private val selfUserId: UserId,
@@ -52,10 +53,22 @@ internal class MLSMigratorImpl(
         selfTeamIdProvider().flatMap {
             it?.let { Either.Right(it) } ?: Either.Left(StorageFailure.DataNotFound)
         }.flatMap { teamId ->
-            conversationRepository.getProteusTeamConversations(teamId)
+            conversationRepository.getTeamConversations(teamId, Protocol.PROTEUS)
                 .flatMap {
                     it.foldToEitherWhileRight(Unit) { conversationId, _ ->
                         migrate(conversationId)
+                    }
+                }
+        }
+
+    override suspend fun finaliseAllProteusConversations(): Either<CoreFailure, Unit> =
+        selfTeamIdProvider().flatMap {
+            it?.let { Either.Right(it) } ?: Either.Left(StorageFailure.DataNotFound)
+        }.flatMap { teamId ->
+            conversationRepository.getTeamConversations(teamId, Protocol.MIXED)
+                .flatMap {
+                    it.foldToEitherWhileRight(Unit) { conversationId, _ ->
+                        finalise(conversationId)
                     }
                 }
         }
@@ -66,7 +79,7 @@ internal class MLSMigratorImpl(
         }.flatMap { teamId ->
             userRepository.fetchKnownUsers()
                 .flatMap {
-                    conversationRepository.getProteusTeamConversationsReadyForFinalisation(teamId)
+                    conversationRepository.getTeamConversationsReadyForFinalisation(teamId)
                         .flatMap {
                             it.foldToEitherWhileRight(Unit) { conversationId, _ ->
                                 finalise(conversationId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -79,7 +79,7 @@ internal class MLSMigratorImpl(
         }.flatMap { teamId ->
             userRepository.fetchKnownUsers()
                 .flatMap {
-                    conversationRepository.getTeamConversationIdsReadyForFinalisation(teamId)
+                    conversationRepository.getTeamConversationIdsReadyToCompleteMigration(teamId)
                         .flatMap {
                             it.foldToEitherWhileRight(Unit) { conversationId, _ ->
                                 finalise(conversationId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.featureFlags
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.seconds
 
 data class KaliumConfigs(
     val isChangeEmailEnabled: Boolean = false,
@@ -45,7 +44,7 @@ data class KaliumConfigs(
     val wipeOnDeviceRemoval: Boolean = false,
     val wipeOnRootedDevice: Boolean = false,
     // Interval between attempts to advance the proteus to MLS migration
-    val mlsMigrationInterval: Duration = 30.seconds //24.hours
+    val mlsMigrationInterval: Duration = 24.hours
 )
 
 sealed interface BuildFileRestrictionState {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.featureFlags
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
 
 data class KaliumConfigs(
     val isChangeEmailEnabled: Boolean = false,
@@ -44,7 +45,7 @@ data class KaliumConfigs(
     val wipeOnDeviceRemoval: Boolean = false,
     val wipeOnRootedDevice: Boolean = false,
     // Interval between attempts to advance the proteus to MLS migration
-    val mlsMigrationInterval: Duration = 24.hours
+    val mlsMigrationInterval: Duration = 30.seconds //24.hours
 )
 
 sealed interface BuildFileRestrictionState {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/SyncConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/SyncConversationsUseCaseTest.kt
@@ -105,8 +105,8 @@ class SyncConversationsUseCaseTest {
             protocol: Conversation.Protocol? = null
         ) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::getGroupConversationIdsByProtocol)
-                .whenInvokedWith(protocol?.let { eq(it) } ?: any())
+                .suspendFunction(conversationRepository::getConversationIds)
+                .whenInvokedWith(eq(Conversation.Type.GROUP), protocol?.let { eq(it) } ?: any(), eq(null))
                 .thenReturn(Either.Right(conversationIds))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -174,14 +174,14 @@ class MLSMigratorTest {
 
         fun withGetProteusTeamConversationsReturning(conversationsIds: List<ConversationId>) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::getProteusTeamConversations)
+                .suspendFunction(conversationRepository::getTeamConversations)
                 .whenInvokedWith(anything())
                 .thenReturn(Either.Right(conversationsIds))
         }
 
         fun withGetProteusTeamConversationsReadyForFinalisationReturning(conversationsIds: List<ConversationId>) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::getProteusTeamConversationsReadyForFinalisation)
+                .suspendFunction(conversationRepository::getTeamConversationsReadyForFinalisation)
                 .whenInvokedWith(anything())
                 .thenReturn(Either.Right(conversationsIds))
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -181,7 +181,7 @@ class MLSMigratorTest {
 
         fun withGetProteusTeamConversationsReadyForFinalisationReturning(conversationsIds: List<ConversationId>) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::getTeamConversationIdsReadyForFinalisation)
+                .suspendFunction(conversationRepository::getTeamConversationIdsReadyToCompleteMigration)
                 .whenInvokedWith(anything())
                 .thenReturn(Either.Right(conversationsIds))
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -174,14 +174,14 @@ class MLSMigratorTest {
 
         fun withGetProteusTeamConversationsReturning(conversationsIds: List<ConversationId>) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::getTeamConversations)
-                .whenInvokedWith(anything())
+                .suspendFunction(conversationRepository::getConversationIds)
+                .whenInvokedWith(eq(Conversation.Type.GROUP), eq(Conversation.Protocol.PROTEUS), anything())
                 .thenReturn(Either.Right(conversationsIds))
         }
 
         fun withGetProteusTeamConversationsReadyForFinalisationReturning(conversationsIds: List<ConversationId>) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::getTeamConversationsReadyForFinalisation)
+                .suspendFunction(conversationRepository::getTeamConversationIdsReadyForFinalisation)
                 .whenInvokedWith(anything())
                 .thenReturn(Either.Right(conversationsIds))
         }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -226,8 +226,8 @@ ORDER BY lastModifiedDate DESC, name COLLATE NOCASE ASC;
 selectAllConversations:
 SELECT * FROM ConversationDetails WHERE type IS NOT 'CONNECTION_PENDING' ORDER BY last_modified_date DESC, name ASC;
 
-selectAllTeamProteusConversations:
-SELECT qualified_id FROM Conversation WHERE type IS 'GROUP' AND protocol IS 'PROTEUS' AND team_id = ?;
+selectAllTeamConversationsWithProtocol:
+SELECT qualified_id FROM Conversation WHERE type IS 'GROUP' AND protocol = :protocol AND team_id = :teamId;
 
 selectAllTeamProteusConversationsReadyForMigration:
 SELECT
@@ -235,7 +235,7 @@ qualified_id,
 (SELECT count(*) FROM Member WHERE conversation = qualified_id) AS memberCount,
 (SELECT count(*) FROM Member LEFT JOIN User ON User.qualified_id = Member.user WHERE Member.conversation = Conversation.qualified_id AND (User.supported_protocols = 'MLS' OR User.supported_protocols = 'MLS,PROTEUS' OR User.supported_protocols = 'PROTEUS,MLS')) AS mlsCapableMemberCount
 FROM Conversation
-WHERE type IS 'GROUP' AND protocol IS 'PROTEUS' AND team_id = ? AND memberCount = mlsCapableMemberCount;
+WHERE type IS 'GROUP' AND protocol IS 'MIXED' AND team_id = ? AND memberCount = mlsCapableMemberCount;
 
 selectByQualifiedId:
 SELECT * FROM ConversationDetails WHERE qualifiedId = ?;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -226,9 +226,6 @@ ORDER BY lastModifiedDate DESC, name COLLATE NOCASE ASC;
 selectAllConversations:
 SELECT * FROM ConversationDetails WHERE type IS NOT 'CONNECTION_PENDING' ORDER BY last_modified_date DESC, name ASC;
 
-selectAllTeamConversationsWithProtocol:
-SELECT qualified_id FROM Conversation WHERE type IS 'GROUP' AND protocol = :protocol AND team_id = :teamId;
-
 selectAllTeamProteusConversationsReadyForMigration:
 SELECT
 qualified_id,
@@ -259,8 +256,8 @@ SELECT * FROM ConversationDetails WHERE mls_group_state = ? AND (protocol IS "ML
 getConversationIdByGroupId:
 SELECT qualified_id FROM Conversation WHERE mls_group_id = ?;
 
-selectGroupConversationIdsByProtocol:
-SELECT qualified_id FROM Conversation WHERE protocol = ? AND type IS 'GROUP';
+selectConversationIds:
+SELECT qualified_id FROM Conversation WHERE protocol = :protocol AND type = :type AND (:teamId IS NULL OR team_id = :teamId);
 
 updateConversationMutingStatus:
 UPDATE Conversation

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -173,8 +173,12 @@ interface ConversationDAO {
     suspend fun updateAllConversationsNotificationDate()
     suspend fun getAllConversations(): Flow<List<ConversationViewEntity>>
     suspend fun getAllConversationDetails(): Flow<List<ConversationViewEntity>>
-    suspend fun getAllTeamConversations(teamId: String, protocol: ConversationEntity.Protocol): List<QualifiedIDEntity>
-    suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity>
+    suspend fun getConversationIds(
+        type: ConversationEntity.Type,
+        protocol: ConversationEntity.Protocol,
+        teamId: String? = null
+    ): List<QualifiedIDEntity>
+    suspend fun getTeamConversationIdsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity>
     suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?>
     suspend fun observeGetConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
     suspend fun getConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity?
@@ -183,7 +187,6 @@ interface ConversationDAO {
     suspend fun getConversationProtocolInfo(qualifiedID: QualifiedIDEntity): ConversationEntity.ProtocolInfo?
     suspend fun getConversationByGroupID(groupID: String): Flow<ConversationViewEntity?>
     suspend fun getConversationIdByGroupID(groupID: String): QualifiedIDEntity?
-    suspend fun getGroupConversationIdsByProtocol(protocol: ConversationEntity.Protocol): List<QualifiedIDEntity>
     suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationViewEntity>
     suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity)
     suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -173,7 +173,7 @@ interface ConversationDAO {
     suspend fun updateAllConversationsNotificationDate()
     suspend fun getAllConversations(): Flow<List<ConversationViewEntity>>
     suspend fun getAllConversationDetails(): Flow<List<ConversationViewEntity>>
-    suspend fun getAllProteusTeamConversations(teamId: String): List<QualifiedIDEntity>
+    suspend fun getAllTeamConversations(teamId: String, protocol: ConversationEntity.Protocol): List<QualifiedIDEntity>
     suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity>
     suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?>
     suspend fun observeGetConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -178,7 +178,7 @@ interface ConversationDAO {
         protocol: ConversationEntity.Protocol,
         teamId: String? = null
     ): List<QualifiedIDEntity>
-    suspend fun getTeamConversationIdsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity>
+    suspend fun getTeamConversationIdsReadyToCompleteMigration(teamId: String): List<QualifiedIDEntity>
     suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?>
     suspend fun observeGetConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
     suspend fun getConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -335,14 +335,17 @@ class ConversationDAOImpl(
             .map { list -> list.map { it.let { conversationMapper.toModel(it) } } }
     }
 
-    override suspend fun getAllTeamConversations(teamId: String, protocol: ConversationEntity.Protocol): List<QualifiedIDEntity> {
+    override suspend fun getConversationIds(
+        type: ConversationEntity.Type,
+        protocol: ConversationEntity.Protocol,
+        teamId: String?
+    ): List<QualifiedIDEntity> {
         return withContext(coroutineContext) {
-            conversationQueries.selectAllTeamConversationsWithProtocol(protocol, teamId)
-                .executeAsList()
+            conversationQueries.selectConversationIds(protocol, type, teamId).executeAsList()
         }
     }
 
-    override suspend fun getAllProteusTeamConversationsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity> {
+    override suspend fun getTeamConversationIdsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity> {
         return withContext(coroutineContext) {
             conversationQueries.selectAllTeamProteusConversationsReadyForMigration(teamId)
                 .executeAsList()
@@ -402,11 +405,6 @@ class ConversationDAOImpl(
     override suspend fun getConversationIdByGroupID(groupID: String) = withContext(coroutineContext) {
         conversationQueries.getConversationIdByGroupId(groupID).executeAsOneOrNull()
     }
-
-    override suspend fun getGroupConversationIdsByProtocol(protocol: ConversationEntity.Protocol): List<QualifiedIDEntity> =
-        withContext(coroutineContext) {
-            conversationQueries.selectGroupConversationIdsByProtocol(protocol).executeAsList()
-        }
 
     override suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationViewEntity> =
         withContext(coroutineContext) {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -345,7 +345,7 @@ class ConversationDAOImpl(
         }
     }
 
-    override suspend fun getTeamConversationIdsReadyToBeFinalised(teamId: String): List<QualifiedIDEntity> {
+    override suspend fun getTeamConversationIdsReadyToCompleteMigration(teamId: String): List<QualifiedIDEntity> {
         return withContext(coroutineContext) {
             conversationQueries.selectAllTeamProteusConversationsReadyForMigration(teamId)
                 .executeAsList()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -335,9 +335,9 @@ class ConversationDAOImpl(
             .map { list -> list.map { it.let { conversationMapper.toModel(it) } } }
     }
 
-    override suspend fun getAllProteusTeamConversations(teamId: String): List<QualifiedIDEntity> {
+    override suspend fun getAllTeamConversations(teamId: String, protocol: ConversationEntity.Protocol): List<QualifiedIDEntity> {
         return withContext(coroutineContext) {
-            conversationQueries.selectAllTeamProteusConversations(teamId)
+            conversationQueries.selectAllTeamConversationsWithProtocol(protocol, teamId)
                 .executeAsList()
         }
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -211,7 +211,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user2.copy(supportedProtocols = allProtocols), conversationEntity6.id)
         insertTeamUserAndMember(team, user3.copy(supportedProtocols = allProtocols), conversationEntity6.id)
 
-        val result = conversationDAO.getTeamConversationIdsReadyToBeFinalised(teamId)
+        val result = conversationDAO.getTeamConversationIdsReadyToCompleteMigration(teamId)
 
         assertEquals(listOf(conversationEntity6.id), result)
     }
@@ -226,7 +226,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user2.copy(supportedProtocols = allProtocols), conversationEntity5.id)
         insertTeamUserAndMember(team, user3.copy(supportedProtocols = setOf(SupportedProtocolEntity.PROTEUS)), conversationEntity5.id)
 
-        val result = conversationDAO.getTeamConversationIdsReadyToBeFinalised(teamId)
+        val result = conversationDAO.getTeamConversationIdsReadyToCompleteMigration(teamId)
 
         assertTrue(result.isEmpty())
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -147,23 +147,48 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingGroupConversations_whenGetGroupConversationIdsByProtocol_ThenConversationIdsWithGivenProtocolIsReturned() = runTest {
+    fun givenExistingConversations_WhenGetConversationIds_ThenConversationsWithGivenProtocolIsReturned() = runTest {
         conversationDAO.insertConversation(conversationEntity4)
         conversationDAO.insertConversation(conversationEntity5)
         insertTeamUserAndMember(team, user2, conversationEntity5.id)
         val result =
-            conversationDAO.getGroupConversationIdsByProtocol(ConversationEntity.Protocol.PROTEUS)
+            conversationDAO.getConversationIds(ConversationEntity.Type.GROUP, ConversationEntity.Protocol.PROTEUS)
         assertEquals(listOf(conversationEntity5.id), result)
     }
 
     @Test
-    fun givenExistingSelfAndOneToOneConversations_whenGetGroupConversationIdsByProtocol_ThenAnEmptyListIsReturned() = runTest {
+    fun givenExistingConversations_WhenGetConversationIds_ThenConversationsWithGivenTeamIdIsReturned() = runTest {
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity4)
+        conversationDAO.insertConversation(conversationEntity5)
+        insertTeamUserAndMember(team, user2, conversationEntity5.id)
+
+        val result =
+            conversationDAO.getConversationIds(ConversationEntity.Type.GROUP, ConversationEntity.Protocol.PROTEUS,  teamId)
+
+        assertEquals(listOf(conversationEntity5.id), result)
+    }
+
+    @Test
+    fun givenExistingConversations_WhenGetConversationIdsWithoutTeamId_ThenConversationsWithAllTeamIdsAreReturned() = runTest {
+        conversationDAO.insertConversation(conversationEntity4.copy( protocolInfo = ConversationEntity.ProtocolInfo.Proteus))
+        conversationDAO.insertConversation(conversationEntity5.copy( teamId = null))
+        insertTeamUserAndMember(team, user2, conversationEntity5.id)
+
+        val result =
+            conversationDAO.getConversationIds(ConversationEntity.Type.GROUP, ConversationEntity.Protocol.PROTEUS)
+
+        assertEquals(setOf(conversationEntity4.id, conversationEntity5.id), result.toSet())
+    }
+
+    @Test
+    fun givenExistingConversations_WhenGetConversationIds_ThenConversationsWithGivenTypeIsReturned() = runTest {
         conversationDAO.insertConversation(conversationEntity1.copy(type = ConversationEntity.Type.SELF))
         conversationDAO.insertConversation(conversationEntity5.copy(type = ConversationEntity.Type.ONE_ON_ONE))
         insertTeamUserAndMember(team, user2, conversationEntity5.id)
         val result =
-            conversationDAO.getGroupConversationIdsByProtocol(ConversationEntity.Protocol.PROTEUS)
-        assertEquals(emptyList(), result)
+            conversationDAO.getConversationIds(ConversationEntity.Type.SELF, ConversationEntity.Protocol.PROTEUS)
+        assertEquals(listOf(conversationEntity1.id), result)
     }
 
     @Test
@@ -177,35 +202,22 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversations_ThenAllProteusTeamConversationsCanBeRetrieved() = runTest {
-        conversationDAO.insertConversation(conversationEntity1)
-        conversationDAO.insertConversation(conversationEntity4)
-        conversationDAO.insertConversation(conversationEntity5)
-        insertTeamUserAndMember(team, user2, conversationEntity5.id)
-
-        val result =
-            conversationDAO.getAllTeamConversations(teamId)
-
-        assertEquals(listOf(conversationEntity5.id), result)
-    }
-
-    @Test
-    fun givenAllMembersAreMlsCapable_WhenGetAllProteusTeamConversationsReadyToBeFinalised_ThenConversationIsReturned() = runTest {
+    fun givenAllMembersAreMlsCapable_WhenGetTeamConversationIdsReadyToBeFinalised_ThenConversationIsReturned() = runTest {
         val allProtocols = setOf(SupportedProtocolEntity.PROTEUS, SupportedProtocolEntity.MLS)
         val selfUser = user1.copy(id = selfUserId, supportedProtocols = allProtocols)
         userDAO.insertUser(selfUser)
 
-        conversationDAO.insertConversation(conversationEntity5)
-        insertTeamUserAndMember(team, user2.copy(supportedProtocols = allProtocols), conversationEntity5.id)
-        insertTeamUserAndMember(team, user3.copy(supportedProtocols = allProtocols), conversationEntity5.id)
+        conversationDAO.insertConversation(conversationEntity6)
+        insertTeamUserAndMember(team, user2.copy(supportedProtocols = allProtocols), conversationEntity6.id)
+        insertTeamUserAndMember(team, user3.copy(supportedProtocols = allProtocols), conversationEntity6.id)
 
-        val result = conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId)
+        val result = conversationDAO.getTeamConversationIdsReadyToBeFinalised(teamId)
 
-        assertEquals(listOf(conversationEntity5.id), result)
+        assertEquals(listOf(conversationEntity6.id), result)
     }
 
     @Test
-    fun givenOnlySomeMembersAreMlsCapable_WhenGetAllProteusTeamConversationsReadyToBeFinalised_ThenConversationIsNotReturned() = runTest {
+    fun givenOnlySomeMembersAreMlsCapable_WhenGetTeamConversationIdsReadyToBeFinalised_ThenConversationIsNotReturned() = runTest {
         val allProtocols = setOf(SupportedProtocolEntity.PROTEUS, SupportedProtocolEntity.MLS)
         val selfUser = user1.copy(id = selfUserId, supportedProtocols = allProtocols)
         userDAO.insertUser(selfUser)
@@ -214,7 +226,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user2.copy(supportedProtocols = allProtocols), conversationEntity5.id)
         insertTeamUserAndMember(team, user3.copy(supportedProtocols = setOf(SupportedProtocolEntity.PROTEUS)), conversationEntity5.id)
 
-        val result = conversationDAO.getAllProteusTeamConversationsReadyToBeFinalised(teamId)
+        val result = conversationDAO.getTeamConversationIdsReadyToBeFinalised(teamId)
 
         assertTrue(result.isEmpty())
     }
@@ -1198,7 +1210,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             QualifiedIDEntity("4", "wire.com"),
             "conversation4",
             ConversationEntity.Type.GROUP,
-            null,
+            teamId,
             ConversationEntity.ProtocolInfo.MLS(
                 "group4",
                 ConversationEntity.GroupState.ESTABLISHED,
@@ -1238,10 +1250,10 @@ class ConversationDAOTest : BaseDatabaseTest() {
         )
 
         val conversationEntity6 = ConversationEntity(
-            QualifiedIDEntity("5", "wire.com"),
+            QualifiedIDEntity("6", "wire.com"),
             "conversation5",
             ConversationEntity.Type.GROUP,
-            null,
+            teamId,
             ConversationEntity.ProtocolInfo.Mixed(
                 "group5",
                 ConversationEntity.GroupState.ESTABLISHED,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -184,7 +184,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user2, conversationEntity5.id)
 
         val result =
-            conversationDAO.getAllProteusTeamConversations(teamId)
+            conversationDAO.getAllTeamConversations(teamId)
 
         assertEquals(listOf(conversationEntity5.id), result)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When the migration configuration has configured an end date (finaliseRegardslessAfter) and this date has arrived we should migrate all team proteus conversation to MLS even though not all members support MLS.

More details: https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/759890302/Use+case+client+checks+if+conversation+migration+can+be+finalised+Proteus+to+MLS+migration

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

### Notes

I also generalised the DAO method for fetching conversation ids so that I don't have to create new method for every use case.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
