### PR TITLE
chore: enable fetching and uploading of prekeys [WPB-3552]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
@@ -39,7 +39,6 @@ import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
 import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
-import com.wire.kalium.network.api.base.authenticated.prekey.UploadPreKeysRequest
 import com.wire.kalium.persistence.dao.PrekeyDAO
 import com.wire.kalium.persistence.dao.client.ClientDAO
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1125,6 +1125,7 @@ class UserSessionScope internal constructor(
         get() = PreKeyDataSource(
             authenticatedNetworkContainer.preKeyApi,
             proteusClientProvider,
+            clientIdProvider,
             userStorage.database.prekeyDAO,
             userStorage.database.clientDAO
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
@@ -281,6 +281,7 @@ class PreKeyRepositoryTest {
     @Test
     fun givenCurrentClientId_whenFetchingRemotePrekeys_thenShouldCallAPIWithCorrectParameters() = runTest {
         val (arrangement, preKeyRepository) = Arrangement()
+            .withGetClientAvailablePrekeysReturning(NetworkResponse.Success(listOf(), mapOf(), HttpStatusCode.OK.value))
             .withCurrentClientIdReturning(Either.Right(TEST_CLIENT_ID_1))
             .arrange()
 
@@ -288,7 +289,7 @@ class PreKeyRepositoryTest {
 
         verify(arrangement.preKeyApi)
             .suspendFunction(arrangement.preKeyApi::getClientAvailablePrekeys)
-            .with(eq(TEST_CLIENT_ID_1))
+            .with(eq(TEST_CLIENT_ID_1.value))
             .wasInvoked(exactly = once)
     }
 
@@ -310,6 +311,7 @@ class PreKeyRepositoryTest {
     fun givenPreKeysAndCurrentClientId_whenUploadingMorePrekeys_thenShouldCallAPIWithCorrectArguments() = runTest {
         val preKeys = listOf(PreKeyCrypto(1, "encodedData"))
         val (arrangement, preKeyRepository) = Arrangement()
+            .withUploadPrekeysReturning(NetworkResponse.Success(Unit, mapOf(), HttpStatusCode.OK.value))
             .withCurrentClientIdReturning(Either.Right(TEST_CLIENT_ID_1))
             .arrange()
 
@@ -318,7 +320,7 @@ class PreKeyRepositoryTest {
 
         verify(arrangement.preKeyApi)
             .suspendFunction(arrangement.preKeyApi::uploadNewPrekeys)
-            .with(eq(TEST_CLIENT_ID_1), eq(preKeys.map { PreKeyDTO(it.id, it.encodedData) }))
+            .with(eq(TEST_CLIENT_ID_1.value), eq(preKeys.map { PreKeyDTO(it.id, it.encodedData) }))
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
@@ -22,17 +22,20 @@ import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.cryptography.createSessions
 import com.wire.kalium.cryptography.exceptions.ProteusException
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.ProteusClientProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
 import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
@@ -42,6 +45,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.PrekeyDAO
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
+import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.errors.IOException
 import io.mockative.Mock
 import io.mockative.any
@@ -51,13 +55,12 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlinx.coroutines.test.runTest
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class PreKeyRepositoryTest {
 
     @Test
@@ -180,7 +183,8 @@ class PreKeyRepositoryTest {
         val exception = ProteusException("PANIC!!!11!eleven!", ProteusException.Code.PANIC)
 
         val preKey = PreKeyDTO(42, "encodedData")
-        val userPreKeysResult = mapOf(TEST_USER_ID_1.domain to mapOf(TEST_USER_ID_1.value to mapOf(TEST_CLIENT_ID_1.value to preKey)))
+        val userPreKeysResult =
+            mapOf(TEST_USER_ID_1.domain to mapOf(TEST_USER_ID_1.value to mapOf(TEST_CLIENT_ID_1.value to preKey)))
 
         val (_, prekeyRepository) = Arrangement()
             .withGetRemoteUsersPreKeySuccess(userPreKeysResult)
@@ -246,6 +250,89 @@ class PreKeyRepositoryTest {
             }
     }
 
+    @Test
+    fun givenCurrentClientIdFails_whenFetchingRemotePrekeys_thenShouldPropagateFailure() = runTest {
+        val failure = CoreFailure.Unknown(null)
+        val (_, preKeyRepository) = Arrangement()
+            .withCurrentClientIdReturning(Either.Left(failure))
+            .arrange()
+
+        preKeyRepository.fetchRemotelyAvailablePrekeys()
+            .shouldFail {
+                assertIs<CoreFailure.Unknown>(it)
+                assertEquals(failure, it)
+            }
+    }
+
+    @Test
+    fun givenSuccess_whenFetchingRemotePrekeys_thenShouldPropagateSuccess() = runTest {
+        val availablePreKeysIds = listOf(1, 3, 6)
+        val result = NetworkResponse.Success(availablePreKeysIds, mapOf(), HttpStatusCode.OK.value)
+        val (_, preKeyRepository) = Arrangement()
+            .withGetClientAvailablePrekeysReturning(result)
+            .arrange()
+
+        preKeyRepository.fetchRemotelyAvailablePrekeys()
+            .shouldSucceed { preKeys ->
+                assertContentEquals(availablePreKeysIds, preKeys)
+            }
+    }
+
+    @Test
+    fun givenCurrentClientId_whenFetchingRemotePrekeys_thenShouldCallAPIWithCorrectParameters() = runTest {
+        val (arrangement, preKeyRepository) = Arrangement()
+            .withCurrentClientIdReturning(Either.Right(TEST_CLIENT_ID_1))
+            .arrange()
+
+        preKeyRepository.fetchRemotelyAvailablePrekeys()
+
+        verify(arrangement.preKeyApi)
+            .suspendFunction(arrangement.preKeyApi::getClientAvailablePrekeys)
+            .with(eq(TEST_CLIENT_ID_1))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenCurrentClientIdFails_whenUploadingPrekeys_thenShouldPropagateFailure() = runTest {
+        val failure = CoreFailure.Unknown(null)
+        val (_, preKeyRepository) = Arrangement()
+            .withCurrentClientIdReturning(Either.Left(failure))
+            .arrange()
+
+        preKeyRepository.uploadNewPrekeyBatch(listOf())
+            .shouldFail {
+                assertIs<CoreFailure.Unknown>(it)
+                assertEquals(failure, it)
+            }
+    }
+
+    @Test
+    fun givenPreKeysAndCurrentClientId_whenUploadingMorePrekeys_thenShouldCallAPIWithCorrectArguments() = runTest {
+        val preKeys = listOf(PreKeyCrypto(1, "encodedData"))
+        val (arrangement, preKeyRepository) = Arrangement()
+            .withCurrentClientIdReturning(Either.Right(TEST_CLIENT_ID_1))
+            .arrange()
+
+        preKeyRepository.uploadNewPrekeyBatch(preKeys)
+            .shouldSucceed()
+
+        verify(arrangement.preKeyApi)
+            .suspendFunction(arrangement.preKeyApi::uploadNewPrekeys)
+            .with(eq(TEST_CLIENT_ID_1), eq(preKeys.map { PreKeyDTO(it.id, it.encodedData) }))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSuccess_whenUploadingMorePrekeys_thenShouldPropagateSuccess() = runTest {
+        val result = NetworkResponse.Success(Unit, mapOf(), HttpStatusCode.OK.value)
+        val (_, preKeyRepository) = Arrangement()
+            .withUploadPrekeysReturning(result)
+            .arrange()
+
+        preKeyRepository.uploadNewPrekeyBatch(listOf())
+            .shouldSucceed()
+    }
+
     private companion object {
         val TEST_USER_ID_1 = TestUser.USER_ID
         val TEST_CLIENT_ID_1 = TestClient.CLIENT_ID
@@ -262,6 +349,9 @@ class PreKeyRepositoryTest {
         val proteusClient: ProteusClient = mock(ProteusClient::class)
 
         @Mock
+        val currentClientIdProvider: CurrentClientIdProvider = mock(CurrentClientIdProvider::class)
+
+        @Mock
         val proteusClientProvider: ProteusClientProvider = mock(ProteusClientProvider::class)
 
         @Mock
@@ -270,7 +360,14 @@ class PreKeyRepositoryTest {
         @Mock
         val clientDAO: ClientDAO = mock(ClientDAO::class)
 
-        private val preKeyRepository: PreKeyDataSource = PreKeyDataSource(preKeyApi, proteusClientProvider, prekeyDAO, clientDAO)
+        private val preKeyRepository: PreKeyDataSource =
+            PreKeyDataSource(
+                preKeyApi = preKeyApi,
+                proteusClientProvider = proteusClientProvider,
+                provideCurrentClientId = currentClientIdProvider,
+                prekeyDAO = prekeyDAO,
+                clientDAO = clientDAO
+            )
 
         init {
             given(proteusClientProvider)
@@ -282,13 +379,21 @@ class PreKeyRepositoryTest {
                 .suspendFunction(proteusClientProvider::getOrError)
                 .whenInvoked()
                 .thenReturn(Either.Right(proteusClient))
+
+            withCurrentClientIdReturning(Either.Right(TEST_CLIENT_ID_1))
         }
 
         fun withGetRemoteUsersPreKeySuccess(preKeyMap: DomainToUserIdToClientsToPreKeyMap) = apply {
             given(preKeyApi)
                 .suspendFunction(preKeyApi::getUsersPreKey)
                 .whenInvokedWith(any())
-                .then { NetworkResponse.Success(ListPrekeysResponse(qualifiedUserClientPrekeys = preKeyMap), emptyMap(), 200) }
+                .then {
+                    NetworkResponse.Success(
+                        ListPrekeysResponse(qualifiedUserClientPrekeys = preKeyMap),
+                        emptyMap(),
+                        200
+                    )
+                }
         }
 
         fun withGetRemoteUsersPreKeyFail(error: NetworkResponse.Error? = null) = apply {
@@ -345,6 +450,27 @@ class PreKeyRepositoryTest {
                 .suspendFunction(proteusClient::createSession)
                 .whenInvokedWith(anything(), anything())
                 .thenThrow(throwable)
+        }
+
+        fun withGetClientAvailablePrekeysReturning(result: NetworkResponse<List<Int>>) = apply {
+            given(preKeyApi)
+                .suspendFunction(preKeyApi::getClientAvailablePrekeys)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withUploadPrekeysReturning(result: NetworkResponse<Unit>) = apply {
+            given(preKeyApi)
+                .suspendFunction(preKeyApi::uploadNewPrekeys)
+                .whenInvokedWith(any(), any())
+                .thenReturn(result)
+        }
+
+        fun withCurrentClientIdReturning(result: Either<CoreFailure, ClientId>) = apply {
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(result)
         }
 
         fun arrange() = this to preKeyRepository

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/prekey/PreKeyApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/prekey/PreKeyApi.kt
@@ -32,7 +32,22 @@ interface PreKeyApi {
         users: Map<String, Map<String, List<String>>>
     ): NetworkResponse<ListPrekeysResponse>
 
+    /**
+     * Retrieves the IDs of the prekeys currently available in the backend
+     * for the provided [clientId].
+     * @see uploadNewPrekeys
+     */
     suspend fun getClientAvailablePrekeys(clientId: String): NetworkResponse<List<Int>>
+
+    /**
+     * Uploads more prekeys to be associated with the provided [clientId],
+     * which can be used by other users to start conversations with the client.
+     * @see getClientAvailablePrekeys
+     */
+    suspend fun uploadNewPrekeys(
+        clientId: String,
+        preKeys: List<PreKeyDTO>
+    ): NetworkResponse<Unit>
 }
 
 typealias DomainToUserIdToClientsToPreKeyMap = Map<String, Map<String, Map<String, PreKeyDTO?>>>

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/prekey/PreKeyDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/prekey/PreKeyDTO.kt
@@ -27,3 +27,8 @@ data class PreKeyDTO(
     @SerialName("key")
     val key: String
 )
+
+@Serializable
+data class UploadPreKeysRequest(
+    @SerialName("prekeys") val prekeys: List<PreKeyDTO>
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/PreKeyApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/PreKeyApiV0.kt
@@ -22,11 +22,14 @@ import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
 import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
+import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyDTO
+import com.wire.kalium.network.api.base.authenticated.prekey.UploadPreKeysRequest
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.get
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 
 internal open class PreKeyApiV0 internal constructor(
@@ -49,6 +52,13 @@ internal open class PreKeyApiV0 internal constructor(
     override suspend fun getClientAvailablePrekeys(clientId: String): NetworkResponse<List<Int>> = wrapKaliumResponse {
         httpClient.get("$PATH_CLIENTS/$clientId/$PATH_PRE_KEY")
     }
+
+    override suspend fun uploadNewPrekeys(clientId: String, preKeys: List<PreKeyDTO>): NetworkResponse<Unit> =
+        wrapKaliumResponse {
+            httpClient.put("$PATH_CLIENTS/$clientId/$PATH_PRE_KEY") {
+                setBody(UploadPreKeysRequest(preKeys))
+            }
+        }
 
     protected companion object {
         const val PATH_USERS = "users"

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/prekey/PrekeyApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/prekey/PrekeyApiV0Test.kt
@@ -24,19 +24,18 @@ import com.wire.kalium.api.json.model.DomainToUserIdToClientsMapJson
 import com.wire.kalium.api.json.model.ErrorResponseJson
 import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
+import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyDTO
 import com.wire.kalium.network.api.v0.authenticated.PreKeyApiV0
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
 
-@ExperimentalCoroutinesApi
 internal class PrekeyApiV0Test : ApiTest() {
 
     @Test
@@ -68,6 +67,44 @@ internal class PrekeyApiV0Test : ApiTest() {
         assertFalse(errorResponse.isSuccessful())
         assertTrue(errorResponse.kException is KaliumException.InvalidRequestError)
         assertEquals((errorResponse.kException as KaliumException.InvalidRequestError).errorResponse, ERROR_RESPONSE)
+    }
+
+    @Test
+    fun givenTheServerReturnsOK_whenUploadingPreKeys_thenTheCorrectResponseIsReturned() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = "",
+            statusCode = HttpStatusCode.OK
+        )
+        val preKeyApi: PreKeyApi = PreKeyApiV0(networkClient)
+        val response = preKeyApi.uploadNewPrekeys("clientId", listOf())
+        assertTrue(response.isSuccessful())
+    }
+
+    @Test
+    fun givenPreKeyAndClientId_whenUploadingPreKeys_thenTheRequestIsConfiguredCorrectly() = runTest {
+        val preKeyDTO = PreKeyDTO(42, "testKey")
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = "",
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertJson()
+                assertJsonBodyContent(
+                    """
+                    |{
+                    |  "prekeys": [
+                    |    {
+                    |      "id": ${preKeyDTO.key},
+                    |      "key": "${preKeyDTO.id}"
+                    |    }
+                    |  ]
+                    |}
+                    """.trimMargin()
+                )
+            }
+        )
+        val preKeyApi: PreKeyApi = PreKeyApiV0(networkClient)
+        val response = preKeyApi.uploadNewPrekeys("clientId", listOf())
+        assertTrue(response.isSuccessful())
     }
 
     private companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/prekey/PrekeyApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/prekey/PrekeyApiV0Test.kt
@@ -93,8 +93,8 @@ internal class PrekeyApiV0Test : ApiTest() {
                     |{
                     |  "prekeys": [
                     |    {
-                    |      "id": ${preKeyDTO.key},
-                    |      "key": "${preKeyDTO.id}"
+                    |      "id": ${preKeyDTO.id},
+                    |      "key": "${preKeyDTO.key}"
                     |    }
                     |  ]
                     |}
@@ -103,7 +103,7 @@ internal class PrekeyApiV0Test : ApiTest() {
             }
         )
         val preKeyApi: PreKeyApi = PreKeyApiV0(networkClient)
-        val response = preKeyApi.uploadNewPrekeys("clientId", listOf())
+        val response = preKeyApi.uploadNewPrekeys("clientId", listOf(preKeyDTO))
         assertTrue(response.isSuccessful())
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Periodically we need to check if the Proteus prekeys we uploaded when we registered the client are consumed and create and upload new ones as they are consumed.

Currently, we have no implementation of the endpoint to upload them, and we lack some of the repository-level operations.

### Solutions

- Add the missing endpoint to upload prekeys in `PrekeyAPI`
- Expose fetching and uploading operations in the `PreKeyRepository`

This will enable us to create a `PreKeyRefiller` in the next PR. This class will be responsible for figuring out if a new batch of prekeys is needed, and if needed it will create and upload some more.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
