### PR TITLE
fix: duplicated timer change system message [WPB-286] (#1935)

### DIFF
--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/E2EIClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/E2EIClientTest.kt
@@ -190,7 +190,7 @@ class E2EIClientTest : BaseMLSClientTest() {
                   }
                ],
                "notBefore":"2023-05-07T12:00:50.1666Z",
-               "notAfter":"2023-08-05T12:00:50.1666Z",
+               "notAfter":"3000-08-05T12:00:50.1666Z",
                "authorizations":[
                   "$AUTHZ_URL"
                ],

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandler.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
-import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
@@ -47,7 +46,7 @@ internal class ConversationMessageTimerEventHandlerImpl(
         updateMessageTimer(event)
             .onSuccess {
                 val message = Message.System(
-                    uuid4().toString(),
+                    event.id,
                     MessageContent.ConversationMessageTimerChanged(
                         messageTimer = event.messageTimer
                     ),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandlerTest.kt
@@ -19,6 +19,8 @@
 package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.functional.Either
@@ -26,6 +28,7 @@ import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
@@ -51,7 +54,19 @@ class ConversationMessageTimerEventHandlerTest {
         with(arrangement) {
             verify(persistMessageUseCase)
                 .suspendFunction(persistMessageUseCase::invoke)
-                .with(any())
+                .with(
+                    eq(Message.System(
+                    event.id,
+                    MessageContent.ConversationMessageTimerChanged(
+                        messageTimer = event.messageTimer
+                    ),
+                    event.conversationId,
+                    event.timestampIso,
+                    event.senderUserId,
+                    Message.Status.SENT,
+                    Message.Visibility.VISIBLE,
+                    expirationData = null
+                )))
                 .wasInvoked(once)
         }
     }


### PR DESCRIPTION
* fix: duplicated timer change system message

* test improvement

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Wrong local id for conversation message timer change event was passed