### PR TITLE
feat(monkeys): Create users automatically for the test [WPB-3682]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ annotation = "1.2.0"
 mordant = "2.0.0-beta13"
 apache-tika = "2.8.0"
 mockk = "1.13.5"
+faker = "1.14.0"
 
 [plugins]
 # Home-made convention plugins
@@ -175,6 +176,7 @@ pbandk-runtime-macArm64 = { module = "pro.streem.pbandk:pbandk-runtime-macosarm6
 pbandk-runtime-common = { module = "pro.streem.pbandk:pbandk-runtime", version.ref = "pbandk" }
 benAsherUUID = { module = "com.benasher44:uuid", version.ref = "benasher-uuid" }
 apacheTika = { module = "org.apache.tika:tika-core", version.ref = "apache-tika" }
+faker = { module = "io.github.serpro69:kotlin-faker", version.ref = "faker" }
 
 # avs
 avs = { module = "com.wire:avs", version.ref = "avs" }

--- a/monkeys/README.md
+++ b/monkeys/README.md
@@ -12,7 +12,6 @@ An [example](example.json) config is in this repo and the schema can be seen [he
 
 ## Current Limitations (to be fixed in the future)
 
-* It is assumed that all users under a backend belongs to a single team
 * The application runs until it receives a `SIGINT` (Ctrl+C) signal. There should be a configuration
   to finish the test run
 * Tests need to be implemented

--- a/monkeys/build.gradle.kts
+++ b/monkeys/build.gradle.kts
@@ -63,8 +63,14 @@ sourceSets {
             implementation(libs.ktxDateTime)
 
             implementation(libs.ktxSerialization)
+            implementation(libs.ktor.serialization)
             implementation(libs.ktor.okHttp)
+            implementation(libs.ktor.contentNegotiation)
+            implementation(libs.ktor.json)
+            implementation(libs.ktor.authClient)
             implementation(libs.okhttp.loggingInterceptor)
+
+            implementation(libs.faker)
         }
     }
 

--- a/monkeys/example.json
+++ b/monkeys/example.json
@@ -43,8 +43,8 @@
                             "type": "PERCENTAGE",
                             "value": 100
                         },
-                        "originDomain": "pirates.dogfood.wire.link",
-                        "targetDomain": "ninjas.dogfood.wire.link",
+                        "originTeam": "Diya",
+                        "targetTeam": "Elna",
                         "delayResponse": 1000,
                         "shouldAccept": true
                     }
@@ -93,7 +93,7 @@
                             "value": 4
                         },
                         "protocol": "PROTEUS",
-                        "domainOwner": "ninjas.dogfood.wire.link"
+                        "teamOwner": "Diya"
                     }
                 },
                 {
@@ -107,7 +107,7 @@
                             "value": 4
                         },
                         "protocol": "MLS",
-                        "domainOwner": "ninjas.dogfood.wire.link"
+                        "teamOwner": "Diya"
                     }
                 },
                 {
@@ -121,7 +121,7 @@
                             "value": 10
                         },
                         "protocol": "PROTEUS",
-                        "domainOwner": "pirates.dogfood.wire.link"
+                        "teamOwner": "Elna"
                     }
                 }
             ]
