### PR TITLE
chore: proteus add log entries when generating prekeys

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepository.kt
@@ -33,6 +33,9 @@ import com.wire.kalium.logic.feature.message.CryptoSessionMapper
 import com.wire.kalium.logic.feature.message.CryptoSessionMapperImpl
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapProteusRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -151,7 +154,15 @@ class PreKeyDataSource(
         firstKeyId: Int,
         keysCount: Int
     ): Either<ProteusFailure, List<PreKeyCrypto>> =
-        wrapProteusRequest { proteusClientProvider.getOrCreate().newPreKeys(firstKeyId, keysCount) }
+        wrapProteusRequest { proteusClientProvider.getOrCreate().newPreKeys(firstKeyId, keysCount) }.onSuccess {
+            kaliumLogger.i(
+                """Generating PreKeys: {"success":true,"firstKeyId":$firstKeyId,"$keysCount":$keysCount}"""
+            )
+        }.onFailure {
+            kaliumLogger.i(
+                """Generating PreKeys: {"success":false,"firstKeyId":$firstKeyId, "$keysCount":$keysCount}"""
+            )
+        }
 
     override suspend fun generateNewLastResortKey(): Either<ProteusFailure, PreKeyCrypto> =
         wrapProteusRequest {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We don't have information abot prekey generation on Proteus.

### Solutions

Add log entries for generation of prekeys so we can debug what IDs are being generated and we can understand if there's a rollover (old prekeys being overwritten by new ones with the same IDs).


### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
