### PR TITLE
fix(sync): recover from 404 when fetching pending events [WPB-267]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -49,7 +49,7 @@ sealed interface CoreFailure {
     /**
      * The attempted operation requires that this client is registered.
      */
-    object MissingClientRegistration : CoreFailure
+    data object MissingClientRegistration : CoreFailure
 
     /**
      * A user has no key packages available which prevents him/her from being added
@@ -61,7 +61,7 @@ sealed interface CoreFailure {
      * It's not allowed to run the application with development API enabled when
      * connecting to the production environment.
      */
-    object DevelopmentAPINotAllowedOnProduction : CoreFailure
+    data object DevelopmentAPINotAllowedOnProduction : CoreFailure
 
     data class Unknown(val rootCause: Throwable?) : CoreFailure
 
@@ -70,19 +70,34 @@ sealed interface CoreFailure {
     /**
      * It's only allowed to insert system messages as bulk for all conversations.
      */
-    object OnlySystemMessageAllowed : FeatureFailure()
+    data object OnlySystemMessageAllowed : FeatureFailure()
 
     /**
      * The sender ID of the event is invalid.
      * usually happens with events that alter a message state [ButtonActionConfirmation]
      * when the sender ID is not the same are the original message sender id
      */
-    object InvalidEventSenderID : FeatureFailure()
+    data object InvalidEventSenderID : FeatureFailure()
 
     /**
      * This operation is not supported by proteus conversations
      */
-    object NotSupportedByProteus : FeatureFailure()
+    data object NotSupportedByProteus : FeatureFailure()
+
+    /**
+     * The desired event was not found when fetching pending events.
+     * This can happen when this client has been offline for a long period of time,
+     * and the backend has deleted old events.
+     *
+     * This is a recoverable error, the client should:
+     * - Do a full slow sync
+     * - Try incremental sync again using the oldest event ID available in the backend
+     * - Warn the user that some events might have been missed.
+     *
+     * This could also mean that the client was deleted. In this case, SlowSync will fail.
+     * The client should identify this scenario through other means and logout.
+     */
+    data object SyncEventOrClientNotFound : FeatureFailure()
 }
 
 sealed class NetworkFailure : CoreFailure {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -893,7 +893,10 @@ class UserSessionScope internal constructor(
         )
     }
     private val incrementalSyncRecoveryHandler: IncrementalSyncRecoveryHandlerImpl
-        get() = IncrementalSyncRecoveryHandlerImpl(restartSlowSyncProcessForRecoveryUseCase)
+        get() = IncrementalSyncRecoveryHandlerImpl(
+            restartSlowSyncProcessForRecoveryUseCase,
+            eventRepository,
+        )
 
     private val incrementalSyncManager by lazy {
         IncrementalSyncManager(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -34,6 +34,8 @@ import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.KaliumSyncException
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
+import com.wire.kalium.network.exceptions.KaliumException
+import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -157,13 +159,8 @@ internal class EventGathererImpl(
         logger.i("Websocket Open")
         eventRepository
             .pendingEvents()
-            .onEach {
-                it.onFailure { failure ->
-                    throw KaliumSyncException(
-                        message = "Failure to fetch pending events, aborting Incremental Sync",
-                        coreFailureCause = failure
-                    )
-                }
+            .onEach { result ->
+                result.onFailure(::throwPendingEventException)
             }
             .filterIsInstance<Either.Right<Event>>()
             .map { offlineEvent -> offlineEvent.value }
@@ -174,5 +171,15 @@ internal class EventGathererImpl(
             }
         logger.i("Offline events collection finished. Collecting Live events.")
         _currentSource.value = EventSource.LIVE
+    }
+
+    private fun throwPendingEventException(failure: CoreFailure) {
+        val networkCause = (failure as? NetworkFailure.ServerMiscommunication)?.rootCause
+        val isEventNotFound = networkCause is KaliumException.InvalidRequestError
+                && networkCause.errorResponse.code == HttpStatusCode.NotFound.value
+        throw KaliumSyncException(
+            message = "Failure to fetch pending events, aborting Incremental Sync",
+            coreFailureCause = if (isEventNotFound) CoreFailure.SyncEventOrClientNotFound else failure
+        )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -19,10 +19,13 @@
 package com.wire.kalium.logic.data.event
 
 import app.cash.turbine.test
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.authenticated.notification.EventResponse
@@ -30,22 +33,24 @@ import com.wire.kalium.network.api.base.authenticated.notification.NotificationA
 import com.wire.kalium.network.api.base.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.base.authenticated.notification.conversation.MessageEventData
 import com.wire.kalium.network.api.base.model.UserId
+import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.MetadataDAO
+import io.ktor.http.HttpStatusCode
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
 import io.mockative.configure
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class EventRepositoryTest {
 
     @Test
@@ -91,7 +96,7 @@ class EventRepositoryTest {
         result.shouldSucceed { assertEquals(pendingEvent.id, it) }
 
         verify(arrangement.notificationApi)
-            .suspendFunction(arrangement.notificationApi::lastNotification)
+            .suspendFunction(arrangement.notificationApi::mostRecentNotification)
             .with(any())
             .wasInvoked(exactly = once)
     }
@@ -135,6 +140,52 @@ class EventRepositoryTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenClientId_whenFetchingOldestEventId_thenShouldPassCorrectIdToAPI() = runTest {
+        val currentClientId = ClientId("testClientId")
+        val (arrangement, eventRepository) = Arrangement()
+            .withCurrentClientIdReturning(currentClientId)
+            .withOldestNotificationReturning(NetworkResponse.Error(KaliumException.NoNetwork()))
+            .arrange()
+
+        eventRepository.fetchOldestAvailableEventId()
+
+        verify(arrangement.notificationApi)
+            .suspendFunction(arrangement.notificationApi::oldestNotification)
+            .with(eq(currentClientId.value))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAPIFailure_whenFetchingOldestEventId_thenShouldPropagateFailure() = runTest {
+        val (_, eventRepository) = Arrangement()
+            .withOldestNotificationReturning(NetworkResponse.Error(KaliumException.NoNetwork()))
+            .arrange()
+
+        eventRepository.fetchOldestAvailableEventId()
+            .shouldFail {
+                assertIs<NetworkFailure.NoNetworkConnection>(it)
+            }
+    }
+
+    @Test
+    fun givenAPISucceeds_whenFetchingOldestEventId_thenShouldPropagateEventId() = runTest {
+        val eventId = "testEventId"
+        val result = NetworkResponse.Success(
+            value = EventResponse(eventId, emptyList()),
+            headers = mapOf(),
+            httpCode = HttpStatusCode.OK.value
+        )
+        val (_, eventRepository) = Arrangement()
+            .withOldestNotificationReturning(result)
+            .arrange()
+
+        eventRepository.fetchOldestAvailableEventId()
+            .shouldSucceed {
+                assertEquals(eventId, it)
+            }
+    }
+
     private companion object {
         const val LAST_PROCESSED_EVENT_ID_KEY = "last_processed_event_id"
     }
@@ -151,6 +202,10 @@ class EventRepositoryTest {
 
         private val eventRepository: EventRepository = EventDataSource(notificationApi, metaDAO, clientIdProvider)
 
+        init {
+            withCurrentClientIdReturning(TestClient.CLIENT_ID)
+        }
+
         suspend fun withLastStoredEventId(value: String?) = apply {
             given(metaDAO)
                 .coroutine { metaDAO.valueByKey(LAST_PROCESSED_EVENT_ID_KEY) }
@@ -166,9 +221,23 @@ class EventRepositoryTest {
 
         fun withLastNotificationRemote(result: NetworkResponse<EventResponse>) = apply {
             given(notificationApi)
-                .suspendFunction(notificationApi::lastNotification)
+                .suspendFunction(notificationApi::mostRecentNotification)
                 .whenInvokedWith(any())
                 .thenReturn(result)
+        }
+
+        fun withOldestNotificationReturning(result: NetworkResponse<EventResponse>) = apply {
+            given(notificationApi)
+                .suspendFunction(notificationApi::oldestNotification)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withCurrentClientIdReturning(clientId: ClientId) = apply {
+            given(clientIdProvider)
+                .suspendFunction(clientIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(Either.Right(clientId))
         }
 
         fun withUpdateLastProcessedEventId() = apply {
@@ -178,10 +247,6 @@ class EventRepositoryTest {
         }
 
         fun arrange(): Pair<Arrangement, EventRepository> {
-            given(clientIdProvider)
-                .suspendFunction(clientIdProvider::invoke)
-                .whenInvoked()
-                .thenReturn(Either.Right(TestClient.CLIENT_ID))
             return this to eventRepository
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
@@ -29,6 +29,8 @@ import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.KaliumSyncException
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
+import com.wire.kalium.network.api.base.model.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
 import io.mockative.Mock
 import io.mockative.configure
 import io.mockative.given
@@ -371,6 +373,38 @@ class EventGathererTest {
 
             // Should not receive another item
             expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenPendingEventsFailWith404_whenGathering_thenShouldThrowExceptionWithEventNotFoundCause() = runTest {
+        val liveEventsChannel = Channel<WebSocketEvent<Event>>(capacity = Channel.UNLIMITED)
+
+        val failureCause = NetworkFailure.ServerMiscommunication(
+            KaliumException.InvalidRequestError(
+                ErrorResponse(
+                    code = 404,
+                    label = "Event not found",
+                    message = "Event not found"
+                )
+            )
+        )
+        val (_, eventGatherer) = Arrangement()
+            .withLastEventIdReturning(Either.Right("lastEventId"))
+            .withPendingEventsReturning(flowOf(Either.Left(failureCause)))
+            .withKeepAliveConnectionPolicy()
+            .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
+            .arrange()
+
+        eventGatherer.gatherEvents().test {
+            // Open Websocket should trigger fetching pending events
+            liveEventsChannel.send(WebSocketEvent.Open())
+            advanceUntilIdle()
+
+            val error = awaitError()
+            assertIs<KaliumSyncException>(error)
+            assertIs<CoreFailure.SyncEventOrClientNotFound>(error.coreFailureCause)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -43,7 +43,6 @@ import io.mockative.once
 import io.mockative.times
 import io.mockative.twice
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/EventRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/EventRepositoryArrangement.kt
@@ -1,0 +1,55 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.repository
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.event.EventRepository
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+
+internal interface EventRepositoryArrangement {
+    val eventRepository: EventRepository
+
+    fun withOldestEventIdReturning(result: Either<CoreFailure, String>)
+
+    fun withUpdateLastProcessedEventIdReturning(result: Either<StorageFailure, Unit>)
+}
+
+internal class EventRepositoryArrangementImpl : EventRepositoryArrangement {
+    @Mock
+    override val eventRepository = mock(classOf<EventRepository>())
+
+    override fun withOldestEventIdReturning(result: Either<CoreFailure, String>) {
+        given(eventRepository)
+            .suspendFunction(eventRepository::fetchOldestAvailableEventId)
+            .whenInvoked()
+            .thenReturn(result)
+    }
+
+    override fun withUpdateLastProcessedEventIdReturning(result: Either<StorageFailure, Unit>) {
+        given(eventRepository)
+            .suspendFunction(eventRepository::updateLastProcessedEventId)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/NotificationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/NotificationApi.kt
@@ -47,9 +47,11 @@ sealed class WebSocketEvent<BinaryPayloadType> {
 }
 
 interface NotificationApi {
-    suspend fun lastNotification(queryClient: String): NetworkResponse<EventResponse>
+    suspend fun mostRecentNotification(queryClient: String): NetworkResponse<EventResponse>
 
     suspend fun notificationsByBatch(querySize: Int, queryClient: String, querySince: String): NetworkResponse<NotificationResponse>
+
+    suspend fun oldestNotification(queryClient: String): NetworkResponse<EventResponse>
 
     /**
      * request Notifications from the beginning of time

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
@@ -64,13 +64,16 @@ internal open class NotificationApiV0 internal constructor(
 
     private val httpClient get() = authenticatedNetworkClient.httpClient
 
-    override suspend fun lastNotification(
+    override suspend fun mostRecentNotification(
         queryClient: String
     ): NetworkResponse<EventResponse> = wrapKaliumResponse {
         httpClient.get("$PATH_NOTIFICATIONS/$PATH_LAST") {
             parameter(CLIENT_QUERY_KEY, queryClient)
         }
     }
+
+    override suspend fun oldestNotification(queryClient: String): NetworkResponse<EventResponse> =
+        getAllNotifications(querySize = 1, queryClient = queryClient).mapSuccess { it.notifications.first() }
 
     override suspend fun notificationsByBatch(
         querySize: Int,
@@ -104,7 +107,7 @@ internal open class NotificationApiV0 internal constructor(
     }
 
     override suspend fun listenToLiveEvents(clientId: String): NetworkResponse<Flow<WebSocketEvent<EventResponse>>> =
-        lastNotification(clientId).mapSuccess {
+        mostRecentNotification(clientId).mapSuccess {
             flow {
                 // TODO: Delete this once we can intercept and handle token refresh when connecting WebSocket
                 //       WebSocket requests are not intercept-able, and they throw

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
@@ -35,6 +35,8 @@ import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureFlag
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.authenticated.notification.EventResponse
+import com.wire.kalium.network.api.base.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.LocationResponse
 import com.wire.kalium.network.api.base.model.QualifiedID
@@ -351,4 +353,33 @@ object NotificationEventsResponseJson {
           ]
         }
     """.trimIndent()
+
+    val notificationResponsePageWithSingleEvent = ValidJsonProvider(
+        NotificationResponse(
+            time = "someTime",
+            hasMore = false,
+            notifications = listOf(
+                EventResponse(
+                    id = "eventId",
+                    payload = listOf(EventContentDTOJson.validUpdateReceiptMode.serializableData),
+                    transient = false
+                )
+            )
+        )
+    ) {
+        """
+        {
+          "time": "${it.time}",
+          "has_more": ${it.hasMore},
+          "notifications": [
+            {
+              "payload": [
+                ${EventContentDTOJson.validUpdateReceiptMode.rawJson}
+              ],
+              "id": "${it.notifications.first().id}"
+            }
+          ]
+        }
+        """.trimIndent()
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the server answers a 404 for missing event, we don't clear the `lastProcessedEventId` and stay in a loop trying to fetch the same event for ever.

### Solutions

Updated the logic for handling failures during incremental sync.

Now, in case of a "not found" response when fetching pending events, the system will update the last processed event and restart a full slow sync. 

This ensures that sync procedure is more robust in case of long periods of client inactivity.

A tiny refactor:
- Instead of bubbling up `ServerMiscommunication`, I'm mapping that kind exception on the `EventGatherer` level and translating it to `SyncEventOrClientNotFound` failure. This reduces the amount of places that are actively checking for HTTP status codes in the domain layer.

### Dependencies

This PR brings changes from the following PR:
- #2025

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
