### PR TITLE
fix: send HEIC images as normal files

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/Asset.kt
@@ -60,7 +60,7 @@ enum class AttachmentType {
 }
 
 fun isDisplayableImageMimeType(mimeType: String): Boolean = mimeType in setOf(
-    "image/jpg", "image/jpeg", "image/png", "image/heic", "image/gif", "image/webp"
+    "image/jpg", "image/jpeg", "image/png", "image/gif", "image/webp"
 )
 
 fun isAudioMimeType(mimeType: String): Boolean = mimeType in setOf(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. atm when we send images the use case will try to resize the image and it will fail and crash when it is an HEIC image
2. HEIC images are not rendered deu to internal coil error 
```
2023-09-13 13:16:27.213 31783-31828 HeifDecoderImpl         com.wire.android.internal.debug      E  getSize: not supported!
2023-09-13 13:16:27.224 31783-31828 HeifDecoderImpl         com.wire.android.internal.debug      E  getSize: not supported!
2023-09-13 13:16:27.225 31783-31828 HeifDecoderImpl         com.wire.android.internal.debug      E  getSize: not supported!
2023-09-13 13:16:27.248 31783-31828 HeifDecoderImpl         com.wire.android.internal.debug      E  getSize: not supported!
2023-09-13 13:16:27.257 31783-31828 HeifDecoderImpl         com.wire.android.internal.debug      E  getSize: not supported!
2023-09-13 13:16:27.259 31783-31828 HeifDecoderImpl         com.wire.android.internal.debug      E  getSize: not supported!
2023-09-13 13:16:27.263 31783-31828 HeifDecoderImpl         com.wire.android.internal.debug      E  decode: videoFrame is a nullptr
``` 

### Solutions

I am uncertain if image resizing should be done by kalium, or even deciding if an image is inline of not.
for now removing heic from the list of inline images solve the issues but we should refactor this part and move the isDisplayableImageMimeType to consumer apps

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
