### PR TITLE
feat(mls): update supported protocols on client deletion

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1364,7 +1364,9 @@ class UserSessionScope internal constructor(
             userRepository,
             authenticationScope.secondFactorVerificationRepository,
             slowSyncRepository,
-            cachedClientIdClearer
+            cachedClientIdClearer,
+            users.updateSupportedProtocols,
+            oneOnOneResolver
         )
     val conversations: ConversationScope
         get() = ConversationScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.CachedClientIdClearer
 import com.wire.kalium.logic.feature.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.ProteusClientProvider
+import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCase
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCaseImpl
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCase
@@ -42,6 +43,7 @@ import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCaseImpl
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCase
 import com.wire.kalium.logic.feature.session.DeregisterTokenUseCaseImpl
 import com.wire.kalium.logic.feature.session.UpgradeCurrentSessionUseCase
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCase
 import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCase
 import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCaseImpl
 import com.wire.kalium.util.DelicateKaliumApi
@@ -66,7 +68,9 @@ class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
     private val userRepository: UserRepository,
     private val secondFactorVerificationRepository: SecondFactorVerificationRepository,
     private val slowSyncRepository: SlowSyncRepository,
-    private val cachedClientIdClearer: CachedClientIdClearer
+    private val cachedClientIdClearer: CachedClientIdClearer,
+    private val updateSupportedProtocols: UpdateSupportedProtocolsUseCase,
+    private val oneOnOneResolver: OneOnOneResolver
 ) {
     @OptIn(DelicateKaliumApi::class)
     val register: RegisterClientUseCase
@@ -85,7 +89,13 @@ class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
 
     val selfClients: FetchSelfClientsFromRemoteUseCase get() = FetchSelfClientsFromRemoteUseCaseImpl(clientRepository, clientIdProvider)
     val observeClientDetailsUseCase: ObserveClientDetailsUseCase get() = ObserveClientDetailsUseCaseImpl(clientRepository, clientIdProvider)
-    val deleteClient: DeleteClientUseCase get() = DeleteClientUseCaseImpl(clientRepository)
+    val deleteClient: DeleteClientUseCase
+        get() = DeleteClientUseCaseImpl(
+            clientRepository,
+            updateSupportedProtocols,
+            userRepository,
+            oneOnOneResolver
+        )
     val needsToRegisterClient: NeedsToRegisterClientUseCase
         get() = NeedsToRegisterClientUseCaseImpl(clientIdProvider, sessionRepository, proteusClientProvider, selfUserId)
     val deregisterNativePushToken: DeregisterTokenUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCase.kt
@@ -22,7 +22,12 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.DeleteClientParam
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCase
+import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isBadRequest
 import com.wire.kalium.network.exceptions.isInvalidCredentials
@@ -36,9 +41,24 @@ interface DeleteClientUseCase {
     suspend operator fun invoke(param: DeleteClientParam): DeleteClientResult
 }
 
-class DeleteClientUseCaseImpl(private val clientRepository: ClientRepository) : DeleteClientUseCase {
+internal class DeleteClientUseCaseImpl(
+    private val clientRepository: ClientRepository,
+    private val updateSupportedProtocols: UpdateSupportedProtocolsUseCase,
+    private val userRepository: UserRepository,
+    private val oneOnOneResolver: OneOnOneResolver
+) : DeleteClientUseCase {
     override suspend operator fun invoke(param: DeleteClientParam): DeleteClientResult =
-        clientRepository.deleteClient(param).fold(
+        clientRepository.deleteClient(param)
+            .onSuccess {
+                updateSupportedProtocols().onSuccess { updated ->
+                    if (updated) {
+                        userRepository.fetchAllOtherUsers().flatMap {
+                            oneOnOneResolver.resolveAllOneOnOneConversations()
+                        }
+                    }
+                }
+            }
+            .fold(
             {
                 handleError(it)
             }, {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.isRight
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.nullableFold
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
@@ -82,7 +83,7 @@ internal class SlowSyncWorkerImpl(
 
         performStep(SlowSyncStep.SELF_USER, syncSelfUser::invoke)
             .continueWithStep(SlowSyncStep.FEATURE_FLAGS, syncFeatureConfigs::invoke)
-            .continueWithStep(SlowSyncStep.UPDATE_SUPPORTED_PROTOCOLS, updateSupportedProtocols::invoke)
+            .continueWithStep(SlowSyncStep.UPDATE_SUPPORTED_PROTOCOLS) { updateSupportedProtocols.invoke().map { } }
             .continueWithStep(SlowSyncStep.CONVERSATIONS, syncConversations::invoke)
             .continueWithStep(SlowSyncStep.CONNECTIONS, syncConnections::invoke)
             .continueWithStep(SlowSyncStep.SELF_TEAM, syncSelfTeam::invoke)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
@@ -594,7 +594,7 @@ class SlowSyncWorkerTest {
             given(updateSupportedProtocols)
                 .suspendFunction(updateSupportedProtocols::invoke)
                 .whenInvoked()
-                .thenReturn(success)
+                .thenReturn(Either.Right(true))
         }
 
         fun withUpdateSupportedProtocolsFailure() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/UserRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/UserRepositoryArrangement.kt
@@ -44,6 +44,8 @@ internal interface UserRepositoryArrangement {
     fun withGetKnownUserReturning(result: Flow<OtherUser?>)
 
     fun withGetUsersWithOneOnOneConversationReturning(result: List<OtherUser>)
+
+    fun withFetchAllOtherUsersReturning(result: Either<CoreFailure, Unit>)
 }
 
 internal class UserRepositoryArrangementImpl: UserRepositoryArrangement {
@@ -95,4 +97,12 @@ internal class UserRepositoryArrangementImpl: UserRepositoryArrangement {
             .whenInvoked()
             .thenReturn(result)
     }
+
+    override fun withFetchAllOtherUsersReturning(result: Either<CoreFailure, Unit>) {
+        given(userRepository)
+            .suspendFunction(userRepository::fetchAllOtherUsers)
+            .whenInvoked()
+            .thenReturn(result)
+    }
+
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When a user delete's a client it could be the last active proteus client which gets delete. We should therefore update supported protocol of the self user after deleting a client. And since we might now support MLS we should also resolve the active conversation for all 1-1 connections.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
