### PR TITLE
fix: invalidate conversation members [WPB-3047]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -33,7 +33,6 @@ import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.message.MessageMapper
 import com.wire.kalium.logic.data.message.UnreadEventType
-import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.SelfTeamIdProvider
@@ -49,7 +48,6 @@ import com.wire.kalium.logic.functional.mapRight
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.logic.sync.slow.CURRENT_VERSION
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapCryptoRequest
 import com.wire.kalium.logic.wrapMLSRequest
@@ -204,7 +202,6 @@ internal class ConversationDataSource internal constructor(
     private val messageDAO: MessageDAO,
     private val clientDAO: ClientDAO,
     private val clientApi: ClientApi,
-    private val slowSyncRepository: SlowSyncRepository, // temporary to resolve issue https://wearezeta.atlassian.net/browse/WPB-3047
     private val idMapper: IdMapper = MapperProvider.idMapper(),
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(),
     private val memberMapper: MemberMapper = MapperProvider.memberMapper(),
@@ -255,17 +252,11 @@ internal class ConversationDataSource internal constructor(
                         kaliumLogger.withFeatureId(CONVERSATIONS)
                             .d("Skipping ${conversations.conversationsNotFound.size} conversations not found")
                     }
-                    // temporary solution to force invalidating all removed members
-                    val lastVersion = slowSyncRepository.getSlowSyncVersion()
-
                     persistConversations(
                         conversations = conversations.conversationsFound,
                         selfUserTeamId = selfTeamIdProvider().getOrNull()?.value,
-                        invalidateMembers = CURRENT_VERSION > lastVersion
+                        invalidateMembers = true
                     )
-                    if (CURRENT_VERSION > lastVersion) {
-                        slowSyncRepository.setSlowSyncVersion(CURRENT_VERSION)
-                    }
 
                 }.onFailure {
                     kaliumLogger.withFeatureId(CONVERSATIONS).e("Error fetching conversation details $it")
@@ -308,12 +299,16 @@ internal class ConversationDataSource internal constructor(
             // do the cleanup of members from conversation in case when self user rejoined conversation
             // and may not received any member remove or leave events
             if (invalidateMembers) {
-                conversationDAO.deleteMembersFromConversation(idMapper.fromApiToDao(conversationsResponse.id))
+                conversationDAO.updateFullMemberList(
+                    memberMapper.fromApiModelToDaoModel(conversationsResponse.members),
+                    idMapper.fromApiToDao(conversationsResponse.id)
+                )
+            } else {
+                conversationDAO.insertMembersWithQualifiedId(
+                    memberMapper.fromApiModelToDaoModel(conversationsResponse.members),
+                    idMapper.fromApiToDao(conversationsResponse.id)
+                )
             }
-            conversationDAO.insertMembersWithQualifiedId(
-                memberMapper.fromApiModelToDaoModel(conversationsResponse.members),
-                idMapper.fromApiToDao(conversationsResponse.id)
-            )
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -263,7 +263,7 @@ internal class ConversationDataSource internal constructor(
                         selfUserTeamId = selfTeamIdProvider().getOrNull()?.value,
                         invalidateMembers = CURRENT_VERSION > lastVersion
                     )
-                    if(CURRENT_VERSION > lastVersion) {
+                    if (CURRENT_VERSION > lastVersion) {
                         slowSyncRepository.setSlowSyncVersion(CURRENT_VERSION)
                     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -485,7 +485,8 @@ class UserSessionScope internal constructor(
             authenticatedNetworkContainer.conversationApi,
             userStorage.database.messageDAO,
             userStorage.database.clientDAO,
-            authenticatedNetworkContainer.clientApi
+            authenticatedNetworkContainer.clientApi,
+            slowSyncRepository
         )
 
     private val conversationGroupRepository: ConversationGroupRepository
@@ -988,7 +989,7 @@ class UserSessionScope internal constructor(
         )
     private val memberJoinHandler: MemberJoinEventHandler
         get() = MemberJoinEventHandlerImpl(
-            conversationRepository, userRepository, persistMessage
+            conversationRepository, userRepository, persistMessage, userId
         )
     private val memberLeaveHandler: MemberLeaveEventHandler
         get() = MemberLeaveEventHandlerImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -485,8 +485,7 @@ class UserSessionScope internal constructor(
             authenticatedNetworkContainer.conversationApi,
             userStorage.database.messageDAO,
             userStorage.database.clientDAO,
-            authenticatedNetworkContainer.clientApi,
-            slowSyncRepository
+            authenticatedNetworkContainer.clientApi
         )
 
     private val conversationGroupRepository: ConversationGroupRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -31,7 +31,6 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -50,17 +49,14 @@ internal class MemberJoinEventHandlerImpl(
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
 
     override suspend fun handle(event: Event.Conversation.MemberJoin) =
-        // Attempt to fetch conversation details if needed, as this might be an unknown conversation
-        conversationRepository.getConversationMembers(event.conversationId)
-            .map {
-                // we need to force fetching conversation when self user rejoined to conversation,
-                // because he may not received member change events
-                if (it.contains(selfUserId)) {
-                    conversationRepository.fetchConversation(event.conversationId)
-                } else {
-                    conversationRepository.fetchConversationIfUnknown(event.conversationId)
-                }
-            }.run {
+        // we need to force fetching conversation when self user rejoined to conversation,
+        // because he may not received member change events
+        if (event.members.map { it.id }.contains(selfUserId)) {
+            conversationRepository.fetchConversation(event.conversationId)
+        } else {
+            conversationRepository.fetchConversationIfUnknown(event.conversationId)
+        }
+            .run {
                 onSuccess {
                     val logMap = mapOf(
                         "event" to event.toLogMap()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -155,6 +155,7 @@ internal class SlowSyncManager(
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
         val MIN_TIME_BETWEEN_SLOW_SYNCS = 7.days
-        const val CURRENT_VERSION = 2 // bump this version to perform slow sync when some new feature flag was added
     }
 }
+
+const val CURRENT_VERSION = 3 // bump this version to perform slow sync when some new feature flag was added

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -45,6 +45,7 @@ object TestUser {
     val USER_ID = UserId(value, domain)
     val OTHER_USER_ID = USER_ID.copy(value = "otherValue")
     val OTHER_USER_ID_2 = USER_ID.copy(value = "otherValue2")
+    val OTHER_FEDERATED_USER_ID = USER_ID.copy(value = "otherValue", "otherDomain")
     val ENTITY_ID = QualifiedIDEntity(value, domain)
     val NETWORK_ID = com.wire.kalium.network.api.base.model.UserId(
         value = value,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -17,6 +17,9 @@ VALUES (?, ?, ?);
 deleteMember:
 DELETE FROM Member WHERE conversation = ? AND user = ?;
 
+deleteMembersFromConversation:
+DELETE FROM Member WHERE conversation = ?;
+
 selectAllMembersByConversation:
 SELECT * FROM Member WHERE conversation LIKE ('%' || :searchQuery || '%');
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -10,6 +10,8 @@ CREATE TABLE Member (
     FOREIGN KEY (user) REFERENCES User(qualified_id) ON DELETE CASCADE
 );
 
+CREATE INDEX member_conversation_index ON Member(conversation);
+
 insertMember:
 INSERT OR IGNORE INTO Member(user, conversation, role)
 VALUES (?, ?, ?);

--- a/persistence/src/commonMain/db_user/migrations/43.sqm
+++ b/persistence/src/commonMain/db_user/migrations/43.sqm
@@ -1,0 +1,1 @@
+CREATE INDEX member_conversation_index ON Member(conversation);

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -169,7 +169,6 @@ interface ConversationDAO {
     suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity)
     suspend fun updateMember(member: Member, conversationID: QualifiedIDEntity)
     suspend fun insertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity)
-    suspend fun insertMembers(memberList: List<Member>, groupId: String)
     suspend fun deleteMemberByQualifiedID(userID: QualifiedIDEntity, conversationID: QualifiedIDEntity)
     suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, conversationID: QualifiedIDEntity)
     suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, groupId: String)
@@ -210,4 +209,5 @@ interface ConversationDAO {
     suspend fun updateMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?)
     suspend fun updateUserMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?)
     suspend fun clearContent(conversationId: QualifiedIDEntity)
+    suspend fun deleteMembersFromConversation(conversationID: QualifiedIDEntity)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAO.kt
@@ -169,6 +169,7 @@ interface ConversationDAO {
     suspend fun insertMember(member: Member, conversationID: QualifiedIDEntity)
     suspend fun updateMember(member: Member, conversationID: QualifiedIDEntity)
     suspend fun insertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity)
+    suspend fun insertMembers(memberList: List<Member>, groupId: String)
     suspend fun deleteMemberByQualifiedID(userID: QualifiedIDEntity, conversationID: QualifiedIDEntity)
     suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, conversationID: QualifiedIDEntity)
     suspend fun deleteMembersByQualifiedID(userIDList: List<QualifiedIDEntity>, groupId: String)
@@ -209,5 +210,5 @@ interface ConversationDAO {
     suspend fun updateMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?)
     suspend fun updateUserMessageTimer(conversationId: QualifiedIDEntity, messageTimer: Long?)
     suspend fun clearContent(conversationId: QualifiedIDEntity)
-    suspend fun deleteMembersFromConversation(conversationID: QualifiedIDEntity)
+    suspend fun updateFullMemberList(memberList: List<Member>, conversationID: QualifiedIDEntity)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -401,9 +401,10 @@ class ConversationDAOImpl(
             nonSuspendInsertMembersWithQualifiedId(memberList, conversationID)
         }
 
-    override suspend fun deleteMembersFromConversation(conversationID: QualifiedIDEntity) =
+    override suspend fun updateFullMemberList(memberList: List<Member>, conversationID: QualifiedIDEntity) =
         withContext(coroutineContext) {
             memberQueries.deleteMembersFromConversation(conversationID)
+            nonSuspendInsertMembersWithQualifiedId(memberList, conversationID)
         }
 
     private fun nonSuspendInsertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity) =
@@ -413,6 +414,14 @@ class ConversationDAOImpl(
                 memberQueries.insertMember(member.user, conversationID, member.role)
             }
         }
+
+    override suspend fun insertMembers(memberList: List<Member>, groupId: String) {
+        withContext(coroutineContext) {
+            getConversationByGroupID(groupId).firstOrNull()?.let {
+                nonSuspendInsertMembersWithQualifiedId(memberList, it.id)
+            }
+        }
+    }
 
     override suspend fun updateOrInsertOneOnOneMemberWithConnectionStatus(
         member: Member,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConversationDAOImpl.kt
@@ -401,6 +401,11 @@ class ConversationDAOImpl(
             nonSuspendInsertMembersWithQualifiedId(memberList, conversationID)
         }
 
+    override suspend fun deleteMembersFromConversation(conversationID: QualifiedIDEntity) =
+        withContext(coroutineContext) {
+            memberQueries.deleteMembersFromConversation(conversationID)
+        }
+
     private fun nonSuspendInsertMembersWithQualifiedId(memberList: List<Member>, conversationID: QualifiedIDEntity) =
         memberQueries.transaction {
             for (member: Member in memberList) {
@@ -408,14 +413,6 @@ class ConversationDAOImpl(
                 memberQueries.insertMember(member.user, conversationID, member.role)
             }
         }
-
-    override suspend fun insertMembers(memberList: List<Member>, groupId: String) {
-        withContext(coroutineContext) {
-            getConversationByGroupID(groupId).firstOrNull()?.let {
-                nonSuspendInsertMembersWithQualifiedId(memberList, it.id)
-            }
-        }
-    }
 
     override suspend fun updateOrInsertOneOnOneMemberWithConnectionStatus(
         member: Member,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user is leaving conversation, after that he will not receive any events about member leave or join that conversation. So after rejoining conversation he will have wrong conversation member list.

Also slow sync will not remove members who left when user was not a member of conversation, because slow sync only adds members.

### Solutions

Because of potential performance problems I forced slow sync with entire members invalidation just once. In next version we can remove it and always invalidate conversation members when user will rejoin conversation