@@ -129,62 +129,34 @@
     ],
     "backends": [
         {
-            "api": "https://nginz-https.pirates.dogfood.wire.link",
-            "webSocket": "https://nginz-ssl.pirates.dogfood.wire.link",
+            "api": "https://nginz-https.diya.wire.link",
+            "webSocket": "https://nginz-ssl.diya.wire.link",
             "blackList": "https://clientblacklist.wire.com/staging",
-            "teams": "https://teams.pirates.dogfood.wire.link",
-            "accounts": "https://account.pirates.dogfood.wire.link",
+            "teams": "https://teams.diya.wire.link",
+            "accounts": "https://account.diya.wire.link",
             "website": "https://wire.com",
-            "title": "pirates.dogfood.wire.link",
+            "title": "diya.wire.link",
             "passwordForUsers": "Aqa123456!",
-            "domain": "pirates.dogfood.wire.link",
-            "users": [
-                {
-                    "email": "augusto.c.dias+pirate@wire.com",
-                    "id": "f979e74b-e43b-40f8-91ef-395f8eea026e"
-                },
-                {
-                    "email": "augusto.c.dias+pirate1@wire.com",
-                    "id": "95900f96-56f1-4125-96ed-50ad0c45294e"
-                },
-                {
-                    "email": "augusto.c.dias+pirate2@wire.com",
-                    "id": "a6cb561d-82f4-4ede-a224-d2de0e7adbcf"
-                },
-                {
-                    "email": "augusto.c.dias+pirate3@wire.com",
-                    "id": "ad287c49-a1f1-47a1-9bb1-0eac11e240db"
-                }
-            ]
+            "domain": "diya.wire.link",
+            "teamName": "Diya",
+            "authUser": "admin",
+            "authPassword": "admin",
+            "userCount": 10
         },
         {
-            "api": "https://nginz-https.ninjas.dogfood.wire.link",
-            "webSocket": "https://nginz-ssl.ninjas.dogfood.wire.link",
+            "api": "https://nginz-https.elna.wire.link",
+            "webSocket": "https://nginz-ssl.elna.wire.link",
             "blackList": "https://clientblacklist.wire.com/staging",
-            "teams": "https://teams.ninjas.dogfood.wire.link",
-            "accounts": "https://account.ninjas.dogfood.wire.link",
+            "teams": "https://teams.elna.wire.link",
+            "accounts": "https://account.elna.wire.link",
             "website": "https://wire.com",
             "passwordForUsers": "Aqa123456!",
-            "domain": "ninjas.dogfood.wire.link",
-            "title": "ninjas.dogfood.wire.link",
-            "users": [
-                {
-                    "email": "augusto.c.dias+ninja@wire.com",
-                    "id": "73b45628-1816-4777-95e7-8f449a559229"
-                },
-                {
-                    "email": "augusto.c.dias+ninja1@wire.com",
-                    "id": "4c5fda2a-a5fe-43fb-8b46-bcdb205ede10"
-                },
-                {
-                    "email": "augusto.c.dias+ninja2@wire.com",
-                    "id": "ea417610-3623-4d85-affc-dba6607182be"
-                },
-                {
-                    "email": "augusto.c.dias+ninja3@wire.com",
-                    "id": "151abef6-0a6f-4661-9f96-815a16b9342b"
-                }
-            ]
+            "domain": "elna.wire.link",
+            "title": "elna.wire.link",
+            "teamName": "Elna",
+            "authUser": "admin",
+            "authPassword": "admin",
+            "userCount": 10
         }
     ]
 }

--- a/monkeys/schema.json
+++ b/monkeys/schema.json
@@ -88,7 +88,9 @@
                     "title",
                     "passwordForUsers",
                     "domain",
-                    "users"
+                    "authUser",
+                    "authPassword",
+                    "userCount"
                 ],
                 "properties": {
                     "api": {
@@ -127,26 +129,17 @@
                         "description": "Domain identifier of the team",
                         "type": "string"
                     },
-                    "users": {
-                        "description": "All users that are going to be used in the test",
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "email",
-                                "id"
-                            ],
-                            "properties": {
-                                "email": {
-                                    "description": "Email of the user",
-                                    "type": "string"
-                                },
-                                "id": {
-                                    "description": "UUID of the user",
-                                    "type": "string"
-                                }
-                            }
-                        }
+                    "authUser": {
+                        "description": "The backend API user to authenticate in order to access its APIs",
+                        "type": "string"
+                    },
+                    "authPassword": {
+                        "description": "The backend API password to authenticate in order to access its APIs",
+                        "type": "string"
+                    },
+                    "userCount": {
+                        "description": "How many users should be created in this team",
+                        "type": "integer"
                     }
                 }
             }
@@ -320,8 +313,8 @@
                         "PROTEUS"
                     ]
                 },
-                "domainOwner": {
-                    "description": "Which domain should the picked user belong to. For better performance, inform this field",
+                "teamOwner": {
+                    "description": "Which team should the picked user belong to. For better performance, inform this field",
                     "type": "string"
                 }
             }
