### PR TITLE
feat: add DB + use cases for archived related operations [WPB-4427]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -155,6 +155,18 @@ interface ConversationRepository {
         mutedStatusTimestamp: Long
     ): Either<NetworkFailure, Unit>
 
+    suspend fun updateArchivedStatusLocally(
+        conversationId: ConversationId,
+        isArchived: Boolean,
+        archivedStatusTimestamp: Long
+    ): Either<StorageFailure, Unit>
+
+    suspend fun updateArchivedStatusRemotely(
+        conversationId: ConversationId,
+        isArchived: Boolean,
+        archivedStatusTimestamp: Long
+    ): Either<NetworkFailure, Unit>
+
     suspend fun getConversationsByGroupState(
         groupState: Conversation.ProtocolInfo.MLS.GroupState
     ): Either<StorageFailure, List<Conversation>>
@@ -629,6 +641,29 @@ internal class ConversationDataSource internal constructor(
     ): Either<NetworkFailure, Unit> = wrapApiRequest {
         conversationApi.updateConversationMemberState(
             memberUpdateRequest = conversationStatusMapper.toMutedStatusApiModel(mutedStatus, mutedStatusTimestamp),
+            conversationId = conversationId.toApi()
+        )
+    }
+
+    override suspend fun updateArchivedStatusLocally(
+        conversationId: ConversationId,
+        isArchived: Boolean,
+        archivedStatusTimestamp: Long
+    ): Either<StorageFailure, Unit> = wrapStorageRequest {
+        conversationDAO.updateConversationArchivedStatus(
+            conversationId = conversationId.toDao(),
+            isArchived = isArchived,
+            archivedStatusTimestamp = archivedStatusTimestamp
+        )
+    }
+
+    override suspend fun updateArchivedStatusRemotely(
+        conversationId: ConversationId,
+        isArchived: Boolean,
+        archivedStatusTimestamp: Long
+    ): Either<NetworkFailure, Unit> = wrapApiRequest {
+        conversationApi.updateConversationMemberState(
+            memberUpdateRequest = conversationStatusMapper.toArchivedStatusApiModel(isArchived, archivedStatusTimestamp),
             conversationId = conversationId.toApi()
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -33,6 +33,7 @@ interface ConversationStatusMapper {
     fun fromMutedStatusDaoModel(mutedStatus: ConversationEntity.MutedStatus): MutedConversationStatus
     fun fromMutedStatusApiToDaoModel(mutedStatus: MutedStatus?): ConversationEntity.MutedStatus
     fun fromRemovedByToLogicModel(removedBy: UserIDEntity): UserId
+    fun toArchivedStatusApiModel(isArchived: Boolean, archivedStatusTimestamp: Long): MemberUpdateDTO
 }
 
 class ConversationStatusMapperImpl(val idMapper: IdMapper) : ConversationStatusMapper {
@@ -70,5 +71,11 @@ class ConversationStatusMapperImpl(val idMapper: IdMapper) : ConversationStatusM
     }
 
     override fun fromRemovedByToLogicModel(removedBy: UserIDEntity): UserId = removedBy.toModel()
-
+    override fun toArchivedStatusApiModel(
+        isArchived: Boolean,
+        archivedStatusTimestamp: Long
+    ): MemberUpdateDTO = MemberUpdateDTO(
+        otrArchived = isArchived,
+        otrArchivedRef = archivedStatusTimestamp.toIsoDateTimeString()
+    )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -221,6 +221,25 @@ sealed class Event(open val id: String, open val transient: Boolean) {
                 )
             }
 
+            data class MemberArchivedStatusChanged(
+                override val id: String,
+                override val conversationId: ConversationId,
+                override val timestampIso: String,
+                override val transient: Boolean,
+                val archivedConversationChangedTime: String,
+                val isArchiving: Boolean
+            ) : MemberChanged(id, conversationId, timestampIso, transient) {
+
+                override fun toLogMap(): Map<String, Any?> = mapOf(
+                    typeKey to "Conversation.MemberMutedStatusChanged",
+                    idKey to id.obfuscateId(),
+                    conversationIdKey to conversationId.toLogString(),
+                    timestampIsoKey to timestampIso,
+                    "isArchiving" to isArchiving,
+                    "mutedConversationChangedTime" to archivedConversationChangedTime
+                )
+            }
+
             data class IgnoredMemberChanged(
                 override val id: String,
                 override val conversationId: ConversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -231,12 +231,12 @@ sealed class Event(open val id: String, open val transient: Boolean) {
             ) : MemberChanged(id, conversationId, timestampIso, transient) {
 
                 override fun toLogMap(): Map<String, Any?> = mapOf(
-                    typeKey to "Conversation.MemberMutedStatusChanged",
+                    typeKey to "Conversation.MemberArchivedStatusChanged",
                     idKey to id.obfuscateId(),
                     conversationIdKey to conversationId.toLogString(),
                     timestampIsoKey to timestampIso,
                     "isArchiving" to isArchiving,
-                    "mutedConversationChangedTime" to archivedConversationChangedTime
+                    "archivedConversationChangedTime" to archivedConversationChangedTime
                 )
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -384,6 +384,17 @@ class EventMapper(
                 )
             }
 
+            eventContentDTO.roleChange.isArchiving != null -> {
+                Event.Conversation.MemberChanged.MemberArchivedStatusChanged(
+                    id = id,
+                    conversationId = eventContentDTO.qualifiedConversation.toModel(),
+                    timestampIso = eventContentDTO.time,
+                    transient = transient,
+                    archivedConversationChangedTime = eventContentDTO.roleChange.archivedRef.orEmpty(),
+                    isArchiving = eventContentDTO.roleChange.isArchiving ?: false
+                )
+            }
+
             else -> {
                 Event.Conversation.MemberChanged.IgnoredMemberChanged(
                     id,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -155,6 +155,9 @@ class ConversationScope internal constructor(
     val updateConversationMutedStatus: UpdateConversationMutedStatusUseCase
         get() = UpdateConversationMutedStatusUseCaseImpl(conversationRepository)
 
+    val updateConversationArchivedStatus: UpdateConversationArchivedStatusUseCase
+        get() = UpdateConversationArchivedStatusUseCaseImpl(conversationRepository)
+
     val observeConnectionList: ObserveConnectionListUseCase
         get() = ObserveConnectionListUseCaseImpl(connectionRepository)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.util.DateTimeUtil
+
+interface UpdateConversationArchivedStatusUseCase {
+    /**
+     * Use case that allows a conversation to mark a conversation as archived or not.
+     *
+     * @param conversationId the id of the conversation where status wants to be changed
+     * @param isConversationArchived new archived status to be updated on the given conversation
+     * @return an [ConversationUpdateStatusResult] containing Success or Failure cases
+     */
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        isConversationArchived: Boolean,
+        archivedStatusTimestamp: Long = DateTimeUtil.currentInstant().toEpochMilliseconds()
+    ): ArchiveStatusUpdateResult
+}
+
+internal class UpdateConversationArchivedStatusUseCaseImpl(
+    private val conversationRepository: ConversationRepository
+) : UpdateConversationArchivedStatusUseCase {
+
+    override suspend operator fun invoke(
+        conversationId: ConversationId,
+        isConversationArchived: Boolean,
+        archivedStatusTimestamp: Long
+    ): ArchiveStatusUpdateResult =
+        conversationRepository.updateArchivedStatusRemotely(conversationId, isConversationArchived, archivedStatusTimestamp)
+            .flatMap {
+                conversationRepository.updateArchivedStatusLocally(conversationId, isConversationArchived, archivedStatusTimestamp)
+            }.fold({
+                kaliumLogger.e("Something went wrong when updating convId (${conversationId.toLogString()}) to ($isConversationArchived")
+                ArchiveStatusUpdateResult.Failure
+            }, {
+                ArchiveStatusUpdateResult.Success
+            })
+
+}
+
+sealed class ArchiveStatusUpdateResult {
+    object Success : ArchiveStatusUpdateResult()
+    object Failure : ArchiveStatusUpdateResult()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
@@ -55,7 +55,8 @@ internal class UpdateConversationMutedStatusUseCaseImpl(
             .flatMap {
                 conversationRepository.updateMutedStatusLocally(conversationId, mutedConversationStatus, mutedStatusTimestamp)
             }.fold({
-                kaliumLogger.e("Something went wrong when updating the convId (${conversationId.toLogString()}) to (${mutedConversationStatus.status}")
+                kaliumLogger.e("Something went wrong when updating the convId: " +
+                        "(${conversationId.toLogString()}) to (${mutedConversationStatus.status}")
                 ConversationUpdateStatusResult.Failure
             }, {
                 ConversationUpdateStatusResult.Success

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
@@ -55,7 +55,7 @@ internal class UpdateConversationMutedStatusUseCaseImpl(
             .flatMap {
                 conversationRepository.updateMutedStatusLocally(conversationId, mutedConversationStatus, mutedStatusTimestamp)
             }.fold({
-                kaliumLogger.e("Something went wrong when updating the convId ($conversationId) to (${mutedConversationStatus.status}")
+                kaliumLogger.e("Something went wrong when updating the convId (${conversationId.toLogString()}) to (${mutedConversationStatus.status}")
                 ConversationUpdateStatusResult.Failure
             }, {
                 ConversationUpdateStatusResult.Success

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
@@ -53,6 +53,18 @@ internal class MemberChangeEventHandlerImpl(
                     )
             }
 
+            is Event.Conversation.MemberChanged.MemberArchivedStatusChanged -> {
+                conversationRepository.updateArchivedStatusLocally(
+                    event.conversationId,
+                    event.isArchiving,
+                    DateTimeUtil.currentInstant().toEpochMilliseconds()
+                )
+                kaliumLogger.logEventProcessing(
+                    EventLoggingStatus.SUCCESS,
+                    event
+                )
+            }
+
             is Event.Conversation.MemberChanged.MemberChangedRole -> {
                 // Attempt to fetch conversation details if needed, as this might be an unknown conversation
                 conversationRepository.fetchConversationIfUnknown(event.conversationId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
@@ -66,37 +66,7 @@ internal class MemberChangeEventHandlerImpl(
             }
 
             is Event.Conversation.MemberChanged.MemberChangedRole -> {
-                // Attempt to fetch conversation details if needed, as this might be an unknown conversation
-                conversationRepository.fetchConversationIfUnknown(event.conversationId)
-                    .run {
-                        onSuccess {
-                            val logMap = mapOf(
-                                "event" to event.toLogMap(),
-                            )
-                            logger.v("Succeeded fetching conversation details on MemberChange Event: ${logMap.toJsonElement()}")
-                        }
-                        onFailure {
-                            val logMap = mapOf(
-                                "event" to event.toLogMap(),
-                                "errorInfo" to "$it"
-                            )
-                            logger.w("Failure fetching conversation details on MemberChange Event: ${logMap.toJsonElement()}")
-                        }
-                        // Even if unable to fetch conversation details, at least attempt updating the member
-                        conversationRepository.updateMemberFromEvent(event.member!!, event.conversationId)
-                    }.onFailure {
-                        val logMap = mapOf(
-                            "event" to event.toLogMap(),
-                            "errorInfo" to "$it"
-                        )
-                        logger.e("Error Handling Event: ${logMap.toJsonElement()}")
-                    }.onSuccess {
-                        kaliumLogger
-                            .logEventProcessing(
-                                EventLoggingStatus.SUCCESS,
-                                event
-                            )
-                    }
+                handleMemberChangedRoleEvent(event)
             }
 
             else -> {
@@ -108,5 +78,39 @@ internal class MemberChangeEventHandlerImpl(
                     )
             }
         }
+    }
+
+    private suspend fun handleMemberChangedRoleEvent(event: Event.Conversation.MemberChanged.MemberChangedRole) {
+        // Attempt to fetch conversation details if needed, as this might be an unknown conversation
+        conversationRepository.fetchConversationIfUnknown(event.conversationId)
+            .run {
+                onSuccess {
+                    val logMap = mapOf(
+                        "event" to event.toLogMap(),
+                    )
+                    logger.v("Succeeded fetching conversation details on MemberChange Event: ${logMap.toJsonElement()}")
+                }
+                onFailure {
+                    val logMap = mapOf(
+                        "event" to event.toLogMap(),
+                        "errorInfo" to "$it"
+                    )
+                    logger.w("Failure fetching conversation details on MemberChange Event: ${logMap.toJsonElement()}")
+                }
+                // Even if unable to fetch conversation details, at least attempt updating the member
+                conversationRepository.updateMemberFromEvent(event.member!!, event.conversationId)
+            }.onFailure {
+                val logMap = mapOf(
+                    "event" to event.toLogMap(),
+                    "errorInfo" to "$it"
+                )
+                logger.e("Error Handling Event: ${logMap.toJsonElement()}")
+            }.onSuccess {
+                kaliumLogger
+                    .logEventProcessing(
+                        EventLoggingStatus.SUCCESS,
+                        event
+                    )
+            }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -410,7 +410,7 @@ class ConversationRepositoryTest {
             .wasInvoked(exactly = once)
 
         verify(arrangement.conversationDAO)
-            .suspendFunction(arrangement.conversationDAO::updateConversationMutedStatus)
+            .suspendFunction(arrangement.conversationDAO::updateConversationArchivedStatus)
             .with(any(), any(), any())
             .wasNotInvoked()
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -369,7 +369,7 @@ class ConversationRepositoryTest {
         }
 
     @Test
-    fun whenCallingUpdateMutedStatusRemotly_thenShouldDelegateCallToConversationApi() = runTest {
+    fun whenCallingUpdateMutedStatusRemotely_thenShouldDelegateCallToConversationApi() = runTest {
         val (arrangement, conversationRepository) = Arrangement()
             .withUpdateConversationMemberStateResult(NetworkResponse.Success(Unit, mapOf(), HttpStatusCode.OK.value))
             .arrange()
@@ -377,6 +377,30 @@ class ConversationRepositoryTest {
         conversationRepository.updateMutedStatusRemotely(
             TestConversation.ID,
             MutedConversationStatus.AllMuted,
+            DateTimeUtil.currentInstant().toEpochMilliseconds()
+        )
+
+        verify(arrangement.conversationApi)
+            .suspendFunction(arrangement.conversationApi::updateConversationMemberState)
+            .with(any(), any())
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.conversationDAO)
+            .suspendFunction(arrangement.conversationDAO::updateConversationMutedStatus)
+            .with(any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun whenCallingUpdateArchivedStatusRemotely_thenShouldDelegateCallToConversationApi() = runTest {
+        val isArchived = false
+        val (arrangement, conversationRepository) = Arrangement()
+            .withUpdateConversationMemberStateResult(NetworkResponse.Success(Unit, mapOf(), HttpStatusCode.OK.value))
+            .arrange()
+
+        conversationRepository.updateArchivedStatusRemotely(
+            TestConversation.ID,
+            isArchived,
             DateTimeUtil.currentInstant().toEpochMilliseconds()
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
@@ -49,6 +49,15 @@ class ConversationStatusMapperTest {
     }
 
     @Test
+    fun givenAConversationModelWithArchivedField_whenMappingToApiModel_thenTheMappingStatusesShouldBeOk() {
+        val isArchived = true
+        val result = conversationStatusMapper.toArchivedStatusApiModel(isArchived = isArchived, 1649708697237L)
+
+        assertEquals(isArchived, result.otrArchived)
+        assertEquals("2022-04-11T20:24:57.237Z", result.otrArchivedRef)
+    }
+
+    @Test
     fun givenAConversationModel_whenMappingToDaoModel_thenTheMappingStatusesShouldBeOk() {
         val result = conversationStatusMapper.toMutedStatusDaoModel(MutedConversationStatus.OnlyMentionsAndRepliesAllowed)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCaseTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UpdateConversationArchivedStatusUseCaseTest {
+    @Mock
+    private val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
+
+    private lateinit var updateConversationArchivedStatus: UpdateConversationArchivedStatusUseCase
+
+    @BeforeTest
+    fun setup() {
+        updateConversationArchivedStatus = UpdateConversationArchivedStatusUseCaseImpl(conversationRepository)
+    }
+
+    @Test
+    fun givenAConversationId_whenInvokingAnArchivedStatusChange_thenShouldDelegateTheCallAndReturnASuccessResult() = runTest {
+        val conversationId = TestConversation.ID
+        val isConversationArchived = true
+        val archivedStatusTimestamp = 123456789L
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::updateArchivedStatusRemotely)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(Either.Right(Unit))
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::updateArchivedStatusLocally)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(Either.Right(Unit))
+
+        val result = updateConversationArchivedStatus(conversationId, isConversationArchived, archivedStatusTimestamp)
+        assertEquals(ArchiveStatusUpdateResult.Success::class, result::class)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::updateArchivedStatusRemotely)
+            .with(any(), eq(isConversationArchived), matching { it == archivedStatusTimestamp})
+            .wasInvoked(exactly = once)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::updateArchivedStatusLocally)
+            .with(any(), eq(isConversationArchived), matching { it == archivedStatusTimestamp})
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAConversationId_whenInvokingAnArchivedStatusChangeAndFails_thenShouldDelegateTheCallAndReturnAFailureResult() = runTest {
+        val conversationId = TestConversation.ID
+        val isConversationArchived = true
+        val archivedStatusTimestamp = 123456789L
+
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::updateArchivedStatusRemotely)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(Either.Left(NetworkFailure.ServerMiscommunication(RuntimeException("some error"))))
+
+        val result = updateConversationArchivedStatus(conversationId, isConversationArchived, archivedStatusTimestamp)
+        assertEquals(ArchiveStatusUpdateResult.Failure::class, result::class)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::updateArchivedStatusRemotely)
+            .with(any(), eq(isConversationArchived), matching { it == archivedStatusTimestamp})
+            .wasInvoked(exactly = once)
+
+        verify(conversationRepository)
+            .suspendFunction(conversationRepository::updateArchivedStatusLocally)
+            .with(any(), eq(isConversationArchived), matching { it == archivedStatusTimestamp})
+            .wasNotInvoked()
+
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -68,6 +68,15 @@ object TestEvent {
         "2022-03-30T15:36:00.000Zp"
     )
 
+    fun memberChangeArchivedStatus(eventId: String = "eventId", isArchiving: Boolean = true) = Event.Conversation.MemberChanged.MemberArchivedStatusChanged(
+        eventId,
+        TestConversation.ID,
+        "2022-03-30T15:36:00.000Z",
+        false,
+        "2022-03-31T16:36:00.000Zp",
+        isArchiving,
+    )
+
     fun memberChangeIgnored(eventId: String = "eventId") = Event.Conversation.MemberChanged.IgnoredMemberChanged(
         eventId,
         TestConversation.ID,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationEvent.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationEvent.kt
@@ -46,6 +46,8 @@ data class ConversationRoleChange(
     @SerialName("conversation_role") val role: String?,
     @SerialName("otr_muted_ref") val mutedRef: String?,
     @SerialName("otr_muted_status") val mutedStatus: Int?,
+    @SerialName("otr_archived") val isArchiving: Boolean?,
+    @SerialName("otr_archived_ref") val archivedRef: String?,
 )
 
 @Serializable

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -272,6 +272,11 @@ UPDATE Conversation
 SET muted_status = ?, muted_time = ?
 WHERE qualified_id = ?;
 
+updateConversationArchivingStatus:
+UPDATE Conversation
+SET archived = ?, archived_date_time = ?
+WHERE qualified_id = ?;
+
 updateAccess:
 UPDATE Conversation SET access_list= ?, access_role_list = ? WHERE qualified_id = ?;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -58,6 +58,12 @@ interface ConversationDAO {
         mutedStatusTimestamp: Long
     )
 
+    suspend fun updateConversationArchivedStatus(
+        conversationId: QualifiedIDEntity,
+        isArchived:Boolean,
+        archivedStatusTimestamp: Long
+    )
+
     suspend fun updateAccess(
         conversationID: QualifiedIDEntity,
         accessList: List<ConversationEntity.Access>,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -60,7 +60,7 @@ interface ConversationDAO {
 
     suspend fun updateConversationArchivedStatus(
         conversationId: QualifiedIDEntity,
-        isArchived:Boolean,
+        isArchived: Boolean,
         archivedStatusTimestamp: Long
     )
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -224,8 +224,12 @@ internal class ConversationDAOImpl internal constructor(
         conversationId: QualifiedIDEntity,
         isArchived: Boolean,
         archivedStatusTimestamp: Long
-    ) = withContext(coroutineContext){
-        conversationQueries.updateConversationArchivingStatus(isArchived, archivedStatusTimestamp.toIsoDateTimeString().toInstant(), conversationId)
+    ) = withContext(coroutineContext) {
+        conversationQueries.updateConversationArchivingStatus(
+            isArchived,
+            archivedStatusTimestamp.toIsoDateTimeString().toInstant(),
+            conversationId
+        )
     }
 
     override suspend fun updateAccess(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.util.mapToList
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -217,6 +218,14 @@ internal class ConversationDAOImpl internal constructor(
         mutedStatusTimestamp: Long
     ) = withContext(coroutineContext) {
         conversationQueries.updateConversationMutingStatus(mutedStatus, mutedStatusTimestamp, conversationId)
+    }
+
+    override suspend fun updateConversationArchivedStatus(
+        conversationId: QualifiedIDEntity,
+        isArchived: Boolean,
+        archivedStatusTimestamp: Long
+    ) = withContext(coroutineContext){
+        conversationQueries.updateConversationArchivingStatus(isArchived, archivedStatusTimestamp.toIsoDateTimeString().toInstant(), conversationId)
     }
 
     override suspend fun updateAccess(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The `otr_archived` field was recently added on our Conversation DB schema, and also on the api conversation response when handling Conversation objects in general. Therefore the next logical step was to add the needed operations on the data and domain layers in order to manipulate and update this field in isolation.


### Solutions

- Added `isArchiving` and `archivedRef` fields to the `ConversationEvent` model object.
- Added the needed operations on the `ConversationRepository` class to update the archived field both locally and remotely.
- Added `MemberArchivedStatusChanged` event to listen to changes on the conversations via websocket.
- Added `UpdateConversationArchivedStatusUseCase`.
- Tests.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
