### PR TITLE
fix: improve stability of MLS 1-1 conversations

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/CoreCryptoExceptionMapper.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/CoreCryptoExceptionMapper.kt
@@ -27,6 +27,7 @@ actual fun mapMLSException(exception: Exception): MLSFailure =
                 is CryptoError.DuplicateMessage -> MLSFailure.DuplicateMessage
                 is CryptoError.SelfCommitIgnored -> MLSFailure.SelfCommitIgnored
                 is CryptoError.UnmergedPendingGroup -> MLSFailure.UnmergedPendingGroup
+                is CryptoError.ConversationAlreadyExists -> MLSFailure.ConversationAlreadyExists
                 else -> MLSFailure.Generic(exception)
             }
         } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -176,6 +176,8 @@ interface MLSFailure : CoreFailure {
 
     object UnmergedPendingGroup : MLSFailure
 
+    object ConversationAlreadyExists : MLSFailure
+
     object ConversationDoesNotSupportMLS : MLSFailure
 
     class Generic(internal val exception: Exception) : MLSFailure {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -518,6 +518,7 @@ internal class MLSConversationDataSource(
         kaliumLogger.w("Discarding the failed commit.")
 
         return mlsClientProvider.getMLSClient().flatMap { mlsClient ->
+            @Suppress("TooGenericExceptionCaught")
             try {
                 mlsClient.clearPendingCommit(idMapper.toCryptoModel(groupID))
             } catch (error: Throwable) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCase.kt
@@ -141,7 +141,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                 conversationRepository.getConversationMembers(conversation.id).flatMap { members ->
                     mlsConversationRepository.establishMLSGroup(
                         protocol.groupId,
-                        listOf(members.first())
+                        members
                     )
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -60,7 +60,10 @@ internal class JoinExistingMLSConversationsUseCaseImpl(
                     joinExistingMLSConversationUseCase(conversation.id)
                         .flatMapLeft {
                             if (it is CoreFailure.NoKeyPackagesAvailable) {
-                                kaliumLogger.w("Failed to establish mls group for ${conversation.id.toLogString()} since some participants are out of key packages, skipping.")
+                                kaliumLogger.w(
+                                    "Failed to establish mls group for ${conversation.id.toLogString()} " +
+                                             "since some participants are out of key packages, skipping."
+                                )
                                 Either.Right(Unit)
                             } else {
                                 Either.Left(it)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -123,6 +123,6 @@ class GetOrCreateOneToOneConversationUseCaseTest {
     private companion object {
         val OTHER_USER = TestUser.OTHER
         val OTHER_USER_ID = OTHER_USER.id
-        val CONVERSATION = TestConversation.ONE_ON_ONE
+        val CONVERSATION = TestConversation.ONE_ON_ONE()
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -127,7 +127,7 @@ class ObserveConversationListDetailsUseCaseTest {
     @Test
     fun givenSomeConversationsDetailsAreUpdated_whenObservingDetailsList_thenTheUpdateIsPropagatedThroughTheFlow() = runTest {
         // Given
-        val oneOnOneConversation = TestConversation.ONE_ON_ONE
+        val oneOnOneConversation = TestConversation.ONE_ON_ONE()
         val groupConversation = TestConversation.GROUP()
         val conversations = listOf(groupConversation, oneOnOneConversation)
 
@@ -286,9 +286,9 @@ class ObserveConversationListDetailsUseCaseTest {
     @Test
     fun givenConversationDetailsFailure_whenObservingDetailsList_thenIgnoreConversationWithFailure() = runTest {
         // Given
-        val successConversation = TestConversation.ONE_ON_ONE.copy(id = ConversationId("successId", "domain"))
+        val successConversation = TestConversation.ONE_ON_ONE().copy(id = ConversationId("successId", "domain"))
         val successConversationDetails = TestConversationDetails.CONVERSATION_ONE_ONE.copy(conversation = successConversation)
-        val failureConversation = TestConversation.ONE_ON_ONE.copy(id = ConversationId("failedId", "domain"))
+        val failureConversation = TestConversation.ONE_ON_ONE().copy(id = ConversationId("failedId", "domain"))
 
         val (_, observeConversationsUseCase) = Arrangement()
             .withConversationsList(listOf(successConversation, failureConversation))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolverTest.kt
@@ -152,7 +152,7 @@ class MLSOneOnOneConversationResolverTest {
     private companion object {
         private val userId = TestUser.USER_ID
 
-        private val CONVERSATION_ONE_ON_ONE_PROTEUS = TestConversation.ONE_ON_ONE.copy(
+        private val CONVERSATION_ONE_ON_ONE_PROTEUS = TestConversation.ONE_ON_ONE().copy(
             id = ConversationId("one-on-one-proteus", "test"),
             protocol = Conversation.ProtocolInfo.Proteus,
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigratorTest.kt
@@ -93,7 +93,7 @@ class OneOnOneMigratorTest {
 
         val (arrangement, oneOneMigrator) = arrange {
             withGetOneOnOneConversationsWithOtherUserReturning(Either.Right(emptyList()))
-            withCreateGroupConversationReturning(Either.Right(TestConversation.ONE_ON_ONE))
+            withCreateGroupConversationReturning(Either.Right(TestConversation.ONE_ON_ONE()))
             withUpdateOneOnOneConversationReturning(Either.Right(Unit))
         }
 
@@ -107,7 +107,7 @@ class OneOnOneMigratorTest {
 
         verify(arrangement.userRepository)
             .suspendFunction(arrangement.userRepository::updateActiveOneOnOneConversation)
-            .with(eq(TestUser.OTHER.id), eq(TestConversation.ONE_ON_ONE.id))
+            .with(eq(TestUser.OTHER.id), eq(TestConversation.ONE_ON_ONE().id))
             .wasInvoked()
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -57,12 +57,12 @@ object TestConversation {
     val ID = ConversationId(conversationValue, conversationDomain)
     fun id(suffix: Int = 0) = ConversationId("${conversationValue}_$suffix", conversationDomain)
 
-    val ONE_ON_ONE = Conversation(
+    fun ONE_ON_ONE(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
         ID.copy(value = "1O1 ID"),
         "ONE_ON_ONE Name",
         Conversation.Type.ONE_ON_ONE,
         TestTeam.TEAM_ID,
-        ProtocolInfo.Proteus,
+        protocolInfo,
         MutedConversationStatus.AllAllowed,
         null,
         null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
@@ -38,7 +38,7 @@ object TestConversationDetails {
     )
 
     val CONVERSATION_ONE_ONE = ConversationDetails.OneOne(
-        TestConversation.ONE_ON_ONE,
+        TestConversation.ONE_ON_ONE(),
         TestUser.OTHER,
         LegalHoldStatus.DISABLED,
         UserType.EXTERNAL,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -507,6 +507,6 @@ INSERT OR IGNORE INTO MessageRecipientFailure(message_id, conversation_id, recip
 VALUES(?, ?, ?, ?);
 
 moveMessages:
-UPDATE Message
+UPDATE OR REPLACE Message
 SET conversation_id = :to
 WHERE conversation_id = :from;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

During testing serval issues were identified:
1. Slow sync fails due to non-recoverable errors and is therefore stuck
2. Message migration for 1-1 conversations would sometimes fail with constraint failure on the primary key
3. When establishing 1-1 MLS groups we didn't add other self clients
4. When establishing an MLS group would sometime fail if the MLS group had already been created locally

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
