### PR TITLE
ci: disable coverage reports for 3rd modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ koverReport {
     }
 }
 
-subprojects {
+fun Project.configureKover() {
     pluginManager.apply("org.jetbrains.kotlinx.kover")
 
     kover {
@@ -113,6 +113,15 @@ subprojects {
             }
         }
     }
+}
+
+subprojects {
+    // We only want coverage reports of actual Kalium
+    // Samples and other side-projects can have their own rules
+    if (name in setOf("monkeys", "testservice", "cli", "android")) {
+        return@subprojects
+    }
+    configureKover()
 }
 
 rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin::class.java) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Our coverage reports keep track of "side-projects" within Kalium, which are not actively maintained and parts of Kalium, but rather other projects that are using it.

When we decide to keep some degree of coverage, or that some rules apply to Kalium, these project won't necessarily follow the same rules.

Currently, `koverXmlReport` is triggering `monkeys` tests for example, which are flaky and are getting in the way of development of Kalium itself.

The same could happen to `testservice`.

Also, coverage for `android`, `cli` doesn't really matter as these are not Kalium itself, but samples and auxiliary tools built on top of it.

### Solutions

Disable code coverage for these other modules. Which also disables running of these tests in CI for now.

In the future, we might need to solve what should Kalium become.
- Should we start publishing it like we do to CoreCrypto and accept a slightly slower release cycle?
- Or, should we get all 3rd projects to just include Kalium as a submodule, in the same way `reloaded` does it?
- We can't say "Use Kalium, it's fun!" for the rest of the company if we're breaking it all the time, so in any scenario: how do we deal with breaking API changes? Maybe [Binary compatibility validator](https://github.com/Kotlin/binary-compatibility-validator) can come into play.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
