### PR TITLE
fix: composite messages are not included in the getLastMessages query [part-5]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -342,7 +342,9 @@ sealed interface MessagePreviewContent {
     sealed interface WithUser : MessagePreviewContent {
         val username: String?
 
-        data class Text(override val username: String?, val messageBody: String?) : WithUser
+        data class Text(override val username: String?, val messageBody: String) : WithUser
+
+        data class Composite(override val username: String?, val messageBody: String?) : WithUser
 
         data class Asset(override val username: String?, val type: AssetType) : WithUser
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -419,7 +419,7 @@ class MessageMapperImpl(
         )
 
         is MessageEntityContent.Composite -> MessageContent.Composite(
-            this.text?.toMessageContent(hidden) as MessageContent.Text,
+            this.text?.toMessageContent(hidden) as? MessageContent.Text,
             this.buttonList.map {
                 MessageContent.Composite.Button(
                     text = it.text,
@@ -522,6 +522,7 @@ private fun MessagePreviewEntityContent.toMessageContent(): MessagePreviewConten
     is MessagePreviewEntityContent.Text -> MessagePreviewContent.WithUser.Text(username = senderName, messageBody = messageBody)
     is MessagePreviewEntityContent.CryptoSessionReset -> MessagePreviewContent.CryptoSessionReset
     MessagePreviewEntityContent.Unknown -> MessagePreviewContent.Unknown
+    is MessagePreviewEntityContent.Composite -> MessagePreviewContent.WithUser.Composite(username = senderName, messageBody = messageBody)
 }
 
 fun AssetTypeEntity.toModel(): AssetType = when (this) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -567,7 +567,7 @@ class UserSessionScope internal constructor(
 
     private val compositeMessageRepository: CompositeMessageRepository
         get() = CompositeMessageDataSource(compositeMessageDAO = userStorage.database.compositeMessageDAO)
-    
+
     private val userRepository: UserRepository = UserDataSource(
         userStorage.database.userDAO,
         userStorage.database.metadataDAO,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -565,6 +565,9 @@ class UserSessionScope internal constructor(
     private val messageMetaDataRepository: MessageMetaDataRepository
         get() = MessageMetaDataDataSource(messageMetaDataDAO = userStorage.database.messageMetaDataDAO)
 
+    private val compositeMessageRepository: CompositeMessageRepository
+        get() = CompositeMessageDataSource(compositeMessageDAO = userStorage.database.compositeMessageDAO)
+    
     private val userRepository: UserRepository = UserDataSource(
         userStorage.database.userDAO,
         userStorage.database.metadataDAO,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessagePreview.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessagePreview.sq
@@ -44,3 +44,14 @@ LEFT JOIN MessageMention AS Mention ON Message.id == Mention.message_id AND Self
 LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
 LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
 LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id;
+
+getLastMessages:
+SELECT * FROM MessagePreview AS message
+WHERE id IN (
+	SELECT id FROM Message
+	WHERE
+		Message.visibility = 'VISIBLE' AND
+		Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE')
+	GROUP BY Message.conversation_id
+	HAVING Message.creation_date = MAX(Message.creation_date)
+);

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -231,22 +231,6 @@ SELECT (
     ELSE (SELECT isSelfMessage == 0 FROM targetMessage) END)
      AS needsToBeNotified FROM targetMessage;
 
-getLastMessages:
-SELECT * FROM MessagePreview AS message
-WHERE id IN (
-	SELECT id FROM Message
-	WHERE
-		Message.visibility = 'VISIBLE' AND
-		Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE')
-	GROUP BY Message.conversation_id
-	HAVING Message.creation_date = MAX(Message.creation_date)
-);
-
-getUnreadMessages:
-SELECT * FROM MessagePreview AS message
-WHERE isUnread AND isSelfMessage = 0
-AND visibility = 'VISIBLE' AND contentType IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL');
-
 getUnreadMessagesCount:
 SELECT
     conversation_id,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.dao.message
 
 import app.cash.sqldelight.coroutines.asFlow
 import com.wire.kalium.persistence.ConversationsQueries
+import com.wire.kalium.persistence.MessagePreviewQueries
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.NotificationQueries
 import com.wire.kalium.persistence.ReactionsQueries
@@ -49,6 +50,7 @@ internal class MessageDAOImpl internal constructor(
     private val notificationQueries: NotificationQueries,
     private val conversationsQueries: ConversationsQueries,
     private val unreadEventsQueries: UnreadEventsQueries,
+    private val messagePreviewQueries: MessagePreviewQueries,
     private val selfUserId: UserIDEntity,
     private val reactionsQueries: ReactionsQueries,
     private val coroutineContext: CoroutineContext,
@@ -291,7 +293,7 @@ internal class MessageDAOImpl internal constructor(
     }
 
     override suspend fun observeLastMessages(): Flow<List<MessagePreviewEntity>> =
-        queries.getLastMessages(mapper::toPreviewEntity).asFlow().flowOn(coroutineContext).mapToList()
+        messagePreviewQueries.getLastMessages(mapper::toPreviewEntity).asFlow().flowOn(coroutineContext).mapToList()
 
     override suspend fun observeConversationsUnreadEvents(): Flow<List<ConversationUnreadEventEntity>> {
         return unreadEventsQueries.getConversationsUnreadEvents(unreadEventMapper::toConversationUnreadEntity)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -351,7 +351,9 @@ data class NotificationMessageEntity(
 
 sealed class MessagePreviewEntityContent {
 
-    data class Text(val senderName: String?, val messageBody: String?) : MessagePreviewEntityContent()
+    data class Text(val senderName: String?, val messageBody: String) : MessagePreviewEntityContent()
+
+    data class Composite(val senderName: String?, val messageBody: String?) : MessagePreviewEntityContent()
 
     data class Asset(val senderName: String?, val type: AssetTypeEntity) : MessagePreviewEntityContent()
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -88,11 +88,15 @@ object MessageMapper {
         senderUserId: QualifiedIDEntity?
     ): MessagePreviewEntityContent {
         return when (contentType) {
-            MessageEntity.ContentType.COMPOSITE,
+            MessageEntity.ContentType.COMPOSITE -> MessagePreviewEntityContent.Composite(
+                senderName = senderName,
+                messageBody = text
+            )
+
             MessageEntity.ContentType.TEXT -> when {
                 isSelfMessage -> MessagePreviewEntityContent.Text(
                     senderName = senderName,
-                    messageBody = text
+                    messageBody = text.requireField("text")
                 )
 
                 (isQuotingSelfUser ?: false) -> MessagePreviewEntityContent.QuotedSelf(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -211,6 +211,7 @@ class UserDatabaseBuilder internal constructor(
             database.notificationQueries,
             database.conversationsQueries,
             database.unreadEventsQueries,
+            database.messagePreviewQueries,
             userId,
             database.reactionsQueries,
             queriesContext,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/LastMessageListTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/LastMessageListTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.persistence.dao
+
+import com.wire.kalium.persistence.BaseDatabaseTest
+import com.wire.kalium.persistence.dao.asset.AssetDAO
+import com.wire.kalium.persistence.dao.conversation.ConversationDAO
+import com.wire.kalium.persistence.dao.member.MemberDAO
+import com.wire.kalium.persistence.dao.message.MessageDAO
+import com.wire.kalium.persistence.dao.message.MessageEntityContent
+import com.wire.kalium.persistence.dao.message.MessagePreviewEntityContent
+import com.wire.kalium.persistence.utils.stubs.newConversationEntity
+import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class LastMessageListTest: BaseDatabaseTest() {
+
+    private lateinit var conversationDAO: ConversationDAO
+    private lateinit var connectionDAO: ConnectionDAO
+    private lateinit var messageDAO: MessageDAO
+    private lateinit var userDAO: UserDAO
+    private lateinit var teamDAO: TeamDAO
+    private lateinit var memberDAO: MemberDAO
+    private lateinit var assertDAO: AssetDAO
+    private val selfUserId = UserIDEntity("selfValue", "selfDomain")
+
+    @BeforeTest
+    fun setUp() {
+        deleteDatabase(selfUserId)
+        val db = createDatabase(selfUserId, encryptedDBSecret, enableWAL = true)
+        conversationDAO = db.conversationDAO
+        connectionDAO = db.connectionDAO
+        messageDAO = db.messageDAO
+        userDAO = db.userDAO
+        teamDAO = db.teamDAO
+        memberDAO = db.memberDAO
+        assertDAO = db.assetDAO
+    }
+
+    @Test
+    fun givenLastMessageIsComposite_thenReturnItAsLastMessage() = runTest {
+        val conversion = newConversationEntity("1")
+        val user = newUserEntity("1")
+        val message = newRegularMessageEntity(
+            content = MessageEntityContent.Composite(text = null, buttonList = listOf()),
+            conversationId = conversion.id,
+            senderUserId = user.id
+        )
+
+        conversationDAO.insertConversation(conversion)
+        userDAO.insertUser(user)
+        messageDAO.insertOrIgnoreMessage(message)
+
+        messageDAO.observeLastMessages().first().also {
+            assertEquals(1, it.size)
+            assertEquals(message.id, it.first().id)
+            assertEquals(message.conversationId, it.first().conversationId)
+            assertIs<MessagePreviewEntityContent.Composite>(it.first().content)
+        }
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

composite messages are not included in the preview

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

add COMPOSITE to the message type in the getLastMessages query

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
