### PR TITLE
fix: clearing new clients was being executed on main thread

### DIFF
--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/newclient/NewClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/newclient/NewClientDAOImpl.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.persistence.dao.client.InsertClientParam
 import com.wire.kalium.persistence.util.mapToList
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlin.coroutines.CoroutineContext
 
@@ -49,12 +50,14 @@ internal class NewClientDAOImpl(
 ) : NewClientDAO {
 
     override suspend fun insertNewClient(client: InsertClientParam) = with(client) {
-        newClientsQueries.insertNewClient(
-            id = id,
-            device_type = deviceType,
-            registration_date = registrationDate,
-            model = model
-        )
+        withContext(queriesContext) {
+            newClientsQueries.insertNewClient(
+                id = id,
+                device_type = deviceType,
+                registration_date = registrationDate,
+                model = model
+            )
+        }
     }
 
     override suspend fun observeNewClients(): Flow<List<NewClientEntity>> =
@@ -63,7 +66,7 @@ internal class NewClientDAOImpl(
             .flowOn(queriesContext)
             .mapToList()
 
-    override suspend fun clearNewClients() {
+    override suspend fun clearNewClients() = withContext(queriesContext) {
         newClientsQueries.clearNewClients()
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
When inserting and clearing new clients, these ops were being executed w/o specifying on which coroutine context, causing some crashes when being invoked by main thread.

### Solutions

Changing context to the queries context injected in the `NewClientsDAO` class

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
