### PR TITLE
chore: improve logging of self deleting messages

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -524,8 +524,8 @@ sealed class DeliveryStatus {
     fun toLogMap(): Map<String, String> = when (this) {
         is PartialDelivery -> mutableMapOf(
             "value" to "PARTIAL_DELIVERY",
-            "failed-with-no-clients" to recipientsFailedWithNoClients.joinToString(",") { it.value },
-            "failed-delivery" to recipientsFailedDelivery.joinToString(",") { it.value }
+            "failed-with-no-clients" to recipientsFailedWithNoClients.joinToString(",") { it.toLogString() },
+            "failed-delivery" to recipientsFailedDelivery.joinToString(",") { it.toLogString() }
         )
 
         is CompleteDelivery -> mutableMapOf(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -50,6 +51,7 @@ sealed interface Message {
         val senderClientId: ClientId
 
         fun toLogString(): String
+        fun toLogMap(): Map<String, Any?>
     }
 
     /**
@@ -85,10 +87,13 @@ sealed interface Message {
         val deliveryStatus: DeliveryStatus = DeliveryStatus.CompleteDelivery
     ) : Sendable, Standalone {
 
-        @Suppress("LongMethod")
         override fun toLogString(): String {
+            return "${toLogMap().toJsonElement()}"
+        }
+        @Suppress("LongMethod")
+        override fun toLogMap(): Map<String, Any?> {
             val typeKey = "type"
-            val properties: MutableMap<String, Any> = when (content) {
+            val properties: MutableMap<String, Any?> = when (content) {
                 is MessageContent.Text -> mutableMapOf(
                     typeKey to "text"
                 )
@@ -136,12 +141,13 @@ sealed interface Message {
                 "senderClientId" to senderClientId.value.obfuscateId(),
                 "editStatus" to editStatus.toLogMap(),
                 "expectsReadConfirmation" to "$expectsReadConfirmation",
-                "deliveryStatus" to "$deliveryStatus"
+                "deliveryStatus" to deliveryStatus.toLogMap(),
+                "expirationData" to expirationData?.toLogMap()
             )
 
             properties.putAll(standardProperties)
 
-            return "${properties.toMap().toJsonElement()}"
+            return properties.toMap()
         }
     }
 
@@ -158,6 +164,11 @@ sealed interface Message {
         override val expirationData: ExpirationData?
     ) : Sendable {
         override fun toLogString(): String {
+            return "${toLogMap().toJsonElement()}"
+        }
+
+        @Suppress("LongMethod")
+        override fun toLogMap(): Map<String, Any?> {
             val typeKey = "type"
 
             val properties: MutableMap<String, Any> = when (content) {
@@ -223,7 +234,7 @@ sealed interface Message {
 
             properties.putAll(standardProperties)
 
-            return "${properties.toJsonElement()}"
+            return properties.toMap()
         }
 
     }
@@ -242,13 +253,17 @@ sealed interface Message {
         val senderUserName: String? = null
     ) : Message, Standalone {
         fun toLogString(): String {
+            return "${toLogMap().toJsonElement()}"
+        }
+
+        fun toLogMap(): Map<String, Any?> {
 
             val typeKey = "type"
             val properties: MutableMap<String, String> = when (content) {
                 is MessageContent.MemberChange -> mutableMapOf(
                     typeKey to "memberChange",
                     "members" to content.members.fold("") { acc, member ->
-                        return "$acc, ${member.value.obfuscateId()}@${member.domain.obfuscateDomain()}"
+                         "$acc, ${member.value.obfuscateId()}@${member.domain.obfuscateDomain()}"
                     }
                 )
 
@@ -294,7 +309,7 @@ sealed interface Message {
 
             val standardProperties = mapOf(
                 "id" to id.obfuscateId(),
-                "conversationId" to "${conversationId.toLogString()}",
+                "conversationId" to conversationId.toLogString(),
                 "date" to date,
                 "senderUserId" to senderUserId.value.obfuscateId(),
                 "status" to "$status",
@@ -303,7 +318,7 @@ sealed interface Message {
 
             properties.putAll(standardProperties)
 
-            return Json.encodeToString(properties.toMap())
+            return properties.toMap()
         }
     }
 
@@ -337,12 +352,30 @@ sealed interface Message {
         }
     }
 
-    data class ExpirationData(val expireAfter: Duration, val selfDeletionStatus: SelfDeletionStatus = SelfDeletionStatus.NotStarted) {
+    data class ExpirationData(
+        val expireAfter: Duration,
+        val selfDeletionStatus: SelfDeletionStatus = SelfDeletionStatus.NotStarted
+    ) {
 
         sealed class SelfDeletionStatus {
             object NotStarted : SelfDeletionStatus()
 
             data class Started(val selfDeletionStartDate: Instant) : SelfDeletionStatus()
+
+            fun toLogMap(): Map<String, String> = when (this) {
+                is NotStarted -> mutableMapOf(
+                    "value" to "NOT_STARTED"
+                )
+
+                is Started -> mutableMapOf(
+                    "value" to "STARTED",
+                    "time" to this.selfDeletionStartDate.toString()
+                )
+            }
+
+            fun toLogString(): String {
+                return Json.encodeToString(toLogMap())
+            }
         }
 
         fun timeLeftForDeletion(): Duration {
@@ -350,7 +383,7 @@ sealed interface Message {
                 val timeElapsedSinceSelfDeletionStartDate = Clock.System.now() - selfDeletionStatus.selfDeletionStartDate
 
                 // time left for deletion it can be a negative value if the time difference between the self deletion start date and
-                // now is greater then expire after millis, we normalize it to 0 seconds
+                // now is greater than expire after millis, we normalize it to 0 seconds
                 val timeLeft = expireAfter - timeElapsedSinceSelfDeletionStartDate
 
                 if (timeLeft.isNegative()) {
@@ -360,6 +393,24 @@ sealed interface Message {
                 }
             } else {
                 expireAfter
+            }
+        }
+
+        fun toLogString(): String {
+            return Json.encodeToString(toLogMap())
+        }
+
+        fun toLogMap(): Map<String, Any?> = mapOf(
+            "expire-after" to expireAfter.inWholeSeconds.toString(),
+            "expire-start-time" to expireStartTimeElement().toString(),
+            "deletion-status" to selfDeletionStatus.toLogMap()
+        )
+
+        private fun expireStartTimeElement(): String? {
+            return when (val selfDeletionStatus = selfDeletionStatus) {
+                SelfDeletionStatus.NotStarted -> null
+                is SelfDeletionStatus.Started ->
+                    selfDeletionStatus.selfDeletionStartDate.toIsoDateTimeString()
             }
         }
     }
@@ -469,4 +520,20 @@ sealed class DeliveryStatus {
     ) : DeliveryStatus()
 
     object CompleteDelivery : DeliveryStatus()
+
+    fun toLogMap(): Map<String, String> = when (this) {
+        is PartialDelivery -> mutableMapOf(
+            "value" to "PARTIAL_DELIVERY",
+            "failed-with-no-clients" to recipientsFailedWithNoClients.joinToString(",") { it.value },
+            "failed-delivery" to recipientsFailedDelivery.joinToString(",") { it.value }
+        )
+
+        is CompleteDelivery -> mutableMapOf(
+            "value" to "COMPLETE_DELIVERY"
+        )
+    }
+
+    fun toLogString(): String {
+        return Json.encodeToString(toLogMap())
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger.kt
@@ -53,7 +53,6 @@ internal sealed class LoggingSelfDeletionEvent(
 
     abstract fun toLogMap(): Map<String, Any?>
 
-
     data class SelfSelfDeletionAlreadyRequested(
         override val message: Message,
         override val expirationData: Message.ExpirationData
@@ -76,7 +75,7 @@ internal sealed class LoggingSelfDeletionEvent(
             return mapOf(
                 "deletion-info" to mapOf(
                     "info" to "marking-self_deletion_start_date",
-                    "start-date-mark" to  startDate.toIsoDateTimeString()
+                    "start-date-mark" to startDate.toIsoDateTimeString()
                 )
             )
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logging of self deleting message doesn't log the full message log structure and mixes a few things together.

### Solutions

Log the full message structure according to the existing log mechanisms and improve the auxiliary information.


### Attachments (Optional)

```
Self-Deletion: {
  "message": {
    "type": "text",
    "id": "7b22797***",
    "conversationId": "9b3ebe0***@wir***",
    "date": "2023-07-20T13:38:25.386Z",
    "senderUserId": "1ba9d96***",
    "status": "SENT",
    "visibility": "VISIBLE",
    "senderClientId": "f487db1***",
    "editStatus": {
      "value": "NOT_EDITED"
    },
    "expectsReadConfirmation": "true",
    "deliveryStatus": {
      "value": "COMPLETE_DELIVERY"
    },
    "expirationData": {
      "expire-after": "10",
      "expire-start-time": "null",
      "deletion-status": {
        "value": "NOT_STARTED"
      }
    }
  },
  "deletion-info": {
    "info": "waiting-for-deletion",
    "delay-wait-time": "10"
  }
}
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
