### PR TITLE
feat(calling): create usecase for ending call on member leave or conversation delete (WPB-2955)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -30,6 +30,8 @@ import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnConversationChangeUseCase
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnConversationChangeUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
@@ -105,15 +107,23 @@ class CallsScope internal constructor(
 
     val startCall: StartCallUseCase get() = StartCallUseCase(callManager, syncManager, kaliumConfigs)
 
-    val answerCall: AnswerCallUseCase get() = AnswerCallUseCaseImpl(
-        allCallsWithSortedParticipants,
-        callManager,
-        muteCall,
-        unMuteCall,
-        kaliumConfigs
-    )
+    val answerCall: AnswerCallUseCase
+        get() = AnswerCallUseCaseImpl(
+            allCallsWithSortedParticipants,
+            callManager,
+            muteCall,
+            unMuteCall,
+            kaliumConfigs
+        )
 
     val endCall: EndCallUseCase get() = EndCallUseCaseImpl(callManager, callRepository, KaliumDispatcherImpl)
+
+    val endCallOnConversationChange: EndCallOnConversationChangeUseCase
+        get() = EndCallOnConversationChangeUseCaseImpl(
+            callRepository = callRepository,
+            conversationRepository = conversationRepository,
+            endCallUseCase = endCall
+        )
 
     val rejectCall: RejectCallUseCase get() = RejectCallUseCase(callManager, callRepository, KaliumDispatcherImpl)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
+/**
+ * End call when conversation is deleted, user is not a member anymore or user is deleted.
+ */
 interface EndCallOnConversationChangeUseCase {
     suspend operator fun invoke()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
@@ -1,0 +1,50 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.functional.fold
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+interface EndCallOnConversationChangeUseCase {
+    suspend operator fun invoke()
+}
+
+class EndCallOnConversationChangeUseCaseImpl(
+    private val callRepository: CallRepository,
+    private val conversationRepository: ConversationRepository,
+    private val endCallUseCase: EndCallUseCase
+) : EndCallOnConversationChangeUseCase {
+    override suspend operator fun invoke() {
+        val callsFlow = callRepository.establishedCallsFlow().map { calls ->
+            calls.map { it.conversationId }
+        }.distinctUntilChanged().cancellable()
+
+        callsFlow.collectLatest { calls ->
+            if (calls.isNotEmpty()) {
+                conversationRepository.observeConversationDetailsById(calls.first()).cancellable().collect { conversationDetails ->
+                    conversationDetails.fold({
+                        // conversation deleted
+                        endCallUseCase(calls.first())
+                    }, {
+                        if (it is ConversationDetails.Group) {
+                            // Not a member anymore
+                            if (!it.isSelfUserMember) {
+                                endCallUseCase(calls.first())
+                            }
+                        } else if (it is ConversationDetails.OneOne) {
+                            // Member blocked or deleted
+                            if (it.otherUser.deleted || it.otherUser.connectionStatus == ConnectionState.BLOCKED) {
+                                endCallUseCase(calls.first())
+                            }
+                        }
+                    })
+                }
+            }
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -1,0 +1,191 @@
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.OtherUser
+import com.wire.kalium.logic.data.user.UserAssetId
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallStatus
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.thenDoNothing
+import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class EndCallOnConversationChangeUseCaseTest {
+
+    @Mock
+    private val callRepository = mock(classOf<CallRepository>())
+
+    @Mock
+    private val conversationRepository = mock(classOf<ConversationRepository>())
+
+    @Mock
+    private val endCall = mock(classOf<EndCallUseCase>())
+
+    private lateinit var endCallOnConversationChange: EndCallOnConversationChangeUseCase
+
+    @BeforeTest
+    fun setup() {
+        endCallOnConversationChange = EndCallOnConversationChangeUseCaseImpl(
+            callRepository = callRepository,
+            conversationRepository = conversationRepository,
+            endCallUseCase = endCall
+        )
+
+        given(callRepository)
+            .suspendFunction(callRepository::establishedCallsFlow)
+            .whenInvoked()
+            .thenReturn(flowOf(listOf(call)))
+
+        given(endCall)
+            .suspendFunction(endCall::invoke)
+            .whenInvokedWith(eq(conversationId))
+            .thenDoNothing()
+    }
+
+    @Test
+    fun givenAnEstablishedCall_whenConversationIsDeleted_thenEndTheCurrentCall() = runTest {
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationDetailsById)
+            .whenInvokedWith(eq(conversationId))
+            .then {
+                flowOf(Either.Left(StorageFailure.DataNotFound))
+            }
+
+        endCallOnConversationChange()
+
+        verify(endCall)
+            .suspendFunction(endCall::invoke)
+            .with(eq(conversationId))
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenAnEstablishedCall_whenUserIsRemovedFromConversation_thenEndTheCurrentCall() = runTest {
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationDetailsById)
+            .whenInvokedWith(eq(conversationId))
+            .then {
+                flowOf(Either.Right(groupConversationDetail))
+            }
+
+        endCallOnConversationChange()
+
+        verify(endCall)
+            .suspendFunction(endCall::invoke)
+            .with(eq(conversationId))
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenAnEstablishedCall_whenUserDeletesHisAccount_thenEndTheCurrentCall() = runTest {
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeConversationDetailsById)
+            .whenInvokedWith(eq(conversationId))
+            .then {
+                flowOf(Either.Right(oneOnOneConversationDetail))
+            }
+
+        endCallOnConversationChange()
+
+        verify(endCall)
+            .suspendFunction(endCall::invoke)
+            .with(eq(conversationId))
+            .wasInvoked(once)
+    }
+
+    companion object {
+        val conversationId = ConversationId("conversationId", "domainId")
+        private val call = Call(
+            conversationId = conversationId,
+            status = CallStatus.ESTABLISHED,
+            callerId = "called-id",
+            isMuted = false,
+            isCameraOn = false,
+            isCbrEnabled = false,
+            conversationName = null,
+            conversationType = Conversation.Type.GROUP,
+            callerName = null,
+            callerTeamName = null,
+            establishedTime = null
+        )
+
+        val conversation = Conversation(
+            id = conversationId,
+            name = "Conv Name",
+            type = Conversation.Type.ONE_ON_ONE,
+            teamId = TeamId("team_id"),
+            protocol = Conversation.ProtocolInfo.Proteus,
+            mutedStatus = MutedConversationStatus.AllAllowed,
+            removedBy = null,
+            lastNotificationDate = null,
+            lastModifiedDate = null,
+            access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+            accessRole = Conversation.defaultGroupAccessRoles.toMutableList().apply { add(Conversation.AccessRole.GUEST) },
+            lastReadDate = "2022-04-04T16:11:28.388Z",
+            creatorId = null,
+            receiptMode = Conversation.ReceiptMode.ENABLED,
+            messageTimer = null,
+            userMessageTimer = null
+        )
+
+        val otherUser = OtherUser(
+            UserId(value = "otherValue", "domain"),
+            name = "otherUsername",
+            handle = "otherHandle",
+            email = "otherEmail",
+            phone = "otherPhone",
+            accentId = 0,
+            teamId = TeamId("otherTeamId"),
+            connectionStatus = ConnectionState.ACCEPTED,
+            previewPicture = UserAssetId("value", "domain"),
+            completePicture = UserAssetId("value", "domain"),
+            availabilityStatus = UserAvailabilityStatus.AVAILABLE,
+            userType = UserType.INTERNAL,
+            botService = null,
+            deleted = true
+        )
+
+        private val groupConversationDetail = ConversationDetails.Group(
+            conversation = conversation,
+            legalHoldStatus = LegalHoldStatus.ENABLED,
+            hasOngoingCall = true,
+            unreadEventCount = mapOf(),
+            lastMessage = null,
+            isSelfUserMember = false,
+            isSelfUserCreator = false,
+            selfRole = null
+        )
+
+        private val oneOnOneConversationDetail = ConversationDetails.OneOne(
+            conversation = conversation,
+            legalHoldStatus = LegalHoldStatus.ENABLED,
+            otherUser = otherUser,
+            unreadEventCount = mapOf(),
+            lastMessage = null,
+            userType = UserType.ADMIN
+        )
+    }
+}


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

This usecase will keep observing the  conversation details that is in active call TO END IT.

The call should be terminated when:
- User leaves that conversation
- User removed from that conversation
- That Conversation got removed
- User Delete his account

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
