### PR TITLE
ci: automatically cherry-pick changes from `release/candidate`

### DIFF
--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -29,21 +29,9 @@ jobs:
                   echo "New branch name: $NEW_BRANCH_NAME"
                   echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
 
-            - name: Check if changes only in kalium submodule
-              id: check_changes
-              run: |
-                  NUM_CHANGES=$(git diff origin/develop --name-only | grep -v '^kalium/' | wc -l)
-                  if [ "$NUM_CHANGES" -gt 0 ]; then
-                    echo "::set-output name=shouldCherryPick::true"
-                  else
-                    echo "No changes outside of kalium submodule, skipping cherry-pick"
-                    echo "::set-output name=shouldCherryPick::false"
-                  fi
-
             - uses: fregante/setup-git-user@v2
 
             - name: Cherry-pick commits
-              if: steps.check_changes.outputs.shouldCherryPick == 'true'
               run: |
                   git fetch origin develop:develop
                   git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
@@ -54,7 +42,6 @@ jobs:
                   git push origin ${{ steps.extract.outputs.newBranchName }}
 
             - name: Create PR
-              if: steps.check_changes.outputs.shouldCherryPick == 'true'
               env:
                   PR_TITLE: ${{ github.event.pull_request.title }}
                   PR_BRANCH: ${{ steps.extract.outputs.newBranchName }}

--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -1,0 +1,63 @@
+name: "Cherry-pick from rc to develop"
+
+on:
+    pull_request:
+        branches:
+            - release/candidate
+        types:
+            - closed
+
+jobs:
+    cherry-pick:
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.merged == true
+
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - name: Append -cherry-pick to branch name
+              id: extract
+              run: |
+                  PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+                  NEW_BRANCH_NAME="${PR_BRANCH}-cherry-pick"
+                  echo "New branch name: $NEW_BRANCH_NAME"
+                  echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
+
+            - name: Check if changes only in kalium submodule
+              id: check_changes
+              run: |
+                  NUM_CHANGES=$(git diff origin/develop --name-only | grep -v '^kalium/' | wc -l)
+                  if [ "$NUM_CHANGES" -gt 0 ]; then
+                    echo "::set-output name=shouldCherryPick::true"
+                  else
+                    echo "No changes outside of kalium submodule, skipping cherry-pick"
+                    echo "::set-output name=shouldCherryPick::false"
+                  fi
+
+            - uses: fregante/setup-git-user@v2
+
+            - name: Cherry-pick commits
+              if: steps.check_changes.outputs.shouldCherryPick == 'true'
+              run: |
+                  git fetch origin develop:develop
+                  git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
+                  # Cherry-picking the last commit on the base branch
+                  git cherry-pick -x ${{ github.event.pull_request.merge_commit_sha }} --strategy-option theirs || true
+                  git add .
+                  git cherry-pick --continue || true
+                  git push origin ${{ steps.extract.outputs.newBranchName }}
+
+            - name: Create PR
+              if: steps.check_changes.outputs.shouldCherryPick == 'true'
+              env:
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+                  PR_BRANCH: ${{ steps.extract.outputs.newBranchName }}
+                  PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
+                  PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n{1}', github.event.pull_request.number, github.event.pull_request.body) }}"
+              run: gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop --head $PR_BRANCH --label "cherry-pick" --assignee "$PR_ASSIGNEE"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have to manually cherry-pick changes from `release/candidate` into `develop`. Which leads to human error and forgotten commits.

### Solutions

Porting the work @Garzas has done on Reloaded into Kalium:

- https://github.com/wireapp/wire-android-reloaded/pull/1951

Which does:

- Add a new GitHub workflow that will listen for merged PRs into `release/candidate`
- Cherry pick the merge commit
- Push to a new branch with `-cherry-pick` suffix
- Create a new PR with:
  - same assignee
  - same title
  - same body
  - `cherry-pick` label

> **Note**: When this PR is merged, it will automatically open a PR on `develop` as well :)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
