### PR TITLE
feat(monkeys): Add and expose metrics of the text execution [WPB-4445]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ mockk = "1.13.5"
 faker = "1.14.0"
 robolectric = "4.9"
 stately = "2.0.0-rc3"
+micrometer = "1.11.3"
 
 [plugins]
 # Home-made convention plugins
@@ -140,6 +141,8 @@ ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-okHttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-iosHttp = { module = "io.ktor:ktor-client-ios", version.ref = "ktor" }
 ktor-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = "ktor" }
+ktor-server = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-serverNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 
 # okio
 okio-core = { module = "com.squareup.okio:okio", version.ref = "okio" }
@@ -188,3 +191,4 @@ jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 
 # logging
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
+micrometer = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }

--- a/monkeys/build.gradle.kts
+++ b/monkeys/build.gradle.kts
@@ -68,7 +68,10 @@ sourceSets {
             implementation(libs.ktor.contentNegotiation)
             implementation(libs.ktor.json)
             implementation(libs.ktor.authClient)
+            implementation(libs.ktor.server)
+            implementation(libs.ktor.serverNetty)
             implementation(libs.okhttp.loggingInterceptor)
+            implementation(libs.micrometer)
 
             implementation(libs.faker)
         }

--- a/monkeys/example.json
+++ b/monkeys/example.json
@@ -1,25 +1,25 @@
 {
+    "conversationDistribution": {
+        "groupPROTEUS": {
+            "userCount": {
+                "type": "PERCENTAGE",
+                "value": 50
+            },
+            "protocol": "PROTEUS",
+            "groupCount": 2
+        },
+        "groupMLS": {
+            "userCount": {
+                "type": "PERCENTAGE",
+                "value": 50
+            },
+            "protocol": "MLS",
+            "groupCount": 2
+        }
+    },
     "testCases": [
         {
             "name": "Example Test Case",
-            "conversationDistribution": {
-                "groupPROTEUS": {
-                    "userCount": {
-                        "type": "PERCENTAGE",
-                        "value": 50
-                    },
-                    "protocol": "PROTEUS",
-                    "groupCount": 2
-                },
-                "groupMLS": {
-                    "userCount": {
-                        "type": "PERCENTAGE",
-                        "value": 50
-                    },
-                    "protocol": "MLS",
-                    "groupCount": 2
-                }
-            },
             "setup": [
                 {
                     "description": "Log everyone in",
@@ -120,7 +120,7 @@
                             "type": "FIXED_COUNT",
                             "value": 10
                         },
-                        "protocol": "PROTEUS",
+                        "protocol": "MLS",
                         "teamOwner": "Elna"
                     }
                 }
@@ -141,7 +141,8 @@
             "teamName": "Diya",
             "authUser": "admin",
             "authPassword": "admin",
-            "userCount": 10
+            "userCount": 10,
+            "dumpUsers": true
         },
         {
             "api": "https://nginz-https.elna.wire.link",
@@ -156,7 +157,8 @@
             "teamName": "Elna",
             "authUser": "admin",
             "authPassword": "admin",
-            "userCount": 10
+            "userCount": 10,
+            "dumpUsers": true
         }
     ]
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/ActionScheduler.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/ActionScheduler.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.actions.Action
 import com.wire.kalium.monkeys.importer.ActionConfig
 import com.wire.kalium.monkeys.pool.MonkeyPool
