### PR TITLE
refactor: allow fetching whole conversations by a member [WPB-2181]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -192,7 +192,7 @@ interface ConversationRepository {
 
     suspend fun deleteUserFromConversations(userId: UserId): Either<CoreFailure, Unit>
 
-    suspend fun getConversationIdsByUserId(userId: UserId): Either<CoreFailure, List<ConversationId>>
+    suspend fun getConversationsByUserId(userId: UserId): Either<CoreFailure, List<Conversation>>
     suspend fun insertConversations(conversations: List<Conversation>): Either<CoreFailure, Unit>
     suspend fun changeConversationName(
         conversationId: ConversationId,
@@ -696,9 +696,9 @@ internal class ConversationDataSource internal constructor(
         conversationDAO.revokeOneOnOneConversationsWithDeletedUser(userId.toDao())
     }
 
-    override suspend fun getConversationIdsByUserId(userId: UserId): Either<CoreFailure, List<ConversationId>> {
-        return wrapStorageRequest { conversationDAO.getConversationIdsByUserId(userId.toDao()) }
-            .map { it.map { conversationIdEntity -> conversationIdEntity.toModel() } }
+    override suspend fun getConversationsByUserId(userId: UserId): Either<CoreFailure, List<Conversation>> {
+        return wrapStorageRequest { conversationDAO.getConversationsByUserId(userId.toDao()) }
+            .map { it.map { entity -> conversationMapper.fromDaoModel(entity) } }
     }
 
     override suspend fun insertConversations(conversations: List<Conversation>): Either<CoreFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
@@ -92,13 +92,13 @@ internal class TeamEventReceiverImpl(
             .onSuccess {
                 val knownUser = userRepository.getKnownUser(userId).first()
                 if (knownUser?.name != null) {
-                    conversationRepository.getConversationIdsByUserId(userId)
+                    conversationRepository.getConversationsByUserId(userId)
                         .onSuccess {
-                            it.forEach { conversationId ->
+                            it.forEach { conversation ->
                                 val message = Message.System(
                                     id = uuid4().toString(), // We generate a random uuid for this new system message
                                     content = MessageContent.TeamMemberRemoved(knownUser.name),
-                                    conversationId = conversationId,
+                                    conversationId = conversation.id,
                                     date = event.timestampIso,
                                     senderUserId = userId,
                                     status = Message.Status.SENT,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -76,7 +76,6 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.persistence.dao.client.ClientTypeEntity
 import com.wire.kalium.persistence.dao.client.DeviceTypeEntity
-import com.wire.kalium.persistence.dao.client.Client as ClientEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationViewEntity
@@ -98,7 +97,6 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.thenDoNothing
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -112,13 +110,21 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import com.wire.kalium.network.api.base.model.ConversationId as ConversationIdDTO
+import com.wire.kalium.persistence.dao.client.Client as ClientEntity
 
 @Suppress("LargeClass")
 class ConversationRepositoryTest {
 
     @Test
     fun givenNewConversationEvent_whenCallingPersistConversation_thenConversationShouldBePersisted() = runTest {
-        val event = Event.Conversation.NewConversation("id", TestConversation.ID, false, TestUser.SELF.id, "time", CONVERSATION_RESPONSE)
+        val event = Event.Conversation.NewConversation(
+            "id",
+            TestConversation.ID,
+            false,
+            TestUser.SELF.id,
+            "time",
+            CONVERSATION_RESPONSE
+        )
         val selfUserFlow = flowOf(TestUser.SELF)
         val (arrangement, conversationRepository) = Arrangement()
             .withSelfUserFlow(selfUserFlow)
@@ -139,104 +145,126 @@ class ConversationRepositoryTest {
     }
 
     @Test
-    fun givenNewConversationEvent_whenCallingPersistConversationFromEvent_thenConversationShouldBePersisted() = runTest {
-        val event = Event.Conversation.NewConversation("id", TestConversation.ID, false, TestUser.SELF.id, "time", CONVERSATION_RESPONSE)
-        val selfUserFlow = flowOf(TestUser.SELF)
-        val (arrangement, conversationRepository) = Arrangement()
-            .withSelfUserFlow(selfUserFlow)
-            .withExpectedConversationBase(null)
-            .arrange()
+    fun givenNewConversationEvent_whenCallingPersistConversationFromEvent_thenConversationShouldBePersisted() =
+        runTest {
+            val event = Event.Conversation.NewConversation(
+                "id",
+                TestConversation.ID,
+                false,
+                TestUser.SELF.id,
+                "time",
+                CONVERSATION_RESPONSE
+            )
+            val selfUserFlow = flowOf(TestUser.SELF)
+            val (arrangement, conversationRepository) = Arrangement()
+                .withSelfUserFlow(selfUserFlow)
+                .withExpectedConversationBase(null)
+                .arrange()
 
-        conversationRepository.persistConversation(event.conversation, "teamId")
+            conversationRepository.persistConversation(event.conversation, "teamId")
 
-        with(arrangement) {
-            verify(conversationDAO)
-                .suspendFunction(conversationDAO::insertConversation)
-                .with(
-                    matching { conversation ->
-                        conversation.id.value == CONVERSATION_RESPONSE.id.value
-                    }
-                )
-                .wasInvoked(exactly = once)
+            with(arrangement) {
+                verify(conversationDAO)
+                    .suspendFunction(conversationDAO::insertConversation)
+                    .with(
+                        matching { conversation ->
+                            conversation.id.value == CONVERSATION_RESPONSE.id.value
+                        }
+                    )
+                    .wasInvoked(exactly = once)
+            }
         }
-    }
 
     @Test
-    fun givenNewConversationEvent_whenCallingPersistConversationFromEventAndExists_thenConversationPersistenceShouldBeSkipped() = runTest {
-        val event = Event.Conversation.NewConversation("id", TestConversation.ID, false, TestUser.SELF.id, "time", CONVERSATION_RESPONSE)
-        val selfUserFlow = flowOf(TestUser.SELF)
-        val (arrangement, conversationRepository) = Arrangement()
-            .withSelfUserFlow(selfUserFlow)
-            .withExpectedConversationBase(TestConversation.ENTITY)
-            .arrange()
+    fun givenNewConversationEvent_whenCallingPersistConversationFromEventAndExists_thenConversationPersistenceShouldBeSkipped() =
+        runTest {
+            val event = Event.Conversation.NewConversation(
+                "id",
+                TestConversation.ID,
+                false,
+                TestUser.SELF.id,
+                "time",
+                CONVERSATION_RESPONSE
+            )
+            val selfUserFlow = flowOf(TestUser.SELF)
+            val (arrangement, conversationRepository) = Arrangement()
+                .withSelfUserFlow(selfUserFlow)
+                .withExpectedConversationBase(TestConversation.ENTITY)
+                .arrange()
 
-        conversationRepository.persistConversation(event.conversation, "teamId")
+            conversationRepository.persistConversation(event.conversation, "teamId")
 
-        with(arrangement) {
-            verify(conversationDAO)
-                .suspendFunction(conversationDAO::insertConversation)
-                .with(
-                    matching { conversation ->
-                        conversation.id.value == CONVERSATION_RESPONSE.id.value
-                    }
-                )
-                .wasNotInvoked()
+            with(arrangement) {
+                verify(conversationDAO)
+                    .suspendFunction(conversationDAO::insertConversation)
+                    .with(
+                        matching { conversation ->
+                            conversation.id.value == CONVERSATION_RESPONSE.id.value
+                        }
+                    )
+                    .wasNotInvoked()
+            }
         }
-    }
 
     @Test
-    fun givenNewConversationEventWithMlsConversation_whenCallingInsertConversation_thenMlsGroupExistenceShouldBeQueried() = runTest {
-        val event = Event.Conversation.NewConversation(
-            "id",
-            TestConversation.ID,
-            false,
-            TestUser.SELF.id,
-            "time",
-            CONVERSATION_RESPONSE.copy(
-                groupId = RAW_GROUP_ID,
-                protocol = MLS,
-                mlsCipherSuiteTag = ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519.cipherSuiteTag
+    fun givenNewConversationEventWithMlsConversation_whenCallingInsertConversation_thenMlsGroupExistenceShouldBeQueried() =
+        runTest {
+            val event = Event.Conversation.NewConversation(
+                "id",
+                TestConversation.ID,
+                false,
+                TestUser.SELF.id,
+                "time",
+                CONVERSATION_RESPONSE.copy(
+                    groupId = RAW_GROUP_ID,
+                    protocol = MLS,
+                    mlsCipherSuiteTag = ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519.cipherSuiteTag
+                )
             )
-        )
-        val protocolInfo = ConversationEntity.ProtocolInfo.MLS(
-            RAW_GROUP_ID,
-            ConversationEntity.GroupState.ESTABLISHED,
-            0UL,
-            Instant.parse("2021-03-30T15:36:00.000Z"),
-            cipherSuite = ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-        )
+            val protocolInfo = ConversationEntity.ProtocolInfo.MLS(
+                RAW_GROUP_ID,
+                ConversationEntity.GroupState.ESTABLISHED,
+                0UL,
+                Instant.parse("2021-03-30T15:36:00.000Z"),
+                cipherSuite = ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            )
 
-        val (arrangement, conversationRepository) = Arrangement()
-            .withSelfUserFlow(flowOf(TestUser.SELF))
-            .withHasEstablishedMLSGroup(true)
-            .arrange()
+            val (arrangement, conversationRepository) = Arrangement()
+                .withSelfUserFlow(flowOf(TestUser.SELF))
+                .withHasEstablishedMLSGroup(true)
+                .arrange()
 
-        conversationRepository.persistConversations(listOf(event.conversation), "teamId", originatedFromEvent = true)
+            conversationRepository.persistConversations(
+                listOf(event.conversation),
+                "teamId",
+                originatedFromEvent = true
+            )
 
-        verify(arrangement.mlsClient)
-            .suspendFunction(arrangement.mlsClient::conversationExists)
-            .with(eq(RAW_GROUP_ID))
-            .wasInvoked(once)
+            verify(arrangement.mlsClient)
+                .suspendFunction(arrangement.mlsClient::conversationExists)
+                .with(eq(RAW_GROUP_ID))
+                .wasInvoked(once)
 
-        verify(arrangement.conversationDAO)
-            .suspendFunction(arrangement.conversationDAO::insertConversations)
-            .with(
-                matching { conversations ->
-                    conversations.any { entity ->
-                        entity.id.value == CONVERSATION_RESPONSE.id.value && entity.protocolInfo == protocolInfo.copy(
-                            keyingMaterialLastUpdate = (entity.protocolInfo as ConversationEntity.ProtocolInfo.MLS).keyingMaterialLastUpdate
-                        )
+            verify(arrangement.conversationDAO)
+                .suspendFunction(arrangement.conversationDAO::insertConversations)
+                .with(
+                    matching { conversations ->
+                        conversations.any { entity ->
+                            entity.id.value == CONVERSATION_RESPONSE.id.value && entity.protocolInfo == protocolInfo.copy(
+                                keyingMaterialLastUpdate = (entity.protocolInfo as ConversationEntity.ProtocolInfo.MLS).keyingMaterialLastUpdate
+                            )
+                        }
                     }
-                }
-            )
-            .wasInvoked(once)
-    }
+                )
+                .wasInvoked(once)
+        }
 
     @Test
     fun givenTwoPagesOfConversation_whenFetchingConversationsAndItsDetails_thenThePagesShouldBeAddedAndPersistOnlyFounds() =
         runTest {
             // given
-            val response = ConversationPagingResponse(listOf(CONVERSATION_IDS_DTO_ONE, CONVERSATION_IDS_DTO_TWO), false, "")
+            val response =
+                ConversationPagingResponse(listOf(CONVERSATION_IDS_DTO_ONE, CONVERSATION_IDS_DTO_TWO), false, "")
 
             val (arrangement, conversationRepository) = Arrangement()
                 .withFetchConversationsIds(NetworkResponse.Success(response, emptyMap(), HttpStatusCode.OK.value))
@@ -274,51 +302,54 @@ class ConversationRepositoryTest {
         }
 
     @Test
-    fun givenConversationDaoReturnsAGroupConversation_whenGettingConversationDetailsById_thenReturnAGroupConversationDetails() = runTest {
-        val conversationEntity = TestConversation.VIEW_ENTITY.copy(type = ConversationEntity.Type.GROUP)
+    fun givenConversationDaoReturnsAGroupConversation_whenGettingConversationDetailsById_thenReturnAGroupConversationDetails() =
+        runTest {
+            val conversationEntity = TestConversation.VIEW_ENTITY.copy(type = ConversationEntity.Type.GROUP)
 
-        val (_, conversationRepository) = Arrangement()
-            .withExpectedObservableConversation(conversationEntity)
-            .arrange()
+            val (_, conversationRepository) = Arrangement()
+                .withExpectedObservableConversation(conversationEntity)
+                .arrange()
 
-        conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
-            assertIs<Either.Right<ConversationDetails.Group>>(awaitItem())
-            awaitComplete()
+            conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
+                assertIs<Either.Right<ConversationDetails.Group>>(awaitItem())
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun givenConversationDaoReturnsASelfConversation_whenGettingConversationDetailsById_thenReturnASelfConversationDetails() = runTest {
-        val conversationEntity = TestConversation.VIEW_ENTITY.copy(type = ConversationEntity.Type.SELF)
+    fun givenConversationDaoReturnsASelfConversation_whenGettingConversationDetailsById_thenReturnASelfConversationDetails() =
+        runTest {
+            val conversationEntity = TestConversation.VIEW_ENTITY.copy(type = ConversationEntity.Type.SELF)
 
-        val (_, conversationRepository) = Arrangement()
-            .withExpectedObservableConversation(conversationEntity)
-            .arrange()
+            val (_, conversationRepository) = Arrangement()
+                .withExpectedObservableConversation(conversationEntity)
+                .arrange()
 
-        conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
-            assertIs<Either.Right<ConversationDetails.Self>>(awaitItem())
-            awaitComplete()
+            conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
+                assertIs<Either.Right<ConversationDetails.Self>>(awaitItem())
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun givenConversationDaoReturnsAOneOneConversation_whenGettingConversationDetailsById_thenReturnAOneOneConversationDetails() = runTest {
-        val conversationId = TestConversation.ENTITY_ID
-        val conversationEntity = TestConversation.VIEW_ENTITY.copy(
-            id = conversationId,
-            type = ConversationEntity.Type.ONE_ON_ONE,
-            otherUserId = QualifiedIDEntity("otherUser", "domain")
-        )
+    fun givenConversationDaoReturnsAOneOneConversation_whenGettingConversationDetailsById_thenReturnAOneOneConversationDetails() =
+        runTest {
+            val conversationId = TestConversation.ENTITY_ID
+            val conversationEntity = TestConversation.VIEW_ENTITY.copy(
+                id = conversationId,
+                type = ConversationEntity.Type.ONE_ON_ONE,
+                otherUserId = QualifiedIDEntity("otherUser", "domain")
+            )
 
-        val (_, conversationRepository) = Arrangement()
-            .withExpectedObservableConversation(conversationEntity)
-            .arrange()
+            val (_, conversationRepository) = Arrangement()
+                .withExpectedObservableConversation(conversationEntity)
+                .arrange()
 
-        conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
-            assertIs<Either.Right<ConversationDetails.OneOne>>(awaitItem())
-            awaitComplete()
+            conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
+                assertIs<Either.Right<ConversationDetails.OneOne>>(awaitItem())
+                awaitComplete()
+            }
         }
-    }
 
     @Test
     fun givenUserHasKnownContactAndConversation_WhenGettingConversationDetailsByExistingConversation_ReturnTheCorrectConversation() =
@@ -453,121 +484,123 @@ class ConversationRepositoryTest {
 
     @Suppress("LongMethod")
     @Test
-    fun givenUpdateAccessRoleSuccess_whenUpdatingConversationAccessInfo_thenTheNewAccessSettingsAreUpdatedLocally() = runTest {
+    fun givenUpdateAccessRoleSuccess_whenUpdatingConversationAccessInfo_thenTheNewAccessSettingsAreUpdatedLocally() =
+        runTest {
 
-        val conversationIdDTO = ConversationIdDTO("conv_id", "conv_domain")
-        val newAccessInfoDTO = ConversationAccessInfoDTO(
-            accessRole = setOf(
-                ConversationAccessRoleDTO.TEAM_MEMBER,
-                ConversationAccessRoleDTO.NON_TEAM_MEMBER,
-                ConversationAccessRoleDTO.SERVICE,
-                ConversationAccessRoleDTO.GUEST,
-            ),
-            access = setOf(
-                ConversationAccessDTO.INVITE,
-                ConversationAccessDTO.CODE,
-                ConversationAccessDTO.PRIVATE,
-                ConversationAccessDTO.LINK
+            val conversationIdDTO = ConversationIdDTO("conv_id", "conv_domain")
+            val newAccessInfoDTO = ConversationAccessInfoDTO(
+                accessRole = setOf(
+                    ConversationAccessRoleDTO.TEAM_MEMBER,
+                    ConversationAccessRoleDTO.NON_TEAM_MEMBER,
+                    ConversationAccessRoleDTO.SERVICE,
+                    ConversationAccessRoleDTO.GUEST,
+                ),
+                access = setOf(
+                    ConversationAccessDTO.INVITE,
+                    ConversationAccessDTO.CODE,
+                    ConversationAccessDTO.PRIVATE,
+                    ConversationAccessDTO.LINK
+                )
             )
-        )
-        val newAccess = UpdateConversationAccessResponse.AccessUpdated(
-            EventContentDTO.Conversation.AccessUpdate(
-                conversationIdDTO,
-                data = newAccessInfoDTO,
-                qualifiedFrom = com.wire.kalium.network.api.base.model.UserId("from_id", "from_domain")
+            val newAccess = UpdateConversationAccessResponse.AccessUpdated(
+                EventContentDTO.Conversation.AccessUpdate(
+                    conversationIdDTO,
+                    data = newAccessInfoDTO,
+                    qualifiedFrom = com.wire.kalium.network.api.base.model.UserId("from_id", "from_domain")
+                )
             )
-        )
 
-        val (arrange, conversationRepository) = Arrangement()
-            .withApiUpdateAccessRoleReturns(NetworkResponse.Success(newAccess, mapOf(), 200))
-            .withDaoUpdateAccessSuccess()
-            .arrange()
+            val (arrange, conversationRepository) = Arrangement()
+                .withApiUpdateAccessRoleReturns(NetworkResponse.Success(newAccess, mapOf(), 200))
+                .withDaoUpdateAccessSuccess()
+                .arrange()
 
-        conversationRepository.updateAccessInfo(
-            conversationID = ConversationId(conversationIdDTO.value, conversationIdDTO.domain),
-            access = setOf(
-                Conversation.Access.INVITE,
-                Conversation.Access.CODE,
-                Conversation.Access.PRIVATE,
-                Conversation.Access.LINK
-            ),
-            accessRole = setOf(
-                Conversation.AccessRole.TEAM_MEMBER,
-                Conversation.AccessRole.NON_TEAM_MEMBER,
-                Conversation.AccessRole.SERVICE,
-                Conversation.AccessRole.GUEST
-            )
-        ).shouldSucceed()
+            conversationRepository.updateAccessInfo(
+                conversationID = ConversationId(conversationIdDTO.value, conversationIdDTO.domain),
+                access = setOf(
+                    Conversation.Access.INVITE,
+                    Conversation.Access.CODE,
+                    Conversation.Access.PRIVATE,
+                    Conversation.Access.LINK
+                ),
+                accessRole = setOf(
+                    Conversation.AccessRole.TEAM_MEMBER,
+                    Conversation.AccessRole.NON_TEAM_MEMBER,
+                    Conversation.AccessRole.SERVICE,
+                    Conversation.AccessRole.GUEST
+                )
+            ).shouldSucceed()
 
-        with(arrange) {
-            verify(conversationApi)
-                .coroutine {
-                    conversationApi.updateAccess(
-                        conversationIdDTO,
-                        UpdateConversationAccessRequest(
-                            newAccessInfoDTO.access,
-                            newAccessInfoDTO.accessRole
+            with(arrange) {
+                verify(conversationApi)
+                    .coroutine {
+                        conversationApi.updateAccess(
+                            conversationIdDTO,
+                            UpdateConversationAccessRequest(
+                                newAccessInfoDTO.access,
+                                newAccessInfoDTO.accessRole
+                            )
                         )
-                    )
-                }
-                .wasInvoked(exactly = once)
+                    }
+                    .wasInvoked(exactly = once)
 
-            verify(conversationDAO)
-                .coroutine {
-                    conversationDAO.updateAccess(
-                        ConversationIDEntity(conversationIdDTO.value, conversationIdDTO.domain),
-                        accessList = listOf(
-                            ConversationEntity.Access.INVITE,
-                            ConversationEntity.Access.CODE,
-                            ConversationEntity.Access.PRIVATE,
-                            ConversationEntity.Access.LINK
-                        ),
-                        accessRoleList = listOf(
-                            ConversationEntity.AccessRole.TEAM_MEMBER,
-                            ConversationEntity.AccessRole.NON_TEAM_MEMBER,
-                            ConversationEntity.AccessRole.SERVICE,
-                            ConversationEntity.AccessRole.GUEST
+                verify(conversationDAO)
+                    .coroutine {
+                        conversationDAO.updateAccess(
+                            ConversationIDEntity(conversationIdDTO.value, conversationIdDTO.domain),
+                            accessList = listOf(
+                                ConversationEntity.Access.INVITE,
+                                ConversationEntity.Access.CODE,
+                                ConversationEntity.Access.PRIVATE,
+                                ConversationEntity.Access.LINK
+                            ),
+                            accessRoleList = listOf(
+                                ConversationEntity.AccessRole.TEAM_MEMBER,
+                                ConversationEntity.AccessRole.NON_TEAM_MEMBER,
+                                ConversationEntity.AccessRole.SERVICE,
+                                ConversationEntity.AccessRole.GUEST
+                            )
                         )
-                    )
-                }
-                .wasInvoked(exactly = once)
+                    }
+                    .wasInvoked(exactly = once)
+            }
         }
-    }
 
     @Test
-    fun givenUpdateConversationMemberRoleSuccess_whenUpdatingConversationMemberRole_thenTheNewRoleIsUpdatedLocally() = runTest {
-        val (arrange, conversationRepository) = Arrangement()
-            .withApiUpdateConversationMemberRoleReturns(NetworkResponse.Success(Unit, mapOf(), 200))
-            .withDaoUpdateConversationMemberRoleSuccess()
-            .arrange()
-        val conversationId = ConversationId("conv_id", "conv_domain")
-        val userId: UserId = UserId("user_id", "user_domain")
-        val newRole = Conversation.Member.Role.Admin
+    fun givenUpdateConversationMemberRoleSuccess_whenUpdatingConversationMemberRole_thenTheNewRoleIsUpdatedLocally() =
+        runTest {
+            val (arrange, conversationRepository) = Arrangement()
+                .withApiUpdateConversationMemberRoleReturns(NetworkResponse.Success(Unit, mapOf(), 200))
+                .withDaoUpdateConversationMemberRoleSuccess()
+                .arrange()
+            val conversationId = ConversationId("conv_id", "conv_domain")
+            val userId: UserId = UserId("user_id", "user_domain")
+            val newRole = Conversation.Member.Role.Admin
 
-        conversationRepository.updateConversationMemberRole(conversationId, userId, newRole).shouldSucceed()
+            conversationRepository.updateConversationMemberRole(conversationId, userId, newRole).shouldSucceed()
 
-        with(arrange) {
-            verify(conversationApi)
-                .coroutine {
-                    conversationApi.updateConversationMemberRole(
-                        conversationId.toApi(),
-                        userId.toApi(),
-                        ConversationMemberRoleDTO(MapperProvider.conversationRoleMapper().toApi(newRole))
-                    )
-                }
-                .wasInvoked(exactly = once)
+            with(arrange) {
+                verify(conversationApi)
+                    .coroutine {
+                        conversationApi.updateConversationMemberRole(
+                            conversationId.toApi(),
+                            userId.toApi(),
+                            ConversationMemberRoleDTO(MapperProvider.conversationRoleMapper().toApi(newRole))
+                        )
+                    }
+                    .wasInvoked(exactly = once)
 
-            verify(memberDAO)
-                .coroutine {
-                    memberDAO.updateConversationMemberRole(
-                        conversationId.toDao(),
-                        userId.toDao(),
-                        MapperProvider.conversationRoleMapper().toDAO(newRole)
-                    )
-                }
-                .wasInvoked(exactly = once)
+                verify(memberDAO)
+                    .coroutine {
+                        memberDAO.updateConversationMemberRole(
+                            conversationId.toDao(),
+                            userId.toDao(),
+                            MapperProvider.conversationRoleMapper().toDAO(newRole)
+                        )
+                    }
+                    .wasInvoked(exactly = once)
+            }
         }
-    }
 
     @Test
     fun givenProteusConversation_WhenDeletingTheConversation_ThenShouldBeDeletedLocally() = runTest {
@@ -610,125 +643,129 @@ class ConversationRepositoryTest {
     }
 
     @Test
-    fun givenAGroupConversationHasNewMessages_whenGettingConversationDetails_ThenCorrectlyGetUnreadMessageCount() = runTest {
-        // given
-        val conversationIdEntity = ConversationIDEntity("some_value", "some_domain")
-        val conversationId = QualifiedID("some_value", "some_domain")
+    fun givenAGroupConversationHasNewMessages_whenGettingConversationDetails_ThenCorrectlyGetUnreadMessageCount() =
+        runTest {
+            // given
+            val conversationIdEntity = ConversationIDEntity("some_value", "some_domain")
+            val conversationId = QualifiedID("some_value", "some_domain")
 
-        val conversationEntity = TestConversation.VIEW_ENTITY.copy(
-            id = conversationIdEntity,
-            type = ConversationEntity.Type.GROUP,
-        )
+            val conversationEntity = TestConversation.VIEW_ENTITY.copy(
+                id = conversationIdEntity,
+                type = ConversationEntity.Type.GROUP,
+            )
 
-        val unreadMessagesCount = 5
-        val conversationUnreadEventEntity = ConversationUnreadEventEntity(
-            conversationIdEntity,
-            mapOf(UnreadEventTypeEntity.MESSAGE to unreadMessagesCount)
-        )
+            val unreadMessagesCount = 5
+            val conversationUnreadEventEntity = ConversationUnreadEventEntity(
+                conversationIdEntity,
+                mapOf(UnreadEventTypeEntity.MESSAGE to unreadMessagesCount)
+            )
 
-        val (_, conversationRepository) = Arrangement()
-            .withConversations(listOf(conversationEntity))
-            .withLastMessages(listOf())
-            .withConversationUnreadEvents(listOf(conversationUnreadEventEntity))
-            .arrange()
+            val (_, conversationRepository) = Arrangement()
+                .withConversations(listOf(conversationEntity))
+                .withLastMessages(listOf())
+                .withConversationUnreadEvents(listOf(conversationUnreadEventEntity))
+                .arrange()
 
-        // when
-        conversationRepository.observeConversationListDetails().test {
-            val result = awaitItem()
+            // when
+            conversationRepository.observeConversationListDetails().test {
+                val result = awaitItem()
 
-            assertContains(result.map { it.conversation.id }, conversationId)
-            val conversation = result.first { it.conversation.id == conversationId }
+                assertContains(result.map { it.conversation.id }, conversationId)
+                val conversation = result.first { it.conversation.id == conversationId }
 
-            assertIs<ConversationDetails.Group>(conversation)
-            assertEquals(conversation.unreadEventCount[UnreadEventType.MESSAGE], unreadMessagesCount)
+                assertIs<ConversationDetails.Group>(conversation)
+                assertEquals(conversation.unreadEventCount[UnreadEventType.MESSAGE], unreadMessagesCount)
 
-            awaitComplete()
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun givenAGroupConversationHasNotNewMessages_whenGettingConversationDetails_ThenReturnZeroUnreadMessageCount() = runTest {
-        // given
-        val conversationEntity = TestConversation.VIEW_ENTITY.copy(
-            type = ConversationEntity.Type.GROUP,
-        )
+    fun givenAGroupConversationHasNotNewMessages_whenGettingConversationDetails_ThenReturnZeroUnreadMessageCount() =
+        runTest {
+            // given
+            val conversationEntity = TestConversation.VIEW_ENTITY.copy(
+                type = ConversationEntity.Type.GROUP,
+            )
 
-        val (_, conversationRepository) = Arrangement()
-            .withExpectedObservableConversation(conversationEntity)
-            .arrange()
+            val (_, conversationRepository) = Arrangement()
+                .withExpectedObservableConversation(conversationEntity)
+                .arrange()
 
-        // when
-        conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
-            // then
-            val conversationDetail = awaitItem()
+            // when
+            conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
+                // then
+                val conversationDetail = awaitItem()
 
-            assertIs<Either.Right<ConversationDetails.Group>>(conversationDetail)
-            assertTrue { conversationDetail.value.lastMessage == null }
+                assertIs<Either.Right<ConversationDetails.Group>>(conversationDetail)
+                assertTrue { conversationDetail.value.lastMessage == null }
 
-            awaitComplete()
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun givenAOneToOneConversationHasNotNewMessages_whenGettingConversationDetails_ThenReturnZeroUnreadMessageCount() = runTest {
-        // given
-        val conversationEntity = TestConversation.VIEW_ENTITY.copy(
-            type = ConversationEntity.Type.ONE_ON_ONE,
-            otherUserId = QualifiedIDEntity("otherUser", "domain")
-        )
+    fun givenAOneToOneConversationHasNotNewMessages_whenGettingConversationDetails_ThenReturnZeroUnreadMessageCount() =
+        runTest {
+            // given
+            val conversationEntity = TestConversation.VIEW_ENTITY.copy(
+                type = ConversationEntity.Type.ONE_ON_ONE,
+                otherUserId = QualifiedIDEntity("otherUser", "domain")
+            )
 
-        val (_, conversationRepository) = Arrangement()
-            .withExpectedObservableConversation(conversationEntity)
-            .arrange()
+            val (_, conversationRepository) = Arrangement()
+                .withExpectedObservableConversation(conversationEntity)
+                .arrange()
 
-        // when
-        conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
-            // then
-            val conversationDetail = awaitItem()
+            // when
+            conversationRepository.observeConversationDetailsById(TestConversation.ID).test {
+                // then
+                val conversationDetail = awaitItem()
 
-            assertIs<Either.Right<ConversationDetails.OneOne>>(conversationDetail)
-            assertTrue { conversationDetail.value.lastMessage == null }
+                assertIs<Either.Right<ConversationDetails.OneOne>>(conversationDetail)
+                assertTrue { conversationDetail.value.lastMessage == null }
 
-            awaitComplete()
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun givenAGroupConversationHasNewMessages_whenObservingConversationListDetails_ThenCorrectlyGetUnreadMessageCount() = runTest {
-        // given
-        val conversationIdEntity = ConversationIDEntity("some_value", "some_domain")
-        val conversationId = QualifiedID("some_value", "some_domain")
+    fun givenAGroupConversationHasNewMessages_whenObservingConversationListDetails_ThenCorrectlyGetUnreadMessageCount() =
+        runTest {
+            // given
+            val conversationIdEntity = ConversationIDEntity("some_value", "some_domain")
+            val conversationId = QualifiedID("some_value", "some_domain")
 
-        val conversationEntity = TestConversation.VIEW_ENTITY.copy(
-            id = conversationIdEntity, type = ConversationEntity.Type.ONE_ON_ONE,
-            otherUserId = QualifiedIDEntity("otherUser", "domain")
-        )
+            val conversationEntity = TestConversation.VIEW_ENTITY.copy(
+                id = conversationIdEntity, type = ConversationEntity.Type.ONE_ON_ONE,
+                otherUserId = QualifiedIDEntity("otherUser", "domain")
+            )
 
-        val unreadMessagesCount = 5
-        val conversationUnreadEventEntity = ConversationUnreadEventEntity(
-            conversationIdEntity,
-            mapOf(UnreadEventTypeEntity.MESSAGE to unreadMessagesCount)
-        )
+            val unreadMessagesCount = 5
+            val conversationUnreadEventEntity = ConversationUnreadEventEntity(
+                conversationIdEntity,
+                mapOf(UnreadEventTypeEntity.MESSAGE to unreadMessagesCount)
+            )
 
-        val (_, conversationRepository) = Arrangement()
-            .withConversations(listOf(conversationEntity))
-            .withLastMessages(listOf())
-            .withConversationUnreadEvents(listOf(conversationUnreadEventEntity))
-            .arrange()
+            val (_, conversationRepository) = Arrangement()
+                .withConversations(listOf(conversationEntity))
+                .withLastMessages(listOf())
+                .withConversationUnreadEvents(listOf(conversationUnreadEventEntity))
+                .arrange()
 
-        // when
-        conversationRepository.observeConversationListDetails().test {
-            val result = awaitItem()
+            // when
+            conversationRepository.observeConversationListDetails().test {
+                val result = awaitItem()
 
-            assertContains(result.map { it.conversation.id }, conversationId)
-            val conversation = result.first { it.conversation.id == conversationId }
+                assertContains(result.map { it.conversation.id }, conversationId)
+                val conversation = result.first { it.conversation.id == conversationId }
 
-            assertIs<ConversationDetails.OneOne>(conversation)
-            assertEquals(conversation.unreadEventCount[UnreadEventType.MESSAGE], unreadMessagesCount)
+                assertIs<ConversationDetails.OneOne>(conversation)
+                assertEquals(conversation.unreadEventCount[UnreadEventType.MESSAGE], unreadMessagesCount)
 
-            awaitComplete()
+                awaitComplete()
+            }
         }
-    }
 
     @Test
     fun givenAConversationDaoFailed_whenUpdatingTheConversationReadDate_thenShouldNotSucceed() = runTest {
@@ -807,7 +844,8 @@ class ConversationRepositoryTest {
         val whoDeletedMe = UserId("deletion-author", "deletion-author-domain")
         val conversationId = ConversationId("conv_id", "conv_domain")
         val selfUserFlow = flowOf(TestUser.SELF)
-        val (arrange, conversationRepository) = Arrangement().withSelfUserFlow(selfUserFlow).withWhoDeletedMe(whoDeletedMe).arrange()
+        val (arrange, conversationRepository) = Arrangement().withSelfUserFlow(selfUserFlow)
+            .withWhoDeletedMe(whoDeletedMe).arrange()
 
         val result = conversationRepository.whoDeletedMe(conversationId)
 
@@ -832,7 +870,8 @@ class ConversationRepositoryTest {
     @Test
     fun givenAConversationId_WhenTheConversationExists_ShouldReturnAConversationInstance() = runTest {
         val conversationId = ConversationId("conv_id", "conv_domain")
-        val (_, conversationRepository) = Arrangement().withExpectedObservableConversation(TestConversation.VIEW_ENTITY).arrange()
+        val (_, conversationRepository) = Arrangement().withExpectedObservableConversation(TestConversation.VIEW_ENTITY)
+            .arrange()
 
         val result = conversationRepository.getConversationById(conversationId)
         assertNotNull(result)
@@ -841,13 +880,15 @@ class ConversationRepositoryTest {
     @Test
     fun givenAnUserId_WhenGettingConversationIds_ShouldReturnSuccess() = runTest {
         val userId = UserId("user_id", "user_domain")
-        val (arrange, conversationRepository) = Arrangement().withConversationIdsByUserId(listOf(TestConversation.ID)).arrange()
+        val (arrange, conversationRepository) = Arrangement()
+            .withConversationsByUserId(listOf(TestConversation.ENTITY))
+            .arrange()
 
-        val result = conversationRepository.getConversationIdsByUserId(userId)
+        val result = conversationRepository.getConversationsByUserId(userId)
         with(result) {
             shouldSucceed()
             verify(arrange.conversationDAO)
-                .suspendFunction(arrange.conversationDAO::getConversationIdsByUserId)
+                .suspendFunction(arrange.conversationDAO::getConversationsByUserId)
                 .with(any())
                 .wasInvoked(exactly = once)
         }
@@ -961,8 +1002,8 @@ class ConversationRepositoryTest {
         with(result) {
             shouldSucceed()
             verify(arrange.conversationDAO)
-            .suspendFunction(arrange.conversationDAO::getConversationsWithoutMetadata)
-            .wasInvoked(exactly = once)
+                .suspendFunction(arrange.conversationDAO::getConversationsWithoutMetadata)
+                .wasInvoked(exactly = once)
 
             verify(arrange.conversationApi)
                 .suspendFunction(arrange.conversationApi::fetchConversationsListDetails)
@@ -1053,8 +1094,8 @@ class ConversationRepositoryTest {
         }
     }
 
-        private class Arrangement :
-            MemberDAOArrangement by MemberDAOArrangementImpl() {
+    private class Arrangement :
+        MemberDAOArrangement by MemberDAOArrangementImpl() {
         @Mock
         val userRepository: UserRepository = mock(UserRepository::class)
 
@@ -1083,7 +1124,8 @@ class ConversationRepositoryTest {
         private val messageDAO = configure(mock(MessageDAO::class)) { stubsUnitByDefault = true }
 
         @Mock
-        val renamedConversationEventHandler = configure(mock(RenamedConversationEventHandler::class)) { stubsUnitByDefault = true }
+        val renamedConversationEventHandler =
+            configure(mock(RenamedConversationEventHandler::class)) { stubsUnitByDefault = true }
 
         val conversationRepository =
             ConversationDataSource(
@@ -1319,13 +1361,11 @@ class ConversationRepositoryTest {
                 .thenReturn(author)
         }
 
-        fun withConversationIdsByUserId(conversationIds: List<ConversationId>) = apply {
-            val conversationIdEntities = conversationIds.map { it.toDao() }
-
+        fun withConversationsByUserId(conversations: List<ConversationEntity>) = apply {
             given(conversationDAO)
-                .suspendFunction(conversationDAO::getConversationIdsByUserId)
+                .suspendFunction(conversationDAO::getConversationsByUserId)
                 .whenInvokedWith(any())
-                .thenReturn(conversationIdEntities)
+                .thenReturn(conversations)
         }
 
         fun withConversationRenameCall(newName: String = "newName") = apply {
@@ -1370,7 +1410,7 @@ class ConversationRepositoryTest {
                     )
                 )
         }
-        
+
         fun withConversationsWithoutMetadataId(result: List<QualifiedIDEntity>) = apply {
             given(conversationDAO)
                 .suspendFunction(conversationDAO::getConversationsWithoutMetadata)
@@ -1469,7 +1509,8 @@ class ConversationRepositoryTest {
         )
         val UPDATE_PROTOCOL_UNCHANGED = NetworkResponse.Success(
             UpdateConversationProtocolResponse.ProtocolUnchanged,
-            emptyMap(), 204)
+            emptyMap(), 204
+        )
 
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiverTest.kt
@@ -18,8 +18,8 @@
 
 package com.wire.kalium.logic.sync.receiver
 
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.team.TeamRole
@@ -78,7 +78,7 @@ class TeamEventReceiverTest {
         val event = TestEvent.teamMemberLeave()
         val (arrangement, eventReceiver) = Arrangement()
             .withMemberLeaveSuccess()
-            .withConversationIdsByUserId(listOf(TestConversation.ID))
+            .withConversationsByUserId(listOf(TestConversation.CONVERSATION))
             .withPersistMessageSuccess()
             .arrange()
 
@@ -143,7 +143,8 @@ class TeamEventReceiverTest {
         }
 
         fun withUpdateTeamSuccess() = apply {
-            given(teamRepository).suspendFunction(teamRepository::updateTeam).whenInvokedWith(any()).thenReturn(Either.Right(Unit))
+            given(teamRepository).suspendFunction(teamRepository::updateTeam).whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
         }
 
         fun withMemberJoinSuccess() = apply {
@@ -163,8 +164,8 @@ class TeamEventReceiverTest {
                 .whenInvokedWith(any(), any(), any()).thenReturn(Either.Right(Unit))
         }
 
-        fun withConversationIdsByUserId(conversationIds: List<ConversationId>) = apply {
-            given(conversationRepository).suspendFunction(conversationRepository::getConversationIdsByUserId)
+        fun withConversationsByUserId(conversationIds: List<Conversation>) = apply {
+            given(conversationRepository).suspendFunction(conversationRepository::getConversationsByUserId)
                 .whenInvokedWith(any()).thenReturn(Either.Right(conversationIds))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -21,8 +21,8 @@ package com.wire.kalium.logic.sync.receiver
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
@@ -98,7 +98,7 @@ class UserEventReceiverTest {
         val event = TestEvent.userDelete(userId = OTHER_USER_ID)
         val (arrangement, eventReceiver) = Arrangement()
             .withUserDeleteSuccess()
-            .withConversationIdsByUserId(listOf(TestConversation.ID))
+            .withConversationsByUserId(listOf(TestConversation.CONVERSATION))
             .arrange()
 
         eventReceiver.onEvent(event)
@@ -195,7 +195,8 @@ class UserEventReceiverTest {
         }
 
         fun withUpdateUserSuccess() = apply {
-            given(userRepository).suspendFunction(userRepository::updateUserFromEvent).whenInvokedWith(any()).thenReturn(Either.Right(Unit))
+            given(userRepository).suspendFunction(userRepository::updateUserFromEvent).whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
         }
 
         fun withUserDeleteSuccess() = apply {
@@ -205,8 +206,8 @@ class UserEventReceiverTest {
                 .whenInvokedWith(any()).thenReturn(Either.Right(Unit))
         }
 
-        fun withConversationIdsByUserId(conversationIds: List<ConversationId>) = apply {
-            given(conversationRepository).suspendFunction(conversationRepository::getConversationIdsByUserId)
+        fun withConversationsByUserId(conversationIds: List<Conversation>) = apply {
+            given(conversationRepository).suspendFunction(conversationRepository::getConversationsByUserId)
                 .whenInvokedWith(any()).thenReturn(Either.Right(conversationIds))
         }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -32,7 +32,30 @@ WHERE ConversationDetails.type = 'ONE_ON_ONE' AND Member.user = ?
 LIMIT  1;
 
 selectConversationsByMember:
-SELECT * FROM Member
+SELECT
+    qualified_id,
+    name,
+    type,
+    team_id,
+    mls_group_id,
+    mls_group_state,
+    mls_epoch,
+    mls_proposal_timer,
+    protocol,
+    muted_status,
+    muted_time,
+    creator_id,
+    last_modified_date,
+    last_notified_date,
+    last_read_date,
+    access_list,
+    access_role_list,
+    mls_last_keying_material_update_date,
+    mls_cipher_suite,
+    receipt_mode,
+    message_timer,
+    user_message_timer
+FROM Member
 JOIN Conversation ON Conversation.qualified_id = Member.conversation
 WHERE Member.user = ?;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -80,7 +80,7 @@ interface ConversationDAO {
     suspend fun updateConversationType(conversationID: QualifiedIDEntity, type: ConversationEntity.Type)
     suspend fun updateConversationProtocol(conversationId: QualifiedIDEntity, protocol: ConversationEntity.Protocol): Boolean
     suspend fun revokeOneOnOneConversationsWithDeletedUser(userId: UserIDEntity)
-    suspend fun getConversationIdsByUserId(userId: UserIDEntity): List<QualifiedIDEntity>
+    suspend fun getConversationsByUserId(userId: UserIDEntity): List<ConversationEntity>
     suspend fun updateConversationReceiptMode(conversationID: QualifiedIDEntity, receiptMode: ConversationEntity.ReceiptMode)
     suspend fun updateGuestRoomLink(conversationId: QualifiedIDEntity, link: String?)
     suspend fun observeGuestRoomLinkByConversationId(conversationId: QualifiedIDEntity): Flow<String?>

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -303,8 +303,8 @@ internal class ConversationDAOImpl internal constructor(
         memberQueries.deleteUserFromGroupConversations(userId, userId)
     }
 
-    override suspend fun getConversationIdsByUserId(userId: UserIDEntity): List<QualifiedIDEntity> = withContext(coroutineContext) {
-        memberQueries.selectConversationsByMember(userId).executeAsList().map { it.conversation }
+    override suspend fun getConversationsByUserId(userId: UserIDEntity): List<ConversationEntity> = withContext(coroutineContext) {
+        memberQueries.selectConversationsByMember(userId, conversationMapper::toModel).executeAsList()
     }
 
     override suspend fun updateConversationReceiptMode(conversationID: QualifiedIDEntity, receiptMode: ConversationEntity.ReceiptMode) =

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -775,10 +775,10 @@ class ConversationDAOTest : BaseDatabaseTest() {
         memberDAO.insertMember(member2, conversationEntity2.id)
 
         // when
-        val conversationIds = conversationDAO.getConversationIdsByUserId(member1.user)
+        val conversationIds = conversationDAO.getConversationsByUserId(member1.user)
 
         // then
-        assertContentEquals(listOf(conversationEntity1.id), conversationIds)
+        assertContentEquals(listOf(conversationEntity1), conversationIds)
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For 1:1 MLS migration, at some point we need to fetch conversations with the other member and see if there is an already-existing MLS 1:1 conversation.

### Solutions

Refactor `selectConversationIdsByUserId` so it becomes `selectConversationsByUserId`.
So instead of returning only the conversation ID, it will return the whole conversation and we can use it.

> **Note**
> Performance-wise, it would be optimal to have a dedicated query that would query and return only IDs, and another dedicated thread that would return full conversations filtering by 1:1 conversation type. However these queries are _not_ used in loops, or used all the time in any way. The performance cost would be lower than maintaining these two queries.

### Testing

Changed tests to work with this refactor.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
