### PR TITLE
feat(mls-one2one): support migrating to mls 1-1

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
@@ -38,6 +38,9 @@ UPDATE Connection SET last_update_date = ? WHERE to_id = ?;
 updateNotificationFlag:
 UPDATE Connection SET should_notify = ? WHERE qualified_to = ?;
 
+updateConnectionConversation:
+UPDATE Connection SET conversation_id = ?, qualified_conversation = ? WHERE qualified_to = ?;
+
 setAllConnectionsAsNotified:
 UPDATE Connection SET should_notify = 0
 WHERE status = 'PENDING' AND should_notify = 1;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -680,3 +680,8 @@ WHERE  conversation_id = ? AND id = ?;
 insertMessageRecipientsFailure:
 INSERT OR IGNORE INTO MessageRecipientFailure(message_id, conversation_id, recipient_failure_list, recipient_failure_type)
 VALUES(?, ?, ?, ?);
+
+moveMessages:
+UPDATE Message
+SET conversation_id = :to
+WHERE conversation_id = :from;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
@@ -66,6 +66,7 @@ interface ConnectionDAO {
     suspend fun insertConnection(connectionEntity: ConnectionEntity)
     suspend fun insertConnections(users: List<ConnectionEntity>)
     suspend fun updateConnectionLastUpdatedTime(lastUpdate: String, id: String)
+    suspend fun updateConnectionConversation(conversationId: QualifiedIDEntity, userId: QualifiedIDEntity)
     suspend fun deleteConnectionDataAndConversation(conversationId: QualifiedIDEntity)
     suspend fun getConnectionRequestsForNotification(): Flow<List<ConnectionEntity>>
     suspend fun updateNotificationFlag(flag: Boolean, userId: QualifiedIDEntity)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
@@ -157,6 +157,10 @@ class ConnectionDAOImpl(
         connectionsQueries.updateConnectionLastUpdated(lastUpdate.toInstant(), id)
     }
 
+    override suspend fun updateConnectionConversation(conversationId: QualifiedIDEntity, userId: QualifiedIDEntity) {
+        connectionsQueries.updateConnectionConversation(conversationId.value, conversationId, userId)
+    }
+
     override suspend fun deleteConnectionDataAndConversation(conversationId: QualifiedIDEntity) = withContext(queriesContext) {
         connectionsQueries.transaction {
             connectionsQueries.deleteConnection(conversationId)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -139,5 +139,7 @@ interface MessageDAO {
         recipientFailureTypeEntity: RecipientFailureTypeEntity
     )
 
+    suspend fun moveMessages(from: ConversationIDEntity, to: ConversationIDEntity)
+
     val platformExtensions: MessageExtensions
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -369,6 +369,11 @@ class MessageDAOImpl(
         queries.insertMessageRecipientsFailure(id, conversationsId, recipientsFailed, recipientFailureTypeEntity)
     }
 
+    override suspend fun moveMessages(from: ConversationIDEntity, to: ConversationIDEntity) =
+        withContext(coroutineContext) {
+            queries.moveMessages(to, from)
+        }
+
     override suspend fun getConversationUnreadEventsCount(conversationId: QualifiedIDEntity): Long = withContext(coroutineContext) {
         unreadEventsQueries.getConversationUnreadEventsCount(conversationId).executeAsOne()
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConnectionDaoTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConnectionDaoTest.kt
@@ -83,15 +83,27 @@ class ConnectionDaoTest : BaseDatabaseTest() {
         assertEquals(false, result[1].shouldNotify)
     }
 
+    @Test
+    fun givenConnection_WhenUpdatingConnectionConversation_ThenItIsUpdated() = runTest {
+        val newConversationId = QualifiedIDEntity("new", "wire.com")
+        db.connectionDAO.insertConnection(connection1)
+        db.connectionDAO.updateConnectionConversation(newConversationId, connection1.qualifiedToId)
+        val result = db.connectionDAO.getConnectionRequests().first()
+        assertEquals(newConversationId, result[0].qualifiedConversationId)
+        assertEquals(newConversationId.value, result[0].conversationId)
+    }
+
     companion object {
+        val OTHER_USER_ID = QualifiedIDEntity("me", "wire.com")
+
         private fun connectionEntity(id: String = "0") = ConnectionEntity(
-            conversationId = "$id@wire.com",
+            conversationId = id,
             from = "from_string",
             lastUpdateDate = "2022-03-30T15:36:00.000Z".toInstant(),
             qualifiedConversationId = QualifiedIDEntity(id, "wire.com"),
-            qualifiedToId = QualifiedIDEntity("me", "wire.com"),
+            qualifiedToId = OTHER_USER_ID,
             status = ConnectionEntity.State.PENDING,
-            toId = "me@wire.com",
+            toId = OTHER_USER_ID.value,
             shouldNotify = true
         )
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -1542,6 +1542,129 @@ class MessageDAOTest : BaseDatabaseTest() {
         }
     }
 
+    @Test
+    fun givenExistingMessagesAtSource_whenMovingMessages_thenMessagesAreAccessibleAtDestination() = runTest {
+        // given
+        val source = conversationEntity1
+        val destination = conversationEntity2
+        userDAO.upsertUsers(listOf(userEntity1, userEntity2))
+        conversationDAO.insertConversation(source)
+        conversationDAO.insertConversation(destination)
+
+        val allMessages = listOf(
+            newRegularMessageEntity(
+                id = "1",
+                senderUserId = userEntity1.id,
+                conversationId = source.id,
+                content = MessageEntityContent.Text(messageBody = "Message 1")
+            ),
+            newRegularMessageEntity(
+                id = "2",
+                senderUserId = userEntity1.id,
+                conversationId = source.id,
+                content = MessageEntityContent.Text(messageBody = "Message 2")
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(allMessages)
+
+        // when
+        messageDAO.moveMessages(source.id, destination.id)
+
+        // then
+        val retrievedMessages = messageDAO.getMessagesByConversationAndVisibility(
+            destination.id,
+            10,
+            0,
+            listOf(MessageEntity.Visibility.VISIBLE)
+        ).first()
+
+        assertEquals(
+            allMessages.map { it.content }.toSet(),
+            retrievedMessages.map { it.content }.toSet())
+    }
+
+    @Test
+    fun givenExistingMessagesAtSourceAndDestination_whenMovingMessages_thenMessagesAreAccessibleAtDestination() = runTest {
+        // given
+        val source = conversationEntity1
+        val destination = conversationEntity2
+        userDAO.upsertUsers(listOf(userEntity1, userEntity2))
+        conversationDAO.insertConversation(source)
+        conversationDAO.insertConversation(destination)
+
+        val allMessages = listOf(
+            newRegularMessageEntity(
+                id = "1",
+                senderUserId = userEntity1.id,
+                conversationId = source.id,
+                content = MessageEntityContent.Text(messageBody = "Message 1")
+            ),
+            newRegularMessageEntity(
+                id = "2",
+                senderUserId = userEntity1.id,
+                conversationId = destination.id,
+                content = MessageEntityContent.Text(messageBody = "Message 2")
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(allMessages)
+
+        // when
+        messageDAO.moveMessages(source.id, destination.id)
+
+        // then
+        val retrievedMessages = messageDAO.getMessagesByConversationAndVisibility(
+            destination.id,
+            10,
+            0,
+            listOf(MessageEntity.Visibility.VISIBLE)
+        ).first()
+
+        assertEquals(
+            allMessages.map { it.content }.toSet(),
+            retrievedMessages.map { it.content }.toSet())
+    }
+
+    @Test
+    fun givenNoExistingMessagesAtSource_whenMovingMessages_thenExistingMessagesAreAccessibleAtDestination() = runTest {
+        // given
+        val source = conversationEntity1
+        val destination = conversationEntity2
+        userDAO.upsertUsers(listOf(userEntity1, userEntity2))
+        conversationDAO.insertConversation(source)
+        conversationDAO.insertConversation(destination)
+
+        val allMessages = listOf(
+            newRegularMessageEntity(
+                id = "1",
+                senderUserId = userEntity1.id,
+                conversationId = destination.id,
+                content = MessageEntityContent.Text(messageBody = "Message 1")
+            ),
+            newRegularMessageEntity(
+                id = "2",
+                senderUserId = userEntity1.id,
+                conversationId = destination.id,
+                content = MessageEntityContent.Text(messageBody = "Message 2")
+            )
+        )
+        messageDAO.insertOrIgnoreMessages(allMessages)
+
+        // when
+        messageDAO.moveMessages(source.id, destination.id)
+
+        // then
+        val retrievedMessages = messageDAO.getMessagesByConversationAndVisibility(
+            destination.id,
+            10,
+            0,
+            listOf(MessageEntity.Visibility.VISIBLE)
+        ).first()
+
+        assertEquals(
+            allMessages.map { it.content }.toSet(),
+            retrievedMessages.map { it.content }.toSet())
+    }
+
     private suspend fun insertInitialData() {
         userDAO.upsertUsers(listOf(userEntity1, userEntity2))
         conversationDAO.insertConversation(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add persistence support methods for migrating from proteus to MLS for 1-1 conversations.

- Change the associated conversation for a connection.
- Move message history from one conversation to another.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
