### PR TITLE
feat(calling): remote mute for participant (WPB-2953)

### DIFF
--- a/calling/src/commonJvmAndroid/kotlin/com.wire.kalium.calling/Calling.kt
+++ b/calling/src/commonJvmAndroid/kotlin/com.wire.kalium.calling/Calling.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.calling.callbacks.ParticipantChangedHandler
 import com.wire.kalium.calling.callbacks.ReadyHandler
 import com.wire.kalium.calling.callbacks.RequestNewEpochHandler
 import com.wire.kalium.calling.callbacks.SFTRequestHandler
+import com.wire.kalium.calling.callbacks.SelfUserMuteHandler
 import com.wire.kalium.calling.callbacks.SendHandler
 import com.wire.kalium.calling.callbacks.VideoReceiveStateHandler
 import com.wire.kalium.calling.types.Handle
@@ -175,6 +176,13 @@ interface Calling : Library {
     fun wcall_set_req_new_epoch_handler(
         inst: Handle,
         requestNewEpochHandler: RequestNewEpochHandler
+    )
+
+    @Suppress("FunctionNaming")
+    fun wcall_set_mute_handler(
+        inst: Handle,
+        selfUserMuteHandler: SelfUserMuteHandler,
+        arg: Pointer?
     )
 
     companion object {

--- a/calling/src/commonJvmAndroid/kotlin/com.wire.kalium.calling/callbacks/SelfUserMuteHandler.kt
+++ b/calling/src/commonJvmAndroid/kotlin/com.wire.kalium.calling/callbacks/SelfUserMuteHandler.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.calling.callbacks
+
+import com.sun.jna.Callback
+import com.sun.jna.Pointer
+
+interface SelfUserMuteHandler : Callback {
+    fun onMuteStateChanged(isMuted: Int, arg: Pointer?)
+}

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -58,6 +58,7 @@ import com.wire.kalium.logic.feature.call.scenario.OnConfigRequest
 import com.wire.kalium.logic.feature.call.scenario.OnEstablishedCall
 import com.wire.kalium.logic.feature.call.scenario.OnIncomingCall
 import com.wire.kalium.logic.feature.call.scenario.OnMissedCall
+import com.wire.kalium.logic.feature.call.scenario.OnMuteStateForSelfUserChanged
 import com.wire.kalium.logic.feature.call.scenario.OnNetworkQualityChanged
 import com.wire.kalium.logic.feature.call.scenario.OnParticipantListChanged
 import com.wire.kalium.logic.feature.call.scenario.OnParticipantsVideoStateChanged
@@ -416,6 +417,7 @@ class CallManagerImpl internal constructor(
         initClientsHandler()
         initActiveSpeakersHandler()
         initRequestNewEpochHandler()
+        initSelfUserMuteHandler()
     }
 
     private fun initParticipantsHandler() {
@@ -508,6 +510,25 @@ class CallManagerImpl internal constructor(
                 )
 
                 callingLogger.d("$TAG - wcall_set_req_new_epoch_handler() called")
+            }
+        }
+    }
+
+    private fun initSelfUserMuteHandler() {
+        scope.launch {
+            withCalling {
+                val selfUserMuteHandler = OnMuteStateForSelfUserChanged(
+                    scope = scope,
+                    callRepository = callRepository
+                ).keepingStrongReference()
+
+                wcall_set_mute_handler(
+                    inst = deferredHandle.await(),
+                    selfUserMuteHandler = selfUserMuteHandler,
+                    arg = null
+                )
+
+                callingLogger.d("$TAG - wcall_set_mute_handler() called")
             }
         }
     }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnMuteStateForSelfUserChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnMuteStateForSelfUserChanged.kt
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.scenario
+
+import com.sun.jna.Pointer
+import com.wire.kalium.calling.callbacks.SelfUserMuteHandler
+import com.wire.kalium.logic.callingLogger
+import com.wire.kalium.logic.data.call.CallRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+internal class OnMuteStateForSelfUserChanged(
+    private val scope: CoroutineScope,
+    private val callRepository: CallRepository
+) : SelfUserMuteHandler {
+
+    override fun onMuteStateChanged(isMuted: Int, arg: Pointer?) {
+        println("onMuteStateChanged start")
+
+        scope.launch {
+            println("onMuteStateChanged called")
+            callingLogger.i("[OnMuteStateForSelfUserChanged] - STARTED")
+            callRepository.establishedCallsFlow().first().takeIf {
+                println("call is not empty: ${it}")
+                it.isNotEmpty()
+            }?.first()?.conversationId?.let {
+                callingLogger.i("[OnMuteStateForSelfUserChanged] - conversationId: $it muted: $isMuted")
+                callRepository.updateIsMutedById(it, isMuted == 1)
+            }
+        }
+    }
+}

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnMuteStateForSelfUserChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnMuteStateForSelfUserChanged.kt
@@ -31,16 +31,12 @@ internal class OnMuteStateForSelfUserChanged(
 ) : SelfUserMuteHandler {
 
     override fun onMuteStateChanged(isMuted: Int, arg: Pointer?) {
-        println("onMuteStateChanged start")
-
         scope.launch {
-            println("onMuteStateChanged called")
             callingLogger.i("[OnMuteStateForSelfUserChanged] - STARTED")
             callRepository.establishedCallsFlow().first().takeIf {
-                println("call is not empty: ${it}")
                 it.isNotEmpty()
             }?.first()?.conversationId?.let {
-                callingLogger.i("[OnMuteStateForSelfUserChanged] - conversationId: $it muted: $isMuted")
+                callingLogger.i("[OnMuteStateForSelfUserChanged] - conversationId: ${it.toLogString()} muted: $isMuted")
                 callRepository.updateIsMutedById(it, isMuted == 1)
             }
         }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnMuteStateForSelfUserChangedTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/scenario/OnMuteStateForSelfUserChangedTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.scenario
+
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.Call
+import com.wire.kalium.logic.feature.call.CallStatus
+import com.wire.kalium.logic.feature.call.scenario.OnMuteStateForSelfUserChanged
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Test
+
+class OnMuteStateForSelfUserChangedTest {
+
+    @Test
+    fun givenNoOngoingCall_whenMuteStateCallbackHappens_thenNothingToDo() = runTest(testScope) {
+        val (arrangement, onMuteStateForSelfUserChanged) = Arrangement()
+            .givenNoOngoingCall()
+            .arrange()
+
+        onMuteStateForSelfUserChanged.onMuteStateChanged(1, null)
+
+        verify(arrangement.callRepository)
+            .function(arrangement.callRepository::updateIsMutedById)
+            .with(any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenAnOngoingCall_whenMuteStateCallbackHappens_thenUpdateMuteState() = runTest(testScope) {
+        val (arrangement, onMuteStateForSelfUserChanged) = Arrangement()
+            .givenAnOngoingCall()
+            .arrange()
+
+        onMuteStateForSelfUserChanged.onMuteStateChanged(1, null)
+
+        yield()
+
+        verify(arrangement.callRepository)
+            .function(arrangement.callRepository::updateIsMutedById)
+            .with(eq(conversationId), eq(true))
+            .wasInvoked(once)
+    }
+
+    companion object {
+        val conversationId = ConversationId("conversationId", "domainId")
+        private val testScope = TestKaliumDispatcher.main
+    }
+
+    internal class Arrangement {
+
+        @Mock
+        val callRepository = mock(classOf<CallRepository>())
+
+        fun arrange() = this to OnMuteStateForSelfUserChanged(
+            CoroutineScope(testScope),
+            callRepository,
+        )
+
+        fun givenNoOngoingCall() = apply {
+            given(callRepository)
+                .suspendFunction(callRepository::establishedCallsFlow)
+                .whenInvoked()
+                .thenReturn(flowOf(listOf()))
+        }
+
+        fun givenAnOngoingCall() = apply {
+            given(callRepository)
+                .suspendFunction(callRepository::establishedCallsFlow)
+                .whenInvoked()
+                .thenReturn(flowOf(listOf(call)))
+        }
+
+        companion object {
+            private val call = Call(
+                conversationId = conversationId,
+                status = CallStatus.ESTABLISHED,
+                callerId = "called-id",
+                isMuted = false,
+                isCameraOn = false,
+                isCbrEnabled = false,
+                conversationName = null,
+                conversationType = Conversation.Type.GROUP,
+                callerName = null,
+                callerTeamName = null,
+                establishedTime = null
+            )
+        }
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

Mute self user in a call if he is muted by a call admin from other client.

Needs #2018 to work

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
