### PR TITLE
feat: handle out of order MLS messages

### DIFF
--- a/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -84,10 +84,9 @@ class MLSClientImpl(
         return toCommitBundle(coreCrypto.joinByExternalCommit(toUByteList(publicGroupState), defaultGroupConfiguration))
     }
 
-    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>? {
+    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId) {
         val groupIdAsBytes = toUByteList(groupId.decodeBase64Bytes())
         coreCrypto.mergePendingGroupFromExternalCommit(groupIdAsBytes)
-        return null
     }
 
     override suspend fun clearPendingGroupExternalCommit(groupId: MLSGroupId) {
@@ -123,8 +122,8 @@ class MLSClientImpl(
         return toByteArray(applicationMessage)
     }
 
-    override suspend fun decryptMessage(groupId: MLSGroupId, message: ApplicationMessage): DecryptedMessageBundle {
-        return toDecryptedMessageBundle(coreCrypto.decryptMessage(toUByteList(groupId.decodeBase64Bytes()), toUByteList(message)))
+    override suspend fun decryptMessage(groupId: MLSGroupId, message: ApplicationMessage): List<DecryptedMessageBundle> {
+        return listOf(toDecryptedMessageBundle(coreCrypto.decryptMessage(toUByteList(groupId.decodeBase64Bytes()), toUByteList(message))))
     }
 
     override suspend fun members(groupId: MLSGroupId): List<CryptoQualifiedClientId> {

--- a/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -84,9 +84,10 @@ class MLSClientImpl(
         return toCommitBundle(coreCrypto.joinByExternalCommit(toUByteList(publicGroupState), defaultGroupConfiguration))
     }
 
-    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId) {
+    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>? {
         val groupIdAsBytes = toUByteList(groupId.decodeBase64Bytes())
         coreCrypto.mergePendingGroupFromExternalCommit(groupIdAsBytes)
+        return null
     }
 
     override suspend fun clearPendingGroupExternalCommit(groupId: MLSGroupId) {

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
@@ -132,7 +132,7 @@ interface MLSClient {
      *
      * @param groupId MLS group ID provided by BE
      */
-    suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId)
+    suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>?
 
     /**
      * Clear pending external commits

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
@@ -132,7 +132,7 @@ interface MLSClient {
      *
      * @param groupId MLS group ID provided by BE
      */
-    suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>?
+    suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId)
 
     /**
      * Clear pending external commits
@@ -221,7 +221,7 @@ interface MLSClient {
     suspend fun decryptMessage(
         groupId: MLSGroupId,
         message: ApplicationMessage
-    ): DecryptedMessageBundle
+    ): List<DecryptedMessageBundle>
 
     /**
      * Current members of the group.
@@ -318,5 +318,3 @@ interface MLSClient {
      */
     suspend fun isGroupVerified(groupId: MLSGroupId): Boolean
 }
-
-// expect class MLSClientImpl(rootDir: String, databaseKey: MlsDBSecret, clientId: CryptoQualifiedClientId) : MLSClient

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
@@ -72,7 +72,7 @@ class MLSClientTest : BaseMLSClientTest() {
         val commit = bobClient.updateKeyingMaterial(MLS_CONVERSATION_ID).commit
         val result = aliceClient.decryptMessage(conversationId, commit)
 
-        assertNull(result.message)
+        assertNull(result.first().message)
     }
 
     @Test
@@ -124,7 +124,7 @@ class MLSClientTest : BaseMLSClientTest() {
         val conversationId = aliceClient.processWelcomeMessage(welcome)
 
         val applicationMessage = aliceClient.encryptMessage(conversationId, PLAIN_TEXT.encodeToByteArray())
-        val plainMessage = bobClient.decryptMessage(conversationId, applicationMessage).message
+        val plainMessage = bobClient.decryptMessage(conversationId, applicationMessage).first().message
 
         assertEquals(PLAIN_TEXT, plainMessage?.decodeToString())
     }
@@ -165,7 +165,7 @@ class MLSClientTest : BaseMLSClientTest() {
             listOf(Pair(CAROL1.qualifiedClientId, carolClient.generateKeyPackages(1).first()))
         )?.commit!!
 
-        assertNull(aliceClient.decryptMessage(MLS_CONVERSATION_ID, commit).message)
+        assertNull(aliceClient.decryptMessage(MLS_CONVERSATION_ID, commit).first().message)
     }
 
     @Test
@@ -186,7 +186,7 @@ class MLSClientTest : BaseMLSClientTest() {
         val clientRemovalList = listOf(CAROL1.qualifiedClientId)
         val commit = bobClient.removeMember(conversationId, clientRemovalList).commit
 
-        assertNull(aliceClient.decryptMessage(conversationId, commit).message)
+        assertNull(aliceClient.decryptMessage(conversationId, commit).first().message)
     }
 
     companion object {

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -48,7 +48,7 @@ class MLSClientImpl : MLSClient {
         TODO("Not yet implemented")
     }
 
-    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId) {
+    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>? {
         TODO("Not yet implemented")
     }
 

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -48,7 +48,7 @@ class MLSClientImpl : MLSClient {
         TODO("Not yet implemented")
     }
 
-    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId): List<DecryptedMessageBundle>? {
+    override suspend fun mergePendingGroupFromExternalCommit(groupId: MLSGroupId) {
         TODO("Not yet implemented")
     }
 
@@ -92,7 +92,7 @@ class MLSClientImpl : MLSClient {
         TODO("Not yet implemented")
     }
 
-    override suspend fun decryptMessage(groupId: MLSGroupId, message: ApplicationMessage): DecryptedMessageBundle {
+    override suspend fun decryptMessage(groupId: MLSGroupId, message: ApplicationMessage): List<DecryptedMessageBundle> {
         TODO("Not yet implemented")
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/DecryptedMessageBundleMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/DecryptedMessageBundleMapper.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.toModel
+
+fun com.wire.kalium.cryptography.DecryptedMessageBundle.toModel(groupID: GroupID): DecryptedMessageBundle =
+    DecryptedMessageBundle(
+        groupID,
+        message?.let { message ->
+            // We will always have senderClientId together with an application message
+            // but CoreCrypto API doesn't express this
+            ApplicationMessage(
+                message = message,
+                senderID = senderClientId!!.toModel().userId,
+                senderClientID = senderClientId!!.toModel().clientId
+            )
+        },
+        commitDelay,
+        identity?.let { identity ->
+            E2EIdentity(
+                identity.clientId,
+                identity.handle,
+                identity.displayName,
+                identity.domain
+            )
+        }
+    )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMappers.kt
@@ -16,9 +16,11 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
+@file:Suppress("TooManyFunctions")
 package com.wire.kalium.logic.data.id
 
 import com.wire.kalium.cryptography.CryptoClientId
+import com.wire.kalium.cryptography.CryptoQualifiedClientId
 import com.wire.kalium.cryptography.CryptoQualifiedID
 import com.wire.kalium.cryptography.MLSGroupId
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -49,3 +51,5 @@ internal fun UserAssetDTO.toModel(domain: String): QualifiedID = QualifiedID(key
 internal fun SubconversationId.toApi(): String = value
 
 internal fun GroupID.toCrypto(): MLSGroupId = value
+
+internal fun CryptoQualifiedClientId.toModel() = QualifiedClientID(ClientId(value), userId.toModel())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1025,11 +1025,10 @@ class UserSessionScope internal constructor(
 
     private val mlsUnpacker: MLSMessageUnpacker
         get() = MLSMessageUnpackerImpl(
-            mlsClientProvider = mlsClientProvider,
             conversationRepository = conversationRepository,
             subconversationRepository = subconversationRepository,
+            mlsConversationRepository = mlsConversationRepository,
             pendingProposalScheduler = pendingProposalScheduler,
-            epochsFlow = epochsFlow,
             selfUserId = userId
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -813,7 +813,8 @@ class UserSessionScope internal constructor(
             authenticatedNetworkContainer.conversationApi,
             clientRepository,
             conversationRepository,
-            mlsConversationRepository
+            mlsConversationRepository,
+            mlsUnpacker
         )
 
     private val recoverMLSConversationsUseCase: RecoverMLSConversationsUseCase
@@ -837,7 +838,8 @@ class UserSessionScope internal constructor(
         get() = JoinSubconversationUseCaseImpl(
             authenticatedNetworkContainer.conversationApi,
             mlsConversationRepository,
-            subconversationRepository
+            subconversationRepository,
+            mlsUnpacker
         )
 
     private val leaveSubconversationUseCase: LeaveSubconversationUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -130,16 +130,10 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                         groupInfo
                     ).flatMapLeft {
                         if (MLSMessageFailureHandler.handleFailure(it) is MLSMessageFailureResolution.Ignore) {
-                            Either.Right(null)
+                            Either.Right(Unit)
                         } else {
                             Either.Left(it)
                         }
-                    }.map { messageBundles ->
-                        // Process any buffered message which arrived before the pending group was merged. We only
-                        // expect to receive proposals which the backend re-creates upon external commits.
-                        messageBundles?.forEach { bundle ->
-                            mlsMessageUnpacker.unpackMlsBundle(bundle, conversation.id, Clock.System.now())
-                        } ?: Unit
                     }
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -26,16 +26,18 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.toApi
-import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureHandler
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureResolution
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.exceptions.KaliumException
@@ -44,6 +46,7 @@ import com.wire.kalium.network.exceptions.isMlsStaleMessage
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 
 /**
  * Send an external commit to join all MLS conversations for which the user is a member,
@@ -54,13 +57,13 @@ interface JoinExistingMLSConversationUseCase {
 }
 
 @Suppress("LongParameterList")
-class JoinExistingMLSConversationUseCaseImpl(
+internal class JoinExistingMLSConversationUseCaseImpl(
     private val featureSupport: FeatureSupport,
     private val conversationApi: ConversationApi,
     private val clientRepository: ClientRepository,
     private val conversationRepository: ConversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
-    private val idMapper: IdMapper = MapperProvider.idMapper(),
+    private val mlsMessageUnpacker: MLSMessageUnpacker,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : JoinExistingMLSConversationUseCase {
     private val dispatcher = kaliumDispatcher.io
@@ -125,7 +128,19 @@ class JoinExistingMLSConversationUseCaseImpl(
                     mlsConversationRepository.joinGroupByExternalCommit(
                         conversation.protocol.groupId,
                         groupInfo
-                    )
+                    ).flatMapLeft {
+                        if (MLSMessageFailureHandler.handleFailure(it) is MLSMessageFailureResolution.Ignore) {
+                            Either.Right(null)
+                        } else {
+                            Either.Left(it)
+                        }
+                    }.map { messageBundles ->
+                        // Process any buffered message which arrived before the pending group was merged. We only
+                        // expect to receive proposals which the backend re-creates upon external commits.
+                        messageBundles?.forEach { bundle ->
+                            mlsMessageUnpacker.unpackMlsBundle(bundle, conversation.id, Clock.System.now())
+                        } ?: Unit
+                    }
                 }
             }
         } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -33,7 +33,6 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.getOrElse
-import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureResolution
@@ -46,7 +45,6 @@ import com.wire.kalium.network.exceptions.isMlsStaleMessage
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
 
 /**
  * Send an external commit to join all MLS conversations for which the user is a member,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCase.kt
@@ -96,16 +96,10 @@ internal class JoinSubconversationUseCaseImpl(
 
                     ).flatMapLeft {
                         if (MLSMessageFailureHandler.handleFailure(it) is MLSMessageFailureResolution.Ignore) {
-                            Either.Right(null)
+                            Either.Right(Unit)
                         } else {
                             Either.Left(it)
                         }
-                    }.map { messageBundles ->
-                        // Process any buffered message which arrived before the pending group was merged. We only
-                        // expect to receive proposals which the backend re-creates upon external commits.
-                        messageBundles?.forEach { bundle ->
-                            mlsMessageUnpacker.unpackMlsBundle(bundle, subconversationDetails.parentId.toModel(), Clock.System.now())
-                        } ?: Unit
                     }
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCase.kt
@@ -8,11 +8,9 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toApi
-import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
-import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation.message
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.MLSFailure
+
+sealed class MLSMessageFailureResolution {
+    object Ignore : MLSMessageFailureResolution()
+    object InformUser : MLSMessageFailureResolution()
+    object OutOfSync : MLSMessageFailureResolution()
+}
+
+internal object MLSMessageFailureHandler {
+    fun handleFailure(failure: CoreFailure): MLSMessageFailureResolution {
+        return when (failure) {
+            // Received messages targeting a future epoch, we might have lost messages.
+            is MLSFailure.WrongEpoch -> MLSMessageFailureResolution.OutOfSync
+            // Received already sent or received message, can safely be ignored.
+            is MLSFailure.DuplicateMessage -> MLSMessageFailureResolution.Ignore
+            // Received self commit, any unmerged group has know when merged by CoreCrypto.
+            is MLSFailure.SelfCommitIgnored -> MLSMessageFailureResolution.Ignore
+            // Message arrive in an unmerged group, it has been buffered and will be consumed later.
+            is MLSFailure.UnmergedPendingGroup -> MLSMessageFailureResolution.Ignore
+            else -> MLSMessageFailureResolution.InformUser
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -124,9 +124,11 @@ internal class NewMessageEventHandlerImpl(
                     }
                 }
             }.onSuccess {
-                if (it is MessageUnpackResult.ApplicationMessage) {
-                    handleSuccessfulResult(it)
-                    onMessageInserted(it)
+                it.forEach {
+                    if (it is MessageUnpackResult.ApplicationMessage) {
+                        handleSuccessfulResult(it)
+                        onMessageInserted(it)
+                    }
                 }
                 kaliumLogger
                     .logEventProcessing(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.sync.receiver.conversation.message
 
 import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.logger.KaliumLogger
-import com.wire.kalium.logic.MLSFailure
 import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.event.Event
@@ -101,40 +100,29 @@ internal class NewMessageEventHandlerImpl(
                     "protocol" to "MLS"
                 )
 
-                logger.e("Failed to decrypt event: ${logMap.toJsonElement()}")
-
-                if (it is MLSFailure.WrongEpoch) {
-                    mlsWrongEpochHandler.onMLSWrongEpoch(event.conversationId, event.timestampIso)
-                    return@onFailure
+                when (MLSMessageFailureHandler.handleFailure(it)) {
+                    is MLSMessageFailureResolution.Ignore -> {
+                        logger.i("Ignoring event: ${logMap.toJsonElement()}")
+                    }
+                    is MLSMessageFailureResolution.InformUser -> {
+                        logger.i("Informing users about decryption error: ${logMap.toJsonElement()}")
+                        applicationMessageHandler.handleDecryptionError(
+                            eventId = event.id,
+                            conversationId = event.conversationId,
+                            timestampIso = event.timestampIso,
+                            senderUserId = event.senderUserId,
+                            senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
+                            content = MessageContent.FailedDecryption(
+                                isDecryptionResolved = false,
+                                senderUserId = event.senderUserId
+                            )
+                        )
+                    }
+                    is MLSMessageFailureResolution.OutOfSync -> {
+                        logger.i("Epoch out of sync error: ${logMap.toJsonElement()}")
+                        mlsWrongEpochHandler.onMLSWrongEpoch(event.conversationId, event.timestampIso)
+                    }
                 }
-
-                if (it is MLSFailure.DuplicateMessage) {
-                    logger.i("Ignoring duplicate event: ${logMap.toJsonElement()}")
-                    return@onFailure
-                }
-
-                if (it is MLSFailure.SelfCommitIgnored) {
-                    logger.i("Ignoring replayed self commit: ${logMap.toJsonElement()}")
-                    return@onFailure
-                }
-
-                if (it is MLSFailure.UnmergedPendingGroup) {
-                    logger.i("Message arrive in an unmerged group, " +
-                            "it has been buffered and will be consumed later: ${logMap.toJsonElement()}")
-                    return@onFailure
-                }
-
-                applicationMessageHandler.handleDecryptionError(
-                    eventId = event.id,
-                    conversationId = event.conversationId,
-                    timestampIso = event.timestampIso,
-                    senderUserId = event.senderUserId,
-                    senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
-                    content = MessageContent.FailedDecryption(
-                        isDecryptionResolved = false,
-                        senderUserId = event.senderUserId
-                    )
-                )
             }.onSuccess {
                 if (it is MessageUnpackResult.ApplicationMessage) {
                     handleSuccessfulResult(it)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -902,22 +902,6 @@ class MLSConversationRepositoryTest {
     }
 
     @Test
-    fun givenBufferedMessages_whenSendingExternalCommitBundle_thenReturnMessages() = runTest(TestKaliumDispatcher.default) {
-        val (_, mlsConversationRepository) = Arrangement()
-            .withGetMLSClientSuccessful()
-            .withJoinConversationSuccessful()
-            .withSendMLSMessageSuccessful()
-            .withSendCommitBundleSuccessful()
-            .withJoinByExternalCommitSuccessful()
-            .withMergePendingGroupFromExternalCommitSuccessful(listOf(Arrangement.DECRYPTED_MESSAGE_BUNDLE))
-            .arrange()
-
-        mlsConversationRepository.joinGroupByExternalCommit(Arrangement.GROUP_ID, ByteArray(0)).shouldSucceed { bundles ->
-            assertEquals(Arrangement.DECRYPTED_MESSAGE_BUNDLE.toModel(Arrangement.GROUP_ID), bundles?.first())
-        }
-    }
-
-    @Test
     fun givenVerifiedConversation_whenGetGroupVerify_thenVerifiedReturned() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetMLSClientSuccessful()
@@ -1093,11 +1077,11 @@ class MLSConversationRepositoryTest {
                 .thenReturn(COMMIT_BUNDLE)
         }
 
-        fun withMergePendingGroupFromExternalCommitSuccessful(result: List<com.wire.kalium.cryptography.DecryptedMessageBundle>? = null) = apply {
+        fun withMergePendingGroupFromExternalCommitSuccessful() = apply {
             given(mlsClient)
                 .suspendFunction(mlsClient::mergePendingGroupFromExternalCommit)
                 .whenInvokedWith(anything())
-                .thenReturn(result)
+                .thenReturn(Unit)
         }
 
         fun withProcessWelcomeMessageSuccessful() = apply {
@@ -1157,7 +1141,7 @@ class MLSConversationRepositoryTest {
             given(mlsClient)
                 .suspendFunction(mlsClient::decryptMessage)
                 .whenInvokedWith(any(), any())
-                .thenReturn(decryptedMessage)
+                .thenReturn(listOf(decryptedMessage))
         }
 
         fun withRemoveMemberSuccessful() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageUnpacker
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
@@ -163,10 +164,14 @@ class JoinSubconversationUseCaseTest {
         @Mock
         val subconversationRepository = mock(classOf<SubconversationRepository>())
 
+        @Mock
+        val mlsMessageUnpacker = mock(classOf<MLSMessageUnpacker>())
+
         fun arrange() = this to JoinSubconversationUseCaseImpl(
             conversationApi,
             mlsConversationRepository,
-            subconversationRepository
+            subconversationRepository,
+            mlsMessageUnpacker
         )
 
         fun withEstablishMLSGroupSuccessful() = apply {
@@ -180,7 +185,7 @@ class JoinSubconversationUseCaseTest {
             given(mlsConversationRepository)
                 .suspendFunction(mlsConversationRepository::joinGroupByExternalCommit)
                 .whenInvokedWith(anything(), anything())
-                .thenReturn(Either.Right(Unit))
+                .thenReturn(Either.Right(null))
         }
 
         fun withJoinByExternalCommitGroupFailing(failure: CoreFailure, times: Int = Int.MAX_VALUE) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCaseTest.kt
@@ -185,7 +185,7 @@ class JoinSubconversationUseCaseTest {
             given(mlsConversationRepository)
                 .suspendFunction(mlsConversationRepository::joinGroupByExternalCommit)
                 .whenInvokedWith(anything(), anything())
-                .thenReturn(Either.Right(null))
+                .thenReturn(Either.Right(Unit))
         }
 
         fun withJoinByExternalCommitGroupFailing(failure: CoreFailure, times: Int = Int.MAX_VALUE) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import io.ktor.util.encodeBase64
 import kotlinx.datetime.Instant
 
 object TestEvent {
@@ -193,7 +194,7 @@ object TestEvent {
         null,
         TestUser.USER_ID,
         timestamp.toIsoDateTimeString(),
-        "content",
+        "content".encodeBase64(),
     )
 
     fun newConversationEvent() = Event.Conversation.NewConversation(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpackerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpackerTest.kt
@@ -141,7 +141,7 @@ class MLSMessageUnpackerTest {
             given(mlsClient)
                 .suspendFunction(mlsClient::decryptMessage)
                 .whenInvokedWith(anything(), anything())
-                .thenReturn(DecryptedMessageBundle(null, commitDelay, null, hasEpochChanged, null))
+                .thenReturn(listOf(DecryptedMessageBundle(null, commitDelay, null, hasEpochChanged, null)))
         }
 
         fun withScheduleCommitSucceeding() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpackerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpackerTest.kt
@@ -18,40 +18,33 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation.message
 
-import com.wire.kalium.cryptography.DecryptedMessageBundle
 import com.wire.kalium.cryptography.MLSClient
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.DecryptedMessageBundle
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.SubconversationRepository
-import com.wire.kalium.logic.data.id.GroupID
-import com.wire.kalium.logic.data.message.PlainMessageBlob
-import com.wire.kalium.logic.data.message.ProtoContent
-import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.PendingProposalScheduler
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.util.DateTimeUtil
+import io.ktor.util.decodeBase64Bytes
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.anything
 import io.mockative.classOf
 import io.mockative.eq
 import io.mockative.given
-import io.mockative.matchers.Matcher
+import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.yield
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
 class MLSMessageUnpackerTest {
@@ -64,7 +57,7 @@ class MLSMessageUnpackerTest {
         val (arrangement, mlsUnpacker) = Arrangement()
             .withMLSClientProviderReturningClient()
             .withGetConversationProtocolInfoSuccessful(TestConversation.MLS_CONVERSATION.protocol)
-            .withDecryptMessageReturningProposal(commitDelay = commitDelay)
+            .withDecryptMessageReturning(Either.Right(listOf(DECRYPTED_MESSAGE_BUNDLE.copy(commitDelay = commitDelay))))
             .withScheduleCommitSucceeding()
             .arrange()
 
@@ -78,24 +71,21 @@ class MLSMessageUnpackerTest {
     }
 
     @Test
-    fun givenNewMLSMessageEventWithCommit_whenUnpacking_thenEmitEpochChange() = runTest(TestKaliumDispatcher.default) {
+    fun givenNewMLSMessageEvent_whenUnpacking_thenDecryptMessage() = runTest {
         val eventTimestamp = DateTimeUtil.currentInstant()
-
         val (arrangement, mlsUnpacker) = Arrangement()
             .withMLSClientProviderReturningClient()
             .withGetConversationProtocolInfoSuccessful(TestConversation.MLS_CONVERSATION.protocol)
-            .withDecryptMessageReturningProposal(hasEpochChanged = true)
+            .withDecryptMessageReturning(Either.Right(listOf(DECRYPTED_MESSAGE_BUNDLE)))
             .arrange()
-
-        val epochChange = async(TestKaliumDispatcher.default) {
-            arrangement.epochsFlow.first()
-        }
-        yield()
 
         val messageEvent = TestEvent.newMLSMessageEvent(eventTimestamp)
         mlsUnpacker.unpackMlsMessage(messageEvent)
 
-        assertEquals(TestConversation.GROUP_ID, epochChange.await())
+        verify(arrangement.mlsConversationRepository)
+            .suspendFunction(arrangement.mlsConversationRepository::decryptMessage)
+            .with(matching { it.contentEquals(messageEvent.content.decodeBase64Bytes()) }, eq(TestConversation.GROUP_ID))
+            .wasInvoked(once)
     }
 
     private class Arrangement {
@@ -110,24 +100,20 @@ class MLSMessageUnpackerTest {
         val conversationRepository = mock(classOf<ConversationRepository>())
 
         @Mock
+        val mlsConversationRepository = mock(classOf<MLSConversationRepository>())
+
+        @Mock
         val pendingProposalScheduler = mock(classOf<PendingProposalScheduler>())
 
         @Mock
         val subconversationRepository = mock(classOf<SubconversationRepository>())
 
-        @Mock
-        val protoContentMapper = mock(classOf<ProtoContentMapper>())
-
-        val epochsFlow = MutableSharedFlow<GroupID>()
-
         private val mlsMessageUnpacker = MLSMessageUnpackerImpl(
-            mlsClientProvider,
             conversationRepository,
             subconversationRepository,
+            mlsConversationRepository,
             pendingProposalScheduler,
-            epochsFlow,
-            SELF_USER_ID,
-            protoContentMapper
+            SELF_USER_ID
         )
 
         fun withMLSClientProviderReturningClient() = apply {
@@ -137,11 +123,11 @@ class MLSMessageUnpackerTest {
                 .then { Either.Right(mlsClient) }
         }
 
-        fun withDecryptMessageReturningProposal(commitDelay: Long? = null, hasEpochChanged: Boolean = false) = apply {
-            given(mlsClient)
-                .suspendFunction(mlsClient::decryptMessage)
+        fun withDecryptMessageReturning(result: Either<CoreFailure, List<DecryptedMessageBundle>>) = apply {
+            given(mlsConversationRepository)
+                .suspendFunction(mlsConversationRepository::decryptMessage)
                 .whenInvokedWith(anything(), anything())
-                .thenReturn(listOf(DecryptedMessageBundle(null, commitDelay, null, hasEpochChanged, null)))
+                .thenReturn(result)
         }
 
         fun withScheduleCommitSucceeding() = apply {
@@ -149,13 +135,6 @@ class MLSMessageUnpackerTest {
                 .suspendFunction(pendingProposalScheduler::scheduleCommit)
                 .whenInvokedWith(any(), any())
                 .thenReturn(Unit)
-        }
-
-        fun withProtoContentMapperReturning(plainBlobMatcher: Matcher<PlainMessageBlob>, protoContent: ProtoContent) = apply {
-            given(protoContentMapper)
-                .function(protoContentMapper::decodeFromProtobuf)
-                .whenInvokedWith(plainBlobMatcher)
-                .thenReturn(protoContent)
         }
 
         fun withGetConversationProtocolInfoSuccessful(protocolInfo: Conversation.ProtocolInfo) = apply {
@@ -170,5 +149,11 @@ class MLSMessageUnpackerTest {
     }
     companion object {
         val SELF_USER_ID = UserId("user-id", "domain")
+        val DECRYPTED_MESSAGE_BUNDLE = DecryptedMessageBundle(
+            groupID = TestConversation.GROUP_ID,
+            applicationMessage = null,
+            commitDelay = null,
+            identity = null
+        )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -128,7 +128,7 @@ class NewMessageEventHandlerTest {
     @Test
     fun givenMLSEvent_whenHandling_shouldAskMLSUnpackerToDecrypt() = runTest {
         val (arrangement, newMessageEventHandler) = Arrangement()
-            .withMLSUnpackerReturning(Either.Right(MessageUnpackResult.HandshakeMessage))
+            .withMLSUnpackerReturning(Either.Right(listOf(MessageUnpackResult.HandshakeMessage)))
             .arrange()
 
         val newMessageEvent = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant())
@@ -347,7 +347,7 @@ class NewMessageEventHandlerTest {
                 .thenReturn(result)
         }
 
-        fun withMLSUnpackerReturning(result: Either<CoreFailure, MessageUnpackResult>) = apply {
+        fun withMLSUnpackerReturning(result: Either<CoreFailure, List<MessageUnpackResult>>) = apply {
             given(mlsMessageUnpacker)
                 .suspendFunction(mlsMessageUnpacker::unpackMlsMessage)
                 .whenInvokedWith(any())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

I'm re-opening https://github.com/wireapp/kalium/pull/1958 because it seems to have gotten lost in a rebase.

After reviewing it again I've changed my approach.

1. Handle out order buffered messages when decrypting a message.2
2. Ignore CC's buffered messages when merging commits, because it's much easier and nicer to avoid out order message by enforcing the order of operations in Kalium.

### Testing

#### Test Coveragex

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
