### PR TITLE
fix(proteus): call correct endpoint for uploading prekeys

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/PreKeyApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/PreKeyApiV0.kt
@@ -55,7 +55,7 @@ internal open class PreKeyApiV0 internal constructor(
 
     override suspend fun uploadNewPrekeys(clientId: String, preKeys: List<PreKeyDTO>): NetworkResponse<Unit> =
         wrapKaliumResponse {
-            httpClient.put("$PATH_CLIENTS/$clientId/$PATH_PRE_KEY") {
+            httpClient.put("$PATH_CLIENTS/$clientId") {
                 setBody(UploadPreKeysRequest(preKeys))
             }
         }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/prekey/PrekeyApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/prekey/PrekeyApiV0Test.kt
@@ -83,10 +83,12 @@ internal class PrekeyApiV0Test : ApiTest() {
     @Test
     fun givenPreKeyAndClientId_whenUploadingPreKeys_thenTheRequestIsConfiguredCorrectly() = runTest {
         val preKeyDTO = PreKeyDTO(42, "testKey")
+        val clientId = "testClientId"
         val networkClient = mockAuthenticatedNetworkClient(
             responseBody = "",
             statusCode = HttpStatusCode.OK,
             assertion = {
+                assertPathEqual("/clients/$clientId")
                 assertJson()
                 assertJsonBodyContent(
                     """
@@ -103,7 +105,7 @@ internal class PrekeyApiV0Test : ApiTest() {
             }
         )
         val preKeyApi: PreKeyApi = PreKeyApiV0(networkClient)
-        val response = preKeyApi.uploadNewPrekeys("clientId", listOf(preKeyDTO))
+        val response = preKeyApi.uploadNewPrekeys(clientId, listOf(preKeyDTO))
         assertTrue(response.isSuccessful())
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When uploading new prekeys, we're calling the wrong endpoint.

### Causes

![giphy](https://github.com/wireapp/kalium/assets/9389043/f9f0e84c-b016-4ead-b013-4d50a21204a7)

### Solutions

Fix the path to call the correct endpoint (PUT to `/client/{clientId}`).

This, by itself should not cause breaking issues, but if there's any prekey rollover, it could lead to `INVALID_SIGNATURE` errors.

On a side note, I've added logs to the prekey generation in

- #2092

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
