### PR TITLE
feat: update conversation call clients on member removal (RC-4.2) (WPB-3017)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1277,7 +1277,6 @@ class UserSessionScope internal constructor(
             userConfigRepository, featureConfigRepository, getGuestRoomLinkFeature, kaliumConfigs, userId
         )
 
-
     val team: TeamScope get() = TeamScope(userRepository, teamRepository, conversationRepository, selfTeamId)
 
     val service: ServiceScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -134,6 +134,8 @@ import com.wire.kalium.logic.feature.call.CallsScope
 import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdaterImpl
+import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCaseImpl
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.client.IsAllowedToRegisterMLSClientUseCase
 import com.wire.kalium.logic.feature.client.IsAllowedToRegisterMLSClientUseCaseImpl
@@ -905,6 +907,17 @@ class UserSessionScope internal constructor(
         globalCallManager.getMediaManager()
     }
 
+    private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater
+        get() = ConversationClientsInCallUpdaterImpl(
+            callManager = callManager,
+            conversationRepository = conversationRepository,
+            federatedIdMapper = federatedIdMapper
+        )
+
+    private val updateConversationClientsForCurrentCall: Lazy<UpdateConversationClientsForCurrentCallUseCase> = lazy {
+        UpdateConversationClientsForCurrentCallUseCaseImpl(callRepository, conversationClientsInCallUpdater)
+    }
+
     private val reactionRepository = ReactionRepositoryImpl(userId, userStorage.database.reactionDAO)
     private val receiptRepository = ReceiptRepositoryImpl(userStorage.database.receiptDAO)
     private val persistReaction: PersistReactionUseCase
@@ -995,7 +1008,7 @@ class UserSessionScope internal constructor(
         )
     private val memberLeaveHandler: MemberLeaveEventHandler
         get() = MemberLeaveEventHandlerImpl(
-            userStorage.database.conversationDAO, userRepository, persistMessage
+            userStorage.database.conversationDAO, userRepository, persistMessage, updateConversationClientsForCurrentCall
         )
     private val memberChangeHandler: MemberChangeEventHandler get() = MemberChangeEventHandlerImpl(conversationRepository)
     private val mlsWelcomeHandler: MLSWelcomeEventHandler
@@ -1264,12 +1277,6 @@ class UserSessionScope internal constructor(
             userConfigRepository, featureConfigRepository, getGuestRoomLinkFeature, kaliumConfigs, userId
         )
 
-    val conversationClientsInCallUpdater: ConversationClientsInCallUpdater
-        get() = ConversationClientsInCallUpdaterImpl(
-            callManager = callManager,
-            conversationRepository = conversationRepository,
-            federatedIdMapper = federatedIdMapper
-        )
 
     val team: TeamScope get() = TeamScope(userRepository, teamRepository, conversationRepository, selfTeamId)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -61,6 +61,8 @@ import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOffUseCase
 import com.wire.kalium.logic.feature.call.usecase.TurnLoudSpeakerOnUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCase
