### PR TITLE
feat: resolve one-on-on conversation when the connection is accepted

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1259,6 +1259,7 @@ class UserSessionScope internal constructor(
             conversationRepository,
             userRepository,
             logout,
+            oneOnOneResolver,
             userId,
             clientIdProvider
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -26,15 +26,20 @@ import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.user.Connection
+import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
+import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.flow.first
 
 internal interface UserEventReceiver : EventReceiver<Event.User>
 
@@ -45,6 +50,7 @@ internal class UserEventReceiverImpl internal constructor(
     private val conversationRepository: ConversationRepository,
     private val userRepository: UserRepository,
     private val logout: LogoutUseCase,
+    private val oneOnOneResolver: OneOnOneResolver,
     private val selfUserId: UserId,
     private val currentClientIdProvider: CurrentClientIdProvider,
 ) : UserEventReceiver {
@@ -79,6 +85,9 @@ internal class UserEventReceiverImpl internal constructor(
 
     private suspend fun handleNewConnection(event: Event.User.NewConnection): Either<CoreFailure, Unit> =
         connectionRepository.insertConnectionFromEvent(event)
+            .flatMap {
+                resolveOneOnOneConversationUponConnectionAccepted(event.connection)
+            }
             .onSuccess {
                 kaliumLogger
                     .logEventProcessing(
@@ -94,6 +103,15 @@ internal class UserEventReceiverImpl internal constructor(
                         Pair("errorInfo", "$it")
                     )
             }
+
+    private suspend fun resolveOneOnOneConversationUponConnectionAccepted(connection: Connection): Either<CoreFailure, Unit> =
+        if (connection.status == ConnectionState.ACCEPTED) {
+            userRepository.getKnownUser(connection.qualifiedToId).first()?.let {
+                oneOnOneResolver.resolveOneOnOneConversationWithUser(it).map { }
+            } ?: Either.Right(Unit)
+        } else {
+            Either.Right(Unit)
+        }
 
     private suspend fun handleClientRemove(event: Event.User.ClientRemove): Either<CoreFailure, Unit> =
         currentClientIdProvider().map { currentClientId ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -84,7 +84,7 @@ object TestEvent {
         false, eventId, TestClient.CLIENT
     )
 
-    fun newConnection(eventId: String = "eventId") = Event.User.NewConnection(
+    fun newConnection(eventId: String = "eventId", status:  ConnectionState = ConnectionState.PENDING) = Event.User.NewConnection(
         false,
         eventId,
         Connection(
@@ -93,7 +93,7 @@ object TestEvent {
             lastUpdate = "lastUpdate",
             qualifiedConversationId = TestConversation.ID,
             qualifiedToId = TestUser.USER_ID,
-            status = ConnectionState.PENDING,
+            status = status,
             toId = "told?"
         )
     )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/UserRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/UserRepositoryArrangement.kt
@@ -31,6 +31,10 @@ import kotlinx.coroutines.flow.Flow
 internal interface UserRepositoryArrangement {
     val userRepository: UserRepository
 
+    fun withUpdateUserSuccess()
+
+    fun withRemoveUserSuccess()
+
     fun withSelfUserReturning(selfUser: SelfUser?)
 
     fun withUserByIdReturning(result: Either<CoreFailure, OtherUser>)
@@ -46,6 +50,16 @@ internal class UserRepositoryArrangementImpl: UserRepositoryArrangement {
 
     @Mock
     override val userRepository: UserRepository = mock(UserRepository::class)
+
+    override fun withUpdateUserSuccess() {
+        given(userRepository).suspendFunction(userRepository::updateUserFromEvent).whenInvokedWith(any())
+            .thenReturn(Either.Right(Unit))
+    }
+
+    override fun withRemoveUserSuccess() {
+        given(userRepository).suspendFunction(userRepository::removeUser)
+            .whenInvokedWith(any()).thenReturn(Either.Right(Unit))
+    }
 
     override fun withSelfUserReturning(selfUser: SelfUser?) {
         given(userRepository)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We need to resolve the active one-on-one conversation after [certain events](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/811958286/Use+case+Migration+of+1+1+conversation+Proteus+to+MLS+migration#Periodically-evaluate-what-protocol-to-use-for-1%3A1-conversation), one these events is after a connection is accepted.

### Dependencies

Needs releases with:

- [x] https://github.com/wireapp/kalium/pull/2033

### Testing

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
