### PR TITLE
fix: testservice self deletion message timer was broken

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -227,6 +227,7 @@ class ConversationResources(private val instanceService: InstanceService) {
                     data,
                     fileName,
                     type,
+                    messageTimer,
                     invalidHash,
                     otherAlgorithm,
                     otherHash
@@ -249,7 +250,8 @@ class ConversationResources(private val instanceService: InstanceService) {
                     data,
                     type,
                     height,
-                    width
+                    width,
+                    messageTimer
                 )
             }
         }
@@ -363,7 +365,8 @@ class ConversationResources(private val instanceService: InstanceService) {
                     ConversationId(conversationId, conversationDomain),
                     text,
                     mentions,
-                    firstMessageId
+                    firstMessageId,
+                    messageTimer
                 )
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The PR #1765 broke the message timer by removing it from the testservice
https://github.com/wireapp/kalium/commit/02755bb4ae06540e5c3a12b52d9dc8d8881da9c7#diff-02b79a0c7124a72acb5e55b1578470e073aa3e6038a7b75c3d0ac9e0f7e9cdfbL164

Additionally the message timer did not work for files and images.

### Solutions

This PR adds the message timer function back and also adds it to image, file and update text endpoints.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
