### PR TITLE
chore: add archived field to conversations table (WPB-4471)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -258,7 +258,7 @@ internal class ConnectionDataSource(
                         messageTimer = null,
                         userMessageTimer = null,
                         archived = false,
-                        archivedRef = ""
+                        archivedDateTime = null
                     )
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -258,7 +258,7 @@ internal class ConnectionDataSource(
                         messageTimer = null,
                         userMessageTimer = null,
                         archived = false,
-                        archivedDateTime = null
+                        archivedInstant = null
                     )
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -257,8 +257,8 @@ internal class ConnectionDataSource(
                         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
                         messageTimer = null,
                         userMessageTimer = null,
-                        otrArchived = false,
-                        otrArchivedRef = ""
+                        archived = false,
+                        archivedRef = ""
                     )
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -256,7 +256,9 @@ internal class ConnectionDataSource(
                         accessRole = emptyList(),
                         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
                         messageTimer = null,
-                        userMessageTimer = null
+                        userMessageTimer = null,
+                        otrArchived = false,
+                        otrArchivedRef = ""
                     )
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -68,7 +68,9 @@ data class Conversation(
     val creatorId: String?,
     val receiptMode: ReceiptMode,
     val messageTimer: Duration?,
-    val userMessageTimer: Duration?
+    val userMessageTimer: Duration?,
+    val otrArchived: Boolean,
+    val otrArchivedRef: String
 ) {
 
     companion object {
@@ -295,7 +297,9 @@ sealed class ConversationDetails(open val conversation: Conversation) {
             creatorId = null,
             receiptMode = Conversation.ReceiptMode.DISABLED,
             messageTimer = null,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
     )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -70,7 +70,7 @@ data class Conversation(
     val messageTimer: Duration?,
     val userMessageTimer: Duration?,
     val archived: Boolean,
-    val archivedRef: String
+    val archivedDateTime: String?
 ) {
 
     companion object {
@@ -299,7 +299,7 @@ sealed class ConversationDetails(open val conversation: Conversation) {
             messageTimer = null,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
     )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -70,7 +70,7 @@ data class Conversation(
     val messageTimer: Duration?,
     val userMessageTimer: Duration?,
     val archived: Boolean,
-    val archivedDateTime: String?
+    val archivedDateTime: Instant?
 ) {
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -69,8 +69,8 @@ data class Conversation(
     val receiptMode: ReceiptMode,
     val messageTimer: Duration?,
     val userMessageTimer: Duration?,
-    val otrArchived: Boolean,
-    val otrArchivedRef: String
+    val archived: Boolean,
+    val archivedRef: String
 ) {
 
     companion object {
@@ -298,8 +298,8 @@ sealed class ConversationDetails(open val conversation: Conversation) {
             receiptMode = Conversation.ReceiptMode.DISABLED,
             messageTimer = null,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
     )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -117,7 +117,9 @@ internal class ConversationMapperImpl(
         receiptMode = receiptModeMapper.fromApiToDaoModel(apiModel.receiptMode),
         messageTimer = apiModel.messageTimer,
         userMessageTimer = null, // user picked self deletion timer is only persisted locally
-        hasIncompleteMetadata = false
+        hasIncompleteMetadata = false,
+        otrArchived = apiModel.members.self.otrArchived ?: false,
+        otrArchivedRef = apiModel.members.self.otrArchivedRef ?: ""
     )
 
     override fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol = when (apiModel) {
@@ -157,7 +159,9 @@ internal class ConversationMapperImpl(
             creatorId = creatorId,
             receiptMode = receiptModeMapper.fromEntityToModel(receiptMode),
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
-            userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS)
+            userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
+            otrArchived = otrArchived,
+            otrArchivedRef = otrArchivedRef
         )
     }
 
@@ -180,7 +184,9 @@ internal class ConversationMapperImpl(
             creatorId = creatorId,
             receiptMode = receiptModeMapper.fromEntityToModel(receiptMode),
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
-            userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS)
+            userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
+            otrArchived = otrArchived,
+            otrArchivedRef = otrArchivedRef
         )
     }
 
@@ -371,6 +377,8 @@ internal class ConversationMapperImpl(
             receiptMode = receiptModeMapper.toDaoModel(conversation.receiptMode),
             messageTimer = messageTimer?.inWholeMilliseconds,
             userMessageTimer = userMessageTimer?.inWholeMilliseconds,
+            otrArchived = otrArchived,
+            otrArchivedRef = otrArchivedRef
         )
     }
 
@@ -396,7 +404,9 @@ internal class ConversationMapperImpl(
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        hasIncompleteMetadata = true
+        hasIncompleteMetadata = true,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -118,8 +118,8 @@ internal class ConversationMapperImpl(
         messageTimer = apiModel.messageTimer,
         userMessageTimer = null, // user picked self deletion timer is only persisted locally
         hasIncompleteMetadata = false,
-        otrArchived = apiModel.members.self.otrArchived ?: false,
-        otrArchivedRef = apiModel.members.self.otrArchivedRef ?: ""
+        archived = apiModel.members.self.otrArchived ?: false,
+        archivedRef = apiModel.members.self.otrArchivedRef ?: ""
     )
 
     override fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol = when (apiModel) {
@@ -160,8 +160,8 @@ internal class ConversationMapperImpl(
             receiptMode = receiptModeMapper.fromEntityToModel(receiptMode),
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
-            otrArchived = otrArchived,
-            otrArchivedRef = otrArchivedRef
+            archived = archived,
+            archivedRef = archivedRef
         )
     }
 
@@ -185,8 +185,8 @@ internal class ConversationMapperImpl(
             receiptMode = receiptModeMapper.fromEntityToModel(receiptMode),
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
-            otrArchived = otrArchived,
-            otrArchivedRef = otrArchivedRef
+            archived = archived,
+            archivedRef = archivedRef
         )
     }
 
@@ -377,8 +377,8 @@ internal class ConversationMapperImpl(
             receiptMode = receiptModeMapper.toDaoModel(conversation.receiptMode),
             messageTimer = messageTimer?.inWholeMilliseconds,
             userMessageTimer = userMessageTimer?.inWholeMilliseconds,
-            otrArchived = otrArchived,
-            otrArchivedRef = otrArchivedRef
+            archived = archived,
+            archivedRef = archivedRef
         )
     }
 
@@ -405,8 +405,8 @@ internal class ConversationMapperImpl(
         messageTimer = null,
         userMessageTimer = null,
         hasIncompleteMetadata = true,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -119,7 +119,7 @@ internal class ConversationMapperImpl(
         userMessageTimer = null, // user picked self deletion timer is only persisted locally
         hasIncompleteMetadata = false,
         archived = apiModel.members.self.otrArchived ?: false,
-        archivedDateTime = apiModel.members.self.otrArchivedRef
+        archivedInstant = apiModel.members.self.otrArchivedRef?.toInstant()
     )
 
     override fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol = when (apiModel) {
@@ -161,7 +161,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
             archived = archived,
-            archivedDateTime = archivedDateTime
+            archivedDateTime = archivedDateTime?.toIsoDateTimeString()
         )
     }
 
@@ -186,7 +186,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
             archived = archived,
-            archivedDateTime = archivedDateTime
+            archivedDateTime = archivedInstant?.toIsoDateTimeString()
         )
     }
 
@@ -378,7 +378,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.inWholeMilliseconds,
             userMessageTimer = userMessageTimer?.inWholeMilliseconds,
             archived = archived,
-            archivedDateTime = archivedDateTime
+            archivedInstant = archivedDateTime?.toInstant()
         )
     }
 
