### PR TITLE
feat(mls-one2one): support fetching mls 1-1 conversation details

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/BaseApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/BaseApi.kt
@@ -21,7 +21,7 @@ import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface BaseApi {
-    fun getApiNotSupportError(apiName: String, apiVersion: Int) = NetworkResponse.Error(
+    fun getApiNotSupportedError(apiName: String, apiVersion: Int) = NetworkResponse.Error(
         APINotSupported("${this::class.simpleName}: $apiName api is only available on API V$apiVersion")
     )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.network.api.base.authenticated.conversation
 
+import com.wire.kalium.network.api.base.authenticated.BaseApi
 import com.wire.kalium.network.api.base.authenticated.conversation.guestroomlink.GenerateGuestRoomLinkResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationMemberRoleDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationReceiptModeDTO
@@ -31,7 +32,7 @@ import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.utils.NetworkResponse
 
 @Suppress("TooManyFunctions")
-interface ConversationApi {
+interface ConversationApi : BaseApi {
 
     /**
      * Fetch conversations id's in a paginated fashion, including federated conversations
@@ -109,6 +110,10 @@ interface ConversationApi {
         code: String,
         key: String
     ): NetworkResponse<LimitedConversationInfo>
+
+    suspend fun fetchMlsOneToOneConversation(
+        userId: UserId
+    ): NetworkResponse<ConversationResponse>
 
     suspend fun fetchSubconversationDetails(
         conversationId: ConversationId,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -261,32 +261,32 @@ internal open class ConversationApiV0 internal constructor(
         }
 
     override suspend fun fetchMlsOneToOneConversation(userId: UserId): NetworkResponse<ConversationResponse> =
-        getApiNotSupportError(::fetchMlsOneToOneConversation.name, MIN_API_VERSION_MLS)
+        getApiNotSupportedError(::fetchMlsOneToOneConversation.name, MIN_API_VERSION_MLS)
 
     override suspend fun fetchSubconversationDetails(
         conversationId: ConversationId,
         subconversationId: SubconversationId
     ): NetworkResponse<SubconversationResponse> =
-        getApiNotSupportError(::fetchSubconversationDetails.name, MIN_API_VERSION_MLS)
+        getApiNotSupportedError(::fetchSubconversationDetails.name, MIN_API_VERSION_MLS)
 
     override suspend fun deleteSubconversation(
         conversationId: ConversationId,
         subconversationId: SubconversationId,
         deleteRequest: SubconversationDeleteRequest
     ): NetworkResponse<Unit> =
-        getApiNotSupportError(::deleteSubconversation.name, MIN_API_VERSION_MLS)
+        getApiNotSupportedError(::deleteSubconversation.name, MIN_API_VERSION_MLS)
 
     override suspend fun fetchSubconversationGroupInfo(
         conversationId: ConversationId,
         subconversationId: SubconversationId
     ): NetworkResponse<ByteArray> =
-        getApiNotSupportError(::fetchSubconversationGroupInfo.name, MIN_API_VERSION_MLS)
+        getApiNotSupportedError(::fetchSubconversationGroupInfo.name, MIN_API_VERSION_MLS)
 
     override suspend fun leaveSubconversation(
         conversationId: ConversationId,
         subconversationId: SubconversationId
     ): NetworkResponse<Unit> =
-        getApiNotSupportError(::leaveSubconversation.name, MIN_API_VERSION_MLS)
+        getApiNotSupportedError(::leaveSubconversation.name, MIN_API_VERSION_MLS)
 
     protected suspend fun handleConversationMemberAddedResponse(
         httpResponse: HttpResponse

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -260,38 +260,33 @@ internal open class ConversationApiV0 internal constructor(
             }
         }
 
+    override suspend fun fetchMlsOneToOneConversation(userId: UserId): NetworkResponse<ConversationResponse> =
+        getApiNotSupportError(::fetchMlsOneToOneConversation.name, MIN_API_VERSION_MLS)
+
     override suspend fun fetchSubconversationDetails(
         conversationId: ConversationId,
         subconversationId: SubconversationId
     ): NetworkResponse<SubconversationResponse> =
-        NetworkResponse.Error(
-            APINotSupported("MLS: fetchSubconversationDetails api is only available on API V3")
-        )
+        getApiNotSupportError(::fetchSubconversationDetails.name, MIN_API_VERSION_MLS)
 
     override suspend fun deleteSubconversation(
         conversationId: ConversationId,
         subconversationId: SubconversationId,
         deleteRequest: SubconversationDeleteRequest
     ): NetworkResponse<Unit> =
-        NetworkResponse.Error(
-            APINotSupported("MLS: deleteSubconversation api is only available on API V3")
-        )
+        getApiNotSupportError(::deleteSubconversation.name, MIN_API_VERSION_MLS)
 
     override suspend fun fetchSubconversationGroupInfo(
         conversationId: ConversationId,
         subconversationId: SubconversationId
     ): NetworkResponse<ByteArray> =
-        NetworkResponse.Error(
-            APINotSupported("MLS: fetchSubconversationGroupInfo api is only available on API V3")
-        )
+        getApiNotSupportError(::fetchSubconversationGroupInfo.name, MIN_API_VERSION_MLS)
 
     override suspend fun leaveSubconversation(
         conversationId: ConversationId,
         subconversationId: SubconversationId
     ): NetworkResponse<Unit> =
-        NetworkResponse.Error(
-            APINotSupported("MLS: leaveSubconversation api is only available on API V3")
-        )
+        getApiNotSupportError(::leaveSubconversation.name, MIN_API_VERSION_MLS)
 
     protected suspend fun handleConversationMemberAddedResponse(
         httpResponse: HttpResponse
@@ -391,10 +386,8 @@ internal open class ConversationApiV0 internal constructor(
         const val PATH_BOTS = "bots"
         const val QUERY_KEY_CODE = "code"
         const val QUERY_KEY_KEY = "key"
-        const val QUERY_KEY_START = "start"
-        const val QUERY_KEY_SIZE = "size"
-        const val QUERY_KEY_IDS = "qualified_ids"
 
         const val MAX_CONVERSATION_DETAILS_COUNT = 1000
+        const val MIN_API_VERSION_MLS = 4
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/SelfApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/SelfApiV0.kt
@@ -86,14 +86,15 @@ internal open class SelfApiV0 internal constructor(
         }
     }
 
-    @Suppress("MagicNumber")
     override suspend fun updateSupportedProtocols(protocols: List<SupportedProtocolDTO>): NetworkResponse<Unit> =
-        getApiNotSupportedError(::updateSupportedProtocols.name, 4)
+        getApiNotSupportedError(::updateSupportedProtocols.name, MIN_API_VERSION_SUPPORTED_PROTOCOLS)
 
     companion object {
         const val PATH_SELF = "self"
         const val PATH_HANDLE = "handle"
         const val PATH_ACCESS = "access"
         const val PATH_EMAIL = "email"
+
+        const val MIN_API_VERSION_SUPPORTED_PROTOCOLS = 4
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/SelfApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/SelfApiV0.kt
@@ -88,7 +88,7 @@ internal open class SelfApiV0 internal constructor(
 
     @Suppress("MagicNumber")
     override suspend fun updateSupportedProtocols(protocols: List<SupportedProtocolDTO>): NetworkResponse<Unit> =
-        getApiNotSupportError(::updateSupportedProtocols.name, 4)
+        getApiNotSupportedError(::updateSupportedProtocols.name, 4)
 
     companion object {
         const val PATH_SELF = "self"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.network.api.v4.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.UpdateConversationProtocolResponse
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
@@ -32,6 +33,7 @@ import com.wire.kalium.network.api.base.model.ApiModelMapperImpl
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.SubconversationId
+import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v3.authenticated.ConversationApiV3
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.mapSuccess
@@ -39,6 +41,7 @@ import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import com.wire.kalium.network.exceptions.KaliumException
+import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.client.request.put
 import io.ktor.client.request.post
@@ -134,9 +137,15 @@ internal open class ConversationApiV4 internal constructor(
         NetworkResponse.Error(KaliumException.GenericError(e))
     }
 
+    override suspend fun fetchMlsOneToOneConversation(userId: UserId): NetworkResponse<ConversationResponse> =
+        wrapKaliumResponse {
+            httpClient.get("$PATH_CONVERSATIONS/$PATH_ONE_TO_ONE/${userId.domain}/${userId.value}")
+        }
+
     companion object {
         const val PATH_PROTOCOL = "protocol"
         const val PATH_GROUP_INFO = "groupinfo"
         const val PATH_SUBCONVERSATIONS = "subconversations"
+        const val PATH_ONE_TO_ONE = "one2one"
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
@@ -42,8 +42,10 @@ import com.wire.kalium.network.api.base.model.ConversationAccessDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.JoinConversationRequest
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v0.authenticated.ConversationApiV0
+import com.wire.kalium.network.api.v0.authenticated.SelfApiV0
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
@@ -51,6 +53,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -415,6 +418,15 @@ internal class ConversationApiV0Test : ApiTest() {
 
         // then
         assertIs<NetworkResponse.Success<Unit>>(response)
+    }
+
+    @Test
+    fun givenRequest_whenFetchingMlsOneToOneConversation_thenRequestShouldFail() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(responseBody = "", statusCode = HttpStatusCode.OK)
+        val conversationApi = ConversationApiV0(networkClient)
+        val response = conversationApi.fetchMlsOneToOneConversation(UserId("domain", "id"))
+
+        assertFalse(response.isSuccessful())
     }
 
     private companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/self/SelfApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/self/SelfApiV0Test.kt
@@ -135,9 +135,6 @@ internal class SelfApiV0Test : ApiTest() {
         assertFalse(response.isSuccessful())
     }
 
-
-
-
     private companion object {
         const val PATH_SELF = "/self"
         val VALID_SELF_RESPONSE = UserDTOJson.valid

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
@@ -85,6 +85,7 @@ internal class ConversationApiV4Test : ApiTest() {
         )
     }
 
+    @Test
     fun given200Response_whenUpdatingConversationProtocol_thenEventIsParsedCorrectly() = runTest {
         val conversationId = ConversationId("conversationId", "conversationDomain")
 
@@ -206,10 +207,34 @@ internal class ConversationApiV4Test : ApiTest() {
         assertIs<UpdateConversationProtocolResponse.ProtocolUnchanged>(response.value)
     }
 
+    @Test
+    fun whenCallingFetchMlsOneToOneConversation_thenTheRequestShouldBeConfiguredOK() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            FETCH_CONVERSATION_RESPONSE,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual("$PATH_CONVERSATIONS/one2one/${USER_ID.domain}/${USER_ID.value}")
+            }
+        )
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.fetchMlsOneToOneConversation(USER_ID)
+    }
+
+    @Test
+    fun given200Response_whenCallingFetchMlsOneToOneConversation_thenResponseIsParsedCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(FETCH_CONVERSATION_RESPONSE, statusCode = HttpStatusCode.OK)
+        val conversationApi = ConversationApiV4(networkClient)
+
+        assertTrue(conversationApi.fetchMlsOneToOneConversation(USER_ID).isSuccessful())
+    }
+
     private companion object {
         const val PATH_CONVERSATIONS = "/conversations"
         const val PATH_PROTOCOL = "protocol"
+        val USER_ID = UserId("id", "domain")
         val CREATE_CONVERSATION_RESPONSE = ConversationResponseJson.v4_withFailedToAdd.rawJson
         val CREATE_CONVERSATION_REQUEST = CreateConversationRequestJson.v3
+        val FETCH_CONVERSATION_RESPONSE = ConversationResponseJson.v0.rawJson
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Support new API for fetching MLS 1-1 conversation metadata.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
