### PR TITLE
feat: check supported protocols when creating/fetching team 1-1

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.configuration
 
 import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionMapper.toSelfDeletionTimerEntity
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionMapper.toTeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSettingsSelfDeletionStatus
@@ -53,6 +54,8 @@ interface UserConfigRepository {
     fun observeE2EISettings(): Flow<Either<StorageFailure, E2EISettings>>
     fun setE2EISettings(setting: E2EISettings): Either<StorageFailure, Unit>
     fun snoozeE2EINotification(duration: Duration): Either<StorageFailure, Unit>
+    fun setDefaultProtocol(protocol: SupportedProtocol): Either<StorageFailure, Unit>
+    fun getDefaultProtocol(): Either<StorageFailure, SupportedProtocol>
     fun setConferenceCallingEnabled(enabled: Boolean): Either<StorageFailure, Unit>
     fun isConferenceCallingEnabled(): Either<StorageFailure, Boolean>
     fun setSecondFactorPasswordChallengeStatus(isRequired: Boolean): Either<StorageFailure, Unit>
@@ -179,6 +182,14 @@ class UserConfigDataSource(
         }
 
     private fun getE2EINotificationTimeOrNull() = wrapStorageRequest { userConfigStorage.getE2EINotificationTime() }.getOrNull()
+
+    override fun setDefaultProtocol(protocol: SupportedProtocol): Either<StorageFailure, Unit> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDefaultProtocol(): Either<StorageFailure, SupportedProtocol> {
+        TODO("Not yet implemented")
+    }
 
     override fun setConferenceCallingEnabled(enabled: Boolean): Either<StorageFailure, Unit> =
         wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -20,6 +20,8 @@ package com.wire.kalium.logic.configuration
 
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.data.user.toDao
+import com.wire.kalium.logic.data.user.toModel
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionMapper.toSelfDeletionTimerEntity
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionMapper.toTeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSettingsSelfDeletionStatus
@@ -183,13 +185,11 @@ class UserConfigDataSource(
 
     private fun getE2EINotificationTimeOrNull() = wrapStorageRequest { userConfigStorage.getE2EINotificationTime() }.getOrNull()
 
-    override fun setDefaultProtocol(protocol: SupportedProtocol): Either<StorageFailure, Unit> {
-        TODO("Not yet implemented")
-    }
+    override fun setDefaultProtocol(protocol: SupportedProtocol): Either<StorageFailure, Unit> =
+        wrapStorageRequest { userConfigStorage.persistDefaultProtocol(protocol.toDao()) }
 
-    override fun getDefaultProtocol(): Either<StorageFailure, SupportedProtocol> {
-        TODO("Not yet implemented")
-    }
+    override fun getDefaultProtocol(): Either<StorageFailure, SupportedProtocol> =
+        wrapStorageRequest { userConfigStorage.defaultProtocol().toModel() }
 
     override fun setConferenceCallingEnabled(enabled: Boolean): Either<StorageFailure, Unit> =
         wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -77,11 +77,13 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
         data?.let {
             MLSModel(
                 it.config.protocolToggleUsers.map { userId -> PlainId(userId) },
+                it.config.defaultProtocol.toModel(),
                 it.config.supportedProtocols.map { it.toModel() }.toSet(),
                 fromDTO(it.status)
             )
         } ?: MLSModel(
             listOf(),
+            SupportedProtocol.PROTEUS,
             setOf(SupportedProtocol.PROTEUS),
             Status.DISABLED
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -80,6 +80,7 @@ data class SelfDeletingMessagesConfigModel(
 
 data class MLSModel(
     val allowedUsers: List<PlainId>,
+    val defaultProtocol: SupportedProtocol,
     val supportedProtocols: Set<SupportedProtocol>,
     val status: Status
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -182,6 +182,8 @@ import com.wire.kalium.logic.feature.conversation.SyncConversationsUseCase
 import com.wire.kalium.logic.feature.conversation.SyncConversationsUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManagerImpl
+import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolver
+import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolverImpl
 import com.wire.kalium.logic.feature.debug.DebugScope
 import com.wire.kalium.logic.feature.e2ei.EnrollE2EIUseCase
 import com.wire.kalium.logic.feature.e2ei.EnrollE2EIUseCaseImpl
@@ -1237,6 +1239,12 @@ class UserSessionScope internal constructor(
             protoContentMapper = protoContentMapper
         )
 
+    private val mlsOneOnOneConversationResolver: MLSOneOnOneConversationResolver
+        get() = MLSOneOnOneConversationResolverImpl(
+            conversationRepository,
+            joinExistingMLSConversationUseCase
+        )
+
     @OptIn(DelicateKaliumApi::class)
     val client: ClientScope
         get() = ClientScope(
@@ -1281,6 +1289,8 @@ class UserSessionScope internal constructor(
             renamedConversationHandler,
             qualifiedIdMapper,
             team.isSelfATeamMember,
+            mlsOneOnOneConversationResolver,
+            userConfigRepository,
             this
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -182,8 +182,6 @@ import com.wire.kalium.logic.feature.conversation.SyncConversationsUseCase
 import com.wire.kalium.logic.feature.conversation.SyncConversationsUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManagerImpl
-import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolver
-import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolverImpl
 import com.wire.kalium.logic.feature.debug.DebugScope
 import com.wire.kalium.logic.feature.e2ei.EnrollE2EIUseCase
 import com.wire.kalium.logic.feature.e2ei.EnrollE2EIUseCaseImpl
@@ -213,6 +211,8 @@ import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationWorkerImpl
 import com.wire.kalium.logic.feature.mlsmigration.MLSMigrator
 import com.wire.kalium.logic.feature.mlsmigration.MLSMigratorImpl
 import com.wire.kalium.logic.feature.notificationToken.PushTokenUpdater
+import com.wire.kalium.logic.feature.protocol.OneOnOneProtocolSelector
+import com.wire.kalium.logic.feature.protocol.OneOnOneProtocolSelectorImpl
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCaseImpl
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveTeamSettingsSelfDeletingStatusUseCase
@@ -1239,10 +1239,9 @@ class UserSessionScope internal constructor(
             protoContentMapper = protoContentMapper
         )
 
-    private val mlsOneOnOneConversationResolver: MLSOneOnOneConversationResolver
-        get() = MLSOneOnOneConversationResolverImpl(
-            conversationRepository,
-            joinExistingMLSConversationUseCase
+    private val oneOnOneProtocolSelector: OneOnOneProtocolSelector
+        get() = OneOnOneProtocolSelectorImpl(
+            userRepository
         )
 
     @OptIn(DelicateKaliumApi::class)
@@ -1277,7 +1276,6 @@ class UserSessionScope internal constructor(
             syncManager,
             mlsConversationRepository,
             clientIdProvider,
-            assetRepository,
             messages.messageSender,
             teamRepository,
             userId,
@@ -1289,8 +1287,7 @@ class UserSessionScope internal constructor(
             renamedConversationHandler,
             qualifiedIdMapper,
             team.isSelfATeamMember,
-            mlsOneOnOneConversationResolver,
-            userConfigRepository,
+            oneOnOneProtocolSelector,
             this
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -19,8 +19,6 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
-import com.wire.kalium.logic.configuration.UserConfigRepository
-import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -49,9 +47,9 @@ import com.wire.kalium.logic.feature.conversation.keyingmaterials.UpdateKeyingMa
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.UpdateKeyingMaterialsUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCase
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCaseImpl
-import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolver
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.SendConfirmationUseCase
+import com.wire.kalium.logic.feature.protocol.OneOnOneProtocolSelector
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCaseImpl
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
@@ -70,7 +68,6 @@ class ConversationScope internal constructor(
     private val syncManager: SyncManager,
     private val mlsConversationRepository: MLSConversationRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
-    private val assetRepository: AssetRepository,
     private val messageSender: MessageSender,
     private val teamRepository: TeamRepository,
     private val selfUserId: UserId,
@@ -82,8 +79,7 @@ class ConversationScope internal constructor(
     private val renamedConversationHandler: RenamedConversationEventHandler,
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val isSelfATeamMember: IsSelfATeamMemberUseCase,
-    private val mlsOneOnOneConversationResolver: MLSOneOnOneConversationResolver,
-    private val userConfigRepository: UserConfigRepository,
+    private val oneOnOneProtocolSelector: OneOnOneProtocolSelector,
     private val scope: CoroutineScope
 ) {
 
@@ -153,8 +149,7 @@ class ConversationScope internal constructor(
         get() = GetOrCreateOneToOneConversationUseCaseImpl(
             conversationRepository,
             conversationGroupRepository,
-            mlsOneOnOneConversationResolver,
-            userConfigRepository
+            oneOnOneProtocolSelector
         )
 
     val updateConversationMutedStatus: UpdateConversationMutedStatusUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
+import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
@@ -48,6 +49,7 @@ import com.wire.kalium.logic.feature.conversation.keyingmaterials.UpdateKeyingMa
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.UpdateKeyingMaterialsUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCase
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCaseImpl
+import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolver
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.SendConfirmationUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
@@ -80,6 +82,8 @@ class ConversationScope internal constructor(
     private val renamedConversationHandler: RenamedConversationEventHandler,
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val isSelfATeamMember: IsSelfATeamMemberUseCase,
+    private val mlsOneOnOneConversationResolver: MLSOneOnOneConversationResolver,
+    private val userConfigRepository: UserConfigRepository,
     private val scope: CoroutineScope
 ) {
 
@@ -146,7 +150,12 @@ class ConversationScope internal constructor(
         get() = AddServiceToConversationUseCase(groupRepository = conversationGroupRepository)
 
     val getOrCreateOneToOneConversationUseCase: GetOrCreateOneToOneConversationUseCase
-        get() = GetOrCreateOneToOneConversationUseCase(conversationRepository, conversationGroupRepository)
+        get() = GetOrCreateOneToOneConversationUseCaseImpl(
+            conversationRepository,
+            conversationGroupRepository,
+            mlsOneOnOneConversationResolver,
+            userConfigRepository
+        )
 
     val updateConversationMutedStatus: UpdateConversationMutedStatusUseCase
         get() = UpdateConversationMutedStatusUseCaseImpl(conversationRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCase.kt
@@ -30,10 +30,6 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.first
 
-interface GetOrCreateOneToOneConversationUseCase {
-    suspend operator fun invoke(otherUserId: UserId): CreateConversationResult
-}
-
 /**
  * Operation that creates one-to-one Conversation with specific [UserId] (only if it is absent in local DB)
  * and returns [Conversation] data.
@@ -42,6 +38,10 @@ interface GetOrCreateOneToOneConversationUseCase {
  * @return Result with [Conversation] in case of success, or [CoreFailure] if something went wrong:
  * can't get data from local DB, or can't create a conversation.
  */
+interface GetOrCreateOneToOneConversationUseCase {
+    suspend operator fun invoke(otherUserId: UserId): CreateConversationResult
+}
+
 internal class GetOrCreateOneToOneConversationUseCaseImpl(
     private val conversationRepository: ConversationRepository,
     private val conversationGroupRepository: ConversationGroupRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.featureConfig.E2EIModel
 import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSettingsSelfDeletionStatus
@@ -139,6 +140,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
         val mlsEnabled = featureConfig.status == Status.ENABLED
         val selfUserIsWhitelisted = featureConfig.allowedUsers.contains(selfUserId.toPlainID())
         userConfigRepository.setMLSEnabled(mlsEnabled && selfUserIsWhitelisted)
+        userConfigRepository.setDefaultProtocol(if (mlsEnabled) featureConfig.defaultProtocol else SupportedProtocol.PROTEUS)
     }
 
     private suspend fun handleSelfDeletingMessagesStatus(model: SelfDeletingMessagesModel) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer.Companion.SELF_DELETION_LOG_TAG
 import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
@@ -95,6 +96,7 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
                 val mlsEnabled = event.model.status == Status.ENABLED
                 val selfUserIsWhitelisted = event.model.allowedUsers.contains(selfUserId.toPlainID())
                 userConfigRepository.setMLSEnabled(mlsEnabled && selfUserIsWhitelisted)
+                userConfigRepository.setDefaultProtocol(if (mlsEnabled) event.model.defaultProtocol else SupportedProtocol.PROTEUS)
 
                 kaliumLogger.logEventProcessing(
                     EventLoggingStatus.SUCCESS,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -158,7 +158,7 @@ class FeatureConfigMapperTest {
             FeatureConfigData.MLS(
                 MLSConfigDTO(
                     listOf("someId"),
-                    ConvProtocol.MLS,
+                    SupportedProtocolDTO.MLS,
                     listOf(SupportedProtocolDTO.MLS),
                     emptyList(),
                     1

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -80,6 +80,7 @@ class FeatureConfigRepositoryTest {
             ConfigsStatusModel(Status.ENABLED),
             MLSModel(
                 emptyList(),
+                SupportedProtocol.PROTEUS,
                 setOf(SupportedProtocol.PROTEUS),
                 Status.ENABLED
             ),
@@ -162,7 +163,7 @@ class FeatureConfigRepositoryTest {
             FeatureConfigData.MLS(
                 MLSConfigDTO(
                     emptyList(),
-                    ConvProtocol.MLS,
+                    SupportedProtocolDTO.PROTEUS,
                     listOf(SupportedProtocolDTO.PROTEUS),
                     emptyList(),
                     1

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.data.featureConfig
 
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import kotlinx.datetime.Instant
 
 object FeatureConfigTest {
@@ -42,7 +43,7 @@ object FeatureConfigTest {
         secondFactorPasswordChallengeModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         ssoModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         validateSAMLEmailsModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
-        mlsModel: MLSModel = MLSModel(listOf(), setOf(), Status.ENABLED),
+        mlsModel: MLSModel = MLSModel(listOf(), SupportedProtocol.PROTEUS, setOf(), Status.ENABLED),
         e2EIModel: E2EIModel = E2EIModel(E2EIConfigModel("url", 10000L), Status.ENABLED),
         mlsMigrationModel: MLSMigrationModel? = MLSMigrationModel(
             Instant.DISTANT_FUTURE,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlsmigration/MLSMigrationRepositoryTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.data.mlsmigration
 
 import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.util.shouldSucceed
@@ -163,7 +164,7 @@ class MLSMigrationRepositoryTest {
                 FeatureConfigData.MLS(
                     MLSConfigDTO(
                         emptyList(),
-                        ConvProtocol.MLS,
+                        SupportedProtocolDTO.MLS,
                         listOf(SupportedProtocolDTO.MLS),
                         emptyList(),
                         1

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -18,116 +18,124 @@
 
 package com.wire.kalium.logic.feature.conversation
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
+import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.MutedConversationStatus
-import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
 import io.mockative.anything
 import io.mockative.classOf
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertIs
 
 class GetOrCreateOneToOneConversationUseCaseTest {
 
-    @Mock
-    private val conversationRepository = mock(classOf<ConversationRepository>())
-
-    @Mock
-    private val conversationGroupRepository = mock(classOf<ConversationGroupRepository>())
-
-    private lateinit var getOrCreateOneToOneConversationUseCase: GetOrCreateOneToOneConversationUseCase
-
-    @BeforeTest
-    fun setUp() {
-        getOrCreateOneToOneConversationUseCase = GetOrCreateOneToOneConversationUseCase(
-            conversationRepository = conversationRepository,
-            conversationGroupRepository = conversationGroupRepository
-        )
-    }
-
     @Test
-    fun givenConversationDoesNotExist_whenCallingTheUseCase_ThenDoNotCreateAConversationButReturnExisting() = runTest {
+    fun givenConversationExist_whenCallingTheUseCase_ThenDoNotCreateAConversationButReturnExisting() = runTest {
         // given
-        given(conversationRepository)
-            .suspendFunction(conversationRepository::observeOneToOneConversationWithOtherUser)
-            .whenInvokedWith(anything())
-            .thenReturn(flowOf(Either.Right(CONVERSATION)))
+        val (arrangement, useCase) = Arrangement()
+            .withObserveOneToOneConversationWithOtherUserReturning(Either.Right(CONVERSATION))
+            .withGetDefaultProtocolReturning(Either.Right(SupportedProtocol.PROTEUS))
+            .arrange()
 
-        given(conversationRepository)
-            .suspendFunction(conversationGroupRepository::createGroupConversation)
-            .whenInvokedWith(anything(), anything(), anything())
-            .thenReturn(Either.Right(CONVERSATION))
         // when
-        val result = getOrCreateOneToOneConversationUseCase.invoke(USER_ID)
+        val result = useCase.invoke(USER_ID)
+
         // then
         assertIs<CreateConversationResult.Success>(result)
 
-        verify(conversationGroupRepository)
-            .suspendFunction(conversationGroupRepository::createGroupConversation)
+        verify(arrangement.conversationGroupRepository)
+            .suspendFunction(arrangement.conversationGroupRepository::createGroupConversation)
             .with(anything(), anything(), anything())
             .wasNotInvoked()
 
-        verify(conversationRepository)
-            .suspendFunction(conversationRepository::observeOneToOneConversationWithOtherUser)
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::observeOneToOneConversationWithOtherUser)
             .with(anything())
             .wasInvoked(exactly = once)
     }
 
     @Test
-    fun givenConversationExist_whenCallingTheUseCase_ThenCreateAConversationAndReturn() = runTest {
+    fun givenConversationDoesNotExist_whenCallingTheUseCase_ThenCreateAConversationAndReturn() = runTest {
         // given
-        given(conversationRepository)
-            .coroutine { observeOneToOneConversationWithOtherUser(USER_ID) }
-            .then { flowOf(Either.Left(StorageFailure.DataNotFound)) }
+        val (arrangement, useCase) = Arrangement()
+            .withObserveOneToOneConversationWithOtherUserReturning(Either.Left(StorageFailure.DataNotFound))
+            .withGetDefaultProtocolReturning(Either.Right(SupportedProtocol.PROTEUS))
+            .withCreateGroupConversationReturning(Either.Right(CONVERSATION))
+            .arrange()
 
-        given(conversationGroupRepository)
-            .suspendFunction(conversationGroupRepository::createGroupConversation)
-            .whenInvokedWith(anything(), anything(), anything())
-            .thenReturn(Either.Right(CONVERSATION))
         // when
-        val result = getOrCreateOneToOneConversationUseCase.invoke(USER_ID)
+        val result = useCase.invoke(USER_ID)
+
         // then
         assertIs<CreateConversationResult.Success>(result)
 
-        verify(conversationGroupRepository)
-            .coroutine { createGroupConversation(usersList = MEMBER) }
+        verify(arrangement.conversationGroupRepository)
+            .suspendFunction(arrangement.conversationGroupRepository::createGroupConversation)
+            .with(eq(null), eq(MEMBER), eq(ConversationOptions()))
             .wasInvoked(exactly = once)
     }
 
-    private companion object {
-        val USER_ID = UserId(value = "userId", domain = "domainId")
-        val MEMBER = listOf(USER_ID)
-        val CONVERSATION_ID = ConversationId(value = "userId", domain = "domainId")
-        val CONVERSATION = Conversation(
-            id = CONVERSATION_ID,
-            name = null,
-            type = Conversation.Type.ONE_ON_ONE,
-            teamId = null,
-            ProtocolInfo.Proteus,
-            MutedConversationStatus.AllAllowed,
-            null,
-            null,
-            null,
-            lastReadDate = "2022-03-30T15:36:00.000Z",
-            access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
-            accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
-            creatorId = null,
-            receiptMode = Conversation.ReceiptMode.DISABLED,
-            messageTimer = null,
-            userMessageTimer = null
+    class Arrangement {
+
+        @Mock
+        val conversationRepository = mock(classOf<ConversationRepository>())
+
+        @Mock
+        val conversationGroupRepository = mock(classOf<ConversationGroupRepository>())
+
+        @Mock
+        val establishMLSOneToOne = mock(classOf<EstablishMLSOneToOneUseCase>())
+
+        @Mock
+        val userConfigRepository = mock(classOf<UserConfigRepository>())
+
+        fun withObserveOneToOneConversationWithOtherUserReturning(result: Either<CoreFailure, Conversation>) = apply {
+            given(conversationRepository)
+                .suspendFunction(conversationRepository::observeOneToOneConversationWithOtherUser)
+                .whenInvokedWith(eq(USER_ID))
+                .thenReturn(flowOf(result))
+        }
+
+        fun withCreateGroupConversationReturning(result: Either<CoreFailure, Conversation>) = apply {
+            given(conversationGroupRepository)
+                .suspendFunction(conversationGroupRepository::createGroupConversation)
+                .whenInvokedWith(anything(), anything(), anything())
+                .thenReturn(result)
+        }
+
+        fun withGetDefaultProtocolReturning(result: Either<StorageFailure, SupportedProtocol>) = apply {
+            given(userConfigRepository)
+                .function(userConfigRepository::getDefaultProtocol)
+                .whenInvoked()
+                .thenReturn(result)
+        }
+
+        fun arrange() = this to GetOrCreateOneToOneConversationUseCase(
+            conversationRepository = conversationRepository,
+            conversationGroupRepository = conversationGroupRepository,
+            establishMLSOneToOne = establishMLSOneToOne,
+            userConfigRepository = userConfigRepository
         )
+    }
+
+    private companion object {
+        val USER_ID = TestUser.USER_ID
+        val MEMBER = listOf(USER_ID)
+        val CONVERSATION = TestConversation.ONE_ON_ONE
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolver
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
@@ -122,8 +123,8 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         // then
         assertIs<CreateConversationResult.Success>(result)
 
-        verify(arrangement.establishMLSOneToOne)
-            .suspendFunction(arrangement.establishMLSOneToOne::invoke)
+        verify(arrangement.mlsOneOnOneConversationResolver)
+            .suspendFunction(arrangement.mlsOneOnOneConversationResolver::invoke)
             .with(eq(USER_ID))
             .wasInvoked(exactly = once)
 
@@ -133,7 +134,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
             .wasInvoked(exactly = once)
     }
 
-    class Arrangement {
+    internal class Arrangement {
 
         @Mock
         val conversationRepository = mock(classOf<ConversationRepository>())
@@ -142,7 +143,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         val conversationGroupRepository = mock(classOf<ConversationGroupRepository>())
 
         @Mock
-        val establishMLSOneToOne = mock(classOf<EstablishMLSOneToOneUseCase>())
+        val mlsOneOnOneConversationResolver = mock(classOf<MLSOneOnOneConversationResolver>())
 
         @Mock
         val userConfigRepository = mock(classOf<UserConfigRepository>())
@@ -176,16 +177,16 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         }
 
         fun withEstablishMLSOneToOneReturning(result: Either<CoreFailure, ConversationId>) = apply {
-            given(establishMLSOneToOne)
-                .suspendFunction(establishMLSOneToOne::invoke)
+            given(mlsOneOnOneConversationResolver)
+                .suspendFunction(mlsOneOnOneConversationResolver::invoke)
                 .whenInvokedWith(anything())
                 .thenReturn(result)
         }
 
-        fun arrange() = this to GetOrCreateOneToOneConversationUseCase(
+        fun arrange() = this to GetOrCreateOneToOneConversationUseCaseImpl(
             conversationRepository = conversationRepository,
             conversationGroupRepository = conversationGroupRepository,
-            establishMLSOneToOne = establishMLSOneToOne,
+            mlsOneOnOneConversationResolver = mlsOneOnOneConversationResolver,
             userConfigRepository = userConfigRepository
         )
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
@@ -103,10 +103,68 @@ class SyncFeatureConfigsUseCaseTest {
     }
 
     @Test
+    fun givenMlsIsEnabledAndMlsIsDefaultProtocol_whenSyncing_thenMlsShouldBeStoredAsDefault() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
+            .withRemoteFeatureConfigsSucceeding(
+                FeatureConfigTest.newModel(mlsModel = MLSModel(
+                    allowedUsers = emptyList(),
+                    defaultProtocol = SupportedProtocol.MLS,
+                    supportedProtocols = emptySet(),
+                    status = Status.ENABLED))
+            ).arrange()
+
+        syncFeatureConfigsUseCase()
+
+        arrangement.userConfigRepository.getDefaultProtocol().shouldSucceed {
+            assertEquals(SupportedProtocol.MLS, it)
+        }
+    }
+
+    @Test
+    fun givenMlsIsEnabledAndProteusIsDefaultProtocol_whenSyncing_thenProteusShouldBeStoredAsDefault() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
+            .withRemoteFeatureConfigsSucceeding(
+                FeatureConfigTest.newModel(mlsModel = MLSModel(
+                    allowedUsers = emptyList(),
+                    defaultProtocol = SupportedProtocol.PROTEUS,
+                    supportedProtocols = emptySet(),
+                    status = Status.ENABLED))
+            ).arrange()
+
+        syncFeatureConfigsUseCase()
+
+        arrangement.userConfigRepository.getDefaultProtocol().shouldSucceed {
+            assertEquals(SupportedProtocol.PROTEUS, it)
+        }
+    }
+
+    @Test
+    fun givenMlsIsDisabledAndMlsIsDefaultProtocol_whenSyncing_thenProteusShouldBeStoredAsDefault() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
+            .withRemoteFeatureConfigsSucceeding(
+                FeatureConfigTest.newModel(mlsModel = MLSModel(
+                    allowedUsers = emptyList(),
+                    defaultProtocol = SupportedProtocol.MLS,
+                    supportedProtocols = emptySet(),
+                    status = Status.DISABLED))
+            ).arrange()
+
+        syncFeatureConfigsUseCase()
+
+        arrangement.userConfigRepository.getDefaultProtocol().shouldSucceed {
+            assertEquals(SupportedProtocol.PROTEUS, it)
+        }
+    }
+
+    @Test
     fun givenMlsIsEnabledAndSelfUserIsWhitelisted_whenSyncing_thenItShouldBeStoredAsEnabled() = runTest {
         val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
             .withRemoteFeatureConfigsSucceeding(
-                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(SELF_USER_ID.toPlainID()), emptySet(), Status.ENABLED))
+                FeatureConfigTest.newModel(mlsModel = MLSModel(
+                    allowedUsers = listOf(SELF_USER_ID.toPlainID()),
+                    defaultProtocol = SupportedProtocol.MLS,
+                    supportedProtocols = emptySet(),
+                    status = Status.ENABLED))
             ).arrange()
 
         syncFeatureConfigsUseCase()
@@ -120,7 +178,11 @@ class SyncFeatureConfigsUseCaseTest {
     fun givenMlsIsEnabledAndSelfUserIsNotWhitelisted_whenSyncing_thenItShouldBeStoredAsDisabled() = runTest {
         val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
             .withRemoteFeatureConfigsSucceeding(
-                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(), emptySet(), Status.ENABLED))
+                FeatureConfigTest.newModel(mlsModel = MLSModel(
+                    allowedUsers = emptyList(),
+                    defaultProtocol = SupportedProtocol.MLS,
+                    supportedProtocols = emptySet(),
+                    status = Status.ENABLED))
             ).arrange()
 
         syncFeatureConfigsUseCase()
@@ -134,7 +196,11 @@ class SyncFeatureConfigsUseCaseTest {
     fun givenMlsIsDisabled_whenSyncing_thenItShouldBeStoredAsDisabled() = runTest {
         val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
             .withRemoteFeatureConfigsSucceeding(
-                FeatureConfigTest.newModel(mlsModel = MLSModel(listOf(), emptySet(), Status.DISABLED))
+                FeatureConfigTest.newModel(mlsModel = MLSModel(
+                    allowedUsers = emptyList(),
+                    defaultProtocol = SupportedProtocol.MLS,
+                    supportedProtocols = emptySet(),
+                    status = Status.DISABLED))
             ).arrange()
 
         syncFeatureConfigsUseCase()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
@@ -297,6 +297,7 @@ class UpdateSupportedProtocolsUseCaseTest {
                 .thenReturn(Either.Right(FeatureConfigTest.newModel(
                     mlsModel = MLSModel(
                         allowedUsers = emptyList(),
+                        defaultProtocol = SupportedProtocol.PROTEUS,
                         supportedProtocols = supportedProtocols,
                         status = Status.ENABLED
                     ),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/protocol/OneOnOneProtocolSelectorArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/protocol/OneOnOneProtocolSelectorArrangement.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.protocol
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.feature.protocol.OneOnOneProtocolSelector
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.given
+import io.mockative.mock
+
+internal interface OneOnOneProtocolSelectorArrangement {
+    val oneOnOneProtocolSelector: OneOnOneProtocolSelector
+    fun withGetProtocolForUser(result: Either<CoreFailure, SupportedProtocol>): OneOnOneProtocolSelectorArrangementImpl
+}
+
+internal open class OneOnOneProtocolSelectorArrangementImpl : OneOnOneProtocolSelectorArrangement {
+    @Mock
+    override val oneOnOneProtocolSelector: OneOnOneProtocolSelector = mock(OneOnOneProtocolSelector::class)
+
+    override fun withGetProtocolForUser(result: Either<CoreFailure, SupportedProtocol>) = apply {
+        given(oneOnOneProtocolSelector)
+            .suspendFunction(oneOnOneProtocolSelector::getProtocolForUser)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationGroupRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationGroupRepositoryArrangement.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.repository
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.given
+import io.mockative.mock
+
+internal interface ConversationGroupRepositoryArrangement {
+    val conversationGroupRepository: ConversationGroupRepository
+
+    fun withCreateGroupConversationReturning(result: Either<CoreFailure, Conversation>)
+}
+
+internal open class ConversationGroupRepositoryArrangementImpl : ConversationGroupRepositoryArrangement {
+
+    @Mock
+    override val conversationGroupRepository: ConversationGroupRepository = mock(ConversationGroupRepository::class)
+
+    override fun withCreateGroupConversationReturning(result: Either<CoreFailure, Conversation>) {
+        given(conversationGroupRepository)
+            .suspendFunction(conversationGroupRepository::createGroupConversation)
+            .whenInvokedWith(anything(), anything(), anything())
+            .thenReturn(result)
+    }
+}
+

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
@@ -21,12 +21,15 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.member.ConversationsWithMembers
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCaseTest
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
 import io.mockative.any
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.matchers.Matcher
 import io.mockative.mock
+import kotlinx.coroutines.flow.flowOf
 
 internal interface ConversationRepositoryArrangement {
     val conversationRepository: ConversationRepository
@@ -39,6 +42,8 @@ internal interface ConversationRepositoryArrangement {
     fun withConversationsForUserIdReturning(result: Either<CoreFailure, List<Conversation>>)
 
     fun withFetchMlsOneToOneConversation(result: Either<CoreFailure, Conversation>)
+
+    fun withObserveOneToOneConversationWithOtherUserReturning(result: Either<CoreFailure, Conversation>)
 }
 
 internal open class ConversationRepositoryArrangementImpl : ConversationRepositoryArrangement {
@@ -69,5 +74,12 @@ internal open class ConversationRepositoryArrangementImpl : ConversationReposito
             .suspendFunction(conversationRepository::fetchMlsOneToOneConversation)
             .whenInvokedWith(any())
             .thenReturn(result)
+    }
+
+    override fun withObserveOneToOneConversationWithOtherUserReturning(result: Either<CoreFailure, Conversation>) {
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::observeOneToOneConversationWithOtherUser)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(result))
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.network.api.base.authenticated.featureConfigs
 
-import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -88,7 +88,7 @@ data class MLSConfigDTO(
     @SerialName("protocolToggleUsers")
     val protocolToggleUsers: List<String>,
     @SerialName("defaultProtocol")
-    val defaultProtocol: ConvProtocol,
+    val defaultProtocol: SupportedProtocolDTO,
     @SerialName("supportedProtocols")
     val supportedProtocols: List<SupportedProtocolDTO> = listOf(SupportedProtocolDTO.PROTEUS),
     @SerialName("allowedCipherSuites")

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/FeatureConfigJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/FeatureConfigJson.kt
@@ -103,6 +103,7 @@ object FeatureConfigJson {
             |    "config": {
             |       "protocolToggleUsers": ["60368759-d23f-4502-ba6f-68b10e926f7a"],
             |       "defaultProtocol": "proteus",
+            |       "supportedProtocols": ["proteus", "mls"],
             |       "allowedCipherSuites": [1],
             |       "defaultCipherSuite": 1
             |    }
@@ -128,7 +129,7 @@ object FeatureConfigJson {
             SSO(FeatureFlagStatusDTO.ENABLED),
             ValidateSAMLEmails(FeatureFlagStatusDTO.ENABLED),
             MLS(
-                MLSConfigDTO(emptyList(), ConvProtocol.PROTEUS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
+                MLSConfigDTO(emptyList(), SupportedProtocolDTO.PROTEUS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
                 FeatureFlagStatusDTO.ENABLED
             ),
             FeatureConfigData.E2EI(E2EIConfigDTO("url", 0L), FeatureFlagStatusDTO.ENABLED),

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
@@ -197,7 +197,7 @@ object NotificationEventsResponseJson {
     private val newMlsFeatureConfigUpdate = ValidJsonProvider(
         EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO(
             MLS(
-                MLSConfigDTO(emptyList(), ConvProtocol.MLS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
+                MLSConfigDTO(emptyList(), SupportedProtocolDTO.MLS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
                 FeatureFlagStatusDTO.ENABLED,
             )
         ),

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.persistence.config
 
+import com.wire.kalium.persistence.dao.SupportedProtocolEntity
 import com.wire.kalium.persistence.kmmSettings.KaliumPreferences
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
@@ -75,6 +76,16 @@ interface UserConfigStorage {
      * @see persistSecondFactorPasswordChallengeStatus
      */
     fun isSecondFactorPasswordChallengeRequired(): Boolean
+
+    /**
+     * Save default protocol to use
+     */
+    fun persistDefaultProtocol(protocol: SupportedProtocolEntity)
+
+    /**
+     * Gets default protocol to use. Defaults to PROTEUS if not default protocol has been saved.
+     */
+    fun defaultProtocol(): SupportedProtocolEntity
 
     /**
      * save flag from the user settings to enable and disable MLS
@@ -269,6 +280,14 @@ class UserConfigStorageImpl(
     override fun isSecondFactorPasswordChallengeRequired(): Boolean =
         kaliumPreferences.getBoolean(REQUIRE_SECOND_FACTOR_PASSWORD_CHALLENGE, false)
 
+    override fun persistDefaultProtocol(protocol: SupportedProtocolEntity) {
+        kaliumPreferences.putString(DEFAULT_PROTOCOL, protocol.name)
+    }
+
+    override fun defaultProtocol(): SupportedProtocolEntity =
+        kaliumPreferences.getString(DEFAULT_PROTOCOL)?.let { SupportedProtocolEntity.valueOf(it) }
+            ?: SupportedProtocolEntity.PROTEUS
+
     override fun enableMLS(enabled: Boolean) {
         kaliumPreferences.putBoolean(ENABLE_MLS, enabled)
     }
@@ -375,5 +394,6 @@ class UserConfigStorageImpl(
         const val DEFAULT_CONFERENCE_CALLING_ENABLED_VALUE = false
         const val REQUIRE_SECOND_FACTOR_PASSWORD_CHALLENGE = "require_second_factor_password_challenge"
         const val ENABLE_SCREENSHOT_CENSORING = "enable_screenshot_censoring"
+        const val DEFAULT_PROTOCOL = "default_protocol"
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/config/UserConfigStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/config/UserConfigStorageTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.config
 
 import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
+import com.wire.kalium.persistence.dao.SupportedProtocolEntity
 import com.wire.kalium.persistence.kmmSettings.KaliumPreferences
 import com.wire.kalium.persistence.kmmSettings.KaliumPreferencesSettings
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -138,5 +139,20 @@ class UserConfigStorageTest {
     fun givenScreenshotCensoringConfigIsSetToTrue_whenGettingItsValue_thenItShouldBeTrue() = runTest {
         userConfigStorage.persistScreenshotCensoring(enabled = true)
         assertEquals(true, userConfigStorage.isScreenshotCensoringEnabledFlow().first())
+    }
+
+    @Test
+    fun givenDefaultProtocolIsNotSet_whenGettingItsValue_thenItShouldBeProteus() {
+        userConfigStorage.defaultProtocol().let {
+            assertEquals(SupportedProtocolEntity.PROTEUS, it)
+        }
+    }
+
+    @Test
+    fun givenDefaultProtocolIsSetToMls_whenGettingItsValue_thenItShouldBeMls() {
+        userConfigStorage.persistDefaultProtocol(SupportedProtocolEntity.MLS)
+        userConfigStorage.defaultProtocol().let {
+            assertEquals(SupportedProtocolEntity.MLS, it)
+        }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When initiating a 1-1 conversation with a team member we should select the correct protocol based on the users' supported protocols and do the following

### MLS
fetch the MLS 1-1 conversation metadata. The underlaying MLS group will be established before sending the first message, this avoids prematurely creating a conversation on the other side. 

### Proteus
create a fake 1-1 conversation (specially configured group conversation)

## Note

Storing the default protocol ended up not being necessary for this feature but will be needed later when deciding which protocol use when creating group conversations.

### Dependencies

Needs releases with:

- [x] https://github.com/wireapp/kalium/pull/1993

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
