### PR TITLE
feat: typing indicator receiver logs and flag check (WPB-4706)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorRepository.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.data.conversation
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.safeComputeAndMutateSetValue
 import kotlinx.coroutines.channels.BufferOverflow
@@ -30,30 +31,35 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 internal interface TypingIndicatorRepository {
-    fun addTypingUserInConversation(conversationId: ConversationId, userId: UserId)
-    fun removeTypingUserInConversation(conversationId: ConversationId, userId: UserId)
+    suspend fun addTypingUserInConversation(conversationId: ConversationId, userId: UserId)
+    suspend fun removeTypingUserInConversation(conversationId: ConversationId, userId: UserId)
     suspend fun observeUsersTyping(conversationId: ConversationId): Flow<Set<ExpiringUserTyping>>
 }
 
 internal class TypingIndicatorRepositoryImpl(
-    private val userTypingCache: ConcurrentMutableMap<ConversationId, MutableSet<ExpiringUserTyping>>
+    private val userTypingCache: ConcurrentMutableMap<ConversationId, MutableSet<ExpiringUserTyping>>,
+    private val userPropertyRepository: UserPropertyRepository
 ) : TypingIndicatorRepository {
 
     private val userTypingDataSourceFlow: MutableSharedFlow<Unit> =
         MutableSharedFlow(extraBufferCapacity = BUFFER_SIZE, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
-    override fun addTypingUserInConversation(conversationId: ConversationId, userId: UserId) {
-        userTypingCache.safeComputeAndMutateSetValue(conversationId) { ExpiringUserTyping(userId, Clock.System.now()) }
-            .also {
-                userTypingDataSourceFlow.tryEmit(Unit)
-            }
+    override suspend fun addTypingUserInConversation(conversationId: ConversationId, userId: UserId) {
+        if (userPropertyRepository.getTypingIndicatorStatus()) {
+            userTypingCache.safeComputeAndMutateSetValue(conversationId) { ExpiringUserTyping(userId, Clock.System.now()) }
+                .also {
+                    userTypingDataSourceFlow.tryEmit(Unit)
+                }
+        }
     }
 
-    override fun removeTypingUserInConversation(conversationId: ConversationId, userId: UserId) {
-        userTypingCache.block { entry ->
-            entry[conversationId]?.apply { this.removeAll { it.userId == userId } }
-        }.also {
-            userTypingDataSourceFlow.tryEmit(Unit)
+    override suspend fun removeTypingUserInConversation(conversationId: ConversationId, userId: UserId) {
+        if (userPropertyRepository.getTypingIndicatorStatus()) {
+            userTypingCache.block { entry ->
+                entry[conversationId]?.apply { this.removeAll { it.userId == userId } }
+            }.also {
+                userTypingDataSourceFlow.tryEmit(Unit)
+            }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorRepository.kt
@@ -54,12 +54,10 @@ internal class TypingIndicatorRepositoryImpl(
     }
 
     override suspend fun removeTypingUserInConversation(conversationId: ConversationId, userId: UserId) {
-        if (userPropertyRepository.getTypingIndicatorStatus()) {
-            userTypingCache.block { entry ->
-                entry[conversationId]?.apply { this.removeAll { it.userId == userId } }
-            }.also {
-                userTypingDataSourceFlow.tryEmit(Unit)
-            }
+        userTypingCache.block { entry ->
+            entry[conversationId]?.apply { this.removeAll { it.userId == userId } }
+        }.also {
+            userTypingDataSourceFlow.tryEmit(Unit)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1155,7 +1155,7 @@ class UserSessionScope internal constructor(
         )
 
     private val typingIndicatorHandler: TypingIndicatorHandler
-        get() = TypingIndicatorHandlerImpl(conversations.typingIndicatorRepository)
+        get() = TypingIndicatorHandlerImpl(userId, conversations.typingIndicatorRepository)
 
     private val conversationEventReceiver: ConversationEventReceiver by lazy {
         ConversationEventReceiverImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1300,6 +1300,7 @@ class UserSessionScope internal constructor(
             team.isSelfATeamMember,
             globalScope.serverConfigRepository,
             userStorage,
+            userPropertyRepository,
             this
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.conversation.TypingIndicatorRepositoryImpl
 import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProvider
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
@@ -86,6 +87,7 @@ class ConversationScope internal constructor(
     private val isSelfATeamMember: IsSelfATeamMemberUseCase,
     private val serverConfigRepository: ServerConfigRepository,
     private val userStorage: UserStorage,
+    private val userPropertyRepository: UserPropertyRepository,
     private val scope: CoroutineScope
 ) {
 
@@ -264,7 +266,7 @@ class ConversationScope internal constructor(
     val observeArchivedUnreadConversationsCount: ObserveArchivedUnreadConversationsCountUseCase
         get() = ObserveArchivedUnreadConversationsCountUseCaseImpl(conversationRepository)
 
-    internal val typingIndicatorRepository = TypingIndicatorRepositoryImpl(ConcurrentMutableMap())
+    internal val typingIndicatorRepository = TypingIndicatorRepositoryImpl(ConcurrentMutableMap(), userPropertyRepository)
 
     val observeUsersTyping: ObserveUsersTypingUseCase
         get() = ObserveUsersTypingUseCaseImpl(typingIndicatorRepository, userRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -68,14 +68,15 @@ object TestEvent {
         "2022-03-30T15:36:00.000Zp"
     )
 
-    fun memberChangeArchivedStatus(eventId: String = "eventId", isArchiving: Boolean = true) = Event.Conversation.MemberChanged.MemberArchivedStatusChanged(
-        eventId,
-        TestConversation.ID,
-        "2022-03-30T15:36:00.000Z",
-        false,
-        "2022-03-31T16:36:00.000Zp",
-        isArchiving,
-    )
+    fun memberChangeArchivedStatus(eventId: String = "eventId", isArchiving: Boolean = true) =
+        Event.Conversation.MemberChanged.MemberArchivedStatusChanged(
+            eventId,
+            TestConversation.ID,
+            "2022-03-30T15:36:00.000Z",
+            false,
+            "2022-03-31T16:36:00.000Zp",
+            isArchiving,
+        )
 
     fun memberChangeIgnored(eventId: String = "eventId") = Event.Conversation.MemberChanged.IgnoredMemberChanged(
         eventId,
@@ -252,7 +253,7 @@ object TestEvent {
         id = "eventId",
         conversationId = TestConversation.ID,
         transient = true,
-        senderUserId = TestUser.USER_ID,
+        senderUserId = TestUser.OTHER_USER_ID,
         timestampIso = "2022-03-30T15:36:00.000Z",
         typingIndicatorMode = typingIndicatorMode
     )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/TypingIndicatorHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/TypingIndicatorHandlerTest.kt
@@ -49,14 +49,14 @@ class TypingIndicatorHandlerTest {
         result.shouldSucceed()
         verify(arrangement.typingIndicatorRepository)
             .function(arrangement.typingIndicatorRepository::addTypingUserInConversation)
-            .with(eq(TestConversation.ID), eq(TestUser.USER_ID))
+            .with(eq(TestConversation.ID), eq(TestUser.SELF.id))
             .wasNotInvoked()
     }
 
     @Test
     fun givenTypingEvent_whenIsModeStarted_thenHandleToAdd() = runTest {
         val (arrangement, handler) = Arrangement()
-            .withTypingIndicatorObserve(setOf(TestUser.USER_ID))
+            .withTypingIndicatorObserve(setOf(TestUser.OTHER_USER_ID))
             .arrange()
 
         val result = handler.handle(TestEvent.typingIndicator(Conversation.TypingIndicatorMode.STARTED))
@@ -64,14 +64,14 @@ class TypingIndicatorHandlerTest {
         result.shouldSucceed()
         verify(arrangement.typingIndicatorRepository)
             .function(arrangement.typingIndicatorRepository::addTypingUserInConversation)
-            .with(eq(TestConversation.ID), eq(TestUser.USER_ID))
+            .with(eq(TestConversation.ID), eq(TestUser.OTHER_USER_ID))
             .wasInvoked(once)
     }
 
     @Test
     fun givenTypingEvent_whenIsModeStopped_thenHandleToRemove() = runTest {
         val (arrangement, handler) = Arrangement()
-            .withTypingIndicatorObserve(setOf(TestUser.USER_ID))
+            .withTypingIndicatorObserve(setOf(TestUser.OTHER_USER_ID))
             .arrange()
 
         val result = handler.handle(TestEvent.typingIndicator(Conversation.TypingIndicatorMode.STOPPED))
@@ -79,14 +79,14 @@ class TypingIndicatorHandlerTest {
         result.shouldSucceed()
         verify(arrangement.typingIndicatorRepository)
             .function(arrangement.typingIndicatorRepository::removeTypingUserInConversation)
-            .with(eq(TestConversation.ID), eq(TestUser.USER_ID))
+            .with(eq(TestConversation.ID), eq(TestUser.OTHER_USER_ID))
             .wasInvoked(once)
     }
 
     @Test
     fun givenTypingEventStopped_whenIsSelfUser_thenSkipIt() = runTest {
         val (arrangement, handler) = Arrangement()
-            .withTypingIndicatorObserve(setOf(TestUser.USER_ID))
+            .withTypingIndicatorObserve(setOf(TestUser.SELF.id))
             .arrange()
 
         val result = handler.handle(TestEvent.typingIndicator(Conversation.TypingIndicatorMode.STOPPED))
@@ -94,7 +94,7 @@ class TypingIndicatorHandlerTest {
         result.shouldSucceed()
         verify(arrangement.typingIndicatorRepository)
             .function(arrangement.typingIndicatorRepository::removeTypingUserInConversation)
-            .with(eq(TestConversation.ID), eq(TestUser.USER_ID))
+            .with(eq(TestConversation.ID), eq(TestUser.SELF.id))
             .wasNotInvoked()
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to perform checks in order to clean the typing indicator.
- Skip self user events
- Take in consideration the user configuration about typing indicator to add to the cache

### Solutions

- Also added logs for the event handling.
- Added more tests.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
