### PR TITLE
fix: add failed remotely to supported RetryFailedMessageUseCase (WPB-4457)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
@@ -61,7 +61,7 @@ class RetryFailedMessageUseCase internal constructor(
      *
      * If it's an asset message, the asset may or may not be already uploaded. The asset will be uploaded if needed.
      *
-     * The resending and possible re-uploading of assets are scheduled but not awaited, so returning [Either.Right] doesn't mean that
+     * The resending and possible reuploading of assets are scheduled but not awaited, so returning [Either.Right] doesn't mean that
      * the message has been sent successfully.
      *
      * @param messageId the id of the failed message to be resent

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
@@ -57,23 +57,23 @@ class RetryFailedMessageUseCase internal constructor(
 
     /**
      * Function that enables resending of failed message to a given conversation with the strategy of fire & forget.
-     * This message must have a status of [Message.Status.FAILED].
+     * This message must have a status of [Message.Status.Failed] or [Message.Status.FailedRemotely].
      *
      * If it's an asset message, the asset may or may not be already uploaded. The asset will be uploaded if needed.
      *
-     * The resending and possible reuploading of assets are scheduled but not awaited, so returning [Either.Right] doesn't mean that
+     * The resending and possible re-uploading of assets are scheduled but not awaited, so returning [Either.Right] doesn't mean that
      * the message has been sent successfully.
      *
      * @param messageId the id of the failed message to be resent
      * @param conversationId the id of the conversation where the failed message wants to be resent
      * @return [Either.Left] in case the message could not be found or has invalid status, [Either.Right] otherwise. Note that this doesn't
-     * imply that the send will succeed, it just confirms that resending is the valid action for this message and it has been started.
+     * imply that send will succeed, it just confirms that resending is the valid action for this message, and it has been started.
      */
     suspend operator fun invoke(messageId: String, conversationId: ConversationId): Either<CoreFailure, Unit> =
         messageRepository.getMessageById(conversationId, messageId)
             .flatMap { message ->
                 when (message.status) {
-                    Message.Status.Failed -> { // TODO should it also cover status FAILED_REMOTELY?
+                    Message.Status.Failed, Message.Status.FailedRemotely -> {
                         messageRepository.updateMessageStatus(
                             messageStatus = MessageEntity.Status.PENDING,
                             conversationId = message.conversationId,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Given a `FAILED_REMOTELY`  messages status, are not retriable as of now.

### Solutions

Add support to `FAILED_REMOTELY` to `RetryFailedMessageUseCase` so we can make use of it, and resend messages when they fail and the BE later comes back alive.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
