### PR TITLE
fix: search users not filtering correctly users connected when domain present (WPB-4793)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
@@ -60,16 +60,18 @@ internal class SearchKnownUsersUseCaseImpl(
         val sanitizedSearchQuery = searchQuery.lowercase()
         return if (isUserLookingForHandle(sanitizedSearchQuery)) {
             searchUserRepository.searchKnownUsersByHandle(
-                handle = sanitizedSearchQuery.removePrefix("@"),
+                handle = sanitizedSearchQuery.substringAfter('@').substringBeforeLast('@'),
                 searchUsersOptions = searchUsersOptions
             )
         } else {
             searchUserRepository.searchKnownUsersByNameOrHandleOrEmail(
-                searchQuery = if (sanitizedSearchQuery.matches(FEDERATION_REGEX))
+                searchQuery = if (sanitizedSearchQuery.matches(FEDERATION_REGEX)) {
                     sanitizedSearchQuery.run {
                         qualifiedIdMapper.fromStringToQualifiedID(this)
                     }.value
-                else sanitizedSearchQuery,
+                } else {
+                    sanitizedSearchQuery.removeSuffix("@")
+                },
                 searchUsersOptions = searchUsersOptions
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
@@ -60,7 +60,7 @@ internal class SearchKnownUsersUseCaseImpl(
         val sanitizedSearchQuery = searchQuery.lowercase()
         return if (isUserLookingForHandle(sanitizedSearchQuery)) {
             searchUserRepository.searchKnownUsersByHandle(
-                handle = sanitizedSearchQuery.substringAfter('@').substringBeforeLast('@'),
+                handle = sanitizedSearchQuery.substringAfter("@").substringBeforeLast("@"),
                 searchUsersOptions = searchUsersOptions
             )
         } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/publicuser/search/SearchKnownUsersUseCase.kt
@@ -60,7 +60,7 @@ internal class SearchKnownUsersUseCaseImpl(
         val sanitizedSearchQuery = searchQuery.lowercase()
         return if (isUserLookingForHandle(sanitizedSearchQuery)) {
             searchUserRepository.searchKnownUsersByHandle(
-                handle = sanitizedSearchQuery.substringAfter("@").substringBeforeLast("@"),
+                handle = sanitizedSearchQuery.sanitizeHandleSearchPattern(),
                 searchUsersOptions = searchUsersOptions
             )
         } else {
@@ -89,3 +89,5 @@ internal class SearchKnownUsersUseCaseImpl(
     }
 
 }
+
+internal fun String.sanitizeHandleSearchPattern() = this.substringAfter("@").substringBefore("@")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/SearchKnownUserUseCaseTest.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCaseImpl
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersResult
+import com.wire.kalium.logic.feature.publicuser.search.sanitizeHandleSearchPattern
 import com.wire.kalium.logic.framework.TestUser
 import io.mockative.Mock
 import io.mockative.any
@@ -276,7 +277,6 @@ class SearchKnownUserUseCaseTest {
             .wasNotInvoked()
     }
 
-
     private class Arrangement {
 
         @Mock
@@ -318,7 +318,7 @@ class SearchKnownUserUseCaseTest {
             given(searchUserRepository)
                 .suspendFunction(searchUserRepository::searchKnownUsersByHandle)
                 .whenInvokedWith(
-                    if (searchQuery == null) any() else eq(searchQuery.substringAfter("@").substringBeforeLast("@")),
+                    if (searchQuery == null) any() else eq(searchQuery.sanitizeHandleSearchPattern()),
                     if (searchUsersOptions == null) any() else eq(searchUsersOptions)
                 )
                 .thenReturn(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When searching for users, if the domain is present, or in detail "@" present, we were not getting users from DB, considering this user as a not connected (having side effects like send a connection request again) This was caused by considering "@" as part of the search term.

### Solutions

Sanitize correctly the search term, so contacts are retrieved correctly if in DB.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
