### PR TITLE
fix(RC): ephemeral messages timer form self user should start automatically

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -186,12 +186,6 @@ import com.wire.kalium.logic.feature.message.PersistMigratedMessagesUseCase
 import com.wire.kalium.logic.feature.message.PersistMigratedMessagesUseCaseImpl
 import com.wire.kalium.logic.feature.message.SessionEstablisher
 import com.wire.kalium.logic.feature.message.SessionEstablisherImpl
-import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCase
-import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl
-import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCase
-import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
-import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
-import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
 import com.wire.kalium.logic.feature.migration.MigrationScope
 import com.wire.kalium.logic.feature.notificationToken.PushTokenUpdater
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
@@ -972,32 +966,11 @@ class UserSessionScope internal constructor(
             userId
         )
 
-    private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCase
-        get() = DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl(messageRepository)
-
-    private val deleteEphemeralMessageForSelfUserAsReceiver: DeleteEphemeralMessageForSelfUserAsReceiverUseCase
-        get() = DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
-            messageRepository = messageRepository,
-            assetRepository = assetRepository,
-            currentClientIdProvider = clientIdProvider,
-            messageSender = messages.messageSender,
-            selfUserId = userId,
-            selfConversationIdProvider = selfConversationIdProvider
-        )
-
-    internal val ephemeralMessageDeletionHandler: EphemeralMessageDeletionHandler =
-        EphemeralMessageDeletionHandlerImpl(
-            userSessionCoroutineScope = this,
-            messageRepository = messageRepository,
-            deleteEphemeralMessageForSelfUserAsReceiver = deleteEphemeralMessageForSelfUserAsReceiver,
-            deleteEphemeralMessageForSelfUserAsSender = deleteEphemeralMessageForSelfUserAsSender,
-        )
-
     private val newMessageHandler: NewMessageEventHandler
         get() = NewMessageEventHandlerImpl(
             proteusUnpacker, mlsUnpacker, applicationMessageHandler,
             { conversationId, messageId ->
-                ephemeralMessageDeletionHandler.startSelfDeletion(conversationId, messageId)
+                messages.ephemeralMessageDeletionHandler.startSelfDeletion(conversationId, messageId)
             }, userId
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -186,6 +186,12 @@ import com.wire.kalium.logic.feature.message.PersistMigratedMessagesUseCase
 import com.wire.kalium.logic.feature.message.PersistMigratedMessagesUseCaseImpl
 import com.wire.kalium.logic.feature.message.SessionEstablisher
 import com.wire.kalium.logic.feature.message.SessionEstablisherImpl
+import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCase
+import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl
+import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCase
+import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
 import com.wire.kalium.logic.feature.migration.MigrationScope
 import com.wire.kalium.logic.feature.notificationToken.PushTokenUpdater
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
@@ -283,6 +289,7 @@ import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessa
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpackerImpl
+import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpacker
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpackerImpl
@@ -964,9 +971,33 @@ class UserSessionScope internal constructor(
             userId
         )
 
-    private val newMessageHandler: NewMessageEventHandlerImpl
+    private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCase
+        get() = DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl(messageRepository)
+
+    private val deleteEphemeralMessageForSelfUserAsReceiver: DeleteEphemeralMessageForSelfUserAsReceiverUseCase
+        get() = DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
+            messageRepository = messageRepository,
+            assetRepository = assetRepository,
+            currentClientIdProvider = clientIdProvider,
+            messageSender = messages.messageSender,
+            selfUserId = userId,
+            selfConversationIdProvider = selfConversationIdProvider
+        )
+
+    internal val ephemeralMessageDeletionHandler: EphemeralMessageDeletionHandler =
+        EphemeralMessageDeletionHandlerImpl(
+            userSessionCoroutineScope = this,
+            messageRepository = messageRepository,
+            deleteEphemeralMessageForSelfUserAsReceiver = deleteEphemeralMessageForSelfUserAsReceiver,
+            deleteEphemeralMessageForSelfUserAsSender = deleteEphemeralMessageForSelfUserAsSender,
+        )
+
+    private val newMessageHandler: NewMessageEventHandler
         get() = NewMessageEventHandlerImpl(
-            proteusUnpacker, mlsUnpacker, applicationMessageHandler
+            proteusUnpacker, mlsUnpacker, applicationMessageHandler,
+            { conversationId, messageId ->
+                ephemeralMessageDeletionHandler.startSelfDeletion(conversationId, messageId)
+            }, userId
         )
 
     private val newConversationHandler: NewConversationEventHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -51,6 +51,7 @@ import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageFor
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCaseImpl
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
 import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
