### PR TITLE
fix: looking for cryptobox files to migrate at wrong location WPB-4658

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/ProteusClientProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/ProteusClientProvider.kt
@@ -97,7 +97,7 @@ class ProteusClientProviderImpl(
     private suspend fun createProteusClient(): ProteusClient {
         return if (kaliumConfigs.encryptProteusStorage) {
             val central = coreCryptoCentral(
-                rootDir = "$rootProteusPath/$KEYSTORE_NAME",
+                rootDir = rootProteusPath,
                 databaseKey = SecurityHelperImpl(passphraseStorage).proteusDBSecret(userId).value
             )
             central.proteusClient()
@@ -108,9 +108,5 @@ class ProteusClientProviderImpl(
                 ioContext = dispatcher.io
             )
         }
-    }
-
-    private companion object {
-        const val KEYSTORE_NAME = "keystore"
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Proteus Cryptobox migration to Proteus CoreCrypto fails (doesn't happen)

### Causes

The path were we are looking for the cryptobox files are wrong (it includes the CC keystore file)

### Solutions

Remove keystore suffix on path.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
