### PR TITLE
feat: bump v4 to supported and remove it from development versions (WPB-4352)

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
@@ -24,8 +24,8 @@ import com.wire.kalium.network.api.base.unbound.versioning.VersionInfoDTO
 import com.wire.kalium.network.tools.ApiVersionDTO
 import com.wire.kalium.network.tools.ServerConfigDTO
 
-val SupportedApiVersions = setOf(0, 1, 2, 3)
-val DevelopmentApiVersions = setOf(4)
+val SupportedApiVersions = setOf(0, 1, 2, 3, 4)
+val DevelopmentApiVersions = setOf(5)
 
 interface BackendMetaDataUtil {
     fun calculateApiVersion(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are approaching finalization of v4 api, meaning when backend mark v4 as supported we can merge this PR.

### Solution

As default in prod builds, will be used v4 api and for dev builds v5.
We are just reusing and configuring accordingly the api versioning mechanism of Kalium.

### When ?
The max supported version should be 4, here.
- https://staging-nginz-https.zinfra.io/api-version
- https://nginz-https.anta.wire.link/api-version

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
