### PR TITLE
fix(notifications): use last event instead of oldest when recoverying from 404 [WPB-267]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -51,11 +51,23 @@ interface EventRepository {
     suspend fun updateLastProcessedEventId(eventId: String): Either<StorageFailure, Unit>
 
     /**
-     * Gets the last processed event ID, if it exists.
-     * Otherwise, it attempts to fetch the last event stored
-     * in remote.
+     * Retrieves the last processed event ID from the storage.
+     *
+     * @return an [Either] object representing either a [StorageFailure] or a [String].
+     *         - If the retrieval is successful, returns [Either.Right] with the last processed event ID as a [String].
+     *         - If there is a failure during retrieval, returns [Either.Left] with a [StorageFailure] object.
      */
-    suspend fun lastEventId(): Either<CoreFailure, String>
+    suspend fun lastProcessedEventId(): Either<StorageFailure, String>
+
+    /**
+     * Clears the last processed event ID.
+     *
+     * @return An [Either] object representing the result of the operation.
+     * The [Either] object contains either a [StorageFailure] if the operation fails, or [Unit] if the operation succeeds.
+     */
+    suspend fun clearLastProcessedEventId(): Either<StorageFailure, Unit>
+
+    suspend fun fetchMostRecentEventId(): Either<CoreFailure, String>
 
     /**
      * Fetches the oldest available event ID from remote.
@@ -130,19 +142,20 @@ class EventDataSource(
         }
     }
 
-    override suspend fun lastEventId(): Either<CoreFailure, String> = wrapStorageRequest {
+    override suspend fun lastProcessedEventId(): Either<StorageFailure, String> = wrapStorageRequest {
         metadataDAO.valueByKey(LAST_PROCESSED_EVENT_ID_KEY)
-    }.fold({
+    }
+
+    override suspend fun clearLastProcessedEventId(): Either<StorageFailure, Unit> = wrapStorageRequest {
+        metadataDAO.deleteValue(LAST_PROCESSED_EVENT_ID_KEY)
+    }
+
+    override suspend fun fetchMostRecentEventId(): Either<CoreFailure, String> =
         currentClientId()
             .flatMap { currentClientId ->
                 wrapApiRequest { notificationApi.mostRecentNotification(currentClientId.value) }
-                    .flatMap { lastEvent ->
-                        updateLastProcessedEventId(lastEvent.id).map { lastEvent.id }
-                    }
+                    .map { it.id }
             }
-    }, {
-        Either.Right(it)
-    })
 
     override suspend fun updateLastProcessedEventId(eventId: String) =
         wrapStorageRequest { metadataDAO.insertValue(eventId, LAST_PROCESSED_EVENT_ID_KEY) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -846,6 +846,7 @@ class UserSessionScope internal constructor(
 
     private val slowSyncWorker: SlowSyncWorker by lazy {
         SlowSyncWorkerImpl(
+            eventRepository,
             syncSelfUser,
             syncFeatureConfigsUseCase,
             syncConversations,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -87,7 +87,7 @@ internal class EventGathererImpl(
     override suspend fun gatherEvents(): Flow<Event> = flow {
         offlineEventBuffer.clear()
         _currentSource.value = EventSource.PENDING
-        eventRepository.lastEventId().flatMap {
+        eventRepository.lastProcessedEventId().flatMap {
             eventRepository.liveEvents()
         }.onSuccess { webSocketEventFlow ->
             handleWebSocketEventsWhilePolicyAllows(webSocketEventFlow)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -45,7 +45,7 @@ internal interface EventProcessor {
      * is not transient.
      * If the processing fails, the last processed event ID will not be updated.
      * @return [Either] [CoreFailure] if the event processing failed, or [Unit] if the event was processed successfully.
-     * @see EventRepository.lastEventId
+     * @see EventRepository.lastProcessedEventId
      * @see EventRepository.updateLastProcessedEventId
      */
     suspend fun processEvent(event: Event): Either<CoreFailure, Unit>

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -145,7 +145,7 @@ internal class SlowSyncManager(
     }
 
     private suspend fun performSlowSync() {
-        slowSyncWorker.performSlowSyncSteps().cancellable().collect { step ->
+        slowSyncWorker.slowSyncStepsFlow().cancellable().collect { step ->
             logger.i("Performing SlowSyncStep $step")
             slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Ongoing(step))
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.sync.incremental
 import app.cash.turbine.test
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.sync.ConnectionPolicy
@@ -433,9 +434,9 @@ class EventGathererTest {
                 .thenReturn(either)
         }
 
-        fun withLastEventIdReturning(either: Either<CoreFailure, String>) = apply {
+        fun withLastEventIdReturning(either: Either<StorageFailure, String>) = apply {
             given(eventRepository)
-                .suspendFunction(eventRepository::lastEventId)
+                .suspendFunction(eventRepository::lastProcessedEventId)
                 .whenInvoked()
                 .thenReturn(either)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -39,7 +39,6 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.twice
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -77,7 +76,7 @@ class SlowSyncManagerTest {
 
         assertTrue(isCollected)
         verify(arrangement.slowSyncWorker)
-            .suspendFunction(arrangement.slowSyncWorker::performSlowSyncSteps)
+            .suspendFunction(arrangement.slowSyncWorker::slowSyncStepsFlow)
             .wasInvoked(exactly = once)
         verify(arrangement.slowSyncRepository)
             .suspendFunction(arrangement.slowSyncRepository::setSlowSyncVersion)
@@ -96,7 +95,7 @@ class SlowSyncManagerTest {
         advanceUntilIdle()
 
         verify(arrangement.slowSyncWorker)
-            .suspendFunction(arrangement.slowSyncWorker::performSlowSyncSteps)
+            .suspendFunction(arrangement.slowSyncWorker::slowSyncStepsFlow)
             .wasInvoked(exactly = twice)
     }
 
@@ -110,7 +109,7 @@ class SlowSyncManagerTest {
         advanceUntilIdle()
 
         verify(arrangement.slowSyncWorker)
-            .suspendFunction(arrangement.slowSyncWorker::performSlowSyncSteps)
+            .suspendFunction(arrangement.slowSyncWorker::slowSyncStepsFlow)
             .wasInvoked(exactly = once)
     }
 
@@ -438,7 +437,7 @@ class SlowSyncManagerTest {
 
         fun withSlowSyncWorkerReturning(stepFlow: Flow<SlowSyncStep>) = apply {
             given(slowSyncWorker)
-                .suspendFunction(slowSyncWorker::performSlowSyncSteps)
+                .suspendFunction(slowSyncWorker::slowSyncStepsFlow)
                 .whenInvoked()
                 .thenReturn(stepFlow)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
@@ -374,7 +374,7 @@ class SlowSyncWorkerTest {
     }
 
     @Test
-    fun givenFetchedEventIdAndSomethingFails_whenWorking_thenShouldNotLastProcessedEventId() = runTest {
+    fun givenFetchedEventIdAndSomethingFails_whenWorking_thenShouldNotUpdateLastProcessedEventId() = runTest {
         val (arrangement, slowSyncWorker) = Arrangement().apply {
             withLastProcessedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
             withFetchMostRecentEventReturning(Either.Right("mostRecentEventId"))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/EventRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/EventRepositoryArrangement.kt
@@ -32,6 +32,12 @@ internal interface EventRepositoryArrangement {
 
     fun withOldestEventIdReturning(result: Either<CoreFailure, String>)
 
+    fun withClearLastEventIdReturning(result: Either<StorageFailure, Unit>)
+
+    fun withFetchMostRecentEventReturning(result: Either<CoreFailure, String>)
+
+    fun withLastProcessedEventIdReturning(result: Either<StorageFailure, String>)
+
     fun withUpdateLastProcessedEventIdReturning(result: Either<StorageFailure, Unit>)
 }
 
@@ -42,6 +48,27 @@ internal class EventRepositoryArrangementImpl : EventRepositoryArrangement {
     override fun withOldestEventIdReturning(result: Either<CoreFailure, String>) {
         given(eventRepository)
             .suspendFunction(eventRepository::fetchOldestAvailableEventId)
+            .whenInvoked()
+            .thenReturn(result)
+    }
+
+    override fun withClearLastEventIdReturning(result: Either<StorageFailure, Unit>) {
+        given(eventRepository)
+            .suspendFunction(eventRepository::clearLastProcessedEventId)
+            .whenInvoked()
+            .thenReturn(result)
+    }
+
+    override fun withFetchMostRecentEventReturning(result: Either<CoreFailure, String>) {
+        given(eventRepository)
+            .suspendFunction(eventRepository::fetchMostRecentEventId)
+            .whenInvoked()
+            .thenReturn(result)
+    }
+
+    override fun withLastProcessedEventIdReturning(result: Either<StorageFailure, String>) {
+        given(eventRepository)
+            .suspendFunction(eventRepository::lastProcessedEventId)
             .whenInvoked()
             .thenReturn(result)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- When attempting to fetch the oldest possible event from the api, some issue prevents us from moving on. See [WPB-4442](https://wearezeta.atlassian.net/browse/WPB-4442).

- We leave open a time gap between registering client and performing slow-sync until we first fetch the last notification from the backend. Which can lead to some events being lost.

### Solutions


1. Move the responsibility of fetching the last notification from remote outside of the repository, and into slow sync. That now fetches and saves the most recent event IDs after successful workflow if there's no previously processed event ID.
This follows more closely the [general sync documentation](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/15566871/Incremental+synchronization#Quick-sync).

2. During incremental sync recovery, clears the last processed event ID and restarts slow sync for Client or EventNotFound failures. Which, as described in **_1_**, will cause the fetching of the last remote event.

3. Refactored method names to align with these changes for better clarity.

### Testing

Tested manually by changing the `lastProcessedEventId` in the database to some garbage, which led to a 404 and successful recovery.

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[WPB-4442]: https://wearezeta.atlassian.net/browse/WPB-4442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