### PR TITLE
fix: do not refetch asset on invalid request response

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -33,10 +33,9 @@ import kotlinx.coroutines.flow.map
 
 sealed interface CoreFailure {
 
-    val isNotFoundFailure: Boolean
+    val isInvalidRequestError: Boolean
         get() = this is NetworkFailure.ServerMiscommunication
                 && this.kaliumException is KaliumException.InvalidRequestError
-                && this.kaliumException.errorResponse.code == HttpStatusCode.NotFound.value
 
     val hasUnreachableDomainsError: Boolean
         get() = this is NetworkFailure.FederatedBackendFailure.FailedDomains && this.domains.isNotEmpty()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -24,7 +24,6 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
-import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetAvatarAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetAvatarAssetUseCase.kt
@@ -45,7 +45,7 @@ internal class GetAvatarAssetUseCaseImpl(
         // TODO(important!!): do local lookup for the profile pic before downloading a new one
         assetDataSource.downloadPublicAsset(assetKey.value, assetKey.domain).fold({
             when {
-                it.isNotFoundFailure -> {
+                it.isInvalidRequestError -> {
                     userRepository.removeUserBrokenAsset(assetKey)
                     PublicAssetResult.Failure(it, false)
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCase.kt
@@ -118,7 +118,7 @@ internal class GetMessageAssetUseCaseImpl(
                             // This should be called if there is an issue while downloading the asset
                             updateAssetMessageDownloadStatus(Message.DownloadStatus.FAILED_DOWNLOAD, conversationId, messageId)
                             when {
-                                it.isNotFoundFailure -> {
+                                it.isInvalidRequestError -> {
                                     assetMetadata.assetKeyDomain?.let { domain ->
                                         userRepository.removeUserBrokenAsset(QualifiedID(assetMetadata.assetKey, domain))
                                     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user have multiple accounts of users that are not federating with each other it tries refetch them in loop (400 error code response)

### Causes (Optional)

Blinking avatar effect on other accounts screen

### Solutions

Don't refetch asset on any invalid request error