### PR TITLE
chore: move MLS api implementations from v3 to v4

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/ConversationApiV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/ConversationApiV3.kt
@@ -22,23 +22,17 @@ import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponseV3
 import com.wire.kalium.network.api.base.authenticated.conversation.CreateConversationRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessResponse
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ApiModelMapper
 import com.wire.kalium.network.api.base.model.ApiModelMapperImpl
 import com.wire.kalium.network.api.base.model.ConversationId
-import com.wire.kalium.network.api.base.model.QualifiedID
-import com.wire.kalium.network.api.base.model.SubconversationId
 import com.wire.kalium.network.api.v2.authenticated.ConversationApiV2
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.delete
-import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -73,13 +67,6 @@ internal open class ConversationApiV3 internal constructor(
         apiModelMapper.fromApiV3(it)
     }
 
-    override suspend fun fetchGroupInfo(conversationId: QualifiedID): NetworkResponse<ByteArray> =
-        wrapKaliumResponse {
-            httpClient.get(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_GROUP_INFO"
-            )
-        }
-
     override suspend fun updateAccess(
         conversationId: ConversationId,
         updateConversationAccessRequest: UpdateConversationAccessRequest
@@ -100,52 +87,5 @@ internal open class ConversationApiV3 internal constructor(
         }
     } catch (e: IOException) {
         NetworkResponse.Error(KaliumException.GenericError(e))
-    }
-
-    override suspend fun fetchSubconversationDetails(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId
-    ): NetworkResponse<SubconversationResponse> =
-        wrapKaliumResponse {
-            httpClient.get(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/subconversations/$subconversationId"
-            )
-        }
-
-    override suspend fun fetchSubconversationGroupInfo(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId
-    ): NetworkResponse<ByteArray> =
-        wrapKaliumResponse {
-            httpClient.get(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/subconversations/$subconversationId/groupinfo"
-            )
-        }
-
-    override suspend fun deleteSubconversation(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId,
-        deleteRequest: SubconversationDeleteRequest
-    ): NetworkResponse<Unit> =
-        wrapKaliumResponse {
-            httpClient.delete(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/subconversations/$subconversationId"
-            ) {
-                setBody(deleteRequest)
-            }
-        }
-
-    override suspend fun leaveSubconversation(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId
-    ): NetworkResponse<Unit> =
-        wrapKaliumResponse {
-        httpClient.delete(
-            "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/subconversations/$subconversationId/self"
-        )
-    }
-
-    companion object {
-        const val PATH_GROUP_INFO = "groupinfo"
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
@@ -21,11 +21,19 @@ package com.wire.kalium.network.api.v4.authenticated
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponseV4
 import com.wire.kalium.network.api.base.authenticated.conversation.CreateConversationRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.model.ApiModelMapper
 import com.wire.kalium.network.api.base.model.ApiModelMapperImpl
+import com.wire.kalium.network.api.base.model.ConversationId
+import com.wire.kalium.network.api.base.model.QualifiedID
+import com.wire.kalium.network.api.base.model.SubconversationId
 import com.wire.kalium.network.api.v3.authenticated.ConversationApiV3
+import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 
@@ -43,4 +51,60 @@ internal open class ConversationApiV4 internal constructor(
             apiModelMapper.fromApiV4(conversationResponseV4)
         }
 
+    override suspend fun fetchGroupInfo(conversationId: QualifiedID): NetworkResponse<ByteArray> =
+        wrapKaliumResponse {
+            httpClient.get(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_GROUP_INFO"
+            )
+        }
+
+    override suspend fun fetchSubconversationDetails(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<SubconversationResponse> =
+        wrapKaliumResponse {
+            httpClient.get(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}" +
+                        "/$PATH_SUBCONVERSATIONS/$subconversationId"
+            )
+        }
+
+    override suspend fun fetchSubconversationGroupInfo(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<ByteArray> =
+        wrapKaliumResponse {
+            httpClient.get(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/" +
+                        "$PATH_SUBCONVERSATIONS/$subconversationId/$PATH_GROUP_INFO"
+            )
+        }
+
+    override suspend fun deleteSubconversation(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId,
+        deleteRequest: SubconversationDeleteRequest
+    ): NetworkResponse<Unit> =
+        wrapKaliumResponse {
+            httpClient.delete(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_SUBCONVERSATIONS/$subconversationId"
+            ) {
+                setBody(deleteRequest)
+            }
+        }
+
+    override suspend fun leaveSubconversation(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<Unit> =
+        wrapKaliumResponse {
+            httpClient.delete(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_SUBCONVERSATIONS/$subconversationId/self"
+            )
+        }
+
+    companion object {
+        const val PATH_GROUP_INFO = "groupinfo"
+        const val PATH_SUBCONVERSATIONS = "subconversations"
+    }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v3/ConversationApiV3Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v3/ConversationApiV3Test.kt
@@ -22,12 +22,8 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.model.EventContentDTOJson
 import com.wire.kalium.model.conversation.ConversationResponseJson
 import com.wire.kalium.model.conversation.CreateConversationRequestJson
-import com.wire.kalium.model.conversation.SubconversationDeleteRequestJson
-import com.wire.kalium.model.conversation.SubconversationDetailsResponseJson
 import com.wire.kalium.model.conversation.UpdateConversationAccessRequestJson
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationAccessResponse
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
@@ -125,107 +121,6 @@ internal class ConversationApiV3Test : ApiTest() {
         ).also {
             assertIs<NetworkResponse.Success<UpdateConversationAccessResponse.AccessUpdated>>(it)
         }
-    }
-
-    @Test
-    fun givenRequest_whenFetchingSubconversationDetails_thenRequestIsConfiguredCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            SubconversationDetailsResponseJson.v3.rawJson,
-            statusCode = HttpStatusCode.OK,
-            assertion = {
-                assertGet()
-                assertPathEqual(
-                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
-                )
-            }
-        )
-
-        val conversationApi = ConversationApiV3(networkClient)
-        conversationApi.fetchSubconversationDetails(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub"
-        )
-    }
-
-    @Test
-    fun givenSuccessSubconversationDetails_whenFetchingSubconversationDetails_thenResponseIsParsedCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            SubconversationDetailsResponseJson.v3.rawJson,
-            statusCode = HttpStatusCode.OK
-        )
-
-        val conversationApi = ConversationApiV3(networkClient)
-        conversationApi.fetchSubconversationDetails(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub"
-        ).also {
-            assertIs<NetworkResponse.Success<SubconversationResponse>>(it)
-        }
-    }
-
-    @Test
-    fun givenRequest_whenFetchingSubconversationGroupInfo_thenRequestIsConfiguredCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            "groupinfo".encodeToByteArray(),
-            statusCode = HttpStatusCode.OK,
-            assertion = {
-                assertGet()
-                assertPathEqual(
-                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub/groupinfo"
-                )
-            }
-        )
-
-        val conversationApi = ConversationApiV3(networkClient)
-        conversationApi.fetchSubconversationGroupInfo(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub"
-        ).also {
-            assertIs<NetworkResponse.Success<ByteArray>>(it)
-        }
-    }
-
-    @Test
-    fun givenRequest_whenDeletingSubconversation_thenRequestIsConfiguredCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            ByteArray(0),
-            statusCode = HttpStatusCode.OK,
-            assertion = {
-                assertDelete()
-                assertPathEqual(
-                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
-                )
-                assertJsonBodyContent(SubconversationDeleteRequestJson.v3.rawJson)
-            }
-        )
-
-        val deleteRequest = SubconversationDeleteRequest(43UL, "groupid")
-        val conversationApi = ConversationApiV3(networkClient)
-        conversationApi.deleteSubconversation(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub",
-            deleteRequest
-        )
-    }
-
-    @Test
-    fun givenRequest_whenLeavingSubconversation_thenRequestIsConfiguredCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            ByteArray(0),
-            statusCode = HttpStatusCode.OK,
-            assertion = {
-                assertDelete()
-                assertPathEqual(
-                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub/self"
-                )
-            }
-        )
-
-        val conversationApi = ConversationApiV3(networkClient)
-        conversationApi.leaveSubconversation(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub",
-        )
     }
 
     private companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