+import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.sync.SyncManager
@@ -124,8 +126,13 @@ class CallsScope internal constructor(
         get() = EndCallOnConversationChangeUseCaseImpl(
             callRepository = callRepository,
             conversationRepository = conversationRepository,
-            endCallUseCase = endCall,
-            conversationClientsInCallUpdater = conversationClientsInCallUpdater
+            endCallUseCase = endCall
+        )
+
+    val updateConversationClientsForCurrentCallUseCase: UpdateConversationClientsForCurrentCallUseCase
+        get() = UpdateConversationClientsForCurrentCallUseCaseImpl(
+            callRepository,
+            conversationClientsInCallUpdater
         )
 
     val rejectCall: RejectCallUseCase get() = RejectCallUseCase(callManager, callRepository, KaliumDispatcherImpl)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
@@ -20,8 +20,7 @@ interface EndCallOnConversationChangeUseCase {
 class EndCallOnConversationChangeUseCaseImpl(
     private val callRepository: CallRepository,
     private val conversationRepository: ConversationRepository,
-    private val endCallUseCase: EndCallUseCase,
-    private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
+    private val endCallUseCase: EndCallUseCase
 ) : EndCallOnConversationChangeUseCase {
     override suspend operator fun invoke() {
         val callsFlow = callRepository.establishedCallsFlow().map { calls ->
@@ -38,7 +37,6 @@ class EndCallOnConversationChangeUseCaseImpl(
                         if (it is ConversationDetails.Group) {
                             // Not a member anymore
                             if (!it.isSelfUserMember) {
-                                conversationClientsInCallUpdater(calls.first())
                                 endCallUseCase(calls.first())
                             }
                         } else if (it is ConversationDetails.OneOne) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UpdateConversationClientsForCurrentCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UpdateConversationClientsForCurrentCallUseCase.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+/**
+ * This use case is responsible for updating conversation clients in a call
+ * Usually called when a member is removed from conversation
+ */
+interface UpdateConversationClientsForCurrentCallUseCase {
+    suspend operator fun invoke(conversationId: ConversationId)
+}
+
+internal class UpdateConversationClientsForCurrentCallUseCaseImpl(
+    private val callRepository: CallRepository,
+    private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater
+) : UpdateConversationClientsForCurrentCallUseCase {
+    override suspend fun invoke(conversationId: ConversationId) {
+        callRepository.establishedCallsFlow().map { calls -> calls.map { it.conversationId } }.first().find {
+            it == conversationId
+        }?.let {
+            conversationClientsInCallUpdater(conversationId)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -42,9 +42,6 @@ class EndCallOnConversationChangeUseCaseTest {
     @Mock
     private val endCall = mock(classOf<EndCallUseCase>())
 
-    @Mock
-    private val conversationClientsInCallUpdater = mock(classOf<ConversationClientsInCallUpdater>())
-
     private lateinit var endCallOnConversationChange: EndCallOnConversationChangeUseCase
 
     @BeforeTest
@@ -52,8 +49,7 @@ class EndCallOnConversationChangeUseCaseTest {
         endCallOnConversationChange = EndCallOnConversationChangeUseCaseImpl(
             callRepository = callRepository,
             conversationRepository = conversationRepository,
-            endCallUseCase = endCall,
-            conversationClientsInCallUpdater = conversationClientsInCallUpdater
+            endCallUseCase = endCall
         )
 
         given(callRepository)
@@ -96,11 +92,6 @@ class EndCallOnConversationChangeUseCaseTest {
             }
 
         endCallOnConversationChange()
-
-        verify(conversationClientsInCallUpdater)
-            .suspendFunction(conversationClientsInCallUpdater::invoke)
-            .with(eq(conversationId))
-            .wasInvoked(once)
 
         verify(endCall)
             .suspendFunction(endCall::invoke)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/UpdateConversationClientsForCurrentCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/UpdateConversationClientsForCurrentCallUseCaseTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallStatus
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class UpdateConversationClientsForCurrentCallUseCaseTest {
+
+    @Mock
+    private val callRepository = mock(classOf<CallRepository>())
+
+    @Mock
+    private val conversationClientsInCallUpdater = mock(classOf<ConversationClientsInCallUpdater>())
+
+    private lateinit var updateConversationClientsForCurrentCall: UpdateConversationClientsForCurrentCallUseCase
+
+    @BeforeTest
+    fun setup() {
+        updateConversationClientsForCurrentCall = UpdateConversationClientsForCurrentCallUseCaseImpl(
+            callRepository = callRepository,
+            conversationClientsInCallUpdater = conversationClientsInCallUpdater
+        )
+    }
+
+    @Test
+    fun givenNoOngoingCall_whenUseCaseIsInvoked_thenNothingToDo() = runTest {
+        given(callRepository)
+            .suspendFunction(callRepository::establishedCallsFlow)
+            .whenInvoked()
+            .thenReturn(flowOf(listOf()))
+
+        updateConversationClientsForCurrentCall(CONVERSATION_ID)
+
+        verify(callRepository)
+            .suspendFunction(callRepository::establishedCallsFlow)
+            .wasInvoked(once)
+
+        verify(conversationClientsInCallUpdater)
+            .suspendFunction(conversationClientsInCallUpdater::invoke)
+            .with(eq(CONVERSATION_ID))
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenAnOngoingCall_whenUseCaseIsInvoked_thenUpdateClients() = runTest {
+        given(callRepository)
+            .suspendFunction(callRepository::establishedCallsFlow)
+            .whenInvoked()
+            .thenReturn(flowOf(listOf(call)))
+
+        updateConversationClientsForCurrentCall(CONVERSATION_ID)
+
+        verify(callRepository)
+            .suspendFunction(callRepository::establishedCallsFlow)
+            .wasInvoked(once)
+        verify(conversationClientsInCallUpdater)
+            .suspendFunction(conversationClientsInCallUpdater::invoke)
+            .with(eq(CONVERSATION_ID))
+            .wasInvoked()
+    }
+
+    companion object {
+        private val CONVERSATION_ID = ConversationId("conversationId", "domain")
+        private val call = Call(
+            conversationId = CONVERSATION_ID,
+            status = CallStatus.ESTABLISHED,
+            callerId = "called-id",
+            isMuted = false,
+            isCameraOn = false,
+            isCbrEnabled = false,
+            conversationName = null,
+            conversationType = Conversation.Type.GROUP,
+            callerName = null,
+            callerTeamName = null,
+            establishedTime = null
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
@@ -39,11 +39,9 @@ import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class MemberJoinEventHandlerTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCase
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.persistence.dao.ConversationDAO
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class MemberLeaveEventHandlerTest {
+
+    @Mock
+    private val conversationDAO = mock(classOf<ConversationDAO>())
+
+    @Mock
+    private val userRepository = mock(classOf<UserRepository>())
+
+    @Mock
+    private val persistMessage = mock(classOf<PersistMessageUseCase>())
+
+    @Mock
+    private val updateConversationClientsForCurrentCall = mock(classOf<UpdateConversationClientsForCurrentCallUseCase>())
+
+    private lateinit var memberLeaveEventHandler: MemberLeaveEventHandler
+
+    @BeforeTest
+    fun setup() {
+        memberLeaveEventHandler = MemberLeaveEventHandlerImpl(
+            conversationDAO = conversationDAO,
+            userRepository = userRepository,
+            persistMessage = persistMessage,
+            updateConversationClientsForCurrentCall = lazy { updateConversationClientsForCurrentCall }
+        )
+    }
+
+    @Test
+    fun givenDaoReturnsSuccess_whenDeletingMember_thenPersistSystemMessage() = runTest {
+        given(conversationDAO).coroutine {
+            deleteMembersByQualifiedID(list, qualifiedConversationIdEntity)
+        }.then { Either.Right(Unit) }
+
+        given(userRepository).coroutine {
+            fetchUsersIfUnknownByIds(memberLeaveEvent.removedList.toSet())
+        }.then { Either.Right(Unit) }
+
+        given(persistMessage).coroutine {
+            persistMessage(message)
+        }.then { Either.Right(Unit) }
+
+        memberLeaveEventHandler.handle(memberLeaveEvent)
+
+        verify(conversationDAO).coroutine {
+            deleteMembersByQualifiedID(list, qualifiedConversationIdEntity)
+        }.wasInvoked(once)
+
+        verify(updateConversationClientsForCurrentCall).coroutine {
+            updateConversationClientsForCurrentCall.invoke(message.conversationId)
+        }.wasInvoked(once)
+
+        verify(persistMessage).coroutine {
+            persistMessage.invoke(message)
+        }.wasInvoked(once)
+
+    }
+
+    @Test
+    fun givenDaoReturnsFailure_whenDeletingMember_thenNothingToDo() = runTest {
+        given(conversationDAO).coroutine {
+            deleteMembersByQualifiedID(list, qualifiedConversationIdEntity)
+        }.then { Either.Left(failure) }
+
+        given(userRepository).coroutine {
+            fetchUsersIfUnknownByIds(memberLeaveEvent.removedList.toSet())
+        }.then { Either.Left(failure) }
+
+        memberLeaveEventHandler.handle(memberLeaveEvent)
+
+        verify(conversationDAO).coroutine {
+            deleteMembersByQualifiedID(list, qualifiedConversationIdEntity)
+        }.wasInvoked(once)
+
+        verify(persistMessage).coroutine {
+            persistMessage.invoke(message)
+        }.wasNotInvoked()
+    }
+
+    companion object {
+        val failure = CoreFailure.MissingClientRegistration
+        val userId = UserId("userId", "domain")
+        private val qualifiedUserIdEntity = QualifiedIDEntity("userId", "domain")
+        private val qualifiedConversationIdEntity = QualifiedIDEntity("conversationId", "domain")
+
+        val conversationId = ConversationId("conversationId", "domain")
+        val list = listOf(qualifiedUserIdEntity)
+
+        val memberLeaveEvent = Event.Conversation.MemberLeave(
+            id = "id",
+            conversationId = conversationId,
+            transient = false,
+            removedBy = userId,
+            removedList = listOf(userId),
+            timestampIso = "timestampIso"
+        )
+        val message = Message.System(
+            id = memberLeaveEvent.id,
+            content = MessageContent.MemberChange.Removed(members = memberLeaveEvent.removedList),
+            conversationId = memberLeaveEvent.conversationId,
+            date = memberLeaveEvent.timestampIso,
+            senderUserId = memberLeaveEvent.removedBy,
+            status = Message.Status.SENT,
+            visibility = Message.Visibility.VISIBLE,
+            expirationData = null
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

I am reverting the changes of #1918 as we need to update the conversation call clients on every client removal, not only the current one as #1918 do

### Solutions

I created `UpdateConversationClientsForCurrentCallUseCase` that will be invoked everytime we notice a member removal

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
