### PR TITLE
feat: move mls specific endpoints to v5 and enable dev support pt.2 (WPB-1124)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/FeatureSupportImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/FeatureSupportImpl.kt
@@ -28,5 +28,5 @@ class FeatureSupportImpl(
     apiVersion: Int
 ) : FeatureSupport {
 
-    override val isMLSSupported: Boolean = kaliumConfigs.isMLSSupportEnabled && apiVersion >= 4
+    override val isMLSSupported: Boolean = kaliumConfigs.isMLSSupportEnabled && apiVersion >= 5
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.network.tools.ApiVersionDTO
 import com.wire.kalium.network.tools.ServerConfigDTO
 
 val SupportedApiVersions = setOf(0, 1, 2, 3)
-val DevelopmentApiVersions = setOf(4)
+val DevelopmentApiVersions = setOf(4, 5)
 
 interface BackendMetaDataUtil {
     fun calculateApiVersion(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/e2ei/E2EIApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/e2ei/E2EIApi.kt
@@ -26,7 +26,7 @@ interface E2EIApi {
     suspend fun getWireNonce(clientId: String): NetworkResponse<String>
 
     companion object {
-        fun getApiNotSupportError(apiName: String, apiVersion: String = "4") = NetworkResponse.Error(
+        fun getApiNotSupportError(apiName: String, apiVersion: String = "5") = NetworkResponse.Error(
             APINotSupported("${this::class.simpleName}: $apiName api is only available on API V$apiVersion")
         )
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -235,7 +235,7 @@ internal open class ConversationApiV0 internal constructor(
 
     override suspend fun fetchGroupInfo(conversationId: QualifiedID): NetworkResponse<ByteArray> =
         NetworkResponse.Error(
-            APINotSupported("MLS: fetchGroupInfo api is only available on API V3")
+            APINotSupported("MLS: fetchGroupInfo api is only available on API V5")
         )
 
     override suspend fun joinConversation(
@@ -269,7 +269,7 @@ internal open class ConversationApiV0 internal constructor(
         subconversationId: SubconversationId
     ): NetworkResponse<SubconversationResponse> =
         NetworkResponse.Error(
-            APINotSupported("MLS: fetchSubconversationDetails api is only available on API V3")
+            APINotSupported("MLS: fetchSubconversationDetails api is only available on API V5")
         )
 
     override suspend fun fetchSubconversationGroupInfo(
@@ -277,7 +277,7 @@ internal open class ConversationApiV0 internal constructor(
         subconversationId: SubconversationId
     ): NetworkResponse<ByteArray> =
         NetworkResponse.Error(
-            APINotSupported("MLS: fetchSubconversationGroupInfo api is only available on API V3")
+            APINotSupported("MLS: fetchSubconversationGroupInfo api is only available on API V5")
         )
 
     override suspend fun deleteSubconversation(
@@ -286,7 +286,7 @@ internal open class ConversationApiV0 internal constructor(
         deleteRequest: SubconversationDeleteRequest
     ): NetworkResponse<Unit> =
         NetworkResponse.Error(
-            APINotSupported("MLS: deleteSubconversation api is only available on API V3")
+            APINotSupported("MLS: deleteSubconversation api is only available on API V5")
         )
 
     override suspend fun leaveSubconversation(
@@ -294,7 +294,7 @@ internal open class ConversationApiV0 internal constructor(
         subconversationId: SubconversationId
     ): NetworkResponse<Unit> =
         NetworkResponse.Error(
-            APINotSupported("MLS: leaveSubconversation api is only available on API V3")
+            APINotSupported("MLS: leaveSubconversation api is only available on API V5")
         )
 
     protected suspend fun handleConversationMemberAddedResponse(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/KeyPackageApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/KeyPackageApiV0.kt
@@ -29,18 +29,18 @@ internal open class KeyPackageApiV0 internal constructor() : KeyPackageApi {
     override suspend fun claimKeyPackages(
         param: KeyPackageApi.Param
     ): NetworkResponse<ClaimedKeyPackageList> = NetworkResponse.Error(
-        APINotSupported("MLS: claimKeyPackages api is only available on API V4")
+        APINotSupported("MLS: claimKeyPackages api is only available on API V5")
     )
 
     override suspend fun uploadKeyPackages(
         clientId: String,
         keyPackages: List<KeyPackage>
     ): NetworkResponse<Unit> = NetworkResponse.Error(
-        APINotSupported("MLS: uploadKeyPackages api is only available on API V4")
+        APINotSupported("MLS: uploadKeyPackages api is only available on API V5")
     )
 
     override suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO> =
         NetworkResponse.Error(
-            APINotSupported("MLS: getAvailableKeyPackageCount api is only available on API V4")
+            APINotSupported("MLS: getAvailableKeyPackageCount api is only available on API V5")
         )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MLSMessageApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MLSMessageApiV0.kt
@@ -26,11 +26,11 @@ import com.wire.kalium.network.utils.NetworkResponse
 internal open class MLSMessageApiV0 internal constructor() : MLSMessageApi {
 
     override suspend fun sendMessage(message: MLSMessageApi.Message): NetworkResponse<SendMLSMessageResponse> = NetworkResponse.Error(
-        APINotSupported("MLS: sendMessage api is only available on API V4")
+        APINotSupported("MLS: sendMessage api is only available on API V5")
     )
 
     override suspend fun sendCommitBundle(bundle: MLSMessageApi.CommitBundle): NetworkResponse<SendMLSMessageResponse> =
         NetworkResponse.Error(
-            APINotSupported("MLS: sendCommitBundle api is only available on API V4")
+            APINotSupported("MLS: sendCommitBundle api is only available on API V5")
         )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MLSPublicKeyApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MLSPublicKeyApiV0.kt
@@ -25,6 +25,6 @@ import com.wire.kalium.network.utils.NetworkResponse
 
 open class MLSPublicKeyApiV0 internal constructor() : MLSPublicKeyApi {
     override suspend fun getMLSPublicKeys(): NetworkResponse<MLSPublicKeysDTO> = NetworkResponse.Error(
-        APINotSupported("MLS: getMLSPublicKeys api is only available on API V4")
+        APINotSupported("MLS: getMLSPublicKeys api is only available on API V5")
     )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.network.api.base.model.ApiModelMapperImpl
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.GenerateGuestLinkRequest
 import com.wire.kalium.network.api.base.model.JoinConversationRequestV4
-import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.SubconversationId
 import com.wire.kalium.network.api.v3.authenticated.ConversationApiV3
 import com.wire.kalium.network.exceptions.KaliumException
@@ -63,58 +62,6 @@ internal open class ConversationApiV4 internal constructor(
             }
         }.mapSuccess { conversationResponseV4 ->
             apiModelMapper.fromApiV3(conversationResponseV4)
-        }
-
-    override suspend fun fetchGroupInfo(conversationId: QualifiedID): NetworkResponse<ByteArray> =
-        wrapKaliumResponse {
-            httpClient.get(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_GROUP_INFO"
-            )
-        }
-
-    override suspend fun fetchSubconversationDetails(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId
-    ): NetworkResponse<SubconversationResponse> =
-        wrapKaliumResponse {
-            httpClient.get(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}" +
-                        "/$PATH_SUBCONVERSATIONS/$subconversationId"
-            )
-        }
-
-    override suspend fun fetchSubconversationGroupInfo(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId
-    ): NetworkResponse<ByteArray> =
-        wrapKaliumResponse {
-            httpClient.get(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/" +
-                        "$PATH_SUBCONVERSATIONS/$subconversationId/$PATH_GROUP_INFO"
-            )
-        }
-
-    override suspend fun deleteSubconversation(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId,
-        deleteRequest: SubconversationDeleteRequest
-    ): NetworkResponse<Unit> =
-        wrapKaliumResponse {
-            httpClient.delete(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_SUBCONVERSATIONS/$subconversationId"
-            ) {
-                setBody(deleteRequest)
-            }
-        }
-
-    override suspend fun leaveSubconversation(
-        conversationId: ConversationId,
-        subconversationId: SubconversationId
-    ): NetworkResponse<Unit> =
-        wrapKaliumResponse {
-            httpClient.delete(
-                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_SUBCONVERSATIONS/$subconversationId/self"
-            )
         }
 
     override suspend fun joinConversation(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationApiV4.kt
@@ -23,8 +23,6 @@ import com.wire.kalium.network.api.base.authenticated.conversation.AddConversati
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberAddedResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponseV3
 import com.wire.kalium.network.api.base.authenticated.conversation.CreateConversationRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.model.ConversationCodeInfo
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ApiModelMapper
@@ -32,7 +30,6 @@ import com.wire.kalium.network.api.base.model.ApiModelMapperImpl
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.GenerateGuestLinkRequest
 import com.wire.kalium.network.api.base.model.JoinConversationRequestV4
-import com.wire.kalium.network.api.base.model.SubconversationId
 import com.wire.kalium.network.api.v3.authenticated.ConversationApiV3
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
@@ -40,7 +37,6 @@ import com.wire.kalium.network.utils.handleUnsuccessfulResponse
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapFederationResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/E2EIApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/E2EIApiV4.kt
@@ -17,56 +17,6 @@
  */
 package com.wire.kalium.network.api.v4.authenticated
 
-import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.base.authenticated.e2ei.AccessTokenResponse
-import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
-import com.wire.kalium.network.serialization.JoseJson
-import com.wire.kalium.network.utils.CustomErrors
-import com.wire.kalium.network.utils.NetworkResponse
-import com.wire.kalium.network.utils.handleUnsuccessfulResponse
-import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.post
-import io.ktor.client.request.prepareHead
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
-import io.ktor.http.isSuccess
+import com.wire.kalium.network.api.v3.authenticated.E2EIApiV3
 
-internal open class E2EIApiV4 internal constructor(private val authenticatedNetworkClient: AuthenticatedNetworkClient) : E2EIApi {
-
-    private val httpClient get() = authenticatedNetworkClient.httpClient
-
-    override suspend fun getWireNonce(clientId: String): NetworkResponse<String> =
-        httpClient.prepareHead("$PATH_CLIENTS/$clientId/$PATH_NONCE") {
-            contentType(ContentType.Application.JoseJson)
-        }.execute { httpResponse ->
-            handleNonceResponse(httpResponse)
-        }
-
-    private suspend fun handleNonceResponse(
-        httpResponse: HttpResponse
-    ): NetworkResponse<String> = if (httpResponse.status.isSuccess())
-        httpResponse.headers[NONCE_HEADER_KEY]?.let { nonce ->
-            NetworkResponse.Success(nonce, httpResponse)
-        } ?: run {
-            CustomErrors.MISSING_NONCE
-        }
-    else {
-        handleUnsuccessfulResponse(httpResponse)
-    }
-
-    override suspend fun getAccessToken(clientId: String, dpopToken: String): NetworkResponse<AccessTokenResponse> = wrapKaliumResponse {
-        httpClient.post("$PATH_CLIENTS/$clientId/$PATH_ACCESS_TOKEN") {
-            headers.append(DPOP_HEADER_KEY, dpopToken)
-        }
-    }
-
-    private companion object {
-        const val PATH_CLIENTS = "clients"
-        const val PATH_NONCE = "nonce"
-        const val PATH_ACCESS_TOKEN = "access-token"
-
-        const val DPOP_HEADER_KEY = "dpop"
-        const val NONCE_HEADER_KEY = "Replay-Nonce"
-    }
-}
+internal open class E2EIApiV4 internal constructor() : E2EIApiV3()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/KeyPackageApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/KeyPackageApiV4.kt
@@ -18,56 +18,6 @@
 
 package com.wire.kalium.network.api.v4.authenticated
 
-import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.base.authenticated.keypackage.ClaimedKeyPackageList
-import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackage
-import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
-import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageCountDTO
-import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageList
 import com.wire.kalium.network.api.v3.authenticated.KeyPackageApiV3
-import com.wire.kalium.network.kaliumLogger
-import com.wire.kalium.network.utils.NetworkResponse
-import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.get
-import io.ktor.client.request.parameter
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
 
-internal open class KeyPackageApiV4 internal constructor(
-    private val authenticatedNetworkClient: AuthenticatedNetworkClient
-) : KeyPackageApiV3() {
-
-    private val httpClient get() = authenticatedNetworkClient.httpClient
-
-    override suspend fun claimKeyPackages(
-        param: KeyPackageApi.Param
-    ): NetworkResponse<ClaimedKeyPackageList> = wrapKaliumResponse {
-        httpClient.post("$PATH_KEY_PACKAGES/$PATH_CLAIM/${param.user.domain}/${param.user.value}") {
-            if (param is KeyPackageApi.Param.SkipOwnClient) {
-                parameter(QUERY_SKIP_OWN, param.selfClientId)
-            }
-        }
-    }
-
-    override suspend fun uploadKeyPackages(
-        clientId: String,
-        keyPackages: List<KeyPackage>
-    ): NetworkResponse<Unit> =
-        wrapKaliumResponse {
-            kaliumLogger.v("Keypackages Count: ${keyPackages.size}")
-            httpClient.post("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId") {
-                setBody(KeyPackageList(keyPackages))
-            }
-        }
-
-    override suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO> =
-        wrapKaliumResponse { httpClient.get("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId/$PATH_COUNT") }
-
-    private companion object {
-        const val PATH_KEY_PACKAGES = "mls/key-packages"
-        const val PATH_CLAIM = "claim"
-        const val PATH_SELF = "self"
-        const val PATH_COUNT = "count"
-        const val QUERY_SKIP_OWN = "skip_own"
-    }
-}
+internal open class KeyPackageApiV4 internal constructor() : KeyPackageApiV3()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/MLSMessageApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/MLSMessageApiV4.kt
@@ -18,42 +18,6 @@
 
 package com.wire.kalium.network.api.v4.authenticated
 
-import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
-import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
 import com.wire.kalium.network.api.v3.authenticated.MLSMessageApiV3
-import com.wire.kalium.network.serialization.Mls
-import com.wire.kalium.network.utils.NetworkResponse
-import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
 
-internal open class MLSMessageApiV4 internal constructor(
-    private val authenticatedNetworkClient: AuthenticatedNetworkClient
-) : MLSMessageApiV3() {
-
-    private val httpClient get() = authenticatedNetworkClient.httpClient
-
-    override suspend fun sendMessage(message: MLSMessageApi.Message): NetworkResponse<SendMLSMessageResponse> =
-        wrapKaliumResponse {
-            httpClient.post(PATH_MESSAGE) {
-                setBody(message.value)
-                contentType(ContentType.Message.Mls)
-            }
-        }
-
-    override suspend fun sendCommitBundle(bundle: MLSMessageApi.CommitBundle): NetworkResponse<SendMLSMessageResponse> =
-        wrapKaliumResponse {
-            httpClient.post(PATH_COMMIT_BUNDLES) {
-                setBody(bundle.value)
-                contentType(ContentType.Message.Mls)
-            }
-        }
-
-    private companion object {
-        const val PATH_COMMIT_BUNDLES = "mls/commit-bundles"
-        const val PATH_MESSAGE = "mls/messages"
-    }
-}
+internal open class MLSMessageApiV4 internal constructor() : MLSMessageApiV3()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/MLSPublicKeyApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/MLSPublicKeyApiV4.kt
@@ -18,24 +18,6 @@
 
 package com.wire.kalium.network.api.v4.authenticated
 
-import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.base.authenticated.serverpublickey.MLSPublicKeysDTO
 import com.wire.kalium.network.api.v3.authenticated.MLSPublicKeyApiV3
-import com.wire.kalium.network.utils.NetworkResponse
-import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.get
 
-internal open class MLSPublicKeyApiV4 internal constructor(
-    private val authenticatedNetworkClient: AuthenticatedNetworkClient
-) : MLSPublicKeyApiV3() {
-
-    private val httpClient get() = authenticatedNetworkClient.httpClient
-
-    override suspend fun getMLSPublicKeys(): NetworkResponse<MLSPublicKeysDTO> =
-        wrapKaliumResponse { httpClient.get("$PATH_MLS/$PATH_PUBLIC_KEYS") }
-
-    private companion object {
-        const val PATH_PUBLIC_KEYS = "public-keys"
-        const val PATH_MLS = "mls"
-    }
-}
+internal open class MLSPublicKeyApiV4 internal constructor() : MLSPublicKeyApiV3()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
@@ -92,13 +92,13 @@ internal class AuthenticatedNetworkContainerV4 internal constructor(
 
     override val messageApi: MessageApi get() = MessageApiV4(networkClient, EnvelopeProtoMapperImpl())
 
-    override val mlsMessageApi: MLSMessageApi get() = MLSMessageApiV4(networkClient)
+    override val mlsMessageApi: MLSMessageApi get() = MLSMessageApiV4()
 
     override val e2eiApi: E2EIApi get() = E2EIApiV4(networkClient)
 
     override val conversationApi: ConversationApi get() = ConversationApiV4(networkClient)
 
-    override val keyPackageApi: KeyPackageApi get() = KeyPackageApiV4(networkClient)
+    override val keyPackageApi: KeyPackageApi get() = KeyPackageApiV4()
 
     override val preKeyApi: PreKeyApi get() = PreKeyApiV4(networkClient)
 
@@ -120,7 +120,7 @@ internal class AuthenticatedNetworkContainerV4 internal constructor(
 
     override val featureConfigApi: FeatureConfigApi get() = FeatureConfigApiV4(networkClient)
 
-    override val mlsPublicKeyApi: MLSPublicKeyApi get() = MLSPublicKeyApiV4(networkClient)
+    override val mlsPublicKeyApi: MLSPublicKeyApi get() = MLSPublicKeyApiV4()
 
     override val propertiesApi: PropertiesApi get() = PropertiesApiV4(networkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
@@ -94,7 +94,7 @@ internal class AuthenticatedNetworkContainerV4 internal constructor(
 
     override val mlsMessageApi: MLSMessageApi get() = MLSMessageApiV4()
 
-    override val e2eiApi: E2EIApi get() = E2EIApiV4(networkClient)
+    override val e2eiApi: E2EIApi get() = E2EIApiV4()
 
     override val conversationApi: ConversationApi get() = ConversationApiV4(networkClient)
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/ConversationApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/ConversationApiV5.kt
@@ -19,8 +19,73 @@
 package com.wire.kalium.network.api.v5.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
+import com.wire.kalium.network.api.base.model.ConversationId
+import com.wire.kalium.network.api.base.model.QualifiedID
+import com.wire.kalium.network.api.base.model.SubconversationId
 import com.wire.kalium.network.api.v4.authenticated.ConversationApiV4
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.setBody
 
 internal open class ConversationApiV5 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient,
-) : ConversationApiV4(authenticatedNetworkClient)
+) : ConversationApiV4(authenticatedNetworkClient) {
+
+    override suspend fun fetchGroupInfo(conversationId: QualifiedID): NetworkResponse<ByteArray> =
+        wrapKaliumResponse {
+            httpClient.get(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_GROUP_INFO"
+            )
+        }
+
+    override suspend fun fetchSubconversationGroupInfo(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<ByteArray> =
+        wrapKaliumResponse {
+            httpClient.get(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/" +
+                        "$PATH_SUBCONVERSATIONS/$subconversationId/$PATH_GROUP_INFO"
+            )
+        }
+
+    override suspend fun fetchSubconversationDetails(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<SubconversationResponse> =
+        wrapKaliumResponse {
+            httpClient.get(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}" +
+                        "/$PATH_SUBCONVERSATIONS/$subconversationId"
+            )
+        }
+
+    override suspend fun deleteSubconversation(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId,
+        deleteRequest: SubconversationDeleteRequest
+    ): NetworkResponse<Unit> =
+        wrapKaliumResponse {
+            httpClient.delete(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_SUBCONVERSATIONS/$subconversationId"
+            ) {
+                setBody(deleteRequest)
+            }
+        }
+
+    override suspend fun leaveSubconversation(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<Unit> =
+        wrapKaliumResponse {
+            httpClient.delete(
+                "$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_SUBCONVERSATIONS/$subconversationId/self"
+            )
+        }
+
+
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/ConversationApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/ConversationApiV5.kt
@@ -87,5 +87,4 @@ internal open class ConversationApiV5 internal constructor(
             )
         }
 
-
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/E2EIApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/E2EIApiV5.kt
@@ -18,8 +18,56 @@
 package com.wire.kalium.network.api.v5.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.e2ei.AccessTokenResponse
 import com.wire.kalium.network.api.v4.authenticated.E2EIApiV4
+import com.wire.kalium.network.serialization.JoseJson
+import com.wire.kalium.network.utils.CustomErrors
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.handleUnsuccessfulResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.prepareHead
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 
 internal open class E2EIApiV5 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient
-) : E2EIApiV4(authenticatedNetworkClient)
+) : E2EIApiV4() {
+    private val httpClient get() = authenticatedNetworkClient.httpClient
+
+    override suspend fun getWireNonce(clientId: String): NetworkResponse<String> =
+        httpClient.prepareHead("$PATH_CLIENTS/$clientId/$PATH_NONCE") {
+            contentType(ContentType.Application.JoseJson)
+        }.execute { httpResponse ->
+            handleNonceResponse(httpResponse)
+        }
+
+    private suspend fun handleNonceResponse(
+        httpResponse: HttpResponse
+    ): NetworkResponse<String> = if (httpResponse.status.isSuccess())
+        httpResponse.headers[NONCE_HEADER_KEY]?.let { nonce ->
+            NetworkResponse.Success(nonce, httpResponse)
+        } ?: run {
+            CustomErrors.MISSING_NONCE
+        }
+    else {
+        handleUnsuccessfulResponse(httpResponse)
+    }
+
+    override suspend fun getAccessToken(clientId: String, dpopToken: String): NetworkResponse<AccessTokenResponse> = wrapKaliumResponse {
+        httpClient.post("$PATH_CLIENTS/$clientId/$PATH_ACCESS_TOKEN") {
+            headers.append(DPOP_HEADER_KEY, dpopToken)
+        }
+    }
+
+    private companion object {
+        const val PATH_CLIENTS = "clients"
+        const val PATH_NONCE = "nonce"
+        const val PATH_ACCESS_TOKEN = "access-token"
+
+        const val DPOP_HEADER_KEY = "dpop"
+        const val NONCE_HEADER_KEY = "Replay-Nonce"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
@@ -19,8 +19,54 @@
 package com.wire.kalium.network.api.v5.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.keypackage.ClaimedKeyPackageList
+import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackage
+import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
+import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageCountDTO
+import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageList
 import com.wire.kalium.network.api.v4.authenticated.KeyPackageApiV4
+import com.wire.kalium.network.kaliumLogger
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 
 internal open class KeyPackageApiV5 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient
-) : KeyPackageApiV4(authenticatedNetworkClient)
+) : KeyPackageApiV4() {
+    private val httpClient get() = authenticatedNetworkClient.httpClient
+
+    override suspend fun claimKeyPackages(
+        param: KeyPackageApi.Param
+    ): NetworkResponse<ClaimedKeyPackageList> = wrapKaliumResponse {
+        httpClient.post("$PATH_KEY_PACKAGES/$PATH_CLAIM/${param.user.domain}/${param.user.value}") {
+            if (param is KeyPackageApi.Param.SkipOwnClient) {
+                parameter(QUERY_SKIP_OWN, param.selfClientId)
+            }
+        }
+    }
+
+    override suspend fun uploadKeyPackages(
+        clientId: String,
+        keyPackages: List<KeyPackage>
+    ): NetworkResponse<Unit> =
+        wrapKaliumResponse {
+            kaliumLogger.v("Keypackages Count: ${keyPackages.size}")
+            httpClient.post("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId") {
+                setBody(KeyPackageList(keyPackages))
+            }
+        }
+
+    override suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO> =
+        wrapKaliumResponse { httpClient.get("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId/$PATH_COUNT") }
+
+    private companion object {
+        const val PATH_KEY_PACKAGES = "mls/key-packages"
+        const val PATH_CLAIM = "claim"
+        const val PATH_SELF = "self"
+        const val PATH_COUNT = "count"
+        const val QUERY_SKIP_OWN = "skip_own"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/MLSMessageApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/MLSMessageApiV5.kt
@@ -19,8 +19,40 @@
 package com.wire.kalium.network.api.v5.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
+import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
 import com.wire.kalium.network.api.v4.authenticated.MLSMessageApiV4
+import com.wire.kalium.network.serialization.Mls
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 
 internal open class MLSMessageApiV5 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient
-) : MLSMessageApiV4(authenticatedNetworkClient)
+) : MLSMessageApiV4() {
+    private val httpClient get() = authenticatedNetworkClient.httpClient
+
+    override suspend fun sendMessage(message: MLSMessageApi.Message): NetworkResponse<SendMLSMessageResponse> =
+        wrapKaliumResponse {
+            httpClient.post(PATH_MESSAGE) {
+                setBody(message.value)
+                contentType(ContentType.Message.Mls)
+            }
+        }
+
+    override suspend fun sendCommitBundle(bundle: MLSMessageApi.CommitBundle): NetworkResponse<SendMLSMessageResponse> =
+        wrapKaliumResponse {
+            httpClient.post(PATH_COMMIT_BUNDLES) {
+                setBody(bundle.value)
+                contentType(ContentType.Message.Mls)
+            }
+        }
+
+    private companion object {
+        const val PATH_COMMIT_BUNDLES = "mls/commit-bundles"
+        const val PATH_MESSAGE = "mls/messages"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/MLSPublicKeyApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/MLSPublicKeyApiV5.kt
@@ -19,8 +19,23 @@
 package com.wire.kalium.network.api.v5.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.serverpublickey.MLSPublicKeysDTO
 import com.wire.kalium.network.api.v4.authenticated.MLSPublicKeyApiV4
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.get
 
 internal open class MLSPublicKeyApiV5 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient
-) : MLSPublicKeyApiV4(authenticatedNetworkClient)
+) : MLSPublicKeyApiV4() {
+
+    private val httpClient get() = authenticatedNetworkClient.httpClient
+
+    override suspend fun getMLSPublicKeys(): NetworkResponse<MLSPublicKeysDTO> =
+        wrapKaliumResponse { httpClient.get("$PATH_MLS/$PATH_PUBLIC_KEYS") }
+
+    private companion object {
+        const val PATH_PUBLIC_KEYS = "public-keys"
+        const val PATH_MLS = "mls"
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v4/ConversationApiV4Test.kt
@@ -22,17 +22,12 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.json.model.ErrorResponseJson
 import com.wire.kalium.model.EventContentDTOJson
 import com.wire.kalium.model.conversation.CreateConversationRequestJson
-import com.wire.kalium.model.conversation.SubconversationDeleteRequestJson
-import com.wire.kalium.model.conversation.SubconversationDetailsResponseJson
 import com.wire.kalium.network.api.base.authenticated.conversation.AddConversationMembersRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.FederationConflictResponse
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v4.authenticated.ConversationApiV4
 import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.UnreachableRemoteBackends
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
@@ -40,7 +35,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 internal class ConversationApiV4Test : ApiTest() {
@@ -72,108 +66,6 @@ internal class ConversationApiV4Test : ApiTest() {
                 conflictingBackends
             )
         }
-
-    @Test
-    fun givenRequest_whenFetchingSubconversationDetails_thenRequestIsConfiguredCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            SubconversationDetailsResponseJson.v4.rawJson,
-            statusCode = HttpStatusCode.OK,
-            assertion = {
-                assertGet()
-                assertPathEqual(
-                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
-                )
-            }
-        )
-
-        val conversationApi = ConversationApiV4(networkClient)
-        conversationApi.fetchSubconversationDetails(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub"
-        )
-    }
-
-    @Test
-    fun givenSuccessSubconversationDetails_whenFetchingSubconversationDetails_thenResponseIsParsedCorrectly() =
-        runTest {
-            val networkClient = mockAuthenticatedNetworkClient(
-                SubconversationDetailsResponseJson.v4.rawJson,
-                statusCode = HttpStatusCode.OK
-            )
-
-            val conversationApi = ConversationApiV4(networkClient)
-            conversationApi.fetchSubconversationDetails(
-                ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-                "sub"
-            ).also {
-                assertIs<NetworkResponse.Success<SubconversationResponse>>(it)
-            }
-        }
-
-    @Test
-    fun givenRequest_whenFetchingSubconversationGroupInfo_thenRequestIsConfiguredCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            "groupinfo".encodeToByteArray(),
-            statusCode = HttpStatusCode.OK,
-            assertion = {
-                assertGet()
-                assertPathEqual(
-                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub/groupinfo"
-                )
-            }
-        )
-
-        val conversationApi = ConversationApiV4(networkClient)
-        conversationApi.fetchSubconversationGroupInfo(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub"
-        ).also {
-            assertIs<NetworkResponse.Success<ByteArray>>(it)
-        }
-    }
-
-    @Test
-    fun givenRequest_whenDeletingSubconversation_thenRequestIsConfiguredCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            ByteArray(0),
-            statusCode = HttpStatusCode.OK,
-            assertion = {
-                assertDelete()
-                assertPathEqual(
-                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
-                )
-                assertJsonBodyContent(SubconversationDeleteRequestJson.v4.rawJson)
-            }
-        )
-
-        val deleteRequest = SubconversationDeleteRequest(43UL, "groupid")
-        val conversationApi = ConversationApiV4(networkClient)
-        conversationApi.deleteSubconversation(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub",
-            deleteRequest
-        )
-    }
-
-    @Test
-    fun givenRequest_whenLeavingSubconversation_thenRequestIsConfiguredCorrectly() = runTest {
-        val networkClient = mockAuthenticatedNetworkClient(
-            ByteArray(0),
-            statusCode = HttpStatusCode.OK,
-            assertion = {
-                assertDelete()
-                assertPathEqual(
-                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub/self"
-                )
-            }
-        )
-
-        val conversationApi = ConversationApiV4(networkClient)
-        conversationApi.leaveSubconversation(
-            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
-            "sub",
-        )
-    }
 
     @Test
     fun whenAddingMemberToGroup_AndRemoteFailureUnreachable_thenTheMemberShouldBeAddedCorrectly() = runTest {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v5/ConversationApiV5Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v5/ConversationApiV5Test.kt
@@ -1,0 +1,145 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.api.v5
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.model.conversation.CreateConversationRequestJson
+import com.wire.kalium.model.conversation.SubconversationDeleteRequestJson
+import com.wire.kalium.model.conversation.SubconversationDetailsResponseJson
+import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
+import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
+import com.wire.kalium.network.api.base.model.ConversationId
+import com.wire.kalium.network.api.v4.authenticated.ConversationApiV4
+import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+internal class ConversationApiV5Test : ApiTest() {
+
+
+    @Test
+    fun givenRequest_whenFetchingSubconversationDetails_thenRequestIsConfiguredCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            SubconversationDetailsResponseJson.v4.rawJson,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual(
+                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
+                )
+            }
+        )
+
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.fetchSubconversationDetails(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub"
+        )
+    }
+
+    @Test
+    fun givenSuccessSubconversationDetails_whenFetchingSubconversationDetails_thenResponseIsParsedCorrectly() =
+        runTest {
+            val networkClient = mockAuthenticatedNetworkClient(
+                SubconversationDetailsResponseJson.v4.rawJson,
+                statusCode = HttpStatusCode.OK
+            )
+
+            val conversationApi = ConversationApiV4(networkClient)
+            conversationApi.fetchSubconversationDetails(
+                ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+                "sub"
+            ).also {
+                assertIs<NetworkResponse.Success<SubconversationResponse>>(it)
+            }
+        }
+
+    @Test
+    fun givenRequest_whenFetchingSubconversationGroupInfo_thenRequestIsConfiguredCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            "groupinfo".encodeToByteArray(),
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual(
+                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub/groupinfo"
+                )
+            }
+        )
+
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.fetchSubconversationGroupInfo(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub"
+        ).also {
+            assertIs<NetworkResponse.Success<ByteArray>>(it)
+        }
+    }
+
+    @Test
+    fun givenRequest_whenDeletingSubconversation_thenRequestIsConfiguredCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            ByteArray(0),
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertDelete()
+                assertPathEqual(
+                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub"
+                )
+                assertJsonBodyContent(SubconversationDeleteRequestJson.v4.rawJson)
+            }
+        )
+
+        val deleteRequest = SubconversationDeleteRequest(43UL, "groupid")
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.deleteSubconversation(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub",
+            deleteRequest
+        )
+    }
+
+    @Test
+    fun givenRequest_whenLeavingSubconversation_thenRequestIsConfiguredCorrectly() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            ByteArray(0),
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertDelete()
+                assertPathEqual(
+                    "/conversations/anta.wire.link/ebafd3d4-1548-49f2-ac4e-b2757e6ca44b/subconversations/sub/self"
+                )
+            }
+        )
+
+        val conversationApi = ConversationApiV4(networkClient)
+        conversationApi.leaveSubconversation(
+            ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
+            "sub",
+        )
+    }
+
+    private companion object {
+        const val PATH_CONVERSATIONS = "/conversations"
+        const val PATH_MEMBERS = "members"
+        val CREATE_CONVERSATION_REQUEST = CreateConversationRequestJson.v3
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v5/ConversationApiV5Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v5/ConversationApiV5Test.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.model.conversation.SubconversationDetailsResponseJson
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.model.ConversationId
-import com.wire.kalium.network.api.v4.authenticated.ConversationApiV4
+import com.wire.kalium.network.api.v5.authenticated.ConversationApiV5
 import com.wire.kalium.network.utils.NetworkResponse
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
@@ -38,7 +38,7 @@ internal class ConversationApiV5Test : ApiTest() {
     @Test
     fun givenRequest_whenFetchingSubconversationDetails_thenRequestIsConfiguredCorrectly() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
-            SubconversationDetailsResponseJson.v4.rawJson,
+            SubconversationDetailsResponseJson.v5.rawJson,
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertGet()
@@ -48,7 +48,7 @@ internal class ConversationApiV5Test : ApiTest() {
             }
         )
 
-        val conversationApi = ConversationApiV4(networkClient)
+        val conversationApi = ConversationApiV5(networkClient)
         conversationApi.fetchSubconversationDetails(
             ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             "sub"
@@ -59,11 +59,11 @@ internal class ConversationApiV5Test : ApiTest() {
     fun givenSuccessSubconversationDetails_whenFetchingSubconversationDetails_thenResponseIsParsedCorrectly() =
         runTest {
             val networkClient = mockAuthenticatedNetworkClient(
-                SubconversationDetailsResponseJson.v4.rawJson,
+                SubconversationDetailsResponseJson.v5.rawJson,
                 statusCode = HttpStatusCode.OK
             )
 
-            val conversationApi = ConversationApiV4(networkClient)
+            val conversationApi = ConversationApiV5(networkClient)
             conversationApi.fetchSubconversationDetails(
                 ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
                 "sub"
@@ -85,7 +85,7 @@ internal class ConversationApiV5Test : ApiTest() {
             }
         )
 
-        val conversationApi = ConversationApiV4(networkClient)
+        val conversationApi = ConversationApiV5(networkClient)
         conversationApi.fetchSubconversationGroupInfo(
             ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             "sub"
@@ -109,7 +109,7 @@ internal class ConversationApiV5Test : ApiTest() {
         )
 
         val deleteRequest = SubconversationDeleteRequest(43UL, "groupid")
-        val conversationApi = ConversationApiV4(networkClient)
+        val conversationApi = ConversationApiV5(networkClient)
         conversationApi.deleteSubconversation(
             ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             "sub",
@@ -130,16 +130,10 @@ internal class ConversationApiV5Test : ApiTest() {
             }
         )
 
-        val conversationApi = ConversationApiV4(networkClient)
+        val conversationApi = ConversationApiV5(networkClient)
         conversationApi.leaveSubconversation(
             ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             "sub",
         )
-    }
-
-    private companion object {
-        const val PATH_CONVERSATIONS = "/conversations"
-        const val PATH_MEMBERS = "members"
-        val CREATE_CONVERSATION_REQUEST = CreateConversationRequestJson.v3
     }
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v5/E2EIApiV5Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v5/E2EIApiV5Test.kt
@@ -15,11 +15,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.api.v4
+package com.wire.kalium.api.v5
 
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
-import com.wire.kalium.network.api.v4.authenticated.E2EIApiV4
+import com.wire.kalium.network.api.v5.authenticated.E2EIApiV5
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
@@ -28,7 +28,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-internal class E2EIApiV4Test : ApiTest() {
+internal class E2EIApiV5Test : ApiTest() {
 
     @Test
     fun giveAValidResponseWithNonceInHeader_whenCallingNonceApi_theResponseShouldBeConfigureCorrectly() = runTest {
@@ -42,7 +42,7 @@ internal class E2EIApiV4Test : ApiTest() {
                 assertPathEqual(NONCE_PATH)
             }
         )
-        val e2EIApi: E2EIApi = E2EIApiV4(networkClient)
+        val e2EIApi: E2EIApi = E2EIApiV5(networkClient)
 
         val response = e2EIApi.getWireNonce(VALID_CLIENT_ID)
         assertTrue(response.isSuccessful())
@@ -60,7 +60,7 @@ internal class E2EIApiV4Test : ApiTest() {
                 assertPathEqual(NONCE_PATH)
             }
         )
-        val e2EIApi: E2EIApi = E2EIApiV4(networkClient)
+        val e2EIApi: E2EIApi = E2EIApiV5(networkClient)
 
         val response = e2EIApi.getWireNonce(VALID_CLIENT_ID)
         assertFalse(response.isSuccessful())

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v5/KeyPackageApiV5Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v5/KeyPackageApiV5Test.kt
@@ -16,13 +16,13 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.api.v4
+package com.wire.kalium.api.v5
 
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.json.model.KeyPackageJson
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
 import com.wire.kalium.network.api.base.model.UserId
-import com.wire.kalium.network.api.v4.authenticated.KeyPackageApiV4
+import com.wire.kalium.network.api.v5.authenticated.KeyPackageApiV5
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
@@ -30,7 +30,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-internal class KeyPackageApiV4Test : ApiTest() {
+internal class KeyPackageApiV5Test : ApiTest() {
 
     @Test
     fun givenAValidClientId_whenCallingGetAvailableKeyPackageCountEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
@@ -42,7 +42,7 @@ internal class KeyPackageApiV4Test : ApiTest() {
                 assertPathEqual(KEY_PACKAGE_COUNT_PATH)
             }
         )
-        val keyPackageApi: KeyPackageApi = KeyPackageApiV4(networkClient)
+        val keyPackageApi: KeyPackageApi = KeyPackageApiV5(networkClient)
 
         val response = keyPackageApi.getAvailableKeyPackageCount(VALID_CLIENT_ID)
         assertTrue(response.isSuccessful())
@@ -60,7 +60,7 @@ internal class KeyPackageApiV4Test : ApiTest() {
                 assertPathEqual(KEY_PACKAGE_UPLOAD_PATH)
             }
         )
-        val keyPackageApi: KeyPackageApi = KeyPackageApiV4(networkClient)
+        val keyPackageApi: KeyPackageApi = KeyPackageApiV5(networkClient)
 
         val response = keyPackageApi.uploadKeyPackages(VALID_CLIENT_ID, listOf(VALID_KEY_PACKAGE))
         assertTrue(response.isSuccessful())
@@ -76,7 +76,7 @@ internal class KeyPackageApiV4Test : ApiTest() {
                 assertPathEqual(KEY_PACKAGE_CLAIM_PATH)
             }
         )
-        val keyPackageApi: KeyPackageApi = KeyPackageApiV4(networkClient)
+        val keyPackageApi: KeyPackageApi = KeyPackageApiV5(networkClient)
 
         val response = keyPackageApi.claimKeyPackages(KeyPackageApi.Param.IncludeOwnClient(VALID_USER_ID))
         assertTrue(response.isSuccessful())

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v5/MLSMessageApiV5Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v5/MLSMessageApiV5Test.kt
@@ -16,15 +16,14 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.api.v4
+package com.wire.kalium.api.v5
 
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.model.SendMLSMessageResponseJson
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.api.v0.authenticated.MLSMessageApiV0
-import com.wire.kalium.network.api.v4.authenticated.MLSMessageApiV4
+import com.wire.kalium.network.api.v5.authenticated.MLSMessageApiV5
 import com.wire.kalium.network.serialization.Mls
-import com.wire.kalium.network.serialization.XProtoBuf
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -35,7 +34,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
-internal class MLSMessageApiV4Test : ApiTest() {
+internal class MLSMessageApiV5Test : ApiTest() {
 
     @Test
     fun givenMessage_whenSendingCommitBundle_theRequestShouldBeConfiguredCorrectly() =
@@ -50,7 +49,7 @@ internal class MLSMessageApiV4Test : ApiTest() {
                     assertPathEqual(PATH_COMMIT_BUNDLES)
                 }
             )
-            val mlsMessageApi: MLSMessageApi = MLSMessageApiV4(networkClient)
+            val mlsMessageApi: MLSMessageApi = MLSMessageApiV5(networkClient)
             val response = mlsMessageApi.sendCommitBundle(COMMIT_BUNDLE)
             assertTrue(response.isSuccessful())
         }
@@ -68,7 +67,7 @@ internal class MLSMessageApiV4Test : ApiTest() {
                     assertPathEqual(PATH_MESSAGE)
                 }
             )
-            val mlsMessageApi: MLSMessageApi = MLSMessageApiV4(networkClient)
+            val mlsMessageApi: MLSMessageApi = MLSMessageApiV5(networkClient)
             val response = mlsMessageApi.sendMessage(MESSAGE)
             assertTrue(response.isSuccessful())
         }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v5/MLSPublicKeysApiV5Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v5/MLSPublicKeysApiV5Test.kt
@@ -16,12 +16,12 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.api.v4
+package com.wire.kalium.api.v5
 
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.model.MLSPublicKeysResponseJson
 import com.wire.kalium.network.api.base.authenticated.serverpublickey.MLSPublicKeyApi
-import com.wire.kalium.network.api.v4.authenticated.MLSPublicKeyApiV4
+import com.wire.kalium.network.api.v5.authenticated.MLSPublicKeyApiV5
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -31,7 +31,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class MLSPublicKeysApiV4Test : ApiTest() {
+internal class MLSPublicKeysApiV5Test : ApiTest() {
 
     @Test
     fun givenWhenGetMLSPublicKeys_theRequestShouldBeConfiguredCorrectly() = runTest {
@@ -45,7 +45,7 @@ internal class MLSPublicKeysApiV4Test : ApiTest() {
                 assertPathEqual("$PATH_MLS/$PATH_PUBLIC_KEYS")
             }
         )
-        val mlsPublicKeyApi: MLSPublicKeyApi = MLSPublicKeyApiV4(networkClient)
+        val mlsPublicKeyApi: MLSPublicKeyApi = MLSPublicKeyApiV5(networkClient)
         val response = mlsPublicKeyApi.getMLSPublicKeys()
         assertTrue(response.isSuccessful())
     }

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/SubconversationDetailsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/conversation/SubconversationDetailsResponseJson.kt
@@ -27,5 +27,5 @@ object SubconversationDetailsResponseJson {
         """.trimIndent()
     }
 
-    val v4 = ValidJsonProvider("", jsonProvider)
+    val v5 = ValidJsonProvider("", jsonProvider)
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR is part 2, and contains

- Move MLS related endpoints to v5 development version.
- Enabling v5 development as BE already supports in certain environments https://nginz-https.anta.wire.link/api-version

Needs releases with:

- https://github.com/wireapp/kalium/pull/2001

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
