### PR TITLE
fix: execute job sending message inside UserSessionScope

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -151,14 +151,15 @@ class MessageScope internal constructor(
 
     val sendTextMessage: SendTextMessageUseCase
         get() = SendTextMessageUseCase(
-            persistMessage,
-            selfUserId,
-            currentClientIdProvider,
-            slowSyncRepository,
-            messageSender,
-            messageSendFailureHandler,
-            userPropertyRepository,
-            observeSelfDeletingMessages
+            persistMessage = persistMessage,
+            selfUserId = selfUserId,
+            provideClientId = currentClientIdProvider,
+            slowSyncRepository = slowSyncRepository,
+            messageSender = messageSender,
+            messageSendFailureHandler = messageSendFailureHandler,
+            userPropertyRepository = userPropertyRepository,
+            selfDeleteTimer = observeSelfDeletingMessages,
+            scope = scope
         )
 
     val sendEditTextMessage: SendEditTextMessageUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -38,11 +38,8 @@ import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
 import kotlin.time.Duration
 
 @Suppress("LongParameterList")
@@ -106,7 +103,14 @@ class SendTextMessageUseCase internal constructor(
             persistMessage(message).flatMap {
                 messageSender.sendMessage(message)
             }
-        }.onFailure { messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, generatedMessageUuid, TYPE) }
+        }.onFailure {
+            messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                failure = it,
+                conversationId = conversationId,
+                messageId = generatedMessageUuid,
+                messageType = TYPE
+            )
+        }
     }.await()
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -104,7 +104,6 @@ class SendTextMessageUseCase internal constructor(
                 isSelfMessage = true
             )
             persistMessage(message).flatMap {
-                delay(5000)
                 messageSender.sendMessage(message)
             }
         }.onFailure { messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, generatedMessageUuid, TYPE) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -68,7 +68,7 @@ class SendTextMessageUseCase internal constructor(
         text: String,
         mentions: List<MessageMention> = emptyList(),
         quotedMessageId: String? = null
-    ): Deferred<Either<CoreFailure, Unit>> = scope.async(dispatchers.io) {
+    ): Either<CoreFailure, Unit> = scope.async(dispatchers.io) {
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }
@@ -107,7 +107,7 @@ class SendTextMessageUseCase internal constructor(
                 messageSender.sendMessage(message)
             }
         }.onFailure { messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, generatedMessageUuid, TYPE) }
-    }
+    }.await()
 
     companion object {
         const val TYPE = "Text"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
@@ -39,6 +39,7 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -53,7 +54,7 @@ class SendTextMessageCaseTest {
     @Test
     fun givenAValidMessage_whenSendingSomeText_thenShouldReturnASuccessResult() = runTest {
         // Given
-        val (arrangement, sendTextMessage) = Arrangement()
+        val (arrangement, sendTextMessage) = Arrangement(this)
             .withToggleReadReceiptsStatus()
             .withCurrentClientProviderSuccess()
             .withPersistMessageSuccess()
@@ -88,7 +89,7 @@ class SendTextMessageCaseTest {
     @Test
     fun givenNoNetwork_whenSendingSomeText_thenShouldReturnAFailure() = runTest {
         // Given
-        val (arrangement, sendTextMessage) = Arrangement()
+        val (arrangement, sendTextMessage) = Arrangement(this)
             .withToggleReadReceiptsStatus()
             .withCurrentClientProviderSuccess()
             .withPersistMessageSuccess()
@@ -120,7 +121,7 @@ class SendTextMessageCaseTest {
             .wasInvoked(once)
     }
 
-    private class Arrangement {
+    private class Arrangement(private val coroutineScope: CoroutineScope) {
 
         @Mock
         val persistMessage = mock(classOf<PersistMessageUseCase>())
@@ -196,7 +197,8 @@ class SendTextMessageCaseTest {
             messageSender,
             messageSendFailureHandler,
             userPropertyRepository,
-            observeSelfDeletionTimerSettingsForConversation
+            observeSelfDeletionTimerSettingsForConversation,
+            scope = coroutineScope
         )
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- When the user leaves the scope launching the action to send the message, if the timing is right, the message could gets stucked at any suspend point. 

### Solutions

- Move the execution of the job to UserSessionScope, to send the message as long as the app is "alive".

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
