### PR TITLE
fix: map and ignore BufferedFutureMessage

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/CoreCryptoExceptionMapper.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/CoreCryptoExceptionMapper.kt
@@ -25,6 +25,7 @@ actual fun mapMLSException(exception: Exception): MLSFailure =
             when (exception.error) {
                 is CryptoError.WrongEpoch -> MLSFailure.WrongEpoch
                 is CryptoError.DuplicateMessage -> MLSFailure.DuplicateMessage
+                is CryptoError.BufferedFutureMessage -> MLSFailure.BufferedFutureMessage
                 is CryptoError.SelfCommitIgnored -> MLSFailure.SelfCommitIgnored
                 is CryptoError.UnmergedPendingGroup -> MLSFailure.UnmergedPendingGroup
                 is CryptoError.ConversationAlreadyExists -> MLSFailure.ConversationAlreadyExists

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -172,6 +172,8 @@ interface MLSFailure : CoreFailure {
 
     object DuplicateMessage : MLSFailure
 
+    object BufferedFutureMessage : MLSFailure
+
     object SelfCommitIgnored : MLSFailure
 
     object UnmergedPendingGroup : MLSFailure

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
@@ -29,11 +29,13 @@ sealed class MLSMessageFailureResolution {
 internal object MLSMessageFailureHandler {
     fun handleFailure(failure: CoreFailure): MLSMessageFailureResolution {
         return when (failure) {
-            // Received messages targeting a future epoch, we might have lost messages.
+            // Received messages targeting a future epoch (outside epoch bounds), we might have lost messages.
             is MLSFailure.WrongEpoch -> MLSMessageFailureResolution.OutOfSync
             // Received already sent or received message, can safely be ignored.
             is MLSFailure.DuplicateMessage -> MLSMessageFailureResolution.Ignore
-            // Received self commit, any unmerged group has know when merged by CoreCrypto.
+            // Received message was targeting a future epoch and been buffered, can safely be ignored.
+            is MLSFailure.BufferedFutureMessage -> MLSMessageFailureResolution.Ignore
+            // Received self commit, any unmerged group has know been when merged by CoreCrypto.
             is MLSFailure.SelfCommitIgnored -> MLSMessageFailureResolution.Ignore
             // Message arrive in an unmerged group, it has been buffered and will be consumed later.
             is MLSFailure.UnmergedPendingGroup -> MLSMessageFailureResolution.Ignore


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When decrypting a message targeting a future epoch CC will buffer the message until the commit arrives. When this happens CC will throw a `BufferedFutureMessage` error which we should ignore.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
