### PR TITLE
chore: create a way to refill Proteus prekeys [WPB-3552]

### DIFF
--- a/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
+++ b/cryptography/src/androidMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
@@ -106,7 +106,7 @@ class ProteusClientCryptoBoxImpl constructor(
         }
     }
 
-    override suspend fun newLastPreKey(): PreKeyCrypto = lock.withLock {
+    override suspend fun newLastResortPreKey(): PreKeyCrypto = lock.withLock {
         withContext(defaultContext) {
             wrapException { toPreKey(box.newLastPreKey()) }
         }

--- a/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/ProteusClientCoreCryptoImpl.kt
+++ b/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/ProteusClientCoreCryptoImpl.kt
@@ -133,7 +133,7 @@ class ProteusClientCoreCryptoImpl constructor(private val rootDir: String, priva
         }
     }
 
-    override suspend fun newLastPreKey(): PreKeyCrypto {
+    override suspend fun newLastResortPreKey(): PreKeyCrypto {
         return wrapException { toPreKey(UShort.MAX_VALUE.toInt(), toByteArray(coreCrypto.proteusNewPrekey(UShort.MAX_VALUE))) }
     }
 

--- a/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -63,8 +63,8 @@ actual class ProteusClientImpl actual constructor(
         return client.newPreKeys(from, count)
     }
 
-    override suspend fun newLastPreKey(): PreKeyCrypto {
-        return client.newLastPreKey()
+    override suspend fun newLastResortPreKey(): PreKeyCrypto {
+        return client.newLastResortPreKey()
     }
 
     override suspend fun doesSessionExist(sessionId: CryptoSessionId): Boolean {

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
@@ -132,7 +132,7 @@ class ProteusClientCoreCryptoImpl internal constructor(
         }
     }
 
-    override suspend fun newLastPreKey(): PreKeyCrypto {
+    override suspend fun newLastResortPreKey(): PreKeyCrypto {
         return wrapException { toPreKey(coreCrypto.proteusLastResortPrekeyId().toInt(), toByteArray(coreCrypto.proteusLastResortPrekey())) }
     }
 

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientImpl.kt
@@ -67,8 +67,8 @@ actual class ProteusClientImpl actual constructor(
         return client.newPreKeys(from, count)
     }
 
-    override suspend fun newLastPreKey(): PreKeyCrypto {
-        return client.newLastPreKey()
+    override suspend fun newLastResortPreKey(): PreKeyCrypto {
+        return client.newLastResortPreKey()
     }
 
     override suspend fun doesSessionExist(sessionId: CryptoSessionId): Boolean {

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
@@ -78,7 +78,7 @@ interface ProteusClient {
     suspend fun newPreKeys(from: Int, count: Int): List<PreKeyCrypto>
 
     @Throws(ProteusException::class, CancellationException::class)
-    suspend fun newLastPreKey(): PreKeyCrypto
+    suspend fun newLastResortPreKey(): PreKeyCrypto
 
     @Throws(ProteusException::class, CancellationException::class)
     suspend fun doesSessionExist(sessionId: CryptoSessionId): Boolean

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
@@ -86,7 +86,7 @@ class ProteusClientTest : BaseProteusClientTest() {
     fun givenProteusClient_whenCallingNewLastKey_thenItReturnsALastPreKey() = runTest {
         val aliceClient = createProteusClient(createProteusStoreRef(alice.id))
         aliceClient.openOrCreate()
-        val lastPreKey = aliceClient.newLastPreKey()
+        val lastPreKey = aliceClient.newLastResortPreKey()
         assertEquals(65535, lastPreKey.id)
     }
 

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientImpl.kt
@@ -83,7 +83,7 @@ actual class ProteusClientImpl actual constructor(
         return preKeys.map { toPreKey(box.getIdentity().public_key, it) } as ArrayList<PreKeyCrypto>
     }
 
-    override suspend fun newLastPreKey(): PreKeyCrypto {
+    override suspend fun newLastResortPreKey(): PreKeyCrypto {
         val preKey = box.lastResortPreKey
         if (preKey != null) {
             return toPreKey(box.getIdentity().public_key, preKey)

--- a/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
+++ b/cryptography/src/jvmMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
@@ -90,7 +90,7 @@ class ProteusClientCryptoBoxImpl constructor(
         TODO("get session is private in Cryptobox4j")
     }
 
-    override suspend fun newLastPreKey(): PreKeyCrypto {
+    override suspend fun newLastResortPreKey(): PreKeyCrypto {
         return wrapException { toPreKey(box.newLastPreKey()) }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
 import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
+import com.wire.kalium.network.api.base.authenticated.prekey.UploadPreKeysRequest
 import com.wire.kalium.persistence.dao.PrekeyDAO
 import com.wire.kalium.persistence.dao.client.ClientDAO
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
@@ -39,7 +39,6 @@ import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.prekey.DomainToUserIdToClientsToPreKeyMap
 import com.wire.kalium.network.api.base.authenticated.prekey.ListPrekeysResponse
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
-import com.wire.kalium.network.api.base.authenticated.prekey.UploadPreKeysRequest
 import com.wire.kalium.persistence.dao.PrekeyDAO
 import com.wire.kalium.persistence.dao.client.ClientDAO
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -150,7 +150,7 @@ class RegisterClientUseCaseImpl @OptIn(DelicateKaliumApi::class) internal constr
                             Either.Right(registeredClient)
                         }.map { client -> client to registerClientParam.preKeys.maxOfOrNull { it.id } }
                     }.flatMap { (client, otrLastKeyId) ->
-                        otrLastKeyId?.let { preKeyRepository.updateOTRLastPreKeyId(it) }
+                        otrLastKeyId?.let { preKeyRepository.updateMostRecentPreKeyId(it) }
                         Either.Right(client)
                     }.fold({ failure ->
                         handleFailure(failure)
@@ -217,7 +217,7 @@ class RegisterClientUseCaseImpl @OptIn(DelicateKaliumApi::class) internal constr
         secondFactorVerificationCode: String? = null,
     ) = withContext(dispatchers.io) {
         preKeyRepository.generateNewPreKeys(FIRST_KEY_ID, preKeysToSend).flatMap { preKeys ->
-            preKeyRepository.generateNewLastKey().flatMap { lastKey ->
+            preKeyRepository.generateNewLastResortKey().flatMap { lastKey ->
                 Either.Right(
                     RegisterClientParam(
                         password = password,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/BreakSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/BreakSessionUseCase.kt
@@ -67,7 +67,7 @@ internal class BreakSessionUseCaseImpl internal constructor(
                 cryptoClientId = CryptoClientId(clientId.value)
             )
             // create a new session with the same session id
-            proteusClient.createSession(proteusClient.newLastPreKey(), cryptoSessionId)
+            proteusClient.createSession(proteusClient.newLastResortPreKey(), cryptoSessionId)
             kaliumLogger.e("Created new session for ${userId.toLogString()} with ${clientId.value.obfuscateId()}")
             return@fold BreakSessionResult.Success
         })

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/proteus/ProteusPreKeyRefiller.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/proteus/ProteusPreKeyRefiller.kt
@@ -30,8 +30,6 @@ internal interface ProteusPreKeyRefiller {
      * Generates more prekeys and upload them to the backend if needed.
      */
     suspend fun refillIfNeeded(): Either<CoreFailure, Unit>
-
-
     companion object {
         const val MINIMUM_PREKEYS_COUNT = 40
         const val REMOTE_PREKEYS_TARGET_COUNT = 100

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/proteus/ProteusPreKeyRefiller.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/proteus/ProteusPreKeyRefiller.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.proteus
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.prekey.PreKeyRepository
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+
+internal interface ProteusPreKeyRefiller {
+    /**
+     * Generates more prekeys and upload them to the backend if needed.
+     */
+    suspend fun refillIfNeeded(): Either<CoreFailure, Unit>
+}
+
+internal class ProteusPreKeyRefillerImpl(
+    private val preKeyRepository: PreKeyRepository,
+    /**
+     * The minimum of prekeys that will trigger the refill.
+     * If the number of available prekeys is lower than this value,
+     * the refill will be triggered.
+     */
+    private val lowOnPrekeysTreshold: Int = MINIMUM_PREKEYS_COUNT,
+    /**
+     * Number of prekeys to be generated and uploaded to the backend,
+     * if a refill is triggered.
+     */
+    private val newPrekeysCount: Int = NEXT_PREKEY_BATCH_SIZE,
+) : ProteusPreKeyRefiller {
+    override suspend fun refillIfNeeded(): Either<CoreFailure, Unit> =
+        preKeyRepository.fetchRemotelyAvailablePrekeys().flatMap { availableKeys ->
+            val isLowOnPrekeys = availableKeys.size < lowOnPrekeysTreshold
+            if (!isLowOnPrekeys) {
+                Either.Right(Unit)
+            } else {
+                val lastKnownPrekeyId = availableKeys.maxOrNull() ?: 0
+                // TODO: Fill logic to generate preKeys and reset after 65k
+                preKeyRepository.generateNewPreKeys(
+                    lastKnownPrekeyId,
+                    newPrekeysCount
+                ).flatMap { generatedPreKeys ->
+                    preKeyRepository.uploadNewPrekeyBatch(generatedPreKeys)
+                }
+            }
+        }
+
+    private companion object {
+        private const val MINIMUM_PREKEYS_COUNT = 20
+        private const val NEXT_PREKEY_BATCH_SIZE = 100
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
@@ -122,13 +122,13 @@ class PreKeyRepositoryTest {
             .withGenerateLastPreKeysSuccess(expected)
             .arrange()
 
-        preKeyRepository.generateNewLastKey().also {
+        preKeyRepository.generateNewLastResortKey().also {
             assertIs<Either.Right<PreKeyCrypto>>(it)
             assertEquals(expected, it.value)
         }
 
         verify(arrange.proteusClient)
-            .suspendFunction(arrange.proteusClient::newLastPreKey)
+            .suspendFunction(arrange.proteusClient::newLastResortPreKey)
             .wasInvoked(exactly = once)
     }
 
@@ -420,7 +420,7 @@ class PreKeyRepositoryTest {
 
         suspend fun withGenerateLastPreKeysSuccess(expected: PreKeyCrypto) = apply {
             given(proteusClient)
-                .coroutine { proteusClient.newLastPreKey() }
+                .coroutine { proteusClient.newLastResortPreKey() }
                 .then { expected }
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -94,7 +94,7 @@ class RegisterClientUseCaseTest {
             .wasInvoked(exactly = once)
 
         verify(arrangement.preKeyRepository)
-            .suspendFunction(arrangement.preKeyRepository::generateNewLastKey)
+            .suspendFunction(arrangement.preKeyRepository::generateNewLastResortKey)
             .wasInvoked(exactly = once)
     }
 
@@ -200,7 +200,7 @@ class RegisterClientUseCaseTest {
             .wasInvoked(exactly = once)
 
         verify(arrangement.preKeyRepository)
-            .suspendFunction(arrangement.preKeyRepository::generateNewLastKey)
+            .suspendFunction(arrangement.preKeyRepository::generateNewLastResortKey)
             .wasInvoked(exactly = once)
     }
 
@@ -223,7 +223,7 @@ class RegisterClientUseCaseTest {
             .wasInvoked(exactly = once)
 
         verify(arrangement.preKeyRepository)
-            .suspendFunction(arrangement.preKeyRepository::generateNewLastKey)
+            .suspendFunction(arrangement.preKeyRepository::generateNewLastResortKey)
             .wasInvoked(exactly = once)
     }
 
@@ -410,7 +410,7 @@ class RegisterClientUseCaseTest {
             .wasInvoked(exactly = once)
 
         verify(arrangement.preKeyRepository)
-            .suspendFunction(arrangement.preKeyRepository::generateNewLastKey)
+            .suspendFunction(arrangement.preKeyRepository::generateNewLastResortKey)
             .wasInvoked(exactly = once)
     }
 
@@ -525,7 +525,7 @@ class RegisterClientUseCaseTest {
                 .then { _, _ -> Either.Right(PRE_KEYS) }
 
             given(preKeyRepository)
-                .suspendFunction(preKeyRepository::generateNewLastKey)
+                .suspendFunction(preKeyRepository::generateNewLastResortKey)
                 .whenInvoked()
                 .then { Either.Right(LAST_KEY) }
 
@@ -586,7 +586,7 @@ class RegisterClientUseCaseTest {
 
         fun withGenerateNewLastKey(result: Either<ProteusFailure, PreKeyCrypto>) = apply {
             given(preKeyRepository)
-                .suspendFunction(preKeyRepository::generateNewLastKey)
+                .suspendFunction(preKeyRepository::generateNewLastResortKey)
                 .whenInvoked()
                 .then { result }
         }
@@ -600,7 +600,7 @@ class RegisterClientUseCaseTest {
 
         fun withUpdateOTRLastPreKeyId(result: Either<StorageFailure, Unit>) = apply {
             given(preKeyRepository)
-                .suspendFunction(preKeyRepository::updateOTRLastPreKeyId)
+                .suspendFunction(preKeyRepository::updateMostRecentPreKeyId)
                 .whenInvokedWith(any())
                 .then { result }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/proteus/ProteusPreKeyRefillerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/proteus/ProteusPreKeyRefillerTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.proteus
+
+class ProteusPreKeyRefillerTest {
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/PreKeyRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/PreKeyRepositoryArrangement.kt
@@ -1,0 +1,82 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement
+
+import com.wire.kalium.cryptography.PreKeyCrypto
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.prekey.PreKeyRepository
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.given
+import io.mockative.mock
+
+interface PreKeyRepositoryArrangement {
+    val preKeyRepository: PreKeyRepository
+
+    fun withRemotelyAvailablePreKeysReturning(result: Either<CoreFailure, List<Int>>)
+
+    fun withUploadNewPrekeyBatchReturning(result: Either<CoreFailure, Unit>)
+
+    fun withGenerateNewPreKeysReturning(result: Either<CoreFailure, List<PreKeyCrypto>>)
+
+    fun withMostRecentPreKeyId(result: Either<StorageFailure, Int>)
+
+    fun withUpdatingMostRecentPrekeyReturning(result: Either<StorageFailure, Unit>)
+}
+
+internal class PreKeyRepositoryArrangementImpl : PreKeyRepositoryArrangement {
+    @Mock
+    override val preKeyRepository: PreKeyRepository = mock(PreKeyRepository::class)
+
+    override fun withRemotelyAvailablePreKeysReturning(result: Either<CoreFailure, List<Int>>) {
+        given(preKeyRepository)
+            .suspendFunction(preKeyRepository::fetchRemotelyAvailablePrekeys)
+            .whenInvoked()
+            .thenReturn(result)
+    }
+
+    override fun withUploadNewPrekeyBatchReturning(result: Either<CoreFailure, Unit>) {
+        given(preKeyRepository)
+            .suspendFunction(preKeyRepository::uploadNewPrekeyBatch)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
+
+    override fun withGenerateNewPreKeysReturning(result: Either<CoreFailure, List<PreKeyCrypto>>) {
+        given(preKeyRepository)
+            .suspendFunction(preKeyRepository::generateNewPreKeys)
+            .whenInvokedWith(any(), any())
+            .thenReturn(result)
+    }
+
+    override fun withMostRecentPreKeyId(result: Either<StorageFailure, Int>) {
+        given(preKeyRepository)
+            .suspendFunction(preKeyRepository::mostRecentPreKeyId)
+            .whenInvoked()
+            .thenReturn(result)
+    }
+
+    override fun withUpdatingMostRecentPrekeyReturning(result: Either<StorageFailure, Unit>) {
+        given(preKeyRepository)
+            .suspendFunction(preKeyRepository::updateMostRecentPreKeyId)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/PrekeyDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/PrekeyDAO.kt
@@ -23,34 +23,39 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 interface PrekeyDAO {
-    suspend fun updateOTRLastPrekeyId(newKeyId: Int)
-    suspend fun forceInsertOTRLastPrekeyId(newKeyId: Int)
-    suspend fun lastOTRPrekeyId(): Int?
+    suspend fun updateMostRecentPreKeyId(newKeyId: Int)
+    suspend fun forceInsertMostRecentPreKeyId(newKeyId: Int)
+    suspend fun mostRecentPreKeyId(): Int?
 }
 
 internal class PrekeyDAOImpl internal constructor(
     private val metadataQueries: MetadataQueries,
     private val queriesContext: CoroutineContext
 ) : PrekeyDAO {
-    override suspend fun updateOTRLastPrekeyId(newKeyId: Int) = withContext(queriesContext) {
+    override suspend fun updateMostRecentPreKeyId(newKeyId: Int) = withContext(queriesContext) {
         metadataQueries.transaction {
-            val currentId = metadataQueries.selectValueByKey(OTR_LAST_PRE_KEY_ID).executeAsOneOrNull()?.toInt()
+            val currentId = metadataQueries.selectValueByKey(MOST_RECENT_PREKEY_ID).executeAsOneOrNull()?.toInt()
             if (currentId == null || newKeyId > currentId) {
-                metadataQueries.insertValue(OTR_LAST_PRE_KEY_ID, newKeyId.toString())
+                metadataQueries.insertValue(MOST_RECENT_PREKEY_ID, newKeyId.toString())
             }
         }
     }
 
-    override suspend fun forceInsertOTRLastPrekeyId(newKeyId: Int) = withContext(queriesContext) {
-        metadataQueries.insertValue(OTR_LAST_PRE_KEY_ID, newKeyId.toString())
+    override suspend fun forceInsertMostRecentPreKeyId(newKeyId: Int) = withContext(queriesContext) {
+        metadataQueries.insertValue(MOST_RECENT_PREKEY_ID, newKeyId.toString())
     }
 
-    override suspend fun lastOTRPrekeyId(): Int? = withContext(queriesContext) {
-        metadataQueries.selectValueByKey(OTR_LAST_PRE_KEY_ID).executeAsOneOrNull()?.toInt()
+    override suspend fun mostRecentPreKeyId(): Int? = withContext(queriesContext) {
+        metadataQueries.selectValueByKey(MOST_RECENT_PREKEY_ID).executeAsOneOrNull()?.toInt()
     }
 
     private companion object {
-        const val OTR_LAST_PRE_KEY_ID = "otr_last_pre_key_id"
+        /**
+         * Key used to store the most recent prekey ID in the metadata table.
+         * In order to not be confused with "last prekey", which is the "last resort" permanent prekey
+         * used when all prekeys are consumed, the variable was renamed to "most recent prekey".
+         */
+        const val MOST_RECENT_PREKEY_ID = "otr_last_pre_key_id"
     }
 
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/PrekeyDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/PrekeyDAOTest.kt
@@ -41,25 +41,25 @@ class PrekeyDAOTest : BaseDatabaseTest() {
     @Test
     fun givenOTRLastPrekeyId_whenUpdating_thenItsOnlyUpdatedIfTheNewIdIsHigher() = runTest {
         val currentStoredId = 100
-        prekeyDAO.forceInsertOTRLastPrekeyId(100)
+        prekeyDAO.forceInsertMostRecentPreKeyId(100)
 
-        prekeyDAO.updateOTRLastPrekeyId(50)
-        assertEquals(currentStoredId, prekeyDAO.lastOTRPrekeyId())
+        prekeyDAO.updateMostRecentPreKeyId(50)
+        assertEquals(currentStoredId, prekeyDAO.mostRecentPreKeyId())
 
-        prekeyDAO.updateOTRLastPrekeyId(101)
-        assertEquals(101, prekeyDAO.lastOTRPrekeyId())
+        prekeyDAO.updateMostRecentPreKeyId(101)
+        assertEquals(101, prekeyDAO.mostRecentPreKeyId())
     }
 
     @Test
     fun whenForceInsertingPrekeyId_thenTheNewIdIsInserted() = runTest {
-        prekeyDAO.forceInsertOTRLastPrekeyId(100)
+        prekeyDAO.forceInsertMostRecentPreKeyId(100)
 
-        prekeyDAO.forceInsertOTRLastPrekeyId(50)
-        assertEquals(50, prekeyDAO.lastOTRPrekeyId())
+        prekeyDAO.forceInsertMostRecentPreKeyId(50)
+        assertEquals(50, prekeyDAO.mostRecentPreKeyId())
     }
 
     @Test
     fun whenNotLastPreKeyIdIsStored_thenReturnNull() = runTest {
-        assertEquals(null, prekeyDAO.lastOTRPrekeyId())
+        assertEquals(null, prekeyDAO.mostRecentPreKeyId())
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

As prekeys from client X are consumed by other clients when initialising conversations with X, we need to generate more and upload them.

### Solutions

In this PR: create a `ProteusPreKeyRefiller` that is responsible for this.

In a next PR: trigger this Refiller based on Sync status

> **Note**
> I've also renamed and added docs to places that said `lastPreKey`; in order to separate the "last resort" prekey from the "rolling" prekeys and avoid confusion.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
