### PR TITLE
feat: add timer to all message types

### DIFF
--- a/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidAndroidTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -148,7 +148,8 @@ class CallManagerTest {
             senderUserId = UserId(value = "value", domain = "domain"),
             senderClientId = ClientId(value = "value"),
             status = Message.Status.SENT,
-            isSelfMessage = false
+            isSelfMessage = false,
+            expirationData = null
         )
     }
 }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
@@ -120,7 +120,8 @@ internal class OnHttpRequest(
             senderUserId = userId,
             senderClientId = clientId,
             status = Message.Status.SENT,
-            isSelfMessage = true
+            isSelfMessage = true,
+            expirationData = null
         )
 
         return messageSender.sendMessage(message, messageTarget)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -347,7 +347,8 @@ internal class CallDataSource(
                 DateTimeUtil.currentIsoDateTimeString(),
                 qualifiedUserId,
                 Message.Status.SENT,
-                Message.Visibility.VISIBLE
+                Message.Visibility.VISIBLE,
+                expirationData = null,
             )
             persistMessage(message)
         } ?: callingLogger.i("[CallRepository] -> Unable to persist Missed Call due to missing Caller ID")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewConversationMembersRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewConversationMembersRepository.kt
@@ -70,7 +70,8 @@ internal class NewConversationMembersRepositoryImpl(
                     DateTimeUtil.currentIsoDateTimeString(),
                     selfUserId,
                     Message.Status.SENT,
-                    Message.Visibility.VISIBLE
+                    Message.Visibility.VISIBLE,
+                    expirationData = null
                 )
                 persistMessage(messageStartedWithMembers)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationStartedMessageCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationStartedMessageCreator.kt
