### PR TITLE
fix: team members are not included when observing all users

### DIFF
--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -27,7 +27,7 @@ jobs:
                   PR_BRANCH="${{ github.event.pull_request.head.ref }}"
                   NEW_BRANCH_NAME="${PR_BRANCH}-cherry-pick"
                   echo "New branch name: $NEW_BRANCH_NAME"
-                  echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
+                  echo "newBranchName=$NEW_BRANCH_NAME" >> $GITHUB_ENV
 
             - uses: fregante/setup-git-user@v2
 
@@ -35,19 +35,19 @@ jobs:
               id: cherry
               run: |
                   git fetch origin develop:develop
-                  git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
+                  git checkout -b ${{ env.newBranchName }} develop
                   # Cherry-picking the last commit on the base branch
                   OUTPUT=$(git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} --strategy-option theirs || true)
-                  CONFLICTS=$(echo "$OUTPUT" | grep 'CONFLICT')
-                  echo "::set-output name=conflicts::$CONFLICTS"
+                  CONFLICTS=$(echo "$OUTPUT" | grep 'CONFLICT' || echo "")
+                  echo "conflicts=$CONFLICTS" >> $GITHUB_ENV
                   git add .
                   git cherry-pick --continue || echo "No cherry-pick in progress"
-                  git push origin ${{ steps.extract.outputs.newBranchName }}
+                  git push origin ${{ env.newBranchName }} || (echo "Failed to push to origin" && exit 1)
 
             - name: Create PR
               env:
                   PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_BRANCH: ${{ steps.extract.outputs.newBranchName }}
+                  PR_BRANCH: ${{ env.newBranchName }}
                   PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
-                  PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n\n ⚠️ Conflicts during cherry-pick:\n {2} \n\n{1}', github.event.pull_request.number, github.event.pull_request.body, steps.cherry.outputs.conflicts) }}"
+                  PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n\n ⚠️ Conflicts during cherry-pick:\n {2} \n\n{1}', github.event.pull_request.number, github.event.pull_request.body, env.conflicts) }}"
               run: gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop --head $PR_BRANCH --label "cherry-pick" --assignee "$PR_ASSIGNEE"

--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -32,13 +32,16 @@ jobs:
             - uses: fregante/setup-git-user@v2
 
             - name: Cherry-pick commits
+              id: cherry
               run: |
                   git fetch origin develop:develop
                   git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
                   # Cherry-picking the last commit on the base branch
-                  git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} --strategy-option theirs || true
+                  OUTPUT=$(git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} --strategy-option theirs || true)
+                  CONFLICTS=$(echo "$OUTPUT" | grep 'CONFLICT')
+                  echo "::set-output name=conflicts::$CONFLICTS"
                   git add .
-                  git cherry-pick --continue || true
+                  git cherry-pick --continue || echo "No cherry-pick in progress"
                   git push origin ${{ steps.extract.outputs.newBranchName }}
 
             - name: Create PR
@@ -46,5 +49,5 @@ jobs:
                   PR_TITLE: ${{ github.event.pull_request.title }}
                   PR_BRANCH: ${{ steps.extract.outputs.newBranchName }}
                   PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
-                  PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n{1}', github.event.pull_request.number, github.event.pull_request.body) }}"
+                  PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n\n ⚠️ Conflicts during cherry-pick:\n {2} \n\n{1}', github.event.pull_request.number, github.event.pull_request.body, steps.cherry.outputs.conflicts) }}"
               run: gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop --head $PR_BRANCH --label "cherry-pick" --assignee "$PR_ASSIGNEE"

--- a/.github/workflows/gradle-android-tests.yml
+++ b/.github/workflows/gradle-android-tests.yml
@@ -13,37 +13,37 @@ jobs:
     detekt:
         uses: ./.github/workflows/codestyle.yml
     gradle-run-tests:
-        needs: [detekt]
+        needs: [ detekt ]
         runs-on: buildjet-4vcpu-ubuntu-2204
         strategy:
             matrix:
-                api-level: [30]
+                api-level: [ 30 ]
 
         steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
+            -   name: Checkout
+                uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0
 
-            - name: Set up JDK
-              uses: actions/setup-java@v3
-              with:
-                  java-version: '17'
-                  distribution: 'temurin'
-                  cache: gradle
+            -   name: Set up JDK
+                uses: actions/setup-java@v3
+                with:
+                    java-version: '17'
+                    distribution: 'temurin'
+                    cache: gradle
 
-            - name: Gradle Setup
-              uses: gradle/gradle-build-action@v2
+            -   name: Gradle Setup
+                uses: gradle/gradle-build-action@v2
 
-            - name: Validate Gradle wrapper
-              uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+            -   name: Validate Gradle wrapper
+                uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
 