@@ -379,8 +372,8 @@
             "required": [
                 "userCount",
                 "targetUserCount",
-                "originDomain",
-                "targetDomain"
+                "originTeam",
+                "targetTeam"
             ],
             "properties": {
                 "userCount": {
@@ -388,15 +381,15 @@
                     "$ref": "#/$defs/UserCount"
                 },
                 "targetUserCount": {
-                    "description": "How many users of the target domain should receive requests",
+                    "description": "How many users of the target team should receive requests",
                     "$ref": "#/$defs/UserCount"
                 },
-                "originDomain": {
-                    "description": "Users from which domain should the requests originate",
+                "originTeam": {
+                    "description": "Users from which team should the requests originate",
                     "type": "string"
                 },
-                "targetDomain": {
-                    "description": "Users from which domain should be targeted",
+                "targetTeam": {
+                    "description": "Users from which team should be targeted",
                     "type": "string"
                 },
                 "delayResponse": {

--- a/monkeys/schema.json
+++ b/monkeys/schema.json
@@ -140,6 +140,10 @@
                     "userCount": {
                         "description": "How many users should be created in this team",
                         "type": "integer"
+                    },
+                    "dumpUsers": {
+                        "description": "Should the application dump the users created into a file",
+                        "type": "boolean"
                     }
                 }
             }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
@@ -72,7 +72,7 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
 
         coreLogic.updateApiVersionsScheduler.scheduleImmediateApiVersionUpdate()
         val testData = TestDataImporter.importFromFile(dataFilePath)
-        val users = TestDataImporter.getUserData(testData)
+        val users = TestDataImporter.generateUserData(testData)
         MonkeyPool.init(users)
         runMonkeys(coreLogic, testData)
     }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/CreateConversationAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/CreateConversationAction.kt
@@ -23,8 +23,8 @@ import com.wire.kalium.monkeys.pool.ConversationPool
 
 class CreateConversationAction(val config: ActionType.CreateConversation) : Action() {
     override suspend fun execute(coreLogic: CoreLogic) {
-        if (this.config.domain != null) {
-            ConversationPool.createDynamicConversation(this.config.domain, this.config.userCount, this.config.protocol)
+        if (this.config.team != null) {
+            ConversationPool.createDynamicConversation(this.config.team, this.config.userCount, this.config.protocol)
         } else {
             ConversationPool.createDynamicConversation(this.config.userCount, this.config.protocol)
         }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendMessageAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendMessageAction.kt
@@ -73,5 +73,5 @@ private suspend fun MonkeyConversation.sendMessage(userCount: UserCount, i: Int)
 }
 
 private fun randomMessage(target: String, i: Int): String {
-    return "Hello $target. Give me ${i + 1} banana(s). ${EMOJI.random()}"
+    return "Hello everyone from $target. Give me ${i + 1} banana(s). ${EMOJI.random()}"
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendRequestAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendRequestAction.kt
@@ -24,9 +24,9 @@ import kotlinx.coroutines.delay
 
 class SendRequestAction(val config: ActionType.SendRequest) : Action() {
     override suspend fun execute(coreLogic: CoreLogic) {
-        val monkeys = MonkeyPool.randomLoggedInMonkeysFromDomain(this.config.originDomain, this.config.userCount)
+        val monkeys = MonkeyPool.randomLoggedInMonkeysFromTeam(this.config.originTeam, this.config.userCount)
         monkeys.forEach { origin ->
-            val targets = MonkeyPool.randomLoggedInMonkeysFromDomain(this.config.targetDomain, this.config.targetUserCount)
+            val targets = MonkeyPool.randomLoggedInMonkeysFromTeam(this.config.targetTeam, this.config.targetUserCount)
             targets.forEach { origin.sendRequest(it) }
             delay(this.config.delayResponse.toLong())
             if (this.config.shouldAccept) {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestData.kt
@@ -143,5 +143,6 @@ data class BackendConfig(
     @SerialName("teamName") val teamName: String,
     @SerialName("authUser") val authUser: String,
     @SerialName("authPassword") val authPassword: String,
-    @SerialName("userCount") val userCount: ULong
+    @SerialName("userCount") val userCount: ULong,
+    @SerialName("dumpUsers") val dumpUsers: Boolean = false
 )

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestData.kt
@@ -96,7 +96,7 @@ sealed class ActionType {
     data class CreateConversation(
         @SerialName("userCount") val userCount: UserCount,
         @SerialName("protocol") val protocol: ConversationOptions.Protocol = ConversationOptions.Protocol.MLS,
-        @SerialName("domainOwner") val domain: String?
+        @SerialName("teamOwner") val team: String?
     ) : ActionType()
 
     @Serializable
@@ -122,8 +122,8 @@ sealed class ActionType {
     data class SendRequest(
         @SerialName("userCount") val userCount: UserCount,
         @SerialName("targetUserCount") val targetUserCount: UserCount,
-        @SerialName("originDomain") val originDomain: String,
-        @SerialName("targetDomain") val targetDomain: String,
+        @SerialName("originTeam") val originTeam: String,
+        @SerialName("targetTeam") val targetTeam: String,
         @SerialName("delayResponse") val delayResponse: ULong = 0u,
         @SerialName("shouldAccept") val shouldAccept: Boolean = true
     ) : ActionType()
@@ -140,11 +140,8 @@ data class BackendConfig(
     @SerialName("title") val title: String,
     @SerialName("passwordForUsers") val passwordForUsers: String,
     @SerialName("domain") val domain: String,
-    @SerialName("users") val users: List<UserAccount>
-)
-
-@Serializable
-data class UserAccount(
-    @SerialName("email") val email: String,
-    @SerialName("id") val unqualifiedId: String
+    @SerialName("teamName") val teamName: String,
+    @SerialName("authUser") val authUser: String,
+    @SerialName("authPassword") val authPassword: String,
+    @SerialName("userCount") val userCount: ULong
 )

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestDataImporter.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestDataImporter.kt
@@ -19,37 +19,45 @@ package com.wire.kalium.monkeys.importer
 
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.monkeys.logger
+import com.wire.kalium.network.KaliumKtorCustomLogging
+import com.wire.kalium.network.tools.KtxSerializer
+import com.wire.kalium.util.serialization.toJsonObject
+import io.github.serpro69.kfaker.Faker
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.UserAgent
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.basic
+import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.jsonPrimitive
 import java.io.File
+import java.net.URLEncoder
+import java.util.UUID
+
+private const val TEAM_ROLE: String = "member"
+
+private val tokenStorage = mutableListOf<BearerTokens>()
+
+private data class Team(val id: String, val backend: Backend, val owner: UserData)
 
 object TestDataImporter {
-    fun getUserData(testData: TestData): List<UserData> {
-        return testData.backends.flatMap { backendDataJsonModel ->
-            val backend = with(backendDataJsonModel) {
-                Backend(
-                    api,
-                    accounts,
-                    webSocket,
-                    blackList,
-                    teams,
-                    website,
-                    title,
-                    domain
-                )
-            }
-            backendDataJsonModel.users.map { user ->
-                UserData(
-                    user.email,
-                    backendDataJsonModel.passwordForUsers,
-                    UserId(user.unqualifiedId, backendDataJsonModel.domain),
-                    backend
-                )
-            }
-        }
-    }
-
     @OptIn(ExperimentalSerializationApi::class)
     fun importFromFile(path: String): TestData {
         val file = File(path)
@@ -57,5 +65,174 @@ object TestDataImporter {
         return Json.decodeFromStream<TestData>(
             file.inputStream()
         )
+    }
+
+    suspend fun generateUserData(testData: TestData): List<UserData> {
+        return testData.backends.flatMap { backendConfig ->
+            val httpClient = basicHttpClient(backendConfig)
+            val team = httpClient.createTeam(backendConfig, backendConfig.passwordForUsers)
+            (1..backendConfig.userCount.toInt()).map { httpClient.createUser(it, team, backendConfig.passwordForUsers) }
+                .also { httpClient.close() }
+        }
+    }
+
+}
+
+private suspend fun HttpClient.createTeam(backendConfig: BackendConfig, ownerPassword: String): Team {
+    val faker = Faker()
+    val ownerName = faker.name.name()
+    val ownerId = "monkey-owner-" + UUID.randomUUID().toString()
+    val email = "$ownerId@wire.com"
+    logger.i("Owner $email in team ${backendConfig.teamName} in backend ${backendConfig.domain}")
+    post("activate/send") {
+        setBody(
+            mapOf(
+                "email" to email
+            )
+        )
+    }
+
+    val code =
+        get("i/users/activation-code?email=${URLEncoder.encode(email, "utf-8")}").body<JsonObject>()["code"]?.jsonPrimitive?.content
+            ?: error("Failed to get activation code for owner")
+    val response = post("register") {
+        setBody(
+            mapOf(
+                "email" to email,
+                "name" to ownerName,
+                "password" to ownerPassword,
+                "email_code" to code,
+                "team" to mapOf(
+                    "name" to backendConfig.teamName,
+                    "icon" to "default",
+                    "binding" to true
+                )
+            ).toJsonObject()
+        )
+    }.body<JsonObject>()
+    val teamId = response["team"]?.jsonPrimitive?.content ?: error("Could not create team.")
+    put("i/teams/$teamId/features/mls") {
+        setBody(
+            mapOf(
+                "config" to mapOf(
+                    "allowedCipherSuites" to listOf(1),
+                    "defaultCipherSuite" to 1,
+                    "defaultProtocol" to "proteus",
+                    "protocolToggleUsers" to listOf<String>(),
+                    "supportedProtocols" to listOf("mls", "proteus")
+                ),
+                "status" to "enabled"
+            ).toJsonObject()
+        )
+    }
+    val backend = with(backendConfig) {
+        Backend(
+            api,
+            accounts,
+            webSocket,
+            blackList,
+            teams,
+            website,
+            title,
+            domain,
+            teamName
+        )
+    }
+    val userId = response["id"]?.jsonPrimitive?.content ?: error("Could not register user")
+    val result = Team(teamId, backend, UserData(email, ownerPassword, UserId(userId, backend.domain), backend))
+    login(result)
+    put("self/handle") {
+        setBody(mapOf("handle" to ownerId).toJsonObject())
+    }
+    return result
+}
+
+private suspend fun HttpClient.createUser(i: Int, team: Team, userPassword: String): UserData {
+    val faker = Faker()
+    val userName = faker.name.name()
+    val userId = "monkey-user-$i-${team.id}"
+    val email = "$userId@wire.com"
+    val invitationCode = invite(team.id, email, userName)
+    val response = post("register") {
+        setBody(
+            mapOf(
+                "email" to email,
+                "name" to userName,
+                "password" to userPassword,
+                "team_code" to invitationCode
+            ).toJsonObject()
+        )
+    }.body<JsonObject>()
+    // needs to login with the newly created user
+//     println(put("self/handle") {
+//         setBody(mapOf("handle" to userId).toJsonObject())
+//     })
+    val newUserId = response["id"]?.jsonPrimitive?.content ?: error("Could not register user in team")
+    logger.d("Created user $email in team ${team.backend.teamName}")
+    return UserData(email, userPassword, UserId(newUserId, team.backend.domain), team.backend)
+}
+
+private suspend fun HttpClient.login(team: Team) {
+    val response = post("login") {
+        setBody(
+            mapOf(
+                "email" to team.owner.email,
+                "password" to team.owner.password,
+                "label" to ""
+            ).toJsonObject()
+        )
+    }.body<JsonObject>()
+    val accessToken = response["access_token"]?.jsonPrimitive?.content ?: error("Could not login")
+    tokenStorage.add(BearerTokens(accessToken, ""))
+}
+
+private suspend fun HttpClient.invite(teamId: String, email: String, name: String): String {
+    val invitationId = post("teams/$teamId/invitations") {
+        setBody(
+            mapOf(
+                "email" to email,
+                "role" to TEAM_ROLE,
+                "inviter_name" to name
+            ).toJsonObject()
+        )
+    }.body<JsonObject>()["id"]?.jsonPrimitive?.content ?: error("Could not invite new user")
+    return get("i/teams/invitation-code?team=$teamId&invitation_id=$invitationId").body<JsonObject>()["code"]?.jsonPrimitive?.content
+        ?: error("Could not retrieve user invitation")
+}
+
+private fun basicHttpClient(backendConfig: BackendConfig) = HttpClient(OkHttp.create()) {
+    val excludedPaths = listOf("register", "login", "activate")
+    defaultRequest {
+        url(backendConfig.api)
+        contentType(ContentType.Application.Json)
+        accept(ContentType.Application.Json)
+    }
+    expectSuccess = true
+    install(KaliumKtorCustomLogging)
+    install(UserAgent) {
+        agent = "Infinite Monkeys"
+    }
+
+    install(ContentNegotiation) {
+        json(KtxSerializer.json)
+    }
+
+    install(Auth) {
+        bearer {
+            sendWithoutRequest {
+                it.url.pathSegments.isNotEmpty() && it.url.pathSegments[0] != "i" && !excludedPaths.contains(it.url.pathSegments[0])
+            }
+            loadTokens {
+                tokenStorage.last()
+            }
+        }
+        basic {
+            sendWithoutRequest {
+                it.url.pathSegments.isNotEmpty() && it.url.pathSegments[0] == "i" && !excludedPaths.contains(it.url.pathSegments[0])
+            }
+            credentials {
+                BasicAuthCredentials(username = backendConfig.authUser, password = backendConfig.authPassword)
+            }
+        }
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestDataImporter.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestDataImporter.kt
@@ -164,10 +164,6 @@ private suspend fun HttpClient.createUser(i: Int, team: Team, userPassword: Stri
             ).toJsonObject()
         )
     }.body<JsonObject>()
-    // needs to login with the newly created user
-//     println(put("self/handle") {
-//         setBody(mapOf("handle" to userId).toJsonObject())
-//     })
     val userId = response["id"]?.jsonPrimitive?.content ?: error("Could not register user in team")
     logger.d("Created user $email (id $userId) in team ${team.backend.teamName}")
     return UserData(email, userPassword, UserId(userId, team.backend.domain), team.backend)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/UserData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/UserData.kt
@@ -36,4 +36,10 @@ data class Backend(
     val title: String,
     val domain: String,
     val teamName: String
-)
+) {
+    companion object {
+        fun fromConfig(config: BackendConfig): Backend = with(config) {
+            Backend(api, accounts, webSocket, blackList, teams, website, title, domain, teamName)
+        }
+    }
+}

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/UserData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/UserData.kt
@@ -34,5 +34,6 @@ data class Backend(
     val teams: String,
     val website: String,
     val title: String,
-    val domain: String
+    val domain: String,
+    val teamName: String
 )

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
@@ -84,11 +84,11 @@ object ConversationPool {
     }
 
     suspend fun createDynamicConversation(
-        domain: String,
+        team: String,
         userCount: UserCount,
         protocol: ConversationOptions.Protocol
     ) {
-        val creator = MonkeyPool.randomMonkeysFromDomain(domain, UserCount.single())[0]
+        val creator = MonkeyPool.randomMonkeysFromTeam(team, UserCount.single())[0]
         this.createDynamicConversation(creator, userCount, protocol)
     }
 

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/MonkeyPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/MonkeyPool.kt
@@ -40,15 +40,15 @@ object MonkeyPool {
     fun init(users: List<UserData>) {
         users.forEach {
             val monkey = Monkey(it)
-            this.pool.getOrPut(it.backend.domain) { mutableListOf() }.add(monkey)
-            this.poolLoggedOut.getOrPut(it.backend.domain) { ConcurrentHashMap() }[it.userId] = monkey
+            this.pool.getOrPut(it.backend.teamName) { mutableListOf() }.add(monkey)
+            this.poolLoggedOut.getOrPut(it.backend.teamName) { ConcurrentHashMap() }[it.userId] = monkey
             this.poolById[it.userId] = monkey
         }
     }
 
-    fun randomMonkeysFromDomain(domain: String, userCount: UserCount): List<Monkey> {
+    fun randomMonkeysFromTeam(team: String, userCount: UserCount): List<Monkey> {
         val count = resolveUserCount(userCount)
-        val backendUsers = this.pool[domain]?.shuffled() ?: error("Domain $domain doesn't exist or there are no monkeys in the domain")
+        val backendUsers = this.pool[team]?.shuffled() ?: error("Team $team doesn't exist or there are no monkeys in the team")
         return backendUsers.take(count.toInt())
     }
 
@@ -61,10 +61,10 @@ object MonkeyPool {
         return allUsers.take(count.toInt())
     }
 
-    fun randomLoggedInMonkeysFromDomain(domain: String, userCount: UserCount): List<Monkey> {
-        val count = resolveUserCount(userCount, domain)
+    fun randomLoggedInMonkeysFromTeam(team: String, userCount: UserCount): List<Monkey> {
+        val count = resolveUserCount(userCount, team)
         val backendUsers =
-            this.poolLoggedIn[domain]?.values?.shuffled() ?: error("Domain $domain doesn't exist or there are not monkeys logged in")
+            this.poolLoggedIn[team]?.values?.shuffled() ?: error("Domain $team doesn't exist or there are not monkeys logged in")
         return backendUsers.take(count.toInt())
     }
 
@@ -87,13 +87,13 @@ object MonkeyPool {
     }
 
     fun loggedIn(monkey: Monkey) {
-        this.poolLoggedIn.getOrPut(monkey.user.backend.domain) { ConcurrentHashMap() }[monkey.user.userId] = monkey
-        this.poolLoggedOut[monkey.user.backend.domain]?.remove(monkey.user.userId)
+        this.poolLoggedIn.getOrPut(monkey.user.backend.teamName) { ConcurrentHashMap() }[monkey.user.userId] = monkey
+        this.poolLoggedOut[monkey.user.backend.teamName]?.remove(monkey.user.userId)
     }
 
     fun loggedOut(monkey: Monkey) {
-        this.poolLoggedIn[monkey.user.backend.domain]?.remove(monkey.user.userId)
-        this.poolLoggedOut.getOrPut(monkey.user.backend.domain) { ConcurrentHashMap() }[monkey.user.userId] = monkey
+        this.poolLoggedIn[monkey.user.backend.teamName]?.remove(monkey.user.userId)
+        this.poolLoggedOut.getOrPut(monkey.user.backend.teamName) { ConcurrentHashMap() }[monkey.user.userId] = monkey
     }
 
     private fun resolveUserCount(userCount: UserCount): UInt {
@@ -101,8 +101,8 @@ object MonkeyPool {
         return resolveUserCount(userCount, totalUsers)
     }
 
-    private fun resolveUserCount(userCount: UserCount, domain: String): UInt {
-        val totalUsers: UInt = this.pool[domain]?.count()?.toUInt() ?: error("Domain $domain not found")
+    private fun resolveUserCount(userCount: UserCount, team: String): UInt {
+        val totalUsers: UInt = this.pool[team]?.count()?.toUInt() ?: error("Domain $team not found")
         return resolveUserCount(userCount, totalUsers)
     }
 

--- a/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/SendRequestActionTest.kt
+++ b/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/SendRequestActionTest.kt
@@ -22,8 +22,8 @@ class SendRequestActionTest {
         val monkeyOrigin = mockk<Monkey>(relaxed = true)
         val monkeyTarget = mockk<Monkey>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
-        every { MonkeyPool.randomLoggedInMonkeysFromDomain(config.originDomain, UserCount.single()) } returns listOf(monkeyOrigin)
-        every { MonkeyPool.randomLoggedInMonkeysFromDomain(config.targetDomain, UserCount.single()) } returns listOf(monkeyTarget)
+        every { MonkeyPool.randomLoggedInMonkeysFromTeam(config.originTeam, UserCount.single()) } returns listOf(monkeyOrigin)
+        every { MonkeyPool.randomLoggedInMonkeysFromTeam(config.targetTeam, UserCount.single()) } returns listOf(monkeyTarget)
         SendRequestAction(config).execute(coreLogic)
         coVerify(exactly = 1) { monkeyOrigin.sendRequest(monkeyTarget) }
         coVerify(exactly = 1) { monkeyTarget.acceptRequest(monkeyOrigin) }
@@ -38,8 +38,8 @@ class SendRequestActionTest {
         val monkeyOrigin = mockk<Monkey>(relaxed = true)
         val monkeyTarget = mockk<Monkey>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
-        every { MonkeyPool.randomLoggedInMonkeysFromDomain(config.originDomain, UserCount.single()) } returns listOf(monkeyOrigin)
-        every { MonkeyPool.randomLoggedInMonkeysFromDomain(config.targetDomain, UserCount.single()) } returns listOf(monkeyTarget)
+        every { MonkeyPool.randomLoggedInMonkeysFromTeam(config.originTeam, UserCount.single()) } returns listOf(monkeyOrigin)
+        every { MonkeyPool.randomLoggedInMonkeysFromTeam(config.targetTeam, UserCount.single()) } returns listOf(monkeyTarget)
         SendRequestAction(config).execute(coreLogic)
         coVerify(exactly = 1) { monkeyOrigin.sendRequest(monkeyTarget) }
         coVerify(exactly = 1) { monkeyTarget.rejectRequest(monkeyOrigin) }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This removes the configuration for setting users and creates the users automatically for the test.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
