### PR TITLE
feat(RC): send pings as self deleting and messsage duration clenup

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -187,7 +187,6 @@ interface ConversationRepository {
     ): Either<CoreFailure, Unit>
 
     suspend fun getConversationUnreadEventsCount(conversationId: ConversationId): Either<StorageFailure, Long>
-    suspend fun getUserSelfDeletionTimer(conversationId: ConversationId): Either<StorageFailure, SelfDeletionTimer?>
     suspend fun updateUserSelfDeletionTimer(conversationId: ConversationId, selfDeletionTimer: SelfDeletionTimer): Either<CoreFailure, Unit>
 }
 
@@ -684,15 +683,6 @@ internal class ConversationDataSource internal constructor(
 
     override suspend fun getConversationUnreadEventsCount(conversationId: ConversationId): Either<StorageFailure, Long> =
         wrapStorageRequest { messageDAO.getConversationUnreadEventsCount(conversationId.toDao()) }
-
-    override suspend fun getUserSelfDeletionTimer(conversationId: ConversationId): Either<StorageFailure, SelfDeletionTimer> =
-        wrapStorageRequest {
-            SelfDeletionTimer.Enabled(
-                conversationDAO.getConversationByQualifiedID(conversationId.toDao())?.messageTimer?.toDuration(
-                    DurationUnit.MILLISECONDS
-                ) ?: ZERO
-            )
-        }
 
     override suspend fun updateUserSelfDeletionTimer(
         conversationId: ConversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -690,7 +690,7 @@ internal class ConversationDataSource internal constructor(
     ): Either<CoreFailure, Unit> = wrapStorageRequest {
         conversationDAO.updateUserMessageTimer(
             conversationId = conversationId.toDao(),
-            messageTimer = selfDeletionTimer.toDuration().inWholeMilliseconds
+            messageTimer = selfDeletionTimer.duration?.inWholeMilliseconds
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -77,9 +77,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
-import kotlin.time.Duration.Companion.ZERO
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 interface ConversationRepository {
     @DelicateKaliumApi("This function does not get values from cache")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -142,9 +142,27 @@ class ProtoContentMapperImpl(
                 )
             }
 
-            else -> {
-                throw IllegalArgumentException("Unexpected message content type for ephemeral message: ${readableContent.getType()}")
+            is MessageContent.Knock -> {
+                val knock = GenericMessage.Content.Knock(Knock(hotKnock = readableContent.hotKnock))
+                Ephemeral.Content.Knock(
+                    knock.value
+                )
             }
+
+            is MessageContent.FailedDecryption,
+            is MessageContent.RestrictedAsset,
+            is MessageContent.Unknown,
+            is MessageContent.Availability,
+            is MessageContent.Calling,
+            is MessageContent.Cleared,
+            MessageContent.ClientAction,
+            is MessageContent.DeleteForMe,
+            is MessageContent.DeleteMessage,
+            MessageContent.Ignored,
+            is MessageContent.LastRead,
+            is MessageContent.Reaction,
+            is MessageContent.Receipt,
+            is MessageContent.TextEdited -> throw IllegalArgumentException("Unexpected message content type for ephemeral message: ${readableContent.getType()}")
         }
         return GenericMessage.Content.Ephemeral(Ephemeral(expireAfterMillis = expireAfterMillis, content = ephemeralContent))
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -162,7 +162,11 @@ class ProtoContentMapperImpl(
             is MessageContent.LastRead,
             is MessageContent.Reaction,
             is MessageContent.Receipt,
-            is MessageContent.TextEdited -> throw IllegalArgumentException("Unexpected message content type for ephemeral message: ${readableContent.getType()}")
+            is MessageContent.TextEdited ->
+                throw IllegalArgumentException(
+                    "Unexpected message content type for ephemeral message:" +
+                            " ${readableContent.getType()}"
+                )
         }
         return GenericMessage.Content.Ephemeral(Ephemeral(expireAfterMillis = expireAfterMillis, content = ephemeralContent))
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
@@ -41,7 +41,6 @@ import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
@@ -60,7 +59,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 
 interface ScheduleNewAssetMessageUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
@@ -135,8 +135,7 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
             when (it) {
                 SelfDeletionTimer.Disabled -> null
                 is SelfDeletionTimer.Enabled -> it.userDuration
-                is SelfDeletionTimer.Enforced.ByGroup -> it.duration
-                is SelfDeletionTimer.Enforced.ByTeam -> it.duration
+                is SelfDeletionTimer.Enforced -> it.enforcedDuration
             }
         }.let {
             if (it == Duration.ZERO) null else it

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -254,7 +254,8 @@ class MessageScope internal constructor(
             currentClientIdProvider,
             slowSyncRepository,
             messageSender,
-            messageSendFailureHandler
+            messageSendFailureHandler,
+            observeSelfDeletingMessages
         )
 
     val markMessagesAsNotified: MarkMessagesAsNotifiedUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -64,15 +64,9 @@ class SendKnockUseCase internal constructor(
         }
 
         val generatedMessageUuid = uuid4().toString()
-        val messageTimer: Duration? = selfDeleteTimer(conversationId, true).first().let {
-            when (it) {
-                SelfDeletionTimer.Disabled -> null
-                is SelfDeletionTimer.Enabled -> it.userDuration
-                is SelfDeletionTimer.Enforced -> it.enforcedDuration
-            }
-        }.let {
-            if (it == Duration.ZERO) null else it
-        }
+        val messageTimer: Duration? = selfDeleteTimer(conversationId, true)
+            .first()
+            .duration
 
         return currentClientIdProvider().flatMap { currentClientId ->
             val message = Message.Regular(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -28,11 +28,14 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
+import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.first
+import kotlin.time.Duration
 
 @Suppress("LongParameterList")
 /**
@@ -44,7 +47,8 @@ class SendKnockUseCase internal constructor(
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSender: MessageSender,
-    private val messageSendFailureHandler: MessageSendFailureHandler
+    private val messageSendFailureHandler: MessageSendFailureHandler,
+    private val selfDeleteTimer: ObserveSelfDeletionTimerSettingsForConversationUseCase
 ) {
 
     /**
@@ -60,6 +64,15 @@ class SendKnockUseCase internal constructor(
         }
 
         val generatedMessageUuid = uuid4().toString()
+        val messageTimer: Duration? = selfDeleteTimer(conversationId, true).first().let {
+            when (it) {
+                SelfDeletionTimer.Disabled -> null
+                is SelfDeletionTimer.Enabled -> it.userDuration
+                is SelfDeletionTimer.Enforced -> it.enforcedDuration
+            }
+        }.let {
+            if (it == Duration.ZERO) null else it
+        }
 
         return currentClientIdProvider().flatMap { currentClientId ->
             val message = Message.Regular(
@@ -71,7 +84,8 @@ class SendKnockUseCase internal constructor(
                 senderClientId = currentClientId,
                 status = Message.Status.PENDING,
                 editStatus = Message.EditStatus.NotEdited,
-                isSelfMessage = true
+                isSelfMessage = true,
+                expirationData = messageTimer?.let { Message.ExpirationData(it) }
             )
             persistMessage(message)
                 .flatMap { messageSender.sendMessage(message) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -73,15 +73,9 @@ class SendTextMessageUseCase internal constructor(
 
         val generatedMessageUuid = uuid4().toString()
         val expectsReadConfirmation = userPropertyRepository.getReadReceiptsStatus()
-        val messageTimer: Duration? = selfDeleteTimer(conversationId, true).first().let {
-            when (it) {
-                SelfDeletionTimer.Disabled -> null
-                is SelfDeletionTimer.Enabled -> it.userDuration
-                is SelfDeletionTimer.Enforced -> it.enforcedDuration
-            }
-        }.let {
-            if (it == Duration.ZERO) null else it
-        }
+        val messageTimer: Duration? = selfDeleteTimer(conversationId, true)
+            .first()
+            .duration
 
         provideClientId().flatMap { clientId ->
             val message = Message.Regular(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -31,12 +31,9 @@ import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer.Companion.SELF_DELETION_LOG_TAG
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -74,13 +74,10 @@ class SendTextMessageUseCase internal constructor(
         val generatedMessageUuid = uuid4().toString()
         val expectsReadConfirmation = userPropertyRepository.getReadReceiptsStatus()
         val messageTimer: Duration? = selfDeleteTimer(conversationId, true).first().let {
-            val logMap = it.toLogString(eventDescription = "Sending text message with self-deletion timer")
-            if (it != SelfDeletionTimer.Disabled) kaliumLogger.d("$SELF_DELETION_LOG_TAG: $logMap")
             when (it) {
                 SelfDeletionTimer.Disabled -> null
                 is SelfDeletionTimer.Enabled -> it.userDuration
-                is SelfDeletionTimer.Enforced.ByGroup -> it.duration
-                is SelfDeletionTimer.Enforced.ByTeam -> it.duration
+                is SelfDeletionTimer.Enforced -> it.enforcedDuration
             }
         }.let {
             if (it == Duration.ZERO) null else it

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
@@ -66,12 +66,12 @@ class ObserveSelfDeletionTimerSettingsForConversationUseCaseImpl internal constr
 
     private fun onTeamEnabled(conversation: Either<StorageFailure, Conversation>, considerSelfUserSettings: Boolean): SelfDeletionTimer =
         conversation.fold({
-            SelfDeletionTimer.Enabled(ZERO)
+            SelfDeletionTimer.Enabled(null)
         }, {
             when {
                 it.messageTimer.isPositiveNotNull() -> SelfDeletionTimer.Enforced.ByGroup(it.messageTimer)
                 considerSelfUserSettings && it.userMessageTimer.isPositiveNotNull() -> SelfDeletionTimer.Enabled(it.userMessageTimer)
-                else -> SelfDeletionTimer.Enabled(ZERO)
+                else -> SelfDeletionTimer.Enabled(null)
             }
         })
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
@@ -27,7 +27,6 @@ import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.util.isPositiveNotNull
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlin.time.Duration.Companion.ZERO
 
 /**
  * When invoked, this use case will start observing on a given conversation, the currently applied [SelfDeletionTimer]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/SelfDeletionTimer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/SelfDeletionTimer.kt
@@ -22,31 +22,28 @@ import com.wire.kalium.util.serialization.toJsonElement
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.ZERO
 
-sealed class SelfDeletionTimer {
+sealed interface SelfDeletionTimer {
+    val duration: Duration?
+
     /**
      * Represents a self deletion timer that is currently disabled
      */
-    object Disabled : SelfDeletionTimer()
+    object Disabled : SelfDeletionTimer {
+        override val duration: Duration? = null
+    }
 
     /**
      * Represents a self deletion timer that is enabled and can be changed/updated by the user
      */
-    data class Enabled(val userDuration: Duration) : SelfDeletionTimer()
+    data class Enabled(override val duration: Duration?) : SelfDeletionTimer
 
     /**
      * Represents a self deletion timer that is imposed by the team or conversation settings that can't be changed by the user
      * @param enforcedDuration the team or conversation imposed timer
      */
-    sealed class Enforced : SelfDeletionTimer() {
-        abstract val enforcedDuration: Duration
-        data class ByTeam(override val enforcedDuration: Duration) : Enforced()
-        data class ByGroup(override val enforcedDuration: Duration) : Enforced()
-    }
-
-    fun toDuration(): Duration = when (this) {
-        is Enabled -> userDuration
-        is Enforced -> enforcedDuration
-        is Disabled -> ZERO
+    sealed interface Enforced : SelfDeletionTimer {
+        data class ByTeam(override val duration: Duration) : Enforced
+        data class ByGroup(override val duration: Duration) : Enforced
     }
 
     fun toLogString(eventDescription: String): String = toLogMap(eventDescription).toJsonElement().toString()
@@ -66,7 +63,7 @@ sealed class SelfDeletionTimer {
     private fun toLogMap(eventDescription: String): Map<String, Any?> = mapOf(
         eventKey to eventDescription,
         typeKey to this::class.simpleName,
-        durationKey to toDuration().inWholeSeconds,
+        durationKey to duration?.inWholeSeconds,
         isEnforcedKey to isEnforced,
         isDisabledKey to isDisabled
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/SelfDeletionTimer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/SelfDeletionTimer.kt
@@ -37,9 +37,10 @@ sealed class SelfDeletionTimer {
      * Represents a self deletion timer that is imposed by the team or conversation settings that can't be changed by the user
      * @param enforcedDuration the team or conversation imposed timer
      */
-    sealed class Enforced(val enforcedDuration: Duration) : SelfDeletionTimer() {
-        data class ByTeam(val duration: Duration) : Enforced(duration)
-        data class ByGroup(val duration: Duration) : Enforced(duration)
+    sealed class Enforced : SelfDeletionTimer() {
+        abstract val enforcedDuration: Duration
+        data class ByTeam(override val enforcedDuration: Duration) : Enforced()
+        data class ByGroup(override val enforcedDuration: Duration) : Enforced()
     }
 
     fun toDuration(): Duration = when (this) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletingMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletingMessagesUseCaseTest.kt
@@ -62,7 +62,7 @@ class ObserveSelfDeletingMessagesUseCaseTest {
         verify(arrangement.userConfigRepository)
             .coroutine { observeTeamSettingsSelfDeletingStatus() }
             .wasInvoked(exactly = once)
-        assertEquals(storedConversationStatus.messageTimer, result.first().toDuration())
+        assertEquals(storedConversationStatus.messageTimer, result.first().duration)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -128,7 +128,7 @@ class ObserveSelfDeletingMessagesUseCaseTest {
             .wasInvoked(exactly = once)
 
 
-        assertEquals(storedTeamSettingsDuration, result.first().toDuration())
+        assertEquals(storedTeamSettingsDuration, result.first().duration)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -157,7 +157,7 @@ class ObserveSelfDeletingMessagesUseCaseTest {
 
 //         verify(arrangement.userConfigRepository).invocation { observeConversationSelfDeletionTimer(conversationId) }
 //             .wasNotInvoked()
-        assertEquals(conversationDuration, result.first().toDuration())
+        assertEquals(conversationDuration, result.first().duration)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -192,7 +192,7 @@ class ObserveSelfDeletingMessagesUseCaseTest {
             .with(any())
             .wasInvoked(exactly = once)
 
-        assertEquals(storedConversationStatus.messageTimer, result.first().toDuration())
+        assertEquals(storedConversationStatus.messageTimer, result.first().duration)
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement.kt
@@ -24,6 +24,7 @@ import io.mockative.Mock
 import io.mockative.any
 import io.mockative.eq
 import io.mockative.given
+import io.mockative.matchers.Matcher
 import io.mockative.mock
 import kotlinx.coroutines.flow.Flow
 
@@ -33,8 +34,8 @@ interface ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement {
 
     fun withConversationTimer(
         result: Flow<SelfDeletionTimer>,
-        conversationId: ConversationId? = null,
-        considerSelfUserSettings: Boolean? = null
+        conversationId: Matcher<ConversationId> = any(),
+        considerSelfUserSettings: Matcher<Boolean> = any()
     )
 }
 
@@ -46,15 +47,14 @@ open class ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangementImpl
 
     override fun withConversationTimer(
         result: Flow<SelfDeletionTimer>,
-        conversationId: ConversationId?,
-        considerSelfUserSettings: Boolean?
+        conversationId: Matcher<ConversationId>,
+        considerSelfUserSettings: Matcher<Boolean>
     ) {
         given(observeSelfDeletionTimerSettingsForConversation)
             .suspendFunction(observeSelfDeletionTimerSettingsForConversation::invoke)
             .whenInvokedWith(
-                conversationId?.let { eq(it) } ?: any(),
-                considerSelfUserSettings?.let { eq(it) } ?: any()
+                conversationId,
+                considerSelfUserSettings
             ).thenReturn(result)
     }
-
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.flow.Flow
+
+interface ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement {
+    @Mock
+    val observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase
+
+    fun withConversationTimer(
+        result: Flow<SelfDeletionTimer>,
+        conversationId: ConversationId? = null,
+        considerSelfUserSettings: Boolean? = null
+    )
+}
+
+open class ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangementImpl :
+    ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement {
+    @Mock
+    override val observeSelfDeletionTimerSettingsForConversation: ObserveSelfDeletionTimerSettingsForConversationUseCase =
+        mock(ObserveSelfDeletionTimerSettingsForConversationUseCase::class)
+
+    override fun withConversationTimer(
+        result: Flow<SelfDeletionTimer>,
+        conversationId: ConversationId?,
+        considerSelfUserSettings: Boolean?
+    ) {
+        given(observeSelfDeletionTimerSettingsForConversation)
+            .suspendFunction(observeSelfDeletionTimerSettingsForConversation::invoke)
+            .whenInvokedWith(
+                conversationId?.let { eq(it) } ?: any(),
+                considerSelfUserSettings?.let { eq(it) } ?: any()
+            ).thenReturn(result)
+    }
+
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement.kt
@@ -57,5 +57,4 @@ open class ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangementImpl
             ).thenReturn(result)
     }
 
-
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

pings are not sent as self deleting

### Solutions

1. set message timer in the knock use case.
2. clean up message duration and remove duplicated code

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
