### PR TITLE
fix: cherry-pick automation

### DIFF
--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -27,7 +27,7 @@ jobs:
                   PR_BRANCH="${{ github.event.pull_request.head.ref }}"
                   NEW_BRANCH_NAME="${PR_BRANCH}-cherry-pick"
                   echo "New branch name: $NEW_BRANCH_NAME"
-                  echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
+                  echo "newBranchName=$NEW_BRANCH_NAME" >> $GITHUB_ENV
 
             - uses: fregante/setup-git-user@v2
 
@@ -35,19 +35,19 @@ jobs:
               id: cherry
               run: |
                   git fetch origin develop:develop
-                  git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
+                  git checkout -b ${{ env.newBranchName }} develop
                   # Cherry-picking the last commit on the base branch
                   OUTPUT=$(git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} --strategy-option theirs || true)
-                  CONFLICTS=$(echo "$OUTPUT" | grep 'CONFLICT')
-                  echo "::set-output name=conflicts::$CONFLICTS"
+                  CONFLICTS=$(echo "$OUTPUT" | grep 'CONFLICT' || echo "")
+                  echo "conflicts=$CONFLICTS" >> $GITHUB_ENV
                   git add .
                   git cherry-pick --continue || echo "No cherry-pick in progress"
-                  git push origin ${{ steps.extract.outputs.newBranchName }}
+                  git push origin ${{ env.newBranchName }} || (echo "Failed to push to origin" && exit 1)
 
             - name: Create PR
               env:
                   PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_BRANCH: ${{ steps.extract.outputs.newBranchName }}
+                  PR_BRANCH: ${{ env.newBranchName }}
                   PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
-                  PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n\n ⚠️ Conflicts during cherry-pick:\n {2} \n\n{1}', github.event.pull_request.number, github.event.pull_request.body, steps.cherry.outputs.conflicts) }}"
+                  PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n\n ⚠️ Conflicts during cherry-pick:\n {2} \n\n{1}', github.event.pull_request.number, github.event.pull_request.body, env.conflicts) }}"
               run: gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop --head $PR_BRANCH --label "cherry-pick" --assignee "$PR_ASSIGNEE"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

I don't know why it stopped working but after updating deprecating functions and adding empty text for conflicts variable it started working 