### PR TITLE
chore(testservice): add default values to testservice config file

### DIFF
--- a/testservice/config.yml
+++ b/testservice/config.yml
@@ -2,6 +2,18 @@ instanceCreationTimeoutInSeconds: 60
 instanceMaximumRuntimeInMinutes: 10
 instanceCleanupPeriodInMinutes: 5
 
+# dropwizard configuration
+server:
+    applicationConnectors:
+    - type: http
+      port: 8080
+      bindHost: 0.0.0.0
+    adminConnectors:
+    - type: http
+      port: 8081
+      # limit administrative monitoring to loopback
+      bindHost: 127.0.0.1
+
 # the only required property is resourcePackage, for more config options see below
 swagger:
     resourcePackage: com.wire.kalium.testservice.api.v1


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The testservice configuration does not contain the fields to configure the listening ports.
Making it non-intuitive to figure out where to configure it, when it needs to be changed

### Solutions

Put default configuration into `config.yml` (and restrict admin interface to 127.0.0.1)


### Testing

#### How to Test

Start the testserivce with the updated config file and check, whether it is still accessible.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
