### PR TITLE
fix: adding participants offline + nfcg new edge case (WPB-4648)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -964,7 +964,6 @@ class ConversationGroupRepositoryTest {
     @Test
     fun givenAConversationFailsWithUnreachableAndNotFromUsersInRequest_whenAddingMembers_thenRetryIsNotExecutedAndCreateSysMessage() =
         runTest {
-            val failedDomain = "unstableDomain1.com"
             // given
             val (arrangement, conversationGroupRepository) = Arrangement()
                 .withConversationDetailsById(TestConversation.CONVERSATION)
@@ -978,8 +977,8 @@ class ConversationGroupRepositoryTest {
                 .arrange()
 
             // when
-            val expectedInitialUsers = listOf(TestConversation.USER_1)
-            conversationGroupRepository.addMembers(expectedInitialUsers, TestConversation.ID).shouldFail()
+            val expectedInitialUsersNotFromUnreachableInformed = listOf(TestConversation.USER_1)
+            conversationGroupRepository.addMembers(expectedInitialUsersNotFromUnreachableInformed, TestConversation.ID).shouldFail()
 
             // then
             verify(arrangement.conversationApi)
@@ -995,7 +994,7 @@ class ConversationGroupRepositoryTest {
             verify(arrangement.newGroupConversationSystemMessagesCreator)
                 .suspendFunction(arrangement.newGroupConversationSystemMessagesCreator::conversationFailedToAddMembers)
                 .with(anything(), matching {
-                    it.containsAll(expectedInitialUsers)
+                    it.containsAll(expectedInitialUsersNotFromUnreachableInformed)
                 })
                 .wasInvoked(once)
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

A new edge case was discovered, and we need to handle when adding members from an online backend A and the conversation already has members of an offline backend, then we need to fail and show the system message.

### Solutions

Fail and persist system message in case of unreachable backend informed and not from users in request.

### Note

This case was introduced, but valid, when BE started performing NFCG checks on current members.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
