### PR TITLE
refactor: move reaction logic [WPB-826]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCase.kt
@@ -42,12 +42,22 @@ internal class PersistReactionUseCaseImpl(
         senderUserId: UserId,
         date: String
     ): Either<CoreFailure, Unit> {
+        val emojiSet = reaction.emojiSet.map {
+            // If we receive the heavy black heart unicode, we convert it to the emoji version.
+            // This is a compatibility layer, so we properly handle reactions sent from older clients
+            // This does not cover the fact that we send the new emoji to older clients.
+            if (it == "❤") { // \u2764
+                "❤️" // \u2764\ufe0f (heavy black heart + variation selector 16)
+            } else {
+                it
+            }
+        }.toSet()
         return reactionRepository.updateReaction(
             reaction.messageId,
             conversationId,
             senderUserId,
             date,
-            reaction.emojiSet
+            emojiSet
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -266,13 +266,7 @@ class ProtoContentMapperImpl(
     private fun unpackReaction(protoContent: GenericMessage.Content.Reaction): MessageContent.Reaction {
         val emoji = protoContent.value.emoji
         val emojiSet = emoji?.split(',')
-            ?.map {
-                it.trim().let { trimmedReaction ->
-                    if (trimmedReaction == "❤️") {
-                        "❤"
-                    } else trimmedReaction
-                }
-            }
+            ?.map { it.trim() }
             ?.filter { it.isNotBlank() }
             ?.toSet()
             ?: emptySet()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCaseTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.data.message.reaction.ReactionRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class PersistReactionUseCaseTest {
+
+
+    @Test
+    fun givenHeavyBlackHeartInReactions_whenPersisting_thenShouldConvertToHeartEmoji() = runTest {
+        val (arrangement, persistReactionUseCase) = Arrangement().arrange()
+
+        persistReactionUseCase(
+            reaction = MessageContent.Reaction(
+                messageId = "messageId",
+                emojiSet = setOf("❤")
+            ),
+            conversationId = TestConversation.ID,
+            senderUserId = TestUser.USER_ID,
+            date = "date"
+        )
+
+        verify(arrangement.reactionRepository)
+            .suspendFunction(arrangement.reactionRepository::updateReaction)
+            .with(any(), any(), any(), any(), eq("❤️"))
+    }
+
+    private class Arrangement {
+        @Mock
+        val reactionRepository = mock(ReactionRepository::class)
+
+        init {
+            given(reactionRepository)
+                .suspendFunction(reactionRepository::updateReaction)
+                .whenInvokedWith(any(), any(), any(), any(), any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun arrange() = this to PersistReactionUseCaseImpl(
+            reactionRepository = reactionRepository
+        )
+    }
+}

--- a/persistence/src/commonMain/db_user/migrations/47.sqm
+++ b/persistence/src/commonMain/db_user/migrations/47.sqm
@@ -1,0 +1,3 @@
+UPDATE Reaction
+SET emoji = "❤️"
+WHERE emoji = "❤";

--- a/persistence/src/commonMain/db_user/migrations/47.sqm
+++ b/persistence/src/commonMain/db_user/migrations/47.sqm
@@ -1,3 +1,3 @@
 UPDATE Reaction
-SET emoji = "❤️"
-WHERE emoji = "❤";
+SET emoji = '❤️'
+WHERE emoji = '❤';


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to keep compatibility with the old Scala app, we added some quick hacks.
Now that iOS and Web are implementing reactions, we need to align the behaviour of the ❤️ emoji.

### Solutions

| Visual Representation | Unicode Symbols           | Comment                                                                      |
|:---------------------:|:-------------------------:|:----------------------------------------------------------------------------:|
| `❤`                     | Single symbol: \u2764     | Expected by old Android and exchanged between clients during the “Likes” era |
| `❤️`                    | Two symbols: \u2764\uFE0F | Default used by Web, iOS and Android during the “Reactions” era              |


1. Move compatibility layer away from the protobuf unpacker, into the generic "persist" logic.
  - This also means: cover in tests
2. Write a migration to replace old `❤` with `❤️`. This means we can take out any kind of UI hack code we've done in Reloaded.

Kalium has no hacks regarding the _sending_  of reactions. That is currently done in Reloaded.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
