### PR TITLE
chore: add logging details of unknown events

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -598,10 +598,14 @@ sealed class Event(open val id: String, open val transient: Boolean) {
     data class Unknown(
         override val id: String,
         override val transient: Boolean,
+        val unknownType: String,
+        val cause: String? = null
     ) : Event(id, transient) {
         override fun toLogMap(): Map<String, Any?> = mapOf(
             typeKey to "User.UnknownEvent",
             idKey to id.obfuscateId(),
+            "unknownType" to unknownType,
+            "cause" to cause
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -41,6 +41,10 @@ import com.wire.kalium.network.api.base.model.getCompleteAssetOrNull
 import com.wire.kalium.network.api.base.model.getPreviewAssetOrNull
 import io.ktor.utils.io.charsets.Charsets
 import io.ktor.utils.io.core.toByteArray
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.serializer
 
 @Suppress("TooManyFunctions")
 class EventMapper(
@@ -74,8 +78,8 @@ class EventMapper(
             is EventContentDTO.User.UserDeleteDTO -> userDelete(id, eventContentDTO, transient)
             is EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO -> featureConfig(id, eventContentDTO, transient)
             is EventContentDTO.User.NewClientDTO -> newClient(id, eventContentDTO, transient)
-            is EventContentDTO.Unknown -> Event.Unknown(id, transient)
-            is EventContentDTO.Conversation.AccessUpdate -> Event.Unknown(id, transient) // TODO: update it after logic code is merged
+            is EventContentDTO.Unknown -> unknown(id, transient, eventContentDTO)
+            is EventContentDTO.Conversation.AccessUpdate -> unknown(id, transient, eventContentDTO)
             is EventContentDTO.Conversation.DeletedConversationDTO -> conversationDeleted(id, eventContentDTO, transient)
             is EventContentDTO.Conversation.ConversationRenameDTO -> conversationRenamed(id, eventContentDTO, transient)
             is EventContentDTO.Team.MemberJoin -> teamMemberJoined(id, eventContentDTO, transient)
@@ -83,11 +87,31 @@ class EventMapper(
             is EventContentDTO.Team.MemberUpdate -> teamMemberUpdate(id, eventContentDTO, transient)
             is EventContentDTO.Team.Update -> teamUpdate(id, eventContentDTO, transient)
             is EventContentDTO.User.UpdateDTO -> userUpdate(id, eventContentDTO, transient)
-            is EventContentDTO.UserProperty.PropertiesSetDTO -> updateUserProperties(id, eventContentDTO.value, transient)
+            is EventContentDTO.UserProperty.PropertiesSetDTO -> updateUserProperties(id, eventContentDTO, transient)
             is EventContentDTO.UserProperty.PropertiesDeleteDTO -> deleteUserProperties(id, eventContentDTO, transient)
             is EventContentDTO.Conversation.ReceiptModeUpdate -> conversationReceiptModeUpdate(id, eventContentDTO, transient)
             is EventContentDTO.Conversation.MessageTimerUpdate -> conversationMessageTimerUpdate(id, eventContentDTO, transient)
         }
+
+    @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+    fun unknown(
+        id: String,
+        transient: Boolean,
+        eventContentDTO: EventContentDTO,
+        cause: String? = null
+    ): Event.Unknown = Event.Unknown(
+        id = id,
+        transient = transient,
+        unknownType = when (eventContentDTO) {
+            is EventContentDTO.Unknown -> eventContentDTO.type
+            else -> try {
+                eventContentDTO::class.serializer().descriptor.serialName
+            } catch (e: SerializationException) {
+                "" // this should never happen, by default serializer returns EventContentDTO.Unknown
+            }
+        },
+        cause = cause
+    )
 
     fun conversationMessageTimerUpdate(
         id: String,
@@ -116,12 +140,17 @@ class EventMapper(
 
     private fun updateUserProperties(
         id: String,
-        eventContentDTO: EventContentDTO.FieldKeyValue,
+        eventContentDTO: EventContentDTO.UserProperty.PropertiesSetDTO,
         transient: Boolean
     ): Event {
-        return when (eventContentDTO) {
-            is EventContentDTO.FieldKeyNumberValue -> ReadReceiptModeSet(id, transient, eventContentDTO.value == 1)
-            is EventContentDTO.FieldUnknownValue -> Event.Unknown(id, transient)
+        return when (val fieldKeyValue = eventContentDTO.value) {
+            is EventContentDTO.FieldKeyNumberValue -> ReadReceiptModeSet(id, transient, fieldKeyValue.value == 1)
+            is EventContentDTO.FieldUnknownValue -> unknown(
+                id = id,
+                transient = transient,
+                eventContentDTO = eventContentDTO,
+                cause = "Unknown value type for key: ${eventContentDTO.key} "
+            )
         }
     }
 
@@ -133,7 +162,12 @@ class EventMapper(
         return if (PropertiesApi.PropertyKey.WIRE_RECEIPT_MODE.key == eventContentDTO.key) {
             ReadReceiptModeSet(id, transient, false)
         } else {
-            Event.Unknown(id, transient)
+            unknown(
+                id = id,
+                transient = transient,
+                eventContentDTO = eventContentDTO,
+                cause = "Unknown key: ${eventContentDTO.key} "
+            )
         }
     }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
@@ -362,7 +362,9 @@ sealed class EventContentDTO {
 
     @Serializable
     @SerialName("unknown")
-    object Unknown : EventContentDTO()
+    data class Unknown(
+        val type: String
+    ) : EventContentDTO()
 }
 
 @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we map multiple different events that we not yet handle as `Event.Unknown`. In logs, there is no way to know which exact type it is.

### Solutions

Add type to unknown event logs. In addition, for some types (like `FieldKeyValue`) also add cause (like "unknown key").

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
