### PR TITLE
feat(mls): handle mls welcome event according to new spec (WPB-2178)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1001,7 +1001,7 @@ class UserSessionScope internal constructor(
     private val memberChangeHandler: MemberChangeEventHandler get() = MemberChangeEventHandlerImpl(conversationRepository)
     private val mlsWelcomeHandler: MLSWelcomeEventHandler
         get() = MLSWelcomeEventHandlerImpl(
-            mlsClientProvider, userStorage.database.conversationDAO
+            mlsClientProvider, userStorage.database.conversationDAO, conversationRepository
         )
     private val renamedConversationHandler: RenamedConversationEventHandler
         get() = RenamedConversationEventHandlerImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -20,17 +20,20 @@ package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.client.MLSClientProvider
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.persistence.dao.ConversationDAO
 import com.wire.kalium.persistence.dao.ConversationEntity
 import io.ktor.util.decodeBase64Bytes
-import kotlinx.coroutines.flow.first
 
 interface MLSWelcomeEventHandler {
     suspend fun handle(event: Event.Conversation.MLSWelcome)
@@ -38,33 +41,39 @@ interface MLSWelcomeEventHandler {
 
 internal class MLSWelcomeEventHandlerImpl(
     val mlsClientProvider: MLSClientProvider,
-    val conversationDAO: ConversationDAO
+    val conversationDAO: ConversationDAO,
+    val conversationRepository: ConversationRepository
 ) : MLSWelcomeEventHandler {
     override suspend fun handle(event: Event.Conversation.MLSWelcome) {
         mlsClientProvider
             .getMLSClient()
             .flatMap { client ->
-                wrapMLSRequest { client.processWelcomeMessage(event.message.decodeBase64Bytes()) }
-                    .flatMap { groupID ->
+                wrapMLSRequest {
+                    client.processWelcomeMessage(event.message.decodeBase64Bytes())
+                }
+            }.flatMap { groupID ->
+                val groupIdLogPair = Pair("groupId", groupID.obfuscateId())
 
-                        var infoLogPair = Pair("info", "Created MLS group from welcome message")
-                        val groupIdLogPair = Pair("groupId", groupID.obfuscateId())
-
-                        wrapStorageRequest {
-                            if (conversationDAO.getConversationByGroupID(groupID).first() != null) {
-                                // Welcome arrived after the conversation create event, updating existing conversation.
-                                conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.ESTABLISHED, groupID)
-                                infoLogPair = Pair("info", "Updated conversation from welcome message")
-                            }
-                            kaliumLogger
-                                .logEventProcessing(
-                                    EventLoggingStatus.SUCCESS,
-                                    event,
-                                    infoLogPair,
-                                    groupIdLogPair
-                                )
-                        }
+                wrapStorageRequest {
+                    conversationRepository.fetchConversationIfUnknown(event.conversationId).map {
+                        conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.ESTABLISHED, groupID)
                     }
+                }.onSuccess {
+                    kaliumLogger
+                        .logEventProcessing(
+                            EventLoggingStatus.SUCCESS,
+                            event,
+                            Pair("info", "Established mls conversation from welcome message"),
+                            groupIdLogPair
+                        )
+                }.onFailure {
+                    kaliumLogger
+                        .logEventProcessing(
+                            EventLoggingStatus.FAILURE,
+                            event,
+                            groupIdLogPair
+                        )
+                }
             }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation
+
+import com.wire.kalium.cryptography.MLSClient
+import com.wire.kalium.cryptography.MLSGroupId
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.MLSClientProvider
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.persistence.dao.ConversationDAO
+import com.wire.kalium.persistence.dao.ConversationEntity
+import io.ktor.util.encodeBase64
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.anything
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MLSWelcomeEventHandlerTest {
+
+    @Test
+    fun givenMLSClientFailsProcessingOfWelcomeMessageFails_thenShouldNotMarkConversationAsEstablished() = runTest {
+        val exception = RuntimeException()
+
+        val (arrangement, mlsWelcomeEventHandler) = Arrangement()
+            .withMLSClientProcessingOfWelcomeMessageFailsWith(exception)
+            .arrange()
+
+        // TODO: make sure failure is propagated
+        //       needs refactoring of EventReceiver
+        mlsWelcomeEventHandler.handle(WELCOME_EVENT)
+
+        verify(arrangement.conversationDAO)
+            .suspendFunction(arrangement.conversationDAO::updateConversationGroupState)
+            .with(any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenConversationFetchFails_thenShouldNotMarkConversationAsEstablished() = runTest {
+        val failure = CoreFailure.Unknown(null)
+        val (arrangement, mlsWelcomeEventHandler) = Arrangement()
+            .withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully(MLS_GROUP_ID)
+            .withFetchConversationIfUnknownFailingWith(failure)
+            .arrange()
+
+        // TODO: make sure failure is propagated
+        //       needs refactoring of EventReceiver
+        mlsWelcomeEventHandler.handle(WELCOME_EVENT)
+
+        verify(arrangement.conversationDAO)
+            .suspendFunction(arrangement.conversationDAO::updateConversationGroupState)
+            .with(any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenProcessingOfWelcomeAndConversationFetchSucceed_thenShouldMarkConversationAsEstablished() = runTest {
+        val (arrangement, mlsWelcomeEventHandler) = Arrangement()
+            .withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully(MLS_GROUP_ID)
+            .withFetchConversationIfUnknownSucceeding()
+            .withUpdateGroupStateSucceeding()
+            .arrange()
+
+        // TODO: make sure failure is propagated
+        //       needs refactoring of EventReceiver
+        mlsWelcomeEventHandler.handle(WELCOME_EVENT)
+
+        verify(arrangement.conversationDAO)
+            .suspendFunction(arrangement.conversationDAO::updateConversationGroupState)
+            .with(eq(ConversationEntity.GroupState.ESTABLISHED), eq(MLS_GROUP_ID))
+            .wasInvoked(exactly = once)
+    }
+
+    // TODO: Implement this test once event handler is refactored
+    @Ignore
+    @Test
+    fun givenUpdateGroupStateFails_thenShouldPropagateError() = runTest {
+        val (_, mlsWelcomeEventHandler) = Arrangement()
+            .withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully(MLS_GROUP_ID)
+            .withFetchConversationIfUnknownSucceeding()
+            .withUpdateGroupStateFailingWith(RuntimeException())
+            .arrange()
+
+        mlsWelcomeEventHandler.handle(WELCOME_EVENT)
+    }
+
+    // TODO: Implement this test once event handler is refactored
+    @Ignore
+    @Test
+    fun givenEverythingSucceeds_thenShouldPropagateSuccess() = runTest {
+        val (_, mlsWelcomeEventHandler) = Arrangement()
+            .withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully(MLS_GROUP_ID)
+            .withFetchConversationIfUnknownSucceeding()
+            .withUpdateGroupStateSucceeding()
+            .arrange()
+
+        mlsWelcomeEventHandler.handle(WELCOME_EVENT)
+    }
+
+    private class Arrangement {
+        @Mock
+        val mlsClient: MLSClient = mock(classOf<MLSClient>())
+
+        @Mock
+        val mlsClientProvider: MLSClientProvider = mock(classOf<MLSClientProvider>())
+
+        @Mock
+        val conversationDAO: ConversationDAO = mock(classOf<ConversationDAO>())
+
+        @Mock
+        val conversationRepository: ConversationRepository = mock(classOf<ConversationRepository>())
+
+        init {
+            withMLSClientProviderReturningMLSClient()
+        }
+
+        fun withMLSClientProviderReturningMLSClient() = apply {
+            given(mlsClientProvider)
+                .suspendFunction(mlsClientProvider::getMLSClient)
+                .whenInvokedWith(anything())
+                .thenReturn(Either.Right(mlsClient))
+        }
+
+        fun withMLSClientProcessingOfWelcomeMessageFailsWith(exception: Exception) = apply {
+            given(mlsClient)
+                .function(mlsClient::processWelcomeMessage)
+                .whenInvokedWith(any())
+                .thenThrow(exception)
+        }
+
+        fun withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully(mlsGroupId: MLSGroupId) = apply {
+            given(mlsClient)
+                .function(mlsClient::processWelcomeMessage)
+                .whenInvokedWith(any())
+                .thenReturn(mlsGroupId)
+        }
+
+        fun withFetchConversationIfUnknownFailingWith(coreFailure: CoreFailure) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::fetchConversationIfUnknown)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Left(coreFailure))
+        }
+
+        fun withFetchConversationIfUnknownSucceeding() = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::fetchConversationIfUnknown)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withUpdateGroupStateFailingWith(exception: Exception) = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::updateConversationGroupState)
+                .whenInvokedWith(any(), any())
+                .thenThrow(exception)
+        }
+
+        fun withUpdateGroupStateSucceeding() = apply {
+            given(conversationDAO)
+                .suspendFunction(conversationDAO::updateConversationGroupState)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Unit)
+        }
+
+        fun arrange() = this to MLSWelcomeEventHandlerImpl(
+            mlsClientProvider = mlsClientProvider,
+            conversationDAO = conversationDAO,
+            conversationRepository = conversationRepository
+        )
+    }
+
+    private companion object {
+        const val MLS_GROUP_ID: MLSGroupId = "test-mlsGroupId"
+        val CONVERSATION_ID = TestConversation.ID
+        val WELCOME = "welcome".encodeToByteArray()
+        val WELCOME_EVENT = Event.Conversation.MLSWelcome(
+            "eventId",
+            CONVERSATION_ID,
+            false,
+            TestUser.USER_ID,
+            WELCOME.encodeBase64(),
+            timestampIso = "2022-03-30T15:36:00.000Z"
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a new 1:1 MLS conversation was created, the backend would send a regular `conversation.create` event.
Now, it does not.

### Causes

MLS spec is being updated.

### Solutions

Now, handle the possibility of the conversation not existing during the receiving of a MLS welcome message.

If the conversation doesn't exist: fetch it.

If it exists, or if it doesn't, update the conversation to make it `ESTABLISHED` in any case.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
