### PR TITLE
feat: resolve one-on-one conversations when receiving a welcome message

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -466,6 +466,13 @@ private fun ConversationEntity.AccessRole.toDAO(): Conversation.AccessRole = whe
     ConversationEntity.AccessRole.EXTERNAL -> Conversation.AccessRole.EXTERNAL
 }
 
+internal fun Conversation.ProtocolInfo.MLSCapable.GroupState.toDao(): ConversationEntity.GroupState = when (this) {
+    Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED -> GroupState.ESTABLISHED
+    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION -> GroupState.PENDING_CREATION
+    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN -> GroupState.PENDING_JOIN
+    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_WELCOME_MESSAGE -> GroupState.PENDING_WELCOME_MESSAGE
+}
+
 internal fun Conversation.Type.toDAO(): ConversationEntity.Type = when (this) {
     Conversation.Type.SELF -> ConversationEntity.Type.SELF
     Conversation.Type.ONE_ON_ONE -> ConversationEntity.Type.ONE_ON_ONE

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.CONVERSATIO
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLSCapable.GroupState
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
@@ -172,9 +173,10 @@ interface ConversationRepository {
     ): Either<NetworkFailure, Unit>
 
     suspend fun getConversationsByGroupState(
-        groupState: Conversation.ProtocolInfo.MLSCapable.GroupState
+        groupState: GroupState
     ): Either<StorageFailure, List<Conversation>>
 
+    suspend fun updateConversationGroupState(groupID: GroupID, groupState: GroupState): Either<StorageFailure, Unit>
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedID): Either<StorageFailure, Unit>
     suspend fun updateAllConversationsNotificationDate(): Either<StorageFailure, Unit>
     suspend fun updateConversationModifiedDate(qualifiedID: QualifiedID, date: Instant): Either<StorageFailure, Unit>
