### PR TITLE
feat(monkeys): Allow to split clients per test cases [WPB-4332]

### DIFF
--- a/monkeys/README.md
+++ b/monkeys/README.md
@@ -37,3 +37,5 @@ An [example](example.json) config is in this repo and the schema can be seen [he
 * Tracing and replaying a test run. For this the order is the important factor, so when replayed it
   won't be executed in parallel.
 * Multi-clients. Right now each user can have just one client within the application
+* Clean-up the data created during the tests
+* Randomising times for action execution

--- a/monkeys/schema.json
+++ b/monkeys/schema.json
@@ -9,6 +9,36 @@
         "backends"
     ],
     "properties": {
+        "conversationDistribution": {
+            "description": "List of predefined groups to run the tests. A random user will be selected to create (if not logged in, it will automatically) and it will include only other users it is connected to.",
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "object",
+                    "required": [
+                        "userCount",
+                        "groupCount"
+                    ],
+                    "properties": {
+                        "userCount": {
+                            "$ref": "#/$defs/UserCount"
+                        },
+                        "protocol": {
+                            "description": "The protocol of the group",
+                            "type": "string",
+                            "enum": [
+                                "MLS",
+                                "PROTEUS"
+                            ]
+                        },
+                        "groupCount": {
+                            "description": "The number of groups that should be created",
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
         "testCases": {
             "description": "List of test cases to run in parallel",
             "type": "array",
@@ -24,36 +54,6 @@
                     "name": {
                         "description": "Name of the test case",
                         "type": "string"
-                    },
-                    "conversationDistribution": {
-                        "description": "List of predefined groups to run the tests. A random user will be selected to create (if not logged in, it will automatically) and it will include only other users it is connected to.",
-                        "type": "object",
-                        "patternProperties": {
-                            ".*": {
-                                "type": "object",
-                                "required": [
-                                    "userCount",
-                                    "groupCount"
-                                ],
-                                "properties": {
-                                    "userCount": {
-                                        "$ref": "#/$defs/UserCount"
-                                    },
-                                    "protocol": {
-                                        "description": "The protocol of the group",
-                                        "type": "string",
-                                        "enum": [
-                                            "MLS",
-                                            "PROTEUS"
-                                        ]
-                                    },
-                                    "groupCount": {
-                                        "description": "The number of groups that should be created",
-                                        "type": "integer"
-                                    }
-                                }
-                            }
-                        }
                     },
                     "setup": {
                         "description": "List of actions to be executed prior to the test's execution. For things like connecting users to each other.",

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/ActionScheduler.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/ActionScheduler.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.monkeys
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.actions.Action
 import com.wire.kalium.monkeys.importer.ActionConfig
-import com.wire.kalium.monkeys.importer.TestCase
+import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -33,8 +33,8 @@ import kotlinx.serialization.serializer
 object ActionScheduler {
     @Suppress("TooGenericExceptionCaught")
     @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
-    suspend fun start(testCases: List<TestCase>, coreLogic: CoreLogic) {
-        testCases.flatMap { it.actions }.forEach { actionConfig ->
+    suspend fun start(actions: List<ActionConfig>, coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+        actions.forEach { actionConfig ->
             CoroutineScope(Dispatchers.Default).launch {
                 while (this.isActive) {
                     try {
@@ -42,7 +42,7 @@ object ActionScheduler {
                         logger.i("Running action $actionName: ${actionConfig.description} ${actionConfig.count} times")
                         repeat(actionConfig.count.toInt()) {
                             val startTime = System.currentTimeMillis()
-                            Action.fromConfig(actionConfig).execute(coreLogic)
+                            Action.fromConfig(actionConfig).execute(coreLogic, monkeyPool)
                             logger.d("Action $actionName took ${System.currentTimeMillis() - startTime} milliseconds")
                         }
                     } catch (e: Exception) {
@@ -54,9 +54,9 @@ object ActionScheduler {
         }
     }
 
-    suspend fun runSetup(actions: List<ActionConfig>, coreLogic: CoreLogic) {
+    suspend fun runSetup(actions: List<ActionConfig>, coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
         actions.forEach {
-            Action.fromConfig(it).execute(coreLogic)
+            Action.fromConfig(it).execute(coreLogic, monkeyPool)
         }
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/Action.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/Action.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.monkeys.actions
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.importer.ActionConfig
 import com.wire.kalium.monkeys.importer.ActionType
+import com.wire.kalium.monkeys.pool.MonkeyPool
 
 abstract class Action {
     companion object {
@@ -37,5 +38,5 @@ abstract class Action {
         }
     }
 
-    abstract suspend fun execute(coreLogic: CoreLogic)
+    abstract suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool)
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/AddUserToConversationAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/AddUserToConversationAction.kt
@@ -20,13 +20,14 @@ package com.wire.kalium.monkeys.actions
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.importer.ActionType
 import com.wire.kalium.monkeys.pool.ConversationPool
+import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class AddUserToConversationAction(val config: ActionType.AddUsersToConversation) : Action() {
-    override suspend fun execute(coreLogic: CoreLogic) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
         val target = ConversationPool.randomDynamicConversations(this.config.countGroups.toInt())
         target.forEach {
             val filterOut = it.membersIds()
-            val participants = it.creator.randomPeers(this.config.userCount, filterOut)
+            val participants = it.creator.randomPeers(this.config.userCount, monkeyPool, filterOut)
             it.addMonkeys(participants)
         }
     }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/CreateConversationAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/CreateConversationAction.kt
@@ -20,13 +20,14 @@ package com.wire.kalium.monkeys.actions
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.importer.ActionType
 import com.wire.kalium.monkeys.pool.ConversationPool
+import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class CreateConversationAction(val config: ActionType.CreateConversation) : Action() {
-    override suspend fun execute(coreLogic: CoreLogic) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
         if (this.config.team != null) {
-            ConversationPool.createDynamicConversation(this.config.team, this.config.userCount, this.config.protocol)
+            ConversationPool.createDynamicConversation(this.config.team, this.config.userCount, this.config.protocol, monkeyPool)
         } else {
-            ConversationPool.createDynamicConversation(this.config.userCount, this.config.protocol)
+            ConversationPool.createDynamicConversation(this.config.userCount, this.config.protocol, monkeyPool)
         }
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/DestroyConversationAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/DestroyConversationAction.kt
@@ -20,9 +20,10 @@ package com.wire.kalium.monkeys.actions
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.importer.ActionType
 import com.wire.kalium.monkeys.pool.ConversationPool
+import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class DestroyConversationAction(val config: ActionType.DestroyConversation) : Action() {
-    override suspend fun execute(coreLogic: CoreLogic) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
         val targets = ConversationPool.randomDynamicConversations(this.config.count.toInt())
         targets.forEach { it.destroy() }
     }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/LeaveConversationAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/LeaveConversationAction.kt
@@ -20,9 +20,10 @@ package com.wire.kalium.monkeys.actions
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.importer.ActionType
 import com.wire.kalium.monkeys.pool.ConversationPool
+import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class LeaveConversationAction(val config: ActionType.LeaveConversation) : Action() {
-    override suspend fun execute(coreLogic: CoreLogic) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
         val targets = ConversationPool.randomDynamicConversations(this.config.countGroups.toInt())
         targets.forEach { conv ->
             val leavers = conv.randomMonkeys(this.config.userCount)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/LoginAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/LoginAction.kt
@@ -24,13 +24,13 @@ import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.delay
 
 class LoginAction(val config: ActionType.Login) : Action() {
-    override suspend fun execute(coreLogic: CoreLogic) {
-        val monkeys = MonkeyPool.randomLoggedOutMonkeys(this.config.userCount)
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+        val monkeys = monkeyPool.randomLoggedOutMonkeys(this.config.userCount)
         logger.i("Logging ${monkeys.count()} monkeys in")
-        monkeys.forEach { it.login(coreLogic, MonkeyPool::loggedIn) }
+        monkeys.forEach { it.login(coreLogic, monkeyPool::loggedIn) }
         if (config.duration > 0u) {
             delay(config.duration.toLong())
-            monkeys.forEach { it.logout(MonkeyPool::loggedOut) }
+            monkeys.forEach { it.logout(monkeyPool::loggedOut) }
         }
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/ReconnectAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/ReconnectAction.kt
@@ -24,11 +24,11 @@ import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.delay
 
 class ReconnectAction(val config: ActionType.Reconnect) : Action() {
-    override suspend fun execute(coreLogic: CoreLogic) {
-        val monkeys = MonkeyPool.randomLoggedInMonkeys(this.config.userCount)
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+        val monkeys = monkeyPool.randomLoggedInMonkeys(this.config.userCount)
         logger.i("Logging ${monkeys.count()} monkeys out")
-        monkeys.forEach { it.logout(MonkeyPool::loggedOut) }
+        monkeys.forEach { it.logout(monkeyPool::loggedOut) }
         delay(config.durationOffline.toLong())
-        monkeys.forEach { it.login(coreLogic, MonkeyPool::loggedOut) }
+        monkeys.forEach { it.login(coreLogic, monkeyPool::loggedOut) }
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendMessageAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendMessageAction.kt
@@ -34,15 +34,14 @@ private val EMOJI: List<String> = listOf(
 )
 
 class SendMessageAction(val config: ActionType.SendMessage) : Action() {
-
-    override suspend fun execute(coreLogic: CoreLogic) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
         repeat(this.config.count.toInt()) { i ->
             if (this.config.targets.isNotEmpty()) {
                 this.config.targets.forEach { target ->
                     if (target == ONE_2_1) {
-                        val monkeys = MonkeyPool.randomLoggedInMonkeys(this.config.userCount)
+                        val monkeys = monkeyPool.randomLoggedInMonkeys(this.config.userCount)
                         monkeys.forEach { monkey ->
-                            val targetMonkey = monkey.randomPeer()
+                            val targetMonkey = monkey.randomPeer(monkeyPool)
                             monkey.sendDirectMessageTo(targetMonkey, randomMessage(targetMonkey.user.email, i))
                         }
                     } else {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendRequestAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendRequestAction.kt
@@ -23,10 +23,10 @@ import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.delay
 
 class SendRequestAction(val config: ActionType.SendRequest) : Action() {
-    override suspend fun execute(coreLogic: CoreLogic) {
-        val monkeys = MonkeyPool.randomLoggedInMonkeysFromTeam(this.config.originTeam, this.config.userCount)
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+        val monkeys = monkeyPool.randomLoggedInMonkeysFromTeam(this.config.originTeam, this.config.userCount)
         monkeys.forEach { origin ->
-            val targets = MonkeyPool.randomLoggedInMonkeysFromTeam(this.config.targetTeam, this.config.targetUserCount)
+            val targets = monkeyPool.randomLoggedInMonkeysFromTeam(this.config.targetTeam, this.config.targetUserCount)
             targets.forEach { origin.sendRequest(it) }
             delay(this.config.delayResponse.toLong())
             if (this.config.shouldAccept) {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
@@ -121,13 +121,13 @@ class Monkey(val user: UserData) {
         callback(this)
     }
 
-    suspend fun randomPeer(): Monkey {
-        return MonkeyPool.get(this.connectedMonkeys().randomOrNull() ?: error("Monkey ${this.user.email} not connected to anyone"))
+    suspend fun randomPeer(monkeyPool: MonkeyPool): Monkey {
+        return monkeyPool.get(this.connectedMonkeys().randomOrNull() ?: error("Monkey ${this.user.email} not connected to anyone"))
     }
 
-    suspend fun randomPeers(userCount: UserCount, filterOut: List<UserId> = listOf()): List<Monkey> {
+    suspend fun randomPeers(userCount: UserCount, monkeyPool: MonkeyPool, filterOut: List<UserId> = listOf()): List<Monkey> {
         val count = resolveUserCount(userCount, this.connectedMonkeys().count().toUInt())
-        return this.connectedMonkeys().filterNot { filterOut.contains(it) }.shuffled().map(MonkeyPool::get).take(count.toInt())
+        return this.connectedMonkeys().filterNot { filterOut.contains(it) }.shuffled().map(monkeyPool::get).take(count.toInt())
     }
 
     suspend fun sendRequest(anotherMonkey: Monkey) {
@@ -148,9 +148,9 @@ class Monkey(val user: UserData) {
         }
     }
 
-    suspend fun <T> makeReadyThen(coreLogic: CoreLogic, func: suspend Monkey.() -> T): T {
+    suspend fun <T> makeReadyThen(coreLogic: CoreLogic, monkeyPool: MonkeyPool, func: suspend Monkey.() -> T): T {
         if (this.monkeyState is MonkeyState.NotReady) {
-            this.login(coreLogic, MonkeyPool::loggedIn)
+            this.login(coreLogic, monkeyPool::loggedIn)
         }
         return this.func()
     }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/homeDirectory.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/homeDirectory.kt
@@ -27,5 +27,16 @@ fun homeDirectory(): String {
 
 fun coreLogic(
     rootPath: String,
-    kaliumConfigs: KaliumConfigs
-): CoreLogic = CoreLogic(rootPath, kaliumConfigs, "Wire Infinite Monkeys")
+): CoreLogic {
+    val coreLogic = CoreLogic(
+        rootPath,
+        kaliumConfigs = KaliumConfigs(
+            developmentApiEnabled = true,
+            encryptProteusStorage = true,
+            isMLSSupportEnabled = true,
+            wipeOnDeviceRemoval = true,
+        ), "Wire Infinite Monkeys"
+    )
+    coreLogic.updateApiVersionsScheduler.scheduleImmediateApiVersionUpdate()
+    return coreLogic
+}

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/importer/TestData.kt
@@ -23,14 +23,14 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class TestData(
+    @SerialName("conversationDistribution") val conversationDistribution: Map<String, GroupConfig> = mapOf(),
     @SerialName("testCases") val testCases: List<TestCase>,
-    @SerialName("backends") val backends: List<BackendConfig>
+    @SerialName("backends") val backends: List<BackendConfig>,
 )
 
 @Serializable
 data class TestCase(
     @SerialName("name") val name: String,
-    @SerialName("conversationDistribution") val conversationDistribution: Map<String, GroupConfig> = mapOf(),
     @SerialName("setup") val setup: List<ActionConfig> = listOf(),
     @SerialName("actions") val actions: List<ActionConfig>
 )

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
@@ -67,29 +67,32 @@ object ConversationPool {
     private suspend fun createDynamicConversation(
         creator: Monkey,
         userCount: UserCount,
-        protocol: ConversationOptions.Protocol
+        protocol: ConversationOptions.Protocol,
+        monkeyPool: MonkeyPool
     ) {
         val name = "By monkey ${creator.user.email} - $protocol - ${Random.nextUInt()}"
-        val monkeyList = creator.randomPeers(userCount)
+        val monkeyList = creator.randomPeers(userCount, monkeyPool)
         val conversation = creator.createConversation(name, monkeyList, protocol)
         this.addToPool(conversation)
     }
 
     suspend fun createDynamicConversation(
         userCount: UserCount,
-        protocol: ConversationOptions.Protocol
+        protocol: ConversationOptions.Protocol,
+        monkeyPool: MonkeyPool
     ) {
-        val creator = MonkeyPool.randomMonkeys(UserCount.single())[0]
-        this.createDynamicConversation(creator, userCount, protocol)
+        val creator = monkeyPool.randomMonkeys(UserCount.single())[0]
+        this.createDynamicConversation(creator, userCount, protocol, monkeyPool)
     }
 
     suspend fun createDynamicConversation(
         team: String,
         userCount: UserCount,
-        protocol: ConversationOptions.Protocol
+        protocol: ConversationOptions.Protocol,
+        monkeyPool: MonkeyPool
     ) {
-        val creator = MonkeyPool.randomMonkeysFromTeam(team, UserCount.single())[0]
-        this.createDynamicConversation(creator, userCount, protocol)
+        val creator = monkeyPool.randomMonkeysFromTeam(team, UserCount.single())[0]
+        this.createDynamicConversation(creator, userCount, protocol, monkeyPool)
     }
 
     // Should be called on the setup free from concurrent access as it is not thread safe
@@ -98,13 +101,14 @@ object ConversationPool {
         prefix: String,
         count: UInt,
         userCount: UserCount,
-        protocol: ConversationOptions.Protocol
+        protocol: ConversationOptions.Protocol,
+        monkeyPool: MonkeyPool
     ) {
         repeat(count.toInt()) { groupIndex ->
-            val creator = MonkeyPool.randomMonkeys(UserCount.single())[0]
+            val creator = monkeyPool.randomMonkeys(UserCount.single())[0]
             val name = "Prefixed $prefix by monkey ${creator.user.email} - $protocol - $groupIndex"
-            val conversation = creator.makeReadyThen(coreLogic) {
-                val participants = creator.randomPeers(userCount)
+            val conversation = creator.makeReadyThen(coreLogic, monkeyPool) {
+                val participants = creator.randomPeers(userCount, monkeyPool)
                 createConversation(name, participants, protocol, false)
             }
             this.addToPool(conversation)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
@@ -96,6 +96,7 @@ object ConversationPool {
     }
 
     // Should be called on the setup free from concurrent access as it is not thread safe
+    @Suppress("LongParameterList")
     suspend fun createPrefixedConversations(
         coreLogic: CoreLogic,
         prefix: String,

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/MonkeyPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/MonkeyPool.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.monkeys.importer.UserData
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.roundToInt
 
-object MonkeyPool {
+class MonkeyPool(users: List<UserData>) {
     // a map of monkeys per domain
     private val pool: ConcurrentHashMap<String, MutableList<Monkey>> = ConcurrentHashMap()
 
@@ -37,7 +37,7 @@ object MonkeyPool {
     // a map of logged out monkeys per domain
     private val poolLoggedOut: ConcurrentHashMap<String, ConcurrentHashMap<UserId, Monkey>> = ConcurrentHashMap()
 
-    fun init(users: List<UserData>) {
+    init {
         users.forEach {
             val monkey = Monkey(it)
             this.pool.getOrPut(it.backend.teamName) { mutableListOf() }.add(monkey)

--- a/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/AddUserToConversationActionTest.kt
+++ b/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/AddUserToConversationActionTest.kt
@@ -6,6 +6,7 @@ import com.wire.kalium.monkeys.conversation.MonkeyConversation
 import com.wire.kalium.monkeys.importer.ActionType
 import com.wire.kalium.monkeys.importer.UserCount
 import com.wire.kalium.monkeys.pool.ConversationPool
+import com.wire.kalium.monkeys.pool.MonkeyPool
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
@@ -23,14 +24,15 @@ class AddUserToConversationActionTest {
     fun givenAddUserConfig_newUsersShouldBeAdded() = runTest {
         val config = ActionType.AddUsersToConversation(1u, UserCount.single())
         mockkObject(ConversationPool)
+        val monkeyPool = mockk<MonkeyPool>()
         val monkey = mockk<Monkey>(relaxed = true)
         val conversation = mockk<MonkeyConversation>(relaxed = true)
         val creator = mockk<Monkey>()
         val coreLogic = mockk<CoreLogic>()
         every { ConversationPool.randomDynamicConversations(config.countGroups.toInt()) } returns listOf(conversation)
         every { conversation.creator } returns creator
-        coEvery { creator.randomPeers(config.userCount) } returns listOf(monkey)
-        AddUserToConversationAction(config).execute(coreLogic)
+        coEvery { creator.randomPeers(config.userCount, any()) } returns listOf(monkey)
+        AddUserToConversationAction(config).execute(coreLogic, monkeyPool)
         coVerify(exactly = 1) { conversation.addMonkeys(listOf(monkey)) }
         verify(exactly = 1) { conversation.creator }
         verify(exactly = 1) { conversation.membersIds() }

--- a/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/LoginActionTest.kt
+++ b/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/LoginActionTest.kt
@@ -9,7 +9,6 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -17,25 +16,25 @@ class LoginActionTest {
 
     @Test
     fun givenLoginConfigProvided_thenShouldLogin() = runTest {
-        mockkObject(MonkeyPool)
+        val monkeyPool = mockk<MonkeyPool>()
         val monkey = mockk<Monkey>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
-        every { MonkeyPool.randomLoggedOutMonkeys(UserCount.single()) } returns listOf(monkey)
-        LoginAction(ActionType.Login(UserCount.single())).execute(coreLogic)
-        coVerify(exactly = 1) { monkey.login(coreLogic, MonkeyPool::loggedIn) }
-        coVerify(exactly = 0) { monkey.logout(MonkeyPool::loggedOut) }
+        every { monkeyPool.randomLoggedOutMonkeys(UserCount.single()) } returns listOf(monkey)
+        LoginAction(ActionType.Login(UserCount.single())).execute(coreLogic, monkeyPool)
+        coVerify(exactly = 1) { monkey.login(coreLogic, monkeyPool::loggedIn) }
+        coVerify(exactly = 0) { monkey.logout(monkeyPool::loggedOut) }
         confirmVerified(monkey)
     }
 
     @Test
     fun givenLoginConfigWithDurationProvided_thenShouldLoginAndLogout() = runTest {
-        mockkObject(MonkeyPool)
+        val monkeyPool = mockk<MonkeyPool>()
         val monkey = mockk<Monkey>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
-        every { MonkeyPool.randomLoggedOutMonkeys(UserCount.single()) } returns listOf(monkey)
-        LoginAction(ActionType.Login(UserCount.single(), 10u)).execute(coreLogic)
-        coVerify(exactly = 1) { monkey.login(coreLogic, MonkeyPool::loggedIn) }
-        coVerify(exactly = 1) { monkey.logout(MonkeyPool::loggedOut) }
+        every { monkeyPool.randomLoggedOutMonkeys(UserCount.single()) } returns listOf(monkey)
+        LoginAction(ActionType.Login(UserCount.single(), 10u)).execute(coreLogic, monkeyPool)
+        coVerify(exactly = 1) { monkey.login(coreLogic, monkeyPool::loggedIn) }
+        coVerify(exactly = 1) { monkey.logout(monkeyPool::loggedOut) }
         confirmVerified(monkey)
     }
 }

--- a/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/SendMessageActionTest.kt
+++ b/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/SendMessageActionTest.kt
@@ -22,14 +22,14 @@ class SendMessageActionTest {
     @Test
     fun givenEmptyTargets_randomConversationsShouldBePicked() = runTest {
         val config = ActionType.SendMessage(UserCount.single(), 1u, 1u, listOf())
-        mockkObject(MonkeyPool)
+        val monkeyPool = mockk<MonkeyPool>()
         mockkObject(ConversationPool)
         val monkey = mockk<Monkey>(relaxed = true)
         val conversation = mockk<MonkeyConversation>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
         every { ConversationPool.randomConversations(config.countGroups) } returns listOf(conversation)
         every { conversation.randomMonkeys(config.userCount) } returns listOf(monkey)
-        SendMessageAction(config).execute(coreLogic)
+        SendMessageAction(config).execute(coreLogic, monkeyPool)
         coVerify(exactly = 1) { monkey.sendMessageTo(any(), any()) }
         verify { conversation.randomMonkeys(config.userCount) }
         verify { conversation.conversation }
@@ -41,14 +41,14 @@ class SendMessageActionTest {
     @Test
     fun givenTargets_PrefixedConversationShouldBePicked() = runTest {
         val config = ActionType.SendMessage(UserCount.single(), 1u, 1u, listOf("group1"))
-        mockkObject(MonkeyPool)
+        val monkeyPool = mockk<MonkeyPool>()
         mockkObject(ConversationPool)
         val monkey = mockk<Monkey>(relaxed = true)
         val conversation = mockk<MonkeyConversation>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
         every { ConversationPool.getFromPrefixed("group1") } returns listOf(conversation)
         every { conversation.randomMonkeys(config.userCount) } returns listOf(monkey)
-        SendMessageAction(config).execute(coreLogic)
+        SendMessageAction(config).execute(coreLogic, monkeyPool)
         coVerify(exactly = 1) { monkey.sendMessageTo(any(), any()) }
         verify { conversation.randomMonkeys(config.userCount) }
         verify { conversation.conversation }
@@ -60,23 +60,23 @@ class SendMessageActionTest {
     @Test
     fun givenOne21Informed_directMessageShouldBeSent() = runTest {
         val config = ActionType.SendMessage(UserCount.single(), 1u, 1u, listOf("One21"))
-        mockkObject(MonkeyPool)
+        val monkeyPool = mockk<MonkeyPool>()
         mockkObject(ConversationPool)
         val monkey = mockk<Monkey>(relaxed = true)
         val targetMonkey = mockk<Monkey>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
-        every { MonkeyPool.randomLoggedInMonkeys(config.userCount) } returns listOf(monkey)
-        coEvery { monkey.randomPeer() } returns targetMonkey
-        SendMessageAction(config).execute(coreLogic)
+        every { monkeyPool.randomLoggedInMonkeys(config.userCount) } returns listOf(monkey)
+        coEvery { monkey.randomPeer(monkeyPool) } returns targetMonkey
+        SendMessageAction(config).execute(coreLogic, monkeyPool)
         coVerify(exactly = 1) { monkey.sendDirectMessageTo(targetMonkey, any()) }
-        coVerify(exactly = 1) { monkey.randomPeer() }
+        coVerify(exactly = 1) { monkey.randomPeer(monkeyPool) }
         confirmVerified(monkey)
     }
 
     @Test
     fun givenOne21AndTargetInformed_multipleMessagesShouldBeSent() = runTest {
         val config = ActionType.SendMessage(UserCount.single(), 1u, 1u, listOf("One21", "group1"))
-        mockkObject(MonkeyPool)
+        val monkeyPool = mockk<MonkeyPool>()
         mockkObject(ConversationPool)
         val monkey = mockk<Monkey>(relaxed = true)
         val targetMonkey = mockk<Monkey>(relaxed = true)
@@ -85,12 +85,12 @@ class SendMessageActionTest {
         every { ConversationPool.getFromPrefixed("group1") } returns listOf(conversation)
         every { conversation.randomMonkeys(config.userCount) } returns listOf(monkey)
 
-        every { MonkeyPool.randomLoggedInMonkeys(config.userCount) } returns listOf(monkey)
-        coEvery { monkey.randomPeer() } returns targetMonkey
-        SendMessageAction(config).execute(coreLogic)
+        every { monkeyPool.randomLoggedInMonkeys(config.userCount) } returns listOf(monkey)
+        coEvery { monkey.randomPeer(monkeyPool) } returns targetMonkey
+        SendMessageAction(config).execute(coreLogic, monkeyPool)
         coVerify(exactly = 1) { monkey.sendDirectMessageTo(targetMonkey, any()) }
         coVerify(exactly = 1) { monkey.sendMessageTo(any(), any()) }
-        coVerify(exactly = 1) { monkey.randomPeer() }
+        coVerify(exactly = 1) { monkey.randomPeer(monkeyPool) }
         verify { conversation.randomMonkeys(config.userCount) }
         verify { conversation.conversation }
         verify { conversation.conversation.name }

--- a/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/SendRequestActionTest.kt
+++ b/monkeys/src/test/kotlin/com/wire/kalium/monkeys/actions/SendRequestActionTest.kt
@@ -9,7 +9,6 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -18,13 +17,13 @@ class SendRequestActionTest {
     @Test
     fun givenAcceptRequestConfig_shouldAcceptRequest() = runTest {
         val config = ActionType.SendRequest(UserCount.single(), UserCount.single(), "wire.com", "wearezeta.com", 0u)
-        mockkObject(MonkeyPool)
+        val monkeyPool = mockk<MonkeyPool>()
         val monkeyOrigin = mockk<Monkey>(relaxed = true)
         val monkeyTarget = mockk<Monkey>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
-        every { MonkeyPool.randomLoggedInMonkeysFromTeam(config.originTeam, UserCount.single()) } returns listOf(monkeyOrigin)
-        every { MonkeyPool.randomLoggedInMonkeysFromTeam(config.targetTeam, UserCount.single()) } returns listOf(monkeyTarget)
-        SendRequestAction(config).execute(coreLogic)
+        every { monkeyPool.randomLoggedInMonkeysFromTeam(config.originTeam, UserCount.single()) } returns listOf(monkeyOrigin)
+        every { monkeyPool.randomLoggedInMonkeysFromTeam(config.targetTeam, UserCount.single()) } returns listOf(monkeyTarget)
+        SendRequestAction(config).execute(coreLogic, monkeyPool)
         coVerify(exactly = 1) { monkeyOrigin.sendRequest(monkeyTarget) }
         coVerify(exactly = 1) { monkeyTarget.acceptRequest(monkeyOrigin) }
         confirmVerified(monkeyOrigin)
@@ -34,13 +33,13 @@ class SendRequestActionTest {
     @Test
     fun givenRejectRequestConfig_shouldRejectRequest() = runTest {
         val config = ActionType.SendRequest(UserCount.single(), UserCount.single(), "wire.com", "wearezeta.com", 0u, false)
-        mockkObject(MonkeyPool)
+        val monkeyPool = mockk<MonkeyPool>()
         val monkeyOrigin = mockk<Monkey>(relaxed = true)
         val monkeyTarget = mockk<Monkey>(relaxed = true)
         val coreLogic = mockk<CoreLogic>()
-        every { MonkeyPool.randomLoggedInMonkeysFromTeam(config.originTeam, UserCount.single()) } returns listOf(monkeyOrigin)
-        every { MonkeyPool.randomLoggedInMonkeysFromTeam(config.targetTeam, UserCount.single()) } returns listOf(monkeyTarget)
-        SendRequestAction(config).execute(coreLogic)
+        every { monkeyPool.randomLoggedInMonkeysFromTeam(config.originTeam, UserCount.single()) } returns listOf(monkeyOrigin)
+        every { monkeyPool.randomLoggedInMonkeysFromTeam(config.targetTeam, UserCount.single()) } returns listOf(monkeyTarget)
+        SendRequestAction(config).execute(coreLogic, monkeyPool)
         coVerify(exactly = 1) { monkeyOrigin.sendRequest(monkeyTarget) }
         coVerify(exactly = 1) { monkeyTarget.rejectRequest(monkeyOrigin) }
         confirmVerified(monkeyOrigin)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds support to run multiple clients within the test. Each test case in the config will use a separate client for the users in the test.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
