### PR TITLE
fix: updating isMLSCapable

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -39,7 +39,7 @@ label = coalesce(excluded.label, label),
 model = coalesce(excluded.model, model),
 is_valid = is_valid,
 last_active = coalesce(excluded.last_active, last_active),
-is_mls_capable = is_mls_capable;
+is_mls_capable = excluded.is_mls_capable OR is_mls_capable;
 
 selectAllClients:
 SELECT * FROM Client;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -39,7 +39,7 @@ label = coalesce(excluded.label, label),
 model = coalesce(excluded.model, model),
 is_valid = is_valid,
 last_active = coalesce(excluded.last_active, last_active),
-is_mls_capable = excluded.is_mls_capable OR is_mls_capable;
+is_mls_capable = excluded.is_mls_capable OR is_mls_capable; -- it's not possible to remove mls capability once added
 
 selectAllClients:
 SELECT * FROM Client;

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -186,6 +186,32 @@ class ClientDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenIsMLSCapableIsFalse_whenUpdatingAClient_thenItShouldUpdatedToTrue() = runTest {
+        val user = user
+        userDAO.insertUser(user)
+        clientDAO.insertClient(insertedClient.copy(
+            isMLSCapable = false
+        ))
+        clientDAO.insertClient(insertedClient.copy(
+            isMLSCapable = true
+        ))
+        assertTrue { clientDAO.getClientsOfUserByQualifiedID(userId).first().isMLSCapable }
+    }
+
+    @Test
+    fun givenIsMLSCapableIsTrue_whenUpdatingAClient_thenItShouldRemainTrue() = runTest {
+        val user = user
+        userDAO.insertUser(user)
+        clientDAO.insertClient(insertedClient.copy(
+            isMLSCapable = true
+        ))
+        clientDAO.insertClient(insertedClient.copy(
+            isMLSCapable = false
+        ))
+        assertTrue { clientDAO.getClientsOfUserByQualifiedID(userId).first().isMLSCapable }
+    }
+
+    @Test
     fun whenInsertingANewClient_thenIsMustBeMarkedAsValid() = runTest {
         val user = user
         userDAO.insertUser(user)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

It should be possible to update `isMLSCapable` from false to true but not the other way around.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
