### PR TITLE
fix: Ghost incoming call appearing randomly (WPB-4717)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -109,7 +109,13 @@ class CallsScope internal constructor(
             callRepository = callRepository,
         )
 
-    val startCall: StartCallUseCase get() = StartCallUseCase(callManager, syncManager, kaliumConfigs)
+    val startCall: StartCallUseCase get() = StartCallUseCase(
+        callManager = callManager,
+        syncManager = syncManager,
+        callRepository = callRepository,
+        answerCall = answerCall,
+        kaliumConfigs = kaliumConfigs
+    )
 
     val answerCall: AnswerCallUseCase
         get() = AnswerCallUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.call.usecase
 
+import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallType
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
@@ -27,6 +28,7 @@ import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 /**
@@ -38,6 +40,8 @@ class StartCallUseCase internal constructor(
     private val callManager: Lazy<CallManager>,
     private val syncManager: SyncManager,
     private val kaliumConfigs: KaliumConfigs,
+    private val callRepository: CallRepository,
+    private val answerCall: AnswerCallUseCase,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
@@ -46,14 +50,22 @@ class StartCallUseCase internal constructor(
         callType: CallType = CallType.AUDIO,
     ) = withContext(dispatchers.default) {
         syncManager.waitUntilLiveOrFailure().fold({
-            Result.SyncFailure
+            return@withContext Result.SyncFailure
         }, {
+            callRepository.incomingCallsFlow().first().run {
+                find {
+                    it.conversationId == conversationId
+                }?.apply {
+                    answerCall(conversationId)
+                    return@withContext Result.Success
+                }
+            }
             callManager.value.startCall(
                 conversationId = conversationId,
                 callType = callType,
                 isAudioCbr = kaliumConfigs.forceConstantBitrateCalls
             )
-            Result.Success
+            return@withContext Result.Success
         })
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Incoming call popping up for some users when they start a call and for others randomly

### Causes (Optional)

When we start a call we don't check if we have an incoming call from the person we are trying to call, causing to create to calls for the same person/group with different statues (Incoming, Started).
For some reasons the incoming call state did not change to Closed and stay on this state causing some ghost calls.

### Solutions

Before Starting a call, we check if have an incoming call from the person/group we try to call. In case we have one, we just answer the call instead of starting a new one.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Call yourself from different client
- Don't answer the call and call the same person/group you got a call from
- Terminate your call
- You should not see incoming calls popping up randomly or when you try to call someone

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
