### PR TITLE
fix: offline connection request actions crash when unreachable

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/ErrorResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/ErrorResponse.kt
@@ -47,5 +47,5 @@ data class FederationConflictResponse(
 
 @Serializable
 data class FederationUnreachableResponse(
-    @SerialName("unreachable_backends") val unreachableBackends: List<String>
+    @SerialName("unreachable_backends") val unreachableBackends: List<String> = emptyList()
 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Discovered in 06.09, playtest. Currently, the connection request endpoint does not respond with unreachable field, so there could be cases when unreachable could not be determined.

### Causes (Optional)

Wrong behavior, as we need this exception to operate on connection request failure, ie: send, ignore, cancel.

### Solutions

Mark the field as optional.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
