### PR TITLE
fix: message status not updated while using the fire and forget asset mechanism (WPB-4519)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
@@ -294,7 +294,9 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
                         expirationData = updatedMessage.expirationData,
                         isSelfMessage = updatedMessage.isSelfMessage
                     )
-                    messageSender.sendMessage(finalMessage)
+                    messageSender.sendMessage(finalMessage).onFailure {
+                        messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, message.id, TYPE)
+                    }
                 }
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
@@ -244,7 +244,7 @@ class ScheduleNewAssetMessageUseCaseTest {
             val expectedAssetId = dummyUploadedAssetId
             val expectedAssetSha256 = SHA256Key("some-asset-sha-256".toByteArray())
             val (arrangement, sendAssetUseCase) = Arrangement(this)
-                .withUnSuccessfulSendMessageResponse(expectedAssetId, expectedAssetSha256)
+                .withUnsuccessfulSendMessageResponse(expectedAssetId, expectedAssetSha256)
                 .withSelfDeleteTimer(SelfDeletionTimer.Disabled)
                 .withObserveMessageVisibility()
                 .withDeleteAssetLocally()
@@ -646,7 +646,7 @@ class ScheduleNewAssetMessageUseCaseTest {
                 .thenReturn(UpdateUploadStatusResult.Success)
         }
 
-        fun withUnSuccessfulSendMessageResponse(
+        fun withUnsuccessfulSendMessageResponse(
             expectedAssetId: UploadedAssetId,
             assetSHA256Key: SHA256Key,
             temporaryAssetId: String = "temporary_id"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
@@ -230,6 +230,57 @@ class ScheduleNewAssetMessageUseCaseTest {
     }
 
     @Test
+    fun givenASuccessfulSendAssetMessageRequest_whenSendingTheAssetAndMessageFails_thenTheMessageStatusIsUpdatedToFailed() =
+        runTest(testDispatcher.default) {
+            // Given
+            val assetToSend = mockedLongAssetData()
+            val assetName = "some-asset.txt"
+            val conversationId = ConversationId("some-convo-id", "some-domain-id")
+            val dataPath = fakeKaliumFileSystem.providePersistentAssetPath(assetName)
+            val expectedAssetId = dummyUploadedAssetId
+            val expectedAssetSha256 = SHA256Key("some-asset-sha-256".toByteArray())
+            val (arrangement, sendAssetUseCase) = Arrangement(this)
+                .withUnSuccessfulSendMessageResponse(expectedAssetId, expectedAssetSha256)
+                .withSelfDeleteTimer(SelfDeletionTimer.Disabled)
+                .withObserveMessageVisibility()
+                .withDeleteAssetLocally()
+                .arrange()
+
+            // When
+            sendAssetUseCase.invoke(
+                conversationId = conversationId,
+                assetDataPath = dataPath,
+                assetDataSize = assetToSend.size.toLong(),
+                assetName = assetName,
+                assetMimeType = "text/plain",
+                assetWidth = null,
+                assetHeight = null,
+                audioLengthInMs = 0
+            )
+
+            advanceUntilIdle()
+
+            // Then
+            verify(arrangement.persistMessage)
+                .suspendFunction(arrangement.persistMessage::invoke)
+                .with(any())
+                .wasInvoked(exactly = twice)
+            verify(arrangement.assetDataSource)
+                .suspendFunction(arrangement.assetDataSource::uploadAndPersistPrivateAsset)
+                .with(any(), any(), any(), any())
+                .wasInvoked(exactly = once)
+            verify(arrangement.messageSender)
+                .suspendFunction(arrangement.messageSender::sendMessage)
+                .with(any())
+                .wasInvoked(exactly = once)
+
+            verify(arrangement.messageSendFailureHandler)
+                .suspendFunction(arrangement.messageSendFailureHandler::handleFailureAndUpdateMessageStatus)
+                .with(any(), any(), any(), any(), any())
+                .wasInvoked(exactly = once)
+        }
+
+    @Test
     fun givenASuccessfulSendAssetMessageRequest_whenCheckingTheMessageRepository_thenTheAssetIsMarkedAsSavedInternally() =
         runTest(testDispatcher.default) {
             // Given
@@ -590,6 +641,41 @@ class ScheduleNewAssetMessageUseCaseTest {
                 .suspendFunction(updateUploadStatus::invoke)
                 .whenInvokedWith(any(), any(), any())
                 .thenReturn(UpdateUploadStatusResult.Success)
+        }
+
+        fun withUnSuccessfulSendMessageResponse(
+            expectedAssetId: UploadedAssetId,
+            assetSHA256Key: SHA256Key,
+            temporaryAssetId: String = "temporary_id"
+        ): Arrangement = apply {
+            given(assetDataSource)
+                .suspendFunction(assetDataSource::persistAsset)
+                .whenInvokedWith(any(), any(), any(), any(), any())
+                .thenReturn(Either.Right(fakeKaliumFileSystem.providePersistentAssetPath(temporaryAssetId)))
+            given(assetDataSource)
+                .suspendFunction(assetDataSource::uploadAndPersistPrivateAsset)
+                .whenInvokedWith(any(), any(), any(), any())
+                .thenReturn(Either.Right(expectedAssetId to assetSHA256Key))
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(Either.Right(someClientId))
+            given(slowSyncRepository)
+                .getter(slowSyncRepository::slowSyncStatus)
+                .whenInvoked()
+                .thenReturn(completeStateFlow)
+            given(persistMessage)
+                .suspendFunction(persistMessage::invoke)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
+            given(messageSendFailureHandler)
+                .suspendFunction(messageSendFailureHandler::handleFailureAndUpdateMessageStatus)
+                .whenInvokedWith(any(), any(), any(), any(), any())
+                .thenReturn(Unit)
         }
 
         fun withUploadAssetErrorResponse(exception: KaliumException): Arrangement = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
@@ -227,6 +227,10 @@ class ScheduleNewAssetMessageUseCaseTest {
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(any())
             .wasInvoked(exactly = once)
+        verify(arrangement.messageSendFailureHandler)
+            .suspendFunction(arrangement.messageSendFailureHandler::handleFailureAndUpdateMessageStatus)
+            .with(any(), any(), any(), any(), any())
+            .wasNotInvoked()
     }
 
     @Test
@@ -273,7 +277,6 @@ class ScheduleNewAssetMessageUseCaseTest {
                 .suspendFunction(arrangement.messageSender::sendMessage)
                 .with(any())
                 .wasInvoked(exactly = once)
-
             verify(arrangement.messageSendFailureHandler)
                 .suspendFunction(arrangement.messageSendFailureHandler::handleFailureAndUpdateMessageStatus)
                 .with(any(), any(), any(), any(), any())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While using `ScheduleNewAssetMessageUseCase` to upload assets and the backend has the federator down (technically online but not reachable to/from by other backends) the asset is uploaded but sending the message fails not reflecting this state in the database.

### Causes (Optional)

No button to retry is visible, and the asset message shows as pending.

### Solutions

Update the status of the message when we can't send the message with our `MessageSendFailureHandler` component, so can be correctly updated to `FAILED`  accordingly.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
