### PR TITLE
fix: connection requests not appearing [WPB-3033]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -213,7 +213,7 @@ SELECT * FROM ConversationDetails
 WHERE type IS NOT 'SELF'
 AND (
     type IS 'GROUP' AND (name IS NOT NULL OR otherUserId IS NOT NULL) --filter deleted groups after first sync
-    OR (type IS 'ONE_ON_ONE' AND (name IS NOT NULL AND otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+    OR (type IS NOT 'GROUP' AND (name IS NOT NULL AND otherUserId IS NOT NULL)) -- show 1:1 convos and connection requests if they have user metadata
     OR (type IS 'ONE_ON_ONE' AND userDeleted = 1) -- show deleted 1:1 convos, to maintain prev, logic
 )
 AND (protocol IS 'PROTEUS' OR (protocol IS 'MLS' AND mls_group_state IS 'ESTABLISHED'))

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -38,7 +38,6 @@ import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newSystemMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
 import com.wire.kalium.util.DateTimeUtil
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -60,6 +59,7 @@ import kotlin.time.Duration.Companion.seconds
 class ConversationDAOTest : BaseDatabaseTest() {
 
     private lateinit var conversationDAO: ConversationDAO
+    private lateinit var connectionDAO: ConnectionDAO
     private lateinit var messageDAO: MessageDAO
     private lateinit var userDAO: UserDAO
     private lateinit var teamDAO: TeamDAO
@@ -72,6 +72,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         deleteDatabase(selfUserId)
         val db = createDatabase(selfUserId, encryptedDBSecret, enableWAL = true)
         conversationDAO = db.conversationDAO
+        connectionDAO = db.connectionDAO
         messageDAO = db.messageDAO
         userDAO = db.userDAO
         teamDAO = db.teamDAO
@@ -787,6 +788,56 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         conversationDAO.getAllConversations().first().forEach {
             assertEquals(instant.toEpochMilliseconds(), it.lastNotificationDate!!.toEpochMilliseconds())
+        }
+    }
+
+    @Test
+    fun givenConnectionRequestAndUserWithName_whenSelectingAllConversationDetails_thenShouldReturnConnectionRequest() = runTest {
+        val conversationId = QualifiedIDEntity("connection-conversationId", "domain")
+        val conversation = conversationEntity1.copy(id = conversationId, type = ConversationEntity.Type.CONNECTION_PENDING)
+        val connectionEntity = ConnectionEntity(
+            conversationId = conversationId.value,
+            from = selfUserId.value,
+            lastUpdateDate = Instant.DISTANT_PAST,
+            qualifiedConversationId = conversationId,
+            qualifiedToId = user1.id,
+            status = ConnectionEntity.State.PENDING,
+            toId = user1.id.value,
+        )
+
+        userDAO.insertUser(user1)
+        conversationDAO.insertConversation(conversation)
+        connectionDAO.insertConnection(connectionEntity)
+
+        conversationDAO.getAllConversationDetails().first().let {
+            assertEquals(1, it.size)
+            val result = it.first()
+
+            assertEquals(conversationId, result.id)
+            assertEquals(ConversationEntity.Type.CONNECTION_PENDING, result.type)
+        }
+    }
+
+    @Test
+    fun givenConnectionRequestAndUserWithoutName_whenSelectingAllConversationDetails_thenShouldReturnConnectionRequest() = runTest {
+        val conversationId = QualifiedIDEntity("connection-conversationId", "domain")
+        val conversation = conversationEntity1.copy(id = conversationId, type = ConversationEntity.Type.CONNECTION_PENDING)
+        val connectionEntity = ConnectionEntity(
+            conversationId = conversationId.value,
+            from = selfUserId.value,
+            lastUpdateDate = Instant.DISTANT_PAST,
+            qualifiedConversationId = conversationId,
+            qualifiedToId = user1.id,
+            status = ConnectionEntity.State.PENDING,
+            toId = user1.id.value,
+        )
+
+        userDAO.insertUser(user1.copy(name = null))
+        conversationDAO.insertConversation(conversation)
+        connectionDAO.insertConnection(connectionEntity)
+
+        conversationDAO.getAllConversationDetails().first().let {
+            assertEquals(0, it.size)
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Incoming connection requests are no longer visible to the user.

### Causes

Small refactoring introduced this bug recently.

### Solutions

Fix the query that fetches the conversation list. A small bug was introduced during rewriting where instead of checking for non-group, it was limiting only to one-on-one conversations, excluding connection requests.

Added test cases for connection requests to make sure this is cemented in place.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
