### PR TITLE
chore(notification): add a way to fetch oldest notification [WPB-267]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -19,10 +19,13 @@
 package com.wire.kalium.logic.data.event
 
 import app.cash.turbine.test
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.authenticated.notification.EventResponse
@@ -30,22 +33,24 @@ import com.wire.kalium.network.api.base.authenticated.notification.NotificationA
 import com.wire.kalium.network.api.base.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.base.authenticated.notification.conversation.MessageEventData
 import com.wire.kalium.network.api.base.model.UserId
+import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.MetadataDAO
+import io.ktor.http.HttpStatusCode
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
 import io.mockative.configure
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class EventRepositoryTest {
 
     @Test
@@ -91,7 +96,7 @@ class EventRepositoryTest {
         result.shouldSucceed { assertEquals(pendingEvent.id, it) }
 
         verify(arrangement.notificationApi)
-            .suspendFunction(arrangement.notificationApi::lastNotification)
+            .suspendFunction(arrangement.notificationApi::mostRecentNotification)
             .with(any())
             .wasInvoked(exactly = once)
     }
@@ -135,6 +140,52 @@ class EventRepositoryTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenClientId_whenFetchingOldestEventId_thenShouldPassCorrectIdToAPI() = runTest {
+        val currentClientId = ClientId("testClientId")
+        val (arrangement, eventRepository) = Arrangement()
+            .withCurrentClientIdReturning(currentClientId)
+            .withOldestNotificationReturning(NetworkResponse.Error(KaliumException.NoNetwork()))
+            .arrange()
+
+        eventRepository.fetchOldestAvailableEventId()
+
+        verify(arrangement.notificationApi)
+            .suspendFunction(arrangement.notificationApi::oldestNotification)
+            .with(eq(currentClientId.value))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAPIFailure_whenFetchingOldestEventId_thenShouldPropagateFailure() = runTest {
+        val (_, eventRepository) = Arrangement()
+            .withOldestNotificationReturning(NetworkResponse.Error(KaliumException.NoNetwork()))
+            .arrange()
+
+        eventRepository.fetchOldestAvailableEventId()
+            .shouldFail {
+                assertIs<NetworkFailure.NoNetworkConnection>(it)
+            }
+    }
+
+    @Test
+    fun givenAPISucceeds_whenFetchingOldestEventId_thenShouldPropagateEventId() = runTest {
+        val eventId = "testEventId"
+        val result = NetworkResponse.Success(
+            value = EventResponse(eventId, emptyList()),
+            headers = mapOf(),
+            httpCode = HttpStatusCode.OK.value
+        )
+        val (_, eventRepository) = Arrangement()
+            .withOldestNotificationReturning(result)
+            .arrange()
+
+        eventRepository.fetchOldestAvailableEventId()
+            .shouldSucceed {
+                assertEquals(eventId, it)
+            }
+    }
+
     private companion object {
         const val LAST_PROCESSED_EVENT_ID_KEY = "last_processed_event_id"
     }
@@ -151,6 +202,10 @@ class EventRepositoryTest {
 
         private val eventRepository: EventRepository = EventDataSource(notificationApi, metaDAO, clientIdProvider)
 
+        init {
+            withCurrentClientIdReturning(TestClient.CLIENT_ID)
+        }
+
         suspend fun withLastStoredEventId(value: String?) = apply {
             given(metaDAO)
                 .coroutine { metaDAO.valueByKey(LAST_PROCESSED_EVENT_ID_KEY) }
@@ -166,9 +221,23 @@ class EventRepositoryTest {
 
         fun withLastNotificationRemote(result: NetworkResponse<EventResponse>) = apply {
             given(notificationApi)
-                .suspendFunction(notificationApi::lastNotification)
+                .suspendFunction(notificationApi::mostRecentNotification)
                 .whenInvokedWith(any())
                 .thenReturn(result)
+        }
+
+        fun withOldestNotificationReturning(result: NetworkResponse<EventResponse>) = apply {
+            given(notificationApi)
+                .suspendFunction(notificationApi::oldestNotification)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withCurrentClientIdReturning(clientId: ClientId) = apply {
+            given(clientIdProvider)
+                .suspendFunction(clientIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(Either.Right(clientId))
         }
 
         fun withUpdateLastProcessedEventId() = apply {
@@ -178,10 +247,6 @@ class EventRepositoryTest {
         }
 
         fun arrange(): Pair<Arrangement, EventRepository> {
-            given(clientIdProvider)
-                .suspendFunction(clientIdProvider::invoke)
-                .whenInvoked()
-                .thenReturn(Either.Right(TestClient.CLIENT_ID))
             return this to eventRepository
         }
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/NotificationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/NotificationApi.kt
@@ -47,9 +47,11 @@ sealed class WebSocketEvent<BinaryPayloadType> {
 }
 
 interface NotificationApi {
-    suspend fun lastNotification(queryClient: String): NetworkResponse<EventResponse>
+    suspend fun mostRecentNotification(queryClient: String): NetworkResponse<EventResponse>
 
     suspend fun notificationsByBatch(querySize: Int, queryClient: String, querySince: String): NetworkResponse<NotificationResponse>
+
+    suspend fun oldestNotification(queryClient: String): NetworkResponse<EventResponse>
 
     /**
      * request Notifications from the beginning of time

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
@@ -64,13 +64,16 @@ internal open class NotificationApiV0 internal constructor(
 
     private val httpClient get() = authenticatedNetworkClient.httpClient
 
-    override suspend fun lastNotification(
+    override suspend fun mostRecentNotification(
         queryClient: String
     ): NetworkResponse<EventResponse> = wrapKaliumResponse {
         httpClient.get("$PATH_NOTIFICATIONS/$PATH_LAST") {
             parameter(CLIENT_QUERY_KEY, queryClient)
         }
     }
+
+    override suspend fun oldestNotification(queryClient: String): NetworkResponse<EventResponse> =
+        getAllNotifications(querySize = 1, queryClient = queryClient).mapSuccess { it.notifications.first() }
 
     override suspend fun notificationsByBatch(
         querySize: Int,
@@ -104,7 +107,7 @@ internal open class NotificationApiV0 internal constructor(
     }
 
     override suspend fun listenToLiveEvents(clientId: String): NetworkResponse<Flow<WebSocketEvent<EventResponse>>> =
-        lastNotification(clientId).mapSuccess {
+        mostRecentNotification(clientId).mapSuccess {
             flow {
                 // TODO: Delete this once we can intercept and handle token refresh when connecting WebSocket
                 //       WebSocket requests are not intercept-able, and they throw

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
@@ -35,6 +35,8 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.authenticated.notification.EventResponse
+import com.wire.kalium.network.api.base.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.LocationResponse
 import com.wire.kalium.network.api.base.model.QualifiedID
@@ -351,4 +353,33 @@ object NotificationEventsResponseJson {
           ]
         }
     """.trimIndent()
+
+    val notificationResponsePageWithSingleEvent = ValidJsonProvider(
+        NotificationResponse(
+            time = "someTime",
+            hasMore = false,
+            notifications = listOf(
+                EventResponse(
+                    id = "eventId",
+                    payload = listOf(EventContentDTOJson.validUpdateReceiptMode.serializableData),
+                    transient = false
+                )
+            )
+        )
+    ) {
+        """
+        {
+          "time": "${it.time}",
+          "has_more": ${it.hasMore},
+          "notifications": [
+            {
+              "payload": [
+                ${EventContentDTOJson.validUpdateReceiptMode.rawJson}
+              ],
+              "id": "${it.notifications.first().id}"
+            }
+          ]
+        }
+        """.trimIndent()
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a client goes offline for a long period, the backend might have deleted the last processed event and now the client faces a 404 during incremental sync.

In order to recovery from this, we need to fetch the oldest possible event from the backend.

### Solutions

Add `oldestNotification` functionality in the `NotificationApi`. 
Renamed `lastNotification` to `mostRecentNotification` for clearer distinction and understanding of the functionality. 

`oldestNotification` calls the notifications API endpoint without a `since` parameter. This way the backend will return the oldest known event.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
