### PR TITLE
feat: avoid race condition when establishing mls 1-1

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -205,7 +205,8 @@ internal class ConversationGroupRepositoryImpl(
                                     eventMapper.conversationMemberJoin(
                                         LocalId.generate(),
                                         response.event,
-                                        true
+                                        true,
+                                        false
                                     )
                                 )
                             }
@@ -244,7 +245,7 @@ internal class ConversationGroupRepositoryImpl(
         conversationId: ConversationId
     ) = if (apiResult.value is ConversationMemberAddedResponse.Changed) {
         memberJoinEventHandler.handle(
-            eventMapper.conversationMemberJoin(LocalId.generate(), apiResult.value.event, true)
+            eventMapper.conversationMemberJoin(LocalId.generate(), apiResult.value.event, true, false)
         ).flatMap {
             if (failedUsersList.isNotEmpty()) {
                 newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(conversationId, failedUsersList)
@@ -311,7 +312,7 @@ internal class ConversationGroupRepositoryImpl(
         if (response is ConversationMemberAddedResponse.Changed) {
             val conversationId = response.event.qualifiedConversation.toModel()
 
-            memberJoinEventHandler.handle(eventMapper.conversationMemberJoin(LocalId.generate(), response.event, true))
+            memberJoinEventHandler.handle(eventMapper.conversationMemberJoin(LocalId.generate(), response.event, true, false))
                 .flatMap {
                     wrapStorageRequest { conversationDAO.getConversationProtocolInfo(conversationId.toDao()) }
                         .flatMap { protocol ->
@@ -359,6 +360,7 @@ internal class ConversationGroupRepositoryImpl(
                     eventMapper.conversationMemberLeave(
                         LocalId.generate(),
                         response.event,
+                        false,
                         false
                     )
                 )
@@ -398,7 +400,8 @@ internal class ConversationGroupRepositoryImpl(
                     eventMapper.conversationMessageTimerUpdate(
                         LocalId.generate(),
                         it,
-                        true
+                        true,
+                        false
                     )
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -285,7 +285,7 @@ internal class MLSConversationDataSource(
 
     private suspend fun processCommitBundleEvents(events: List<EventContentDTO>) {
         events.forEach { eventContentDTO ->
-            val event = MapperProvider.eventMapper().fromEventContentDTO("", eventContentDTO, true)
+            val event = MapperProvider.eventMapper().fromEventContentDTO("", eventContentDTO, true, false)
             if (event is Event.Conversation) {
                 commitBundleEventReceiver.onEvent(event)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -307,7 +307,12 @@ class EventMapper(
         connectionMapper.fromApiToModel(eventConnectionDTO.connection)
     )
 
-    private fun userDelete(id: String, eventUserDelete: EventContentDTO.User.UserDeleteDTO, transient: Boolean, live: Boolean): Event.User.UserDelete {
+    private fun userDelete(
+        id: String,
+        eventUserDelete: EventContentDTO.User.UserDeleteDTO,
+        transient: Boolean,
+        live: Boolean
+    ): Event.User.UserDelete {
         return Event.User.UserDelete(transient, live, id, eventUserDelete.userId.toModel())
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -57,59 +57,61 @@ class EventMapper(
     private val receiptModeMapper: ReceiptModeMapper = MapperProvider.receiptModeMapper(),
     private val clientMapper: ClientMapper = MapperProvider.clientMapper()
 ) {
-    fun fromDTO(eventResponse: EventResponse): List<Event> {
+    fun fromDTO(eventResponse: EventResponse, live: Boolean = false): List<Event> {
         // TODO(edge-case): Multiple payloads in the same event have the same ID, is this an issue when marking lastProcessedEventId?
         val id = eventResponse.id
         return eventResponse.payload?.map { eventContentDTO ->
-            fromEventContentDTO(id, eventContentDTO, eventResponse.transient)
+            fromEventContentDTO(id, eventContentDTO, eventResponse.transient, live)
         } ?: listOf()
     }
 
     @Suppress("ComplexMethod")
-    fun fromEventContentDTO(id: String, eventContentDTO: EventContentDTO, transient: Boolean): Event =
+    fun fromEventContentDTO(id: String, eventContentDTO: EventContentDTO, transient: Boolean, live: Boolean): Event =
         when (eventContentDTO) {
-            is EventContentDTO.Conversation.NewMessageDTO -> newMessage(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.NewConversationDTO -> newConversation(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.MemberJoinDTO -> conversationMemberJoin(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.MemberLeaveDTO -> conversationMemberLeave(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.MemberUpdateDTO -> memberUpdate(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.MLSWelcomeDTO -> welcomeMessage(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.NewMLSMessageDTO -> newMLSMessage(id, eventContentDTO, transient)
-            is EventContentDTO.User.NewConnectionDTO -> connectionUpdate(id, eventContentDTO, transient)
-            is EventContentDTO.User.ClientRemoveDTO -> clientRemove(id, eventContentDTO, transient)
-            is EventContentDTO.User.UserDeleteDTO -> userDelete(id, eventContentDTO, transient)
-            is EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO -> featureConfig(id, eventContentDTO, transient)
-            is EventContentDTO.User.NewClientDTO -> newClient(id, eventContentDTO, transient)
-            is EventContentDTO.Unknown -> unknown(id, transient, eventContentDTO)
-            is EventContentDTO.Conversation.AccessUpdate -> unknown(id, transient, eventContentDTO)
-            is EventContentDTO.Conversation.DeletedConversationDTO -> conversationDeleted(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.ConversationRenameDTO -> conversationRenamed(id, eventContentDTO, transient)
-            is EventContentDTO.Team.MemberJoin -> teamMemberJoined(id, eventContentDTO, transient)
-            is EventContentDTO.Team.MemberLeave -> teamMemberLeft(id, eventContentDTO, transient)
-            is EventContentDTO.Team.MemberUpdate -> teamMemberUpdate(id, eventContentDTO, transient)
-            is EventContentDTO.Team.Update -> teamUpdate(id, eventContentDTO, transient)
-            is EventContentDTO.User.UpdateDTO -> userUpdate(id, eventContentDTO, transient)
-            is EventContentDTO.UserProperty.PropertiesSetDTO -> updateUserProperties(id, eventContentDTO, transient)
-            is EventContentDTO.UserProperty.PropertiesDeleteDTO -> deleteUserProperties(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.ReceiptModeUpdate -> conversationReceiptModeUpdate(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.MessageTimerUpdate -> conversationMessageTimerUpdate(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.CodeDeleted -> conversationCodeDeleted(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.CodeUpdated -> conversationCodeUpdated(id, eventContentDTO, transient)
-            is EventContentDTO.Federation -> federationTerminated(id, eventContentDTO, transient)
-            is EventContentDTO.Conversation.ProtocolUpdate -> conversationProtocolUpdate(id, eventContentDTO, transient)
+            is EventContentDTO.Conversation.NewMessageDTO -> newMessage(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.NewConversationDTO -> newConversation(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.MemberJoinDTO -> conversationMemberJoin(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.MemberLeaveDTO -> conversationMemberLeave(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.MemberUpdateDTO -> memberUpdate(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.MLSWelcomeDTO -> welcomeMessage(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.NewMLSMessageDTO -> newMLSMessage(id, eventContentDTO, transient, live)
+            is EventContentDTO.User.NewConnectionDTO -> connectionUpdate(id, eventContentDTO, transient, live)
+            is EventContentDTO.User.ClientRemoveDTO -> clientRemove(id, eventContentDTO, transient, live)
+            is EventContentDTO.User.UserDeleteDTO -> userDelete(id, eventContentDTO, transient, live)
+            is EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO -> featureConfig(id, eventContentDTO, transient, live)
+            is EventContentDTO.User.NewClientDTO -> newClient(id, eventContentDTO, transient, live)
+            is EventContentDTO.Unknown -> unknown(id, transient, live, eventContentDTO)
+            is EventContentDTO.Conversation.AccessUpdate -> unknown(id, transient, live, eventContentDTO)
+            is EventContentDTO.Conversation.DeletedConversationDTO -> conversationDeleted(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.ConversationRenameDTO -> conversationRenamed(id, eventContentDTO, transient, live)
+            is EventContentDTO.Team.MemberJoin -> teamMemberJoined(id, eventContentDTO, transient, live)
+            is EventContentDTO.Team.MemberLeave -> teamMemberLeft(id, eventContentDTO, transient, live)
+            is EventContentDTO.Team.MemberUpdate -> teamMemberUpdate(id, eventContentDTO, transient, live)
+            is EventContentDTO.Team.Update -> teamUpdate(id, eventContentDTO, transient, live)
+            is EventContentDTO.User.UpdateDTO -> userUpdate(id, eventContentDTO, transient, live)
+            is EventContentDTO.UserProperty.PropertiesSetDTO -> updateUserProperties(id, eventContentDTO, transient, live)
+            is EventContentDTO.UserProperty.PropertiesDeleteDTO -> deleteUserProperties(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.ReceiptModeUpdate -> conversationReceiptModeUpdate(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.MessageTimerUpdate -> conversationMessageTimerUpdate(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.CodeDeleted -> conversationCodeDeleted(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.CodeUpdated -> conversationCodeUpdated(id, eventContentDTO, transient, live)
+            is EventContentDTO.Federation -> federationTerminated(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.ProtocolUpdate -> conversationProtocolUpdate(id, eventContentDTO, transient, live)
         }
 
-    private fun federationTerminated(id: String, eventContentDTO: EventContentDTO.Federation, transient: Boolean): Event =
+    private fun federationTerminated(id: String, eventContentDTO: EventContentDTO.Federation, transient: Boolean, live: Boolean): Event =
         when (eventContentDTO) {
             is EventContentDTO.Federation.FederationConnectionRemovedDTO -> Event.Federation.ConnectionRemoved(
                 id,
                 transient,
+                live,
                 eventContentDTO.domains
             )
 
             is EventContentDTO.Federation.FederationDeleteDTO -> Event.Federation.Delete(
                 id,
                 transient,
+                live,
                 eventContentDTO.domain
             )
         }
@@ -117,17 +119,20 @@ class EventMapper(
     private fun conversationCodeDeleted(
         id: String,
         event: EventContentDTO.Conversation.CodeDeleted,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event.Conversation.CodeDeleted = Event.Conversation.CodeDeleted(
         id = id,
         transient = transient,
+        live = live,
         conversationId = event.qualifiedConversation.toModel()
     )
 
     private fun conversationCodeUpdated(
         id: String,
         event: EventContentDTO.Conversation.CodeUpdated,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event.Conversation.CodeUpdated = Event.Conversation.CodeUpdated(
         id = id,
         key = event.data.key,
@@ -135,18 +140,21 @@ class EventMapper(
         uri = event.data.uri,
         isPasswordProtected = event.data.hasPassword,
         conversationId = event.qualifiedConversation.toModel(),
-        transient = transient
+        transient = transient,
+        live = live,
     )
 
     @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
     fun unknown(
         id: String,
         transient: Boolean,
+        live: Boolean,
         eventContentDTO: EventContentDTO,
         cause: String? = null
     ): Event.Unknown = Event.Unknown(
         id = id,
         transient = transient,
+        live = live,
         unknownType = when (eventContentDTO) {
             is EventContentDTO.Unknown -> eventContentDTO.type
             else -> try {
@@ -161,11 +169,13 @@ class EventMapper(
     private fun conversationProtocolUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.ProtocolUpdate,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event = Event.Conversation.ConversationProtocol(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         transient = transient,
+        live = live,
         protocol = eventContentDTO.data.protocol.toModel(),
         senderUserId = eventContentDTO.qualifiedFrom.toModel()
     )
@@ -173,11 +183,13 @@ class EventMapper(
     fun conversationMessageTimerUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MessageTimerUpdate,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.ConversationMessageTimer(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         transient = transient,
+        live = live,
         messageTimer = eventContentDTO.data.messageTimer,
         senderUserId = eventContentDTO.qualifiedFrom.toModel(),
         timestampIso = eventContentDTO.time
@@ -186,11 +198,13 @@ class EventMapper(
     private fun conversationReceiptModeUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.ReceiptModeUpdate,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event = Event.Conversation.ConversationReceiptMode(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         transient = transient,
+        live = live,
         receiptMode = receiptModeMapper.fromApiToModel(eventContentDTO.data.receiptMode),
         senderUserId = eventContentDTO.qualifiedFrom.toModel()
     )
@@ -198,13 +212,15 @@ class EventMapper(
     private fun updateUserProperties(
         id: String,
         eventContentDTO: EventContentDTO.UserProperty.PropertiesSetDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event {
         return when (val fieldKeyValue = eventContentDTO.value) {
-            is EventContentDTO.FieldKeyNumberValue -> ReadReceiptModeSet(id, transient, fieldKeyValue.value == 1)
+            is EventContentDTO.FieldKeyNumberValue -> ReadReceiptModeSet(id, transient, live, fieldKeyValue.value == 1)
             is EventContentDTO.FieldUnknownValue -> unknown(
                 id = id,
                 transient = transient,
+                live = live,
                 eventContentDTO = eventContentDTO,
                 cause = "Unknown value type for key: ${eventContentDTO.key} "
             )
@@ -214,14 +230,16 @@ class EventMapper(
     private fun deleteUserProperties(
         id: String,
         eventContentDTO: EventContentDTO.UserProperty.PropertiesDeleteDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event {
         return if (PropertiesApi.PropertyKey.WIRE_RECEIPT_MODE.key == eventContentDTO.key) {
-            ReadReceiptModeSet(id, transient, false)
+            ReadReceiptModeSet(id, transient, live, false)
         } else {
             unknown(
                 id = id,
                 transient = transient,
+                live = live,
                 eventContentDTO = eventContentDTO,
                 cause = "Unknown key: ${eventContentDTO.key} "
             )
@@ -231,11 +249,13 @@ class EventMapper(
     private fun welcomeMessage(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MLSWelcomeDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.MLSWelcome(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
         transient,
+        live,
         eventContentDTO.qualifiedFrom.toModel(),
         eventContentDTO.message,
     )
@@ -243,11 +263,13 @@ class EventMapper(
     private fun newMessage(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.NewMessageDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.NewMessage(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
         transient,
+        live,
         eventContentDTO.qualifiedFrom.toModel(),
         ClientId(eventContentDTO.data.sender),
         eventContentDTO.time,
@@ -260,11 +282,13 @@ class EventMapper(
     private fun newMLSMessage(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.NewMLSMessageDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.NewMLSMessage(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
         transient,
+        live,
         eventContentDTO.subconversation?.let { SubconversationId(it) },
         eventContentDTO.qualifiedFrom.toModel(),
         eventContentDTO.time,
@@ -274,32 +298,37 @@ class EventMapper(
     private fun connectionUpdate(
         id: String,
         eventConnectionDTO: EventContentDTO.User.NewConnectionDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.User.NewConnection(
         transient,
+        live,
         id,
         connectionMapper.fromApiToModel(eventConnectionDTO.connection)
     )
 
-    private fun userDelete(id: String, eventUserDelete: EventContentDTO.User.UserDeleteDTO, transient: Boolean): Event.User.UserDelete {
-        return Event.User.UserDelete(transient, id, eventUserDelete.userId.toModel())
+    private fun userDelete(id: String, eventUserDelete: EventContentDTO.User.UserDeleteDTO, transient: Boolean, live: Boolean): Event.User.UserDelete {
+        return Event.User.UserDelete(transient, live, id, eventUserDelete.userId.toModel())
     }
 
     private fun clientRemove(
         id: String,
         eventClientRemove: EventContentDTO.User.ClientRemoveDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event.User.ClientRemove {
-        return Event.User.ClientRemove(transient, id, ClientId(eventClientRemove.client.clientId))
+        return Event.User.ClientRemove(transient, live, id, ClientId(eventClientRemove.client.clientId))
     }
 
     private fun newClient(
         id: String,
         eventNewClient: EventContentDTO.User.NewClientDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event.User.NewClient {
         return Event.User.NewClient(
             transient = transient,
+            live = live,
             id = id,
             client = clientMapper.fromClientDto(eventNewClient.client)
         )
@@ -308,11 +337,13 @@ class EventMapper(
     private fun newConversation(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.NewConversationDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.NewConversation(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
         transient,
+        live,
         eventContentDTO.qualifiedFrom.toModel(),
         eventContentDTO.time,
         eventContentDTO.data
@@ -321,33 +352,38 @@ class EventMapper(
     fun conversationMemberJoin(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MemberJoinDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.MemberJoin(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         addedBy = eventContentDTO.qualifiedFrom.toModel(),
         members = eventContentDTO.members.users.map { memberMapper.fromApiModel(it) },
         timestampIso = eventContentDTO.time,
-        transient = transient
+        transient = transient,
+        live = live,
     )
 
     fun conversationMemberLeave(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MemberLeaveDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.MemberLeave(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         removedBy = eventContentDTO.qualifiedFrom.toModel(),
         removedList = eventContentDTO.members.qualifiedUserIds.map { it.toModel() },
         timestampIso = eventContentDTO.time,
-        transient = transient
+        transient = transient,
+        live = live,
     )
 
     private fun memberUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MemberUpdateDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ): Event.Conversation.MemberChanged {
         return when {
             eventContentDTO.roleChange.role?.isNotEmpty() == true -> {
@@ -356,6 +392,7 @@ class EventMapper(
                     conversationId = eventContentDTO.qualifiedConversation.toModel(),
                     timestampIso = eventContentDTO.time,
                     transient = transient,
+                    live = live,
                     member = Conversation.Member(
                         id = eventContentDTO.roleChange.qualifiedUserId.toModel(),
                         role = roleMapper.fromApi(eventContentDTO.roleChange.role.orEmpty())
@@ -370,6 +407,7 @@ class EventMapper(
                     timestampIso = eventContentDTO.time,
                     mutedConversationChangedTime = eventContentDTO.roleChange.mutedRef.orEmpty(),
                     transient = transient,
+                    live = live,
                     mutedConversationStatus = mapConversationMutedStatus(eventContentDTO.roleChange.mutedStatus)
                 )
             }
@@ -378,7 +416,8 @@ class EventMapper(
                 Event.Conversation.MemberChanged.IgnoredMemberChanged(
                     id,
                     eventContentDTO.qualifiedConversation.toModel(),
-                    transient
+                    transient,
+                    live
                 )
             }
         }
@@ -395,129 +434,150 @@ class EventMapper(
     private fun featureConfig(
         id: String,
         featureConfigUpdatedDTO: EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = when (featureConfigUpdatedDTO.data) {
         is FeatureConfigData.FileSharing -> Event.FeatureConfig.FileSharingUpdated(
             id,
             transient,
+            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.FileSharing)
         )
 
         is FeatureConfigData.SelfDeletingMessages -> Event.FeatureConfig.SelfDeletingMessagesConfig(
             id,
             transient,
+            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.SelfDeletingMessages)
         )
 
         is FeatureConfigData.MLS -> Event.FeatureConfig.MLSUpdated(
             id,
             transient,
+            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.MLS)
         )
 
         is FeatureConfigData.ClassifiedDomains -> Event.FeatureConfig.ClassifiedDomainsUpdated(
             id,
             transient,
+            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.ClassifiedDomains)
         )
 
         is FeatureConfigData.ConferenceCalling -> Event.FeatureConfig.ConferenceCallingUpdated(
             id,
             transient,
+            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.ConferenceCalling)
         )
 
         is FeatureConfigData.ConversationGuestLinks -> Event.FeatureConfig.GuestRoomLinkUpdated(
             id,
             transient,
+            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.ConversationGuestLinks)
         )
 
         is FeatureConfigData.E2EI -> Event.FeatureConfig.MLSE2EIUpdated(
             id,
             transient,
+            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.E2EI)
         )
 
-        else -> Event.FeatureConfig.UnknownFeatureUpdated(id, transient)
+        else -> Event.FeatureConfig.UnknownFeatureUpdated(id, transient, live)
     }
 
     private fun conversationDeleted(
         id: String,
         deletedConversationDTO: EventContentDTO.Conversation.DeletedConversationDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.DeletedConversation(
         id = id,
         conversationId = deletedConversationDTO.qualifiedConversation.toModel(),
         senderUserId = deletedConversationDTO.qualifiedFrom.toModel(),
         transient = transient,
+        live = live,
         timestampIso = deletedConversationDTO.time
     )
 
     fun conversationRenamed(
         id: String,
         event: EventContentDTO.Conversation.ConversationRenameDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Conversation.RenamedConversation(
         id = id,
         conversationId = event.qualifiedConversation.toModel(),
         senderUserId = event.qualifiedFrom.toModel(),
         conversationName = event.updateNameData.conversationName,
         transient = transient,
+        live = live,
         timestampIso = event.time,
     )
 
     private fun teamMemberJoined(
         id: String,
         event: EventContentDTO.Team.MemberJoin,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Team.MemberJoin(
         id = id,
         teamId = event.teamId,
         transient = transient,
+        live = live,
         memberId = event.teamMember.nonQualifiedUserId
     )
 
     private fun teamMemberLeft(
         id: String,
         event: EventContentDTO.Team.MemberLeave,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Team.MemberLeave(
         id = id,
         teamId = event.teamId,
         memberId = event.teamMember.nonQualifiedUserId,
         transient = transient,
+        live = live,
         timestampIso = event.time
     )
 
     private fun teamMemberUpdate(
         id: String,
         event: EventContentDTO.Team.MemberUpdate,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Team.MemberUpdate(
         id = id,
         teamId = event.teamId,
         memberId = event.permissionsResponse.nonQualifiedUserId,
         transient = transient,
+        live = live,
         permissionCode = event.permissionsResponse.permissions.own
     )
 
     private fun teamUpdate(
         id: String,
         event: EventContentDTO.Team.Update,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.Team.Update(
         id = id,
         teamId = event.teamId,
         icon = event.teamUpdate.icon,
         transient = transient,
+        live = live,
         name = event.teamUpdate.name
     )
 
     private fun userUpdate(
         id: String,
         event: EventContentDTO.User.UpdateDTO,
-        transient: Boolean
+        transient: Boolean,
+        live: Boolean
     ) = Event.User.Update(
         id = id,
         userId = event.userData.nonQualifiedUserId,
@@ -528,6 +588,7 @@ class EventMapper(
         email = event.userData.email,
         previewAssetId = event.userData.assets?.getPreviewAssetOrNull()?.key,
         transient = transient,
+        live = live,
         completeAssetId = event.userData.assets?.getCompleteAssetOrNull()?.key,
         supportedProtocols = event.userData.supportedProtocols?.toModel()
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -108,7 +108,7 @@ class EventDataSource(
                     }
 
                     is WebSocketEvent.BinaryPayloadReceived -> {
-                        eventMapper.fromDTO(webSocketEvent.payload).asFlow().map { WebSocketEvent.BinaryPayloadReceived(it) }
+                        eventMapper.fromDTO(webSocketEvent.payload, true).asFlow().map { WebSocketEvent.BinaryPayloadReceived(it) }
                     }
                 }
             }.flattenConcat()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -885,7 +885,8 @@ class UserSessionScope internal constructor(
         get() = OneOnOneResolverImpl(
             userRepository,
             oneOnOneProtocolSelector,
-            oneOnOneMigrator
+            oneOnOneMigrator,
+            incrementalSyncRepository
         )
 
     private val slowSyncWorker: SlowSyncWorker by lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCase.kt
@@ -54,7 +54,7 @@ internal class RenameConversationUseCaseImpl(
             .onSuccess { response ->
                 if (response is ConversationRenameResponse.Changed)
                     renamedConversationEventHandler.handle(
-                        eventMapper.conversationRenamed(LocalId.generate(), response.event, true)
+                        eventMapper.conversationRenamed(LocalId.generate(), response.event, true, false)
                     )
             }
             .fold({

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/guestroomlink/GenerateGuestRoomLinkUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/guestroomlink/GenerateGuestRoomLinkUseCase.kt
@@ -51,6 +51,7 @@ class GenerateGuestRoomLinkUseCaseImpl internal constructor(
                     id = uuid4().toString(),
                     isPasswordProtected = it.data.hasPassword,
                     transient = false,
+                    live = false,
                     key = it.data.key,
                     uri = it.data.uri
                 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.logout.LogoutReason
-import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
@@ -39,6 +38,13 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 internal interface UserEventReceiver : EventReceiver<Event.User>
 
@@ -52,7 +58,12 @@ internal class UserEventReceiverImpl internal constructor(
     private val oneOnOneResolver: OneOnOneResolver,
     private val selfUserId: UserId,
     private val currentClientIdProvider: CurrentClientIdProvider,
+    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : UserEventReceiver {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = kaliumDispatcher.default.limitedParallelism(1)
+    private val resolveActiveOneOnOneScope = CoroutineScope(dispatcher)
 
     override suspend fun onEvent(event: Event.User): Either<CoreFailure, Unit> {
         return when (event) {
@@ -85,7 +96,20 @@ internal class UserEventReceiverImpl internal constructor(
     private suspend fun handleNewConnection(event: Event.User.NewConnection): Either<CoreFailure, Unit> =
         connectionRepository.insertConnectionFromEvent(event)
             .flatMap {
-                resolveActiveOneOnOneConversationUponConnectionAccepted(event.connection)
+                if (event.connection.status != ConnectionState.ACCEPTED) {
+                    return@flatMap Either.Right(Unit)
+                }
+
+                if (event.live) {
+                    resolveActiveOneOnOneScope.launch {
+                        kaliumLogger.d("Delay resolving active one-on-one since we are live to avoid race conditions")
+                        delay(3.seconds)
+                        oneOnOneResolver.resolveOneOnOneConversationWithUserId(event.connection.qualifiedToId).map { }
+                    }
+                    Either.Right(Unit)
+                } else {
+                    oneOnOneResolver.resolveOneOnOneConversationWithUserId(event.connection.qualifiedToId).map { }
+                }
             }
             .onSuccess {
                 kaliumLogger
@@ -102,13 +126,6 @@ internal class UserEventReceiverImpl internal constructor(
                         Pair("errorInfo", "$it")
                     )
             }
-
-    private suspend fun resolveActiveOneOnOneConversationUponConnectionAccepted(connection: Connection): Either<CoreFailure, Unit> =
-        if (connection.status == ConnectionState.ACCEPTED) {
-            oneOnOneResolver.resolveOneOnOneConversationWithUserId(connection.qualifiedToId).map { }
-        } else {
-            Either.Right(Unit)
-        }
 
     private suspend fun handleClientRemove(event: Event.User.ClientRemove): Either<CoreFailure, Unit> =
         currentClientIdProvider().map { currentClientId ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -122,6 +122,7 @@ class ConversationRepositoryTest {
             "id",
             TestConversation.ID,
             false,
+            false,
             TestUser.SELF.id,
             "time",
             CONVERSATION_RESPONSE
@@ -151,6 +152,7 @@ class ConversationRepositoryTest {
             val event = Event.Conversation.NewConversation(
                 "id",
                 TestConversation.ID,
+                false,
                 false,
                 TestUser.SELF.id,
                 "time",
@@ -183,6 +185,7 @@ class ConversationRepositoryTest {
                 "id",
                 TestConversation.ID,
                 false,
+                false,
                 TestUser.SELF.id,
                 "time",
                 CONVERSATION_RESPONSE
@@ -213,6 +216,7 @@ class ConversationRepositoryTest {
             val event = Event.Conversation.NewConversation(
                 "id",
                 TestConversation.ID,
+                false,
                 false,
                 TestUser.SELF.id,
                 "time",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1258,6 +1258,7 @@ class MLSConversationRepositoryTest {
                 "eventId",
                 TestConversation.ID,
                 false,
+                false,
                 TestUser.USER_ID,
                 WELCOME.encodeBase64(),
                 timestampIso = "2022-03-30T15:36:00.000Z"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -22,6 +22,8 @@ import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.UserRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneMigratorArrangement
@@ -119,14 +121,16 @@ class OneOnOneResolverTest {
     private class Arrangement(private val block: Arrangement.() -> Unit) :
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
         OneOnOneProtocolSelectorArrangement by OneOnOneProtocolSelectorArrangementImpl(),
-        OneOnOneMigratorArrangement by OneOnOneMigratorArrangementImpl()
+        OneOnOneMigratorArrangement by OneOnOneMigratorArrangementImpl(),
+        IncrementalSyncRepositoryArrangement by IncrementalSyncRepositoryArrangementImpl()
     {
         fun arrange() = run {
             block()
             this@Arrangement to OneOnOneResolverImpl(
                 userRepository = userRepository,
                 oneOnOneProtocolSelector = oneOnOneProtocolSelector,
-                oneOnOneMigrator = oneOnOneMigrator
+                oneOnOneMigrator = oneOnOneMigrator,
+                incrementalSyncRepository = incrementalSyncRepository
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -36,6 +36,7 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         false,
+        false,
         TestUser.USER_ID,
         members,
         "2022-03-30T15:36:00.000Z"
@@ -44,6 +45,7 @@ object TestEvent {
     fun memberLeave(eventId: String = "eventId", members: List<Member> = listOf()) = Event.Conversation.MemberLeave(
         eventId,
         TestConversation.ID,
+        false,
         false,
         TestUser.USER_ID,
         listOf(),
@@ -55,6 +57,7 @@ object TestEvent {
         TestConversation.ID,
         "2022-03-30T15:36:00.000Z",
         false,
+        false,
         member
     )
 
@@ -62,6 +65,7 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         "2022-03-30T15:36:00.000Z",
+        false,
         false,
         MutedConversationStatus.AllAllowed,
         "2022-03-30T15:36:00.000Zp"
@@ -71,20 +75,22 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         false,
+        false
     )
 
-    fun clientRemove(eventId: String = "eventId", clientId: ClientId) = Event.User.ClientRemove(false, eventId, clientId)
-    fun userDelete(eventId: String = "eventId", userId: UserId) = Event.User.UserDelete(false, eventId, userId)
+    fun clientRemove(eventId: String = "eventId", clientId: ClientId) = Event.User.ClientRemove(false, false, eventId, clientId)
+    fun userDelete(eventId: String = "eventId", userId: UserId) = Event.User.UserDelete(false, false, eventId, userId)
     fun updateUser(eventId: String = "eventId", userId: UserId) = Event.User.Update(
         eventId,
-        false, userId.toString(), null, false, "newName", null, null, null, null, null
+        false, false, userId.toString(), null, false, "newName", null, null, null, null, null
     )
 
     fun newClient(eventId: String = "eventId", clientId: ClientId = ClientId("client")) = Event.User.NewClient(
-        false, eventId, TestClient.CLIENT
+        false, false, eventId, TestClient.CLIENT
     )
 
     fun newConnection(eventId: String = "eventId", status:  ConnectionState = ConnectionState.PENDING) = Event.User.NewConnection(
+        false,
         false,
         eventId,
         Connection(
@@ -102,6 +108,7 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         false,
+        false,
         TestUser.USER_ID,
         "2022-03-30T15:36:00.000Z"
     )
@@ -109,6 +116,7 @@ object TestEvent {
     fun renamedConversation(eventId: String = "eventId") = Event.Conversation.RenamedConversation(
         eventId,
         TestConversation.ID,
+        false,
         false,
         "newName",
         TestUser.USER_ID,
@@ -119,6 +127,7 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         false,
+        false,
         receiptMode = Conversation.ReceiptMode.ENABLED,
         senderUserId = TestUser.USER_ID
     )
@@ -128,13 +137,15 @@ object TestEvent {
         teamId = "teamId",
         name = "teamName",
         transient = false,
+        live = false,
         icon = "icon",
     )
 
     fun teamMemberJoin(eventId: String = "eventId") = Event.Team.MemberJoin(
         eventId,
         teamId = "teamId",
-        false,
+        transient = false,
+        live = false,
         memberId = "memberId"
     )
 
@@ -143,7 +154,8 @@ object TestEvent {
         teamId = "teamId",
         memberId = "memberId",
         timestampIso = "2022-03-30T15:36:00.000Z",
-        transient = false
+        transient = false,
+        live = false
     )
 
     fun teamMemberUpdate(eventId: String = "eventId", permissionCode: Int) = Event.Team.MemberUpdate(
@@ -151,13 +163,15 @@ object TestEvent {
         teamId = "teamId",
         memberId = "memberId",
         permissionCode = permissionCode,
-        transient = false
+        transient = false,
+        live = false
     )
 
     fun timerChanged(eventId: String = "eventId") = Event.Conversation.ConversationMessageTimer(
         id = eventId,
         conversationId = TestConversation.ID,
         transient = false,
+        live = false,
         messageTimer = 3000,
         senderUserId = TestUser.USER_ID,
         timestampIso = "2022-03-30T15:36:00.000Z"
@@ -166,6 +180,7 @@ object TestEvent {
     fun userPropertyReadReceiptMode(eventId: String = "eventId") = Event.UserProperty.ReadReceiptModeSet(
         id = eventId,
         transient = false,
+        live = false,
         value = true
     )
 
@@ -176,6 +191,7 @@ object TestEvent {
     ) = Event.Conversation.NewMessage(
         "eventId",
         TestConversation.ID,
+        false,
         false,
         senderUserId,
         TestClient.CLIENT_ID,
@@ -190,6 +206,7 @@ object TestEvent {
         "eventId",
         TestConversation.ID,
         false,
+        false,
         null,
         TestUser.USER_ID,
         timestamp.toIsoDateTimeString(),
@@ -200,6 +217,7 @@ object TestEvent {
         id = "eventId",
         conversationId = TestConversation.ID,
         transient = false,
+        live = false,
         timestampIso = "timestamp",
         conversation = TestConversation.CONVERSATION_RESPONSE,
         senderUserId = TestUser.SELF.id
@@ -208,6 +226,7 @@ object TestEvent {
     fun newMLSWelcomeEvent() = Event.Conversation.MLSWelcome(
         "eventId",
         TestConversation.ID,
+        false,
         false,
         TestUser.USER_ID,
         "dummy-message",
@@ -219,13 +238,15 @@ object TestEvent {
         conversationId = TestConversation.ID,
         data = TestConversation.CONVERSATION_RESPONSE,
         qualifiedFrom = TestUser.USER_ID,
-        transient = false
+        transient = false,
+        live = false
     )
 
     fun codeUpdated() = Event.Conversation.CodeUpdated(
         id = "eventId",
         conversationId = TestConversation.ID,
         transient = false,
+        live = false,
         code = "code",
         key = "key",
         uri = "uri",
@@ -236,5 +257,6 @@ object TestEvent {
         id = "eventId",
         conversationId = TestConversation.ID,
         transient = false,
+        live = false
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -436,19 +436,19 @@ class FeatureConfigEventReceiverTest {
 
         fun newMLSUpdatedEvent(
             model: MLSModel
-        ) = Event.FeatureConfig.MLSUpdated("eventId", false, model)
+        ) = Event.FeatureConfig.MLSUpdated("eventId", false, false, model)
 
         fun newFileSharingUpdatedEvent(
             model: ConfigsStatusModel
-        ) = Event.FeatureConfig.FileSharingUpdated("eventId", false, model)
+        ) = Event.FeatureConfig.FileSharingUpdated("eventId", false, false, model)
 
         fun newConferenceCallingUpdatedEvent(
             model: ConferenceCallingModel
-        ) = Event.FeatureConfig.ConferenceCallingUpdated("eventId", false, model)
+        ) = Event.FeatureConfig.ConferenceCallingUpdated("eventId", false, false, model)
 
         fun newSelfDeletingMessagesUpdatedEvent(
             model: SelfDeletingMessagesModel
-        ) = Event.FeatureConfig.SelfDeletingMessagesConfig("eventId", false, model)
+        ) = Event.FeatureConfig.SelfDeletingMessagesConfig("eventId", false, false, model)
 
         fun arrange() = this to featureConfigEventReceiver
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiverTest.kt
@@ -100,6 +100,7 @@ class FederationEventReceiverTest {
         val event = Event.Federation.Delete(
             "id",
             true,
+            false,
             defederatedDomain
         )
 
@@ -170,6 +171,7 @@ class FederationEventReceiverTest {
             val event = Event.Federation.ConnectionRemoved(
                 "id",
                 true,
+                false,
                 listOf(defederatedDomain, defederatedDomainTwo)
             )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/CodeDeletedHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/CodeDeletedHandlerTest.kt
@@ -41,7 +41,8 @@ class CodeDeletedHandlerTest {
         val event = Event.Conversation.CodeDeleted(
             conversationId = ConversationId("conversationId", "domain"),
             id = "event-id",
-            transient = false
+            transient = false,
+            live = false
         )
 
         handler.handle(event)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/CodeUpdateHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/CodeUpdateHandlerTest.kt
@@ -45,7 +45,8 @@ class CodeUpdateHandlerTest {
             code = "code",
             key = "key",
             id = "event-id",
-            transient = false
+            transient = false,
+            live = false
         )
 
         handler.handle(event)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -242,6 +242,7 @@ class MLSWelcomeEventHandlerTest {
             "eventId",
             CONVERSATION_ID,
             false,
+            false,
             TestUser.USER_ID,
             WELCOME.encodeBase64(),
             timestampIso = "2022-03-30T15:36:00.000Z"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
@@ -129,6 +129,7 @@ class MemberLeaveEventHandlerTest {
             id = "id",
             conversationId = conversationId,
             transient = false,
+            live = false,
             removedBy = userId,
             removedList = listOf(userId),
             timestampIso = "timestampIso"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -62,6 +62,7 @@ class NewConversationEventHandlerTest {
             id = "eventId",
             conversationId = TestConversation.ID,
             transient = false,
+            live = false,
             timestampIso = "timestamp",
             conversation = TestConversation.CONVERSATION_RESPONSE,
             senderUserId = TestUser.SELF.id
@@ -103,7 +104,8 @@ class NewConversationEventHandlerTest {
         val event = Event.Conversation.NewConversation(
             id = "eventId",
             conversationId = TestConversation.ID,
-            false,
+            transient =false,
+            live = false,
             timestampIso = "timestamp",
             conversation = TestConversation.CONVERSATION_RESPONSE,
             senderUserId = TestUser.SELF.id
@@ -142,6 +144,7 @@ class NewConversationEventHandlerTest {
             id = "eventId",
             conversationId = TestConversation.ID,
             transient = false,
+            live = false,
             timestampIso = "timestamp",
             conversation = TestConversation.CONVERSATION_RESPONSE.copy(
                 creator = "creatorId@creatorDomain",
@@ -202,6 +205,7 @@ class NewConversationEventHandlerTest {
                 id = "eventId",
                 conversationId = TestConversation.ID,
                 transient = false,
+                live = false,
                 timestampIso = "timestamp",
                 conversation = TestConversation.CONVERSATION_RESPONSE.copy(
                     creator = "creatorId@creatorDomain",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/OneOnOneResolverArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/OneOnOneResolverArrangement.kt
@@ -25,10 +25,13 @@ import io.mockative.Mock
 import io.mockative.any
 import io.mockative.given
 import io.mockative.mock
+import kotlinx.coroutines.Job
 
 interface OneOnOneResolverArrangement {
 
     val oneOnOneResolver: OneOnOneResolver
+
+    fun withScheduleResolveOneOnOneConversationWithUserId()
     fun withResolveOneOnOneConversationWithUserIdReturning(result: Either<CoreFailure, ConversationId>)
     fun withResolveOneOnOneConversationWithUserReturning(result: Either<CoreFailure, ConversationId>)
     fun withResolveAllOneOnOneConversationsReturning(result: Either<CoreFailure, Unit>)
@@ -39,6 +42,13 @@ class OneOnOneResolverArrangementImpl : OneOnOneResolverArrangement {
 
     @Mock
     override val oneOnOneResolver = mock(OneOnOneResolver::class)
+    override fun withScheduleResolveOneOnOneConversationWithUserId() {
+        given(oneOnOneResolver)
+            .suspendFunction(oneOnOneResolver::scheduleResolveOneOnOneConversationWithUserId)
+            .whenInvokedWith(any(), any())
+            .thenReturn(Job())
+    }
+
     override fun withResolveOneOnOneConversationWithUserIdReturning(result: Either<CoreFailure, ConversationId>) {
         given(oneOnOneResolver)
             .suspendFunction(oneOnOneResolver::resolveOneOnOneConversationWithUserId)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Clients will attempt to establish a MLS 1-1 when a connection request is accepted. If more than one client is "online"
 when a connection request is accepted this will result in a race to establish the MLS group, which only one client can win. This is wasteful because the clients who loose the race will also consume key packages but they will be discarded when they realise they have lost the race.

### Solutions

1. Distinguish between live events (Websocket) & catchup events (`GET /notifications`)
2. Add a small delay (3s) before attempting to establish the MLS 1-1 upon receiving a live connection accepted event.

### Testing

- [x] I have added automated test to this contribution

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
