### PR TITLE
fix: add LocalNotification SelfDeleteKnock (WPB-3175)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -186,7 +186,7 @@ class MessageMapperImpl(
         )
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "LongMethod")
     override fun fromMessageToLocalNotificationMessage(
         message: NotificationMessageEntity
     ): LocalNotificationMessage? {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -195,10 +195,16 @@ class MessageMapperImpl(
             message.senderImage?.toModel()
         )
         if (message.isSelfDelete) {
-            return LocalNotificationMessage.SelfDeleteMessage(
-                message.id,
-                message.date
-            )
+            return when (message.contentType) {
+                MessageEntity.ContentType.KNOCK -> LocalNotificationMessage.SelfDeleteKnock(
+                    message.id,
+                    message.date
+                )
+                else -> LocalNotificationMessage.SelfDeleteMessage(
+                    message.id,
+                    message.date
+                )
+            }
         }
         return when (message.contentType) {
             MessageEntity.ContentType.TEXT -> LocalNotificationMessage.Text(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
@@ -57,6 +57,11 @@ sealed class LocalNotificationMessage(
         override val time: Instant
     ) : LocalNotificationMessage(messageId, null, time)
 
+    data class SelfDeleteKnock(
+        override val messageId: String,
+        override val time: Instant
+    ) : LocalNotificationMessage(messageId, null, time)
+
     data class Text(
         override val messageId: String,
         override val author: LocalNotificationMessageAuthor,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
This PR only adds `LocalNotificationMessage.SelfDeleteKnock` and its mapping needed for AR PR : https://github.com/wireapp/wire-android-reloaded/pull/2269
