### PR TITLE
fix: fixed wrong query in `ConversationDAO` to fetch all conversations

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.cryptography.utils.AES256Key
 import com.wire.kalium.cryptography.utils.EncryptedData
 import com.wire.kalium.cryptography.utils.decryptDataWithAES256
 import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.event.Event
@@ -75,7 +76,18 @@ internal class ProteusMessageUnpackerImpl(
             .onFailure {
                 when (it) {
                     is CoreFailure.Unknown -> logger.e("UnknownFailure when processing message: $it", it.rootCause)
-                    is ProteusFailure -> logger.e("ProteusFailure when processing message: ${it.proteusException.code.name}")
+
+                    is ProteusFailure -> {
+                        val loggableException =
+                            "{ \"code\": \"${it.proteusException.code.name}\", \"message\": \"${it.proteusException.message}\", " +
+                                    "\"error\": \"${it.proteusException.stackTraceToString()}\"," +
+                                    "\"senderClientId\": \"${event.senderClientId.value.obfuscateId()}\"," +
+                                    "\"senderUserId\": \"${event.senderUserId.value.obfuscateId()}\"," +
+                                    "\"cryptoClientId\": \"${cryptoSessionId.cryptoClientId.value.obfuscateId()}\"," +
+                                    "\"cryptoUserId\": \"${cryptoSessionId.userId.value.obfuscateId()}\"}"
+                        logger.e("ProteusFailure when processing message detail: $loggableException")
+                    }
+
                     else -> logger.e("Failure when processing message: $it")
                 }
             }.map { readableContent ->

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -240,7 +240,7 @@ WHERE
     OR (type IS 'ONE_ON_ONE' AND userDeleted = 1) -- show deleted 1:1 convos, to maintain prev, logic
     )
     AND (protocol IS 'PROTEUS' OR (protocol IS 'MLS' AND mls_group_state IS 'ESTABLISHED'))
-    AND archived = 0 OR archived = :isArchived
+    AND (archived = 0 OR archived = :isArchived)
 ORDER BY lastModifiedDate DESC, name IS NULL, name COLLATE NOCASE ASC;
 
 selectAllConversations:

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -240,7 +240,7 @@ WHERE
     OR (type IS 'ONE_ON_ONE' AND userDeleted = 1) -- show deleted 1:1 convos, to maintain prev, logic
     )
     AND (protocol IS 'PROTEUS' OR (protocol IS 'MLS' AND mls_group_state IS 'ESTABLISHED'))
-    AND archived = ?
+    AND archived = 0 OR archived = :isArchived
 ORDER BY lastModifiedDate DESC, name IS NULL, name COLLATE NOCASE ASC;
 
 selectAllConversations:

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.persistence.dao.asset.AssetDAO
 import com.wire.kalium.persistence.dao.asset.AssetEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
+import com.wire.kalium.persistence.dao.conversation.ConversationMapper
 import com.wire.kalium.persistence.dao.conversation.ConversationViewEntity
 import com.wire.kalium.persistence.dao.conversation.MLS_DEFAULT_LAST_KEY_MATERIAL_UPDATE_MILLI
 import com.wire.kalium.persistence.dao.conversation.ProposalTimerEntity
@@ -859,6 +860,24 @@ class ConversationDAOTest : BaseDatabaseTest() {
             assertEquals(1, it.size)
             assertEquals(conversationEntity1.id, it.first().id)
         }
+    }
+
+    @Test
+    fun givenLocalConversations_whenGettingAllArchivedAndNotArchivedConversations_thenShouldReturnThemAll() = runTest {
+        val includeArchived = true
+        conversationDAO.insertConversation(conversationEntity1.copy(archived = true))
+        conversationDAO.insertConversation(conversationEntity2.copy(archived = false))
+
+        userDAO.insertUser(user1)
+        userDAO.insertUser(user2)
+
+        memberDAO.insertMember(member1, conversationEntity1.id)
+        memberDAO.insertMember(member2, conversationEntity2.id)
+
+        val result = conversationDAO.getAllConversationDetails(includeArchived).first()
+
+        assertEquals(2, result.size)
+
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -821,7 +821,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenConnectionRequestAndUserWithoutName_whenSelectingAllConversationDetails_thenShouldReturnConnectionRequest() = runTest {
+    fun givenConnectionRequestAndUserWithoutName_whenSelectingAllConversationDetails_thenShouldNotReturnConnectionRequest() = runTest {
         val includeArchived = false
         val conversationId = QualifiedIDEntity("connection-conversationId", "domain")
         val conversation = conversationEntity1.copy(id = conversationId, type = ConversationEntity.Type.CONNECTION_PENDING)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
DB query `selectAllConversationDetails` was fetching only `archived` conversations when passing a value of `includeArchived=true`.

### Solutions

This new modification should be able to fetch archived and non archived conversations when `includeArchived` flag is set to `true` now.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

We should still add a separate method to fetch only the archived ones on the `ConversationDAO` class.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
