### PR TITLE
fix: fetch  group id on protocol change event WPB-4336

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -225,11 +225,24 @@ interface ConversationRepository {
     ): Either<CoreFailure, OneOnOneMembers>
 
     /**
-     * Update a conversation's protocol.
+     * Update a conversation's protocol remotely.
+     *
+     *  This also fetches the newly assigned `groupID` from the backend, if this operation fails the whole
+     *  operation is cancelled and protocol change is not persisted.
      *
      * @return **true** if the protocol was changed or **false** if the protocol was unchanged.
      */
-    suspend fun updateProtocol(conversationId: ConversationId, protocol: Conversation.Protocol): Either<CoreFailure, Boolean>
+    suspend fun updateProtocolRemotely(conversationId: ConversationId, protocol: Conversation.Protocol): Either<CoreFailure, Boolean>
+
+    /**
+     * Update a conversation's protocol locally.
+     *
+     * This also fetches the newly assigned `groupID` from the backend, if this operation fails the whole
+     * operation is cancelled and protocol change is not persisted.
+     *
+     * @return **true** if the protocol was changed or **false** if the protocol was unchanged.
+     */
+    suspend fun updateProtocolLocally(conversationId: ConversationId, protocol: Conversation.Protocol): Either<CoreFailure, Boolean>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -845,7 +858,7 @@ internal class ConversationDataSource internal constructor(
         }
     }
 