+import io.micrometer.core.instrument.Tag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -33,20 +34,28 @@ import kotlinx.serialization.serializer
 object ActionScheduler {
     @Suppress("TooGenericExceptionCaught")
     @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
-    suspend fun start(actions: List<ActionConfig>, coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    suspend fun start(testCase: String, actions: List<ActionConfig>, coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
         actions.forEach { actionConfig ->
             CoroutineScope(Dispatchers.Default).launch {
                 while (this.isActive) {
+                    val actionName = actionConfig.type::class.serializer().descriptor.serialName
+                    val tags = listOf(Tag.of("testCase", testCase))
                     try {
-                        val actionName = actionConfig.type::class.serializer().descriptor.serialName
                         logger.i("Running action $actionName: ${actionConfig.description} ${actionConfig.count} times")
                         repeat(actionConfig.count.toInt()) {
                             val startTime = System.currentTimeMillis()
-                            Action.fromConfig(actionConfig).execute(coreLogic, monkeyPool)
+                            MetricsCollector.time("t_$actionName", tags) {
+                                Action.fromConfig(actionConfig).execute(coreLogic, monkeyPool)
+                            }
+                            MetricsCollector.count("c_$actionName", tags)
                             logger.d("Action $actionName took ${System.currentTimeMillis() - startTime} milliseconds")
                         }
                     } catch (e: Exception) {
-                        logger.e("Error in action ${actionConfig.description}", e)
+                        logger.e("Error in action ${actionConfig.description}:", e)
+                        if (e.cause != null) {
+                            logger.e("Cause for error in ${actionConfig.description}:", e.cause)
+                        }
+                        MetricsCollector.count("c_errors", tags.plusElement(Tag.of("action", actionName)))
                     }
                     delay(actionConfig.repeatInterval.toLong())
                 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MetricsCollector.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MetricsCollector.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.monkeys
+
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Timer
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import kotlin.time.measureTimedValue
+import kotlin.time.toJavaDuration
+
+object MetricsCollector {
+    private val registry = PrometheusMeterRegistry { null }
+
+    fun metrics(): String {
+        return this.registry.scrape()
+    }
+
+    fun count(key: String, tags: List<Tag>) {
+        this.registry.counter(key, tags).increment()
+    }
+
+    suspend fun <T> time(key: String, tags: List<Tag>, func: suspend () -> T): T {
+        val timer: Timer = Timer
+            .builder(key)
+            .tags(tags)
+            .publishPercentiles(0.3, 0.5, 0.95)
+            .publishPercentileHistogram()
+            .register(this.registry)
+        val (result, duration) = measureTimedValue { func() }
+        timer.record(duration.toJavaDuration())
+        return result
+    }
+
+    fun <T> gaugeCollection(key: String, tags: List<Tag>, collection: Collection<T>) {
+        this.registry.gaugeCollectionSize(key, tags, collection)
+    }
+
+    fun <K, V> gaugeMap(key: String, tags: List<Tag>, collection: Map<K, V>) {
+        this.registry.gaugeMapSize(key, tags, collection)
+    }
+
+    fun distribution(key: String, tags: List<Tag>, amount: Double) {
+        val distribution = DistributionSummary
+            .builder(key)
+            .tags(tags)
+            .publishPercentiles(0.3, 0.5, 0.95)
+            .publishPercentileHistogram()
+            .register(this.registry)
+        distribution.record(amount)
+    }
+}

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MetricsCollector.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MetricsCollector.kt
@@ -35,6 +35,7 @@ object MetricsCollector {
         this.registry.counter(key, tags).increment()
     }
 
+    @Suppress("MagicNumber")
     suspend fun <T> time(key: String, tags: List<Tag>, func: suspend () -> T): T {
         val timer: Timer = Timer
             .builder(key)
@@ -55,6 +56,7 @@ object MetricsCollector {
         this.registry.gaugeMapSize(key, tags, collection)
     }
 
+    @Suppress("MagicNumber")
     fun distribution(key: String, tags: List<Tag>, amount: Double) {
         val distribution = DistributionSummary
             .builder(key)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
@@ -126,8 +126,9 @@ class Monkey(val user: UserData) {
     }
 
     suspend fun randomPeers(userCount: UserCount, monkeyPool: MonkeyPool, filterOut: List<UserId> = listOf()): List<Monkey> {
-        val count = resolveUserCount(userCount, this.connectedMonkeys().count().toUInt())
-        return this.connectedMonkeys().filterNot { filterOut.contains(it) }.shuffled().map(monkeyPool::get).take(count.toInt())
+        val connectedMonkeys = this.connectedMonkeys()
+        val count = resolveUserCount(userCount, connectedMonkeys.count().toUInt())
+        return connectedMonkeys.filterNot { filterOut.contains(it) }.shuffled().map(monkeyPool::get).take(count.toInt())
     }
 
     suspend fun sendRequest(anotherMonkey: Monkey) {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
@@ -31,8 +31,8 @@ import com.wire.kalium.logic.feature.auth.AuthenticationScope
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase
+import com.wire.kalium.logic.feature.conversation.CreateConversationResult
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
-import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationUseCase
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsResult
 import com.wire.kalium.monkeys.importer.Backend
 import com.wire.kalium.monkeys.importer.UserCount
@@ -168,7 +168,7 @@ class Monkey(val user: UserData) {
                 ConversationOptions(protocol = protocol)
             )
             if (result is CreateGroupConversationUseCase.Result.Success) {
-                MonkeyConversation(self, result.conversation, isDestroyable)
+                MonkeyConversation(self, result.conversation, isDestroyable, monkeyList)
             } else {
                 error("${self.user.email} could not create group $name: $result")
             }
@@ -214,14 +214,11 @@ class Monkey(val user: UserData) {
     suspend fun sendDirectMessageTo(anotherMonkey: Monkey, message: String) {
         val self = this.user.email
         this.monkeyState.readyThen {
-            conversations.getOneToOneConversation(anotherMonkey.user.userId).collect { result ->
-                if (result is GetOneToOneConversationUseCase.Result.Success) {
-                    messages.sendTextMessage(
-                        result.conversation.id, message
-                    )
-                } else {
-                    error("$self failed contacting ${anotherMonkey.user.email}: $result")
-                }
+            val result = conversations.getOrCreateOneToOneConversationUseCase(anotherMonkey.user.userId)
+            if (result is CreateConversationResult.Success) {
+                messages.sendTextMessage(result.conversation.id, message)
+            } else {
+                error("$self failed contacting ${anotherMonkey.user.email}: $result")
             }
         }
     }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/MonkeyConversation.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/MonkeyConversation.kt
@@ -37,7 +37,6 @@ class MonkeyConversation(val creator: Monkey, val conversation: Conversation, va
         MetricsCollector.gaugeCollection("g_conversationMembers", listOf(Tag.of("id", conversation.id.toString())), this.participants)
     }
 
-
     /**
      * Return a [count] number of random [Monkey] from the conversation.
      * It returns only logged-in users, if there are none an empty list will be returned

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/MonkeyConversation.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/MonkeyConversation.kt
@@ -19,20 +19,24 @@ package com.wire.kalium.monkeys.conversation
 
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.monkeys.MetricsCollector
 import com.wire.kalium.monkeys.importer.UserCount
 import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.resolveUserCount
+import io.micrometer.core.instrument.Tag
 
 /**
  * This is a shallow wrapper over the conversation (it contains only details), since the operations need to be done on the
  * user scope, they're done inside the [Monkey] class.
  */
-class MonkeyConversation(
-    val creator: Monkey,
-    val conversation: Conversation,
-    val isDestroyable: Boolean = true
-) {
-    private var participants: MutableSet<Monkey> = mutableSetOf(creator)
+class MonkeyConversation(val creator: Monkey, val conversation: Conversation, val isDestroyable: Boolean = true, monkeyList: List<Monkey>) {
+    private var participants: MutableSet<Monkey>
+
+    init {
+        this.participants = mutableSetOf(creator).also { it.addAll(monkeyList) }
+        MetricsCollector.gaugeCollection("g_conversationMembers", listOf(Tag.of("id", conversation.id.toString())), this.participants)
+    }
+
 
     /**
      * Return a [count] number of random [Monkey] from the conversation.

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.monkeys.pool
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.monkeys.MetricsCollector
 import com.wire.kalium.monkeys.conversation.Monkey
 import com.wire.kalium.monkeys.conversation.MonkeyConversation
 import com.wire.kalium.monkeys.importer.UserCount
@@ -32,6 +33,10 @@ object ConversationPool {
 
     // since this is created in the setup, there's no need to be thread safe
     private val prefixedConversations: MutableMap<String, MutableList<ConversationId>> = mutableMapOf()
+
+    init {
+        MetricsCollector.gaugeMap("g_conversations", listOf(), this.pool)
+    }
 
     fun get(conversationId: ConversationId): MonkeyConversation? {
         return this.pool[conversationId]
@@ -122,6 +127,4 @@ object ConversationPool {
             this.pool[it] ?: error("Inconsistent state. Conversation $it is in the prefixed pool but not on the general")
         } ?: error("Conversation from target $target not found in the pool")
     }
-
-    fun size(): UInt = this.pool.size.toUInt()
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/MonkeyPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/MonkeyPool.kt
@@ -18,13 +18,15 @@
 package com.wire.kalium.monkeys.pool
 
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.monkeys.MetricsCollector
 import com.wire.kalium.monkeys.conversation.Monkey
 import com.wire.kalium.monkeys.importer.UserCount
 import com.wire.kalium.monkeys.importer.UserData
+import io.micrometer.core.instrument.Tag
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.roundToInt
 
-class MonkeyPool(users: List<UserData>) {
+class MonkeyPool(users: List<UserData>, testCase: String) {
     // a map of monkeys per domain
     private val pool: ConcurrentHashMap<String, MutableList<Monkey>> = ConcurrentHashMap()
 
@@ -43,6 +45,22 @@ class MonkeyPool(users: List<UserData>) {
             this.pool.getOrPut(it.backend.teamName) { mutableListOf() }.add(monkey)
             this.poolLoggedOut.getOrPut(it.backend.teamName) { ConcurrentHashMap() }[it.userId] = monkey
             this.poolById[it.userId] = monkey
+        }
+        this.poolLoggedOut.forEach { (domain, usersById) ->
+            MetricsCollector.gaugeMap(
+                "g_loggedOutUsers",
+                listOf(Tag.of("domain", domain), Tag.of("testCase", testCase)),
+                usersById
+            )
+            // init so we can have metrics for it
+            this.poolLoggedIn[domain] = ConcurrentHashMap()
+        }
+        this.poolLoggedIn.forEach { (domain, usersById) ->
+            MetricsCollector.gaugeMap(
+                "g_loggedInUsers",
+                listOf(Tag.of("domain", domain), Tag.of("testCase", testCase)),
+                usersById
+            )
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

# What's new in this PR?

Exposes metrics in prometheus format at runtime on the port 9090. With that, tests can be monitored at runtime about it's state and performance. Now there'll always be a log file for the application and it was split from the kalium log. A custom log file can be specified, otherwise it will be `$CWD/monkeys.log`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
