### PR TITLE
feat: resolve active 1-1 after accepting a connection request

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1547,7 +1547,12 @@ class UserSessionScope internal constructor(
             kaliumConfigs
         )
 
-    val connection: ConnectionScope get() = ConnectionScope(connectionRepository, conversationRepository)
+    val connection: ConnectionScope
+        get() = ConnectionScope(
+            connectionRepository,
+            conversationRepository,
+            oneOnOneResolver
+        )
 
     val observeSecurityClassificationLabel: ObserveSecurityClassificationLabelUseCase
         get() = ObserveSecurityClassificationLabelUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCase.kt
@@ -23,8 +23,10 @@ import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.util.DateTimeUtil
 
@@ -44,6 +46,7 @@ fun interface AcceptConnectionRequestUseCase {
 internal class AcceptConnectionRequestUseCaseImpl(
     private val connectionRepository: ConnectionRepository,
     private val conversationRepository: ConversationRepository,
+    private val oneOnOneResolver: OneOnOneResolver
 ) : AcceptConnectionRequestUseCase {
 
     override suspend fun invoke(userId: UserId): AcceptConnectionRequestUseCaseResult {
@@ -51,6 +54,7 @@ internal class AcceptConnectionRequestUseCaseImpl(
             .flatMap {
                 conversationRepository.fetchConversation(it.qualifiedConversationId)
                 conversationRepository.updateConversationModifiedDate(it.qualifiedConversationId, DateTimeUtil.currentInstant())
+                oneOnOneResolver.resolveOneOnOneConversationWithUserId(it.qualifiedToId).map { }
             }
             .fold({
                 kaliumLogger.e("An error occurred when accepting the connection request from $userId")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCase.kt
@@ -54,9 +54,14 @@ internal class AcceptConnectionRequestUseCaseImpl(
             .flatMap { connection ->
                 conversationRepository.fetchConversation(connection.qualifiedConversationId)
                     .flatMap {
-                        conversationRepository.updateConversationModifiedDate(connection.qualifiedConversationId, DateTimeUtil.currentInstant())
+                        conversationRepository.updateConversationModifiedDate(
+                            connection.qualifiedConversationId,
+                            DateTimeUtil.currentInstant()
+                        )
                     }.flatMap {
-                        oneOnOneResolver.resolveOneOnOneConversationWithUserId(connection.qualifiedToId).map { }
+                        oneOnOneResolver.resolveOneOnOneConversationWithUserId(
+                            connection.qualifiedToId
+                        ).map { }
                     }
             }
             .fold({

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/ConnectionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/ConnectionScope.kt
@@ -20,17 +20,20 @@ package com.wire.kalium.logic.feature.connection
 
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 
 class ConnectionScope(
     private val connectionRepository: ConnectionRepository,
     private val conversationRepository: ConversationRepository,
+    private val oneOnOneResolver: OneOnOneResolver
 ) {
     val sendConnectionRequest: SendConnectionRequestUseCase get() = SendConnectionRequestUseCaseImpl(connectionRepository)
 
     val acceptConnectionRequest: AcceptConnectionRequestUseCase
         get() = AcceptConnectionRequestUseCaseImpl(
             connectionRepository,
-            conversationRepository
+            conversationRepository,
+            oneOnOneResolver
         )
 
     val cancelConnectionRequest: CancelConnectionRequestUseCase get() = CancelConnectionRequestUseCaseImpl(connectionRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -87,7 +87,13 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                     if (failure.kaliumException.isMlsStaleMessage()) {
                         kaliumLogger.w("Epoch out of date for conversation ${conversation.id}, re-fetching and re-trying")
                         // Re-fetch current epoch and try again
-                        conversationRepository.fetchConversation(conversation.id).flatMap {
+                        if (conversation.type == Conversation.Type.ONE_ON_ONE) {
+                            conversationRepository.getConversationMembers(conversation.id).flatMap {
+                                conversationRepository.fetchMlsOneToOneConversation(it.first())
+                            }
+                        } else {
+                            conversationRepository.fetchConversation(conversation.id)
+                        }.flatMap {
                             conversationRepository.baseInfoById(conversation.id).flatMap { conversation ->
                                 joinOrEstablishMLSGroup(conversation)
                             }
@@ -131,6 +137,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
             }
 
             type == Conversation.Type.ONE_ON_ONE -> {
+                kaliumLogger.i("Establish group for ${conversation.type}")
                 conversationRepository.getConversationMembers(conversation.id).flatMap { members ->
                     mlsConversationRepository.establishMLSGroup(
                         protocol.groupId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolver.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.feature.conversation.JoinExistingMLSConversationUse
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.kaliumLogger
 
 /**
  * Attempts to find an existing MLS-capable one-on-one conversation,
@@ -62,8 +63,10 @@ internal class MLSOneOnOneConversationResolverImpl(
             }
 
             if (initializedMLSOneOnOne != null) {
+                kaliumLogger.d("Already established mls group for one-on-one with ${userId.toLogString()}, skipping.")
                 Either.Right(initializedMLSOneOnOne.id)
             } else {
+                kaliumLogger.d("Establishing mls group for one-on-one with ${userId.toLogString()}")
                 conversationRepository.fetchMlsOneToOneConversation(userId).flatMap { conversation ->
                     joinExistingMLSConversationUseCase(conversation.id).map { conversation.id }
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
@@ -31,7 +31,6 @@ import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 
 interface OneOnOneResolver {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
@@ -18,9 +18,11 @@
 package com.wire.kalium.logic.feature.conversation.mls
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.protocol.OneOnOneProtocolSelector
 import com.wire.kalium.logic.functional.Either
@@ -29,9 +31,11 @@ import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
+import kotlinx.coroutines.flow.first
 
 interface OneOnOneResolver {
     suspend fun resolveAllOneOnOneConversations(): Either<CoreFailure, Unit>
+    suspend fun resolveOneOnOneConversationWithUserId(userId: UserId): Either<CoreFailure, ConversationId>
     suspend fun resolveOneOnOneConversationWithUser(user: OtherUser): Either<CoreFailure, ConversationId>
 }
 
@@ -48,6 +52,11 @@ internal class OneOnOneResolverImpl(
             resolveOneOnOneConversationWithUser(item).map { }
         }
     }
+
+    override suspend fun resolveOneOnOneConversationWithUserId(userId: UserId): Either<CoreFailure, ConversationId> =
+        userRepository.getKnownUser(userId).first()?.let {
+            resolveOneOnOneConversationWithUser(it)
+        } ?: Either.Left(StorageFailure.DataNotFound)
 
     override suspend fun resolveOneOnOneConversationWithUser(user: OtherUser): Either<CoreFailure, ConversationId> =
         oneOnOneProtocolSelector.getProtocolForUser(user.id).flatMap { supportedProtocol ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -39,7 +39,6 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
-import kotlinx.coroutines.flow.first
 
 internal interface UserEventReceiver : EventReceiver<Event.User>
 
@@ -86,7 +85,7 @@ internal class UserEventReceiverImpl internal constructor(
     private suspend fun handleNewConnection(event: Event.User.NewConnection): Either<CoreFailure, Unit> =
         connectionRepository.insertConnectionFromEvent(event)
             .flatMap {
-                resolveOneOnOneConversationUponConnectionAccepted(event.connection)
+                resolveActiveOneOnOneConversationUponConnectionAccepted(event.connection)
             }
             .onSuccess {
                 kaliumLogger
@@ -104,11 +103,9 @@ internal class UserEventReceiverImpl internal constructor(
                     )
             }
 
-    private suspend fun resolveOneOnOneConversationUponConnectionAccepted(connection: Connection): Either<CoreFailure, Unit> =
+    private suspend fun resolveActiveOneOnOneConversationUponConnectionAccepted(connection: Connection): Either<CoreFailure, Unit> =
         if (connection.status == ConnectionState.ACCEPTED) {
-            userRepository.getKnownUser(connection.qualifiedToId).first()?.let {
-                oneOnOneResolver.resolveOneOnOneConversationWithUser(it).map { }
-            } ?: Either.Right(Unit)
+            oneOnOneResolver.resolveOneOnOneConversationWithUserId(connection.qualifiedToId).map { }
         } else {
             Either.Right(Unit)
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
-import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.Conversation

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -57,29 +57,26 @@ internal class MLSWelcomeEventHandlerImpl(
                     client.processWelcomeMessage(event.message.decodeBase64Bytes())
                 }
             }.flatMap { groupID ->
-                val groupIdLogPair = Pair("groupId", groupID.obfuscateId())
-
                 conversationRepository.fetchConversationIfUnknown(event.conversationId)
                     .flatMap {
                         markConversationAsEstablished(GroupID(groupID))
                     }.flatMap {
                         resolveConversationIfOneOnOne(event.conversationId)
-                    }.onSuccess {
-                        kaliumLogger
-                            .logEventProcessing(
-                                EventLoggingStatus.SUCCESS,
-                                event,
-                                Pair("info", "Established mls conversation from welcome message"),
-                                groupIdLogPair
-                            )
-                    }.onFailure {
-                        kaliumLogger
-                            .logEventProcessing(
-                                EventLoggingStatus.FAILURE,
-                                event,
-                                groupIdLogPair
-                        )
-                }
+                    }
+            }.onSuccess {
+                kaliumLogger
+                    .logEventProcessing(
+                        EventLoggingStatus.SUCCESS,
+                        event,
+                        Pair("info", "Established mls conversation from welcome message")
+                    )
+            }.onFailure {
+                kaliumLogger
+                    .logEventProcessing(
+                        EventLoggingStatus.FAILURE,
+                        event,
+                        Pair("failure", it)
+                    )
             }
 
     private suspend fun markConversationAsEstablished(groupID: GroupID): Either<CoreFailure, Unit> =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCaseTest.kt
@@ -19,100 +19,140 @@
 package com.wire.kalium.logic.feature.connection
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.connection.ConnectionRepository
-import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
-import io.mockative.Mock
+import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
+import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.ConnectionRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.ConnectionRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import io.mockative.any
 import io.mockative.eq
-import io.mockative.given
-import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class AcceptConnectionRequestUseCaseTest {
 
-    @Mock
-    private val connectionRepository: ConnectionRepository = mock(ConnectionRepository::class)
-
-    @Mock
-    private val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
-
-    lateinit var acceptConnectionRequestUseCase: AcceptConnectionRequestUseCase
-
-    @BeforeTest
-    fun setUp() {
-        acceptConnectionRequestUseCase = AcceptConnectionRequestUseCaseImpl(connectionRepository, conversationRepository)
-    }
-
     @Test
-    fun givenAConnectionRequest_whenInvokingAcceptConnectionRequestAndOk_thenShouldReturnsASuccessResult() = runTest {
+    fun givenSuccess_whenInvokingUseCase_thenShouldUpdateConnectionStatusToAccepted() = runTest {
         // given
-        given(connectionRepository)
-            .suspendFunction(connectionRepository::updateConnectionStatus)
-            .whenInvokedWith(eq(userId), eq(ConnectionState.ACCEPTED))
-            .thenReturn(Either.Right(connection))
-
-        given(conversationRepository)
-            .suspendFunction(conversationRepository::fetchConversation)
-            .whenInvokedWith(eq(conversationId))
-            .thenReturn(Either.Right(Unit))
-
-        given(conversationRepository)
-            .suspendFunction(conversationRepository::updateConversationModifiedDate)
-            .whenInvokedWith(eq(conversationId), any())
-            .thenReturn(Either.Right(Unit))
+        val (arrangement, acceptConnectionRequestUseCase) = arrange {
+            withUpdateConnectionStatus(Either.Right(CONNECTION))
+            withFetchConversation(Either.Right(Unit))
+            withUpdateConversationModifiedDate(Either.Right(Unit))
+            withResolveOneOnOneConversationWithUserIdReturning(Either.Right(TestConversation.ID))
+        }
 
         // when
-        val resultOk = acceptConnectionRequestUseCase(userId)
+        val result = acceptConnectionRequestUseCase(USER_ID)
 
         // then
-        assertEquals(AcceptConnectionRequestUseCaseResult.Success, resultOk)
-        verify(connectionRepository)
-            .suspendFunction(connectionRepository::updateConnectionStatus)
-            .with(eq(userId), eq(ConnectionState.ACCEPTED))
+        assertEquals(AcceptConnectionRequestUseCaseResult.Success, result)
+        verify(arrangement.connectionRepository)
+            .suspendFunction(arrangement.connectionRepository::updateConnectionStatus)
+            .with(eq(USER_ID), eq(ConnectionState.ACCEPTED))
             .wasInvoked(once)
     }
 
     @Test
-    fun givenAConnectionRequest_whenInvokingAcceptConnectionRequestAndFails_thenShouldReturnsAFailureResult() = runTest {
+    fun givenSuccess_whenInvokingUseCase_thenShouldUpdateConversationModifiedDate() = runTest {
         // given
-        given(connectionRepository)
-            .suspendFunction(connectionRepository::updateConnectionStatus)
-            .whenInvokedWith(eq(userId), eq(ConnectionState.ACCEPTED))
-            .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("Some error"))))
+        val (arrangement, acceptConnectionRequestUseCase) = arrange {
+            withUpdateConnectionStatus(Either.Right(CONNECTION))
+            withFetchConversation(Either.Right(Unit))
+            withUpdateConversationModifiedDate(Either.Right(Unit))
+            withResolveOneOnOneConversationWithUserIdReturning(Either.Right(TestConversation.ID))
+        }
 
         // when
-        val resultFailure = acceptConnectionRequestUseCase(userId)
+        val result = acceptConnectionRequestUseCase(USER_ID)
+
+        // then
+        assertEquals(AcceptConnectionRequestUseCaseResult.Success, result)
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateConversationModifiedDate)
+            .with(eq(CONNECTION.qualifiedConversationId), any())
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenSuccess_whenInvokingUseCase_thenShouldResolveActiveOneOnOneConversation() = runTest {
+        // given
+        val (arrangement, acceptConnectionRequestUseCase) = arrange {
+            withUpdateConnectionStatus(Either.Right(CONNECTION))
+            withFetchConversation(Either.Right(Unit))
+            withUpdateConversationModifiedDate(Either.Right(Unit))
+            withResolveOneOnOneConversationWithUserIdReturning(Either.Right(TestConversation.ID))
+        }
+
+        // when
+        val result = acceptConnectionRequestUseCase(USER_ID)
+
+        // then
+        assertEquals(AcceptConnectionRequestUseCaseResult.Success, result)
+        verify(arrangement.oneOnOneResolver)
+            .suspendFunction(arrangement.oneOnOneResolver::resolveOneOnOneConversationWithUserId)
+            .with(eq(CONNECTION.qualifiedToId))
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenFailure_whenInvokingUseCase_thenShouldReturnsAFailureResult() = runTest {
+        // given
+        val failure = CoreFailure.Unknown(RuntimeException("Some error"))
+        val (arrangement, acceptConnectionRequestUseCase) = arrange {
+            withUpdateConnectionStatus(Either.Left(failure))
+        }
+
+        // when
+        val resultFailure = acceptConnectionRequestUseCase(USER_ID)
 
         // then
         assertEquals(AcceptConnectionRequestUseCaseResult.Failure::class, resultFailure::class)
-        verify(connectionRepository)
-            .suspendFunction(connectionRepository::updateConnectionStatus)
-            .with(eq(userId), eq(ConnectionState.ACCEPTED))
+        verify(arrangement.connectionRepository)
+            .suspendFunction(arrangement.connectionRepository::updateConnectionStatus)
+            .with(eq(USER_ID), eq(ConnectionState.ACCEPTED))
             .wasInvoked(once)
     }
 
+    private class Arrangement(private val block: Arrangement.() -> Unit) :
+        ConnectionRepositoryArrangement by ConnectionRepositoryArrangementImpl(),
+        ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
+        OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl()
+    {
+        fun arrange() = run {
+            block()
+            this@Arrangement to AcceptConnectionRequestUseCaseImpl(
+                connectionRepository = connectionRepository,
+                conversationRepository = conversationRepository,
+                oneOnOneResolver = oneOnOneResolver
+            )
+        }
+    }
+
     private companion object {
-        val userId = UserId("some_user", "some_domain")
-        val conversationId = ConversationId("someId", "someDomain")
-        val connection = Connection(
+        fun arrange(configuration: Arrangement.() -> Unit) = Arrangement(configuration).arrange()
+
+        val USER_ID = UserId("some_user", "some_domain")
+        val CONVERSATION_ID = ConversationId("someId", "someDomain")
+        val CONNECTION = Connection(
             "someId",
             "from",
             "lastUpdate",
-            conversationId,
-            conversationId,
+            CONVERSATION_ID,
+            CONVERSATION_ID,
             ConnectionState.ACCEPTED,
             "toId",
             null
         )
     }
+
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -182,15 +182,14 @@ class UserEventReceiverTest {
         val event = TestEvent.newConnection(status = ConnectionState.ACCEPTED).copy()
         val (arrangement, eventReceiver) = arrange {
             withInsertConnectionFromEventSucceeding()
-            withGetKnownUserReturning(flowOf(TestUser.OTHER))
-            withResolveOneOnOneConversationWithUserReturning(Either.Right(TestConversation.ID))
+            withResolveOneOnOneConversationWithUserIdReturning(Either.Right(TestConversation.ID))
         }
 
         eventReceiver.onEvent(event)
 
         verify(arrangement.oneOnOneResolver)
-            .suspendFunction(arrangement.oneOnOneResolver::resolveOneOnOneConversationWithUser)
-            .with(eq(TestUser.OTHER))
+            .suspendFunction(arrangement.oneOnOneResolver::resolveOneOnOneConversationWithUserId)
+            .with(eq(event.connection.qualifiedToId))
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/OneOnOneResolverArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/OneOnOneResolverArrangement.kt
@@ -29,7 +29,7 @@ import io.mockative.mock
 interface OneOnOneResolverArrangement {
 
     val oneOnOneResolver: OneOnOneResolver
-
+    fun withResolveOneOnOneConversationWithUserIdReturning(result: Either<CoreFailure, ConversationId>)
     fun withResolveOneOnOneConversationWithUserReturning(result: Either<CoreFailure, ConversationId>)
     fun withResolveAllOneOnOneConversationsReturning(result: Either<CoreFailure, Unit>)
 
@@ -39,6 +39,12 @@ class OneOnOneResolverArrangementImpl : OneOnOneResolverArrangement {
 
     @Mock
     override val oneOnOneResolver = mock(OneOnOneResolver::class)
+    override fun withResolveOneOnOneConversationWithUserIdReturning(result: Either<CoreFailure, ConversationId>) {
+        given(oneOnOneResolver)
+            .suspendFunction(oneOnOneResolver::resolveOneOnOneConversationWithUserId)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
 
     override fun withResolveOneOnOneConversationWithUserReturning(result: Either<CoreFailure, ConversationId>) {
         given(oneOnOneResolver)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConnectionRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConnectionRepositoryArrangement.kt
@@ -17,13 +17,18 @@
  */
 package com.wire.kalium.logic.util.arrangement.repository
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.Connection
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCaseTest
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
 import io.mockative.any
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.matchers.Matcher
 import io.mockative.mock
@@ -35,6 +40,7 @@ internal interface ConnectionRepositoryArrangement {
     fun withGetConnections(result: Either<StorageFailure, Flow<List<ConversationDetails>>>)
     fun withDeleteConnection(result: Either<StorageFailure, Unit>, conversationId: Matcher<ConversationId> = any())
     fun withConnectionList(connectionsFlow: Flow<List<ConversationDetails>>)
+    fun withUpdateConnectionStatus(result: Either<CoreFailure, Connection>)
 }
 
 internal open class ConnectionRepositoryArrangementImpl : ConnectionRepositoryArrangement {
@@ -65,5 +71,12 @@ internal open class ConnectionRepositoryArrangementImpl : ConnectionRepositoryAr
             .suspendFunction(connectionRepository::observeConnectionRequestsForNotification)
             .whenInvoked()
             .thenReturn(connectionsFlow)
+    }
+
+    override fun withUpdateConnectionStatus(result: Either<CoreFailure, Connection>) {
+        given(connectionRepository)
+            .suspendFunction(connectionRepository::updateConnectionStatus)
+            .whenInvokedWith(any(), any())
+            .thenReturn(result)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
@@ -26,9 +26,11 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCaseTest
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
 import io.mockative.any
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.matchers.Matcher
 import io.mockative.mock
@@ -53,6 +55,7 @@ internal interface ConversationRepositoryArrangement {
     fun withGetConversation(conversation: Conversation? = TestConversation.CONVERSATION)
     fun withConversationsForUserIdReturning(result: Either<CoreFailure, List<Conversation>>)
     fun withFetchMlsOneToOneConversation(result: Either<CoreFailure, Conversation>)
+    fun withFetchConversation(result: Either<CoreFailure, Unit>)
     fun withObserveOneToOneConversationWithOtherUserReturning(result: Either<CoreFailure, Conversation>)
 
     fun withObserveConversationDetailsByIdReturning(result: Either<StorageFailure, ConversationDetails>)
@@ -80,6 +83,13 @@ internal interface ConversationRepositoryArrangement {
     fun withUpdateGroupStateReturning(result: Either<StorageFailure, Unit>) {
         given(conversationRepository)
             .suspendFunction(conversationRepository::updateConversationGroupState)
+            .whenInvokedWith(any(), any())
+            .thenReturn(result)
+    }
+
+    fun withUpdateConversationModifiedDate(result: Either<StorageFailure, Unit>) {
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::updateConversationModifiedDate)
             .whenInvokedWith(any(), any())
             .thenReturn(result)
     }
@@ -142,6 +152,13 @@ internal open class ConversationRepositoryArrangementImpl : ConversationReposito
     override fun withFetchMlsOneToOneConversation(result: Either<CoreFailure, Conversation>) {
         given(conversationRepository)
             .suspendFunction(conversationRepository::fetchMlsOneToOneConversation)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
+
+    override fun withFetchConversation(result: Either<CoreFailure, Unit>) {
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::fetchConversation)
             .whenInvokedWith(any())
             .thenReturn(result)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We need to resolve the active one-on-one conversation after [certain events](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/811958286/Use+case+Migration+of+1+1+conversation+Proteus+to+MLS+migration#Periodically-evaluate-what-protocol-to-use-for-1%3A1-conversation), one these events is after a connection is accepted.

This is a follow up on https://github.com/wireapp/kalium/pull/2034 since the client which accepts the connection request won't get any event via the web socket, it instead gets the same information in the response of changing the connection status.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
