### PR TITLE
chore: remove global team conversations

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -154,8 +154,7 @@ data class Conversation(
         SELF,
         ONE_ON_ONE,
         GROUP,
-        CONNECTION_PENDING,
-        GLOBAL_TEAM;
+        CONNECTION_PENDING
     }
 
     enum class AccessRole {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -182,10 +182,6 @@ internal class ConversationMapperImpl(
                     ConversationDetails.Self(fromDaoModel(daoModel))
                 }
 
-                ConversationEntity.Type.GLOBAL_TEAM -> {
-                    ConversationDetails.Team(fromDaoModel(daoModel))
-                }
-
                 ConversationEntity.Type.ONE_ON_ONE -> {
                     ConversationDetails.OneOne(
                         conversation = fromDaoModel(daoModel),
@@ -417,7 +413,6 @@ internal class ConversationMapperImpl(
 
             ConversationResponse.Type.ONE_TO_ONE -> ConversationEntity.Type.ONE_ON_ONE
             ConversationResponse.Type.WAIT_FOR_CONNECTION -> ConversationEntity.Type.CONNECTION_PENDING
-            ConversationResponse.Type.GLOBAL_TEAM -> ConversationEntity.Type.GLOBAL_TEAM
         }
     }
 }
@@ -427,7 +422,6 @@ private fun ConversationEntity.Type.fromDaoModelToType(): Conversation.Type = wh
     ConversationEntity.Type.ONE_ON_ONE -> Conversation.Type.ONE_ON_ONE
     ConversationEntity.Type.GROUP -> Conversation.Type.GROUP
     ConversationEntity.Type.CONNECTION_PENDING -> Conversation.Type.CONNECTION_PENDING
-    ConversationEntity.Type.GLOBAL_TEAM -> Conversation.Type.GLOBAL_TEAM
 }
 
 private fun ConversationAccessRoleDTO.toDAO(): ConversationEntity.AccessRole = when (this) {
@@ -467,7 +461,6 @@ private fun Conversation.Type.toDAO(): ConversationEntity.Type = when (this) {
     Conversation.Type.ONE_ON_ONE -> ConversationEntity.Type.ONE_ON_ONE
     Conversation.Type.GROUP -> ConversationEntity.Type.GROUP
     Conversation.Type.CONNECTION_PENDING -> ConversationEntity.Type.CONNECTION_PENDING
-    Conversation.Type.GLOBAL_TEAM -> ConversationEntity.Type.GLOBAL_TEAM
 }
 
 private fun Conversation.AccessRole.toDAO(): ConversationEntity.AccessRole = when (this) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -55,7 +55,6 @@ import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
-import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationRenameResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
@@ -91,7 +90,6 @@ interface ConversationRepository {
     @DelicateKaliumApi("This function does not get values from cache")
     suspend fun getMLSSelfConversationId(): Either<StorageFailure, ConversationId>
 
-    suspend fun fetchGlobalTeamConversation(): Either<CoreFailure, Unit>
     suspend fun fetchConversations(): Either<CoreFailure, Unit>
 
     // TODO make all functions to have only logic models
@@ -241,18 +239,6 @@ internal class ConversationDataSource internal constructor(
         return fetchAllConversationsFromAPI()
     }
 
-    // TODO temporary method until backend API is changed: https://wearezeta.atlassian.net/browse/FS-1260
-    override suspend fun fetchGlobalTeamConversation(): Either<CoreFailure, Unit> =
-        selfTeamIdProvider().flatMap { teamId ->
-            teamId?.let {
-                wrapApiRequest {
-                    conversationApi.fetchGlobalTeamConversationDetails(selfUserId.toApi(), teamId.value)
-                }.flatMap {
-                    persistConversations(listOf(it), teamId.value)
-                }
-            } ?: Either.Right(Unit)
-        }
-
     private suspend fun fetchAllConversationsFromAPI(): Either<NetworkFailure, Unit> {
         var hasMore = true
         var lastPagingState: String? = null
@@ -318,8 +304,6 @@ internal class ConversationDataSource internal constructor(
         originatedFromEvent: Boolean,
     ) = wrapStorageRequest {
         val conversationEntities = conversations
-            // TODO work-around for a bug in the backend. Can be removed when fixed: https://wearezeta.atlassian.net/browse/FS-1262
-            .filter { !(it.type == ConversationResponse.Type.GLOBAL_TEAM && it.protocol == ConvProtocol.PROTEUS) }
             .map { conversationResponse ->
                 conversationMapper.fromApiModelToDaoModel(
                     conversationResponse,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -109,10 +109,7 @@ class JoinExistingMLSConversationUseCaseImpl(
     private suspend fun joinOrEstablishMLSGroup(conversation: Conversation): Either<CoreFailure, Unit> {
         return if (conversation.protocol is Conversation.ProtocolInfo.MLS) {
             if (conversation.protocol.epoch == 0UL) {
-                if (
-                    conversation.type == Conversation.Type.GLOBAL_TEAM ||
-                    conversation.type == Conversation.Type.SELF
-                ) {
+                if (conversation.type == Conversation.Type.SELF) {
                     kaliumLogger.i("Establish group for ${conversation.type}")
                     mlsConversationRepository.establishMLSGroup(
                         conversation.protocol.groupId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -125,24 +125,6 @@ class JoinExistingMLSConversationUseCaseTest {
         }
 
     @Test
-    fun givenGlobalTeamConversationWithZeroEpoch_whenInvokingUseCase_ThenEstablishGroup() =
-        runTest {
-            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
-                .withIsMLSSupported(true)
-                .withHasRegisteredMLSClient(true)
-                .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_GLOBAL_TEAM_CONVERSATION)
-                .withEstablishMLSGroupSuccessful()
-                .arrange()
-
-            joinExistingMLSConversationsUseCase(Arrangement.MLS_UNESTABLISHED_GLOBAL_TEAM_CONVERSATION.id).shouldSucceed()
-
-            verify(arrangement.mlsConversationRepository)
-                .suspendFunction(arrangement.mlsConversationRepository::establishMLSGroup)
-                .with(eq(Arrangement.GROUP_ID_TEAM), eq(emptyList()))
-                .wasInvoked(once)
-        }
-
-    @Test
     fun givenOutOfDateEpochFailure_whenInvokingUseCase_ThenRetryWithNewEpoch() = runTest {
         val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
             .withIsMLSSupported(true)
@@ -332,16 +314,6 @@ class JoinExistingMLSConversationUseCaseTest {
                     cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
                 )
             ).copy(id = ConversationId("self", "domain"))
-
-            val MLS_UNESTABLISHED_GLOBAL_TEAM_CONVERSATION = TestConversation.GLOBAL_TEAM(
-                Conversation.ProtocolInfo.MLS(
-                    GROUP_ID_TEAM,
-                    Conversation.ProtocolInfo.MLS.GroupState.PENDING_JOIN,
-                    epoch = 0UL,
-                    keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
-                    cipherSuite = Conversation.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-                )
-            ).copy(id = ConversationId("team", "domain"))
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -94,25 +94,6 @@ object TestConversation {
         userMessageTimer = null
     )
 
-    fun GLOBAL_TEAM(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
-        ID.copy(value = "GLOBAL TEAM ID"),
-        "GLOBAL TEAM Name",
-        Conversation.Type.GLOBAL_TEAM,
-        TestTeam.TEAM_ID,
-        protocolInfo,
-        MutedConversationStatus.AllAllowed,
-        null,
-        null,
-        null,
-        lastReadDate = "2022-03-30T15:36:00.000Z",
-        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
-        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
-        creatorId = null,
-        receiptMode = Conversation.ReceiptMode.DISABLED,
-        messageTimer = null,
-        userMessageTimer = null
-    )
-
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
         ID,
         "GROUP Name",

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.ServiceAddedResponse
 import com.wire.kalium.network.api.base.model.SubconversationId
-import com.wire.kalium.network.api.base.model.TeamId
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.utils.NetworkResponse
 
@@ -49,11 +48,6 @@ interface ConversationApi {
 
     suspend fun fetchConversationDetails(
         conversationId: ConversationId
-    ): NetworkResponse<ConversationResponse>
-
-    suspend fun fetchGlobalTeamConversationDetails(
-        selfUserId: UserId,
-        teamId: TeamId
     ): NetworkResponse<ConversationResponse>
 
     suspend fun createNewConversation(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationResponse.kt
@@ -36,36 +36,6 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 @Serializable
-data class GlobalTeamConversationResponse(
-    @SerialName("creator")
-    val creator: String?,
-
-    @SerialName("name")
-    val name: String?,
-
-    @SerialName("qualified_id")
-    val id: ConversationId,
-
-    @SerialName("group_id")
-    val groupId: String?,
-
-    @SerialName("epoch")
-    val epoch: ULong?,
-
-    @SerialName("team")
-    val teamId: TeamId?,
-
-    @SerialName("cipher_suite")
-    val mlsCipherSuiteTag: Int?,
-
-    @SerialName("receipt_mode")
-    val receiptMode: ReceiptMode,
-
-    @SerialName("access")
-    val access: Set<ConversationAccessDTO>
-)
-
-@Serializable
 data class ConversationResponse(
     @SerialName("creator")
     val creator: String,
@@ -124,7 +94,7 @@ data class ConversationResponse(
 
     @Suppress("MagicNumber")
     enum class Type(val id: Int) {
-        GROUP(0), SELF(1), ONE_TO_ONE(2), WAIT_FOR_CONNECTION(3), GLOBAL_TEAM(4);
+        GROUP(0), SELF(1), ONE_TO_ONE(2), WAIT_FOR_CONNECTION(3);
 
         companion object {
             fun fromId(id: Int): Type = values().first { type -> type.id == id }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -50,7 +50,6 @@ import com.wire.kalium.network.api.base.model.PaginationRequest
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.ServiceAddedResponse
 import com.wire.kalium.network.api.base.model.SubconversationId
-import com.wire.kalium.network.api.base.model.TeamId
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.exceptions.KaliumException
@@ -101,11 +100,6 @@ internal open class ConversationApiV0 internal constructor(
                 "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}"
             )
         }
-
-    override suspend fun fetchGlobalTeamConversationDetails(selfUserId: UserId, teamId: TeamId): NetworkResponse<ConversationResponse> =
-        NetworkResponse.Error(
-            APINotSupported("fetchGlobalTeamConversationDetails api is only available on API V3")
-        )
 
     /**
      * returns 201 when a new conversation is created or 200 if the conversation already existed

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/ConversationApiV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/ConversationApiV3.kt
@@ -18,15 +18,10 @@
 
 package com.wire.kalium.network.api.v3.authenticated
 
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
-import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberDTO
-import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMembersResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponseV3
 import com.wire.kalium.network.api.base.authenticated.conversation.CreateConversationRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.GlobalTeamConversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessRequest
@@ -37,8 +32,6 @@ import com.wire.kalium.network.api.base.model.ApiModelMapperImpl
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.SubconversationId
-import com.wire.kalium.network.api.base.model.TeamId
-import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v2.authenticated.ConversationApiV2
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
@@ -86,36 +79,6 @@ internal open class ConversationApiV3 internal constructor(
                 "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_GROUP_INFO"
             )
         }
-
-    override suspend fun fetchGlobalTeamConversationDetails(selfUserId: UserId, teamId: TeamId): NetworkResponse<ConversationResponse> {
-        return wrapKaliumResponse<GlobalTeamConversationResponse> {
-            httpClient.get("$PATH_TEAM/$teamId/$PATH_CONVERSATIONS/$PATH_GLOBAL")
-        }.mapSuccess { response ->
-            ConversationResponse(
-                response.creator ?: "",
-                ConversationMembersResponse(
-                    ConversationMemberDTO.Self(
-                        selfUserId,
-                        "wire_default",
-                    ),
-                    emptyList()
-                ),
-                response.name,
-                response.id,
-                response.groupId,
-                response.epoch,
-                ConversationResponse.Type.GLOBAL_TEAM,
-                0,
-                response.teamId,
-                ConvProtocol.MLS,
-                DateTimeUtil.currentIsoDateTimeString(),
-                response.mlsCipherSuiteTag,
-                response.access,
-                emptySet(),
-                response.receiptMode
-            )
-        }
-    }
 
     override suspend fun updateAccess(
         conversationId: ConversationId,
@@ -183,8 +146,6 @@ internal open class ConversationApiV3 internal constructor(
     }
 
     companion object {
-        const val PATH_TEAM = "team"
-        const val PATH_GLOBAL = "global"
         const val PATH_GROUP_INFO = "groupinfo"
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -49,7 +49,7 @@ data class ConversationEntity(
 
     enum class Access { PRIVATE, INVITE, SELF_INVITE, LINK, CODE; }
 
-    enum class Type { SELF, ONE_ON_ONE, GROUP, CONNECTION_PENDING, GLOBAL_TEAM }
+    enum class Type { SELF, ONE_ON_ONE, GROUP, CONNECTION_PENDING }
 
     enum class GroupState { PENDING_CREATION, PENDING_JOIN, PENDING_WELCOME_MESSAGE, ESTABLISHED }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -1400,13 +1400,6 @@ class MessageDAOTest : BaseDatabaseTest() {
                 type = ConversationEntity.Type.CONNECTION_PENDING
             )
         )
-        val globalTeamConversation = QualifiedIDEntity("globalTeamConversation", "someDomain")
-        conversationDAO.insertConversation(
-            newConversationEntity(id = globalTeamConversation).copy(
-                type = ConversationEntity.Type.GLOBAL_TEAM
-            )
-        )
-
         val messageId = "systemMessage"
         userDAO.insertUser(userEntity1)
 
@@ -1438,17 +1431,12 @@ class MessageDAOTest : BaseDatabaseTest() {
             id = messageId,
             conversationId = connectionPendingConversation
         )
-        val resultForGlobalTeamConversation = messageDAO.getMessageById(
-            id = messageId,
-            conversationId = globalTeamConversation
-        )
 
         assertTrue {
             resultForSelfConversation == null &&
                     resultForOneOnOneConversation?.content == MessageEntityContent.HistoryLost &&
                     resultForGroupConversation?.content == MessageEntityContent.HistoryLost &&
-                    resultForConnectionPendingConversation == null &&
-                    resultForGlobalTeamConversation == null
+                    resultForConnectionPendingConversation == null
         }
     }
 


### PR DESCRIPTION
# What's new in this PR?

Remove any references to global team conversations since the feature was dropped and was never released.

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
