### PR TITLE
feat: E2EI renew logic (WPB-3326)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/E2EISettings.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/E2EISettings.kt
@@ -23,19 +23,17 @@ import kotlinx.datetime.Instant
 data class E2EISettings(
     val isRequired: Boolean,
     val discoverUrl: String,
-    val notifyUserAfter: Instant?,
     val gracePeriodEnd: Instant?
 ) {
 
     fun toEntity() = E2EISettingsEntity(
-        isRequired, discoverUrl, notifyUserAfter?.toEpochMilliseconds(), gracePeriodEnd?.toEpochMilliseconds()
+        isRequired, discoverUrl, gracePeriodEnd?.toEpochMilliseconds()
     )
 
     companion object {
         fun fromEntity(entity: E2EISettingsEntity) = E2EISettings(
             entity.status,
             entity.discoverUrl,
-            entity.notifyUserAfterMs?.let { Instant.fromEpochMilliseconds(it) },
             entity.gracePeriodEndMs?.let { Instant.fromEpochMilliseconds(it) },
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -34,7 +34,6 @@ import com.wire.kalium.persistence.config.IsFileSharingEnabledEntity
 import com.wire.kalium.persistence.config.TeamSettingsSelfDeletionStatusEntity
 import com.wire.kalium.persistence.config.UserConfigStorage
 import com.wire.kalium.persistence.dao.unread.UserConfigDAO
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -34,8 +34,10 @@ import com.wire.kalium.persistence.config.IsFileSharingEnabledEntity
 import com.wire.kalium.persistence.config.TeamSettingsSelfDeletionStatusEntity
 import com.wire.kalium.persistence.config.UserConfigStorage
 import com.wire.kalium.persistence.dao.unread.UserConfigDAO
+import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
 
 @Suppress("TooManyFunctions")
@@ -71,6 +73,8 @@ interface UserConfigRepository {
 
     suspend fun markTeamSettingsSelfDeletingMessagesStatusAsNotified(): Either<StorageFailure, Unit>
     suspend fun observeTeamSettingsSelfDeletingStatus(): Flow<Either<StorageFailure, TeamSettingsSelfDeletionStatus>>
+    fun observeE2EINotificationTime(): Flow<Either<StorageFailure, Instant?>>
+    fun setE2EINotificationTime(instant: Instant): Either<StorageFailure, Unit>
 }
 
 @Suppress("TooManyFunctions")
@@ -159,15 +163,23 @@ class UserConfigDataSource(
     override fun setE2EISettings(setting: E2EISettings): Either<StorageFailure, Unit> =
         wrapStorageRequest { userConfigStorage.setE2EISettings(setting.toEntity()) }
 
+    override fun observeE2EINotificationTime(): Flow<Either<StorageFailure, Instant?>> =
+        userConfigStorage.e2EINotificationTimeFlow()
+            .wrapStorageRequest()
+            .mapRight { Instant.fromEpochMilliseconds(it) }
+
+    override fun setE2EINotificationTime(instant: Instant): Either<StorageFailure, Unit> =
+        wrapStorageRequest { userConfigStorage.setE2EINotificationTime(instant.toEpochMilliseconds()) }
+
     override fun snoozeE2EINotification(duration: Duration): Either<StorageFailure, Unit> =
         wrapStorageRequest {
-            getE2EISettingEntityOrNull()?.let { current ->
-                val notifyUserAfterMs = current.notifyUserAfterMs?.plus(duration.inWholeMilliseconds)
-                userConfigStorage.setE2EISettings(current.copy(notifyUserAfterMs = notifyUserAfterMs))
+            getE2EINotificationTimeOrNull()?.let { current ->
+                val notifyUserAfterMs = current.plus(duration.inWholeMilliseconds)
+                userConfigStorage.setE2EINotificationTime(notifyUserAfterMs)
             }
         }
 
-    private fun getE2EISettingEntityOrNull() = wrapStorageRequest { userConfigStorage.getE2EISettings() }.getOrNull()
+    private fun getE2EINotificationTimeOrNull() = wrapStorageRequest { userConfigStorage.getE2EINotificationTime() }.getOrNull()
 
     override fun setConferenceCallingEnabled(enabled: Boolean): Either<StorageFailure, Unit> =
         wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -172,9 +172,9 @@ internal class SyncFeatureConfigsUseCaseImpl(
             E2EISettings(
                 isRequired = featureConfig.status == Status.ENABLED,
                 discoverUrl = featureConfig.config.discoverUrl,
-                notifyUserAfter = DateTimeUtil.currentInstant(),
                 gracePeriodEnd = Instant.fromEpochMilliseconds(gracePeriodEndMs)
             )
         )
+        userConfigRepository.setE2EINotificationTime(DateTimeUtil.currentInstant())
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/MarkEnablingE2EIAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/MarkEnablingE2EIAsNotifiedUseCase.kt
@@ -27,17 +27,21 @@ import kotlin.time.Duration.Companion.minutes
  * Mark the MLS End-to-End Identity enabling status change as notified
  * need to be called after notifying the user about the change
  * e.g. after showing a dialog, or a toast etc.
+ *
+ * @param tillTheEndOfGracePeriod is the [Duration] that is left till the end of GracePeriod for creating/renewing E2EI certificate.
+ * Based on this Duration we calculate how much to snooze the notification for.
+ * This duration should be just passed from the [E2EIRequiredResult.WithGracePeriod].
  */
 interface MarkEnablingE2EIAsNotifiedUseCase {
-    suspend operator fun invoke(timeLeft: Duration)
+    suspend operator fun invoke(tillTheEndOfGracePeriod: Duration)
 }
 
 internal class MarkEnablingE2EIAsNotifiedUseCaseImpl(
     private val userConfigRepository: UserConfigRepository
 ) : MarkEnablingE2EIAsNotifiedUseCase {
 
-    override suspend fun invoke(timeLeft: Duration) {
-        userConfigRepository.snoozeE2EINotification(snoozeTime(timeLeft))
+    override suspend fun invoke(tillTheEndOfGracePeriod: Duration) {
+        userConfigRepository.snoozeE2EINotification(snoozeTime(tillTheEndOfGracePeriod))
     }
 
     private fun snoozeTime(timeLeft: Duration): Duration =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/MarkEnablingE2EIAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/MarkEnablingE2EIAsNotifiedUseCase.kt
@@ -18,7 +18,10 @@
 package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.configuration.UserConfigRepository
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Mark the MLS End-to-End Identity enabling status change as notified
@@ -26,18 +29,23 @@ import kotlin.time.Duration.Companion.days
  * e.g. after showing a dialog, or a toast etc.
  */
 interface MarkEnablingE2EIAsNotifiedUseCase {
-    suspend operator fun invoke()
+    suspend operator fun invoke(timeLeft: Duration)
 }
 
 internal class MarkEnablingE2EIAsNotifiedUseCaseImpl(
     private val userConfigRepository: UserConfigRepository
 ) : MarkEnablingE2EIAsNotifiedUseCase {
 
-    override suspend fun invoke() {
-        userConfigRepository.snoozeE2EINotification(SNOOZE_MLS_ENABLE_CHANGE_MS)
+    override suspend fun invoke(timeLeft: Duration) {
+        userConfigRepository.snoozeE2EINotification(snoozeTime(timeLeft))
     }
 
-    companion object {
-        val SNOOZE_MLS_ENABLE_CHANGE_MS = 1.days
-    }
+    private fun snoozeTime(timeLeft: Duration): Duration =
+        when {
+            timeLeft > 1.days -> 1.days
+            timeLeft > 4.hours -> 4.hours
+            timeLeft > 1.hours -> 1.hours
+            timeLeft > 15.minutes -> 15.minutes
+            else -> 5.minutes
+        }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveE2EIRequiredUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveE2EIRequiredUseCase.kt
@@ -79,14 +79,18 @@ internal class ObserveE2EIRequiredUseCaseImpl(
         // TODO get current client E2EI certificate data here
         return flowOf(Unit).flowOn(dispatcher)
     }
-}
 
-private fun Flow<Instant>.delayUntilNotifyTime(): Flow<Instant> = flatMapLatest { instant ->
-    val delayMillis = instant
-        .minus(DateTimeUtil.currentInstant())
-        .inWholeMilliseconds
-        .coerceAtLeast(0L)
-    flowOf(instant).onStart { delay(delayMillis) }
+    private fun Flow<Instant>.delayUntilNotifyTime(): Flow<Instant> = flatMapLatest { instant ->
+        val delayMillis = instant
+            .minus(DateTimeUtil.currentInstant())
+            .inWholeMilliseconds
+            .coerceAtLeast(NO_DELAY_MS)
+        flowOf(instant).onStart { delay(delayMillis) }
+    }
+
+    companion object {
+        private const val NO_DELAY_MS = 0L
+    }
 }
 
 sealed class E2EIRequiredResult {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveE2EIRequiredUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveE2EIRequiredUseCase.kt
@@ -20,18 +20,20 @@ package com.wire.kalium.logic.feature.user
 import com.wire.kalium.logic.configuration.E2EISettings
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.functional.getOrNull
+import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
 
 /**
@@ -50,28 +52,50 @@ internal class ObserveE2EIRequiredUseCaseImpl(
 ) : ObserveE2EIRequiredUseCase {
 
     override fun invoke(): Flow<E2EIRequiredResult> = userConfigRepository
-        .observeE2EISettings()
+        .observeE2EINotificationTime()
         .map { it.getOrNull() }
         .filterNotNull()
-        .filter { setting -> setting.isRequired && setting.gracePeriodEnd != null }
         .delayUntilNotifyTime()
-        .map { setting ->
-            if (setting.gracePeriodEnd!! <= DateTimeUtil.currentInstant()) E2EIRequiredResult.NoGracePeriod
-            else E2EIRequiredResult.WithGracePeriod(setting.gracePeriodEnd.minus(DateTimeUtil.currentInstant()))
+        .flatMapLatest {
+            combine(observeE2EISettings(), observeCurrentE2EICertificate()) { setting, currentCertificate ->
+                if (!setting.isRequired)
+                    E2EIRequiredResult.NotRequired
+
+                // TODO check here if current certificate needs to be renewed (soon, or now)
+
+                else if (setting.gracePeriodEnd == null || setting.gracePeriodEnd <= DateTimeUtil.currentInstant())
+                    E2EIRequiredResult.NoGracePeriod.Create
+                else E2EIRequiredResult.WithGracePeriod.Create(setting.gracePeriodEnd.minus(DateTimeUtil.currentInstant()))
+            }
         }
         .flowOn(dispatcher)
+
+    private fun observeE2EISettings() = userConfigRepository.observeE2EISettings().onlyRight().flowOn(dispatcher)
+
+    private fun observeCurrentE2EICertificate(): Flow<Unit> {
+        // TODO get current client E2EI certificate data here
+        return flowOf(Unit).flowOn(dispatcher)
+    }
 }
 
-private fun Flow<E2EISettings>.delayUntilNotifyTime(): Flow<E2EISettings> = flatMapLatest { setting ->
-    val delayMillis = setting.notifyUserAfter
-        ?.minus(DateTimeUtil.currentInstant())
-        ?.inWholeMilliseconds
-        ?.coerceAtLeast(0L)
-        ?: 0L
-    flowOf(setting).onStart { delay(delayMillis) }
+private fun Flow<Instant>.delayUntilNotifyTime(): Flow<Instant> = flatMapLatest { instant ->
+    val delayMillis = instant
+        .minus(DateTimeUtil.currentInstant())
+        .inWholeMilliseconds
+        .coerceAtLeast(0L)
+    flowOf(instant).onStart { delay(delayMillis) }
 }
 
 sealed class E2EIRequiredResult {
-    data class WithGracePeriod(val gracePeriod: Duration) : E2EIRequiredResult()
-    object NoGracePeriod : E2EIRequiredResult()
+    sealed class WithGracePeriod(open val timeLeft: Duration) : E2EIRequiredResult() {
+        data class Create(override val timeLeft: Duration) : WithGracePeriod(timeLeft)
+        data class Renew(override val timeLeft: Duration) : WithGracePeriod(timeLeft)
+    }
+
+    sealed class NoGracePeriod : E2EIRequiredResult() {
+        data object Create : NoGracePeriod()
+        data object Renew : NoGracePeriod()
+    }
+
+    data object NotRequired : E2EIRequiredResult()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -151,10 +151,10 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
                     E2EISettings(
                         isRequired = event.model.status == Status.ENABLED,
                         discoverUrl = event.model.config.discoverUrl,
-                        notifyUserAfter = DateTimeUtil.currentInstant(),
                         gracePeriodEnd = Instant.fromEpochMilliseconds(gracePeriodEndMs)
                     )
                 )
+                userConfigRepository.setE2EINotificationTime(DateTimeUtil.currentInstant())
 
                 kaliumLogger.logEventProcessing(
                     EventLoggingStatus.SUCCESS,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/MarkEnablingE2EIAsNotifiedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/MarkEnablingE2EIAsNotifiedUseCaseTest.kt
@@ -65,7 +65,7 @@ class MarkEnablingE2EIAsNotifiedUseCaseTest {
     fun whenMarkAsNotifiedIsCalledWithMoreThen1Hour_thenSnoozeIsCalledWith1Hour() = runTest {
         val (arrangement, useCase) = Arrangement().arrange()
 
-        useCase(1.hours)
+        useCase(2.hours)
 
         verify(arrangement.userConfigRepository)
             .suspendFunction(arrangement.userConfigRepository::snoozeE2EINotification)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/MarkEnablingE2EIAsNotifiedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/MarkEnablingE2EIAsNotifiedUseCaseTest.kt
@@ -31,18 +31,69 @@ import io.mockative.verify
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 class MarkEnablingE2EIAsNotifiedUseCaseTest {
 
     @Test
-    fun whenMarkAsNotifiedIsCalled_thenSnoozeIsCalled() = runTest {
+    fun whenMarkAsNotifiedIsCalledWithMoreThen1Day_thenSnoozeIsCalledWith1day() = runTest {
         val (arrangement, useCase) = Arrangement().arrange()
 
-        useCase()
+        useCase(2.days)
 
         verify(arrangement.userConfigRepository)
             .suspendFunction(arrangement.userConfigRepository::snoozeE2EINotification)
-            .with(eq(MarkEnablingE2EIAsNotifiedUseCaseImpl.SNOOZE_MLS_ENABLE_CHANGE_MS))
+            .with(eq(1.days))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun whenMarkAsNotifiedIsCalledWithMoreThen4Hours_thenSnoozeIsCalledWith4Hours() = runTest {
+        val (arrangement, useCase) = Arrangement().arrange()
+
+        useCase(5.hours)
+
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::snoozeE2EINotification)
+            .with(eq(4.hours))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun whenMarkAsNotifiedIsCalledWithMoreThen1Hour_thenSnoozeIsCalledWith1Hour() = runTest {
+        val (arrangement, useCase) = Arrangement().arrange()
+
+        useCase(1.hours)
+
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::snoozeE2EINotification)
+            .with(eq(1.hours))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun whenMarkAsNotifiedIsCalledWithMoreThen15Minutes_thenSnoozeIsCalledWith15Minutes() = runTest {
+        val (arrangement, useCase) = Arrangement().arrange()
+
+        useCase(16.minutes)
+
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::snoozeE2EINotification)
+            .with(eq(15.minutes))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun whenMarkAsNotifiedIsCalledWithLessThen15Minutes_thenSnoozeIsCalledWith5Minutes() = runTest {
+        val (arrangement, useCase) = Arrangement().arrange()
+
+        useCase(14.minutes)
+
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::snoozeE2EINotification)
+            .with(eq(5.minutes))
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ObserveE2EIRequiredUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ObserveE2EIRequiredUseCaseTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
@@ -52,6 +53,7 @@ class ObserveE2EIRequiredUseCaseTest {
             .arrange()
 
         useCase().test {
+            advanceUntilIdle()
             awaitComplete()
         }
     }
@@ -147,6 +149,7 @@ class ObserveE2EIRequiredUseCaseTest {
             .arrange()
 
         useCase().test {
+            assertTrue { awaitItem() == E2EIRequiredResult.NotRequired }
             awaitComplete()
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmmSettings/KaliumPreferences.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmmSettings/KaliumPreferences.kt
@@ -44,6 +44,10 @@ interface KaliumPreferences {
     fun getBoolean(key: String, defaultValue: Boolean): Boolean
     fun getBoolean(key: String): Boolean?
 
+    fun putLong(key: String, value: Long)
+    fun getLong(key: String, defaultValue: Long): Long
+    fun getLong(key: String): Long?
+
 }
 
 class KaliumPreferencesSettings(
@@ -60,6 +64,14 @@ class KaliumPreferencesSettings(
 
     override fun getBoolean(key: String): Boolean? =
         encryptedSettings.getBooleanOrNull(key)
+
+    override fun putLong(key: String, value: Long) {
+        encryptedSettings.putLong(key, value)
+    }
+
+    override fun getLong(key: String, defaultValue: Long): Long = encryptedSettings.getLong(key, defaultValue)
+
+    override fun getLong(key: String): Long? = encryptedSettings.getLongOrNull(key)
 
     override fun remove(key: String) = encryptedSettings.remove(key)
 


### PR DESCRIPTION
# What's new in this PR?

- Updated `ObserveE2EIRequiredUseCase` to observe not only BE-setting if E2EI is required but also check the client's certificate if it's needed, or if it needs to be renewed soon. Actually, the checking itself is not implemented yet (can't be done for now) but everything is ready for it, so we'll need to do a tiny part of work when it will be ready. 
- Updated `MarkEnablingE2EIAsNotifiedUseCase` to snooze that notification according to the documentation (the snooze period depends the time that is left for creating/renewing the certificate)

Needs releases with:

- https://github.com/wireapp/wire-android-reloaded/pull/2067

