### PR TITLE
fix: getCallManagerForClient is not thread safe

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -85,22 +85,22 @@ actual class GlobalCallManager(
         conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
         kaliumConfigs: KaliumConfigs
     ): CallManager {
-        return callManagerHolder[userId] ?: CallManagerImpl(
-            calling = calling,
-            callRepository = callRepository,
-            userRepository = userRepository,
-            currentClientIdProvider = currentClientIdProvider,
-            selfConversationIdProvider = selfConversationIdProvider,
-            callMapper = callMapper,
-            messageSender = messageSender,
-            conversationRepository = conversationRepository,
-            federatedIdMapper = federatedIdMapper,
-            qualifiedIdMapper = qualifiedIdMapper,
-            videoStateChecker = videoStateChecker,
-            conversationClientsInCallUpdater = conversationClientsInCallUpdater,
-            kaliumConfigs = kaliumConfigs
-        ).also {
-            callManagerHolder[userId] = it
+        return callManagerHolder.computeIfAbsent(userId) {
+            CallManagerImpl(
+                calling = calling,
+                callRepository = callRepository,
+                userRepository = userRepository,
+                currentClientIdProvider = currentClientIdProvider,
+                selfConversationIdProvider = selfConversationIdProvider,
+                callMapper = callMapper,
+                messageSender = messageSender,
+                conversationRepository = conversationRepository,
+                federatedIdMapper = federatedIdMapper,
+                qualifiedIdMapper = qualifiedIdMapper,
+                videoStateChecker = videoStateChecker,
+                conversationClientsInCallUpdater = conversationClientsInCallUpdater,
+                kaliumConfigs = kaliumConfigs
+            )
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`GlobalCallManager.getCallManagerForClient` is not thread safe, this can cause a case where multiple instances of AVS being created 

### Solutions

use `computeIfAbsent` to fix the issue


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
