### PR TITLE
chore: Store junit reports for upload to DataDog (WPB-3489)

### DIFF
--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -89,6 +89,15 @@ jobs:
                   name: test-reports
                   path: ./**/build/reports/tests/**
 
+            - name: Archive Test Results
+              if: always()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: test-results
+                  path: |
+                    ./**/build/test-results/**/*.xml
+                    ./**/build/outputs/androidTest-results/**/*.xml
+
             - name: Publish Unit Test Results
               uses: EnricoMi/publish-unit-test-result-action/composite@v1.25
               if: always()
@@ -114,7 +123,7 @@ jobs:
             uses: actions/download-artifact@v3
             continue-on-error: true
             with:
-                name: test-reports
+                name: test-results
             - uses: actions/setup-node@v3
             with:
                 node-version: 18

--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -133,4 +133,4 @@ jobs:
             env:
                 DD_API_KEY: ${{ secrets.DD_API_KEY }}
             run: |
-                DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-android ./*.xml
+                DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-android ./**/*.xml

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -57,6 +57,15 @@ jobs:
             name: test-reports
             path: ./**/build/reports/tests/**
 
+      - name: Archive Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+            name: test-results
+            path: |
+              ./**/build/test-results/testDebugUnitTest/**/*.xml
+              ./**/build/test-results/**/*.xml
+
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v1.25
         if: always()
@@ -82,7 +91,7 @@ jobs:
             uses: actions/download-artifact@v3
             continue-on-error: true
             with:
-                name: test-reports
+                name: test-results
           - uses: actions/setup-node@v3
             with:
               node-version: 18

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -101,4 +101,4 @@ jobs:
         env:
             DD_API_KEY: ${{ secrets.DD_API_KEY }}
         run: |
-            DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-ios ./*.xml
+            DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-ios ./**/*.xml

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -81,24 +81,24 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
-    upload-test-results-datadadog:
-      runs-on: ubuntu-latest
-      needs: gradle-run-tests
-      if: always()
+  upload-test-results-datadadog:
+    runs-on: ubuntu-latest
+    needs: gradle-run-tests
+    if: always()
 
-      steps:
-          - name: Download tests results
-            uses: actions/download-artifact@v3
-            continue-on-error: true
-            with:
-                name: test-results
-          - uses: actions/setup-node@v3
-            with:
-              node-version: 18
-          - name: Install datadog-ci
-            run: npm install -g @datadog/datadog-ci
-          - name: "Upload results"
-            env:
-                DD_API_KEY: ${{ secrets.DD_API_KEY }}
-            run: |
-                DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-ios ./*.xml
+    steps:
+      - name: Download tests results
+        uses: actions/download-artifact@v3
+        continue-on-error: true
+        with:
+            name: test-results
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install datadog-ci
+        run: npm install -g @datadog/datadog-ci
+      - name: "Upload results"
+        env:
+            DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        run: |
+            DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-ios ./*.xml

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -112,6 +112,9 @@ jobs:
         continue-on-error: true
         with:
             name: test-results
+            path: test-results
+      - name: Display structure of downloaded files
+        run: ls -R
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -64,6 +64,13 @@ jobs:
             name: test-reports
             path: ./**/build/reports/tests/**
 
+      - name: Archive Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+            name: test-results
+            path: ./**/build/test-results/**/*.xml
+
       - name: Install Pip for test result publishing
         run: |
           sudo apt-get update
@@ -104,7 +111,7 @@ jobs:
             uses: actions/download-artifact@v3
             continue-on-error: true
             with:
-                name: test-reports
+                name: test-results
           - uses: actions/setup-node@v3
             with:
               node-version: 18

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -121,4 +121,4 @@ jobs:
         env:
             DD_API_KEY: ${{ secrets.DD_API_KEY }}
         run: |
-            DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-jvm ./*.xml
+            DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-jvm ./**/*.xml

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -124,4 +124,5 @@ jobs:
         env:
             DD_API_KEY: ${{ secrets.DD_API_KEY }}
         run: |
-            DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-jvm ./**/*.xml
+            datadog-ci version
+            DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --verbose --service kalium-jvm **/*.xml

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -101,24 +101,24 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
-    upload-test-results-datadadog:
-      runs-on: ubuntu-latest
-      needs: gradle-run-tests
-      if: always()
+  upload-test-results-datadadog:
+    runs-on: ubuntu-latest
+    needs: gradle-run-tests
+    if: always()
 
-      steps:
-          - name: Download tests results
-            uses: actions/download-artifact@v3
-            continue-on-error: true
-            with:
-                name: test-results
-          - uses: actions/setup-node@v3
-            with:
-              node-version: 18
-          - name: Install datadog-ci
-            run: npm install -g @datadog/datadog-ci
-          - name: "Upload results"
-            env:
-                DD_API_KEY: ${{ secrets.DD_API_KEY }}
-            run: |
-                DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-jvm ./*.xml
+    steps:
+      - name: Download tests results
+        uses: actions/download-artifact@v3
+        continue-on-error: true
+        with:
+            name: test-results
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install datadog-ci
+        run: npm install -g @datadog/datadog-ci
+      - name: "Upload results"
+        env:
+            DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        run: |
+            DATADOG_API_KEY="${DD_API_KEY}" DD_ENV=ci DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service kalium-jvm ./*.xml


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

DataDog needs junit reports but these reports were not stored as artifacts

### Solutions

Upload JUnit reports as artifacts 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