-    override suspend fun updateProtocol(
+    override suspend fun updateProtocolRemotely(
         conversationId: ConversationId,
         protocol: Conversation.Protocol
     ): Either<CoreFailure, Boolean> =
@@ -859,18 +872,31 @@ internal class ConversationDataSource internal constructor(
                 }
 
                 is UpdateConversationProtocolResponse.ProtocolUpdated -> {
-                    when (protocol) {
-                        Conversation.Protocol.PROTEUS -> Either.Right(Unit)
-                        Conversation.Protocol.MIXED -> fetchConversation(conversationId)
-                        Conversation.Protocol.MLS -> {
-                            wrapStorageRequest {
-                                conversationDAO.updateConversationProtocol(
-                                    conversationId = conversationId.toDao(),
-                                    protocol = protocol.toDao()
-                                )
-                            }.map {}
-                        }
-                    }.map { true }
+                    updateProtocolLocally(conversationId, protocol)
+                }
+            }
+        }
+
+    override suspend fun updateProtocolLocally(
+        conversationId: ConversationId,
+        protocol: Conversation.Protocol
+    ): Either<CoreFailure, Boolean> =
+        wrapApiRequest {
+            conversationApi.fetchConversationDetails(conversationId.toApi())
+        }.flatMap { conversationResponse ->
+            wrapStorageRequest {
+                conversationDAO.updateConversationProtocol(
+                    conversationId = conversationId.toDao(),
+                    protocol = protocol.toDao()
+                )
+            }.flatMap { updated ->
+                if (updated) {
+                    val selfUserTeamId = selfTeamIdProvider().getOrNull()
+                    persistConversations(listOf(conversationResponse), selfUserTeamId?.value, invalidateMembers = true)
+                } else {
+                    Either.Right(Unit)
+                }.map {
+                    updated
                 }
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1200,7 +1200,7 @@ class UserSessionScope internal constructor(
 
     private val protocolUpdateEventHandler: ProtocolUpdateEventHandler
         get() = ProtocolUpdateEventHandlerImpl(
-            conversationDAO = userStorage.database.conversationDAO,
+            conversationRepository = conversationRepository,
             systemMessageInserter = systemMessageBuilder
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -90,7 +90,7 @@ internal class MLSMigratorImpl(
 
     private suspend fun migrate(conversationId: ConversationId): Either<CoreFailure, Unit> {
         kaliumLogger.i("migrating ${conversationId.toLogString()} to mixed")
-        return conversationRepository.updateProtocol(conversationId, Protocol.MIXED)
+        return conversationRepository.updateProtocolRemotely(conversationId, Protocol.MIXED)
             .flatMap { updated ->
                 if (updated) {
                     systemMessageInserter.insertProtocolChangedSystemMessage(
@@ -106,7 +106,7 @@ internal class MLSMigratorImpl(
 
     private suspend fun finalise(conversationId: ConversationId): Either<CoreFailure, Unit> {
         kaliumLogger.i("finalising ${conversationId.toLogString()} to mls")
-        return conversationRepository.updateProtocol(conversationId, Protocol.MLS)
+        return conversationRepository.updateProtocolRemotely(conversationId, Protocol.MLS)
             .fold({ failure ->
                 kaliumLogger.w("failed to finalise ${conversationId.toLogString()} to mls: $failure")
                 Either.Right(Unit)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -116,7 +116,6 @@ internal class ConversationEventReceiverImpl(
 
             is Event.Conversation.ConversationProtocol -> {
                 protocolUpdateEventHandler.handle(event)
-                Either.Right(Unit)
             }
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -45,6 +45,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.receiver.conversation.RenamedConversationEventHandler
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConvProtocol
@@ -69,6 +70,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.model.Convers
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
+import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -1061,29 +1063,6 @@ class ConversationRepositoryTest {
     }
 
     @Test
-    fun givenConversation_whenUpdatingProtocolToMls_thenShouldUpdateLocally() = runTest {
-        // given
-        val protocol = Conversation.Protocol.MLS
-
-        val (arrange, conversationRepository) = Arrangement()
-            .withUpdateProtocolResponse(UPDATE_PROTOCOL_SUCCESS)
-            .withDaoUpdateProtocolSuccess()
-            .arrange()
-
-        // when
-        val result = conversationRepository.updateProtocol(CONVERSATION_ID, protocol)
-
-        // then
-        with(result) {
-            shouldSucceed()
-            verify(arrange.conversationDAO)
-                .suspendFunction(arrange.conversationDAO::updateConversationProtocol)
-                .with(eq(CONVERSATION_ID.toDao()), eq(protocol.toDao()))
-                .wasInvoked(exactly = once)
-        }
-    }
-
-    @Test
     fun givenNoChange_whenUpdatingProtocolToMls_thenShouldNotUpdateLocally() = runTest {
         // given
         val protocol = Conversation.Protocol.MLS
@@ -1093,7 +1072,7 @@ class ConversationRepositoryTest {
             .arrange()
 
         // when
-        val result = conversationRepository.updateProtocol(CONVERSATION_ID, protocol)
+        val result = conversationRepository.updateProtocolRemotely(CONVERSATION_ID, protocol)
 
         // then
         with(result) {
@@ -1106,7 +1085,7 @@ class ConversationRepositoryTest {
     }
 
     @Test
-    fun givenConversation_whenUpdatingProtocolToMixed_thenShouldFetchConversation() = runTest {
+    fun givenChange_whenUpdatingProtocol_thenShouldFetchConversationDetails() = runTest {
         // given
         val protocol = Conversation.Protocol.MIXED
         val conversationResponse = NetworkResponse.Success(
@@ -1118,10 +1097,11 @@ class ConversationRepositoryTest {
         val (arrangement, conversationRepository) = Arrangement()
             .withUpdateProtocolResponse(UPDATE_PROTOCOL_SUCCESS)
             .withFetchConversationsDetails(conversationResponse)
+            .withDaoUpdateProtocolSuccess()
             .arrange()
 
         // when
-        val result = conversationRepository.updateProtocol(CONVERSATION_ID, protocol)
+        val result = conversationRepository.updateProtocolRemotely(CONVERSATION_ID, protocol)
 
         // then
         with(result) {
@@ -1130,6 +1110,85 @@ class ConversationRepositoryTest {
                 .suspendFunction(arrangement.conversationApi::fetchConversationDetails)
                 .with(eq(CONVERSATION_ID.toApi()))
                 .wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenChange_whenUpdatingProtocol_thenShouldUpdateLocally() = runTest {
+        // given
+        val protocol = Conversation.Protocol.MLS
+        val conversationResponse = NetworkResponse.Success(
+            TestConversation.CONVERSATION_RESPONSE,
+            emptyMap(),
+            HttpStatusCode.OK.value
+        )
+
+        val (arrange, conversationRepository) = Arrangement()
+            .withUpdateProtocolResponse(UPDATE_PROTOCOL_SUCCESS)
+            .withFetchConversationsDetails(conversationResponse)
+            .withDaoUpdateProtocolSuccess()
+            .arrange()
+
+        // when
+        val result = conversationRepository.updateProtocolRemotely(CONVERSATION_ID, protocol)
+
+        // then
+        with(result) {
+            shouldSucceed()
+            verify(arrange.conversationDAO)
+                .suspendFunction(arrange.conversationDAO::updateConversationProtocol)
+                .with(eq(CONVERSATION_ID.toDao()), eq(protocol.toDao()))
+                .wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenSuccessFetchingConversationDetails_whenUpdatingProtocolLocally_thenShouldUpdateLocally() = runTest {
+        // given
+        val protocol = Conversation.Protocol.MLS
+        val conversationResponse = NetworkResponse.Success(
+            TestConversation.CONVERSATION_RESPONSE,
+            emptyMap(),
+            HttpStatusCode.OK.value
+        )
+
+        val (arrange, conversationRepository) = Arrangement()
+            .withFetchConversationsDetails(conversationResponse)
+            .withDaoUpdateProtocolSuccess()
+            .arrange()
+
+        // when
+        val result = conversationRepository.updateProtocolLocally(CONVERSATION_ID, protocol)
+
+        // then
+        with(result) {
+            shouldSucceed()
+            verify(arrange.conversationDAO)
+                .suspendFunction(arrange.conversationDAO::updateConversationProtocol)
+                .with(eq(CONVERSATION_ID.toDao()), eq(protocol.toDao()))
+                .wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenFailureFetchingConversationDetails_whenUpdatingProtocolLocally_thenShouldNotUpdateLocally() = runTest {
+        // given
+        val protocol = Conversation.Protocol.MLS
+        val (arrange, conversationRepository) = Arrangement()
+            .withFetchConversationsDetails(NetworkResponse.Error(KaliumException.NoNetwork()))
+            .withDaoUpdateProtocolSuccess()
+            .arrange()
+
+        // when
+        val result = conversationRepository.updateProtocolLocally(CONVERSATION_ID, protocol)
+
+        // then
+        with(result) {
+            shouldFail()
+            verify(arrange.conversationDAO)
+                .suspendFunction(arrange.conversationDAO::updateConversationProtocol)
+                .with(eq(CONVERSATION_ID.toDao()), eq(protocol.toDao()))
+                .wasNotInvoked()
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -72,7 +72,7 @@ class MLSMigratorTest {
         migrator.migrateProteusConversations()
 
         verify(arrangement.conversationRepository)
-            .suspendFunction(arrangement.conversationRepository::updateProtocol)
+            .suspendFunction(arrangement.conversationRepository::updateProtocolRemotely)
             .with(eq(conversation.id), eq(Conversation.Protocol.MIXED))
             .wasInvoked(once)
 
@@ -126,7 +126,7 @@ class MLSMigratorTest {
             .wasInvoked(once)
 
         verify(arrangement.conversationRepository)
-            .suspendFunction(arrangement.conversationRepository::updateProtocol)
+            .suspendFunction(arrangement.conversationRepository::updateProtocolRemotely)
             .with(eq(conversation.id), eq(Conversation.Protocol.MLS))
             .wasInvoked(once)
     }
@@ -208,7 +208,7 @@ class MLSMigratorTest {
         }
         fun withUpdateProtocolReturns(result: Either<CoreFailure, Boolean> = Either.Right(true)) = apply {
             given(conversationRepository)
-                .suspendFunction(conversationRepository::updateProtocol)
+                .suspendFunction(conversationRepository::updateProtocolRemotely)
                 .whenInvokedWith(any(), any())
                 .thenReturn(result)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -237,4 +237,12 @@ object TestEvent {
         conversationId = TestConversation.ID,
         transient = false,
     )
+
+    fun newConversationProtocolEvent() = Event.Conversation.ConversationProtocol(
+        id = "eventId",
+        conversationId = TestConversation.ID,
+        transient = false,
+        protocol = Conversation.Protocol.MIXED,
+        senderUserId = TestUser.OTHER_USER_ID
+    )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ProtocolUpdateEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ProtocolUpdateEventHandlerTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.framework.TestEvent
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.receiver.conversation.ProtocolUpdateEventHandler
+import com.wire.kalium.logic.sync.receiver.conversation.ProtocolUpdateEventHandlerImpl
+import com.wire.kalium.logic.util.arrangement.SystemMessageInserterArrangement
+import com.wire.kalium.logic.util.arrangement.SystemMessageInserterArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import io.mockative.eq
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ProtocolUpdateEventHandlerTest {
+
+    @Test
+    fun givenEventIsSuccessfullyConsumed_whenHandlerInvoked_thenProtocolIsUpdatedLocally() = runTest {
+        val event = TestEvent.newConversationProtocolEvent()
+
+        val (arrangement, useCase) = arrange {
+            withUpdateProtocolLocally(Either.Right(true))
+            withInsertProtocolChangedSystemMessage()
+        }
+
+        useCase.handle(event).shouldSucceed()
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateProtocolLocally)
+            .with(eq(event.conversationId), eq(event.protocol))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenEventFailsToBeConsumed_whenHandlerInvoked_thenErrorIsPropagated() = runTest {
+        val event = TestEvent.newConversationProtocolEvent()
+        val failure = NetworkFailure.NoNetworkConnection(null)
+
+        val (arrangement, useCase) = arrange {
+            withUpdateProtocolLocally(Either.Left(failure))
+            withInsertProtocolChangedSystemMessage()
+        }
+
+        useCase.handle(event).shouldFail {
+            assertEquals(failure, it)
+        }
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateProtocolLocally)
+            .with(eq(event.conversationId), eq(event.protocol))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProtocolWasNotAlreadyUpdated_whenHandlerInvoked_thenSystemMessageIsInserted() = runTest {
+        val event = TestEvent.newConversationProtocolEvent()
+
+        val (arrangement, useCase) = arrange {
+            withUpdateProtocolLocally(Either.Right(true))
+            withInsertProtocolChangedSystemMessage()
+        }
+
+        useCase.handle(event).shouldSucceed()
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateProtocolLocally)
+            .with(eq(event.conversationId), eq(event.protocol))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProtocolWasAlreadyUpdated_whenHandlerInvoked_thenSystemMessageIsNotInserted() = runTest {
+        val event = TestEvent.newConversationProtocolEvent()
+
+        val (arrangement, useCase) = arrange {
+            withUpdateProtocolLocally(Either.Right(false))
+            withInsertProtocolChangedSystemMessage()
+        }
+
+        useCase.handle(event).shouldSucceed()
+
+        verify(arrangement.systemMessageInserter)
+            .suspendFunction(arrangement.systemMessageInserter::insertProtocolChangedSystemMessage)
+            .with(eq(event.conversationId), eq(event.senderUserId), eq(event.protocol))
+            .wasNotInvoked()
+    }
+
+    private class Arrangement(private val block: Arrangement.() -> Unit) :
+        ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
+        SystemMessageInserterArrangement by SystemMessageInserterArrangementImpl()
+    {
+        private val protocolUpdateEventHandler: ProtocolUpdateEventHandler = ProtocolUpdateEventHandlerImpl(
+            conversationRepository,
+            systemMessageInserter
+        )
+
+        fun arrange() = run {
+            block()
+            this@Arrangement to protocolUpdateEventHandler
+        }
+    }
+
+    companion object {
+        private fun arrange(configuration: Arrangement.() -> Unit) = Arrangement(configuration).arrange()
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/SystemMessageInserterArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/SystemMessageInserterArrangement.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement
+
+import com.wire.kalium.logic.data.message.SystemMessageInserter
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.given
+import io.mockative.mock
+
+internal interface SystemMessageInserterArrangement {
+    val systemMessageInserter: SystemMessageInserter
+
+    fun withInsertProtocolChangedSystemMessage()
+}
+
+internal class SystemMessageInserterArrangementImpl: SystemMessageInserterArrangement {
+
+    @Mock
+    override val systemMessageInserter = mock(SystemMessageInserter::class)
+
+    override fun withInsertProtocolChangedSystemMessage() {
+        given(systemMessageInserter)
+            .suspendFunction(systemMessageInserter::insertProtocolChangedSystemMessage)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(Unit)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
@@ -48,6 +48,7 @@ internal interface ConversationRepositoryArrangement {
     fun withDeletingConversationSucceeding(conversationId: Matcher<ConversationId> = any())
     fun withDeletingConversationFailing(conversationId: Matcher<ConversationId> = any())
     fun withGetConversation(conversation: Conversation? = TestConversation.CONVERSATION)
+    fun withUpdateProtocolLocally(result: Either<CoreFailure, Boolean>)
 }
 
 internal open class ConversationRepositoryArrangementImpl : ConversationRepositoryArrangement {
@@ -94,5 +95,12 @@ internal open class ConversationRepositoryArrangementImpl : ConversationReposito
             .suspendFunction(conversationRepository::getConversationById)
             .whenInvokedWith(any())
             .thenReturn(conversation)
+    }
+
+    override fun withUpdateProtocolLocally(result: Either<CoreFailure, Boolean>) {
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::updateProtocolLocally)
+            .whenInvokedWith(any(), any())
+            .thenReturn(result)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After someone else has migrated a conversation proteus to `mls` messages fail to decrypt. 

### Causes

When a conversation is migrated to mls this will result in a `conversation.protocol` update event informing everyone that the conversation is now using a different protocol. We were correctly processing this event and updating the protocol field of the conversation but we didn't fetch & persist the group ID which a conversation gets assign when migrates to `mixed` or `mls`.

On processing an incoming message in the migrated conversation we would fail to lookup the groupID which is necessary in order to decrypt the message, instead the whole operation fails and we present it as a decryption error to the user.

### Solutions

Fetch group ID in addition to persisting the new protocol.

This is slightly tricky because we want to do this as an atomic operation which can be retried in case of network failure.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