@@ -113,7 +114,7 @@ class MessageScope internal constructor(
     private val messageSendingInterceptor: MessageSendingInterceptor
         get() = MessageSendingInterceptorImpl(messageContentEncoder, messageRepository)
 
-    internal val ephemeralMessageDeletionHandler =
+    internal val ephemeralMessageDeletionHandler: EphemeralMessageDeletionHandler =
         EphemeralMessageDeletionHandlerImpl(
             userSessionCoroutineScope = scope,
             messageRepository = messageRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -59,7 +59,9 @@ internal class ConversationEventReceiverImpl(
             is Event.Conversation.MLSWelcome -> mlsWelcomeHandler.handle(event)
             is Event.Conversation.RenamedConversation -> renamedConversationHandler.handle(event)
             is Event.Conversation.ConversationReceiptMode -> receiptModeUpdateEventHandler.handle(event)
-            is Event.Conversation.AccessUpdate -> TODO()
+            is Event.Conversation.AccessUpdate -> {
+                /* no-op */
+            }
             is Event.Conversation.ConversationMessageTimer -> conversationMessageTimerEventHandler.handle(event)
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -199,12 +199,13 @@ internal class ApplicationMessageHandlerImpl(
     private suspend fun processMessage(message: Message.Regular) {
         logger.i(message = "Message received: { \"message\" : ${message.toLogString()} }")
         when (val content = message.content) {
-            // Persist Messages - > lists
             is MessageContent.Text -> handleTextMessage(message, content)
             is MessageContent.FailedDecryption -> persistMessage(message)
             is MessageContent.Knock -> persistMessage(message)
             is MessageContent.Asset -> assetMessageHandler.handle(message)
-            is MessageContent.RestrictedAsset -> TODO()
+            is MessageContent.RestrictedAsset -> {
+                /* no-op */
+            }
             is MessageContent.Unknown -> {
                 logger.i(message = "Unknown Message received: { \"message\" : ${message.toLogString()} }")
                 persistMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -27,11 +27,7 @@ import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageContent
-import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
-import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
-import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -30,6 +30,8 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -44,7 +46,7 @@ internal class NewMessageEventHandlerImpl(
     private val proteusMessageUnpacker: ProteusMessageUnpacker,
     private val mlsMessageUnpacker: MLSMessageUnpacker,
     private val applicationMessageHandler: ApplicationMessageHandler,
-    private val enqueueMessageSelfDeletionUseCase: EnqueueMessageSelfDeletionUseCase,
+    private val enqueueSelfDeletion: (conversationId: ConversationId, messageId: String) -> Unit,
     private val selfUserId: UserId
 ) : NewMessageEventHandler {
 
@@ -130,7 +132,7 @@ internal class NewMessageEventHandlerImpl(
 
     private fun onMessageInserted(result: MessageUnpackResult.ApplicationMessage) {
         if (result.senderUserId == selfUserId && result.content.expiresAfterMillis != null) {
-            enqueueMessageSelfDeletionUseCase(
+            enqueueSelfDeletion(
                 result.conversationId,
                 result.content.messageUid
             )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -21,9 +21,16 @@ package com.wire.kalium.logic.sync.receiver.conversation.message
 import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.ProteusFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.ProtoContent
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -35,6 +42,7 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -59,7 +67,16 @@ class NewMessageEventHandlerTest {
     @Test
     fun givenProteusDUPLICATED_MESSAGE_whenHandling_thenErrorShouldBeIgnored() = runTest {
         val (arrangement, newMessageEventHandler) = Arrangement()
-            .withProteusUnpackerReturning(Either.Left(ProteusFailure(ProteusException(message = null, code = ProteusException.Code.DUPLICATE_MESSAGE))))
+            .withProteusUnpackerReturning(
+                Either.Left(
+                    ProteusFailure(
+                        ProteusException(
+                            message = null,
+                            code = ProteusException.Code.DUPLICATE_MESSAGE
+                        )
+                    )
+                )
+            )
             .arrange()
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
@@ -80,7 +97,16 @@ class NewMessageEventHandlerTest {
     @Test
     fun givenProteus_whenHandling_thenErrorShouldBeHandled() = runTest {
         val (arrangement, newMessageEventHandler) = Arrangement()
-            .withProteusUnpackerReturning(Either.Left(ProteusFailure(ProteusException(message = null, code = ProteusException.Code.INVALID_SIGNATURE))))
+            .withProteusUnpackerReturning(
+                Either.Left(
+                    ProteusFailure(
+                        ProteusException(
+                            message = null,
+                            code = ProteusException.Code.INVALID_SIGNATURE
+                        )
+                    )
+                )
+            )
             .arrange()
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
@@ -114,6 +140,145 @@ class NewMessageEventHandlerTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenEphemeralMessageFromSelf_whenHandling_thenEnqueueForSelfDelete() = runTest {
+        val conversationID = ConversationId("conversationID", "domain")
+        val senderUserId = SELF_USER_ID
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withProteusUnpackerReturning(
+                Either.Right(
+                    MessageUnpackResult.ApplicationMessage(
+                        conversationID,
+                        Instant.DISTANT_PAST.toIsoDateTimeString(),
+                        senderUserId,
+                        ClientId("clientID"),
+                        ProtoContent.Readable(
+                            messageUid = "messageUID",
+                             messageContent = MessageContent.Text(
+                                 value = "messageContent"
+                             ),
+                            expectsReadConfirmation = false,
+                            expiresAfterMillis = 123L
+                        )
+                    )
+                )
+            )
+            .arrange()
+
+        val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
+
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+
+        verify(arrangement.proteusMessageUnpacker)
+            .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
+            .with(eq(newMessageEvent))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.applicationMessageHandler)
+            .suspendFunction(arrangement.applicationMessageHandler::handleDecryptionError)
+            .with(any(), any(), any(), any(), any(), any())
+            .wasNotInvoked()
+
+        verify(arrangement.ephemeralMessageDeletionHandler)
+            .function(arrangement.ephemeralMessageDeletionHandler::startSelfDeletion)
+            .with(any(), any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenEphemeralMessage_whenHandling_thenDoNotEnqueueForSelfDelete() = runTest {
+        val conversationID = ConversationId("conversationID", "domain")
+        val senderUserId = UserId("otherUserId", "domain")
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withProteusUnpackerReturning(
+                Either.Right(
+                    MessageUnpackResult.ApplicationMessage(
+                        conversationID,
+                        Instant.DISTANT_PAST.toIsoDateTimeString(),
+                        senderUserId,
+                        ClientId("clientID"),
+                        ProtoContent.Readable(
+                            messageUid = "messageUID",
+                            messageContent = MessageContent.Text(
+                                value = "messageContent"
+                            ),
+                            expectsReadConfirmation = false,
+                            expiresAfterMillis = 123L
+                        )
+                    )
+                )
+            )
+            .arrange()
+
+        val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
+
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+
+        verify(arrangement.proteusMessageUnpacker)
+            .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
+            .with(eq(newMessageEvent))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.applicationMessageHandler)
+            .suspendFunction(arrangement.applicationMessageHandler::handleDecryptionError)
+            .with(any(), any(), any(), any(), any(), any())
+            .wasNotInvoked()
+
+        verify(arrangement.ephemeralMessageDeletionHandler)
+            .function(arrangement.ephemeralMessageDeletionHandler::startSelfDeletion)
+            .with(any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenMessageFromSelf_whenHandling_thenDoNotEnqueueForSelfDelete() = runTest {
+        val conversationID = ConversationId("conversationID", "domain")
+        val senderUserId = SELF_USER_ID
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withProteusUnpackerReturning(
+                Either.Right(
+                    MessageUnpackResult.ApplicationMessage(
+                        conversationID,
+                        Instant.DISTANT_PAST.toIsoDateTimeString(),
+                        senderUserId,
+                        ClientId("clientID"),
+                        ProtoContent.Readable(
+                            messageUid = "messageUID",
+                            messageContent = MessageContent.Text(
+                                value = "messageContent"
+                            ),
+                            expectsReadConfirmation = false,
+                            expiresAfterMillis = null
+                        )
+                    )
+                )
+            )
+            .arrange()
+
+        val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
+
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+
+        verify(arrangement.proteusMessageUnpacker)
+            .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
+            .with(eq(newMessageEvent))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.applicationMessageHandler)
+            .suspendFunction(arrangement.applicationMessageHandler::handleDecryptionError)
+            .with(any(), any(), any(), any(), any(), any())
+            .wasNotInvoked()
+
+        verify(arrangement.ephemeralMessageDeletionHandler)
+            .function(arrangement.ephemeralMessageDeletionHandler::startSelfDeletion)
+            .with(any(), any())
+            .wasNotInvoked()
+    }
+
+    private companion object {
+        val SELF_USER_ID = UserId("selfUserId", "selfDomain")
+    }
+
     private class Arrangement {
 
         @Mock
@@ -127,9 +292,22 @@ class NewMessageEventHandlerTest {
             stubsUnitByDefault = true
         }
 
+        @Mock
+        val ephemeralMessageDeletionHandler = mock(EphemeralMessageDeletionHandler::class)
+
         private val newMessageEventHandler: NewMessageEventHandler = NewMessageEventHandlerImpl(
-            proteusMessageUnpacker, mlsMessageUnpacker, applicationMessageHandler
+            proteusMessageUnpacker,
+            mlsMessageUnpacker,
+            applicationMessageHandler,
+            { conversationId, messageId -> ephemeralMessageDeletionHandler.startSelfDeletion(conversationId, messageId) },
+            SELF_USER_ID
         )
+
+        fun withEnqueueSelfDeleteSuccess() = apply {
+            given(ephemeralMessageDeletionHandler)
+                .function(ephemeralMessageDeletionHandler::startSelfDeletion)
+                .whenInvokedWith(any(), any())
+        }
 
         fun withProteusUnpackerReturning(result: Either<CoreFailure, MessageUnpackResult>) = apply {
             given(proteusMessageUnpacker)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -303,12 +303,6 @@ class NewMessageEventHandlerTest {
             SELF_USER_ID
         )
 
-        fun withEnqueueSelfDeleteSuccess() = apply {
-            given(ephemeralMessageDeletionHandler)
-                .function(ephemeralMessageDeletionHandler::startSelfDeletion)
-                .whenInvokedWith(any(), any())
-        }
-
         fun withProteusUnpackerReturning(result: Either<CoreFailure, MessageUnpackResult>) = apply {
             given(proteusMessageUnpacker)
                 .suspendFunction(proteusMessageUnpacker::unpackProteusMessage)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

self ephemeral messages timer is not starting automatically

### Solutions

after receiving a message, enqueue it for self delete if it is ephemeral and the sender is self

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
