### PR TITLE
feat(federation): adding handling of failed to sent message in MLS (WPB-451)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -145,7 +145,7 @@ interface MessageRepository {
         messageOption: BroadcastMessageOption
     ): Either<CoreFailure, String>
 
-    suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, String>
+    suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, MessageSent>
 
     suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>>
     suspend fun getPendingConfirmationMessagesByConversationAfterDate(
@@ -438,11 +438,11 @@ class MessageDataSource(
         })
     }
 
-    override suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, String> =
+    override suspend fun sendMLSMessage(conversationId: ConversationId, message: MLSMessageApi.Message): Either<CoreFailure, MessageSent> =
         wrapApiRequest {
             mlsMessageApi.sendMessage(message)
         }.flatMap { response ->
-            Either.Right(response.time)
+            Either.Right(sendMessagePartialFailureMapper.fromMlsDTO(response))
         }
 
     override suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>> = wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
@@ -18,9 +18,11 @@
 
 package com.wire.kalium.logic.data.message
 
+import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedUserIdToClientMap
+import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
 
 /**
  * Maps the [QualifiedSendMessageResponse] to a [MessageSent] object.
@@ -29,6 +31,7 @@ import com.wire.kalium.network.api.base.authenticated.message.QualifiedUserIdToC
  */
 interface SendMessagePartialFailureMapper {
     fun fromDTO(sendMessageResponse: QualifiedSendMessageResponse): MessageSent
+    fun fromMlsDTO(sendMLSMessageResponse: SendMLSMessageResponse): MessageSent
 }
 
 internal class SendMessagePartialFailureMapperImpl : SendMessagePartialFailureMapper {
@@ -43,6 +46,21 @@ internal class SendMessagePartialFailureMapperImpl : SendMessagePartialFailureMa
                 time = sendMessageResponse.time,
                 missing = mapNestedUsersIntoUserIds(sendMessageResponse.missing)
             )
+        }
+    }
+
+    override fun fromMlsDTO(sendMLSMessageResponse: SendMLSMessageResponse): MessageSent {
+        return when {
+            sendMLSMessageResponse.failedToSend.isNotEmpty() -> MessageSent(
+                time = sendMLSMessageResponse.time,
+                failed = sendMLSMessageResponse.failedToSend.map { it.toModel() }
+            )
+
+            else -> {
+                MessageSent(
+                    time = sendMLSMessageResponse.time
+                )
+            }
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapperTest.kt
@@ -19,10 +19,12 @@
 package com.wire.kalium.logic.data.message
 
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCaseTest.Arrangement.Companion.TEST_USER_ID
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser.OTHER_USER_ID_2
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
+import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -34,6 +36,19 @@ class SendMessagePartialFailureMapperTest {
     fun testFromDTOMapping() {
         assertEquals(
             MessageSent("2022-04-21T20:56:22.393Z", listOf(TEST_USER_ID, OTHER_USER_ID_2)), mapper.fromDTO(RESULT_DTO)
+        )
+    }
+
+    @Test
+    fun testFromMlsDTOMapping() {
+        val expectedUsersFailedToSend = listOf(TEST_USER_ID, OTHER_USER_ID_2)
+        assertEquals(
+            MessageSent("2022-04-21T20:56:22.393Z", expectedUsersFailedToSend),
+            mapper.fromMlsDTO(
+                SendMLSMessageResponse("2022-04-21T20:56:22.393Z",
+                    emptyList(),
+                    expectedUsersFailedToSend.map { it.toApi() })
+            )
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -798,7 +798,7 @@ class MessageSenderTest {
     }
 
     @Test
-fun givenError_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldNotStart() {
+    fun givenError_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldNotStart() {
         val duration = Duration.parse("PT1M")
         val message = TestMessage.TEXT_MESSAGE.copy(
             expirationData = Message.ExpirationData(duration)
@@ -823,6 +823,31 @@ fun givenError_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldNotStart()
         }
     }
 
+    @Test
+    fun givenARemoteMlsConversationPartiallyFails_whenSendingAMessage_ThenReturnSuccessAndPersistFailedToSendUsers() {
+        // given
+        val (arrangement, messageSender) = Arrangement()
+            .withCommitPendingProposals()
+            .withSendMlsMessage(
+                sendMlsMessageWithResult = Either.Right(MessageSent(MESSAGE_SENT_TIME, listOf(TEST_MEMBER_2))),
+            )
+            .withWaitUntilLiveOrFailure()
+            .withPromoteMessageToSentUpdatingServerTime()
+            .withSendMessagePartialSuccess()
+            .arrange()
+
+        arrangement.testScope.runTest {
+            // when
+            val result = messageSender.sendPendingMessage(Arrangement.TEST_CONVERSATION_ID, Arrangement.TEST_MESSAGE_UUID)
+
+            // then
+            result.shouldSucceed()
+            verify(arrangement.messageRepository)
+                .suspendFunction(arrangement.messageRepository::persistRecipientsDeliveryFailure)
+                .with(anything(), anything(), eq(listOf(TEST_MEMBER_2)))
+                .wasInvoked(once)
+        }
+    }
 
     private class Arrangement {
         @Mock
@@ -964,7 +989,7 @@ fun givenError_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldNotStart()
         }
 
         fun withSendOutgoingMlsMessage(
-            result: Either<CoreFailure, String> = Either.Right(MESSAGE_SENT_TIME),
+            result: Either<CoreFailure, MessageSent> = Either.Right(MessageSent(MESSAGE_SENT_TIME)),
             times: Int = Int.MAX_VALUE
         ) = apply {
             var invocationCounter = 0
@@ -1035,7 +1060,7 @@ fun givenError_WhenSendingOutgoingSelfDeleteMessage_ThenTheTimerShouldNotStart()
         }
 
         fun withSendMlsMessage(
-            sendMlsMessageWithResult: Either<CoreFailure, String>? = null,
+            sendMlsMessageWithResult: Either<CoreFailure, MessageSent>? = null,
         ) = apply {
             withGetMessageById()
             withGetProtocolInfo(protocolInfo = MLS_PROTOCOL_INFO)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/SendMLSMessageResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/SendMLSMessageResponse.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.network.api.base.authenticated.message
 
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.model.QualifiedID
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,5 +28,7 @@ data class SendMLSMessageResponse(
     @SerialName("time")
     val time: String,
     @SerialName("events")
-    val events: List<EventContentDTO>
+    val events: List<EventContentDTO>,
+    @SerialName("failed_to_send")
+    val failedToSend: List<QualifiedID> = emptyList()
 )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -459,7 +459,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             // given
             // established updated group
             val updatedConversation = conversationEntity2
-            val updatedDate = Instant.parse("2023-03-30T15:36:00.000Z")
+            val updatedDate = Instant.parse("2099-03-30T15:36:00.000Z")
             val updatedGroupId = (updatedConversation.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId
             teamDAO.insertTeam(team)
             conversationDAO.insertConversation(updatedConversation)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to support partial delivery (some participants offline) while sending a message using the MLS protocol.
More info about the flow, is defined here:

https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/556564601/Use+case+sending+a+message+MLS

### Solutions

Parse new optional response, and handle this list of user ids, as we did with proteus.

### Testing

#### Test Coverage (Optional)

#### 

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
