### PR TITLE
feat(v4.1): handling configuration for websocket enabled by default (WPB-967)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -107,7 +107,8 @@ class GlobalKaliumScope internal constructor(
             SessionDataSource(
                 globalDatabase.value.accountsDAO,
                 globalPreferences.value.authTokenStorage,
-                serverConfigRepository
+                serverConfigRepository,
+                kaliumConfigs
             )
 
     val observePersistentWebSocketConnectionStatus: ObservePersistentWebSocketConnectionStatusUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.logic.feature.auth.Account
 import com.wire.kalium.logic.feature.auth.AccountInfo
 import com.wire.kalium.logic.feature.auth.AuthTokens
 import com.wire.kalium.logic.feature.auth.PersistentWebSocketStatus
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
@@ -84,6 +85,7 @@ internal class SessionDataSource(
     private val accountsDAO: AccountsDAO,
     private val authTokenStorage: AuthTokenStorage,
     private val serverConfigRepository: ServerConfigRepository,
+    private val kaliumConfigs: KaliumConfigs,
     private val sessionMapper: SessionMapper = MapperProvider.sessionMapper(),
     private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : SessionRepository {
@@ -99,7 +101,7 @@ internal class SessionDataSource(
                 authTokens.userId.toDao(),
                 sessionMapper.toSsoIdEntity(ssoId),
                 serverConfigId,
-                isPersistentWebSocketEnabled = false
+                isPersistentWebSocketEnabled = kaliumConfigs.isWebSocketEnabledByDefault
             )
         }.flatMap {
             wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -37,5 +37,6 @@ data class KaliumConfigs(
     val guestRoomLink: Boolean = true,
     val wipeOnCookieInvalid: Boolean = false,
     val wipeOnDeviceRemoval: Boolean = false,
-    val wipeOnRootedDevice: Boolean = false
+    val wipeOnRootedDevice: Boolean = false,
+    val isWebSocketEnabledByDefault: Boolean = false
 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionRepositoryTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.data.session
 
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.persistence.client.AuthTokenStorage
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.daokaliumdb.AccountInfoEntity
@@ -86,9 +87,14 @@ class SessionRepositoryTest {
         val authTokenStorage: AuthTokenStorage = mock(AuthTokenStorage::class)
 
         @Mock
+        val kaliumConfigs: KaliumConfigs = mock(KaliumConfigs::class)
+
+
+        @Mock
         val serverConfigRepository: ServerConfigRepository = mock(ServerConfigRepository::class)
 
-        private val sessionRepository = SessionDataSource(accountsDAO, authTokenStorage, serverConfigRepository, sessionMapper, idMapper)
+        private val sessionRepository =
+            SessionDataSource(accountsDAO, authTokenStorage, serverConfigRepository, kaliumConfigs, sessionMapper, idMapper)
 
         val validAccountIndoEntity = AccountInfoEntity(userIDEntity = UserIDEntity("1", "domain"), null)
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -459,7 +459,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             // given
             // established updated group
             val updatedConversation = conversationEntity2
-            val updatedDate = Instant.parse("2023-03-30T15:36:00.000Z")
+            val updatedDate = Instant.parse("2099-03-30T15:36:00.000Z")
             val updatedGroupId = (updatedConversation.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId
             teamDAO.insertTeam(team)
             conversationDAO.insertConversation(updatedConversation)

--- a/scripts/dev.mk
+++ b/scripts/dev.mk
@@ -3,10 +3,25 @@
 db/verify-global-migration:
 	./gradlew :persistence:verifyCommonMainGlobalDatabaseMigration
 
+# the delete of 2.db and the migrations files from 1 -> 33 is a workaround for the following issue:
+# https://github.com/cashapp/sqldelight/issues/4154
+# TL,DR: the 33.sqm use UPDPATE table AS alias syntax which is a valid SQLtite syntax but sqldelight doesn't support it
+# it result to false nigaive when validating the migration
+# and need to be reverted as soon as https://github.com/cashapp/sqldelight/issues/4154 is fixed
 db/verify-user-migration:
+	rm persistence/src/commonMain/db_user/schemas/2.db
+	for i in {1..33}; \
+	do \
+		rm persistence/src/commonMain/db_user/migrations/$$i.sqm; \
+	done
 	./gradlew :persistence:verifyCommonMainUserDatabaseMigration
 
 db/verify-all-migrations:
+	rm persistence/src/commonMain/db_user/schemas/2.db
+	for i in {1..33}; \
+	do \
+		rm persistence/src/commonMain/db_user/migrations/$$i.sqm; \
+	done
 	./gradlew :persistence:verifySqlDelightMigration
 
 # detekt


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to enable the websocket by default on devices that doesn't support google play services. ie. col1/3/fdroid builds

### Solutions

When storing the session of the user, persist this config accordingly by configuration given by `KaliumConfig`

### Dependencies (Optional)

We need to raise a PR in reloaded for this.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
