### PR TITLE
fix: app stuck on setting up wire after account creation

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.feature.call
 
-import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.sun.jna.Pointer
 import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.ENVIRONMENT_DEFAULT
@@ -41,13 +40,15 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.util.CurrentPlatform
 import com.wire.kalium.logic.util.PlatformContext
 import com.wire.kalium.logic.util.PlatformType
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 
 actual class GlobalCallManager(
     appContext: PlatformContext
 ) {
 
-    private val callManagerHolder: ConcurrentMutableMap<QualifiedID, CallManager> by lazy {
-        ConcurrentMutableMap()
+    private val callManagerHolder: ConcurrentMap<QualifiedID, CallManager> by lazy {
+        ConcurrentHashMap()
     }
 
     private val calling by lazy {
@@ -85,22 +86,22 @@ actual class GlobalCallManager(
         conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
         kaliumConfigs: KaliumConfigs
     ): CallManager {
-        return callManagerHolder[userId] ?: CallManagerImpl(
-            calling = calling,
-            callRepository = callRepository,
-            userRepository = userRepository,
-            currentClientIdProvider = currentClientIdProvider,
-            selfConversationIdProvider = selfConversationIdProvider,
-            callMapper = callMapper,
-            messageSender = messageSender,
-            conversationRepository = conversationRepository,
-            federatedIdMapper = federatedIdMapper,
-            qualifiedIdMapper = qualifiedIdMapper,
-            videoStateChecker = videoStateChecker,
-            conversationClientsInCallUpdater = conversationClientsInCallUpdater,
-            kaliumConfigs = kaliumConfigs
-        ).also {
-            callManagerHolder[userId] = it
+        return callManagerHolder.computeIfAbsent(userId) {
+            CallManagerImpl(
+                calling = calling,
+                callRepository = callRepository,
+                userRepository = userRepository,
+                currentClientIdProvider = currentClientIdProvider,
+                selfConversationIdProvider = selfConversationIdProvider,
+                callMapper = callMapper,
+                messageSender = messageSender,
+                conversationRepository = conversationRepository,
+                federatedIdMapper = federatedIdMapper,
+                qualifiedIdMapper = qualifiedIdMapper,
+                videoStateChecker = videoStateChecker,
+                conversationClientsInCallUpdater = conversationClientsInCallUpdater,
+                kaliumConfigs = kaliumConfigs
+            )
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/UserStorageProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/UserStorageProvider.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.logic.di
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.util.computeIfAbsent
+import com.wire.kalium.logic.util.safeComputeIfAbsent
 import com.wire.kalium.persistence.db.UserDatabaseBuilder
 import com.wire.kalium.persistence.kmmSettings.UserPrefBuilder
 
@@ -31,7 +31,7 @@ abstract class UserStorageProvider {
         userId: UserId,
         platformUserStorageProperties: PlatformUserStorageProperties,
         shouldEncryptData: Boolean = true
-    ): UserStorage = inMemoryUserStorage.computeIfAbsent(userId) {
+    ): UserStorage = inMemoryUserStorage.safeComputeIfAbsent(userId) {
         create(userId, shouldEncryptData, platformUserStorageProperties)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
@@ -22,7 +22,7 @@ import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.UserStorageProvider
 import com.wire.kalium.logic.feature.call.GlobalCallManager
-import com.wire.kalium.logic.util.computeIfAbsent
+import com.wire.kalium.logic.util.safeComputeIfAbsent
 
 interface UserSessionScopeProvider {
     fun get(userId: UserId): UserSessionScope?
@@ -41,7 +41,7 @@ abstract class UserSessionScopeProviderCommon(
     }
 
     override fun getOrCreate(userId: UserId): UserSessionScope =
-        userScopeStorage.computeIfAbsent(userId) {
+        userScopeStorage.safeComputeIfAbsent(userId) {
             create(userId)
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -38,7 +38,7 @@ import com.wire.kalium.logic.feature.appVersioning.CheckIfUpdateRequiredUseCaseI
 import com.wire.kalium.logic.feature.auth.sso.SSOLoginScope
 import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerificationCodeUseCase
 import com.wire.kalium.logic.feature.register.RegisterScope
-import com.wire.kalium.logic.util.computeIfAbsent
+import com.wire.kalium.logic.util.safeComputeIfAbsent
 import com.wire.kalium.network.NetworkStateObserver
 import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkContainer
 import com.wire.kalium.network.session.CertificatePinning
@@ -59,7 +59,7 @@ class AuthenticationScopeProvider internal constructor(
         networkStateObserver: NetworkStateObserver,
         certConfig: () -> CertificatePinning
     ): AuthenticationScope =
-        authenticationScopeStorage.computeIfAbsent(serverConfig to proxyCredentials) {
+        authenticationScopeStorage.safeComputeIfAbsent(serverConfig to proxyCredentials) {
             AuthenticationScope(
                 userAgent,
                 serverConfig,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/CommonUtils.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/CommonUtils.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.util
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
+import com.wire.kalium.logic.kaliumLogger
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.time.Duration
@@ -86,7 +87,7 @@ fun Int?.isGreaterThan(other: Int?): Boolean {
 }
 
 // Convenience method to compute a value if absent in a "Stately" concurrent map
-fun <K, V> ConcurrentMutableMap<K, V>.computeIfAbsent(key: K, f: () -> V): V {
+fun <K, V> ConcurrentMutableMap<K, V>.safeComputeIfAbsent(key: K, f: () -> V): V {
     return this.block {
         if (this.containsKey(key)) return@block this[key]!!
         val value = f()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/CommonUtils.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/CommonUtils.kt
@@ -19,7 +19,6 @@
 package com.wire.kalium.logic.util
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
-import com.wire.kalium.logic.kaliumLogger
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.time.Duration

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/ConcurrentMutableMapTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/ConcurrentMutableMapTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util
+
+import co.touchlab.stately.collections.ConcurrentMutableMap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConcurrentMutableMapTest {
+
+    @Test
+    fun givenConcurrentMap_whenSafeComputeIfAbsentIsCalledWith_thenTheSecondIsIgnored() {
+        val map = ConcurrentMutableMap<String, String>()
+        map.safeComputeIfAbsent("a") { "c" }
+        map.safeComputeIfAbsent("a") { "d" }
+        assertEquals("c", map["a"])
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

app stuck on setting up wire after creation an account

### Solutions

the function inside the unti `computeIfAbsent` is not being called for a tricky reason 
ConcurrentMutableMap inherent from MutableMap and in java HashMaps already have a `computeIfAbsent` and in runtime the one form parent is called ignoring the extension function

this can be confirmed by the app still compiling if I simply delete the extension function we added and kipping everything else as it is


solution: rename it to something else

i also noticed that the calling manager function `getCallManagerForClient` is not thread safe, so I fixed this as well. 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
