### PR TITLE
fix: network logging not getting enabled

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
@@ -22,6 +22,7 @@ import co.touchlab.kermit.LogWriter
 import com.wire.kalium.cryptography.CryptographyLogger
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.network.NetworkLogger
 import com.wire.kalium.network.NetworkUtilLogger
 import com.wire.kalium.persistence.PersistenceLogger
 
@@ -46,6 +47,7 @@ object CoreLogger {
             logWriters = logWriters
         )
 
+        NetworkLogger.setLoggingLevel(level = level, logWriters = logWriters)
         NetworkUtilLogger.setLoggingLevel(level = level, logWriters = logWriters)
         CryptographyLogger.setLoggingLevel(level = level, logWriters = logWriters)
         PersistenceLogger.setLoggingLevel(level = level, logWriters = logWriters)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

RC copy of:  https://github.com/wireapp/kalium/pull/2030

### Issues

Network logs are missing

### Causes

Network logger activation is missing for CoreLogger.

### Solutions

Add it back.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
