### PR TITLE
fix(RC): include self user id when sending a delete message to a conversion

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1141,7 +1141,6 @@ class UserSessionScope internal constructor(
             syncManager,
             slowSyncRepository,
             messageSendingScheduler,
-            selfConversationIdProvider,
             this
         )
     val messages: MessageScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.feature.debug
 
-import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.MLSClientProvider
@@ -74,7 +73,6 @@ class DebugScope internal constructor(
     private val syncManager: SyncManager,
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSendingScheduler: MessageSendingScheduler,
-    private val selfConversationIdProvider: SelfConversationIdProvider,
     private val scope: CoroutineScope,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
@@ -149,7 +147,6 @@ class DebugScope internal constructor(
             currentClientIdProvider = currentClientIdProvider,
             messageSender = messageSender,
             selfUserId = userId,
-            selfConversationIdProvider = selfConversationIdProvider
         )
 
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -300,7 +300,6 @@ class MessageScope internal constructor(
             assetRepository = assetRepository,
             currentClientIdProvider = currentClientIdProvider,
             messageSender = messageSender,
-            selfUserId = selfUserId,
-            selfConversationIdProvider = selfConversationIdProvider
+            selfUserId = selfUserId
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.feature.message.ephemeral
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.ASSETS
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
@@ -33,7 +32,6 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.MessageTarget
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
-import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -60,51 +58,23 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val messageSender: MessageSender,
     private val selfUserId: UserId,
-    private val selfConversationIdProvider: SelfConversationIdProvider
 ) : DeleteEphemeralMessageForSelfUserAsReceiverUseCase {
     override suspend fun invoke(conversationId: ConversationId, messageId: String): Either<CoreFailure, Unit> =
         currentClientIdProvider().flatMap { currentClientId ->
             messageRepository.getMessageById(conversationId, messageId)
                 .flatMap { message ->
-                    sendDeleteMessageToSelf(
+                    sendDeleteMessageToOriginalSender(
                         message.id,
-                        conversationId,
+                        message.conversationId,
+                        message.senderUserId,
                         currentClientId
-                    ).flatMap {
-                        sendDeleteMessageToOriginalSender(
-                            message.id,
-                            message.conversationId,
-                            message.senderUserId,
-                            currentClientId
-                        )
-                    }.onSuccess {
+                    ).onSuccess {
                         deleteMessageAssetIfExists(message)
-                    }.flatMap {
-                        messageRepository.deleteMessage(messageId, conversationId)
                     }
+                }.flatMap {
+                    messageRepository.deleteMessage(messageId, conversationId)
                 }
         }
-
-    private suspend fun sendDeleteMessageToSelf(
-        messageToDelete: String,
-        conversationId: ConversationId,
-        currentClientId: ClientId
-    ): Either<CoreFailure, Unit> = selfConversationIdProvider().flatMap { selfConversaionIdList ->
-        selfConversaionIdList.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
-            Message.Signaling(
-                id = uuid4().toString(),
-                content = MessageContent.DeleteForMe(messageToDelete, conversationId),
-                conversationId = selfConversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
-                senderUserId = selfUserId,
-                senderClientId = currentClientId,
-                status = Message.Status.PENDING,
-                isSelfMessage = true
-            ).let { deleteSignalingMessage ->
-                messageSender.sendMessage(deleteSignalingMessage, MessageTarget.Conversation)
-            }
-        }
-    }
 
     private suspend fun sendDeleteMessageToOriginalSender(
         messageToDelete: String,
@@ -123,7 +93,7 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
     ).let { deleteSignalingMessage ->
         messageSender.sendMessage(
             deleteSignalingMessage,
-            MessageTarget.Users(userId = listOf(originalMessageSender))
+            MessageTarget.Users(userId = listOf(originalMessageSender, selfUserId))
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest.kt
@@ -51,7 +51,7 @@ import kotlin.test.Test
 class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest {
 
     @Test
-    fun givenMessage_whenDeleting_then2DeleteMessagesAreSentForSelfAndOriginalSender() = runTest {
+    fun givenMessage_whenDeleting_thenSendDeleteMessageWithOnlySelfAndOriginalSenderAsRecipient() = runTest {
         val messageId = "messageId"
         val conversationId = ConversationId("conversationId", "conversationDomain.com")
         val currentClientId = CURRENT_CLIENT_ID
@@ -83,22 +83,10 @@ class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest {
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(
                 matching {
-                    it.conversationId == SELF_CONVERSION_ID.first() &&
-                            it.content == MessageContent.DeleteForMe(messageId, conversationId)
-                }, matching {
-                    it == MessageTarget.Conversation
-                })
-            .wasInvoked(exactly = once)
-
-
-        verify(arrangement.messageSender)
-            .suspendFunction(arrangement.messageSender::sendMessage)
-            .with(
-                matching {
                     it.conversationId == conversationId &&
                             it.content == MessageContent.DeleteMessage(messageId)
                 }, matching {
-                    it == MessageTarget.Users(listOf(senderUserID))
+                    it == MessageTarget.Users(listOf(senderUserID, selfUserId))
                 })
             .wasInvoked(exactly = once)
 
@@ -126,7 +114,6 @@ class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest {
                 messageRepository = messageRepository,
                 messageSender = messageSender,
                 selfUserId = selfUserId,
-                selfConversationIdProvider = selfConversationIdProvider,
                 assetRepository = assetRepository,
                 currentClientIdProvider = currentClientIdProvider
             )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

endless loop when sending a delete message in a conversation
 
### Solutions

the backend report that a clients of self user are missing, even so self was NOT included as a message recipient

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
