### PR TITLE
fix: search does not ignore case while performing search

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
+import io.ktor.util.toLowerCasePreservingASCIIRules
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -57,18 +58,19 @@ internal class SearchKnownUsersUseCaseImpl(
         searchQuery: String,
         searchUsersOptions: SearchUsersOptions
     ): Flow<SearchUsersResult> {
-        return if (isUserLookingForHandle(searchQuery)) {
+        val sanitizedSearchQuery = searchQuery.toLowerCasePreservingASCIIRules()
+        return if (isUserLookingForHandle(sanitizedSearchQuery)) {
             searchUserRepository.searchKnownUsersByHandle(
-                handle = searchQuery.removePrefix("@"),
+                handle = sanitizedSearchQuery.removePrefix("@"),
                 searchUsersOptions = searchUsersOptions
             )
         } else {
             searchUserRepository.searchKnownUsersByNameOrHandleOrEmail(
-                searchQuery = if (searchQuery.matches(FEDERATION_REGEX))
-                    searchQuery.run {
+                searchQuery = if (sanitizedSearchQuery.matches(FEDERATION_REGEX))
+                    sanitizedSearchQuery.run {
                         qualifiedIdMapper.fromStringToQualifiedID(this)
                     }.value
-                else searchQuery,
+                else sanitizedSearchQuery,
                 searchUsersOptions = searchUsersOptions
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
-import io.ktor.util.toLowerCasePreservingASCIIRules
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -58,7 +57,7 @@ internal class SearchKnownUsersUseCaseImpl(
         searchQuery: String,
         searchUsersOptions: SearchUsersOptions
     ): Flow<SearchUsersResult> {
-        val sanitizedSearchQuery = searchQuery.toLowerCasePreservingASCIIRules()
+        val sanitizedSearchQuery = searchQuery.lowercase()
         return if (isUserLookingForHandle(sanitizedSearchQuery)) {
             searchUserRepository.searchKnownUsersByHandle(
                 handle = sanitizedSearchQuery.removePrefix("@"),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchPublicUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchPublicUsersUseCase.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import io.ktor.http.HttpStatusCode
-import io.ktor.util.toLowerCasePreservingASCIIRules
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -64,7 +63,7 @@ internal class SearchPublicUsersUseCaseImpl(
         maxResultSize: Int?,
         searchUsersOptions: SearchUsersOptions
     ): Flow<SearchUsersResult> {
-        val sanitizedSearchQuery = searchQuery.toLowerCasePreservingASCIIRules()
+        val sanitizedSearchQuery = searchQuery.lowercase()
         val qualifiedID = qualifiedIdMapper.fromStringToQualifiedID(sanitizedSearchQuery)
 
         return connectionRepository.observeConnectionList()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchPublicUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchPublicUsersUseCase.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import io.ktor.http.HttpStatusCode
+import io.ktor.util.toLowerCasePreservingASCIIRules
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -63,7 +64,8 @@ internal class SearchPublicUsersUseCaseImpl(
         maxResultSize: Int?,
         searchUsersOptions: SearchUsersOptions
     ): Flow<SearchUsersResult> {
-        val qualifiedID = qualifiedIdMapper.fromStringToQualifiedID(searchQuery)
+        val sanitizedSearchQuery = searchQuery.toLowerCasePreservingASCIIRules()
+        val qualifiedID = qualifiedIdMapper.fromStringToQualifiedID(sanitizedSearchQuery)
 
         return connectionRepository.observeConnectionList()
             .map { connections ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCaseImpl
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersResult
 import com.wire.kalium.logic.framework.TestUser
+import io.ktor.util.toLowerCasePreservingASCIIRules
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.anything
@@ -57,7 +58,7 @@ class SearchKnownUserUseCaseTest {
     @Test
     fun givenAnInputStartingWithAtSymbol_whenSearchingUsers_thenSearchOnlyByHandle() = runTest {
         // given
-        val handleSearchQuery = "@someHandle"
+        val handleSearchQuery = "@somehandle"
 
         val (arrangement, searchKnownUsersUseCase) = Arrangement()
             .withSuccessFullSelfUserRetrieve()
@@ -97,7 +98,7 @@ class SearchKnownUserUseCaseTest {
 
             verify(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchKnownUsersByNameOrHandleOrEmail)
-                .with(eq(searchQuery), anything())
+                .with(eq(searchQuery.toLowerCasePreservingASCIIRules()), anything())
                 .wasInvoked(exactly = once)
         }
     }
@@ -174,7 +175,7 @@ class SearchKnownUserUseCaseTest {
     @Test
     fun givenSearchingForHandleWithConversationExcluded_whenSearchingUsers_ThenPropagateTheSearchOption() = runTest {
         // given
-        val searchQuery = "@someHandle"
+        val searchQuery = "@somehandle"
 
         val searchUsersOptions = SearchUsersOptions(
             ConversationMemberExcludedOptions.ConversationExcluded(
@@ -279,7 +280,7 @@ class SearchKnownUserUseCaseTest {
 
             given(qualifiedIdMapper)
                 .function(qualifiedIdMapper::fromStringToQualifiedID)
-                .whenInvokedWith(eq("someSearchQuery@wire.com"))
+                .whenInvokedWith(eq("someSearchQuery@wire.com".toLowerCasePreservingASCIIRules()))
                 .thenReturn(QualifiedID("someSearchQuery", "wire.com"))
 
             return this
@@ -332,6 +333,7 @@ class SearchKnownUserUseCaseTest {
             extraOtherUser: OtherUser? = null,
             searchUsersOptions: SearchUsersOptions? = null
         ): Arrangement {
+            val query = searchQuery?.toLowerCasePreservingASCIIRules()
             val otherUsers = listOf(
                 OtherUser(
                     id = QualifiedID(
@@ -362,7 +364,7 @@ class SearchKnownUserUseCaseTest {
             given(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchKnownUsersByNameOrHandleOrEmail)
                 .whenInvokedWith(
-                    if (searchQuery == null) any() else eq(searchQuery.removePrefix("@")),
+                    if (query == null) any() else eq(query.removePrefix("@")),
                     if (searchUsersOptions == null) any() else eq(searchUsersOptions)
                 )
                 .thenReturn(flowOf(UserSearchResult(otherUsers)))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCaseImpl
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersResult
 import com.wire.kalium.logic.framework.TestUser
-import io.ktor.util.toLowerCasePreservingASCIIRules
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.anything
@@ -98,7 +97,7 @@ class SearchKnownUserUseCaseTest {
 
             verify(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchKnownUsersByNameOrHandleOrEmail)
-                .with(eq(searchQuery.toLowerCasePreservingASCIIRules()), anything())
+                .with(eq(searchQuery.lowercase()), anything())
                 .wasInvoked(exactly = once)
         }
     }
@@ -280,7 +279,7 @@ class SearchKnownUserUseCaseTest {
 
             given(qualifiedIdMapper)
                 .function(qualifiedIdMapper::fromStringToQualifiedID)
-                .whenInvokedWith(eq("someSearchQuery@wire.com".toLowerCasePreservingASCIIRules()))
+                .whenInvokedWith(eq("someSearchQuery@wire.com".lowercase()))
                 .thenReturn(QualifiedID("someSearchQuery", "wire.com"))
 
             return this
@@ -333,7 +332,7 @@ class SearchKnownUserUseCaseTest {
             extraOtherUser: OtherUser? = null,
             searchUsersOptions: SearchUsersOptions? = null
         ): Arrangement {
-            val query = searchQuery?.toLowerCasePreservingASCIIRules()
+            val query = searchQuery?.lowercase()
             val otherUsers = listOf(
                 OtherUser(
                     id = QualifiedID(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
@@ -40,7 +40,6 @@ import com.wire.kalium.logic.feature.publicuser.search.SearchUsersResult
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.api.base.model.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
-import io.ktor.util.toLowerCasePreservingASCIIRules
 import io.mockative.Mock
 import io.mockative.Times
 import io.mockative.any
@@ -171,7 +170,7 @@ class SearchUserUseCaseTest {
         given(qualifiedIdMapper)
             .function(qualifiedIdMapper::fromStringToQualifiedID)
             .whenInvokedWith(anything())
-            .thenReturn(QualifiedID(TEST_QUERY.toLowerCasePreservingASCIIRules(), "wire.com"))
+            .thenReturn(QualifiedID(TEST_QUERY.lowercase(), "wire.com"))
 
         given(searchUserRepository)
             .suspendFunction(searchUserRepository::searchUserDirectory)
@@ -188,7 +187,7 @@ class SearchUserUseCaseTest {
 
             verify(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchUserDirectory)
-                .with(eq(TEST_QUERY.toLowerCasePreservingASCIIRules()), any(), eq(null), any())
+                .with(eq(TEST_QUERY.lowercase()), any(), eq(null), any())
                 .wasInvoked(once)
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchUserUseCaseTest.kt
@@ -84,12 +84,12 @@ class SearchUserUseCaseTest {
 
         given(qualifiedIdMapper)
             .function(qualifiedIdMapper::fromStringToQualifiedID)
-            .whenInvokedWith(eq(TEST_QUERY))
+            .whenInvokedWith(eq(TEST_QUERY.lowercase()))
             .thenReturn(QualifiedID(TEST_QUERY, ""))
 
         given(qualifiedIdMapper)
             .function(qualifiedIdMapper::fromStringToQualifiedID)
-            .whenInvokedWith(eq(TEST_QUERY_FEDERATED))
+            .whenInvokedWith(eq(TEST_QUERY_FEDERATED.lowercase()))
             .thenReturn(QualifiedID(TEST_QUERY, "wire.com"))
 
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If you search on android for `QueenBellaPlume@bella.wire.link` no results are shown
But if you search for `queenbellaplume@bella.wire.link` you have match.

### Solutions

Ignore case, sanitize input, while performing search

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
