### PR TITLE
refactor: handle event processing failure

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -79,7 +79,7 @@ interface ClientRepository {
         verified: Boolean
     ): Either<StorageFailure, Unit>
 
-    suspend fun saveNewClientEvent(newClientEvent: Event.User.NewClient)
+    suspend fun saveNewClientEvent(newClientEvent: Event.User.NewClient): Either<CoreFailure, Unit>
     suspend fun clearNewClients()
     suspend fun observeNewClients(): Flow<Either<StorageFailure, List<Client>>>
 }
@@ -221,7 +221,9 @@ class ClientDataSource(
         clientDAO.updateClientVerificationStatus(userId.toDao(), clientId.value, verified)
     }
 
-    override suspend fun saveNewClientEvent(newClientEvent: Event.User.NewClient) {
+    override suspend fun saveNewClientEvent(
+        newClientEvent: Event.User.NewClient
+    ): Either<CoreFailure, Unit> = wrapStorageRequest {
         newClientDAO.insertNewClient(clientMapper.toInsertClientParam(selfUserID, newClientEvent))
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/CommitBundleEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/CommitBundleEventReceiver.kt
@@ -18,7 +18,10 @@
 
 package com.wire.kalium.logic.data.conversation
 
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.MLSFailure
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.EventReceiver
 import com.wire.kalium.logic.sync.receiver.conversation.MemberJoinEventHandler
@@ -30,11 +33,16 @@ class CommitBundleEventReceiverImpl(
     private val memberJoinEventHandler: MemberJoinEventHandler,
     private val memberLeaveEventHandler: MemberLeaveEventHandler
 ) : CommitBundleEventReceiver {
-    override suspend fun onEvent(event: Event.Conversation) {
-        when (event) {
+    override suspend fun onEvent(event: Event.Conversation): Either<CoreFailure, Unit> {
+        return when (event) {
             is Event.Conversation.MemberJoin -> memberJoinEventHandler.handle(event)
             is Event.Conversation.MemberLeave -> memberLeaveEventHandler.handle(event)
-            else -> kaliumLogger.w("Unexpected event received by commit bundle: ${event.toLogString()}")
+            else -> {
+                // This should never happen. If it does, we assume a catastrophic failure and stop event processing.
+                val exception = IllegalArgumentException("Unexpected event received by commit bundle: ${event.toLogString()}")
+                kaliumLogger.e("Unexpected event received by commit bundle: ${event.toLogString()}", exception)
+                Either.Left(MLSFailure.Generic(exception))
+            }
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -57,8 +57,6 @@ sealed class Event(open val id: String, open val transient: Boolean) {
         const val selfDeletionDurationKey = "selfDeletionDuration"
     }
 
-    fun shouldUpdateLastProcessedEventId() = !transient
-
     open fun toLogString(): String {
         return "${toLogMap().toJsonElement()}"
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -18,7 +18,9 @@
 
 package com.wire.kalium.logic.sync.receiver
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.receiver.conversation.ConversationMessageTimerEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.DeletedConversationEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MLSWelcomeEventHandler
@@ -47,20 +49,64 @@ internal class ConversationEventReceiverImpl(
     private val receiptModeUpdateEventHandler: ReceiptModeUpdateEventHandler,
     private val conversationMessageTimerEventHandler: ConversationMessageTimerEventHandler
 ) : ConversationEventReceiver {
-    override suspend fun onEvent(event: Event.Conversation) {
-        when (event) {
-            is Event.Conversation.NewMessage -> newMessageHandler.handleNewProteusMessage(event)
-            is Event.Conversation.NewMLSMessage -> newMessageHandler.handleNewMLSMessage(event)
-            is Event.Conversation.NewConversation -> newConversationHandler.handle(event)
-            is Event.Conversation.DeletedConversation -> deletedConversationHandler.handle(event)
+    override suspend fun onEvent(event: Event.Conversation): Either<CoreFailure, Unit> {
+        // TODO: Make sure errors are accounted for by each handler.
+        //       onEvent now requires Either, so we can propagate errors,
+        //       but not all handlers are using it yet.
+        //       Returning Either.Right is the equivalent of how it was originally working.
+        return when (event) {
+            is Event.Conversation.NewMessage -> {
+                newMessageHandler.handleNewProteusMessage(event)
+                Either.Right(Unit)
+            }
+
+            is Event.Conversation.NewMLSMessage -> {
+                newMessageHandler.handleNewMLSMessage(event)
+                Either.Right(Unit)
+            }
+
+            is Event.Conversation.NewConversation -> {
+                newConversationHandler.handle(event)
+                Either.Right(Unit)
+            }
+
+            is Event.Conversation.DeletedConversation -> {
+                deletedConversationHandler.handle(event)
+                Either.Right(Unit)
+            }
+
             is Event.Conversation.MemberJoin -> memberJoinHandler.handle(event)
+
             is Event.Conversation.MemberLeave -> memberLeaveHandler.handle(event)
-            is Event.Conversation.MemberChanged -> memberChangeHandler.handle(event)
-            is Event.Conversation.MLSWelcome -> mlsWelcomeHandler.handle(event)
-            is Event.Conversation.RenamedConversation -> renamedConversationHandler.handle(event)
-            is Event.Conversation.ConversationReceiptMode -> receiptModeUpdateEventHandler.handle(event)
-            is Event.Conversation.AccessUpdate -> TODO()
-            is Event.Conversation.ConversationMessageTimer -> conversationMessageTimerEventHandler.handle(event)
+
+            is Event.Conversation.MemberChanged -> {
+                memberChangeHandler.handle(event)
+                Either.Right(Unit)
+            }
+
+            is Event.Conversation.MLSWelcome -> {
+                mlsWelcomeHandler.handle(event)
+                Either.Right(Unit)
+            }
+
+            is Event.Conversation.RenamedConversation -> {
+                renamedConversationHandler.handle(event)
+                Either.Right(Unit)
+            }
+
+            is Event.Conversation.ConversationReceiptMode -> {
+                receiptModeUpdateEventHandler.handle(event)
+                Either.Right(Unit)
+            }
+
+            is Event.Conversation.AccessUpdate -> {
+                TODO()
+            }
+
+            is Event.Conversation.ConversationMessageTimer -> {
+                conversationMessageTimerEventHandler.handle(event)
+                Either.Right(Unit)
+            }
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/EventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/EventReceiver.kt
@@ -18,8 +18,10 @@
 
 package com.wire.kalium.logic.sync.receiver
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.functional.Either
 
 fun interface EventReceiver<T : Event> {
-    suspend fun onEvent(event: T)
+    suspend fun onEvent(event: T): Either<CoreFailure, Unit>
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.receiver
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.event.Event
@@ -30,6 +31,7 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer.Comp
 import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
@@ -47,8 +49,12 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
     private val selfUserId: UserId
 ) : FeatureConfigEventReceiver {
 
-    override suspend fun onEvent(event: Event.FeatureConfig) {
+    override suspend fun onEvent(event: Event.FeatureConfig): Either<CoreFailure, Unit> {
         handleFeatureConfigEvent(event)
+        // TODO: Make sure errors are accounted for.
+        //       onEvent now requires Either, so we can propagate errors.
+        //       Returning Either.Right is the equivalent of how it was originally working.
+        return Either.Right(Unit)
     }
 
     @Suppress("LongMethod", "ComplexMethod")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.sync.receiver
 
 import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
@@ -30,6 +31,7 @@ import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -45,13 +47,18 @@ internal class TeamEventReceiverImpl(
     private val selfUserId: UserId,
 ) : TeamEventReceiver {
 
-    override suspend fun onEvent(event: Event.Team) {
+    override suspend fun onEvent(event: Event.Team): Either<CoreFailure, Unit> {
         when (event) {
             is Event.Team.MemberJoin -> handleMemberJoin(event)
             is Event.Team.MemberLeave -> handleMemberLeave(event)
             is Event.Team.MemberUpdate -> handleMemberUpdate(event)
             is Event.Team.Update -> handleUpdate(event)
         }
+        // TODO: Make sure errors are accounted for by each handler.
+        //       onEvent now requires Either, so we can propagate errors,
+        //       but not all handlers are using it yet.
+        //       Returning Either.Right is the equivalent of how it was originally working.
+        return Either.Right(Unit)
     }
 
     private suspend fun handleMemberJoin(event: Event.Team.MemberJoin) =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.receiver
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -29,6 +30,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
@@ -47,8 +49,8 @@ class UserEventReceiverImpl internal constructor(
     private val currentClientIdProvider: CurrentClientIdProvider,
 ) : UserEventReceiver {
 
-    override suspend fun onEvent(event: Event.User) {
-        when (event) {
+    override suspend fun onEvent(event: Event.User): Either<CoreFailure, Unit> {
+        return when (event) {
             is Event.User.NewConnection -> handleNewConnection(event)
             is Event.User.ClientRemove -> handleClientRemove(event)
             is Event.User.UserDelete -> handleUserDelete(event)
@@ -57,7 +59,7 @@ class UserEventReceiverImpl internal constructor(
         }
     }
 
-    private suspend fun handleUserUpdate(event: Event.User.Update) {
+    private suspend fun handleUserUpdate(event: Event.User.Update) =
         userRepository.updateUserFromEvent(event)
             .onSuccess {
                 kaliumLogger
@@ -74,9 +76,8 @@ class UserEventReceiverImpl internal constructor(
                         Pair("errorInfo", "$it")
                     )
             }
-    }
 
-    private suspend fun handleNewConnection(event: Event.User.NewConnection) =
+    private suspend fun handleNewConnection(event: Event.User.NewConnection): Either<CoreFailure, Unit> =
         connectionRepository.insertConnectionFromEvent(event)
             .onSuccess {
                 kaliumLogger
@@ -94,7 +95,7 @@ class UserEventReceiverImpl internal constructor(
                     )
             }
 
-    private suspend fun handleClientRemove(event: Event.User.ClientRemove) {
+    private suspend fun handleClientRemove(event: Event.User.ClientRemove): Either<CoreFailure, Unit> =
         currentClientIdProvider().map { currentClientId ->
             if (currentClientId == event.clientId) {
                 kaliumLogger
@@ -113,15 +114,14 @@ class UserEventReceiverImpl internal constructor(
                     )
             }
         }
-    }
 
-    private suspend fun handleNewClient(event: Event.User.NewClient) {
+    private suspend fun handleNewClient(event: Event.User.NewClient): Either<CoreFailure, Unit> =
         clientRepository.saveNewClientEvent(event)
-    }
 
-    private suspend fun handleUserDelete(event: Event.User.UserDelete) {
+    private suspend fun handleUserDelete(event: Event.User.UserDelete): Either<CoreFailure, Unit> =
         if (selfUserId == event.userId) {
             logout(LogoutReason.DELETED_ACCOUNT)
+            Either.Right(Unit)
         } else {
             userRepository.removeUser(event.userId)
                 .onSuccess {
@@ -152,5 +152,4 @@ class UserEventReceiverImpl internal constructor(
                         )
                 }
         }
-    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiver.kt
@@ -18,10 +18,12 @@
 
 package com.wire.kalium.logic.sync.receiver
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -32,15 +34,17 @@ class UserPropertiesEventReceiverImpl internal constructor(
     private val userConfigRepository: UserConfigRepository
 ) : UserPropertiesEventReceiver {
 
-    override suspend fun onEvent(event: Event.UserProperty) {
-        when (event) {
+    override suspend fun onEvent(event: Event.UserProperty): Either<CoreFailure, Unit> {
+        return when (event) {
             is Event.UserProperty.ReadReceiptModeSet -> {
                 handleReadReceiptMode(event)
             }
         }
     }
 
-    private fun handleReadReceiptMode(event: Event.UserProperty.ReadReceiptModeSet) {
+    private fun handleReadReceiptMode(
+        event: Event.UserProperty.ReadReceiptModeSet
+    ): Either<CoreFailure, Unit> =
         userConfigRepository
             .setReadReceiptsStatus(event.value)
             .onSuccess {
@@ -58,5 +62,4 @@ class UserPropertiesEventReceiverImpl internal constructor(
                         Pair("errorInfo", "$it")
                     )
             }
-    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -19,9 +19,9 @@
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.cryptography.CommitBundle
-import com.wire.kalium.cryptography.MLSClient
 import com.wire.kalium.cryptography.GroupInfoBundle
 import com.wire.kalium.cryptography.GroupInfoEncryptionType
+import com.wire.kalium.cryptography.MLSClient
 import com.wire.kalium.cryptography.RatchetTreeType
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.event.Event
@@ -74,7 +74,6 @@ import io.mockative.once
 import io.mockative.thenDoNothing
 import io.mockative.twice
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
@@ -85,7 +84,6 @@ import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class MLSConversationRepositoryTest {
     @Test
     fun givenSuccessfulResponses_whenCallingEstablishMLSGroup_thenGroupIsCreatedAndCommitBundleIsSentAndAccepted() = runTest {
@@ -865,7 +863,6 @@ class MLSConversationRepositoryTest {
     }
 
 
-
     @Test
     fun givenSuccessResponse_whenSendingCommitBundle_thenEmitEpochChange() = runTest(TestKaliumDispatcher.default) {
         val (_, mlsConversationRepository) = Arrangement()
@@ -940,6 +937,17 @@ class MLSConversationRepositoryTest {
         val epochsFlow = MutableSharedFlow<GroupID>()
 
         val proposalTimersFlow = MutableSharedFlow<ProposalTimer>()
+
+        init {
+            withCommitBundleEventReceiverSucceeding()
+        }
+
+        fun withCommitBundleEventReceiverSucceeding() = apply {
+            given(commitBundleEventReceiver)
+                .suspendFunction(commitBundleEventReceiver::onEvent)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+        }
 
         fun withGetConversationByGroupIdSuccessful() = apply {
             given(conversationDAO)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -172,6 +172,17 @@ class UserEventReceiverTest {
             currentClientIdProvider
         )
 
+        init {
+            withSaveNewClientSucceeding()
+        }
+
+        fun withSaveNewClientSucceeding() = apply {
+            given(clientRepository)
+                .suspendFunction(clientRepository::saveNewClientEvent)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+        }
+
         fun withCurrentClientIdIs(clientId: ClientId) = apply {
             given(currentClientIdProvider)
                 .suspendFunction(currentClientIdProvider::invoke)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, there's no possibility of gracefuly handling errors during event processing.

For MLS - for example - there are delicate event handling where network requests need to be made and in case of failure or network instability, we should abort sync and retry later again.

Currently when an exception is thrown: Sync will stop.

This is _in parts_ what we want. However, most of our code wraps exceptions and returns as `Either.Left` without throwing exceptions.

### Solutions

Streamline the processing of events, by making handlers return `Either` as well.
In case of failures, the `lastProcessedEventId` shouldn't be updated, and `IncrementalSyncWorker` should throw a `KaliumSyncException`, making Sync stop.

I have _not_ addressed 100% of the event handlers in this PR. Only a few that were easy to tackle as this refactoring would be huge.

I've opted to keep `Either.Right(Unit)` on other cases, as it keeps the same behaviour.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
