### PR TITLE
fix: ephemeral messages timer form self user should start automat…

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -288,6 +288,7 @@ import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessa
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpackerImpl
+import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSWrongEpochHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSWrongEpochHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandlerImpl
@@ -991,9 +992,13 @@ class UserSessionScope internal constructor(
             joinExistingMLSConversation = joinExistingMLSConversationUseCase
         )
 
-    private val newMessageHandler: NewMessageEventHandlerImpl
+    private val newMessageHandler: NewMessageEventHandler
         get() = NewMessageEventHandlerImpl(
-            proteusUnpacker, mlsUnpacker, applicationMessageHandler, mlsWrongEpochHandler
+            proteusUnpacker, mlsUnpacker, applicationMessageHandler,
+            { conversationId, messageId ->
+                messages.ephemeralMessageDeletionHandler.startSelfDeletion(conversationId, messageId)
+            }, userId,
+            mlsWrongEpochHandler
         )
 
     private val newConversationHandler: NewConversationEventHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -51,6 +51,7 @@ import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageFor
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCaseImpl
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
 import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
@@ -113,7 +114,7 @@ class MessageScope internal constructor(
     private val messageSendingInterceptor: MessageSendingInterceptor
         get() = MessageSendingInterceptorImpl(messageContentEncoder, messageRepository)
 
-    internal val ephemeralMessageDeletionHandler =
+    internal val ephemeralMessageDeletionHandler: EphemeralMessageDeletionHandler =
         EphemeralMessageDeletionHandlerImpl(
             userSessionCoroutineScope = scope,
             messageRepository = messageRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -100,7 +100,8 @@ internal class ConversationEventReceiverImpl(
             }
 
             is Event.Conversation.AccessUpdate -> {
-                TODO()
+                /* no-op */
+                Either.Right(Unit)
             }
 
             is Event.Conversation.ConversationMessageTimer -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -199,12 +199,13 @@ internal class ApplicationMessageHandlerImpl(
     private suspend fun processMessage(message: Message.Regular) {
         logger.i(message = "Message received: { \"message\" : ${message.toLogString()} }")
         when (val content = message.content) {
-            // Persist Messages - > lists
             is MessageContent.Text -> handleTextMessage(message, content)
             is MessageContent.FailedDecryption -> persistMessage(message)
             is MessageContent.Knock -> persistMessage(message)
             is MessageContent.Asset -> assetMessageHandler.handle(message)
-            is MessageContent.RestrictedAsset -> TODO()
+            is MessageContent.RestrictedAsset -> {
+                /* no-op */
+            }
             is MessageContent.Unknown -> {
                 logger.i(message = "Unknown Message received: { \"message\" : ${message.toLogString()} }")
                 persistMessage(message)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -26,7 +26,9 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -41,6 +43,8 @@ internal class NewMessageEventHandlerImpl(
     private val proteusMessageUnpacker: ProteusMessageUnpacker,
     private val mlsMessageUnpacker: MLSMessageUnpacker,
     private val applicationMessageHandler: ApplicationMessageHandler,
+    private val enqueueSelfDeletion: (conversationId: ConversationId, messageId: String) -> Unit,
+    private val selfUserId: UserId,
     private val mlsWrongEpochHandler: MLSWrongEpochHandler
 ) : NewMessageEventHandler {
 
@@ -76,7 +80,10 @@ internal class NewMessageEventHandlerImpl(
                     )
                 )
             }.onSuccess {
-                handleSuccessfulResult(it)
+                if (it is MessageUnpackResult.ApplicationMessage) {
+                    handleSuccessfulResult(it)
+                    onMessageInserted(it)
+                }
                 kaliumLogger
                     .logEventProcessing(
                         EventLoggingStatus.SUCCESS,
@@ -113,7 +120,10 @@ internal class NewMessageEventHandlerImpl(
                     )
                 )
             }.onSuccess {
-                handleSuccessfulResult(it)
+                if (it is MessageUnpackResult.ApplicationMessage) {
+                    handleSuccessfulResult(it)
+                    onMessageInserted(it)
+                }
                 kaliumLogger
                     .logEventProcessing(
                         EventLoggingStatus.SUCCESS,
@@ -122,17 +132,22 @@ internal class NewMessageEventHandlerImpl(
             }
     }
 
-    private suspend fun handleSuccessfulResult(result: MessageUnpackResult) {
-        if (result is MessageUnpackResult.ApplicationMessage) {
-            applicationMessageHandler.handleContent(
-                conversationId = result.conversationId,
-                timestampIso = result.timestampIso,
-                senderUserId = result.senderUserId,
-                senderClientId = result.senderClientId,
-                content = result.content
+    private fun onMessageInserted(result: MessageUnpackResult.ApplicationMessage) {
+        if (result.senderUserId == selfUserId && result.content.expiresAfterMillis != null) {
+            enqueueSelfDeletion(
+                result.conversationId,
+                result.content.messageUid
             )
-        } else {
-            // NO-OP. Pure Protocol messages are handled by the unpackers
         }
+    }
+
+    private suspend fun handleSuccessfulResult(result: MessageUnpackResult.ApplicationMessage) {
+        applicationMessageHandler.handleContent(
+            conversationId = result.conversationId,
+            timestampIso = result.timestampIso,
+            senderUserId = result.senderUserId,
+            senderClientId = result.senderClientId,
+            content = result.content
+        )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -22,9 +22,16 @@ import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.MLSFailure
 import com.wire.kalium.logic.ProteusFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.ProtoContent
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -36,6 +43,7 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -60,7 +68,16 @@ class NewMessageEventHandlerTest {
     @Test
     fun givenProteusDUPLICATED_MESSAGE_whenHandling_thenErrorShouldBeIgnored() = runTest {
         val (arrangement, newMessageEventHandler) = Arrangement()
-            .withProteusUnpackerReturning(Either.Left(ProteusFailure(ProteusException(message = null, code = ProteusException.Code.DUPLICATE_MESSAGE))))
+            .withProteusUnpackerReturning(
+                Either.Left(
+                    ProteusFailure(
+                        ProteusException(
+                            message = null,
+                            code = ProteusException.Code.DUPLICATE_MESSAGE
+                        )
+                    )
+                )
+            )
             .arrange()
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
@@ -81,7 +98,16 @@ class NewMessageEventHandlerTest {
     @Test
     fun givenProteus_whenHandling_thenErrorShouldBeHandled() = runTest {
         val (arrangement, newMessageEventHandler) = Arrangement()
-            .withProteusUnpackerReturning(Either.Left(ProteusFailure(ProteusException(message = null, code = ProteusException.Code.INVALID_SIGNATURE))))
+            .withProteusUnpackerReturning(
+                Either.Left(
+                    ProteusFailure(
+                        ProteusException(
+                            message = null,
+                            code = ProteusException.Code.INVALID_SIGNATURE
+                        )
+                    )
+                )
+            )
             .arrange()
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
@@ -113,6 +139,145 @@ class NewMessageEventHandlerTest {
             .suspendFunction(arrangement.mlsMessageUnpacker::unpackMlsMessage)
             .with(eq(newMessageEvent))
             .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenEphemeralMessageFromSelf_whenHandling_thenEnqueueForSelfDelete() = runTest {
+        val conversationID = ConversationId("conversationID", "domain")
+        val senderUserId = SELF_USER_ID
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withProteusUnpackerReturning(
+                Either.Right(
+                    MessageUnpackResult.ApplicationMessage(
+                        conversationID,
+                        Instant.DISTANT_PAST.toIsoDateTimeString(),
+                        senderUserId,
+                        ClientId("clientID"),
+                        ProtoContent.Readable(
+                            messageUid = "messageUID",
+                             messageContent = MessageContent.Text(
+                                 value = "messageContent"
+                             ),
+                            expectsReadConfirmation = false,
+                            expiresAfterMillis = 123L
+                        )
+                    )
+                )
+            )
+            .arrange()
+
+        val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
+
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+
+        verify(arrangement.proteusMessageUnpacker)
+            .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
+            .with(eq(newMessageEvent))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.applicationMessageHandler)
+            .suspendFunction(arrangement.applicationMessageHandler::handleDecryptionError)
+            .with(any(), any(), any(), any(), any(), any())
+            .wasNotInvoked()
+
+        verify(arrangement.ephemeralMessageDeletionHandler)
+            .function(arrangement.ephemeralMessageDeletionHandler::startSelfDeletion)
+            .with(any(), any())
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenEphemeralMessage_whenHandling_thenDoNotEnqueueForSelfDelete() = runTest {
+        val conversationID = ConversationId("conversationID", "domain")
+        val senderUserId = UserId("otherUserId", "domain")
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withProteusUnpackerReturning(
+                Either.Right(
+                    MessageUnpackResult.ApplicationMessage(
+                        conversationID,
+                        Instant.DISTANT_PAST.toIsoDateTimeString(),
+                        senderUserId,
+                        ClientId("clientID"),
+                        ProtoContent.Readable(
+                            messageUid = "messageUID",
+                            messageContent = MessageContent.Text(
+                                value = "messageContent"
+                            ),
+                            expectsReadConfirmation = false,
+                            expiresAfterMillis = 123L
+                        )
+                    )
+                )
+            )
+            .arrange()
+
+        val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
+
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+
+        verify(arrangement.proteusMessageUnpacker)
+            .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
+            .with(eq(newMessageEvent))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.applicationMessageHandler)
+            .suspendFunction(arrangement.applicationMessageHandler::handleDecryptionError)
+            .with(any(), any(), any(), any(), any(), any())
+            .wasNotInvoked()
+
+        verify(arrangement.ephemeralMessageDeletionHandler)
+            .function(arrangement.ephemeralMessageDeletionHandler::startSelfDeletion)
+            .with(any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenMessageFromSelf_whenHandling_thenDoNotEnqueueForSelfDelete() = runTest {
+        val conversationID = ConversationId("conversationID", "domain")
+        val senderUserId = SELF_USER_ID
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withProteusUnpackerReturning(
+                Either.Right(
+                    MessageUnpackResult.ApplicationMessage(
+                        conversationID,
+                        Instant.DISTANT_PAST.toIsoDateTimeString(),
+                        senderUserId,
+                        ClientId("clientID"),
+                        ProtoContent.Readable(
+                            messageUid = "messageUID",
+                            messageContent = MessageContent.Text(
+                                value = "messageContent"
+                            ),
+                            expectsReadConfirmation = false,
+                            expiresAfterMillis = null
+                        )
+                    )
+                )
+            )
+            .arrange()
+
+        val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
+
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+
+        verify(arrangement.proteusMessageUnpacker)
+            .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
+            .with(eq(newMessageEvent))
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.applicationMessageHandler)
+            .suspendFunction(arrangement.applicationMessageHandler::handleDecryptionError)
+            .with(any(), any(), any(), any(), any(), any())
+            .wasNotInvoked()
+
+        verify(arrangement.ephemeralMessageDeletionHandler)
+            .function(arrangement.ephemeralMessageDeletionHandler::startSelfDeletion)
+            .with(any(), any())
+            .wasNotInvoked()
+    }
+
+    private companion object {
+        val SELF_USER_ID = UserId("selfUserId", "selfDomain")
     }
 
     @Test
@@ -163,10 +328,15 @@ class NewMessageEventHandlerTest {
         @Mock
         val mlsWrongEpochHandler = mock(classOf<MLSWrongEpochHandler>())
 
+        @Mock
+        val ephemeralMessageDeletionHandler = mock(EphemeralMessageDeletionHandler::class)
+
         private val newMessageEventHandler: NewMessageEventHandler = NewMessageEventHandlerImpl(
             proteusMessageUnpacker,
             mlsMessageUnpacker,
             applicationMessageHandler,
+            { conversationId, messageId -> ephemeralMessageDeletionHandler.startSelfDeletion(conversationId, messageId) },
+            SELF_USER_ID,
             mlsWrongEpochHandler
         )
 


### PR DESCRIPTION
…ically (#1863)

* fix: start deleting timer for messages from self after receive

* unit test

* unit test

* NoUnusedImports

* fix

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
