### PR TITLE
test: cover some missed classes of sync with unit test - PART 2 (WPB-3472)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
@@ -101,10 +101,10 @@ internal class SlowSyncRepositoryImpl(private val metadataDao: MetadataDAO) : Sl
         return metadataDao.valueByKey(key = SLOW_SYNC_VERSION_KEY)?.toIntOrNull() ?: 0
     }
 
-    private companion object {
+    companion object {
         const val LAST_SLOW_SYNC_INSTANT_KEY = "lastSlowSyncInstant"
-        const val SLOW_SYNC_VERSION_KEY = "slowSyncVersion"
-        const val MLS_NEEDS_RECOVERY_KEY = "mlsNeedsRecovery"
-        const val NEEDS_TO_PERSIST_HISTORY_LOST_MESSAGES_KEY = "needsToPersistHistoryLostMessages"
+        private const val SLOW_SYNC_VERSION_KEY = "slowSyncVersion"
+        private const val MLS_NEEDS_RECOVERY_KEY = "mlsNeedsRecovery"
+        private const val NEEDS_TO_PERSIST_HISTORY_LOST_MESSAGES_KEY = "needsToPersistHistoryLostMessages"
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -104,10 +104,7 @@ internal class ConversationEventReceiverImpl(
                 Either.Right(Unit)
             }
 
-            is Event.Conversation.ConversationMessageTimer -> {
-                conversationMessageTimerEventHandler.handle(event)
-                Either.Right(Unit)
-            }
+            is Event.Conversation.ConversationMessageTimer -> conversationMessageTimerEventHandler.handle(event)
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepositoryTest.kt
@@ -27,7 +27,6 @@ import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -204,7 +203,6 @@ class IncrementalSyncRepositoryTest {
         assertEquals(initialValue, state)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun givenASlowStateCollector_whenStateIsUpdatedManyTimes_thenUpdateEmissionShouldNotBeBlockedByOverflownBuffer() = runTest {
         val updateCount = 10_000
@@ -231,7 +229,6 @@ class IncrementalSyncRepositoryTest {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun givenASlowPolicyCollector_whenPolicyIsUpdatedManyTimes_thenUpdateEmissionShouldNotBeBlockedByOverflownBuffer() = runTest {
         val updateCount = 10_000

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.data.sync
 
 import app.cash.turbine.test
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
-import com.wire.kalium.logic.util.IgnoreIOS
 import com.wire.kalium.persistence.TestUserDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.util.DateTimeUtil
@@ -30,6 +29,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class SlowSyncRepositoryTest {
@@ -59,7 +59,6 @@ class SlowSyncRepositoryTest {
         assertEquals(version, slowSyncRepository.getSlowSyncVersion())
     }
 
-    @IgnoreIOS // TODO investigate why test is failing
     @Test
     fun givenLastInstantWasNeverSet_whenGettingLastInstant_thenTheStateIsNull() = runTest(testDispatcher) {
         // Empty Given
@@ -69,9 +68,6 @@ class SlowSyncRepositoryTest {
         assertNull(lastSyncInstant)
     }
 
-    // TODO: Re-enable once we can update Turbine to 0.11.0+ (Requires Kotlin 1.6.21+)
-    // @Ignore
-    @IgnoreIOS // TODO investigate why test is failing
     @Test
     fun givenAnInstantIsUpdated_whenObservingTheLastSlowSyncInstant_thenTheNewStateIsPropagatedForObservers() = runTest(testDispatcher) {
         val firstInstant = DateTimeUtil.currentInstant()
@@ -131,5 +127,14 @@ class SlowSyncRepositoryTest {
         val currentState = slowSyncRepository.needsToRecoverMLSGroups()
 
         assertEquals(newStatus, currentState)
+    }
+
+    @Test
+    fun givenMetaDataDao_whenClearLastSlowSyncCompletionInstantIsCalled_thenInvokeDeleteValueOnce() = runTest(testDispatcher) {
+        slowSyncRepository.setNeedsToPersistHistoryLostMessage(true)
+
+        val result = slowSyncRepository.needsToPersistHistoryLostMessage()
+
+        assertTrue { result }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.data.sync
 
 import app.cash.turbine.test
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import com.wire.kalium.logic.util.IgnoreIOS
 import com.wire.kalium.persistence.TestUserDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.util.DateTimeUtil
@@ -59,6 +60,7 @@ class SlowSyncRepositoryTest {
         assertEquals(version, slowSyncRepository.getSlowSyncVersion())
     }
 
+    @IgnoreIOS // TODO investigate why test is failing on iOS
     @Test
     fun givenLastInstantWasNeverSet_whenGettingLastInstant_thenTheStateIsNull() = runTest(testDispatcher) {
         // Empty Given

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepositoryTest.kt
@@ -45,6 +45,15 @@ class SlowSyncRepositoryTest {
     }
 
     @Test
+    fun givenLastInstantWasNeverSet_whenGettingLastInstant_thenTheStateIsNull() = runTest(testDispatcher) {
+        // Empty Given
+
+        val lastSyncInstant = slowSyncRepository.observeLastSlowSyncCompletionInstant().first()
+
+        assertNull(lastSyncInstant)
+    }
+
+    @Test
     fun givenInstantIsUpdated_whenGettingTheLastSlowSyncInstant_thenShouldReturnTheNewState() = runTest(testDispatcher) {
         val instant = DateTimeUtil.currentInstant()
 
@@ -58,16 +67,6 @@ class SlowSyncRepositoryTest {
 
         slowSyncRepository.setSlowSyncVersion(version)
         assertEquals(version, slowSyncRepository.getSlowSyncVersion())
-    }
-
-    @IgnoreIOS // TODO investigate why test is failing on iOS
-    @Test
-    fun givenLastInstantWasNeverSet_whenGettingLastInstant_thenTheStateIsNull() = runTest(testDispatcher) {
-        // Empty Given
-
-        val lastSyncInstant = slowSyncRepository.observeLastSlowSyncCompletionInstant().first()
-
-        assertNull(lastSyncInstant)
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -27,8 +27,6 @@ import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.network.api.base.authenticated.client.ClientTypeDTO
-import com.wire.kalium.network.api.base.authenticated.client.DeviceTypeDTO
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Instant
 
@@ -40,6 +38,15 @@ object TestEvent {
         false,
         TestUser.USER_ID,
         members,
+        "2022-03-30T15:36:00.000Z"
+    )
+
+    fun memberLeave(eventId: String = "eventId", members: List<Member> = listOf()) = Event.Conversation.MemberLeave(
+        eventId,
+        TestConversation.ID,
+        false,
+        TestUser.USER_ID,
+        listOf(),
         "2022-03-30T15:36:00.000Z"
     )
 
@@ -187,5 +194,31 @@ object TestEvent {
         TestUser.USER_ID,
         timestamp.toIsoDateTimeString(),
         "content",
+    )
+
+    fun newConversationEvent() = Event.Conversation.NewConversation(
+        id = "eventId",
+        conversationId = TestConversation.ID,
+        transient = false,
+        timestampIso = "timestamp",
+        conversation = TestConversation.CONVERSATION_RESPONSE,
+        senderUserId = TestUser.SELF.id
+    )
+
+    fun newMLSWelcomeEvent() = Event.Conversation.MLSWelcome(
+        "eventId",
+        TestConversation.ID,
+        false,
+        TestUser.USER_ID,
+        "dummy-message",
+        timestampIso = "2022-03-30T15:36:00.000Z"
+    )
+
+    fun newAccessUpdateEvent() = Event.Conversation.AccessUpdate(
+        id = "eventId",
+        conversationId = TestConversation.ID,
+        data = TestConversation.CONVERSATION_RESPONSE,
+        qualifiedFrom = TestUser.USER_ID,
+        transient = false
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/MissingMetadataUpdateManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/MissingMetadataUpdateManagerTest.kt
@@ -32,12 +32,10 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.test.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class MissingMetadataUpdateManagerTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorkerTest.kt
@@ -32,12 +32,10 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class PendingMessagesSenderWorkerTest {
 
     @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -42,13 +42,11 @@ import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FeatureConfigEventReceiverTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiverTest.kt
@@ -35,12 +35,10 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class TeamEventReceiverTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -39,11 +39,9 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class UserEventReceiverTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiverTest.kt
@@ -28,11 +28,9 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class UserPropertiesEventReceiverTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
@@ -35,11 +35,9 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class MemberChangeEventHandlerTest {
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Follow up PR of #1973 to increase sync unit test

 Mainly covering `ObserveSyncStateUseCase` and `ConversationEventReceiver` with unit tests

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
