### PR TITLE
chore: default selfUser when creator field is missing

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -98,7 +98,7 @@ internal class ConversationGroupRepositoryImpl(
     private val newGroupConversationSystemMessagesCreator: Lazy<NewGroupConversationSystemMessagesCreator>,
     private val selfUserId: UserId,
     private val teamIdProvider: SelfTeamIdProvider,
-    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(),
+    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId),
     private val eventMapper: EventMapper = MapperProvider.eventMapper(),
     private val protocolInfoMapper: ProtocolInfoMapper = MapperProvider.protocolInfoMapper(),
 ) : ConversationGroupRepository {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -83,6 +83,7 @@ interface ConversationMapper {
 
 @Suppress("TooManyFunctions", "LongParameterList")
 internal class ConversationMapperImpl(
+    private val selfUserId: UserId,
     private val idMapper: IdMapper,
     private val conversationStatusMapper: ConversationStatusMapper,
     private val protocolInfoMapper: ProtocolInfoMapper,
@@ -106,7 +107,7 @@ internal class ConversationMapperImpl(
         mutedStatus = conversationStatusMapper.fromMutedStatusApiToDaoModel(apiModel.members.self.otrMutedStatus),
         mutedTime = apiModel.members.self.otrMutedRef?.let { Instant.parse(it) }?.toEpochMilliseconds() ?: 0,
         removedBy = null,
-        creatorId = apiModel.creator,
+        creatorId = apiModel.creator ?: selfUserId.value, // NOTE mls 1-1 does not have the creator field set.
         lastReadDate = Instant.UNIX_FIRST_DATE,
         lastNotificationDate = null,
         lastModifiedDate = apiModel.lastEventTime.toInstant(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -253,7 +253,7 @@ internal class ConversationDataSource internal constructor(
     private val clientApi: ClientApi,
     private val conversationMetaDataDAO: ConversationMetaDataDAO,
     private val idMapper: IdMapper = MapperProvider.idMapper(),
-    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(),
+    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId),
     private val memberMapper: MemberMapper = MapperProvider.memberMapper(),
     private val conversationStatusMapper: ConversationStatusMapper = MapperProvider.conversationStatusMapper(),
     private val conversationRoleMapper: ConversationRoleMapper = MapperProvider.conversationRoleMapper(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -132,6 +132,7 @@ private fun CoreFailure.getStrategy(
 
 @Suppress("TooManyFunctions", "LongParameterList")
 internal class MLSConversationDataSource(
+    private val selfUserId: UserId,
     private val keyPackageRepository: KeyPackageRepository,
     private val mlsClientProvider: MLSClientProvider,
     private val mlsMessageApi: MLSMessageApi,
@@ -143,7 +144,7 @@ internal class MLSConversationDataSource(
     private val epochsFlow: MutableSharedFlow<GroupID>,
     private val proposalTimersFlow: MutableSharedFlow<ProposalTimer>,
     private val idMapper: IdMapper = MapperProvider.idMapper(),
-    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(),
+    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId),
     private val mlsPublicKeysMapper: MLSPublicKeysMapper = MapperProvider.mlsPublicKeyMapper(),
     private val mlsCommitBundleMapper: MLSCommitBundleMapper = MapperProvider.mlsCommitBundleMapper()
 ) : MLSConversationRepository {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
@@ -116,7 +116,7 @@ internal class NewGroupConversationSystemMessagesCreatorImpl(
 
         persistReadReceiptSystemMessage(
             conversationId = conversation.id.toModel(),
-            creatorId = qualifiedIdMapper.fromStringToQualifiedID(conversation.creator),
+            creatorId = conversation.creator?.let { qualifiedIdMapper.fromStringToQualifiedID(it) } ?: selfUserId,
             receiptMode = conversation.receiptMode == ReceiptMode.ENABLED
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -118,8 +118,9 @@ internal object MapperProvider {
     )
 
     fun memberMapper(): MemberMapper = MemberMapperImpl(idMapper(), conversationRoleMapper())
-    fun conversationMapper(): ConversationMapper =
+    fun conversationMapper(selfUserId: UserId): ConversationMapper =
         ConversationMapperImpl(
+            selfUserId,
             idMapper(),
             ConversationStatusMapperImpl(idMapper()),
             ProtocolInfoMapperImpl(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -528,6 +528,7 @@ class UserSessionScope internal constructor(
 
     private val mlsConversationRepository: MLSConversationRepository
         get() = MLSConversationDataSource(
+            userId,
             keyPackageRepository,
             mlsClientProvider,
             authenticatedNetworkContainer.mlsMessageApi,
@@ -1373,7 +1374,7 @@ class UserSessionScope internal constructor(
             this
         )
 
-    val migration get() = MigrationScope(userStorage.database)
+    val migration get() = MigrationScope(userId, userStorage.database)
     val debug: DebugScope
         get() = DebugScope(
             messageRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
@@ -63,12 +63,12 @@ interface RestoreWebBackupUseCase {
 @Suppress("TooManyFunctions", "LongParameterList", "NestedBlockDepth")
 internal class RestoreWebBackupUseCaseImpl(
     private val kaliumFileSystem: KaliumFileSystem,
-    private val userId: UserId,
+    private val selfUserId: UserId,
     private val persistMigratedMessages: PersistMigratedMessagesUseCase,
     private val restartSlowSyncProcessForRecovery: RestartSlowSyncProcessForRecoveryUseCase,
     private val migrationDAO: MigrationDAO,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl,
-    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper()
+    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId)
 ) : RestoreWebBackupUseCase {
 
     override suspend operator fun invoke(backupRootPath: Path, metadata: BackupMetadata): RestoreBackupResult =
@@ -100,7 +100,7 @@ internal class RestoreWebBackupUseCaseImpl(
                     while (iterator.hasNext()) {
                         try {
                             val webConversation = iterator.next()
-                            val migratedConversation = webConversation.toConversation(userId)
+                            val migratedConversation = webConversation.toConversation(selfUserId)
                             if (migratedConversation != null) {
                                 migratedConversations.add(migratedConversation)
                             }
@@ -128,7 +128,7 @@ internal class RestoreWebBackupUseCaseImpl(
                     while (iterator.hasNext()) {
                         try {
                             val webContent = iterator.next()
-                            val migratedMessage = webContent.toMigratedMessage(userId.domain)
+                            val migratedMessage = webContent.toMigratedMessage(selfUserId.domain)
                             if (migratedMessage != null) {
                                 migratedMessagesBatch.add(migratedMessage)
                             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/PersistMigratedConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/PersistMigratedConversationUseCase.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.CONVERSATIO
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationMapper
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapStorageRequest
@@ -46,8 +47,9 @@ fun interface PersistMigratedConversationUseCase {
 }
 
 internal class PersistMigratedConversationUseCaseImpl(
+    private val selfUserId: UserId,
     private val migrationDAO: MigrationDAO,
-    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper()
+    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId)
 ) : PersistMigratedConversationUseCase {
 
     val logger by lazy { kaliumLogger.withFeatureId(CONVERSATIONS) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/migration/MigrationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/migration/MigrationScope.kt
@@ -18,15 +18,17 @@
 
 package com.wire.kalium.logic.feature.migration
 
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.PersistMigratedConversationUseCase
 import com.wire.kalium.logic.feature.conversation.PersistMigratedConversationUseCaseImpl
 import com.wire.kalium.persistence.db.UserDatabaseBuilder
 
 class MigrationScope(
+    private val selfUserId: UserId,
     private val userDatabase: UserDatabaseBuilder
 ) {
 
     val persistMigratedConversation: PersistMigratedConversationUseCase
-        get() = PersistMigratedConversationUseCaseImpl(userDatabase.migrationDAO)
+        get() = PersistMigratedConversationUseCaseImpl(selfUserId, userDatabase.migrationDAO)
 
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.AvailabilityStatusMapper
 import com.wire.kalium.logic.data.user.type.DomainUserTypeMapper
+import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationMembersResponse
@@ -74,6 +75,7 @@ class ConversationMapperTest {
     @BeforeTest
     fun setup() {
         conversationMapper = ConversationMapperImpl(
+            TestUser.SELF.id,
             idMapper,
             conversationStatusMapper,
             protocolInfoMapper,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1197,6 +1197,7 @@ class MLSConversationRepositoryTest {
         }
 
         fun arrange() = this to MLSConversationDataSource(
+            TestUser.SELF.id,
             keyPackageRepository,
             mlsClientProvider,
             mlsMessageApi,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCaseTest.kt
@@ -192,7 +192,7 @@ class RestoreWebBackupUseCaseTest {
 
         fun arrange() = this to RestoreWebBackupUseCaseImpl(
             kaliumFileSystem = fakeFileSystem,
-            userId = selfUserId,
+            selfUserId = selfUserId,
             migrationDAO = migrationDAO,
             persistMigratedMessages = persistMigratedMessagesUseCase,
             restartSlowSyncProcessForRecovery = restartSlowSyncProcessForRecoveryUseCase

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationResponse.kt
@@ -37,7 +37,7 @@ import kotlinx.serialization.encoding.Encoder
 @Serializable
 data class ConversationResponse(
     @SerialName("creator")
-    val creator: String,
+    val creator: String?,
 
     @SerialName("members")
     val members: ConversationMembersResponse,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In API v5 the `creator` field has become optional because it's not set for MLS 1-1 conversations. 

### Solutions

The concept for a creator doesn't make sense for 1-1 conversations but for proteus it was assigned to the self user so I decided to do the same for MLS 1-1 conversations until we decide to refactor the persistence layer and make the creator optional there

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