@@ -406,7 +406,7 @@ internal class ConversationMapperImpl(
         userMessageTimer = null,
         hasIncompleteMetadata = true,
         archived = false,
-        archivedDateTime = null
+        archivedInstant = null
     )
 
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -119,7 +119,7 @@ internal class ConversationMapperImpl(
         userMessageTimer = null, // user picked self deletion timer is only persisted locally
         hasIncompleteMetadata = false,
         archived = apiModel.members.self.otrArchived ?: false,
-        archivedRef = apiModel.members.self.otrArchivedRef ?: ""
+        archivedDateTime = apiModel.members.self.otrArchivedRef
     )
 
     override fun fromApiModelToDaoModel(apiModel: ConvProtocol): Protocol = when (apiModel) {
@@ -161,7 +161,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
             archived = archived,
-            archivedRef = archivedRef
+            archivedDateTime = archivedDateTime
         )
     }
 
@@ -186,7 +186,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
             archived = archived,
-            archivedRef = archivedRef
+            archivedDateTime = archivedDateTime
         )
     }
 
@@ -378,7 +378,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.inWholeMilliseconds,
             userMessageTimer = userMessageTimer?.inWholeMilliseconds,
             archived = archived,
-            archivedRef = archivedRef
+            archivedDateTime = archivedDateTime
         )
     }
 
@@ -406,7 +406,7 @@ internal class ConversationMapperImpl(
         userMessageTimer = null,
         hasIncompleteMetadata = true,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -161,7 +161,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
             archived = archived,
-            archivedDateTime = archivedDateTime?.toIsoDateTimeString()
+            archivedDateTime = archivedDateTime
         )
     }
 
@@ -186,7 +186,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = userMessageTimer?.toDuration(DurationUnit.MILLISECONDS),
             archived = archived,
-            archivedDateTime = archivedInstant?.toIsoDateTimeString()
+            archivedDateTime = archivedInstant
         )
     }
 