@@ -65,7 +65,7 @@ internal class ConversationApiV4Test : ApiTest() {
     @Test
     fun givenRequest_whenFetchingSubconversationDetails_thenRequestIsConfiguredCorrectly() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
-            SubconversationDetailsResponseJson.v3.rawJson,
+            SubconversationDetailsResponseJson.v4.rawJson,
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertGet()
@@ -85,7 +85,7 @@ internal class ConversationApiV4Test : ApiTest() {
     @Test
     fun givenSuccessSubconversationDetails_whenFetchingSubconversationDetails_thenResponseIsParsedCorrectly() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
-            SubconversationDetailsResponseJson.v3.rawJson,
+            SubconversationDetailsResponseJson.v4.rawJson,
             statusCode = HttpStatusCode.OK
         )
 
@@ -130,7 +130,7 @@ internal class ConversationApiV4Test : ApiTest() {
                 assertPathEqual(
                     "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
                 )
-                assertJsonBodyContent(SubconversationDeleteRequestJson.v3.rawJson)
+                assertJsonBodyContent(SubconversationDeleteRequestJson.v4.rawJson)
             }
         )
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
@@ -21,14 +21,21 @@ package com.wire.kalium.api.v4
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.model.conversation.ConversationResponseJson
 import com.wire.kalium.model.conversation.CreateConversationRequestJson
