### PR TITLE
feat: handle buffered events

### DIFF
--- a/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -84,9 +84,10 @@ class MLSClientImpl(
         return toCommitBundle(coreCrypto.joinByExternalCommit(toUByteList(publicGroupState), defaultGroupConfiguration))
     }
 
-    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId) {
+    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>? {
         val groupIdAsBytes = toUByteList(groupId.decodeBase64Bytes())
         coreCrypto.mergePendingGroupFromExternalCommit(groupIdAsBytes)
+        return null
     }
 
     override suspend fun clearPendingGroupExternalCommit(groupId: MLSGroupId) {

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -96,9 +96,11 @@ class MLSClientImpl(
         )
     }
 
-    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId) {
+    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>? {
         val groupIdAsBytes = toUByteList(groupId.decodeBase64Bytes())
-        coreCrypto.mergePendingGroupFromExternalCommit(groupIdAsBytes)
+        return coreCrypto.mergePendingGroupFromExternalCommit(groupIdAsBytes)?.let { messages ->
+            messages.map { toDecryptedMessageBundle(it) }
+        }
     }
 
     override suspend fun clearPendingGroupExternalCommit(groupId: MLSGroupId) {

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
@@ -132,7 +132,7 @@ interface MLSClient {
      *
      * @param groupId MLS group ID provided by BE
      */
-    suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId)
+    suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>?
 
     /**
      * Clear pending external commits

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -48,7 +48,7 @@ class MLSClientImpl : MLSClient {
         TODO("Not yet implemented")
     }
 
-    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId) {
+    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>? {
         TODO("Not yet implemented")
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/DecryptedMessageBundleMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/DecryptedMessageBundleMapper.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.toModel
+
+fun com.wire.kalium.cryptography.DecryptedMessageBundle.toModel(groupID: GroupID): DecryptedMessageBundle =
+    DecryptedMessageBundle(
+        groupID,
+        message?.let { message ->
+            // We will always have senderClientId together with an application message
+            // but CoreCrypto API doesn't express this
+            ApplicationMessage(
+                message = message,
+                senderID = senderClientId!!.toModel().userId,
+                senderClientID = senderClientId!!.toModel().clientId
+            )
+        },
+        commitDelay,
+        identity?.let { identity ->
+            E2EIdentity(
+                identity.clientId,
+                identity.handle,
+                identity.displayName,
+                identity.domain
+            )
+        }
+    )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMappers.kt
@@ -16,9 +16,11 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
+@file:Suppress("TooManyFunctions")
 package com.wire.kalium.logic.data.id
 
 import com.wire.kalium.cryptography.CryptoClientId
+import com.wire.kalium.cryptography.CryptoQualifiedClientId
 import com.wire.kalium.cryptography.CryptoQualifiedID
 import com.wire.kalium.cryptography.MLSGroupId
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -49,3 +51,5 @@ internal fun UserAssetDTO.toModel(domain: String): QualifiedID = QualifiedID(key
 internal fun SubconversationId.toApi(): String = value
 
 internal fun GroupID.toCrypto(): MLSGroupId = value
+
+internal fun CryptoQualifiedClientId.toModel() = QualifiedClientID(ClientId(value), userId.toModel())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -786,7 +786,8 @@ class UserSessionScope internal constructor(
             authenticatedNetworkContainer.conversationApi,
             clientRepository,
             conversationRepository,
-            mlsConversationRepository
+            mlsConversationRepository,
+            mlsUnpacker
         )
 
     private val recoverMLSConversationsUseCase: RecoverMLSConversationsUseCase
@@ -810,7 +811,8 @@ class UserSessionScope internal constructor(
         get() = JoinSubconversationUseCaseImpl(
             authenticatedNetworkContainer.conversationApi,
             mlsConversationRepository,
-            subconversationRepository
+            subconversationRepository,
+            mlsUnpacker
         )
 
     private val leaveSubconversationUseCase: LeaveSubconversationUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -26,16 +26,18 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.toApi
-import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureHandler
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureResolution
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.exceptions.KaliumException
@@ -44,6 +46,7 @@ import com.wire.kalium.network.exceptions.isMlsStaleMessage
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 
 /**
  * Send an external commit to join all MLS conversations for which the user is a member,
@@ -54,13 +57,13 @@ interface JoinExistingMLSConversationUseCase {
 }
 
 @Suppress("LongParameterList")
-class JoinExistingMLSConversationUseCaseImpl(
+internal class JoinExistingMLSConversationUseCaseImpl(
     private val featureSupport: FeatureSupport,
     private val conversationApi: ConversationApi,
     private val clientRepository: ClientRepository,
     private val conversationRepository: ConversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
-    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val mlsMessageUnpacker: MLSMessageUnpacker,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : JoinExistingMLSConversationUseCase {
     private val dispatcher = kaliumDispatcher.io
@@ -125,7 +128,19 @@ class JoinExistingMLSConversationUseCaseImpl(
                     mlsConversationRepository.joinGroupByExternalCommit(
                         conversation.protocol.groupId,
                         groupInfo
-                    )
+                    ).flatMapLeft {
+                        if (MLSMessageFailureHandler.handleFailure(it) is MLSMessageFailureResolution.Ignore) {
+                            Either.Right(null)
+                        } else {
+                            Either.Left(it)
+                        }
+                    }.map { messageBundles ->
+                        // Process any buffered message which arrived before the pending group was merged. We only
+                        // expect to receive proposals which the backend re-creates upon external commits.
+                        messageBundles?.forEach { bundle ->
+                            mlsMessageUnpacker.unpackMlsBundle(bundle, conversation.id, Clock.System.now())
+                        } ?: Unit
+                    }
                 }
             }
         } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation.message
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.MLSFailure
+
+sealed class MLSMessageFailureResolution {
+    object Ignore : MLSMessageFailureResolution()
+    object InformUser : MLSMessageFailureResolution()
+    object OutOfSync : MLSMessageFailureResolution()
+}
+
+internal object MLSMessageFailureHandler {
+    fun handleFailure(failure: CoreFailure): MLSMessageFailureResolution {
+        return when (failure) {
+            // Received messages targeting a future epoch, we might have lost messages.
+            is MLSFailure.WrongEpoch -> MLSMessageFailureResolution.OutOfSync
+            // Received already sent or received message, can safely be ignored.
+            is MLSFailure.DuplicateMessage -> MLSMessageFailureResolution.Ignore
+            // Received self commit, any unmerged group has know when merged by CoreCrypto.
+            is MLSFailure.SelfCommitIgnored -> MLSMessageFailureResolution.Ignore
+            // Message arrive in an unmerged group, it has been buffered and will be consumed later.
+            is MLSFailure.UnmergedPendingGroup -> MLSMessageFailureResolution.Ignore
+            else -> MLSMessageFailureResolution.InformUser
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.sync.receiver.conversation.message
 
 import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.logger.KaliumLogger
-import com.wire.kalium.logic.MLSFailure
 import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.event.Event
@@ -101,40 +100,29 @@ internal class NewMessageEventHandlerImpl(
                     "protocol" to "MLS"
                 )
 
-                logger.e("Failed to decrypt event: ${logMap.toJsonElement()}")
-
-                if (it is MLSFailure.WrongEpoch) {
-                    mlsWrongEpochHandler.onMLSWrongEpoch(event.conversationId, event.timestampIso)
-                    return@onFailure
+                when (MLSMessageFailureHandler.handleFailure(it)) {
+                    is MLSMessageFailureResolution.Ignore -> {
+                        logger.i("Ignoring event: ${logMap.toJsonElement()}")
+                    }
+                    is MLSMessageFailureResolution.InformUser -> {
+                        logger.i("Informing users about decryption error: ${logMap.toJsonElement()}")
+                        applicationMessageHandler.handleDecryptionError(
+                            eventId = event.id,
+                            conversationId = event.conversationId,
+                            timestampIso = event.timestampIso,
+                            senderUserId = event.senderUserId,
+                            senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
+                            content = MessageContent.FailedDecryption(
+                                isDecryptionResolved = false,
+                                senderUserId = event.senderUserId
+                            )
+                        )
+                    }
+                    is MLSMessageFailureResolution.OutOfSync -> {
+                        logger.i("Epoch out of sync error: ${logMap.toJsonElement()}")
+                        mlsWrongEpochHandler.onMLSWrongEpoch(event.conversationId, event.timestampIso)
+                    }
                 }
-
-                if (it is MLSFailure.DuplicateMessage) {
-                    logger.i("Ignoring duplicate event: ${logMap.toJsonElement()}")
-                    return@onFailure
-                }
-
-                if (it is MLSFailure.SelfCommitIgnored) {
-                    logger.i("Ignoring replayed self commit: ${logMap.toJsonElement()}")
-                    return@onFailure
-                }
-
-                if (it is MLSFailure.UnmergedPendingGroup) {
-                    logger.i("Message arrive in an unmerged group, " +
-                            "it has been buffered and will be consumed later: ${logMap.toJsonElement()}")
-                    return@onFailure
-                }
-
-                applicationMessageHandler.handleDecryptionError(
-                    eventId = event.id,
-                    conversationId = event.conversationId,
-                    timestampIso = event.timestampIso,
-                    senderUserId = event.senderUserId,
-                    senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
-                    content = MessageContent.FailedDecryption(
-                        isDecryptionResolved = false,
-                        senderUserId = event.senderUserId
-                    )
-                )
             }.onSuccess {
                 if (it is MessageUnpackResult.ApplicationMessage) {
                     handleSuccessfulResult(it)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
@@ -163,10 +164,14 @@ class JoinSubconversationUseCaseTest {
         @Mock
         val subconversationRepository = mock(classOf<SubconversationRepository>())
 
+        @Mock
+        val mlsMessageUnpacker = mock(classOf<MLSMessageUnpacker>())
+
         fun arrange() = this to JoinSubconversationUseCaseImpl(
             conversationApi,
             mlsConversationRepository,
-            subconversationRepository
+            subconversationRepository,
+            mlsMessageUnpacker
         )
 
         fun withEstablishMLSGroupSuccessful() = apply {
@@ -180,7 +185,7 @@ class JoinSubconversationUseCaseTest {
             given(mlsConversationRepository)
                 .suspendFunction(mlsConversationRepository::joinGroupByExternalCommit)
                 .whenInvokedWith(anything(), anything())
-                .thenReturn(Either.Right(Unit))
+                .thenReturn(Either.Right(null))
         }
 
         fun withJoinByExternalCommitGroupFailing(failure: CoreFailure, times: Int = Int.MAX_VALUE) = apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

CoreCrypo 1.0.0 introduced a new feature where it will buffer message received after joining a conversation via external commit but before `mergePendingGroupFromExternalCommit` has been called. This scenario will happen if an MLS group has any pending external remove proposals when joining via external commit. The reason is that the backend will immediately re-create the remove proposals because they get invalidated by the external commit.

This PR updates `JoinExistingMLSConversationUseCase` and `JoinSubconversationUseCase` to process any buffered proposals.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

1. Create MLS group with user A and B
2. Make user A's client is offline so it can process proposals 
3. Leave the group with user B's client (the group will now have pending remove proposal)
4. Login with a second client for user A (after login a client will join all known MLS groups via external commit)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