-            - name: Build the samples
-              env:
-                  GITHUB_USER: ${{ github.actor }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  ./gradlew :samples:compileDebugSources
+            -   name: Build the samples
+                env:
+                    GITHUB_USER: ${{ github.actor }}
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: |
+                    ./gradlew :samples:compileDebugSources
 
             # - name: AVD cache
             #   uses: actions/cache@v3
@@ -68,38 +68,72 @@ jobs:
             #       disable-animations: false
             #       script: echo "Generated AVD snapshot for caching."
 
-            - name: Android Instrumentation Tests
-              uses: reactivecircus/android-emulator-runner@v2.27.0
-              with:
-                  api-level: ${{ matrix.api-level }}
-                  target: google_apis
-                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                  cores: 4
-                  ram-size: 4096M
-                  heap-size: 2048M
-                  script: ./gradlew connectedAndroidOnlyAffectedTest
-              env:
-                  GITHUB_USER: ${{ github.actor }}
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Android Instrumentation Tests
+                uses: reactivecircus/android-emulator-runner@v2.27.0
+                with:
+                    api-level: ${{ matrix.api-level }}
+                    target: google_apis
+                    emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                    cores: 4
+                    ram-size: 4096M
+                    heap-size: 2048M
+                    script: ./gradlew connectedAndroidOnlyAffectedTest
+                env:
+                    GITHUB_USER: ${{ github.actor }}
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Archive Test Reports
-              if: always()
-              uses: actions/upload-artifact@v3
-              with:
-                  name: test-reports
-                  path: ./**/build/reports/tests/**
+            -   name: Archive Test Reports
+                if: always()
+                uses: actions/upload-artifact@v3
+                with:
+                    name: test-reports
+                    path: ./**/build/reports/tests/**
 
-            - name: Publish Unit Test Results
-              uses: EnricoMi/publish-unit-test-result-action/composite@v1.25
-              if: always()
-              with:
-                  files: |
-                      **/build/test-results/**/*.xml
-                      **/build/outputs/androidTest-results/**/*.xml
+            -   name: Archive Test Results
+                if: always()
+                uses: actions/upload-artifact@v3
+                with:
+                    name: test-results
+                    path: |
+                        ./**/build/test-results/**/*.xml
+                        ./**/build/outputs/androidTest-results/**/*.xml
 
-            - name: Cleanup Gradle Cache
-                # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+            -   name: Publish Unit Test Results
+                uses: EnricoMi/publish-unit-test-result-action/composite@v1.25
+                if: always()
+                with:
+                    files: |
+                        **/build/test-results/**/*.xml
+                        **/build/outputs/androidTest-results/**/*.xml
+
+            -   name: Cleanup Gradle Cache
+                  # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
                 # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-              run: |
-                  rm -f ~/.gradle/caches/modules-2/modules-2.lock
-                  rm -f ~/.gradle/caches/modules-2/gc.properties
+                run: |
+                    rm -f ~/.gradle/caches/modules-2/modules-2.lock
+                    rm -f ~/.gradle/caches/modules-2/gc.properties
+
+    upload-test-results-datadadog:
+        runs-on: ubuntu-latest
+        needs: gradle-run-tests
+        if: always()
+
+        steps:
+            -   name: Download tests results
+                uses: actions/download-artifact@v3
+                continue-on-error: true
+                with:
+                    name: test-results
+                    uses: actions/setup-node@v3
+                    with:
+                    node-version: 18
+            -   name: Install datadog-ci
+                run: |
+                    npm install -g @datadog/datadog-ci
+            -   name: "Upload results"
+                env:
+                    DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
+                    DD_ENV: ci
+                    DATADOG_SITE: datadoghq.eu
+                run: |
+                    find . -name "*.xml" -type f | sed 's/ /\\ /g' | tr '\n' ' ' | xargs -L 1 datadog-ci junit upload --service kalium-android .

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -57,6 +57,15 @@ jobs:
             name: test-reports
             path: ./**/build/reports/tests/**
 
+      - name: Archive Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+            name: test-results
+            path: |
+              ./**/build/test-results/testDebugUnitTest/**/*.xml
+              ./**/build/test-results/**/*.xml
+
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v1.25
         if: always()
@@ -71,3 +80,27 @@ jobs:
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
+
+  upload-test-results-datadadog:
+    runs-on: ubuntu-latest
+    needs: gradle-run-tests
+    if: always()
+
+    steps:
+      - name: Download tests results
+        uses: actions/download-artifact@v3
+        continue-on-error: true
+        with:
+            name: test-results
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install datadog-ci
+        run: npm install -g @datadog/datadog-ci
+      - name: "Upload results"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_ENV: ci
+          DATADOG_SITE: datadoghq.eu
+        run: |
+          find . -name "*.xml" -type f | sed 's/ /\\ /g' | tr '\n' ' ' | xargs -L 1 datadog-ci junit upload --service kalium-ios .

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -64,6 +64,13 @@ jobs:
             name: test-reports
             path: ./**/build/reports/tests/**
 
+      - name: Archive Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+            name: test-results
+            path: ./**/build/test-results/**/*.xml
+
       - name: Install Pip for test result publishing
         run: |
           sudo apt-get update
@@ -93,3 +100,27 @@ jobs:
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
+
+  upload-test-results-datadadog:
+    runs-on: ubuntu-latest
+    needs: gradle-run-tests
+    if: always()
+
+    steps:
+      - name: Download tests results
+        uses: actions/download-artifact@v3
+        continue-on-error: true
+      - name: Display structure of downloaded files
+        run: ls -R
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install datadog-ci
+        run: npm install -g @datadog/datadog-ci
+      - name: "Upload results"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_ENV: ci
+          DATADOG_SITE: datadoghq.eu
+        run: |
+          find . -name "*.xml" -type f | sed 's/ /\\ /g' | tr '\n' ' ' | xargs -L 1 datadog-ci junit upload --service kalium-jvm .

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -19,7 +19,7 @@ jobs:
     needs: [detekt]
     runs-on: ubuntu-22.04
     # TODO: When migrating away from Cryptobox, use a regular Ubuntu machine with JDK 17 and caching
-    container: wirebot/cryptobox:1.3.0
+    container: wirebot/cryptobox:1.4.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -50,12 +50,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
 

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonAndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonAndroidConfig.kt
@@ -50,9 +50,10 @@ fun LibraryExtension.commonAndroidLibConfig(
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
+
     packagingOptions {
         resources.pickFirsts.add("google/protobuf/*.proto")
         jniLibs.pickFirsts.add("**/libsodium.so")

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonJvmConfig.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonJvmConfig.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 fun KotlinJvmTarget.commonJvmConfig(includeNativeInterop: Boolean) {
     compilations.all {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.jvmTarget = "17"
         kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
     testRuns.getByName("test").executionTask.configure {

--- a/detekt/baseline.xml
+++ b/detekt/baseline.xml
@@ -165,7 +165,7 @@
     <ID>NoUnusedImports:com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCaseTest.kt:4</ID>
     <ID>NoUnusedImports:com.wire.kalium.logic.feature.call.MediaManagerServiceImpl.kt:6</ID>
     <ID>NoUnusedImports:com.wire.kalium.logic.feature.call.MediaManagerServiceImpl.kt:7</ID>
-    <ID>NoUnusedImports:com.wire.kalium.logic.feature.call.RejectCallUseCaseTest.kt:5</ID>
+    <ID>NoUnusedImports:com.wire.kalium.logic.feature.call.usecase.RejectCallUseCaseTest.kt:5</ID>
     <ID>NoUnusedImports:com.wire.kalium.logic.feature.user.UploadUserAvatarUseCaseTest.kt:5</ID>
     <ID>NoWildcardImports:com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCaseTest.kt:8</ID>
     <ID>ObjectPropertyNaming:Decoder.module_@wireapp_cbor.kt$Decoder.Companion$var _check_overflow: Any</ID>
@@ -178,7 +178,7 @@
     <ID>SpacingAroundColon:com.wire.kalium.cryptography.exceptions.ProteusException.kt:3</ID>
     <ID>SpacingAroundColon:com.wire.kalium.logic.feature.session.SessionResult.kt:7</ID>
     <ID>SpacingAroundColon:com.wire.kalium.persistence.client.LastRetrievedNotificationEventStorage.kt:19</ID>
-    <ID>SpacingAroundCurly:com.wire.kalium.logic.feature.call.RejectCallUseCaseTest.kt:27</ID>
+    <ID>SpacingAroundCurly:com.wire.kalium.logic.feature.call.usecase.RejectCallUseCaseTest.kt:27</ID>
     <ID>StringTemplate:com.wire.kalium.cryptography.IDs.kt:26</ID>
     <ID>StringTemplate:com.wire.kalium.logic.data.sso.SSOUtil.kt:5</ID>
     <ID>TooGenericExceptionCaught:CoreFailure.kt$e: Exception</ID>

--- a/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 
 class CallManagerTest {
 
@@ -79,6 +80,9 @@ class CallManagerTest {
     private val qualifiedIdMapper = mock(classOf<QualifiedIdMapper>())
 
     @Mock
+    private val conversationClientsInCallUpdater = mock(classOf<ConversationClientsInCallUpdater>())
+
+    @Mock
     private val videoStateChecker = mock(classOf<VideoStateChecker>())
 
     private val dispatcher = TestKaliumDispatcher
@@ -104,6 +108,7 @@ class CallManagerTest {
             qualifiedIdMapper = qualifiedIdMapper,
             videoStateChecker = videoStateChecker,
             callMapper = callMapper,
+            conversationClientsInCallUpdater = conversationClientsInCallUpdater,
             kaliumConfigs = kaliumConfigs
         )
     }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -67,4 +67,8 @@ class CallManagerImpl : CallManager {
     override suspend fun updateEpochInfo(conversationId: ConversationId, epochInfo: EpochInfo) {
         TODO("Not yet implemented")
     }
+
+    override suspend fun updateConversationClients(conversationId: ConversationId, clients: String) {
+        TODO("Not yet implemented")
+    }
 }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 
@@ -46,6 +47,7 @@ actual class GlobalCallManager {
         federatedIdMapper: FederatedIdMapper,
         qualifiedIdMapper: QualifiedIdMapper,
         videoStateChecker: VideoStateChecker,
+        conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
         kaliumConfigs: KaliumConfigs
     ): CallManager {
         return CallManagerImpl()

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -64,6 +64,7 @@ import com.wire.kalium.logic.feature.call.scenario.OnParticipantsVideoStateChang
 import com.wire.kalium.logic.feature.call.scenario.OnRequestNewEpoch
 import com.wire.kalium.logic.feature.call.scenario.OnSFTRequest
 import com.wire.kalium.logic.feature.call.scenario.OnSendOTR
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.fold
@@ -96,6 +97,7 @@ class CallManagerImpl internal constructor(
     private val federatedIdMapper: FederatedIdMapper,
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val videoStateChecker: VideoStateChecker,
+    private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
     private val kaliumConfigs: KaliumConfigs,
     kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) : CallManager {
@@ -394,6 +396,16 @@ class CallManagerImpl internal constructor(
         }
     }
 
+    override suspend fun updateConversationClients(conversationId: ConversationId, clients: String) {
+        withCalling {
+            wcall_set_clients_for_conv(
+                it,
+                federatedIdMapper.parseToFederatedId(conversationId),
+                clients
+            )
+        }
+    }
+
     /**
      * onCallingReady
      * Will start the handlers for: ParticipantsChanged, NetworkQuality, ClientsRequest and ActiveSpeaker
@@ -448,9 +460,7 @@ class CallManagerImpl internal constructor(
         scope.launch {
             withCalling {
                 val onClientsRequest = OnClientsRequest(
-                    calling = calling,
-                    conversationRepository = conversationRepository,
-                    federatedIdMapper = federatedIdMapper,
+                    conversationClientsInCallUpdater = conversationClientsInCallUpdater,
                     qualifiedIdMapper = qualifiedIdMapper,
                     callingScope = scope
                 ).keepingStrongReference()

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -34,10 +34,11 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
-import com.wire.kalium.logic.util.PlatformContext
 import com.wire.kalium.logic.util.CurrentPlatform
+import com.wire.kalium.logic.util.PlatformContext
 import com.wire.kalium.logic.util.PlatformType
 import io.ktor.util.collections.ConcurrentMap
 
@@ -81,6 +82,7 @@ actual class GlobalCallManager(
         federatedIdMapper: FederatedIdMapper,
         qualifiedIdMapper: QualifiedIdMapper,
         videoStateChecker: VideoStateChecker,
+        conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
         kaliumConfigs: KaliumConfigs
     ): CallManager {
         return callManagerHolder[userId] ?: CallManagerImpl(
@@ -95,6 +97,7 @@ actual class GlobalCallManager(
             federatedIdMapper = federatedIdMapper,
             qualifiedIdMapper = qualifiedIdMapper,
             videoStateChecker = videoStateChecker,
+            conversationClientsInCallUpdater = conversationClientsInCallUpdater,
             kaliumConfigs = kaliumConfigs
         ).also {
             callManagerHolder[userId] = it

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
@@ -19,25 +19,16 @@
 package com.wire.kalium.logic.feature.call.scenario
 
 import com.sun.jna.Pointer
-import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.callbacks.ClientsRequestHandler
 import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.logic.callingLogger
-import com.wire.kalium.logic.data.call.CallClient
-import com.wire.kalium.logic.data.call.CallClientList
-import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
-import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.logic.functional.onSuccess
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 internal class OnClientsRequest(
-    private val calling: Calling,
-    private val conversationRepository: ConversationRepository,
-    private val federatedIdMapper: FederatedIdMapper,
+    private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val callingScope: CoroutineScope
 ) : ClientsRequestHandler {
@@ -46,36 +37,7 @@ internal class OnClientsRequest(
         callingScope.launch {
             callingLogger.d("[OnClientsRequest] -> ConversationId: $conversationId")
             val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
-            val conversationRecipients = conversationRepository.getConversationRecipientsForCalling(
-                conversationId = conversationIdWithDomain
-            )
-
-            conversationRecipients.map { recipients ->
-                callingLogger.d("[OnClientsRequest] -> Mapping ${recipients.size} recipients")
-                recipients
-                    .flatMap { recipient ->
-                        recipient.clients.map { clientId ->
-                            CallClient(
-                                userId = federatedIdMapper.parseToFederatedId(recipient.id),
-                                clientId = clientId.value
-                            )
-                        }
-                    }
-            }.map {
-                CallClientList(it)
-            }.onSuccess { avsClients ->
-                callingLogger.d("[OnClientsRequest] -> Sending recipients")
-                // TODO: use a json serializer and not recreate everytime it is used
-                val callClients = avsClients.toJsonString()
-                calling.wcall_set_clients_for_conv(
-                    inst = inst,
-                    convId = federatedIdMapper.parseToFederatedId(conversationId),
-                    clientsJson = callClients
-                )
-                callingLogger.d("[OnClientsRequest] -> Success")
-            }.onFailure {
-                callingLogger.d("[OnClientsRequest] -> Failure")
-            }
+            conversationClientsInCallUpdater(conversationIdWithDomain)
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/PublicUserMapper.kt
@@ -94,7 +94,8 @@ class PublicUserMapperImpl(
             userType = userEntityTypeMapper.fromUserType(userType),
             botService = botService?.let { BotIdEntity(it.id, it.provider) },
             deleted = deleted,
-            expiresAt = expiresAt
+            expiresAt = expiresAt,
+            hasIncompleteMetadata = false
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -124,7 +124,8 @@ internal class UserMapperImpl(
             userType = UserTypeEntity.STANDARD,
             botService = null,
             deleted = false,
-            expiresAt = expiresAt
+            expiresAt = expiresAt,
+            hasIncompleteMetadata = false
         )
     }
 
@@ -143,7 +144,8 @@ internal class UserMapperImpl(
             userType = UserTypeEntity.STANDARD,
             botService = null,
             deleted = userDTO.deleted ?: false,
-            expiresAt = expiresAt?.toInstant()
+            expiresAt = expiresAt?.toInstant(),
+            hasIncompleteMetadata = false
         )
     }
 
@@ -203,7 +205,8 @@ internal class UserMapperImpl(
             userType = userEntityTypeMapper.teamRoleCodeToUserType(permissionCode),
             botService = null,
             deleted = false,
-            expiresAt = null
+            expiresAt = null,
+            hasIncompleteMetadata = false
         )
 
     override fun fromUserProfileDtoToUserEntity(
@@ -227,7 +230,8 @@ internal class UserMapperImpl(
         userType = userTypeEntity,
         botService = userProfile.service?.let { BotIdEntity(it.id, it.provider) },
         deleted = userProfile.deleted ?: false,
-        expiresAt = userProfile.expiresAt?.toInstant()
+        expiresAt = userProfile.expiresAt?.toInstant(),
+        hasIncompleteMetadata = false
     )
 
     override fun fromUserUpdateEventToUserEntity(event: Event.User.Update, userEntity: UserEntity): UserEntity {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -88,7 +88,7 @@ internal interface UserRepository {
     suspend fun observeSelfUserWithTeam(): Flow<Pair<SelfUser, Team?>>
     suspend fun updateSelfUser(newName: String? = null, newAccent: Int? = null, newAssetId: String? = null): Either<CoreFailure, SelfUser>
     suspend fun getSelfUser(): SelfUser?
-    fun observeAllKnownUsers(): Flow<Either<StorageFailure, List<OtherUser>>>
+    suspend fun observeAllKnownUsers(): Flow<Either<StorageFailure, List<OtherUser>>>
     suspend fun getKnownUser(userId: UserId): Flow<OtherUser?>
     suspend fun getKnownUserMinimized(userId: UserId): OtherUserMinimized?
     suspend fun observeUser(userId: UserId): Flow<User?>
@@ -328,7 +328,7 @@ internal class UserDataSource internal constructor(
     override suspend fun getSelfUser(): SelfUser? =
         observeSelfUser().firstOrNull()
 
-    override fun observeAllKnownUsers(): Flow<Either<StorageFailure, List<OtherUser>>> {
+    override suspend fun observeAllKnownUsers(): Flow<Either<StorageFailure, List<OtherUser>>> {
         val selfUserId = selfUserId.toDao()
         return userDAO.observeAllUsersByConnectionStatus(connectionState = ConnectionEntity.State.ACCEPTED)
             .wrapStorageRequest()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -136,6 +136,8 @@ import com.wire.kalium.logic.feature.backup.VerifyBackupUseCase
 import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.call.CallsScope
 import com.wire.kalium.logic.feature.call.GlobalCallManager
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdaterImpl
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.client.IsAllowedToRegisterMLSClientUseCase
 import com.wire.kalium.logic.feature.client.IsAllowedToRegisterMLSClientUseCaseImpl
@@ -211,15 +213,15 @@ import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCaseImpl
-import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.MarkEnablingE2EIAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.MarkEnablingE2EIAsNotifiedUseCaseImpl
+import com.wire.kalium.logic.feature.user.MarkFileSharingChangeAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.MarkSelfDeletionStatusAsNotifiedUseCase
 import com.wire.kalium.logic.feature.user.MarkSelfDeletionStatusAsNotifiedUseCaseImpl
-import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCase
-import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCaseImpl
 import com.wire.kalium.logic.feature.user.ObserveE2EIRequiredUseCase
 import com.wire.kalium.logic.feature.user.ObserveE2EIRequiredUseCaseImpl
+import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCase
+import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCaseImpl
 import com.wire.kalium.logic.feature.user.SyncContactsUseCase
 import com.wire.kalium.logic.feature.user.SyncContactsUseCaseImpl
 import com.wire.kalium.logic.feature.user.SyncSelfUserUseCase
@@ -300,9 +302,9 @@ import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessa
 import com.wire.kalium.logic.sync.receiver.conversation.message.ApplicationMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpackerImpl
-import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSWrongEpochHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSWrongEpochHandlerImpl
+import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpacker
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpackerImpl
@@ -943,6 +945,7 @@ class UserSessionScope internal constructor(
             qualifiedIdMapper = qualifiedIdMapper,
             videoStateChecker = videoStateChecker,
             callMapper = callMapper,
+            conversationClientsInCallUpdater = conversationClientsInCallUpdater,
             kaliumConfigs = kaliumConfigs
         )
     }
@@ -1324,6 +1327,13 @@ class UserSessionScope internal constructor(
             userConfigRepository, featureConfigRepository, getGuestRoomLinkFeature, kaliumConfigs, userId
         )
 
+    val conversationClientsInCallUpdater: ConversationClientsInCallUpdater
+        get() = ConversationClientsInCallUpdaterImpl(
+            callManager = callManager,
+            conversationRepository = conversationRepository,
+            federatedIdMapper = federatedIdMapper
+        )
+
     val team: TeamScope get() = TeamScope(userRepository, teamRepository, conversationRepository, selfTeamId)
 
     val service: ServiceScope
@@ -1345,6 +1355,7 @@ class UserSessionScope internal constructor(
             qualifiedIdMapper,
             clientIdProvider,
             userConfigRepository,
+            conversationClientsInCallUpdater,
             kaliumConfigs
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -44,4 +44,5 @@ interface CallManager {
     suspend fun updateVideoState(conversationId: ConversationId, videoState: VideoState)
     suspend fun requestVideoStreams(conversationId: ConversationId, callClients: CallClientList)
     suspend fun updateEpochInfo(conversationId: ConversationId, epochInfo: EpochInfo)
+    suspend fun updateConversationClients(conversationId: ConversationId, clients: String)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.call.usecase.EndCallOnConversationChangeUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallOnConversationChangeUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
@@ -77,6 +78,7 @@ class CallsScope internal constructor(
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val userConfigRepository: UserConfigRepository,
+    private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
     private val kaliumConfigs: KaliumConfigs
 ) {
 
@@ -122,7 +124,8 @@ class CallsScope internal constructor(
         get() = EndCallOnConversationChangeUseCaseImpl(
             callRepository = callRepository,
             conversationRepository = conversationRepository,
-            endCallUseCase = endCall
+            endCallUseCase = endCall,
+            conversationClientsInCallUpdater = conversationClientsInCallUpdater
         )
 
     val rejectCall: RejectCallUseCase get() = RejectCallUseCase(callManager, callRepository, KaliumDispatcherImpl)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 
@@ -47,6 +48,7 @@ expect class GlobalCallManager {
         federatedIdMapper: FederatedIdMapper,
         qualifiedIdMapper: QualifiedIdMapper,
         videoStateChecker: VideoStateChecker,
+        conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
         kaliumConfigs: KaliumConfigs
     ): CallManager
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ConversationClientsInCallUpdater.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ConversationClientsInCallUpdater.kt
@@ -1,0 +1,74 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.callingLogger
+import com.wire.kalium.logic.data.call.CallClient
+import com.wire.kalium.logic.data.call.CallClientList
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.FederatedIdMapper
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
+
+/**
+ * This class is responsible for updating conversation clients in a call
+ * Usually called when a member is removed from conversation
+ */
+interface ConversationClientsInCallUpdater {
+    suspend operator fun invoke(conversationId: ConversationId)
+}
+
+class ConversationClientsInCallUpdaterImpl(
+    private val callManager: Lazy<CallManager>,
+    private val conversationRepository: ConversationRepository,
+    private val federatedIdMapper: FederatedIdMapper,
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
+) : ConversationClientsInCallUpdater {
+    override suspend fun invoke(conversationId: ConversationId) {
+        conversationRepository.getConversationRecipientsForCalling(
+            conversationId = conversationId
+        ).map {
+            it.flatMap { recipient ->
+                recipient.clients.map { clientId ->
+                    CallClient(
+                        userId = federatedIdMapper.parseToFederatedId(recipient.id),
+                        clientId = clientId.value
+                    )
+                }
+            }
+        }.map {
+            CallClientList(it)
+        }.onSuccess {
+            callingLogger.d("[ConversationClientsInCallUpdater] -> Sending recipients $it")
+            val callClients = it.toJsonString()
+            withContext(dispatchers.default) {
+                callManager.value.updateConversationClients(conversationId, callClients)
+            }
+            callingLogger.d("[ConversationClientsInCallUpdater] -> recipients sent")
+        }.onFailure {
+            callingLogger.d("[ConversationClientsInCallUpdater] -> failed tp send recipients")
+        }
+    }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
@@ -20,7 +20,8 @@ interface EndCallOnConversationChangeUseCase {
 class EndCallOnConversationChangeUseCaseImpl(
     private val callRepository: CallRepository,
     private val conversationRepository: ConversationRepository,
-    private val endCallUseCase: EndCallUseCase
+    private val endCallUseCase: EndCallUseCase,
+    private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
 ) : EndCallOnConversationChangeUseCase {
     override suspend operator fun invoke() {
         val callsFlow = callRepository.establishedCallsFlow().map { calls ->
@@ -37,6 +38,7 @@ class EndCallOnConversationChangeUseCaseImpl(
                         if (it is ConversationDetails.Group) {
                             // Not a member anymore
                             if (!it.isSelfUserMember) {
+                                conversationClientsInCallUpdater(calls.first())
                                 endCallUseCase(calls.first())
                             }
                         } else if (it is ConversationDetails.OneOne) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -151,14 +151,15 @@ class MessageScope internal constructor(
 
     val sendTextMessage: SendTextMessageUseCase
         get() = SendTextMessageUseCase(
-            persistMessage,
-            selfUserId,
-            currentClientIdProvider,
-            slowSyncRepository,
-            messageSender,
-            messageSendFailureHandler,
-            userPropertyRepository,
-            observeSelfDeletingMessages
+            persistMessage = persistMessage,
+            selfUserId = selfUserId,
+            provideClientId = currentClientIdProvider,
+            slowSyncRepository = slowSyncRepository,
+            messageSender = messageSender,
+            messageSendFailureHandler = messageSendFailureHandler,
+            userPropertyRepository = userPropertyRepository,
+            selfDeleteTimer = observeSelfDeletingMessages,
+            scope = scope
         )
 
     val sendEditTextMessage: SendEditTextMessageUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -37,8 +37,9 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
 import kotlin.time.Duration
 
 @Suppress("LongParameterList")
@@ -55,7 +56,8 @@ class SendTextMessageUseCase internal constructor(
     private val messageSendFailureHandler: MessageSendFailureHandler,
     private val userPropertyRepository: UserPropertyRepository,
     private val selfDeleteTimer: ObserveSelfDeletionTimerSettingsForConversationUseCase,
-    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl,
+    private val scope: CoroutineScope
 ) {
 
     suspend operator fun invoke(
@@ -63,7 +65,7 @@ class SendTextMessageUseCase internal constructor(
         text: String,
         mentions: List<MessageMention> = emptyList(),
         quotedMessageId: String? = null
-    ): Either<CoreFailure, Unit> = withContext(dispatchers.io) {
+    ): Either<CoreFailure, Unit> = scope.async(dispatchers.io) {
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }
@@ -98,9 +100,18 @@ class SendTextMessageUseCase internal constructor(
                 expirationData = messageTimer?.let { Message.ExpirationData(it) },
                 isSelfMessage = true
             )
-            persistMessage(message).flatMap { messageSender.sendMessage(message) }
-        }.onFailure { messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, generatedMessageUuid, TYPE) }
-    }
+            persistMessage(message).flatMap {
+                messageSender.sendMessage(message)
+            }
+        }.onFailure {
+            messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                failure = it,
+                conversationId = conversationId,
+                messageId = generatedMessageUuid,
+                messageType = TYPE
+            )
+        }
+    }.await()
 
     companion object {
         const val TYPE = "Text"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/GetAllContactsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/GetAllContactsUseCase.kt
@@ -31,14 +31,14 @@ import kotlinx.coroutines.flow.map
  * @return GetAllContactsResult with list of known users
  */
 interface GetAllContactsUseCase {
-    operator fun invoke(): Flow<GetAllContactsResult>
+    operator suspend fun invoke(): Flow<GetAllContactsResult>
 }
 
 internal class GetAllContactsUseCaseImpl internal constructor(
     private val userRepository: UserRepository
 ) : GetAllContactsUseCase {
 
-    override fun invoke(): Flow<GetAllContactsResult> =
+    override suspend fun invoke(): Flow<GetAllContactsResult> =
         userRepository.observeAllKnownUsers()
             .map { it.fold(GetAllContactsResult::Failure, GetAllContactsResult::Success) }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/AnswerCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/AnswerCallUseCaseTest.kt
@@ -16,14 +16,13 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCaseImpl
-import com.wire.kalium.logic.feature.call.usecase.GetAllCallsWithSortedParticipantsUseCase
-import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.CallStatus
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import io.mockative.Mock
 import io.mockative.classOf

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ConversationClientsInCallUpdaterTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ConversationClientsInCallUpdaterTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.Recipient
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.FederatedIdMapper
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class ConversationClientsInCallUpdaterTest {
+
+    @Mock
+    private val callManager = mock(classOf<CallManager>())
+
+    @Mock
+    private val conversationRepository = mock(classOf<ConversationRepository>())
+
+    @Mock
+    private val federatedIdMapper = mock(classOf<FederatedIdMapper>())
+
+    private lateinit var conversationClientsInCallUpdater: ConversationClientsInCallUpdater
+
+    @BeforeTest
+    fun setup() {
+        conversationClientsInCallUpdater = ConversationClientsInCallUpdaterImpl(
+            callManager = lazy { callManager },
+            conversationRepository = conversationRepository,
+            federatedIdMapper = federatedIdMapper
+        )
+    }
+
+    @Test
+    fun givenConversationRepositoryReturnsFailure_whenGettingConversationRecipients_thenDoNothing() = runTest {
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationRecipientsForCalling)
+            .whenInvokedWith(eq(conversationId))
+            .thenReturn(Either.Left(CoreFailure.MissingClientRegistration))
+
+        conversationClientsInCallUpdater(conversationId)
+
+        verify(callManager)
+            .suspendFunction(callManager::updateConversationClients)
+            .with(any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenConversationRepositoryReturnsValidValues_whenGettingConversationRecipients_thenUpdateConversationClients() = runTest {
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::getConversationRecipientsForCalling)
+            .whenInvokedWith(eq(conversationId))
+            .thenReturn(Either.Right(recipients))
+
+        given(federatedIdMapper).coroutine { parseToFederatedId(userId) }
+            .thenReturn(userIdString)
+
+        conversationClientsInCallUpdater(conversationId)
+
+        verify(callManager)
+            .suspendFunction(callManager::updateConversationClients)
+            .with(any(), any())
+            .wasInvoked(once)
+    }
+
+    companion object {
+        private val conversationId = ConversationId("conversation", "wire.com")
+        private val userId = UserId("someone", "wire.com")
+        private const val userIdString = "someone@wire.com"
+        private val clientId = ClientId("someone")
+        val recipients = listOf(Recipient(userId, listOf(clientId)))
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -42,6 +42,9 @@ class EndCallOnConversationChangeUseCaseTest {
     @Mock
     private val endCall = mock(classOf<EndCallUseCase>())
 
+    @Mock
+    private val conversationClientsInCallUpdater = mock(classOf<ConversationClientsInCallUpdater>())
+
     private lateinit var endCallOnConversationChange: EndCallOnConversationChangeUseCase
 
     @BeforeTest
@@ -49,7 +52,8 @@ class EndCallOnConversationChangeUseCaseTest {
         endCallOnConversationChange = EndCallOnConversationChangeUseCaseImpl(
             callRepository = callRepository,
             conversationRepository = conversationRepository,
-            endCallUseCase = endCall
+            endCallUseCase = endCall,
+            conversationClientsInCallUpdater = conversationClientsInCallUpdater
         )
 
         given(callRepository)
@@ -92,6 +96,11 @@ class EndCallOnConversationChangeUseCaseTest {
             }
 
         endCallOnConversationChange()
+
+        verify(conversationClientsInCallUpdater)
+            .suspendFunction(conversationClientsInCallUpdater::invoke)
+            .with(eq(conversationId))
+            .wasInvoked(once)
 
         verify(endCall)
             .suspendFunction(endCall::invoke)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCaseTest.kt
@@ -16,13 +16,14 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.EndCallUseCaseImpl
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.CallStatus
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -32,13 +33,11 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.thenDoNothing
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class EndCallUseCaseTest {
 
     @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/FlipToBackCameraUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/FlipToBackCameraUseCaseTest.kt
@@ -15,10 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
+import com.wire.kalium.logic.feature.call.FlowManagerService
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.eq

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/FlipToFrontCameraUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/FlipToFrontCameraUseCaseTest.kt
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+package com.wire.kalium.logic.feature.call.usecase
 
-package com.wire.kalium.logic.feature.call
-
-import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.RejectCallUseCase
+import com.wire.kalium.logic.feature.call.FlowManagerService
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.eq
@@ -34,47 +32,35 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
-class RejectCallUseCaseTest {
+class FlipToFrontCameraUseCaseTest {
 
     @Mock
-    private val callManager = mock(classOf<CallManager>())
+    private val flowManagerService = mock(classOf<FlowManagerService>())
 
-    @Mock
-    private val callRepository = mock(classOf<CallRepository>())
-
-    private lateinit var rejectCallUseCase: RejectCallUseCase
+    private lateinit var flipToFrontCamera: FlipToFrontCameraUseCase
 
     @BeforeTest
     fun setup() {
-        rejectCallUseCase = RejectCallUseCase(lazy{ callManager }, callRepository)
+        flipToFrontCamera = FlipToFrontCameraUseCase(flowManagerService)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun givenCallingParams_whenRunningUseCase_thenInvokeRejectCallOnce() = runTest {
-        val conversationId = ConversationId("someone", "wire.com")
-
-        given(callManager)
-            .suspendFunction(callManager::rejectCall)
+    fun givenFlowManagerService_whenUseCaseCaseIsInvoked_thenInvokeFlipToFrontCameraOnce() = runTest {
+        given(flowManagerService)
+            .suspendFunction(flowManagerService::flipToFrontCamera)
             .whenInvokedWith(eq(conversationId))
             .thenDoNothing()
 
-        given(callRepository)
-            .suspendFunction(callRepository::updateCallStatusById)
-            .whenInvokedWith(eq(conversationId), eq(CallStatus.REJECTED))
-            .thenDoNothing()
+        flipToFrontCamera(conversationId)
 
-        rejectCallUseCase.invoke(conversationId)
-
-        verify(callManager)
-            .suspendFunction(callManager::rejectCall)
+        verify(flowManagerService)
+            .function(flowManagerService::flipToFrontCamera)
             .with(eq(conversationId))
-            .wasInvoked(once)
-
-        verify(callRepository)
-            .suspendFunction(callRepository::updateCallStatusById)
-            .with(eq(conversationId), eq(CallStatus.REJECTED))
             .wasInvoked(once)
     }
 
+    companion object {
+        val conversationId = ConversationId("someone", "wire.com")
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetAllCallsWithSortedParticipantsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetAllCallsWithSortedParticipantsUseCaseTest.kt
@@ -16,15 +16,15 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.logic.feature.call.usecase
 
 import app.cash.turbine.test
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallingParticipantsOrder
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.GetAllCallsWithSortedParticipantsUseCase
-import com.wire.kalium.logic.feature.call.usecase.GetAllCallsWithSortedParticipantsUseCaseImpl
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallStatus
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.given

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCaseTest.kt
@@ -37,7 +37,6 @@ import io.mockative.any
 import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -45,7 +44,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class GetIncomingCallsUseCaseTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/IsCallRunningUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/IsCallRunningUseCaseTest.kt
@@ -27,14 +27,12 @@ import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class IsCallRunningUseCaseTest {
 
     @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/MuteCallUseCaseTest.kt
@@ -16,13 +16,14 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCaseImpl
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.CallStatus
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.eq

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingCallsUseCaseTest.kt
@@ -24,26 +24,20 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.call.CallStatus
-import com.wire.kalium.logic.sync.SyncManager
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ObserveOngoingCallsUseCaseTest {
 
     @Mock
-    val syncManager: SyncManager = mock(classOf<SyncManager>())
-
-    @Mock
-    val callRepository: CallRepository = mock(classOf<CallRepository>())
+    val callRepository = mock(classOf<CallRepository>())
 
     private lateinit var observeOngoingCalls: ObserveOngoingCallsUseCase
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCaseTest.kt
@@ -16,12 +16,12 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.call.CallType
-import com.wire.kalium.logic.feature.call.usecase.StartCallUseCase
+import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCaseTest.kt
@@ -16,13 +16,14 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
-import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCaseImpl
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.CallStatus
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.eq

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/UpdateVideoStateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/UpdateVideoStateUseCaseTest.kt
@@ -16,13 +16,15 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.CallStatus
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
@@ -39,6 +39,7 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -53,7 +54,7 @@ class SendTextMessageCaseTest {
     @Test
     fun givenAValidMessage_whenSendingSomeText_thenShouldReturnASuccessResult() = runTest {
         // Given
-        val (arrangement, sendTextMessage) = Arrangement()
+        val (arrangement, sendTextMessage) = Arrangement(this)
             .withToggleReadReceiptsStatus()
             .withCurrentClientProviderSuccess()
             .withPersistMessageSuccess()
@@ -88,7 +89,7 @@ class SendTextMessageCaseTest {
     @Test
     fun givenNoNetwork_whenSendingSomeText_thenShouldReturnAFailure() = runTest {
         // Given
-        val (arrangement, sendTextMessage) = Arrangement()
+        val (arrangement, sendTextMessage) = Arrangement(this)
             .withToggleReadReceiptsStatus()
             .withCurrentClientProviderSuccess()
             .withPersistMessageSuccess()
@@ -120,7 +121,7 @@ class SendTextMessageCaseTest {
             .wasInvoked(once)
     }
 
-    private class Arrangement {
+    private class Arrangement(private val coroutineScope: CoroutineScope) {
 
         @Mock
         val persistMessage = mock(classOf<PersistMessageUseCase>())
@@ -196,7 +197,8 @@ class SendTextMessageCaseTest {
             messageSender,
             messageSendFailureHandler,
             userPropertyRepository,
-            observeSelfDeletionTimerSettingsForConversation
+            observeSelfDeletionTimerSettingsForConversation,
+            scope = coroutineScope
         )
     }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -64,7 +64,7 @@ WHERE qualified_id = ?;
 
 updateTeamMemberUser:
 UPDATE User
-SET name = ?, handle = ?, email = ?, phone = ?, accent_id = ?, team = ?, preview_asset_id = ?, complete_asset_id = ?, bot_service = ?
+SET name = ?, handle = ?, email = ?, phone = ?, accent_id = ?, team = ?, preview_asset_id = ?, complete_asset_id = ?, bot_service = ?, incomplete_metadata = 0
 WHERE qualified_id = ?;
 
 updateTeamMemberType:

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -166,7 +166,7 @@ interface UserDAO {
      */
     suspend fun updateUser(user: UserEntity)
     suspend fun getAllUsers(): Flow<List<UserEntity>>
-    fun observeAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): Flow<List<UserEntity>>
+    suspend fun observeAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): Flow<List<UserEntity>>
     suspend fun getUserByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<UserEntity?>
     suspend fun getUserWithTeamByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<Pair<UserEntity, TeamEntity?>?>
     suspend fun getUserMinimizedByQualifiedID(qualifiedID: QualifiedIDEntity): UserEntityMinimized?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -129,21 +129,21 @@ class UserDAOImpl internal constructor(
 
     override suspend fun insertUser(user: UserEntity) = withContext(queriesContext) {
         userQueries.insertUser(
-            user.id,
-            user.name,
-            user.handle,
-            user.email,
-            user.phone,
-            user.accentId,
-            user.team,
-            user.connectionStatus,
-            user.previewAssetId,
-            user.completeAssetId,
-            user.userType,
-            user.botService,
-            user.deleted,
-            user.hasIncompleteMetadata,
-            user.expiresAt
+            qualified_id = user.id,
+            name = user.name,
+            handle = user.handle,
+            email = user.email,
+            phone = user.phone,
+            accent_id = user.accentId,
+            team = user.team,
+            preview_asset_id = user.previewAssetId,
+            complete_asset_id = user.completeAssetId,
+            user_type = user.userType,
+            bot_service = user.botService,
+            incomplete_metadata = false,
+            expires_at = user.expiresAt,
+            connection_status = user.connectionStatus,
+            deleted = user.deleted
         )
     }
 
@@ -151,21 +151,21 @@ class UserDAOImpl internal constructor(
         userQueries.transaction {
             for (user: UserEntity in users) {
                 userQueries.insertOrIgnoreUser(
-                    user.id,
-                    user.name,
-                    user.handle,
-                    user.email,
-                    user.phone,
-                    user.accentId,
-                    user.team,
-                    user.connectionStatus,
-                    user.previewAssetId,
-                    user.completeAssetId,
-                    user.userType,
-                    user.botService,
-                    user.deleted,
-                    user.hasIncompleteMetadata,
-                    user.expiresAt
+                    qualified_id = user.id,
+                    name = user.name,
+                    handle = user.handle,
+                    email = user.email,
+                    phone = user.phone,
+                    accent_id = user.accentId,
+                    team = user.team,
+                    preview_asset_id = user.previewAssetId,
+                    complete_asset_id = user.completeAssetId,
+                    user_type = user.userType,
+                    bot_service = user.botService,
+                    incomplete_metadata = false,
+                    expires_at = user.expiresAt,
+                    connection_status = user.connectionStatus,
+                    deleted = user.deleted
                 )
             }
         }
@@ -175,35 +175,35 @@ class UserDAOImpl internal constructor(
         userQueries.transaction {
             for (user: UserEntity in users) {
                 userQueries.updateTeamMemberUser(
-                    user.name,
-                    user.handle,
-                    user.email,
-                    user.phone,
-                    user.accentId,
-                    user.team,
-                    user.previewAssetId,
-                    user.completeAssetId,
-                    user.botService,
-                    user.id,
+                    qualified_id = user.id,
+                    name = user.name,
+                    handle = user.handle,
+                    email = user.email,
+                    phone = user.phone,
+                    accent_id = user.accentId,
+                    team = user.team,
+                    preview_asset_id = user.previewAssetId,
+                    complete_asset_id = user.completeAssetId,
+                    bot_service = user.botService,
                 )
                 val recordDidNotExist = userQueries.selectChanges().executeAsOne() == 0L
                 if (recordDidNotExist) {
                     userQueries.insertUser(
-                        user.id,
-                        user.name,
-                        user.handle,
-                        user.email,
-                        user.phone,
-                        user.accentId,
-                        user.team,
-                        user.connectionStatus,
-                        user.previewAssetId,
-                        user.completeAssetId,
-                        user.userType,
-                        user.botService,
-                        user.deleted,
-                        user.hasIncompleteMetadata,
-                        user.expiresAt
+                        qualified_id = user.id,
+                        name = user.name,
+                        handle = user.handle,
+                        email = user.email,
+                        phone = user.phone,
+                        accent_id = user.accentId,
+                        team = user.team,
+                        preview_asset_id = user.previewAssetId,
+                        complete_asset_id = user.completeAssetId,
+                        user_type = user.userType,
+                        bot_service = user.botService,
+                        incomplete_metadata = user.hasIncompleteMetadata,
+                        expires_at = user.expiresAt,
+                        connection_status = user.connectionStatus,
+                        deleted = user.deleted
                     )
                 }
             }
@@ -214,38 +214,38 @@ class UserDAOImpl internal constructor(
         userQueries.transaction {
             for (user: UserEntity in users) {
                 userQueries.updateUser(
-                    user.name,
-                    user.handle,
-                    user.email,
-                    user.phone,
-                    user.accentId,
-                    user.team,
-                    user.previewAssetId,
-                    user.completeAssetId,
-                    user.userType,
-                    user.botService,
-                    false,
-                    user.expiresAt,
-                    user.id,
+                    qualified_id = user.id,
+                    name = user.name,
+                    handle = user.handle,
+                    email = user.email,
+                    phone = user.phone,
+                    accent_id = user.accentId,
+                    team = user.team,
+                    preview_asset_id = user.previewAssetId,
+                    complete_asset_id = user.completeAssetId,
+                    user_type = user.userType,
+                    bot_service = user.botService,
+                    incomplete_metadata = false,
+                    expires_at = user.expiresAt
                 )
                 val recordDidNotExist = userQueries.selectChanges().executeAsOne() == 0L
                 if (recordDidNotExist) {
                     userQueries.insertUser(
-                        user.id,
-                        user.name,
-                        user.handle,
-                        user.email,
-                        user.phone,
-                        user.accentId,
-                        user.team,
-                        user.connectionStatus,
-                        user.previewAssetId,
-                        user.completeAssetId,
-                        user.userType,
-                        user.botService,
-                        user.deleted,
-                        user.hasIncompleteMetadata,
-                        user.expiresAt
+                        qualified_id = user.id,
+                        name = user.name,
+                        handle = user.handle,
+                        email = user.email,
+                        phone = user.phone,
+                        accent_id = user.accentId,
+                        team = user.team,
+                        connection_status = user.connectionStatus,
+                        preview_asset_id = user.previewAssetId,
+                        complete_asset_id = user.completeAssetId,
+                        user_type = user.userType,
+                        bot_service = user.botService,
+                        deleted = user.deleted,
+                        incomplete_metadata = user.hasIncompleteMetadata,
+                        expires_at = user.expiresAt
                     )
                 }
             }
@@ -259,21 +259,21 @@ class UserDAOImpl internal constructor(
                 val recordDidNotExist = userQueries.selectChanges().executeAsOne() == 0L
                 if (recordDidNotExist) {
                     userQueries.insertUser(
-                        user.id,
-                        user.name,
-                        user.handle,
-                        user.email,
-                        user.phone,
-                        user.accentId,
-                        user.team,
-                        user.connectionStatus,
-                        user.previewAssetId,
-                        user.completeAssetId,
-                        user.userType,
-                        user.botService,
-                        user.deleted,
-                        user.hasIncompleteMetadata,
-                        user.expiresAt
+                        qualified_id = user.id,
+                        name = user.name,
+                        handle = user.handle,
+                        email = user.email,
+                        phone = user.phone,
+                        accent_id = user.accentId,
+                        team = user.team,
+                        connection_status = user.connectionStatus,
+                        preview_asset_id = user.previewAssetId,
+                        complete_asset_id = user.completeAssetId,
+                        user_type = user.userType,
+                        bot_service = user.botService,
+                        deleted = user.deleted,
+                        incomplete_metadata = user.hasIncompleteMetadata,
+                        expires_at = user.expiresAt
                     )
                 }
             }
@@ -282,13 +282,13 @@ class UserDAOImpl internal constructor(
 
     override suspend fun updateUser(user: UserEntity) = withContext(queriesContext) {
         userQueries.updateSelfUser(
-            user.name,
-            user.handle,
-            user.email,
-            user.accentId,
-            user.previewAssetId,
-            user.completeAssetId,
-            user.id
+            qualified_id = user.id,
+            name = user.name,
+            handle = user.handle,
+            email = user.email,
+            accent_id = user.accentId,
+            preview_asset_id = user.previewAssetId,
+            complete_asset_id = user.completeAssetId,
         )
     }
 
@@ -388,12 +388,14 @@ class UserDAOImpl internal constructor(
             userQueries.insertOrIgnoreUserIdWithConnectionStatus(qualifiedID, connectionStatus)
         }
 
-    override fun observeAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): Flow<List<UserEntity>> =
-        userQueries.selectAllUsersWithConnectionStatus(connectionState)
-            .asFlow()
-            .flowOn(queriesContext)
-            .mapToList()
-            .map { it.map(mapper::toModel) }
+    override suspend fun observeAllUsersByConnectionStatus(connectionState: ConnectionEntity.State): Flow<List<UserEntity>> =
+        withContext(queriesContext) {
+            userQueries.selectAllUsersWithConnectionStatus(connectionState)
+                .asFlow()
+                .flowOn(queriesContext)
+                .mapToList()
+                .map { it.map(mapper::toModel) }
+        }
 
     override suspend fun getAllUsersByTeam(teamId: String): List<UserEntity> = withContext(queriesContext) {
         userQueries.selectUsersByTeam(teamId)

--- a/testservice/build.gradle.kts
+++ b/testservice/build.gradle.kts
@@ -33,6 +33,17 @@ object Versions {
 
 val mainFunctionClassName = "com.wire.kalium.testservice.TestserviceApplication"
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
 application {
     mainClass.set(mainFunctionClassName)
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

during sync, we do add members first and then fetch users info, and recently we added the incomplete user info value to the DB, so when we insert a user id form member it is marked as incomplete and in a later step in sync we do fetch all users info. so far so good, the issue begin in the upsert team user it does not update the incomplete user value to false meaning it will not be included when observing all users

### Solutions

set incomplete metadata to false when updating user info

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
