### PR TITLE
feat: support joining conversation with password protected code [WPB-1531]

### DIFF
--- a/cryptography/src/androidInstrumentedTest/kotlin/com/wire/kalium/cryptography/BaseProteusClientTest.kt
+++ b/cryptography/src/androidInstrumentedTest/kotlin/com/wire/kalium/cryptography/BaseProteusClientTest.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import java.nio.file.Files
 
-@OptIn(ExperimentalCoroutinesApi::class)
 actual open class BaseProteusClientTest {
 
     private val testCoroutineScheduler = TestCoroutineScheduler()

--- a/cryptography/src/appleTest/kotlin/com/wire/kalium/cryptography/BaseProteusClientTest.kt
+++ b/cryptography/src/appleTest/kotlin/com/wire/kalium/cryptography/BaseProteusClientTest.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSURL
 
-@OptIn(ExperimentalCoroutinesApi::class)
 actual open class BaseProteusClientTest actual constructor() {
 
     private val testCoroutineScheduler = TestCoroutineScheduler()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCase.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.network.api.base.authenticated.conversation.model.LimitedConversationInfo
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationCodeInfo
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isAccessDenied
 import com.wire.kalium.network.exceptions.isConversationNotFound
@@ -62,9 +62,9 @@ class CheckConversationInviteCodeUseCase internal constructor(
             }
         )
 
-    private suspend fun handleSuccess(response: LimitedConversationInfo, domain: String?): Result.Success {
+    private suspend fun handleSuccess(response: ConversationCodeInfo, domain: String?): Result.Success {
         val conversationId = ConversationId(
-            response.nonQualifiedConversationId,
+            response.nonQualifiedId,
             domain ?: selfUserId.domain
         )
         val isSelfMember = conversationRepository.observeIsUserMember(
@@ -103,11 +103,11 @@ class CheckConversationInviteCodeUseCase internal constructor(
         ) : Result
 
         sealed interface Failure : Result {
-            object InvalidCodeOrKey : Failure
-            object RequestingUserIsNotATeamMember : Failure
-            object AccessDenied : Failure
-            object ConversationNotFound : Failure
-            object GuestLinksDisabled : Failure
+            data object InvalidCodeOrKey : Failure
+            data object RequestingUserIsNotATeamMember : Failure
+            data object AccessDenied : Failure
+            data object ConversationNotFound : Failure
+            data object GuestLinksDisabled : Failure
             data class Generic(val failure: CoreFailure) : Failure
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCase.kt
@@ -71,7 +71,7 @@ class CheckConversationInviteCodeUseCase internal constructor(
             conversationId,
             selfUserId
         ).first().fold({ false }, { it })
-        return Result.Success(response.name, conversationId, isSelfMember)
+        return Result.Success(response.name, conversationId, isSelfMember, response.hasPassword)
     }
 
     private fun handleServerMissCommunicationError(error: NetworkFailure.ServerMiscommunication): Result.Failure =
@@ -99,7 +99,8 @@ class CheckConversationInviteCodeUseCase internal constructor(
         data class Success(
             val name: String?,
             val conversationId: ConversationId,
-            val isSelfMember: Boolean
+            val isSelfMember: Boolean,
+            val isPasswordProtected: Boolean
         ) : Result
 
         sealed interface Failure : Result {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinConversationViaCodeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinConversationViaCodeUseCase.kt
@@ -18,17 +18,14 @@
 
 package com.wire.kalium.logic.feature.conversation
 
-import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.conversation.Result
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberAddedResponse
 import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.network.exceptions.isInvalidCode
 import com.wire.kalium.network.exceptions.isWrongConversationPassword
 
 /**

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -63,7 +63,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AssetRepositoryTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -53,7 +53,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ConversationR
 import com.wire.kalium.network.api.base.authenticated.conversation.ReceiptMode
 import com.wire.kalium.network.api.base.authenticated.conversation.guestroomlink.GenerateGuestRoomLinkResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.messagetimer.ConversationMessageTimerDTO
-import com.wire.kalium.network.api.base.authenticated.conversation.model.LimitedConversationInfo
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationCodeInfo
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.Cause
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
@@ -423,7 +423,10 @@ class ConversationGroupRepositoryTest {
 
     @Test
     fun givenProteusConversation_whenJoiningConversationSuccessWithChanged_thenResponseIsHandled() = runTest {
-        val (code, key, uri) = Triple("code", "key", null)
+        val code = "code"
+        val key = "key"
+        val uri = null
+        val password = null
 
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
@@ -437,7 +440,7 @@ class ConversationGroupRepositoryTest {
             .withSuccessfulHandleMemberJoinEvent()
             .arrange()
 
-        conversationGroupRepository.joinViaInviteCode(code, key, uri)
+        conversationGroupRepository.joinViaInviteCode(code, key, uri, password)
             .shouldSucceed()
 
         verify(arrangement.conversationApi)
@@ -453,7 +456,10 @@ class ConversationGroupRepositoryTest {
 
     @Test
     fun givenMlsConversation_whenJoiningConversationSuccessWithChanged_thenAddSelfClientsToMlsGroup() = runTest {
-        val (code, key, uri) = Triple("code", "key", null)
+        val code = "code"
+        val key = "key"
+        val uri = null
+        val password = null
 
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
@@ -469,7 +475,7 @@ class ConversationGroupRepositoryTest {
             .withSuccessfulAddMemberToMLSGroup()
             .arrange()
 
-        conversationGroupRepository.joinViaInviteCode(code, key, uri)
+        conversationGroupRepository.joinViaInviteCode(code, key, uri, password)
             .shouldSucceed()
 
         verify(arrangement.conversationApi)
@@ -495,7 +501,10 @@ class ConversationGroupRepositoryTest {
 
     @Test
     fun givenProteusConversation_whenJoiningConversationSuccessWithUnchanged_thenMemberJoinEventHandlerIsNotInvoked() = runTest {
-        val (code, key, uri) = Triple("code", "key", null)
+        val code = "code"
+        val key = "key"
+        val uri = null
+        val password = null
 
         val (arrangement, conversationGroupRepository) = Arrangement()
             .withConversationDetailsById(TestConversation.CONVERSATION)
@@ -509,7 +518,7 @@ class ConversationGroupRepositoryTest {
             .withSuccessfulHandleMemberJoinEvent()
             .arrange()
 
-        conversationGroupRepository.joinViaInviteCode(code, key, uri)
+        conversationGroupRepository.joinViaInviteCode(code, key, uri, password)
             .shouldSucceed()
 
         verify(arrangement.conversationApi)
@@ -842,7 +851,7 @@ class ConversationGroupRepositoryTest {
         fun withFetchLimitedConversationInfo(
             code: String,
             key: String,
-            result: NetworkResponse<LimitedConversationInfo>
+            result: NetworkResponse<ConversationCodeInfo>
         ): Arrangement = apply {
             given(conversationApi)
                 .suspendFunction(conversationApi::fetchLimitedInformationViaCode)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -540,7 +540,7 @@ class ConversationGroupRepositoryTest {
             .withFetchLimitedConversationInfo(
                 code,
                 key,
-                NetworkResponse.Success(TestConversation.LIMITED_CONVERSATION_INFO, emptyMap(), 200)
+                NetworkResponse.Success(TestConversation.CONVERSATION_CODE_INFO, emptyMap(), 200)
             )
             .arrange()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
-import com.wire.kalium.network.api.base.authenticated.conversation.model.LimitedConversationInfo
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationCodeInfo
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.eq
@@ -47,13 +47,13 @@ class CheckConversationInviteCodeUseCaseTest {
 
     @Test
     fun givenSuccess_whenFetchingConversationInfoViaCode_thenReturnSuccess() = runTest {
-        val conversationInfo = LimitedConversationInfo("id", null)
+        val conversationInfo = ConversationCodeInfo("id", null)
         val (code, key, domain) = Triple("code", "key", "domain")
 
         val (arrangement, useCase) = Arrangement()
             .withFetchLimitedInfoViaInviteCodeResult(code, key, Either.Right(conversationInfo))
             .withObserveIsUserMemberResult(
-                ConversationId(conversationInfo.nonQualifiedConversationId, domain),
+                ConversationId(conversationInfo.nonQualifiedId, domain),
                 selfUserId,
                 Either.Right(true)
             )
@@ -62,7 +62,7 @@ class CheckConversationInviteCodeUseCaseTest {
         useCase(code, key, domain).also { result ->
             assertIs<CheckConversationInviteCodeUseCase.Result.Success>(result)
             assertEquals(conversationInfo.name, result.name)
-            assertEquals(result.conversationId, ConversationId(conversationInfo.nonQualifiedConversationId, domain))
+            assertEquals(result.conversationId, ConversationId(conversationInfo.nonQualifiedId, domain))
             assertTrue(result.isSelfMember)
         }
 
@@ -81,13 +81,13 @@ class CheckConversationInviteCodeUseCaseTest {
 
     @Test
     fun whenNoDomainIsPassed_thenUseTheUserSelfDomain() = runTest {
-        val conversationInfo = LimitedConversationInfo("id", null)
+        val conversationInfo = ConversationCodeInfo("id", null)
         val (code, key, domain) = Triple("code", "key", null)
 
         val (arrangement, useCase) = Arrangement()
             .withFetchLimitedInfoViaInviteCodeResult(code, key, Either.Right(conversationInfo))
             .withObserveIsUserMemberResult(
-                ConversationId(conversationInfo.nonQualifiedConversationId, selfUserId.domain),
+                ConversationId(conversationInfo.nonQualifiedId, selfUserId.domain),
                 selfUserId,
                 Either.Right(true)
             )
@@ -96,7 +96,7 @@ class CheckConversationInviteCodeUseCaseTest {
         useCase(code, key, domain).also { result ->
             assertIs<CheckConversationInviteCodeUseCase.Result.Success>(result)
             assertEquals(conversationInfo.name, result.name)
-            assertEquals(result.conversationId, ConversationId(conversationInfo.nonQualifiedConversationId, selfUserId.domain))
+            assertEquals(result.conversationId, ConversationId(conversationInfo.nonQualifiedId, selfUserId.domain))
             assertTrue(result.isSelfMember)
         }
 
@@ -278,7 +278,7 @@ class CheckConversationInviteCodeUseCaseTest {
         fun withFetchLimitedInfoViaInviteCodeResult(
             code: String,
             key: String,
-            result: Either<NetworkFailure, LimitedConversationInfo>
+            result: Either<NetworkFailure, ConversationCodeInfo>
         ) = apply {
             given(conversationGroupRepository)
                 .suspendFunction(conversationGroupRepository::fetchLimitedInfoViaInviteCode)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -36,7 +36,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ConversationM
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationUsers
 import com.wire.kalium.network.api.base.authenticated.conversation.ReceiptMode
-import com.wire.kalium.network.api.base.authenticated.conversation.model.LimitedConversationInfo
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationCodeInfo
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
@@ -340,5 +340,5 @@ object TestConversation {
         userMessageTimer = null
     )
 
-    val LIMITED_CONVERSATION_INFO: LimitedConversationInfo = LimitedConversationInfo("conv_id_value", "name")
+    val LIMITED_CONVERSATION_INFO: ConversationCodeInfo = ConversationCodeInfo("conv_id_value", "name")
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -340,5 +340,5 @@ object TestConversation {
         userMessageTimer = null
     )
 
-    val LIMITED_CONVERSATION_INFO: ConversationCodeInfo = ConversationCodeInfo("conv_id_value", "name")
+    val CONVERSATION_CODE_INFO: ConversationCodeInfo = ConversationCodeInfo("conv_id_value", "name")
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
@@ -19,9 +19,9 @@
 package com.wire.kalium.network.api.base.authenticated.conversation
 
 import com.wire.kalium.network.api.base.authenticated.conversation.guestroomlink.GenerateGuestRoomLinkResponse
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationCodeInfo
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationMemberRoleDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationReceiptModeDTO
-import com.wire.kalium.network.api.base.authenticated.conversation.model.LimitedConversationInfo
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.QualifiedID
@@ -102,13 +102,14 @@ interface ConversationApi {
     suspend fun joinConversation(
         code: String,
         key: String,
-        uri: String?
+        uri: String?,
+        password: String?
     ): NetworkResponse<ConversationMemberAddedResponse>
 
     suspend fun fetchLimitedInformationViaCode(
         code: String,
         key: String
-    ): NetworkResponse<LimitedConversationInfo>
+    ): NetworkResponse<ConversationCodeInfo>
 
     suspend fun fetchSubconversationDetails(
         conversationId: ConversationId,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationCodeInfo.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/model/ConversationCodeInfo.kt
@@ -22,7 +22,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class LimitedConversationInfo(
-    @SerialName("id") val nonQualifiedConversationId: String,
-    @SerialName("name") val name: String?
+data class ConversationCodeInfo(
+    @SerialName("id") val nonQualifiedId: String,
+    @SerialName("name") val name: String?,
+    @SerialName("has_password") val hasPassword: Boolean = false
 )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/JoinConversationRequest.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/JoinConversationRequest.kt
@@ -22,8 +22,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class JoinConversationRequest(
+internal data class JoinConversationRequestV0(
     @SerialName("code") val code: String,
     @SerialName("key") val key: String,
     @SerialName("uri") val uri: String?
+)
+
+@Serializable
+internal data class JoinConversationRequestV4(
+    @SerialName("code") val code: String,
+    @SerialName("key") val key: String,
+    @SerialName("uri") val uri: String?,
+    @SerialName("password") val password: String?
 )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
@@ -19,14 +19,17 @@
 package com.wire.kalium.network.api.v4.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberAddedResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponseV4
 import com.wire.kalium.network.api.base.authenticated.conversation.CreateConversationRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
+import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationCodeInfo
 import com.wire.kalium.network.api.base.model.ApiModelMapper
 import com.wire.kalium.network.api.base.model.ApiModelMapperImpl
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.FederationConflictResponse
+import com.wire.kalium.network.api.base.model.JoinConversationRequestV4
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.SubconversationId
 import com.wire.kalium.network.api.v3.authenticated.ConversationApiV3
@@ -39,7 +42,9 @@ import io.ktor.client.call.NoTransformationFoundException
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import io.ktor.client.request.post
+import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode.Companion.Conflict
 
@@ -119,6 +124,26 @@ internal open class ConversationApiV4 internal constructor(
             httpClient.delete(
                 "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_SUBCONVERSATIONS/$subconversationId/self"
             )
+        }
+
+    override suspend fun joinConversation(
+        code: String,
+        key: String,
+        uri: String?,
+        password: String?
+    ): NetworkResponse<ConversationMemberAddedResponse> =
+
+        httpClient.preparePost("$PATH_CONVERSATIONS/$PATH_JOIN") {
+            setBody(JoinConversationRequestV4(code, key, uri, password))
+        }.execute { httpResponse ->
+            handleConversationMemberAddedResponse(httpResponse)
+        }
+    override suspend fun fetchLimitedInformationViaCode(code: String, key: String): NetworkResponse<ConversationCodeInfo> =
+        wrapKaliumResponse {
+            httpClient.get("$PATH_CONVERSATIONS/$PATH_JOIN") {
+                parameter(QUERY_KEY_CODE, code)
+                parameter(QUERY_KEY_KEY, key)
+            }
         }
 
     companion object {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -50,6 +50,7 @@ import com.wire.kalium.network.exceptions.NetworkErrorLabel.TOO_MANY_CLIENTS
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.TOO_MANY_MEMBERS
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.UNKNOWN_CLIENT
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.USER_CREATION_RESTRICTED
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.WRONG_CONVERSATION_PASSWORD
 import io.ktor.http.HttpStatusCode
 
 sealed class KaliumException : Exception() {
@@ -204,6 +205,10 @@ fun KaliumException.InvalidRequestError.isGuestLinkDisabled(): Boolean {
 
 fun KaliumException.InvalidRequestError.isAccessDenied(): Boolean {
     return errorResponse.label == ACCESS_DENIED
+}
+
+fun KaliumException.InvalidRequestError.isWrongConversationPassword(): Boolean {
+    return errorResponse.label == WRONG_CONVERSATION_PASSWORD
 }
 
 val KaliumException.InvalidRequestError.authenticationCodeFailure: AuthenticationCodeFailure?

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -208,7 +208,8 @@ fun KaliumException.InvalidRequestError.isAccessDenied(): Boolean {
 }
 
 fun KaliumException.InvalidRequestError.isWrongConversationPassword(): Boolean {
-    return errorResponse.label == WRONG_CONVERSATION_PASSWORD
+    return (errorResponse.label == WRONG_CONVERSATION_PASSWORD) ||
+        (errorResponse.label == BAD_REQUEST && errorResponse.message.contains("password"))
 }
 
 val KaliumException.InvalidRequestError.authenticationCodeFailure: AuthenticationCodeFailure?

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -48,6 +48,7 @@ internal object NetworkErrorLabel {
     const val NO_CONVERSATION_CODE = "no-conversation-code"
     const val GUEST_LINKS_DISABLED = "guest-links-disabled"
     const val ACCESS_DENIED = "access-denied"
+    const val WRONG_CONVERSATION_PASSWORD = "invalid-conversation-password"
 
     object KaliumCustom {
         const val MISSING_REFRESH_TOKEN = "missing-refresh_token"

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
@@ -41,7 +41,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.model.Convers
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
 import com.wire.kalium.network.api.base.model.ConversationId
-import com.wire.kalium.network.api.base.model.JoinConversationRequest
+import com.wire.kalium.network.api.base.model.JoinConversationRequestV0
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v0.authenticated.ConversationApiV0
 import com.wire.kalium.network.utils.NetworkResponse
@@ -309,7 +309,7 @@ internal class ConversationApiV0Test : ApiTest() {
 
     @Test
     fun whenJoiningConversationViaCode_whenResponseWith200_thenEventIsParsedCorrectly() = runTest {
-        val request = JoinConversationRequest("code", "key", null)
+        val request = JoinConversationRequestV0("code", "key", null)
 
         val networkClient = mockAuthenticatedNetworkClient(
             EventContentDTOJson.validMemberJoin.rawJson, statusCode = HttpStatusCode.OK,
@@ -319,7 +319,7 @@ internal class ConversationApiV0Test : ApiTest() {
             }
         )
         val conversationApi = ConversationApiV0(networkClient)
-        val response = conversationApi.joinConversation(request.code, request.key, request.uri)
+        val response = conversationApi.joinConversation(request.code, request.key, request.uri, null)
 
         assertIs<NetworkResponse.Success<ConversationMemberAddedResponse>>(response)
         assertIs<ConversationMemberAddedResponse.Changed>(response.value)
@@ -331,7 +331,7 @@ internal class ConversationApiV0Test : ApiTest() {
 
     @Test
     fun whenJoiningConversationViaCode_whenResponseWith204_thenEventIsParsedCorrectly() = runTest {
-        val request = JoinConversationRequest("code", "key", null)
+        val request = JoinConversationRequestV0("code", "key", null)
 
         val networkClient = mockAuthenticatedNetworkClient(
             "", statusCode = HttpStatusCode.NoContent,
@@ -341,7 +341,7 @@ internal class ConversationApiV0Test : ApiTest() {
             }
         )
         val conversationApi = ConversationApiV0(networkClient)
-        val response = conversationApi.joinConversation(request.code, request.key, request.uri)
+        val response = conversationApi.joinConversation(request.code, request.key, request.uri, null)
 
         assertIs<NetworkResponse.Success<ConversationMemberAddedResponse>>(response)
         assertIs<ConversationMemberAddedResponse.Unchanged>(response.value)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

[WPB-1531]

### Solutions

support password protected guest links, this feature is api v4 only 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[WPB-1531]: https://wearezeta.atlassian.net/browse/WPB-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