@@ -53,7 +53,8 @@ internal class NewGroupConversationStartedMessageCreatorImpl(
                 DateTimeUtil.currentIsoDateTimeString(),
                 selfUserId,
                 Message.Status.SENT,
-                Message.Visibility.VISIBLE
+                Message.Visibility.VISIBLE,
+                expirationData = null
             )
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -38,6 +38,7 @@ sealed interface Message {
     val date: String
     val senderUserId: UserId
     val status: Status
+    val expirationData: ExpirationData?
 
     /**
      * Messages that can be sent from one client to another.
@@ -78,7 +79,7 @@ sealed interface Message {
         override val isSelfMessage: Boolean,
         override val senderClientId: ClientId,
         val editStatus: EditStatus,
-        val expirationData: ExpirationData? = null,
+        override val expirationData: ExpirationData? = null,
         val reactions: Reactions = Reactions.EMPTY,
         val expectsReadConfirmation: Boolean = false
     ) : Sendable, Standalone {
@@ -152,6 +153,7 @@ sealed interface Message {
         override val status: Status,
         override val senderUserName: String? = null,
         override val isSelfMessage: Boolean,
+        override val expirationData: ExpirationData?
     ) : Sendable {
         override fun toLogString(): String {
             val typeKey = "type"
@@ -232,9 +234,10 @@ sealed interface Message {
         override val senderUserId: UserId,
         override val status: Status,
         override val visibility: Visibility = Visibility.VISIBLE,
+        override val expirationData: ExpirationData?,
         // TODO(refactor): move senderName to inside the specific `content`
         //                 instead of having it nullable in all system messages
-        val senderUserName: String? = null,
+        val senderUserName: String? = null
     ) : Message, Standalone {
         fun toLogString(): String {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -101,6 +101,13 @@ class MessageMapperImpl(
                 status = status,
                 visibility = visibility,
                 senderName = message.senderUserName,
+                expireAfterMs = message.expirationData?.let { it.expireAfter.inWholeMilliseconds },
+                selfDeletionStartDate = message.expirationData?.let {
+                    when (val status = it.selfDeletionStatus) {
+                        is Message.ExpirationData.SelfDeletionStatus.Started -> status.selfDeletionStartDate
+                        is Message.ExpirationData.SelfDeletionStatus.NotStarted -> null
+                    }
+                },
             )
         }
     }
@@ -150,6 +157,13 @@ class MessageMapperImpl(
                 status = status,
                 visibility = message.visibility.toModel(),
                 senderUserName = message.senderName,
+                expirationData = message.expireAfterMs?.let {
+                    Message.ExpirationData(
+                        expireAfter = it.toDuration(DurationUnit.MILLISECONDS),
+                        selfDeletionStatus = message.selfDeletionStartDate
+                            ?.let { Message.ExpirationData.SelfDeletionStatus.Started(it) }
+                            ?: Message.ExpirationData.SelfDeletionStatus.NotStarted)
+                }
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -142,9 +142,27 @@ class ProtoContentMapperImpl(
                 )
             }
 
-            else -> {
-                throw IllegalArgumentException("Unexpected message content type for ephemeral message: ${readableContent.getType()}")
+            is MessageContent.Knock -> {
+                val knock = GenericMessage.Content.Knock(Knock(hotKnock = readableContent.hotKnock))
+                Ephemeral.Content.Knock(knock.value)
             }
+
+            is MessageContent.FailedDecryption,
+            is MessageContent.RestrictedAsset,
+            is MessageContent.Unknown,
+            is MessageContent.Availability,
+            is MessageContent.Calling,
+            is MessageContent.Cleared,
+            MessageContent.ClientAction,
+            is MessageContent.DeleteForMe,
+            is MessageContent.DeleteMessage,
+            MessageContent.Ignored,
+            is MessageContent.LastRead,
+            is MessageContent.Reaction,
+            is MessageContent.Receipt,
+            is MessageContent.TextEdited -> throw IllegalArgumentException(
+                "Unexpected message content type: ${readableContent.getType()}"
+            )
         }
         return GenericMessage.Content.Ephemeral(Ephemeral(expireAfterMillis = expireAfterMillis, content = ephemeralContent))
     }
@@ -216,7 +234,9 @@ class ProtoContentMapperImpl(
             is GenericMessage.Content.LastRead -> unpackLastRead(genericMessage, protoContent)
             is GenericMessage.Content.Location -> MessageContent.Unknown(typeName, encodedContent.data)
             is GenericMessage.Content.Reaction -> unpackReaction(protoContent)
-            else -> {
+
+            is GenericMessage.Content.External,
+            null -> {
                 kaliumLogger.w("Null content when parsing protobuf. Message UUID = ${genericMessage.messageId.obfuscateId()}")
                 MessageContent.Ignored
             }
@@ -355,7 +375,7 @@ class ProtoContentMapperImpl(
             }
 
             null -> {
-                kaliumLogger.w("Edit content is unexpected. Message UUID = $genericMessage.")
+                kaliumLogger.w("Edit content is unexpected. Message UUID = ${genericMessage.messageId.obfuscateId()}")
                 MessageContent.Ignored
             }
         }
@@ -448,8 +468,16 @@ class ProtoContentMapperImpl(
                 unpackAsset(genericAssetContent)
             }
 
+            is Ephemeral.Content.Knock -> {
+                MessageContent.Knock(
+                    ephemeralContent.value.hotKnock
+                )
+            }
+
             // Handle self-deleting Location messages when they are implemented
-            else -> {
+            is Ephemeral.Content.Image,
+            is Ephemeral.Content.Location,
+            null -> {
                 MessageContent.Ignored
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -235,7 +235,10 @@ class ProtoContentMapperImpl(
             is GenericMessage.Content.Location -> MessageContent.Unknown(typeName, encodedContent.data)
             is GenericMessage.Content.Reaction -> unpackReaction(protoContent)
 
-            is GenericMessage.Content.External,
+            is GenericMessage.Content.External -> {
+                kaliumLogger.w("External content when parsing protobuf. Message UUID = ${genericMessage.messageId.obfuscateId()}")
+                MessageContent.Ignored
+            }
             null -> {
                 kaliumLogger.w("Null content when parsing protobuf. Message UUID = ${genericMessage.messageId.obfuscateId()}")
                 MessageContent.Ignored

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase.kt
@@ -73,7 +73,8 @@ internal class ClearConversationContentUseCaseImpl(
                             senderUserId = selfUserId,
                             senderClientId = currentClientId,
                             status = Message.Status.PENDING,
-                            isSelfMessage = true
+                            isSelfMessage = true,
+                            expirationData = null
                         )
                         messageSender.sendMessage(regularMessage)
                     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CreateGroupConversationUseCase.kt
@@ -96,7 +96,8 @@ class CreateGroupConversationUseCase internal constructor(
                 DateTimeUtil.currentIsoDateTimeString(),
                 selfUserId,
                 Message.Status.SENT,
-                Message.Visibility.VISIBLE
+                Message.Visibility.VISIBLE,
+                expirationData = null
             )
 
             persistMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -91,7 +91,8 @@ class UpdateConversationReadDateUseCase internal constructor(
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
-                isSelfMessage = true
+                isSelfMessage = true,
+                expirationData = null
             )
             messageSender.sendMessage(regularMessage)
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReceiptModeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReceiptModeUseCase.kt
@@ -78,7 +78,8 @@ internal class UpdateConversationReceiptModeUseCaseImpl(
             DateTimeUtil.currentIsoDateTimeString(),
             selfUserId,
             Message.Status.SENT,
-            Message.Visibility.VISIBLE
+            Message.Visibility.VISIBLE,
+            expirationData = null
         )
 
         persistMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/messagetimer/UpdateMessageTimerUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/messagetimer/UpdateMessageTimerUseCase.kt
@@ -58,7 +58,8 @@ class UpdateMessageTimerUseCaseImpl internal constructor(
                     DateTimeUtil.currentIsoDateTimeString(),
                     selfUserId,
                     Message.Status.SENT,
-                    Message.Visibility.VISIBLE
+                    Message.Visibility.VISIBLE,
+                    expirationData = null
                 )
                 persistMessage(message)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -161,5 +161,6 @@ class DebugScope internal constructor(
             messageRepository = messageRepository,
             deleteEphemeralMessageForSelfUserAsReceiver = deleteEphemeralMessageForSelfUserAsReceiver,
             deleteEphemeralMessageForSelfUserAsSender = deleteEphemeralMessageForSelfUserAsSender,
+            selfUserId = userId
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
@@ -70,7 +70,8 @@ class SendConfirmationUseCase internal constructor(
                 senderUserId = selfUser.id,
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
-                isSelfMessage = true
+                isSelfMessage = true,
+                expirationData = null
             )
             messageSender.sendMessage(message)
         }.onFailure {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -50,6 +50,7 @@ class AddSystemMessageToAllConversationsUseCaseImpl internal constructor(
             date = DateTimeUtil.currentIsoDateTimeString(),
             senderUserId = selfUserId,
             status = Message.Status.SENT,
+            expirationData = null
         )
         messageRepository.persistSystemMessageToAllConversations(message)
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -90,7 +90,8 @@ class DeleteMessageUseCase internal constructor(
                                     senderUserId = selfUserId,
                                     senderClientId = currentClientId,
                                     status = Message.Status.PENDING,
-                                    isSelfMessage = true
+                                    isSelfMessage = true,
+                                    expirationData = null
                                 )
                                 messageSender.sendMessage(regularMessage)
                             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreator.kt
@@ -84,7 +84,7 @@ class MessageEnvelopeCreatorImpl(
             messageUid = message.id,
             messageContent = message.content,
             expectsReadConfirmation = expectsReadConfirmation,
-            expiresAfterMillis = (message as? Message.Regular)?.expirationData?.expireAfter?.inWholeMilliseconds
+            expiresAfterMillis = message.expirationData?.expireAfter?.inWholeMilliseconds
         )
 
         return createEnvelope(actualMessageContent, recipients, senderClientId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -120,6 +120,7 @@ class MessageScope internal constructor(
             messageRepository = messageRepository,
             deleteEphemeralMessageForSelfUserAsReceiver = deleteEphemeralMessageForSelfUserAsReceiver,
             deleteEphemeralMessageForSelfUserAsSender = deleteEphemeralMessageForSelfUserAsSender,
+            selfUserId = selfUserId
         )
 
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -229,8 +229,8 @@ internal class MessageSenderImpl internal constructor(
     }
 
     private fun startSelfDeletionIfNeeded(message: Message.Sendable) {
-        if (message.expirationData != null) {
-            enqueueSelfDeletion(message, message.expirationData!!)
+        message.expirationData?.let { expirationData ->
+            enqueueSelfDeletion(message, expirationData)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -131,7 +131,7 @@ internal class MessageSenderImpl internal constructor(
     private val mlsMessageCreator: MLSMessageCreator,
     private val messageSendingInterceptor: MessageSendingInterceptor,
     private val userRepository: UserRepository,
-    private val enqueueSelfDeletion: (Message.Regular, Message.ExpirationData) -> Unit,
+    private val enqueueSelfDeletion: (Message, Message.ExpirationData) -> Unit,
     private val scope: CoroutineScope
 ) : MessageSender {
 
@@ -229,8 +229,8 @@ internal class MessageSenderImpl internal constructor(
     }
 
     private fun startSelfDeletionIfNeeded(message: Message.Sendable) {
-        if (message is Message.Regular && message.expirationData != null) {
-            enqueueSelfDeletion(message, message.expirationData)
+        if (message.expirationData != null) {
+            enqueueSelfDeletion(message, message.expirationData!!)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
@@ -126,7 +126,8 @@ class RetryFailedMessageUseCase internal constructor(
                     senderUserId = message.senderUserId,
                     senderClientId = message.senderClientId,
                     status = Message.Status.PENDING,
-                    isSelfMessage = true
+                    isSelfMessage = true,
+                    expirationData = null
                 )
                 retrySendingMessage(editMessage)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCase.kt
@@ -88,7 +88,8 @@ internal class SendConfirmationUseCase internal constructor(
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
-                isSelfMessage = true
+                isSelfMessage = true,
+                expirationData = null
             )
 
             messageSender.sendMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
@@ -90,7 +90,8 @@ class SendEditTextMessageUseCase internal constructor(
                 senderUserId = selfUserId,
                 senderClientId = clientId,
                 status = Message.Status.PENDING,
-                isSelfMessage = true
+                isSelfMessage = true,
+                expirationData = null
             )
             // until the edit send is completed and accepted by the backend, we don't change the message id to be able to handle any
             // incoming edits from other clients that happened in the meantime and already changed the message id

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionResetSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionResetSender.kt
@@ -68,7 +68,8 @@ class SessionResetSenderImpl internal constructor(
                 senderUserId = selfUserId,
                 senderClientId = selfClientId,
                 status = Message.Status.SENT,
-                isSelfMessage = true
+                isSelfMessage = true,
+                expirationData = null
             )
             val recipient = Recipient(userId, listOf(clientId))
             messageSender.sendMessage(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
@@ -114,7 +114,8 @@ class ToggleReactionUseCase internal constructor(
                     senderUserId = userId,
                     senderClientId = clientId,
                     status = Message.Status.PENDING,
-                    isSelfMessage = true
+                    isSelfMessage = true,
+                    expirationData = null
                 )
                 messageSender.sendMessage(regularMessage)
             }
@@ -141,7 +142,8 @@ class ToggleReactionUseCase internal constructor(
                     senderUserId = userId,
                     senderClientId = clientId,
                     status = Message.Status.PENDING,
-                    isSelfMessage = true
+                    isSelfMessage = true,
+                    expirationData = null
                 )
                 messageSender.sendMessage(regularMessage)
             }.flatMapLeft {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
@@ -101,7 +101,8 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
-                isSelfMessage = true
+                isSelfMessage = true,
+                expirationData = null
             ).let { deleteSignalingMessage ->
                 messageSender.sendMessage(deleteSignalingMessage, MessageTarget.Conversation)
             }
@@ -121,7 +122,8 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
         senderUserId = selfUserId,
         senderClientId = currentClientId,
         status = Message.Status.PENDING,
-        isSelfMessage = true
+        isSelfMessage = true,
+        expirationData = null
     ).let { deleteSignalingMessage ->
         messageSender.sendMessage(
             deleteSignalingMessage,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.message.ephemeral
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
@@ -20,12 +21,13 @@ import kotlin.coroutines.CoroutineContext
 internal interface EphemeralMessageDeletionHandler {
 
     fun startSelfDeletion(conversationId: ConversationId, messageId: String)
-    fun enqueueSelfDeletion(message: Message.Regular, expirationData: Message.ExpirationData)
-    fun enqueuePendingSelfDeletionMessages()
+    fun enqueueSelfDeletion(message: Message, expirationData: Message.ExpirationData)
+    suspend fun enqueuePendingSelfDeletionMessages()
 }
 
 internal class EphemeralMessageDeletionHandlerImpl(
     private val messageRepository: MessageRepository,
+    private val selfUserId: UserId,
     private val kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl,
     private val deleteEphemeralMessageForSelfUserAsReceiver: DeleteEphemeralMessageForSelfUserAsReceiverUseCase,
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCase,
@@ -39,10 +41,10 @@ internal class EphemeralMessageDeletionHandlerImpl(
     override fun startSelfDeletion(conversationId: ConversationId, messageId: String) {
         launch {
             messageRepository.getMessageById(conversationId, messageId).map { message ->
-                if (message is Message.Regular && message.expirationData != null && message.status != Message.Status.PENDING) {
+                if (message.expirationData != null && message.status != Message.Status.PENDING) {
                     enqueueSelfDeletion(
                         message = message,
-                        expirationData = message.expirationData
+                        expirationData = message.expirationData!!
                     )
                 } else {
                     kaliumLogger.i(
@@ -53,7 +55,7 @@ internal class EphemeralMessageDeletionHandlerImpl(
         }
     }
 
-    override fun enqueueSelfDeletion(message: Message.Regular, expirationData: Message.ExpirationData) {
+    override fun enqueueSelfDeletion(message: Message, expirationData: Message.ExpirationData) {
         SelfDeletionEventLogger.log(
             LoggingSelfDeletionEvent.InvalidMessageStatus(
                 message,
@@ -89,10 +91,10 @@ internal class EphemeralMessageDeletionHandlerImpl(
         }
     }
 
-    private suspend fun deleteMessage(message: Message.Regular, expirationData: Message.ExpirationData) {
+    private suspend fun deleteMessage(message: Message, expirationData: Message.ExpirationData) {
         removeFromOutgoingDeletion(message)
 
-        if (message.isSelfMessage) {
+        if (message.senderUserId == selfUserId) {
             SelfDeletionEventLogger.log(
                 LoggingSelfDeletionEvent.AttemptingToDelete(
                     message,
@@ -151,13 +153,13 @@ internal class EphemeralMessageDeletionHandlerImpl(
         }
     }
 
-    private suspend fun removeFromOutgoingDeletion(message: Message.Regular) {
+    private suspend fun removeFromOutgoingDeletion(message: Message) {
         ongoingSelfDeletionMessagesMutex.withLock {
             ongoingSelfDeletionMessages - message.conversationId to message.id
         }
     }
 
-    private suspend fun markDeletionDateAndWait(message: Message.Regular, expirationData: Message.ExpirationData) {
+    private suspend fun markDeletionDateAndWait(message: Message, expirationData: Message.ExpirationData) {
         with(expirationData) {
             if (selfDeletionStatus is Message.ExpirationData.SelfDeletionStatus.NotStarted) {
                 SelfDeletionEventLogger.log(
@@ -198,23 +200,21 @@ internal class EphemeralMessageDeletionHandlerImpl(
         }
     }
 
-    private fun addToOutgoingDeletion(message: Message.Regular) {
+    private fun addToOutgoingDeletion(message: Message) {
         ongoingSelfDeletionMessages[message.conversationId to message.id] = Unit
     }
 
-    override fun enqueuePendingSelfDeletionMessages() {
-        launch {
-            messageRepository.getEphemeralMessagesMarkedForDeletion()
-                .onSuccess { ephemeralMessages ->
-                    ephemeralMessages.forEach { ephemeralMessage ->
-                        if (ephemeralMessage is Message.Regular && ephemeralMessage.expirationData != null) {
-                            enqueueSelfDeletion(
-                                message = ephemeralMessage,
-                                expirationData = ephemeralMessage.expirationData
-                            )
-                        }
+    override suspend fun enqueuePendingSelfDeletionMessages() {
+        messageRepository.getEphemeralMessagesMarkedForDeletion()
+            .onSuccess { ephemeralMessages ->
+                ephemeralMessages.forEach { ephemeralMessage ->
+                    if (ephemeralMessage.expirationData != null) {
+                        enqueueSelfDeletion(
+                            message = ephemeralMessage,
+                            expirationData = ephemeralMessage.expirationData!!
+                        )
                     }
                 }
-        }
+            }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
@@ -209,10 +209,10 @@ internal class EphemeralMessageDeletionHandlerImpl(
         messageRepository.getEphemeralMessagesMarkedForDeletion()
             .onSuccess { ephemeralMessages ->
                 ephemeralMessages.forEach { ephemeralMessage ->
-                    if (ephemeralMessage.expirationData != null) {
+                    ephemeralMessage.expirationData?.let { expirationData ->
                         enqueueSelfDeletion(
                             message = ephemeralMessage,
-                            expirationData = ephemeralMessage.expirationData!!
+                            expirationData = expirationData
                         )
                     }
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandler.kt
@@ -3,6 +3,7 @@ package com.wire.kalium.logic.feature.message.ephemeral
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.getType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
@@ -48,7 +49,7 @@ internal class EphemeralMessageDeletionHandlerImpl(
                     )
                 } else {
                     kaliumLogger.i(
-                        "Self deletion requested for message without expiration data or a system message: $message"
+                        "Self deletion requested for message without expiration data: ${message.content.getType()}"
                     )
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger .kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger .kt
@@ -34,7 +34,7 @@ internal object SelfDeletionEventLogger {
 }
 
 internal sealed class LoggingSelfDeletionEvent(
-    open val message: Message.Regular,
+    open val message: Message,
     open val expirationData: Message.ExpirationData
 ) {
     private companion object {
@@ -61,7 +61,7 @@ internal sealed class LoggingSelfDeletionEvent(
     }
 
     data class SelfSelfDeletionAlreadyRequested(
-        override val message: Message.Regular,
+        override val message: Message,
         override val expirationData: Message.ExpirationData
     ) : LoggingSelfDeletionEvent(message, expirationData) {
         override fun eventJsonMap(): Map<String, String> {
@@ -72,7 +72,7 @@ internal sealed class LoggingSelfDeletionEvent(
     }
 
     data class MarkingSelfSelfDeletionStartDate(
-        override val message: Message.Regular,
+        override val message: Message,
         override val expirationData: Message.ExpirationData,
         val startDate: Instant
     ) : LoggingSelfDeletionEvent(message, expirationData) {
@@ -85,7 +85,7 @@ internal sealed class LoggingSelfDeletionEvent(
     }
 
     data class WaitingForSelfDeletion(
-        override val message: Message.Regular,
+        override val message: Message,
         override val expirationData: Message.ExpirationData,
         val delayWaitTime: Duration
     ) : LoggingSelfDeletionEvent(message, expirationData) {
@@ -98,7 +98,7 @@ internal sealed class LoggingSelfDeletionEvent(
     }
 
     data class StartingSelfSelfDeletion(
-        override val message: Message.Regular,
+        override val message: Message,
         override val expirationData: Message.ExpirationData,
     ) : LoggingSelfDeletionEvent(message, expirationData) {
         override fun eventJsonMap(): Map<String, String> {
@@ -109,49 +109,49 @@ internal sealed class LoggingSelfDeletionEvent(
     }
 
     data class AttemptingToDelete(
-        override val message: Message.Regular,
+        override val message: Message,
         override val expirationData: Message.ExpirationData
     ) : LoggingSelfDeletionEvent(message, expirationData) {
         override fun eventJsonMap(): Map<String, String> {
             return mapOf(
-                "deletion-status" to "attempting-to-delete",
-                "is-self-user-sender" to message.isSelfMessage.toString()
+                "deletion-status" to "attempting-to-delete"
+                //"is-self-user-sender" to message.isSelfMessage.toString()
             )
         }
     }
 
     data class SuccessfullyDeleted(
-        override val message: Message.Regular,
+        override val message: Message,
         override val expirationData: Message.ExpirationData,
     ) : LoggingSelfDeletionEvent(message, expirationData) {
         override fun eventJsonMap(): Map<String, String> {
             return mapOf(
                 "deletion-status" to "self-deletion-succeed",
-                "is-self-user-sender" to message.isSelfMessage.toString()
+               // "is-self-user-sender" to message.isSelfMessage.toString()
             )
         }
     }
 
     data class InvalidMessageStatus(
-        override val message: Message.Regular,
+        override val message: Message,
         override val expirationData: Message.ExpirationData
     ) : LoggingSelfDeletionEvent(message, expirationData) {
         override fun eventJsonMap(): Map<String, String> {
             return mapOf(
-                "deletion-status" to "invalid-message-status",
-                "is-self-user-sender" to message.isSelfMessage.toString(),
+                "deletion-status" to "invalid-message-status"
+                //"is-self-user-sender" to ,
             )
         }
     }
     data class SelfDeletionFailed(
-        override val message: Message.Regular,
+        override val message: Message,
         override val expirationData: Message.ExpirationData,
         val coreFailure: CoreFailure
     ) : LoggingSelfDeletionEvent(message, expirationData) {
         override fun eventJsonMap(): Map<String, String> {
             return mapOf(
                 "deletion-status" to "self-deletion-failed",
-                "is-self-user-sender" to message.isSelfMessage.toString(),
+                //"is-self-user-sender" to message.isSelfMessage.toString(),
                 "reason" to coreFailure.toString()
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger .kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger .kt
@@ -115,7 +115,6 @@ internal sealed class LoggingSelfDeletionEvent(
         override fun eventJsonMap(): Map<String, String> {
             return mapOf(
                 "deletion-status" to "attempting-to-delete"
-                //"is-self-user-sender" to message.isSelfMessage.toString()
             )
         }
     }
@@ -127,7 +126,6 @@ internal sealed class LoggingSelfDeletionEvent(
         override fun eventJsonMap(): Map<String, String> {
             return mapOf(
                 "deletion-status" to "self-deletion-succeed",
-               // "is-self-user-sender" to message.isSelfMessage.toString()
             )
         }
     }
@@ -139,10 +137,10 @@ internal sealed class LoggingSelfDeletionEvent(
         override fun eventJsonMap(): Map<String, String> {
             return mapOf(
                 "deletion-status" to "invalid-message-status"
-                //"is-self-user-sender" to ,
             )
         }
     }
+
     data class SelfDeletionFailed(
         override val message: Message,
         override val expirationData: Message.ExpirationData,
@@ -151,7 +149,6 @@ internal sealed class LoggingSelfDeletionEvent(
         override fun eventJsonMap(): Map<String, String> {
             return mapOf(
                 "deletion-status" to "self-deletion-failed",
-                //"is-self-user-sender" to message.isSelfMessage.toString(),
                 "reason" to coreFailure.toString()
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
@@ -95,7 +95,8 @@ internal class TeamEventReceiverImpl(
                                     date = event.timestampIso,
                                     senderUserId = userId,
                                     status = Message.Status.SENT,
-                                    visibility = Message.Visibility.VISIBLE
+                                    visibility = Message.Visibility.VISIBLE,
+                                    expirationData = null
                                 )
                                 persistMessage(message)
                             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandler.kt
@@ -54,7 +54,8 @@ internal class ConversationMessageTimerEventHandlerImpl(
                     DateTimeUtil.currentIsoDateTimeString(),
                     event.senderUserId,
                     Message.Status.SENT,
-                    Message.Visibility.VISIBLE
+                    Message.Visibility.VISIBLE,
+                    expirationData = null
                 )
 
                 persistMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -74,7 +74,8 @@ internal class MemberJoinEventHandlerImpl(
                     date = event.timestampIso,
                     senderUserId = event.addedBy,
                     status = Message.Status.SENT,
-                    visibility = Message.Visibility.VISIBLE
+                    visibility = Message.Visibility.VISIBLE,
+                    expirationData = null
                 )
                 persistMessage(message)
                 kaliumLogger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandler.kt
@@ -64,7 +64,8 @@ internal class MemberLeaveEventHandlerImpl(
                     date = event.timestampIso,
                     senderUserId = event.removedBy,
                     status = Message.Status.SENT,
-                    visibility = Message.Visibility.VISIBLE
+                    visibility = Message.Visibility.VISIBLE,
+                    expirationData = null
                 )
                 persistMessage(message)
                 kaliumLogger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -75,7 +75,8 @@ internal class NewConversationEventHandlerImpl(
                     DateTimeUtil.currentIsoDateTimeString(),
                     qualifiedIdMapper.fromStringToQualifiedID(event.conversation.creator),
                     Message.Status.SENT,
-                    Message.Visibility.VISIBLE
+                    Message.Visibility.VISIBLE,
+                    expirationData = null
                 )
                 persistMessage(message)
                 kaliumLogger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
@@ -61,7 +61,8 @@ internal class ReceiptModeUpdateEventHandlerImpl(
                     DateTimeUtil.currentIsoDateTimeString(),
                     event.senderUserId,
                     Message.Status.SENT,
-                    Message.Visibility.VISIBLE
+                    Message.Visibility.VISIBLE,
+                    expirationData = null
                 )
 
                 persistMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandler.kt
@@ -53,6 +53,7 @@ internal class RenamedConversationEventHandlerImpl(
                     date = event.timestampIso,
                     senderUserId = event.senderUserId,
                     status = Message.Status.SENT,
+                    expirationData = null
                 )
                 persistMessage(message)
                 logger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -143,7 +143,13 @@ internal class ApplicationMessageHandlerImpl(
                     senderUserId = senderUserId,
                     senderClientId = senderClientId,
                     status = Message.Status.SENT,
-                    isSelfMessage = senderUserId == selfUserId
+                    isSelfMessage = senderUserId == selfUserId,
+                    expirationData = content.expiresAfterMillis?.let {
+                        Message.ExpirationData(
+                            expireAfter = it.toDuration(DurationUnit.MILLISECONDS),
+                            selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.NotStarted
+                        )
+                    }
                 )
                 processSignaling(signalingMessage)
             }
@@ -171,7 +177,8 @@ internal class ApplicationMessageHandlerImpl(
                     date = signaling.date,
                     senderUserId = signaling.senderUserId,
                     status = signaling.status,
-                    senderUserName = signaling.senderUserName
+                    senderUserName = signaling.senderUserName,
+                    expirationData = null
                 )
 
                 logger.i(message = "Persisting crypto session reset system message..")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -463,7 +463,8 @@ class GetNotificationsUseCaseTest {
                 conversationId = conversationId,
                 date = "some_time",
                 senderUserId = senderId,
-                status = Message.Status.SENT
+                status = Message.Status.SENT,
+                expirationData = null
             )
 
         private fun notificationMessageText(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -355,7 +355,8 @@ class MessageSenderTest {
             senderUserId = UserId("userValue", "userDomain"),
             senderClientId = ClientId("clientId"),
             status = Message.Status.SENT,
-            isSelfMessage = false
+            isSelfMessage = false,
+            expirationData = null
         )
 
         val messageTarget = MessageTarget.Client(
@@ -407,7 +408,8 @@ class MessageSenderTest {
             senderUserId = UserId("userValue", "userDomain"),
             senderClientId = ClientId("clientId"),
             status = Message.Status.SENT,
-            isSelfMessage = false
+            isSelfMessage = true,
+            expirationData = null
         )
 
         val messageTarget = MessageTarget.Conversation
@@ -655,7 +657,8 @@ class MessageSenderTest {
             senderUserId = UserId("userValue", "userDomain"),
             senderClientId = ClientId("clientId"),
             status = Message.Status.PENDING,
-            isSelfMessage = false
+            isSelfMessage = false,
+            expirationData = null
         )
 
         arrangement.testScope.runTest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
@@ -71,6 +71,7 @@ object TestMessage {
         date = TEST_DATE_STRING,
         senderUserId = TEST_SENDER_USER_ID,
         status = Message.Status.PENDING,
+        expirationData = null
     )
 
     fun assetMessage(assetId: String = TEST_MESSAGE_ID) = Message.Regular(
@@ -118,6 +119,7 @@ object TestMessage {
         senderUserId = TEST_SENDER_USER_ID,
         senderClientId = TEST_SENDER_CLIENT_ID,
         status = Message.Status.SENT,
-        isSelfMessage = false
+        isSelfMessage = false,
+        expirationData = null
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
@@ -142,7 +142,8 @@ class ReceiptMessageHandlerTest {
                 senderUserId = senderUserId,
                 senderClientId = ClientId("SomeClientId"),
                 status = Message.Status.SENT,
-                isSelfMessage = false
+                isSelfMessage = false,
+                expirationData = null
             ),
             messageContent = content
         )

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -28,16 +28,18 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Suppress("LongParameterList")
-sealed class MessageEntity(
-    open val id: String,
-    open val content: MessageEntityContent,
-    open val conversationId: QualifiedIDEntity,
-    open val date: Instant,
-    open val senderUserId: QualifiedIDEntity,
-    open val status: Status,
-    open val visibility: Visibility,
-    open val isSelfMessage: Boolean,
-) {
+sealed interface MessageEntity {
+    val id: String
+    val content: MessageEntityContent
+    val conversationId: QualifiedIDEntity
+    val date: Instant
+    val senderUserId: QualifiedIDEntity
+    val status: Status
+    val visibility: Visibility
+    val isSelfMessage: Boolean
+    val expireAfterMs: Long?
+    val selfDeletionStartDate: Instant?
+
     data class Regular(
         override val id: String,
         override val conversationId: QualifiedIDEntity,
@@ -47,23 +49,14 @@ sealed class MessageEntity(
         override val visibility: Visibility = Visibility.VISIBLE,
         override val content: MessageEntityContent.Regular,
         override val isSelfMessage: Boolean = false,
+        override val expireAfterMs: Long? = null,
+        override val selfDeletionStartDate: Instant? = null,
         val senderName: String?,
         val senderClientId: String,
         val editStatus: EditStatus,
-        val expireAfterMs: Long? = null,
-        val selfDeletionStartDate: Instant? = null,
         val reactions: ReactionsEntity = ReactionsEntity.EMPTY,
         val expectsReadConfirmation: Boolean = false
-    ) : MessageEntity(
-        id = id,
-        content = content,
-        conversationId = conversationId,
-        date = date,
-        senderUserId = senderUserId,
-        status = status,
-        visibility = visibility,
-        isSelfMessage = isSelfMessage
-    )
+    ) : MessageEntity
 
     data class System(
         override val id: String,
@@ -72,19 +65,12 @@ sealed class MessageEntity(
         override val date: Instant,
         override val senderUserId: QualifiedIDEntity,
         override val status: Status,
+        override val expireAfterMs: Long?,
+        override val selfDeletionStartDate: Instant?,
         override val visibility: Visibility = Visibility.VISIBLE,
         override val isSelfMessage: Boolean = false,
         val senderName: String?,
-    ) : MessageEntity(
-        id = id,
-        content = content,
-        conversationId = conversationId,
-        date = date,
-        senderUserId = senderUserId,
-        status = status,
-        visibility = visibility,
-        isSelfMessage = isSelfMessage
-    )
+    ) : MessageEntity
 
     enum class Status {
         /**

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -325,7 +325,9 @@ object MessageMapper {
             status = status,
             visibility = visibility,
             senderName = senderName,
-            isSelfMessage = isSelfMessage
+            isSelfMessage = isSelfMessage,
+            expireAfterMs = expireAfterMillis,
+            selfDeletionStartDate = selfDeletionStartDate
         )
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
@@ -220,7 +220,9 @@ class UserDatabaseDataGenerator(
                     senderUserId = senderUser.id,
                     status = MessageEntity.Status.values()[index % MessageEntity.Status.values().size],
                     visibility = sanitizedVisibility,
-                    senderName = "$messagePrefix SenderName"
+                    senderName = "$messagePrefix SenderName",
+                    expireAfterMs = null,
+                    selfDeletionStartDate = null
                 )
             )
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
@@ -71,5 +71,7 @@ fun newSystemMessageEntity(
     senderUserId = senderUserId,
     status = status,
     visibility = visibility,
-    senderName = "senderName"
+    senderName = "senderName",
+    expireAfterMs = null,
+    selfDeletionStartDate = null
 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

atm message timer is only applicable to Text and Asset Messages.

### Solutions

1. when mapping from proto Text, Asset, Location, Knock and Image message content have a timer. And since the message timer value in the DB is applicable to all message types.
2. map knock messages from ephemeral content.
3. remove any type check when queuing ephemeral messages  

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
