### PR TITLE
feat(proteus): periodically refill prekeys when live [WPB-3552]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1127,7 +1127,8 @@ class UserSessionScope internal constructor(
             proteusClientProvider,
             clientIdProvider,
             userStorage.database.prekeyDAO,
-            userStorage.database.clientDAO
+            userStorage.database.clientDAO,
+            userStorage.database.metadataDAO,
         )
 
     private val keyPackageRepository: KeyPackageRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/proteus/ProteusSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/proteus/ProteusSyncWorker.kt
@@ -1,0 +1,79 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.proteus
+
+import com.wire.kalium.cryptography.ProteusClient
+import com.wire.kalium.logic.data.prekey.PreKeyRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
+import kotlinx.datetime.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+
+/**
+ * Represents an interface for a ProteusSyncWorker,
+ * which is should keep the [ProteusClient] healthy.
+ *
+ * It will wait until the incremental sync is live and then refill the pre-keys if needed.
+ */
+internal interface ProteusSyncWorker {
+    suspend fun execute()
+}
+
+/**
+ * Base implementation of [ProteusSyncWorker].
+ *
+ * @param incrementalSyncRepository The incremental sync repository.
+ * @param proteusPreKeyRefiller The proteus pre-key refiller.
+ * @param preKeyRepository The pre-key repository.
+ * @param minInterValBetweenRefills The minimum interval between prekey refills.
+ */
+internal class ProteusSyncWorkerImpl(
+    private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val proteusPreKeyRefiller: ProteusPreKeyRefiller,
+    private val preKeyRepository: PreKeyRepository,
+    private val minInterValBetweenRefills: Duration = MIN_INTEVAL_BETWEEN_REFILLS
+) : ProteusSyncWorker {
+
+    override suspend fun execute() {
+        preKeyRepository.lastPreKeyRefillCheckInstantFlow()
+            .collectLatest { lastRefill ->
+                val now = Clock.System.now()
+                val nextCheckTime = lastRefill?.plus(minInterValBetweenRefills) ?: now
+                val delayUntilNextCheck = nextCheckTime - now
+                delay(delayUntilNextCheck)
+                waitUntilLiveAndRefillPreKeysIfNeeded()
+                preKeyRepository.setLastPreKeyRefillCheckInstant(Clock.System.now())
+            }
+    }
+
+    private suspend fun waitUntilLiveAndRefillPreKeysIfNeeded() {
+        incrementalSyncRepository.incrementalSyncState
+            .filter { it is IncrementalSyncStatus.Live }
+            .collect {
+                proteusPreKeyRefiller.refillIfNeeded()
+            }
+    }
+
+    private companion object {
+        val MIN_INTEVAL_BETWEEN_REFILLS = 1.days
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
 import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.PrekeyDAO
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
@@ -360,6 +361,9 @@ class PreKeyRepositoryTest {
         val prekeyDAO: PrekeyDAO = mock(PrekeyDAO::class)
 
         @Mock
+        val metadataDAO: MetadataDAO = mock(MetadataDAO::class)
+
+        @Mock
         val clientDAO: ClientDAO = mock(ClientDAO::class)
 
         private val preKeyRepository: PreKeyDataSource =
@@ -368,7 +372,8 @@ class PreKeyRepositoryTest {
                 proteusClientProvider = proteusClientProvider,
                 provideCurrentClientId = currentClientIdProvider,
                 prekeyDAO = prekeyDAO,
-                clientDAO = clientDAO
+                clientDAO = clientDAO,
+                metadataDAO = metadataDAO,
             )
 
         init {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/proteus/ProteusSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/proteus/ProteusSyncWorkerTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.proteus
+
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.PreKeyRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.PreKeyRepositoryArrangementImpl
+import io.mockative.Mock
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+
+class ProteusSyncWorkerTest {
+
+    @Test
+    fun givenLastCheckWasRecentAndSyncIsLive_thenShouldNotAttemptToRefillPreKeys() = runTest {
+        val now = Clock.System.now() - 23.hours
+        val (arrangement, proteusSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            withObserveLastPreKeyUploadInstantReturning(flowOf(now))
+            withIncrementalSyncState(flowOf(IncrementalSyncStatus.Live))
+            withSetLastPreKeyUploadInstantReturning(Either.Right(Unit))
+        }
+
+        launch {
+            proteusSyncWorker.execute()
+        }
+
+        verify(arrangement.proteusPreKeyRefiller)
+            .suspendFunction(arrangement.proteusPreKeyRefiller::refillIfNeeded)
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenLastCheckWasLongAgoAndSyncIsLive_thenShouldAttemptToRefillPreKeys() = runTest {
+        val now = Clock.System.now() - 24.hours
+        val (arrangement, proteusSyncWorker) = arrange {
+            minIntervalBetweenRefills = 23.hours
+            withObserveLastPreKeyUploadInstantReturning(flowOf(now))
+            withIncrementalSyncState(flowOf(IncrementalSyncStatus.Live))
+            withSetLastPreKeyUploadInstantReturning(Either.Right(Unit))
+        }
+
+        proteusSyncWorker.execute()
+
+        verify(arrangement.proteusPreKeyRefiller)
+            .suspendFunction(arrangement.proteusPreKeyRefiller::refillIfNeeded)
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenLastCheckWasRecentAndSyncIsLive_whenTimeElapses_thenShouldAttemptToRefillPreKeys() = runTest {
+        val now = Clock.System.now() - 23.hours
+        val (arrangement, proteusSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            withObserveLastPreKeyUploadInstantReturning(flowOf(now))
+            withIncrementalSyncState(flowOf(IncrementalSyncStatus.Live))
+            withSetLastPreKeyUploadInstantReturning(Either.Right(Unit))
+        }
+
+        launch {
+            proteusSyncWorker.execute()
+        }
+
+        verify(arrangement.proteusPreKeyRefiller)
+            .suspendFunction(arrangement.proteusPreKeyRefiller::refillIfNeeded)
+            .wasNotInvoked()
+
+        // Advance time until it's time to refill
+        advanceTimeBy(2.hours)
+
+        verify(arrangement.proteusPreKeyRefiller)
+            .suspendFunction(arrangement.proteusPreKeyRefiller::refillIfNeeded)
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement(private val configure: Arrangement.() -> Unit) :
+        IncrementalSyncRepositoryArrangement by IncrementalSyncRepositoryArrangementImpl(),
+        PreKeyRepositoryArrangement by PreKeyRepositoryArrangementImpl() {
+
+        @Mock
+        val proteusPreKeyRefiller = mock(ProteusPreKeyRefiller::class)
+        var minIntervalBetweenRefills: Duration = 1.days
+
+        init {
+            given(proteusPreKeyRefiller)
+                .suspendFunction(proteusPreKeyRefiller::refillIfNeeded)
+                .whenInvoked()
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun arrange(): Pair<Arrangement, ProteusSyncWorker> = run {
+            configure()
+            this@Arrangement to ProteusSyncWorkerImpl(
+                incrementalSyncRepository = incrementalSyncRepository,
+                proteusPreKeyRefiller = proteusPreKeyRefiller,
+                preKeyRepository = preKeyRepository,
+                minInterValBetweenRefills = minIntervalBetweenRefills
+            )
+        }
+    }
+
+    private companion object {
+        fun arrange(configure: Arrangement.() -> Unit) = Arrangement(configure).arrange()
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/IncrementalSyncRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/IncrementalSyncRepositoryArrangement.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement
+
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import io.mockative.Mock
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.flow.Flow
+
+internal interface IncrementalSyncRepositoryArrangement {
+    val incrementalSyncRepository: IncrementalSyncRepository
+
+    fun withIncrementalSyncState(flow: Flow<IncrementalSyncStatus>)
+}
+
+internal class IncrementalSyncRepositoryArrangementImpl: IncrementalSyncRepositoryArrangement {
+    @Mock
+    override val incrementalSyncRepository = mock(IncrementalSyncRepository::class)
+
+    override fun withIncrementalSyncState(flow: Flow<IncrementalSyncStatus>) {
+        given(incrementalSyncRepository)
+            .getter(incrementalSyncRepository::incrementalSyncState)
+            .whenInvoked()
+            .thenReturn(flow)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/PreKeyRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/PreKeyRepositoryArrangement.kt
@@ -26,6 +26,8 @@ import io.mockative.Mock
 import io.mockative.any
 import io.mockative.given
 import io.mockative.mock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
 
 interface PreKeyRepositoryArrangement {
     val preKeyRepository: PreKeyRepository
@@ -39,6 +41,10 @@ interface PreKeyRepositoryArrangement {
     fun withMostRecentPreKeyId(result: Either<StorageFailure, Int>)
 
     fun withUpdatingMostRecentPrekeyReturning(result: Either<StorageFailure, Unit>)
+
+    fun withSetLastPreKeyUploadInstantReturning(result: Either<StorageFailure, Unit>)
+
+    fun withObserveLastPreKeyUploadInstantReturning(flow: Flow<Instant?>)
 }
 
 internal class PreKeyRepositoryArrangementImpl : PreKeyRepositoryArrangement {
@@ -78,5 +84,19 @@ internal class PreKeyRepositoryArrangementImpl : PreKeyRepositoryArrangement {
             .suspendFunction(preKeyRepository::updateMostRecentPreKeyId)
             .whenInvokedWith(any())
             .thenReturn(result)
+    }
+
+    override fun withSetLastPreKeyUploadInstantReturning(result: Either<StorageFailure, Unit>) {
+        given(preKeyRepository)
+            .suspendFunction(preKeyRepository::setLastPreKeyRefillCheckInstant)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
+
+    override fun withObserveLastPreKeyUploadInstantReturning(flow: Flow<Instant?>) {
+        given(preKeyRepository)
+            .suspendFunction(preKeyRepository::lastPreKeyRefillCheckInstantFlow)
+            .whenInvoked()
+            .thenReturn(flow)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Every so often, we need to refill Proteus prekeys as they are consumed.

### Solutions

Add a `ProteusSyncWorker` that is responsible for triggering `ProteusPreKeyRefiller` when we are Live, with a minimum interval of 1 day.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