@@ -240,7 +242,7 @@ interface ConversationRepository {
     suspend fun updateProtocol(conversationId: ConversationId, protocol: Conversation.Protocol): Either<CoreFailure, Boolean>
 }
 
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
 internal class ConversationDataSource internal constructor(
     private val selfUserId: UserId,
     private val mlsClientProvider: MLSClientProvider,
@@ -599,11 +601,19 @@ internal class ConversationDataSource internal constructor(
         }
 
     override suspend fun getConversationsByGroupState(
-        groupState: Conversation.ProtocolInfo.MLSCapable.GroupState
+        groupState: GroupState
     ): Either<StorageFailure, List<Conversation>> =
         wrapStorageRequest {
             conversationDAO.getConversationsByGroupState(conversationMapper.toDAOGroupState(groupState))
                 .map(conversationMapper::fromDaoModel)
+        }
+
+    override suspend fun updateConversationGroupState(
+        groupID: GroupID,
+        groupState: GroupState
+    ): Either<StorageFailure, Unit> =
+        wrapStorageRequest {
+            conversationDAO.updateConversationGroupState(groupState.toDao(), groupID.value)
         }
 
     override suspend fun updateConversationNotificationDate(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1199,7 +1199,7 @@ class UserSessionScope internal constructor(
         )
     private val mlsWelcomeHandler: MLSWelcomeEventHandler
         get() = MLSWelcomeEventHandlerImpl(
-            mlsClientProvider, userStorage.database.conversationDAO, conversationRepository
+            mlsClientProvider, conversationRepository, oneOnOneResolver
         )
     private val renamedConversationHandler: RenamedConversationEventHandler
         get() = RenamedConversationEventHandlerImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -19,32 +19,37 @@
 package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.logger.obfuscateId
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapMLSRequest
-import com.wire.kalium.logic.wrapStorageRequest
-import com.wire.kalium.persistence.dao.conversation.ConversationDAO
-import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import io.ktor.util.decodeBase64Bytes
+import kotlinx.coroutines.flow.first
 
 interface MLSWelcomeEventHandler {
-    suspend fun handle(event: Event.Conversation.MLSWelcome)
+    suspend fun handle(event: Event.Conversation.MLSWelcome): Either<CoreFailure, Unit>
 }
 
 internal class MLSWelcomeEventHandlerImpl(
     val mlsClientProvider: MLSClientProvider,
-    val conversationDAO: ConversationDAO,
-    val conversationRepository: ConversationRepository
+    val conversationRepository: ConversationRepository,
+    val oneOnOneResolver: OneOnOneResolver
 ) : MLSWelcomeEventHandler {
-    override suspend fun handle(event: Event.Conversation.MLSWelcome) {
+    override suspend fun handle(event: Event.Conversation.MLSWelcome): Either<CoreFailure, Unit> =
         mlsClientProvider
             .getMLSClient()
             .flatMap { client ->
@@ -54,26 +59,41 @@ internal class MLSWelcomeEventHandlerImpl(
             }.flatMap { groupID ->
                 val groupIdLogPair = Pair("groupId", groupID.obfuscateId())
 
-                wrapStorageRequest {
-                    conversationRepository.fetchConversationIfUnknown(event.conversationId).map {
-                        conversationDAO.updateConversationGroupState(ConversationEntity.GroupState.ESTABLISHED, groupID)
-                    }
-                }.onSuccess {
-                    kaliumLogger
-                        .logEventProcessing(
-                            EventLoggingStatus.SUCCESS,
-                            event,
-                            Pair("info", "Established mls conversation from welcome message"),
-                            groupIdLogPair
-                        )
-                }.onFailure {
-                    kaliumLogger
-                        .logEventProcessing(
-                            EventLoggingStatus.FAILURE,
-                            event,
-                            groupIdLogPair
+                conversationRepository.fetchConversationIfUnknown(event.conversationId)
+                    .flatMap {
+                        markConversationAsEstablished(GroupID(groupID))
+                    }.flatMap {
+                        resolveConversationIfOneOnOne(event.conversationId)
+                    }.onSuccess {
+                        kaliumLogger
+                            .logEventProcessing(
+                                EventLoggingStatus.SUCCESS,
+                                event,
+                                Pair("info", "Established mls conversation from welcome message"),
+                                groupIdLogPair
+                            )
+                    }.onFailure {
+                        kaliumLogger
+                            .logEventProcessing(
+                                EventLoggingStatus.FAILURE,
+                                event,
+                                groupIdLogPair
                         )
                 }
             }
-    }
+
+    private suspend fun markConversationAsEstablished(groupID: GroupID): Either<CoreFailure, Unit> =
+        conversationRepository.updateConversationGroupState(groupID, Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED)
+
+    private suspend fun resolveConversationIfOneOnOne(conversationId: ConversationId): Either<CoreFailure, Unit> =
+        conversationRepository.observeConversationDetailsById(conversationId)
+            .first()
+            .flatMap {
+                if (it is ConversationDetails.OneOne) {
+                    oneOnOneResolver.resolveOneOnOneConversationWithUser(it.otherUser).map { Unit }
+                } else {
+                    Either.Right(Unit)
+                }
+            }
+
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -172,12 +172,14 @@ class ConversationEventReceiverTest {
     fun givenMLSWelcomeEvent_whenOnEventInvoked_thenMlsWelcomeHandlerShouldBeCalled() = runTest {
         val mlsWelcomeEvent = TestEvent.newMLSWelcomeEvent()
 
-        val (arrangement, featureConfigEventReceiver) = Arrangement().arrange()
+        val (arrangement, featureConfigEventReceiver) = Arrangement()
+            .withMLSWelcomeEventSucceeded()
+            .arrange()
 
         val result = featureConfigEventReceiver.onEvent(mlsWelcomeEvent)
 
-        verify(arrangement.mLSWelcomeEventHandler)
-            .suspendFunction(arrangement.mLSWelcomeEventHandler::handle)
+        verify(arrangement.mlsWelcomeEventHandler)
+            .suspendFunction(arrangement.mlsWelcomeEventHandler::handle)
             .with(eq(mlsWelcomeEvent))
             .wasInvoked(once)
         result.shouldSucceed()
@@ -336,7 +338,7 @@ class ConversationEventReceiverTest {
         val renamedConversationEventHandler = mock(classOf<RenamedConversationEventHandler>())
 
         @Mock
-        val mLSWelcomeEventHandler = mock(classOf<MLSWelcomeEventHandler>())
+        val mlsWelcomeEventHandler = mock(classOf<MLSWelcomeEventHandler>())
 
         @Mock
         val memberChangeEventHandler = mock(classOf<MemberChangeEventHandler>())
@@ -366,7 +368,7 @@ class ConversationEventReceiverTest {
             memberJoinHandler = memberJoinEventHandler,
             memberLeaveHandler = memberLeaveEventHandler,
             memberChangeHandler = memberChangeEventHandler,
-            mlsWelcomeHandler = mLSWelcomeEventHandler,
+            mlsWelcomeHandler = mlsWelcomeEventHandler,
             renamedConversationHandler = renamedConversationEventHandler,
             receiptModeUpdateEventHandler = receiptModeUpdateEventHandler,
             conversationMessageTimerEventHandler = conversationMessageTimerEventHandler,
@@ -399,6 +401,14 @@ class ConversationEventReceiverTest {
                 .whenInvokedWith(any())
                 .thenReturn(Either.Left(failure))
         }
+
+        fun withMLSWelcomeEventSucceeded() = apply {
+            given(mlsWelcomeEventHandler)
+                .suspendFunction(mlsWelcomeEventHandler::handle)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+        }
+
     }
 
     companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We need to resolve the active one-on-one conversation after [certain events](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/811958286/Use+case+Migration+of+1+1+conversation+Proteus+to+MLS+migration#Periodically-evaluate-what-protocol-to-use-for-1%3A1-conversation), one these events is after receiving a welcome message for a 1-1 conversation.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
