### PR TITLE
feat: Add user typing indicator configuration [WPB-4589]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -59,6 +59,8 @@ interface UserConfigRepository {
     fun isSecondFactorPasswordChallengeRequired(): Either<StorageFailure, Boolean>
     fun isReadReceiptsEnabled(): Flow<Either<StorageFailure, Boolean>>
     fun setReadReceiptsStatus(enabled: Boolean): Either<StorageFailure, Unit>
+    fun isTypingIndicatorEnabled(): Flow<Either<StorageFailure, Boolean>>
+    fun setTypingIndicatorStatus(isTyping: Boolean): Either<StorageFailure, Unit>
     fun setGuestRoomStatus(status: Boolean, isStatusChanged: Boolean?): Either<StorageFailure, Unit>
     fun getGuestRoomLinkStatus(): Either<StorageFailure, GuestRoomLinkStatus>
     fun observeGuestRoomLinkFeatureFlag(): Flow<Either<StorageFailure, GuestRoomLinkStatus>>
@@ -200,12 +202,19 @@ class UserConfigDataSource(
     }
 
     override fun isReadReceiptsEnabled(): Flow<Either<StorageFailure, Boolean>> =
-        userConfigStorage.isReadReceiptsEnabled().wrapStorageRequest()
+        userConfigStorage.areReadReceiptsEnabled().wrapStorageRequest()
 
     override fun setReadReceiptsStatus(enabled: Boolean): Either<StorageFailure, Unit> =
         wrapStorageRequest {
             userConfigStorage.persistReadReceipts(enabled)
         }
+
+    override fun isTypingIndicatorEnabled(): Flow<Either<StorageFailure, Boolean>> =
+        userConfigStorage.isTypingIndicatorEnabled().wrapStorageRequest()
+
+    override fun setTypingIndicatorStatus(isTyping: Boolean): Either<StorageFailure, Unit> = wrapStorageRequest {
+        userConfigStorage.persistTypingIndicator(isTyping)
+    }
 
     override fun setGuestRoomStatus(status: Boolean, isStatusChanged: Boolean?): Either<StorageFailure, Unit> =
         wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/properties/UserPropertyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/properties/UserPropertyRepository.kt
@@ -33,6 +33,10 @@ interface UserPropertyRepository {
     suspend fun observeReadReceiptsStatus(): Flow<Either<CoreFailure, Boolean>>
     suspend fun setReadReceiptsEnabled(): Either<CoreFailure, Unit>
     suspend fun deleteReadReceiptsProperty(): Either<CoreFailure, Unit>
+    suspend fun getTypingIndicatorStatus(): Boolean
+    suspend fun observeTypingIndicatorStatus(): Flow<Either<CoreFailure, Boolean>>
+    suspend fun setTypingIndicatorEnabled(): Either<CoreFailure, Unit>
+    suspend fun removeTypingIndicatorProperty(): Either<CoreFailure, Unit>
 }
 
 internal class UserPropertyDataSource(
@@ -58,4 +62,23 @@ internal class UserPropertyDataSource(
         userConfigRepository.setReadReceiptsStatus(false)
     }
 
+    override suspend fun getTypingIndicatorStatus(): Boolean =
+        userConfigRepository.isTypingIndicatorEnabled()
+            .firstOrNull()
+            ?.fold({ false }, { it }) ?: false
+
+    override suspend fun observeTypingIndicatorStatus(): Flow<Either<CoreFailure, Boolean>> =
+        userConfigRepository.isTypingIndicatorEnabled()
+
+    override suspend fun setTypingIndicatorEnabled(): Either<CoreFailure, Unit> = wrapApiRequest {
+        propertiesApi.setProperty(PropertiesApi.PropertyKey.WIRE_TYPING_MODE, 1)
+    }.flatMap {
+        userConfigRepository.setTypingIndicatorStatus(true)
+    }
+
+    override suspend fun removeTypingIndicatorProperty(): Either<CoreFailure, Unit> = wrapApiRequest {
+        propertiesApi.deleteProperty(PropertiesApi.PropertyKey.WIRE_TYPING_MODE)
+    }.flatMap {
+        userConfigRepository.setTypingIndicatorStatus(false)
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -58,6 +58,10 @@ import com.wire.kalium.logic.feature.user.readReceipts.ObserveReadReceiptsEnable
 import com.wire.kalium.logic.feature.user.readReceipts.ObserveReadReceiptsEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.user.readReceipts.PersistReadReceiptsStatusConfigUseCase
 import com.wire.kalium.logic.feature.user.readReceipts.PersistReadReceiptsStatusConfigUseCaseImpl
+import com.wire.kalium.logic.feature.user.typingIndicator.ObserveTypingIndicatorEnabledUseCase
+import com.wire.kalium.logic.feature.user.typingIndicator.ObserveTypingIndicatorEnabledUseCaseImpl
+import com.wire.kalium.logic.feature.user.typingIndicator.PersistTypingIndicatorStatusConfigUseCase
+import com.wire.kalium.logic.feature.user.typingIndicator.PersistTypingIndicatorStatusConfigUseCaseImpl
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.persistence.dao.MetadataDAO
 
@@ -127,8 +131,16 @@ class UserScope internal constructor(
         get() = ObserveReadReceiptsEnabledUseCaseImpl(
             userPropertyRepository = userPropertyRepository
         )
+
+    val observeTypingIndicatorEnabled: ObserveTypingIndicatorEnabledUseCase
+        get() = ObserveTypingIndicatorEnabledUseCaseImpl(
+            userPropertyRepository = userPropertyRepository
+        )
     val persistReadReceiptsStatusConfig: PersistReadReceiptsStatusConfigUseCase
         get() = PersistReadReceiptsStatusConfigUseCaseImpl(userPropertyRepository = userPropertyRepository)
+
+    val persistTypingIndicatorStatusConfig: PersistTypingIndicatorStatusConfigUseCase
+        get() = PersistTypingIndicatorStatusConfigUseCaseImpl(userPropertyRepository = userPropertyRepository)
 
     val serverLinks get() = SelfServerConfigUseCase(selfUserId, serverConfigRepository)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/typingIndicator/ObserveTypingIndicatorEnabledUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/typingIndicator/ObserveTypingIndicatorEnabledUseCase.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.user.typingIndicator
+
+import com.wire.kalium.logic.data.properties.UserPropertyRepository
+import com.wire.kalium.logic.functional.fold
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * UseCase allowing to observe changes of the global configuration flag regarding User Typing Indicator feature
+ */
+interface ObserveTypingIndicatorEnabledUseCase {
+    suspend operator fun invoke(): Flow<Boolean>
+}
+
+internal class ObserveTypingIndicatorEnabledUseCaseImpl(
+    val userPropertyRepository: UserPropertyRepository,
+) : ObserveTypingIndicatorEnabledUseCase {
+
+    override suspend fun invoke(): Flow<Boolean> {
+        return userPropertyRepository.observeTypingIndicatorStatus().map { result ->
+            result.fold({
+                true
+            }, {
+                it
+            })
+        }
+    }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/typingIndicator/PersistTypingIndicatorStatusConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/typingIndicator/PersistTypingIndicatorStatusConfigUseCase.kt
@@ -1,0 +1,58 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.user.typingIndicator
+
+import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.LOCAL_STORAGE
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.properties.UserPropertyRepository
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.kaliumLogger
+
+/**
+ * UseCase allowing to persist the global configuration flag regarding User Typing Indicator feature
+ */
+interface PersistTypingIndicatorStatusConfigUseCase {
+    suspend operator fun invoke(enabled: Boolean): TypingIndicatorConfigResult
+}
+
+internal class PersistTypingIndicatorStatusConfigUseCaseImpl(
+    private val userPropertyRepository: UserPropertyRepository,
+) : PersistTypingIndicatorStatusConfigUseCase {
+
+    private val logger by lazy { kaliumLogger.withFeatureId(LOCAL_STORAGE) }
+
+    override suspend fun invoke(enabled: Boolean): TypingIndicatorConfigResult {
+        val result = when (enabled) {
+            true -> userPropertyRepository.setTypingIndicatorEnabled()
+            false -> userPropertyRepository.removeTypingIndicatorProperty()
+        }
+
+        return result.fold({
+            logger.e("Failed trying to update Typing Indicator configuration flag")
+            TypingIndicatorConfigResult.Failure(it)
+        }) {
+            TypingIndicatorConfigResult.Success
+        }
+    }
+}
+
+sealed class TypingIndicatorConfigResult {
+    object Success : TypingIndicatorConfigResult()
+    data class Failure(val cause: CoreFailure) : TypingIndicatorConfigResult()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/typingIndicator/ObserveTypingIndicatorEnabledUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/typingIndicator/ObserveTypingIndicatorEnabledUseCaseTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user.typingIndicator
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.properties.UserPropertyRepository
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ObserveTypingIndicatorEnabledUseCaseTest {
+
+    @Test
+    fun givenATypingIndicatorState_whenInvokingObserveTypingIndicatorEnabled_thenShouldReturnsSuccessResult() = runTest {
+        val (arrangement, observeTypingIndicatorEnabled) = Arrangement()
+            .withSuccessfulState()
+            .arrange()
+
+        val result = observeTypingIndicatorEnabled()
+
+        result.test {
+            val item = awaitItem()
+            assertTrue(item)
+
+            verify(arrangement.userPropertyRepository)
+                .function(arrangement.userPropertyRepository::observeTypingIndicatorStatus)
+                .with()
+                .wasInvoked(once)
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenATypingIndicatorState_whenFailureInvokingObserveTypingIndicatorEnabled_thenShouldReturnsTrueAndSuccessAsFallbackResult() =
+        runTest {
+            val (arrangement, observeTypingIndicatorEnabled) = Arrangement()
+                .withFailureState()
+                .arrange()
+
+            val result = observeTypingIndicatorEnabled()
+
+            result.test {
+                val item = awaitItem()
+                assertTrue(item)
+
+                verify(arrangement.userPropertyRepository)
+                    .function(arrangement.userPropertyRepository::observeTypingIndicatorStatus)
+                    .with()
+                    .wasInvoked(once)
+
+                awaitComplete()
+            }
+        }
+
+    private class Arrangement {
+        @Mock
+        val userPropertyRepository = mock(classOf<UserPropertyRepository>())
+
+        val observeTypingIndicatorEnabled = ObserveTypingIndicatorEnabledUseCaseImpl(userPropertyRepository)
+
+        fun withSuccessfulState() = apply {
+            given(userPropertyRepository)
+                .suspendFunction(userPropertyRepository::observeTypingIndicatorStatus)
+                .whenInvoked()
+                .thenReturn(flowOf(Either.Right(true)))
+
+            return this
+        }
+
+        fun withFailureState() = apply {
+            given(userPropertyRepository)
+                .suspendFunction(userPropertyRepository::observeTypingIndicatorStatus)
+                .whenInvoked()
+                .thenReturn(flowOf(Either.Left(StorageFailure.DataNotFound)))
+
+            return this
+        }
+
+        fun arrange() = this to observeTypingIndicatorEnabled
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/typingIndicator/PersistTypingIndicatorStatusConfigUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/typingIndicator/PersistTypingIndicatorStatusConfigUseCaseTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user.typingIndicator
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.properties.UserPropertyRepository
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class PersistTypingIndicatorStatusConfigUseCaseTest {
+
+    @Test
+    fun givenATrueValue_shouldCallSetTypingIndicator() = runTest {
+        val (arrangement, persistTypingIndicatorStatusConfig) = Arrangement()
+            .withSuccessfulCall()
+            .arrange()
+
+        val actual = persistTypingIndicatorStatusConfig(true)
+
+        verify(arrangement.userPropertyRepository)
+            .suspendFunction(arrangement.userPropertyRepository::setTypingIndicatorEnabled)
+            .wasInvoked(once)
+        assertTrue(actual is TypingIndicatorConfigResult.Success)
+    }
+
+    @Test
+    fun givenAFalseValue_shouldCallRemoveTypingIndicator() = runTest {
+        val (arrangement, persistTypingIndicatorStatusConfig) = Arrangement()
+            .withSuccessfulCallToDelete()
+            .arrange()
+
+        val actual = persistTypingIndicatorStatusConfig(false)
+
+        verify(arrangement.userPropertyRepository)
+            .suspendFunction(arrangement.userPropertyRepository::removeTypingIndicatorProperty)
+            .wasInvoked(once)
+
+        assertTrue(actual is TypingIndicatorConfigResult.Success)
+    }
+
+    @Test
+    fun givenAValue_whenInvokedWithAFailureShouldReturnACoreFailureResult() = runTest {
+        val (arrangement, persistTypingIndicatorStatusConfig) = Arrangement()
+            .withFailureCallToRepo()
+            .arrange()
+
+        val actual = persistTypingIndicatorStatusConfig(true)
+
+        verify(arrangement.userPropertyRepository)
+            .suspendFunction(arrangement.userPropertyRepository::setTypingIndicatorEnabled)
+            .wasInvoked(once)
+
+        assertTrue(actual is TypingIndicatorConfigResult.Failure)
+    }
+
+    private class Arrangement {
+        @Mock
+        val userPropertyRepository = mock(classOf<UserPropertyRepository>())
+
+        val persistTypingIndicatorStatusConfig = PersistTypingIndicatorStatusConfigUseCaseImpl(userPropertyRepository)
+
+        fun withSuccessfulCall() = apply {
+            given(userPropertyRepository)
+                .suspendFunction(userPropertyRepository::setTypingIndicatorEnabled)
+                .whenInvoked()
+                .thenReturn(Either.Right(Unit))
+
+            return this
+        }
+
+        fun withSuccessfulCallToDelete() = apply {
+            given(userPropertyRepository)
+                .suspendFunction(userPropertyRepository::removeTypingIndicatorProperty)
+                .whenInvoked()
+                .thenReturn(Either.Right(Unit))
+
+            return this
+        }
+
+        fun withFailureCallToRepo() = apply {
+            given(userPropertyRepository)
+                .suspendFunction(userPropertyRepository::setTypingIndicatorEnabled)
+                .whenInvoked()
+                .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("Some error"))))
+
+            return this
+        }
+
+        fun arrange() = this to persistTypingIndicatorStatusConfig
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/properties/PropertiesApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/properties/PropertiesApi.kt
@@ -26,7 +26,8 @@ interface PropertiesApi {
     suspend fun deleteProperty(propertyKey: PropertyKey): NetworkResponse<Unit>
 
     enum class PropertyKey(val key: String) {
-        WIRE_RECEIPT_MODE("WIRE_RECEIPT_MODE")
+        WIRE_RECEIPT_MODE("WIRE_RECEIPT_MODE"),
+        WIRE_TYPING_MODE("WIRE_TYPING_MODE")
         // TODO map other event like -ie. 'labels'-
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
@@ -33,30 +33,30 @@ import kotlin.time.Duration
 interface UserConfigStorage {
 
     /**
-     * save flag from the file sharing api, and if the status changes
+     * Save flag from the file sharing api, and if the status changes
      */
     fun persistFileSharingStatus(status: Boolean, isStatusChanged: Boolean?)
 
     /**
-     * get the saved flag that been saved to know if the file sharing is enabled or not with the flag
+     * Get the saved flag that been saved to know if the file sharing is enabled or not with the flag
      * to know if there was a status change
      */
     fun isFileSharingEnabled(): IsFileSharingEnabledEntity?
 
     /**
-     * returns the Flow of file sharing status
+     * Returns the Flow of file sharing status
      */
     fun isFileSharingEnabledFlow(): Flow<IsFileSharingEnabledEntity?>
 
     fun setFileSharingAsNotified()
 
     /**
-     * returns a Flow containing the status and list of classified domains
+     * Returns a Flow containing the status and list of classified domains
      */
     fun isClassifiedDomainsEnabledFlow(): Flow<ClassifiedDomainsEntity>
 
     /**
-     * save the flag and list of trusted domains
+     *Save the flag and list of trusted domains
      */
     fun persistClassifiedDomainsStatus(status: Boolean, classifiedDomains: List<String>)
 
@@ -77,49 +77,59 @@ interface UserConfigStorage {
     fun isSecondFactorPasswordChallengeRequired(): Boolean
 
     /**
-     * save flag from the user settings to enable and disable MLS
+     * Save flag from the user settings to enable and disable MLS
      */
     fun enableMLS(enabled: Boolean)
 
     /**
-     * get the saved flag to know if MLS enabled or not
+     * Get the saved flag to know if MLS enabled or not
      */
     fun isMLSEnabled(): Boolean
 
     /**
-     * save MLSE2EISetting
+     * Save MLSE2EISetting
      */
     fun setE2EISettings(settingEntity: E2EISettingsEntity)
 
     /**
-     * get MLSE2EISetting
+     * Get MLSE2EISetting
      */
     fun getE2EISettings(): E2EISettingsEntity?
 
     /**
-     * get Flow of the saved MLSE2EISetting
+     * Get Flow of the saved MLSE2EISetting
      */
     fun e2EISettingsFlow(): Flow<E2EISettingsEntity?>
 
     /**
-     * save flag from user settings to enable or disable Conference Calling
+     * Save flag from user settings to enable or disable Conference Calling
      */
     fun persistConferenceCalling(enabled: Boolean)
 
     /**
-     * get the saved flag to know if Conference Calling is enabled or not
+     * Get the saved flag to know if Conference Calling is enabled or not
      */
     fun isConferenceCallingEnabled(): Boolean
 
     /**
-     * get the saved flag to know if user's Read Receipts are enabled or not
+     * Get the saved flag to know whether user's Read Receipts are currently enabled or not
      */
-    fun isReadReceiptsEnabled(): Flow<Boolean>
+    fun areReadReceiptsEnabled(): Flow<Boolean>
 
     /**
-     * save the flag to know if user's Read Receipts are enabled or not
+     * Persist the flag to indicate if user's Read Receipts are enabled or not.
      */
     fun persistReadReceipts(enabled: Boolean)
+
+    /**
+     * Get the saved global flag to know whether user's typing indicator is currently enabled or not.
+     */
+    fun isTypingIndicatorEnabled(): Flow<Boolean>
+
+    /**
+     * Persist the flag to indicate whether user's typing indicator global flag is enabled or not.
+     */
+    fun persistTypingIndicator(enabled: Boolean)
 
     fun persistGuestRoomLinkFeatureFlag(status: Boolean, isStatusChanged: Boolean?)
     fun isGuestRoomLinkEnabled(): IsGuestRoomLinkEnabledEntity?
@@ -183,7 +193,10 @@ class UserConfigStorageImpl(
     private val kaliumPreferences: KaliumPreferences
 ) : UserConfigStorage {
 
-    private val isReadReceiptsEnabledFlow =
+    private val areReadReceiptsEnabledFlow =
+        MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    private val isTypingIndicatorEnabledFlow =
         MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
     private val isFileSharingEnabledFlow =
@@ -319,14 +332,25 @@ class UserConfigStorageImpl(
     override fun isConferenceCallingEnabled(): Boolean =
         kaliumPreferences.getBoolean(ENABLE_CONFERENCE_CALLING, DEFAULT_CONFERENCE_CALLING_ENABLED_VALUE)
 
-    override fun isReadReceiptsEnabled(): Flow<Boolean> = isReadReceiptsEnabledFlow
+    override fun areReadReceiptsEnabled(): Flow<Boolean> = areReadReceiptsEnabledFlow
         .map { kaliumPreferences.getBoolean(ENABLE_READ_RECEIPTS, true) }
         .onStart { emit(kaliumPreferences.getBoolean(ENABLE_READ_RECEIPTS, true)) }
         .distinctUntilChanged()
 
     override fun persistReadReceipts(enabled: Boolean) {
         kaliumPreferences.putBoolean(ENABLE_READ_RECEIPTS, enabled).also {
-            isReadReceiptsEnabledFlow.tryEmit(Unit)
+            areReadReceiptsEnabledFlow.tryEmit(Unit)
+        }
+    }
+
+    override fun isTypingIndicatorEnabled(): Flow<Boolean> = isTypingIndicatorEnabledFlow
+        .map { kaliumPreferences.getBoolean(ENABLE_TYPING_INDICATOR, true) }
+        .onStart { emit(kaliumPreferences.getBoolean(ENABLE_TYPING_INDICATOR, true)) }
+        .distinctUntilChanged()
+
+    override fun persistTypingIndicator(enabled: Boolean) {
+        kaliumPreferences.putBoolean(ENABLE_TYPING_INDICATOR, enabled).also {
+            isTypingIndicatorEnabledFlow.tryEmit(Unit)
         }
     }
 
@@ -375,5 +399,6 @@ class UserConfigStorageImpl(
         const val DEFAULT_CONFERENCE_CALLING_ENABLED_VALUE = false
         const val REQUIRE_SECOND_FACTOR_PASSWORD_CHALLENGE = "require_second_factor_password_challenge"
         const val ENABLE_SCREENSHOT_CENSORING = "enable_screenshot_censoring"
+        const val ENABLE_TYPING_INDICATOR = "enable_typing_indicator"
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/config/UserConfigStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/config/UserConfigStorageTest.kt
@@ -79,7 +79,7 @@ class UserConfigStorageTest {
     @Test
     fun givenAReadReceiptsSetValue_whenPersistingIt_saveAndThenRestoreTheValueLocally() = runTest {
         userConfigStorage.persistReadReceipts(true)
-        assertTrue(userConfigStorage.isReadReceiptsEnabled().first())
+        assertTrue(userConfigStorage.areReadReceiptsEnabled().first())
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to be able to switch on and off the global user setting for displaying typing indicator, the right classes needed to be added on the api, repository and use case layers.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