@@ -378,7 +378,7 @@ internal class ConversationMapperImpl(
             messageTimer = messageTimer?.inWholeMilliseconds,
             userMessageTimer = userMessageTimer?.inWholeMilliseconds,
             archived = archived,
-            archivedInstant = archivedDateTime?.toInstant()
+            archivedInstant = archivedDateTime
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
@@ -166,7 +166,7 @@ fun WebConversationContent.toConversation(selfUserId: UserId): Conversation? {
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = null,
             archived = archivedState ?: false,
-            archivedRef = archivedTimestamp?.toDuration(DurationUnit.MILLISECONDS)?.toString() ?: ""
+            archivedDateTime = archivedTimestamp?.toDuration(DurationUnit.MILLISECONDS)?.toString()
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
@@ -164,7 +164,9 @@ fun WebConversationContent.toConversation(selfUserId: UserId): Conversation? {
             creatorId = creator,
             receiptMode = fromScalaReceiptMode(receiptMode),
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = archivedState ?: false,
+            otrArchivedRef = archivedTimestamp?.toDuration(DurationUnit.MILLISECONDS)?.toString() ?: ""
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
@@ -143,6 +143,9 @@ fun WebConversationContent.toConversation(selfUserId: UserId): Conversation? {
         } else {
             DateTimeUtil.fromEpochMillisToIsoDateTimeString(lastReadTimestamp)
         }
+        val conversationArchivedTimestamp = archivedTimestamp?.let { timestamp ->
+            DateTimeUtil.fromEpochMillisToIsoDateTimeString(timestamp)
+        }
 
         Conversation(
             id = toQualifiedId(id, domain, selfUserId),
@@ -166,7 +169,7 @@ fun WebConversationContent.toConversation(selfUserId: UserId): Conversation? {
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = null,
             archived = archivedState ?: false,
-            archivedDateTime = archivedTimestamp?.toDuration(DurationUnit.MILLISECONDS)?.toString()
+            archivedDateTime = conversationArchivedTimestamp
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
@@ -143,8 +143,8 @@ fun WebConversationContent.toConversation(selfUserId: UserId): Conversation? {
         } else {
             DateTimeUtil.fromEpochMillisToIsoDateTimeString(lastReadTimestamp)
         }
-        val conversationArchivedTimestamp = archivedTimestamp?.let { timestamp ->
-            DateTimeUtil.fromEpochMillisToIsoDateTimeString(timestamp)
+        val conversationArchivedTimestamp: Instant? = archivedTimestamp?.let { timestamp ->
+            Instant.fromEpochMilliseconds(timestamp)
         }
 
         Conversation(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
@@ -165,8 +165,8 @@ fun WebConversationContent.toConversation(selfUserId: UserId): Conversation? {
             receiptMode = fromScalaReceiptMode(receiptMode),
             messageTimer = messageTimer?.toDuration(DurationUnit.MILLISECONDS),
             userMessageTimer = null,
-            otrArchived = archivedState ?: false,
-            otrArchivedRef = archivedTimestamp?.toDuration(DurationUnit.MILLISECONDS)?.toString() ?: ""
+            archived = archivedState ?: false,
+            archivedRef = archivedTimestamp?.toDuration(DurationUnit.MILLISECONDS)?.toString() ?: ""
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -149,8 +149,8 @@ class EndCallOnConversationChangeUseCaseTest {
             receiptMode = Conversation.ReceiptMode.ENABLED,
             messageTimer = null,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
 
         val otherUser = OtherUser(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -150,7 +150,7 @@ class EndCallOnConversationChangeUseCaseTest {
             messageTimer = null,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
 
         val otherUser = OtherUser(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -148,7 +148,9 @@ class EndCallOnConversationChangeUseCaseTest {
             creatorId = null,
             receiptMode = Conversation.ReceiptMode.ENABLED,
             messageTimer = null,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
 
         val otherUser = OtherUser(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -127,7 +127,9 @@ class GetOrCreateOneToOneConversationUseCaseTest {
             creatorId = null,
             receiptMode = Conversation.ReceiptMode.DISABLED,
             messageTimer = null,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -128,8 +128,8 @@ class GetOrCreateOneToOneConversationUseCaseTest {
             receiptMode = Conversation.ReceiptMode.DISABLED,
             messageTimer = null,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -129,7 +129,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
             messageTimer = null,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
@@ -406,7 +406,9 @@ class UpdateConversationAccessUseCaseTest {
             creatorId = "someCreatorId",
             receiptMode = Conversation.ReceiptMode.DISABLED,
             messageTimer = null,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
@@ -407,8 +407,8 @@ class UpdateConversationAccessUseCaseTest {
             receiptMode = Conversation.ReceiptMode.DISABLED,
             messageTimer = null,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
@@ -408,7 +408,7 @@ class UpdateConversationAccessUseCaseTest {
             messageTimer = null,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -75,7 +75,7 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     fun SELF(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -96,7 +96,7 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -117,7 +117,7 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     fun GROUP_VIEW_ENTITY(protocolInfo: ConversationEntity.ProtocolInfo = ConversationEntity.ProtocolInfo.Proteus) = ConversationViewEntity(
@@ -159,7 +159,7 @@ object TestConversation {
         userMessageTimer = null,
         userDefederated = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     fun one_on_one(convId: ConversationId) = Conversation(
@@ -180,7 +180,7 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     val NETWORK_ID = QualifiedID("valueConversation", "domainConversation")
@@ -270,7 +270,7 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
     val VIEW_ENTITY = ConversationViewEntity(
         id = ENTITY_ID,
@@ -309,7 +309,7 @@ object TestConversation {
         userMessageTimer = null,
         userDefederated = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     val CONVERSATION = Conversation(
@@ -330,7 +330,7 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     val MLS_CONVERSATION = Conversation(
@@ -357,7 +357,7 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     val CONVERSATION_CODE_INFO: ConversationCodeInfo = ConversationCodeInfo("conv_id_value", "name")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -73,7 +73,9 @@ object TestConversation {
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     fun SELF(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -92,7 +94,9 @@ object TestConversation {
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -111,7 +115,9 @@ object TestConversation {
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     fun GROUP_VIEW_ENTITY(protocolInfo: ConversationEntity.ProtocolInfo = ConversationEntity.ProtocolInfo.Proteus) = ConversationViewEntity(
@@ -151,7 +157,9 @@ object TestConversation {
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        userDefederated = null
+        userDefederated = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     fun one_on_one(convId: ConversationId) = Conversation(
@@ -170,7 +178,9 @@ object TestConversation {
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     val NETWORK_ID = QualifiedID("valueConversation", "domainConversation")
@@ -258,7 +268,9 @@ object TestConversation {
         accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = null,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
     val VIEW_ENTITY = ConversationViewEntity(
         id = ENTITY_ID,
@@ -295,7 +307,9 @@ object TestConversation {
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        userDefederated = null
+        userDefederated = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     val CONVERSATION = Conversation(
@@ -314,7 +328,9 @@ object TestConversation {
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     val MLS_CONVERSATION = Conversation(
@@ -339,7 +355,9 @@ object TestConversation {
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     val CONVERSATION_CODE_INFO: ConversationCodeInfo = ConversationCodeInfo("conv_id_value", "name")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -74,8 +74,8 @@ object TestConversation {
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     fun SELF(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -95,8 +95,8 @@ object TestConversation {
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     fun GROUP(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -116,8 +116,8 @@ object TestConversation {
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     fun GROUP_VIEW_ENTITY(protocolInfo: ConversationEntity.ProtocolInfo = ConversationEntity.ProtocolInfo.Proteus) = ConversationViewEntity(
@@ -158,8 +158,8 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         userDefederated = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     fun one_on_one(convId: ConversationId) = Conversation(
@@ -179,8 +179,8 @@ object TestConversation {
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     val NETWORK_ID = QualifiedID("valueConversation", "domainConversation")
@@ -269,8 +269,8 @@ object TestConversation {
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
     val VIEW_ENTITY = ConversationViewEntity(
         id = ENTITY_ID,
@@ -308,8 +308,8 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         userDefederated = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     val CONVERSATION = Conversation(
@@ -329,8 +329,8 @@ object TestConversation {
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     val MLS_CONVERSATION = Conversation(
@@ -356,8 +356,8 @@ object TestConversation {
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     val CONVERSATION_CODE_INFO: ConversationCodeInfo = ConversationCodeInfo("conv_id_value", "name")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -270,7 +270,7 @@ object TestConversation {
         messageTimer = null,
         userMessageTimer = null,
         archived = false,
-        archivedDateTime = null
+        archivedInstant = null
     )
     val VIEW_ENTITY = ConversationViewEntity(
         id = ENTITY_ID,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -39,7 +39,7 @@ CREATE TABLE Conversation (
     mls_degraded_notified INTEGER AS Boolean NOT NULL DEFAULT 0,
     is_guest_password_protected INTEGER AS Boolean DEFAULT 0 NOT NULL,
     archived INTEGER AS Boolean NOT NULL DEFAULT 0,
-    archived_ref TEXT NOT NULL DEFAULT ""
+    archived_date_time TEXT
 );
 
 -- Optimise comparisons and sorting by dates:
@@ -55,7 +55,7 @@ deleteConversation:
 DELETE FROM Conversation WHERE qualified_id = ?;
 
 insertConversation:
-INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata, archived, archived_ref)
+INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata, archived, archived_date_time)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
@@ -79,7 +79,7 @@ message_timer = excluded.message_timer,
 user_message_timer = excluded.user_message_timer,
 incomplete_metadata = excluded.incomplete_metadata,
 archived = excluded.archived,
-archived_ref = excluded.archived_ref;
+archived_date_time = excluded.archived_date_time;
 
 updateConversation:
 UPDATE Conversation
@@ -214,7 +214,7 @@ Conversation.message_timer,
 Conversation.user_message_timer,
 Conversation.incomplete_metadata,
 Conversation.archived,
-Conversation.archived_ref
+Conversation.archived_date_time
 FROM Conversation
 LEFT JOIN Member ON Conversation.qualified_id = Member.conversation
     AND Conversation.type IS 'ONE_ON_ONE'
@@ -249,7 +249,7 @@ selectByQualifiedId:
 SELECT * FROM ConversationDetails WHERE qualifiedId = ?;
 
 selectConversationByQualifiedId:
-SELECT qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, mls_proposal_timer, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, last_read_date, access_list, access_role_list, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, archived, archived_ref FROM Conversation WHERE qualified_id = ?;
+SELECT qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, mls_proposal_timer, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, last_read_date, access_list, access_role_list, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, archived, archived_date_time FROM Conversation WHERE qualified_id = ?;
 
 selectProtocolInfoByQualifiedId:
 SELECT protocol, mls_group_id, mls_group_state, mls_epoch ,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -38,8 +38,8 @@ CREATE TABLE Conversation (
     incomplete_metadata INTEGER AS Boolean NOT NULL DEFAULT 0,
     mls_degraded_notified INTEGER AS Boolean NOT NULL DEFAULT 0,
     is_guest_password_protected INTEGER AS Boolean DEFAULT 0 NOT NULL,
-    otr_archived INTEGER AS Boolean NOT NULL DEFAULT 0,
-    otr_archived_ref TEXT NOT NULL DEFAULT ""
+    archived INTEGER AS Boolean NOT NULL DEFAULT 0,
+    archived_ref TEXT NOT NULL DEFAULT ""
 );
 
 -- Optimise comparisons and sorting by dates:
@@ -55,7 +55,7 @@ deleteConversation:
 DELETE FROM Conversation WHERE qualified_id = ?;
 
 insertConversation:
-INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata, otr_archived, otr_archived_ref)
+INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata, archived, archived_ref)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
@@ -78,8 +78,8 @@ receipt_mode = excluded.receipt_mode,
 message_timer = excluded.message_timer,
 user_message_timer = excluded.user_message_timer,
 incomplete_metadata = excluded.incomplete_metadata,
-otr_archived = excluded.otr_archived,
-otr_archived_ref = excluded.otr_archived_ref;
+archived = excluded.archived,
+archived_ref = excluded.archived_ref;
 
 updateConversation:
 UPDATE Conversation
@@ -213,8 +213,8 @@ Conversation.receipt_mode,
 Conversation.message_timer,
 Conversation.user_message_timer,
 Conversation.incomplete_metadata,
-Conversation.otr_archived,
-Conversation.otr_archived_ref
+Conversation.archived,
+Conversation.archived_ref
 FROM Conversation
 LEFT JOIN Member ON Conversation.qualified_id = Member.conversation
     AND Conversation.type IS 'ONE_ON_ONE'
@@ -249,7 +249,7 @@ selectByQualifiedId:
 SELECT * FROM ConversationDetails WHERE qualifiedId = ?;
 
 selectConversationByQualifiedId:
-SELECT qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, mls_proposal_timer, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, last_read_date, access_list, access_role_list, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, otr_archived, otr_archived_ref FROM Conversation WHERE qualified_id = ?;
+SELECT qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, mls_proposal_timer, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, last_read_date, access_list, access_role_list, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, archived, archived_ref FROM Conversation WHERE qualified_id = ?;
 
 selectProtocolInfoByQualifiedId:
 SELECT protocol, mls_group_id, mls_group_state, mls_epoch ,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -37,7 +37,9 @@ CREATE TABLE Conversation (
     user_message_timer INTEGER DEFAULT(NULL),
     incomplete_metadata INTEGER AS Boolean NOT NULL DEFAULT 0,
     mls_degraded_notified INTEGER AS Boolean NOT NULL DEFAULT 0,
-    is_guest_password_protected INTEGER AS Boolean DEFAULT 0 NOT NULL
+    is_guest_password_protected INTEGER AS Boolean DEFAULT 0 NOT NULL,
+    otr_archived INTEGER AS Boolean NOT NULL DEFAULT 0,
+    otr_archived_ref TEXT
 );
 
 -- Optimise comparisons and sorting by dates:
@@ -53,8 +55,8 @@ deleteConversation:
 DELETE FROM Conversation WHERE qualified_id = ?;
 
 insertConversation:
-INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata, otr_archived, otr_archived_ref)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
 type = excluded.type,
@@ -75,7 +77,9 @@ mls_cipher_suite = excluded.mls_cipher_suite,
 receipt_mode = excluded.receipt_mode,
 message_timer = excluded.message_timer,
 user_message_timer = excluded.user_message_timer,
-incomplete_metadata = excluded.incomplete_metadata;
+incomplete_metadata = excluded.incomplete_metadata,
+otr_archived = excluded.otr_archived,
+otr_archived_ref = excluded.otr_archived_ref;
 
 updateConversation:
 UPDATE Conversation
@@ -208,7 +212,9 @@ Conversation.last_modified_date,
 Conversation.receipt_mode,
 Conversation.message_timer,
 Conversation.user_message_timer,
-Conversation.incomplete_metadata
+Conversation.incomplete_metadata,
+Conversation.otr_archived,
+Conversation.otr_archived_ref
 FROM Conversation
 LEFT JOIN Member ON Conversation.qualified_id = Member.conversation
     AND Conversation.type IS 'ONE_ON_ONE'

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -39,7 +39,7 @@ CREATE TABLE Conversation (
     mls_degraded_notified INTEGER AS Boolean NOT NULL DEFAULT 0,
     is_guest_password_protected INTEGER AS Boolean DEFAULT 0 NOT NULL,
     otr_archived INTEGER AS Boolean NOT NULL DEFAULT 0,
-    otr_archived_ref TEXT
+    otr_archived_ref TEXT NOT NULL DEFAULT ""
 );
 
 -- Optimise comparisons and sorting by dates:
@@ -249,7 +249,7 @@ selectByQualifiedId:
 SELECT * FROM ConversationDetails WHERE qualifiedId = ?;
 
 selectConversationByQualifiedId:
-SELECT qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, mls_proposal_timer, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, last_read_date, access_list, access_role_list, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer FROM Conversation WHERE qualified_id = ?;
+SELECT qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, mls_proposal_timer, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, last_read_date, access_list, access_role_list, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, otr_archived, otr_archived_ref FROM Conversation WHERE qualified_id = ?;
 
 selectProtocolInfoByQualifiedId:
 SELECT protocol, mls_group_id, mls_group_state, mls_epoch ,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -39,7 +39,7 @@ CREATE TABLE Conversation (
     mls_degraded_notified INTEGER AS Boolean NOT NULL DEFAULT 0,
     is_guest_password_protected INTEGER AS Boolean DEFAULT 0 NOT NULL,
     archived INTEGER AS Boolean NOT NULL DEFAULT 0,
-    archived_date_time TEXT
+    archived_date_time INTEGER AS Instant
 );
 
 -- Optimise comparisons and sorting by dates:

--- a/persistence/src/commonMain/db_user/migrations/57.sqm
+++ b/persistence/src/commonMain/db_user/migrations/57.sqm
@@ -1,5 +1,5 @@
 ALTER TABLE Conversation ADD COLUMN archived INTEGER AS Boolean NOT NULL DEFAULT 0;
-ALTER TABLE Conversation ADD COLUMN archived_ref TEXT NOT NULL DEFAULT "";
+ALTER TABLE Conversation ADD COLUMN archived_date_time TEXT;
 
 DROP VIEW IF EXISTS ConversationDetails;
 
@@ -79,7 +79,7 @@ Conversation.message_timer,
 Conversation.user_message_timer,
 Conversation.incomplete_metadata,
 Conversation.archived,
-Conversation.archived_ref
+Conversation.archived_date_time
 FROM Conversation
 LEFT JOIN Member ON Conversation.qualified_id = Member.conversation
     AND Conversation.type IS 'ONE_ON_ONE'

--- a/persistence/src/commonMain/db_user/migrations/57.sqm
+++ b/persistence/src/commonMain/db_user/migrations/57.sqm
@@ -1,5 +1,5 @@
-ALTER TABLE Conversation ADD COLUMN otr_archived INTEGER AS Boolean NOT NULL DEFAULT 0;
-ALTER TABLE Conversation ADD COLUMN otr_archived_ref TEXT NOT NULL DEFAULT "";
+ALTER TABLE Conversation ADD COLUMN archived INTEGER AS Boolean NOT NULL DEFAULT 0;
+ALTER TABLE Conversation ADD COLUMN archived_ref TEXT NOT NULL DEFAULT "";
 
 DROP VIEW IF EXISTS ConversationDetails;
 
@@ -78,8 +78,8 @@ Conversation.receipt_mode,
 Conversation.message_timer,
 Conversation.user_message_timer,
 Conversation.incomplete_metadata,
-Conversation.otr_archived,
-Conversation.otr_archived_ref
+Conversation.archived,
+Conversation.archived_ref
 FROM Conversation
 LEFT JOIN Member ON Conversation.qualified_id = Member.conversation
     AND Conversation.type IS 'ONE_ON_ONE'

--- a/persistence/src/commonMain/db_user/migrations/57.sqm
+++ b/persistence/src/commonMain/db_user/migrations/57.sqm
@@ -1,0 +1,96 @@
+ALTER TABLE Conversation ADD COLUMN otr_archived INTEGER AS Boolean NOT NULL DEFAULT 0;
+ALTER TABLE Conversation ADD COLUMN otr_archived_ref TEXT NOT NULL DEFAULT "";
+
+DROP VIEW IF EXISTS ConversationDetails;
+
+CREATE VIEW IF NOT EXISTS ConversationDetails AS
+SELECT
+Conversation.qualified_id AS qualifiedId,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.name
+    WHEN 'CONNECTION_PENDING' THEN connection_user.name
+    ELSE Conversation.name
+END AS name,
+Conversation.type,
+Call.status AS callStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.preview_asset_id
+    WHEN 'CONNECTION_PENDING' THEN connection_user.preview_asset_id
+END AS previewAssetId,
+Conversation.muted_status AS mutedStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN User.team
+    ELSE Conversation.team_id
+END AS teamId,
+CASE (Conversation.type)
+    WHEN 'CONNECTION_PENDING' THEN Connection.last_update_date
+    ELSE Conversation.last_modified_date
+END AS lastModifiedDate,
+Conversation.last_read_date AS lastReadDate,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.user_availability_status
+    WHEN 'CONNECTION_PENDING' THEN connection_user.user_availability_status
+END AS userAvailabilityStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.user_type
+    WHEN 'CONNECTION_PENDING' THEN connection_user.user_type
+END AS userType,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.bot_service
+    WHEN 'CONNECTION_PENDING' THEN connection_user.bot_service
+END AS botService,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.deleted
+    WHEN 'CONNECTION_PENDING' THEN connection_user.deleted
+END AS userDeleted,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.defederated
+    WHEN 'CONNECTION_PENDING' THEN connection_user.defederated
+END AS userDefederated,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.connection_status
+    WHEN 'CONNECTION_PENDING' THEN connection_user.connection_status
+END AS connectionStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.qualified_id
+    WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
+END AS otherUserId,
+CASE
+    WHEN ((SELECT id FROM SelfUser LIMIT 1) LIKE (Conversation.creator_id || '@%')) THEN 1
+    ELSE 0
+END AS isCreator,
+Conversation.last_notified_date AS lastNotifiedMessageDate,
+memberRole. role AS selfRole,
+Conversation.protocol,
+Conversation.mls_cipher_suite,
+Conversation.mls_epoch,
+Conversation.mls_group_id,
+Conversation.mls_last_keying_material_update_date,
+Conversation.mls_group_state,
+Conversation.access_list,
+Conversation.access_role_list,
+Conversation.team_id,
+Conversation.mls_proposal_timer,
+Conversation.muted_time,
+Conversation.creator_id,
+Conversation.last_modified_date,
+Conversation.receipt_mode,
+Conversation.message_timer,
+Conversation.user_message_timer,
+Conversation.incomplete_metadata,
+Conversation.otr_archived,
+Conversation.otr_archived_ref
+FROM Conversation
+LEFT JOIN Member ON Conversation.qualified_id = Member.conversation
+    AND Conversation.type IS 'ONE_ON_ONE'
+    AND Member.user IS NOT (SELECT SelfUser.id FROM SelfUser LIMIT 1)
+LEFT JOIN Member AS memberRole ON Conversation.qualified_id = memberRole.conversation
+    AND memberRole.user IS (SELECT SelfUser.id FROM SelfUser LIMIT 1)
+LEFT JOIN User ON User.qualified_id = Member.user
+LEFT JOIN Connection ON Connection.qualified_conversation = Conversation.qualified_id
+    AND (Connection.status = 'SENT'
+         OR Connection.status = 'PENDING'
+         OR Connection.status = 'NOT_CONNECTED'
+         AND Conversation.type IS 'CONNECTION_PENDING')
+LEFT JOIN User AS connection_user ON Connection.qualified_to = connection_user.qualified_id
+LEFT JOIN Call ON Call.id IS (SELECT id FROM Call WHERE Call.conversation_id = Conversation.qualified_id AND Call.status IS 'STILL_ONGOING' ORDER BY created_at DESC LIMIT 1);

--- a/persistence/src/commonMain/db_user/migrations/57.sqm
+++ b/persistence/src/commonMain/db_user/migrations/57.sqm
@@ -1,5 +1,5 @@
 ALTER TABLE Conversation ADD COLUMN archived INTEGER AS Boolean NOT NULL DEFAULT 0;
-ALTER TABLE Conversation ADD COLUMN archived_date_time TEXT;
+ALTER TABLE Conversation ADD COLUMN archived_date_time INTEGER AS Instant;
 
 DROP VIEW IF EXISTS ConversationDetails;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -100,7 +100,7 @@ internal class ConversationDAOImpl internal constructor(
                 userMessageTimer,
                 hasIncompleteMetadata,
                 archived,
-                archivedRef
+                archivedDateTime
             )
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -98,7 +98,9 @@ internal class ConversationDAOImpl internal constructor(
                 receiptMode,
                 messageTimer,
                 userMessageTimer,
-                hasIncompleteMetadata
+                hasIncompleteMetadata,
+                otrArchived,
+                otrArchivedRef
             )
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -100,7 +100,7 @@ internal class ConversationDAOImpl internal constructor(
                 userMessageTimer,
                 hasIncompleteMetadata,
                 archived,
-                archivedDateTime
+                archivedInstant
             )
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -99,8 +99,8 @@ internal class ConversationDAOImpl internal constructor(
                 messageTimer,
                 userMessageTimer,
                 hasIncompleteMetadata,
-                otrArchived,
-                otrArchivedRef
+                archived,
+                archivedRef
             )
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
@@ -43,7 +43,7 @@ data class ConversationEntity(
     val userMessageTimer: Long?,
     val hasIncompleteMetadata: Boolean = false,
     val archived: Boolean = false,
-    val archivedRef: String
+    val archivedDateTime: String?
 ) {
     enum class AccessRole { TEAM_MEMBER, NON_TEAM_MEMBER, GUEST, SERVICE, EXTERNAL; }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
@@ -43,7 +43,7 @@ data class ConversationEntity(
     val userMessageTimer: Long?,
     val hasIncompleteMetadata: Boolean = false,
     val archived: Boolean = false,
-    val archivedDateTime: String?
+    val archivedInstant: Instant?
 ) {
     enum class AccessRole { TEAM_MEMBER, NON_TEAM_MEMBER, GUEST, SERVICE, EXTERNAL; }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
@@ -42,8 +42,8 @@ data class ConversationEntity(
     val messageTimer: Long?,
     val userMessageTimer: Long?,
     val hasIncompleteMetadata: Boolean = false,
-    val otrArchived: Boolean = false,
-    val otrArchivedRef: String
+    val archived: Boolean = false,
+    val archivedRef: String
 ) {
     enum class AccessRole { TEAM_MEMBER, NON_TEAM_MEMBER, GUEST, SERVICE, EXTERNAL; }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
@@ -41,7 +41,9 @@ data class ConversationEntity(
     val guestRoomLink: String? = null,
     val messageTimer: Long?,
     val userMessageTimer: Long?,
-    val hasIncompleteMetadata: Boolean = false
+    val hasIncompleteMetadata: Boolean = false,
+    val otrArchived: Boolean = false,
+    val otrArchivedRef: String
 ) {
     enum class AccessRole { TEAM_MEMBER, NON_TEAM_MEMBER, GUEST, SERVICE, EXTERNAL; }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
@@ -65,8 +65,8 @@ internal class ConversationMapper {
             messageTimer = message_timer,
             userMessageTimer = user_message_timer,
             userDefederated = userDefederated,
-            otrArchived = otr_archived,
-            otrArchivedRef = otr_archived_ref
+            archived = archived,
+            archivedRef = archived_ref
         )
     }
 
@@ -94,8 +94,8 @@ internal class ConversationMapper {
         receiptMode: ConversationEntity.ReceiptMode,
         messageTimer: Long?,
         userMessageTimer: Long?,
-        otrArchived: Boolean,
-        otrArchivedRef: String
+        archived: Boolean,
+        archivedRef: String
     ) = ConversationEntity(
         id = qualifiedId,
         name = name,
@@ -120,8 +120,8 @@ internal class ConversationMapper {
         receiptMode = receiptMode,
         messageTimer = messageTimer,
         userMessageTimer = userMessageTimer,
-        otrArchived = otrArchived,
-        otrArchivedRef = otrArchivedRef
+        archived = archived,
+        archivedRef = archivedRef
     )
 
     fun fromOneToOneToModel(conversation: SelectConversationByMember?): ConversationViewEntity? {
@@ -168,8 +168,8 @@ internal class ConversationMapper {
                 messageTimer = message_timer,
                 userMessageTimer = user_message_timer,
                 userDefederated = userDefederated,
-                otrArchived = otr_archived,
-                otrArchivedRef = otr_archived_ref
+                archived = archived,
+                archivedRef = archived_ref
             )
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
@@ -66,7 +66,7 @@ internal class ConversationMapper {
             userMessageTimer = user_message_timer,
             userDefederated = userDefederated,
             archived = archived,
-            archivedRef = archived_ref
+            archivedDateTime = archived_date_time
         )
     }
 
@@ -95,7 +95,7 @@ internal class ConversationMapper {
         messageTimer: Long?,
         userMessageTimer: Long?,
         archived: Boolean,
-        archivedRef: String
+        archivedDateTime: String?
     ) = ConversationEntity(
         id = qualifiedId,
         name = name,
@@ -121,7 +121,7 @@ internal class ConversationMapper {
         messageTimer = messageTimer,
         userMessageTimer = userMessageTimer,
         archived = archived,
-        archivedRef = archivedRef
+        archivedDateTime = archivedDateTime
     )
 
     fun fromOneToOneToModel(conversation: SelectConversationByMember?): ConversationViewEntity? {
@@ -169,7 +169,7 @@ internal class ConversationMapper {
                 userMessageTimer = user_message_timer,
                 userDefederated = userDefederated,
                 archived = archived,
-                archivedRef = archived_ref
+                archivedDateTime = archived_date_time
             )
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
@@ -95,7 +95,7 @@ internal class ConversationMapper {
         messageTimer: Long?,
         userMessageTimer: Long?,
         archived: Boolean,
-        archivedDateTime: String?
+        archivedDateTime: Instant?
     ) = ConversationEntity(
         id = qualifiedId,
         name = name,
@@ -121,7 +121,7 @@ internal class ConversationMapper {
         messageTimer = messageTimer,
         userMessageTimer = userMessageTimer,
         archived = archived,
-        archivedDateTime = archivedDateTime
+        archivedInstant = archivedDateTime
     )
 
     fun fromOneToOneToModel(conversation: SelectConversationByMember?): ConversationViewEntity? {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
@@ -64,7 +64,9 @@ internal class ConversationMapper {
             receiptMode = receipt_mode,
             messageTimer = message_timer,
             userMessageTimer = user_message_timer,
-            userDefederated = userDefederated
+            userDefederated = userDefederated,
+            otrArchived = otr_archived,
+            otrArchivedRef = otr_archived_ref
         )
     }
 
@@ -92,6 +94,8 @@ internal class ConversationMapper {
         receiptMode: ConversationEntity.ReceiptMode,
         messageTimer: Long?,
         userMessageTimer: Long?,
+        otrArchived: Boolean,
+        otrArchivedRef: String
     ) = ConversationEntity(
         id = qualifiedId,
         name = name,
@@ -116,6 +120,8 @@ internal class ConversationMapper {
         receiptMode = receiptMode,
         messageTimer = messageTimer,
         userMessageTimer = userMessageTimer,
+        otrArchived = otrArchived,
+        otrArchivedRef = otrArchivedRef
     )
 
     fun fromOneToOneToModel(conversation: SelectConversationByMember?): ConversationViewEntity? {
@@ -161,7 +167,9 @@ internal class ConversationMapper {
                 receiptMode = receipt_mode,
                 messageTimer = message_timer,
                 userMessageTimer = user_message_timer,
-                userDefederated = userDefederated
+                userDefederated = userDefederated,
+                otrArchived = otr_archived,
+                otrArchivedRef = otr_archived_ref
             )
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
@@ -65,7 +65,7 @@ data class ConversationViewEntity(
     val messageTimer: Long?,
     val userMessageTimer: Long?,
     val archived: Boolean,
-    val archivedDateTime: String?
+    val archivedDateTime: Instant?
 ) {
     val isMember: Boolean get() = selfRole != null
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
@@ -65,7 +65,7 @@ data class ConversationViewEntity(
     val messageTimer: Long?,
     val userMessageTimer: Long?,
     val archived: Boolean,
-    val archivedRef: String
+    val archivedDateTime: String?
 ) {
     val isMember: Boolean get() = selfRole != null
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
@@ -64,8 +64,8 @@ data class ConversationViewEntity(
     val receiptMode: ConversationEntity.ReceiptMode,
     val messageTimer: Long?,
     val userMessageTimer: Long?,
-    val otrArchived: Boolean,
-    val otrArchivedRef: String
+    val archived: Boolean,
+    val archivedRef: String
 ) {
     val isMember: Boolean get() = selfRole != null
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
@@ -63,7 +63,9 @@ data class ConversationViewEntity(
     val removedBy: UserIDEntity? = null, // TODO how to calculate?,
     val receiptMode: ConversationEntity.ReceiptMode,
     val messageTimer: Long?,
-    val userMessageTimer: Long?
+    val userMessageTimer: Long?,
+    val otrArchived: Boolean,
+    val otrArchivedRef: String
 ) {
     val isMember: Boolean get() = selfRole != null
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
@@ -95,6 +95,7 @@ internal object TableMapper {
         last_modified_dateAdapter = InstantTypeAdapter,
         last_notified_dateAdapter = InstantTypeAdapter,
         mls_last_keying_material_update_dateAdapter = InstantTypeAdapter,
+        archived_date_timeAdapter = InstantTypeAdapter
     )
     val memberAdapter = Member.Adapter(
         userAdapter = QualifiedIDAdapter,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
@@ -653,7 +653,7 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 messageTimer = null,
                 userMessageTimer = null,
                 archived = false,
-                archivedDateTime = null
+                archivedInstant = null
             )
         }
     }
@@ -691,7 +691,7 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 messageTimer = null,
                 userMessageTimer = null,
                 archived = false,
-                archivedDateTime = null
+                archivedInstant = null
             )
 
             conversationAdded.add(overlappingConversation)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
@@ -653,7 +653,7 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 messageTimer = null,
                 userMessageTimer = null,
                 archived = false,
-                archivedRef = ""
+                archivedDateTime = null
             )
         }
     }
@@ -691,7 +691,7 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 messageTimer = null,
                 userMessageTimer = null,
                 archived = false,
-                archivedRef = ""
+                archivedDateTime = null
             )
 
             conversationAdded.add(overlappingConversation)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
@@ -652,8 +652,8 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 receiptMode = receiptMode,
                 messageTimer = null,
                 userMessageTimer = null,
-                otrArchived = false,
-                otrArchivedRef = ""
+                archived = false,
+                archivedRef = ""
             )
         }
     }
@@ -690,8 +690,8 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 receiptMode = ConversationEntity.ReceiptMode.DISABLED,
                 messageTimer = null,
                 userMessageTimer = null,
-                otrArchived = false,
-                otrArchivedRef = ""
+                archived = false,
+                archivedRef = ""
             )
 
             conversationAdded.add(overlappingConversation)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
@@ -651,7 +651,9 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 accessRole = accessRoleList,
                 receiptMode = receiptMode,
                 messageTimer = null,
-                userMessageTimer = null
+                userMessageTimer = null,
+                otrArchived = false,
+                otrArchivedRef = ""
             )
         }
     }
@@ -687,7 +689,9 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 accessRole = listOf(ConversationEntity.AccessRole.values()[index % ConversationEntity.AccessRole.values().size]),
                 receiptMode = ConversationEntity.ReceiptMode.DISABLED,
                 messageTimer = null,
-                userMessageTimer = null
+                userMessageTimer = null,
+                otrArchived = false,
+                otrArchivedRef = ""
             )
 
             conversationAdded.add(overlappingConversation)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
@@ -277,7 +277,9 @@ class UserDatabaseDataGenerator(
                     accessRole = listOf(ConversationEntity.AccessRole.values()[index % ConversationEntity.AccessRole.values().size]),
                     receiptMode = DEFAULT_RECEIPT_MODE,
                     messageTimer = null,
-                    userMessageTimer = null
+                    userMessageTimer = null,
+                    otrArchived = false,
+                    otrArchivedRef = ""
                 )
             )
 
@@ -319,7 +321,9 @@ class UserDatabaseDataGenerator(
             accessRole = listOf(ConversationEntity.AccessRole.values()[index % ConversationEntity.AccessRole.values().size]),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = null,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
         userDatabaseBuilder.conversationDAO.insertConversation(conversation)
         return conversation
@@ -385,7 +389,9 @@ class UserDatabaseDataGenerator(
                 accessRole = listOf(ConversationEntity.AccessRole.values()[index % ConversationEntity.AccessRole.values().size]),
                 receiptMode = DEFAULT_RECEIPT_MODE,
                 messageTimer = null,
-                userMessageTimer = null
+                userMessageTimer = null,
+                otrArchived = false,
+                otrArchivedRef = ""
             )
 
             userDatabaseBuilder.conversationDAO.insertConversation(conversationEntity)
@@ -450,7 +456,9 @@ class UserDatabaseDataGenerator(
                     accessRole = listOf(ConversationEntity.AccessRole.values()[index % ConversationEntity.AccessRole.values().size]),
                     receiptMode = DEFAULT_RECEIPT_MODE,
                     messageTimer = null,
-                    userMessageTimer = null
+                    userMessageTimer = null,
+                    otrArchived = false,
+                    otrArchivedRef = ""
                 )
             )
 
@@ -493,7 +501,9 @@ class UserDatabaseDataGenerator(
                     accessRole = listOf(ConversationEntity.AccessRole.values()[index % ConversationEntity.AccessRole.values().size]),
                     receiptMode = DEFAULT_RECEIPT_MODE,
                     messageTimer = null,
-                    userMessageTimer = null
+                    userMessageTimer = null,
+                    otrArchived = false,
+                    otrArchivedRef = ""
                 )
             )
 
@@ -605,7 +615,9 @@ class UserDatabaseDataGenerator(
                     accessRole = listOf(ConversationEntity.AccessRole.values()[index % ConversationEntity.AccessRole.values().size]),
                     receiptMode = DEFAULT_RECEIPT_MODE,
                     messageTimer = null,
-                    userMessageTimer = null
+                    userMessageTimer = null,
+                    otrArchived = false,
+                    otrArchivedRef = ""
                 )
             )
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
@@ -279,7 +279,7 @@ class UserDatabaseDataGenerator(
                     messageTimer = null,
                     userMessageTimer = null,
                     archived = false,
-                    archivedRef = ""
+                    archivedDateTime = null
                 )
             )
 
@@ -323,7 +323,7 @@ class UserDatabaseDataGenerator(
             messageTimer = null,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
         userDatabaseBuilder.conversationDAO.insertConversation(conversation)
         return conversation
@@ -391,7 +391,7 @@ class UserDatabaseDataGenerator(
                 messageTimer = null,
                 userMessageTimer = null,
                 archived = false,
-                archivedRef = ""
+                archivedDateTime = null
             )
 
             userDatabaseBuilder.conversationDAO.insertConversation(conversationEntity)
@@ -458,7 +458,7 @@ class UserDatabaseDataGenerator(
                     messageTimer = null,
                     userMessageTimer = null,
                     archived = false,
-                    archivedRef = ""
+                    archivedDateTime = null
                 )
             )
 
@@ -503,7 +503,7 @@ class UserDatabaseDataGenerator(
                     messageTimer = null,
                     userMessageTimer = null,
                     archived = false,
-                    archivedRef = ""
+                    archivedDateTime = null
                 )
             )
 
@@ -617,7 +617,7 @@ class UserDatabaseDataGenerator(
                     messageTimer = null,
                     userMessageTimer = null,
                     archived = false,
-                    archivedRef = ""
+                    archivedDateTime = null
                 )
             )
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
@@ -278,8 +278,8 @@ class UserDatabaseDataGenerator(
                     receiptMode = DEFAULT_RECEIPT_MODE,
                     messageTimer = null,
                     userMessageTimer = null,
-                    otrArchived = false,
-                    otrArchivedRef = ""
+                    archived = false,
+                    archivedRef = ""
                 )
             )
 
@@ -322,8 +322,8 @@ class UserDatabaseDataGenerator(
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = null,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
         userDatabaseBuilder.conversationDAO.insertConversation(conversation)
         return conversation
@@ -390,8 +390,8 @@ class UserDatabaseDataGenerator(
                 receiptMode = DEFAULT_RECEIPT_MODE,
                 messageTimer = null,
                 userMessageTimer = null,
-                otrArchived = false,
-                otrArchivedRef = ""
+                archived = false,
+                archivedRef = ""
             )
 
             userDatabaseBuilder.conversationDAO.insertConversation(conversationEntity)
@@ -457,8 +457,8 @@ class UserDatabaseDataGenerator(
                     receiptMode = DEFAULT_RECEIPT_MODE,
                     messageTimer = null,
                     userMessageTimer = null,
-                    otrArchived = false,
-                    otrArchivedRef = ""
+                    archived = false,
+                    archivedRef = ""
                 )
             )
 
@@ -502,8 +502,8 @@ class UserDatabaseDataGenerator(
                     receiptMode = DEFAULT_RECEIPT_MODE,
                     messageTimer = null,
                     userMessageTimer = null,
-                    otrArchived = false,
-                    otrArchivedRef = ""
+                    archived = false,
+                    archivedRef = ""
                 )
             )
 
@@ -616,8 +616,8 @@ class UserDatabaseDataGenerator(
                     receiptMode = DEFAULT_RECEIPT_MODE,
                     messageTimer = null,
                     userMessageTimer = null,
-                    otrArchived = false,
-                    otrArchivedRef = ""
+                    archived = false,
+                    archivedRef = ""
                 )
             )
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
@@ -279,7 +279,7 @@ class UserDatabaseDataGenerator(
                     messageTimer = null,
                     userMessageTimer = null,
                     archived = false,
-                    archivedDateTime = null
+                    archivedInstant = null
                 )
             )
 
@@ -323,7 +323,7 @@ class UserDatabaseDataGenerator(
             messageTimer = null,
             userMessageTimer = null,
             archived = false,
-            archivedDateTime = null
+            archivedInstant = null
         )
         userDatabaseBuilder.conversationDAO.insertConversation(conversation)
         return conversation
@@ -391,7 +391,7 @@ class UserDatabaseDataGenerator(
                 messageTimer = null,
                 userMessageTimer = null,
                 archived = false,
-                archivedDateTime = null
+                archivedInstant = null
             )
 
             userDatabaseBuilder.conversationDAO.insertConversation(conversationEntity)
@@ -458,7 +458,7 @@ class UserDatabaseDataGenerator(
                     messageTimer = null,
                     userMessageTimer = null,
                     archived = false,
-                    archivedDateTime = null
+                    archivedInstant = null
                 )
             )
 
@@ -503,7 +503,7 @@ class UserDatabaseDataGenerator(
                     messageTimer = null,
                     userMessageTimer = null,
                     archived = false,
-                    archivedDateTime = null
+                    archivedInstant = null
                 )
             )
 
@@ -617,7 +617,7 @@ class UserDatabaseDataGenerator(
                     messageTimer = null,
                     userMessageTimer = null,
                     archived = false,
-                    archivedDateTime = null
+                    archivedInstant = null
                 )
             )
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -983,7 +983,9 @@ class ConversationDAOTest : BaseDatabaseTest() {
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
             userMessageTimer = null,
-            userDefederated = if (type == ConversationEntity.Type.ONE_ON_ONE) userEntity?.defederated else null
+            userDefederated = if (type == ConversationEntity.Type.ONE_ON_ONE) userEntity?.defederated else null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
     }
 
@@ -1012,7 +1014,9 @@ class ConversationDAOTest : BaseDatabaseTest() {
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
         val conversationEntity2 = ConversationEntity(
             QualifiedIDEntity("2", "wire.com"),
@@ -1035,7 +1039,9 @@ class ConversationDAOTest : BaseDatabaseTest() {
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
 
         val conversationEntity3 = ConversationEntity(
@@ -1061,7 +1067,9 @@ class ConversationDAOTest : BaseDatabaseTest() {
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
 
         val conversationEntity4 = ConversationEntity(
@@ -1087,7 +1095,9 @@ class ConversationDAOTest : BaseDatabaseTest() {
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
 
         val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -985,7 +985,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             userMessageTimer = null,
             userDefederated = if (type == ConversationEntity.Type.ONE_ON_ONE) userEntity?.defederated else null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
     }
 
@@ -1016,7 +1016,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
         val conversationEntity2 = ConversationEntity(
             QualifiedIDEntity("2", "wire.com"),
@@ -1041,7 +1041,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
 
         val conversationEntity3 = ConversationEntity(
@@ -1069,7 +1069,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
 
         val conversationEntity4 = ConversationEntity(
@@ -1097,7 +1097,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
 
         val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -24,7 +24,6 @@ import com.wire.kalium.persistence.dao.asset.AssetDAO
 import com.wire.kalium.persistence.dao.asset.AssetEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
-import com.wire.kalium.persistence.dao.conversation.ConversationGuestLinkEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationViewEntity
 import com.wire.kalium.persistence.dao.conversation.MLS_DEFAULT_LAST_KEY_MATERIAL_UPDATE_MILLI
 import com.wire.kalium.persistence.dao.conversation.ProposalTimerEntity
@@ -1016,7 +1015,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             archived = false,
-            archivedDateTime = null
+            archivedInstant = null
         )
         val conversationEntity2 = ConversationEntity(
             QualifiedIDEntity("2", "wire.com"),
@@ -1041,7 +1040,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             archived = false,
-            archivedDateTime = null
+            archivedInstant = null
         )
 
         val conversationEntity3 = ConversationEntity(
@@ -1069,7 +1068,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             archived = false,
-            archivedDateTime = null
+            archivedInstant = null
         )
 
         val conversationEntity4 = ConversationEntity(
@@ -1097,7 +1096,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             archived = false,
-            archivedDateTime = null
+            archivedInstant = null
         )
 
         val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -984,8 +984,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
             messageTimer = messageTimer,
             userMessageTimer = null,
             userDefederated = if (type == ConversationEntity.Type.ONE_ON_ONE) userEntity?.defederated else null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
     }
 
@@ -1015,8 +1015,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
         val conversationEntity2 = ConversationEntity(
             QualifiedIDEntity("2", "wire.com"),
@@ -1040,8 +1040,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
 
         val conversationEntity3 = ConversationEntity(
@@ -1068,8 +1068,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
 
         val conversationEntity4 = ConversationEntity(
@@ -1096,8 +1096,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = messageTimer,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
 
         val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
@@ -85,7 +85,7 @@ class ConversationMetaDataDAOTest : BaseDatabaseTest() {
             messageTimer = 5000L,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
@@ -84,8 +84,8 @@ class ConversationMetaDataDAOTest : BaseDatabaseTest() {
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = 5000L,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
@@ -21,7 +21,6 @@ import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationMetaDataDAO
-import com.wire.kalium.persistence.db.UserDatabaseBuilder
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.toInstant
 import kotlin.test.BeforeTest
@@ -85,7 +84,7 @@ class ConversationMetaDataDAOTest : BaseDatabaseTest() {
             messageTimer = 5000L,
             userMessageTimer = null,
             archived = false,
-            archivedDateTime = null
+            archivedInstant = null
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
@@ -83,7 +83,9 @@ class ConversationMetaDataDAOTest : BaseDatabaseTest() {
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = 5000L,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -368,7 +368,7 @@ class ClientDAOTest : BaseDatabaseTest() {
             messageTimer = null,
             userMessageTimer = null,
             archived = false,
-            archivedRef = ""
+            archivedDateTime = null
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -366,7 +366,9 @@ class ClientDAOTest : BaseDatabaseTest() {
             accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = null,
-            userMessageTimer = null
+            userMessageTimer = null,
+            otrArchived = false,
+            otrArchivedRef = ""
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -368,7 +368,7 @@ class ClientDAOTest : BaseDatabaseTest() {
             messageTimer = null,
             userMessageTimer = null,
             archived = false,
-            archivedDateTime = null
+            archivedInstant = null
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -367,8 +367,8 @@ class ClientDAOTest : BaseDatabaseTest() {
             receiptMode = ConversationEntity.ReceiptMode.DISABLED,
             messageTimer = null,
             userMessageTimer = null,
-            otrArchived = false,
-            otrArchivedRef = ""
+            archived = false,
+            archivedRef = ""
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
@@ -38,8 +38,8 @@ fun newConversationEntity(id: String = "test") = ConversationEntity(
     receiptMode = ConversationEntity.ReceiptMode.DISABLED,
     messageTimer = null,
     userMessageTimer = null,
-    otrArchived = false,
-    otrArchivedRef = ""
+    archived = false,
+    archivedRef = ""
 )
 
 fun newConversationEntity(
@@ -61,6 +61,6 @@ fun newConversationEntity(
     receiptMode = ConversationEntity.ReceiptMode.DISABLED,
     messageTimer = null,
     userMessageTimer = null,
-    otrArchived = false,
-    otrArchivedRef = ""
+    archived = false,
+    archivedRef = ""
 )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
@@ -39,7 +39,7 @@ fun newConversationEntity(id: String = "test") = ConversationEntity(
     messageTimer = null,
     userMessageTimer = null,
     archived = false,
-    archivedRef = ""
+    archivedDateTime = null
 )
 
 fun newConversationEntity(
@@ -62,5 +62,5 @@ fun newConversationEntity(
     messageTimer = null,
     userMessageTimer = null,
     archived = false,
-    archivedRef = ""
+    archivedDateTime = null
 )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
@@ -39,7 +39,7 @@ fun newConversationEntity(id: String = "test") = ConversationEntity(
     messageTimer = null,
     userMessageTimer = null,
     archived = false,
-    archivedDateTime = null
+    archivedInstant = null
 )
 
 fun newConversationEntity(
@@ -62,5 +62,5 @@ fun newConversationEntity(
     messageTimer = null,
     userMessageTimer = null,
     archived = false,
-    archivedDateTime = null
+    archivedInstant = null
 )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
@@ -37,7 +37,9 @@ fun newConversationEntity(id: String = "test") = ConversationEntity(
     accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
     receiptMode = ConversationEntity.ReceiptMode.DISABLED,
     messageTimer = null,
-    userMessageTimer = null
+    userMessageTimer = null,
+    otrArchived = false,
+    otrArchivedRef = ""
 )
 
 fun newConversationEntity(
@@ -58,5 +60,7 @@ fun newConversationEntity(
     accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
     receiptMode = ConversationEntity.ReceiptMode.DISABLED,
     messageTimer = null,
-    userMessageTimer = null
+    userMessageTimer = null,
+    otrArchived = false,
+    otrArchivedRef = ""
 )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
@@ -52,7 +52,7 @@ internal object TestStubs {
         messageTimer = messageTimer,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
     val conversationEntity2 = ConversationEntity(
         QualifiedIDEntity("2", "wire.com"),
@@ -77,7 +77,7 @@ internal object TestStubs {
         messageTimer = messageTimer,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     val conversationEntity3 = ConversationEntity(
@@ -105,7 +105,7 @@ internal object TestStubs {
         messageTimer = messageTimer,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     val conversationEntity4 = ConversationEntity(
@@ -133,7 +133,7 @@ internal object TestStubs {
         messageTimer = messageTimer,
         userMessageTimer = null,
         archived = false,
-        archivedRef = ""
+        archivedDateTime = null
     )
 
     val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
@@ -52,7 +52,7 @@ internal object TestStubs {
         messageTimer = messageTimer,
         userMessageTimer = null,
         archived = false,
-        archivedDateTime = null
+        archivedInstant = null
     )
     val conversationEntity2 = ConversationEntity(
         QualifiedIDEntity("2", "wire.com"),
@@ -77,7 +77,7 @@ internal object TestStubs {
         messageTimer = messageTimer,
         userMessageTimer = null,
         archived = false,
-        archivedDateTime = null
+        archivedInstant = null
     )
 
     val conversationEntity3 = ConversationEntity(
@@ -105,7 +105,7 @@ internal object TestStubs {
         messageTimer = messageTimer,
         userMessageTimer = null,
         archived = false,
-        archivedDateTime = null
+        archivedInstant = null
     )
 
     val conversationEntity4 = ConversationEntity(
@@ -133,7 +133,7 @@ internal object TestStubs {
         messageTimer = messageTimer,
         userMessageTimer = null,
         archived = false,
-        archivedDateTime = null
+        archivedInstant = null
     )
 
     val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
@@ -50,7 +50,9 @@ internal object TestStubs {
         accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = messageTimer,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
     val conversationEntity2 = ConversationEntity(
         QualifiedIDEntity("2", "wire.com"),
@@ -73,7 +75,9 @@ internal object TestStubs {
         accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = messageTimer,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     val conversationEntity3 = ConversationEntity(
@@ -99,7 +103,9 @@ internal object TestStubs {
         accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = messageTimer,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     val conversationEntity4 = ConversationEntity(
@@ -125,7 +131,9 @@ internal object TestStubs {
         accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = messageTimer,
-        userMessageTimer = null
+        userMessageTimer = null,
+        otrArchived = false,
+        otrArchivedRef = ""
     )
 
     val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
@@ -51,8 +51,8 @@ internal object TestStubs {
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = messageTimer,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
     val conversationEntity2 = ConversationEntity(
         QualifiedIDEntity("2", "wire.com"),
@@ -76,8 +76,8 @@ internal object TestStubs {
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = messageTimer,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     val conversationEntity3 = ConversationEntity(
@@ -104,8 +104,8 @@ internal object TestStubs {
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = messageTimer,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     val conversationEntity4 = ConversationEntity(
@@ -132,8 +132,8 @@ internal object TestStubs {
         receiptMode = ConversationEntity.ReceiptMode.DISABLED,
         messageTimer = messageTimer,
         userMessageTimer = null,
-        otrArchived = false,
-        otrArchivedRef = ""
+        archived = false,
+        archivedRef = ""
     )
 
     val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were retrieving `otr_archived` and `otr_archived_ref` from the API but not persisting in the database.

### Solutions

Add `otr_archived` and `otr_archived_ref` to conversation table when getting from API.



### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Currently the only way to test is:
- Fresh install/login
- check from App Inspection that you have both fields in the `Conversation` table and if you have any archived conversation, it should be represented as such (1 = true, 0 = false)