### PR TITLE
fix: sync failing when trying to update unknown user [WPB-4805]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -18,6 +18,8 @@
 
 package com.wire.kalium.logic.sync.receiver
 
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -41,6 +43,7 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 
 class UserEventReceiverTest {
 
@@ -119,12 +122,37 @@ class UserEventReceiverTest {
             .withUpdateUserSuccess()
             .arrange()
 
-        eventReceiver.onEvent(event)
+        val result = eventReceiver.onEvent(event)
 
+        assertIs<Either.Right<Unit>>(result)
         verify(arrangement.userRepository)
             .suspendFunction(arrangement.userRepository::updateUserFromEvent)
             .with(any())
             .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenUserUpdateEvent_whenUserIsNotFoundInLocalDB_thenShouldIgnoreThisEventFailure() = runTest {
+        val event = TestEvent.updateUser(userId = OTHER_USER_ID)
+        val (_, eventReceiver) = Arrangement()
+            .withUpdateUserFailure(StorageFailure.DataNotFound)
+            .arrange()
+
+        val result = eventReceiver.onEvent(event)
+
+        assertIs<Either.Right<Unit>>(result)
+    }
+
+    @Test
+    fun givenUserUpdateEvent_whenFailsWitOtherError_thenShouldFail() = runTest {
+        val event = TestEvent.updateUser(userId = OTHER_USER_ID)
+        val (_, eventReceiver) = Arrangement()
+            .withUpdateUserFailure(StorageFailure.Generic(Throwable("error")))
+            .arrange()
+
+        val result = eventReceiver.onEvent(event)
+
+        assertIs<Either.Left<StorageFailure.Generic>>(result)
     }
 
     @Test
@@ -194,6 +222,11 @@ class UserEventReceiverTest {
 
         fun withUpdateUserSuccess() = apply {
             given(userRepository).suspendFunction(userRepository::updateUserFromEvent).whenInvokedWith(any()).thenReturn(Either.Right(Unit))
+        }
+
+        fun withUpdateUserFailure(coreFailure: CoreFailure) = apply {
+            given(userRepository).suspendFunction(userRepository::updateUserFromEvent)
+                .whenInvokedWith(any()).thenReturn(Either.Left(coreFailure))
         }
 
         fun withUserDeleteSuccess() = apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The user is "stuck in connecting" after another user was added and removed from the team while he/she was offline.

### Causes (Optional)

The app is stuck, because, while being offline, the other user was added and removed from the team we are in, so when we are back online, we receive `team.memberjoin`, `user.update` and only then `team.memberleave`. At the time we handle first one, the user is no longer in the team, so we get `404` when fetching user data and this user is not added to our local db. We ignore errors for team-specific events so it moves to handling the next one, which is `user.update` and again - we can’t handle it because we can’t update the user that’s not in our local db, but this time it results in a sync failure. `lastProcessedEventId` is not being updated because of this failure so it loops indefinitely when we retry the sync, because we try to handle the same event again.

### Solutions

If the user that we want to update is not found in the local db, it means that this user is not in my team, is not my contact nor member of any of groups that I'm in. This means, that we can just safely ignore this event and move on to handle next ones without a failure.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

STR:

- log in using the team member account A
- terminate the app to be sure it’s offline
- invite another member B to the team 
- join to the team by member B and set up the user handle (it probably creates `user.update` event)
- remove this new member B from the team
- open the app with user A logged in and it’s stuck

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