+import com.wire.kalium.model.conversation.SubconversationDeleteRequestJson
+import com.wire.kalium.model.conversation.SubconversationDetailsResponseJson
+import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
+import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v4.authenticated.ConversationApiV4
+import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -54,6 +61,107 @@ internal class ConversationApiV4Test : ApiTest() {
             assertTrue(result.value.failedToAdd.isNotEmpty())
             assertEquals(result.value.failedToAdd.first(), UserId("failedId", "failedDomain"))
         }
+
+    @Test
+    fun givenRequest_whenFetchingSubconversationDetails_thenRequestIsConfiguredCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            SubconversationDetailsResponseJson.v3.rawJson,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual(
+                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
+                )
+            }
+        )
+
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.fetchSubconversationDetails(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub"
+        )
+    }
+
+    @Test
+    fun givenSuccessSubconversationDetails_whenFetchingSubconversationDetails_thenResponseIsParsedCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            SubconversationDetailsResponseJson.v3.rawJson,
+            statusCode = HttpStatusCode.OK
+        )
+
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.fetchSubconversationDetails(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub"
+        ).also {
+            assertIs<NetworkResponse.Success<SubconversationResponse>>(it)
+        }
+    }
+
+    @Test
+    fun givenRequest_whenFetchingSubconversationGroupInfo_thenRequestIsConfiguredCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            "groupinfo".encodeToByteArray(),
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual(
+                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub/groupinfo"
+                )
+            }
+        )
+
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.fetchSubconversationGroupInfo(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub"
+        ).also {
+            assertIs<NetworkResponse.Success<ByteArray>>(it)
+        }
+    }
+
+    @Test
+    fun givenRequest_whenDeletingSubconversation_thenRequestIsConfiguredCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            ByteArray(0),
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertDelete()
+                assertPathEqual(
+                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
+                )
+                assertJsonBodyContent(SubconversationDeleteRequestJson.v3.rawJson)
+            }
+        )
+
+        val deleteRequest = SubconversationDeleteRequest(43UL, "groupid")
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.deleteSubconversation(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub",
+            deleteRequest
+        )
+    }
+
+    @Test
+    fun givenRequest_whenLeavingSubconversation_thenRequestIsConfiguredCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            ByteArray(0),
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertDelete()
+                assertPathEqual(
+                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub/self"
+                )
+            }
+        )
+
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.leaveSubconversation(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub",
+        )
+    }
 
     private companion object {
         const val PATH_CONVERSATIONS = "/conversations"

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/SubconversationDeleteRequestJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/SubconversationDeleteRequestJson.kt
@@ -14,5 +14,5 @@ object SubconversationDeleteRequestJson {
         """.trimIndent()
     }
 
-    val v3 = ValidJsonProvider(serializableData = SubconversationDeleteRequest(43UL, "groupid"), jsonProvider)
+    val v4 = ValidJsonProvider(serializableData = SubconversationDeleteRequest(43UL, "groupid"), jsonProvider)
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/SubconversationDetailsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/SubconversationDetailsResponseJson.kt
@@ -27,5 +27,5 @@ object SubconversationDetailsResponseJson {
         """.trimIndent()
     }
 
-    val v3 = ValidJsonProvider("", jsonProvider)
+    val v4 = ValidJsonProvider("", jsonProvider)
 }


### PR DESCRIPTION
# What's new in this PR?

The MLS APIs have been moved to V4 so we should also move the implementation to V4.

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
