### PR TITLE
feat(mls-migration): ignore inactive clients when calculating supported protocols #11

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
@@ -20,7 +20,9 @@ package com.wire.kalium.logic.data.client
 
 import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.logic.data.conversation.ClientId
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.days
 
 data class RegisterClientParam(
     val password: String?,
@@ -60,7 +62,11 @@ data class Client(
     val label: String?,
     val model: String?,
     val isMLSCapable: Boolean
-)
+) {
+    companion object {
+        val INACTIVE_DURATION = 28.days
+    }
+}
 
 enum class ClientType {
     Temporary,
@@ -86,3 +92,12 @@ data class OtherUserClient(
     val isValid: Boolean,
     val isVerified: Boolean
 )
+
+/**
+ * True if the client is considered to be in active use.
+ *
+ * A client is considered active if it has connected to the backend within
+ * the `INACTIVE_DURATION`.
+ */
+val Client.isActive: Boolean
+    get() = lastActive?.let { (Clock.System.now() - it) < Client.INACTIVE_DURATION } ?: false

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCase.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.client.isActive
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
 import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.featureConfig.MLSModel
@@ -99,10 +100,10 @@ internal class UpdateSupportedProtocolsUseCaseImpl(
     ): Boolean {
         val mlsIsSupported = mlsConfiguration.supportedProtocols.contains(SupportedProtocol.MLS)
         val mlsMigrationHasEnded = migrationConfiguration.hasMigrationEnded()
-        val allSelfClientsAreMLSCapable = selfClients.all { it.isMLSCapable }
+        val allSelfClientsAreMLSCapable = selfClients.filter { it.isActive }.all { it.isMLSCapable }
         kaliumLogger.d(
             "mls is supported = $mlsIsSupported, " +
-                    "all self clients are mls capable = $allSelfClientsAreMLSCapable " +
+                    "all active self clients are mls capable = $allSelfClientsAreMLSCapable " +
                     "migration has ended = $mlsMigrationHasEnded"
         )
         return mlsIsSupported && (mlsMigrationHasEnded || allSelfClientsAreMLSCapable)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.client
+
+import com.wire.kalium.logic.framework.TestClient
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+
+class ClientTest {
+
+    @Test
+    fun givenLastActiveIsNull_thenIsActiveIsFalse() {
+        val client = TestClient.CLIENT.copy(
+            lastActive = null
+        )
+        assertFalse(client.isActive)
+    }
+
+    @Test
+    fun givenLastActiveIsOlderThanInactivityDuration_thenIsActiveIsFalse() {
+        val client = TestClient.CLIENT.copy(
+            lastActive = Clock.System.now() - (Client.INACTIVE_DURATION + 1.days)
+        )
+        assertFalse(client.isActive)
+    }
+
+    @Test
+    fun givenLastActiveIsNewerThanInactivityDuration_thenIsActiveIsTrue() {
+        val client = TestClient.CLIENT.copy(
+            lastActive = Clock.System.now() - (Client.INACTIVE_DURATION - 1.days)
+        )
+        assertTrue(client.isActive)
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When migration to MLS we are waiting for a user to update all his clients to version which supports MLS. The problem is this might never happen since it's very common to end up with abandon clients which is not longer tied to a physical device and thus it will never become MLS capable.

The solution is to only wait for clients which are actively in use to become MLS capable.

Further reading: 
* https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/791970001/1+1+conversations+with+MLS?focusedCommentId=792657968#Updating-your-supported-protocols
* https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/810450986/Tracking+active+clients+on+the+backend

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
