### PR TITLE
fix(RC): if self sent a delete message event to a conversation then messa…

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/DeleteMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/DeleteMessageHandler.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.onSuccess
+import com.wire.kalium.logic.kaliumLogger
 
 internal interface DeleteMessageHandler {
     suspend operator fun invoke(
@@ -43,6 +44,8 @@ internal class DeleteMessageHandlerImpl internal constructor(
         conversationId: ConversationId,
         senderUserId: UserId
     ) {
+        kaliumLogger.d("DeleteMessageHandler: $content")
+
         messageRepository.getMessageById(conversationId, content.messageId).onSuccess { messageToRemove ->
             val isSelfSender = messageToRemove.senderUserId == selfUserId
             val isOriginalEphemeral = (messageToRemove as? Message.Regular)?.expirationData != null
@@ -78,7 +81,7 @@ internal class DeleteMessageHandlerImpl internal constructor(
     private fun isSenderVerified(
         message: Message,
         deleteMessageSenderId: UserId
-    ): Boolean = deleteMessageSenderId == message.senderUserId
+    ): Boolean = (deleteMessageSenderId == message.senderUserId || deleteMessageSenderId == selfUserId)
 
     private suspend fun removeAssetIfExists(messageToRemove: Message) {
         (messageToRemove.content as? MessageContent.Asset)?.value?.remoteData?.let { assetToRemove ->


### PR DESCRIPTION
…ge is not deleted

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when self sends a delete event to a conversation, then the message is not deleted

### Causes (Optional)

the app will only delete if the original sender is the same as the sender of the delete event

### Solutions

allow self user to delete any message

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
