### PR TITLE
feat(typing): send typing indicator event tests pt3. (WPB-4590)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -27,9 +27,10 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreatorImpl
-import com.wire.kalium.logic.data.conversation.TypingIndicatorOutgoingRepositoryImpl
 import com.wire.kalium.logic.data.conversation.TypingIndicatorIncomingRepositoryImpl
+import com.wire.kalium.logic.data.conversation.TypingIndicatorOutgoingRepositoryImpl
 import com.wire.kalium.logic.data.conversation.TypingIndicatorSenderHandler
+import com.wire.kalium.logic.data.conversation.TypingIndicatorSenderHandlerImpl
 import com.wire.kalium.logic.data.conversation.UpdateKeyingMaterialThresholdProvider
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
@@ -269,7 +270,7 @@ class ConversationScope internal constructor(
         get() = ObserveArchivedUnreadConversationsCountUseCaseImpl(conversationRepository)
 
     private val typingIndicatorSenderHandler: TypingIndicatorSenderHandler =
-        TypingIndicatorSenderHandler(conversationRepository = conversationRepository, userSessionCoroutineScope = scope)
+        TypingIndicatorSenderHandlerImpl(conversationRepository = conversationRepository, userSessionCoroutineScope = scope)
 
     internal val typingIndicatorIncomingRepository =
         TypingIndicatorIncomingRepositoryImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorIncomingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorIncomingRepositoryTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.data.conversation
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import io.mockative.Mock
@@ -88,6 +89,23 @@ class TypingIndicatorIncomingRepositoryTest {
             verify(arrangement.userPropertyRepository)
                 .suspendFunction(arrangement.userPropertyRepository::getTypingIndicatorStatus)
                 .wasInvoked()
+        }
+
+    @Test
+    fun givenUsersTypingInAConversation_whenClearExpiredItsCalled_thenShouldNotBePresentAnyInCached() =
+        runTest(TestKaliumDispatcher.default) {
+            val expectedUserTyping = setOf<UserId>()
+            val (_, typingIndicatorRepository) = Arrangement().withTypingIndicatorStatus().arrange()
+
+            typingIndicatorRepository.addTypingUserInConversation(conversationOne, TestConversation.USER_1)
+            typingIndicatorRepository.addTypingUserInConversation(conversationOne, TestConversation.USER_2)
+
+            typingIndicatorRepository.clearExpiredTypingIndicators()
+
+            assertEquals(
+                expectedUserTyping,
+                typingIndicatorRepository.observeUsersTyping(conversationOne).firstOrNull()?.map { it }?.toSet()
+            )
         }
 
     private class Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorIncomingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorIncomingRepositoryTest.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class TypingIndicatorRepositoryTest {
+class TypingIndicatorIncomingRepositoryTest {
 
     @Test
     fun givenUsersInOneConversation_whenTheyAreTyping_thenAddItToTheListOfUsersTypingInConversation() =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorOutgoingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/TypingIndicatorOutgoingRepositoryTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.logic.data.properties.UserPropertyRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class TypingIndicatorOutgoingRepositoryTest {
+
+    @Test
+    fun givenAStartedTypingEvent_whenUserConfigNotEnabled_thenShouldNotSendAnyIndication() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, typingIndicatorRepository) = Arrangement()
+                .withTypingIndicatorStatus(false)
+                .withSenderHandlerCall()
+                .arrange()
+
+            typingIndicatorRepository.sendTypingIndicatorStatus(conversationOne, Conversation.TypingIndicatorMode.STARTED)
+
+            verify(arrangement.userPropertyRepository)
+                .suspendFunction(arrangement.userPropertyRepository::getTypingIndicatorStatus)
+                .wasInvoked()
+
+            verify(arrangement.typingIndicatorSenderHandler)
+                .function(arrangement.typingIndicatorSenderHandler::sendStartedAndEnqueueStoppingEvent)
+                .with(any())
+                .wasNotInvoked()
+        }
+
+    @Test
+    fun givenAStartedTypingEvent_whenUserConfigIsEnabled_thenShouldSendAnyIndication() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, typingIndicatorRepository) = Arrangement()
+                .withTypingIndicatorStatus(true)
+                .withSenderHandlerCall()
+                .arrange()
+
+            typingIndicatorRepository.sendTypingIndicatorStatus(conversationOne, Conversation.TypingIndicatorMode.STARTED)
+
+            verify(arrangement.userPropertyRepository)
+                .suspendFunction(arrangement.userPropertyRepository::getTypingIndicatorStatus)
+                .wasInvoked()
+
+            verify(arrangement.typingIndicatorSenderHandler)
+                .function(arrangement.typingIndicatorSenderHandler::sendStartedAndEnqueueStoppingEvent)
+                .with(any())
+                .wasInvoked()
+        }
+
+    private class Arrangement {
+        @Mock
+        val userPropertyRepository: UserPropertyRepository = mock(UserPropertyRepository::class)
+
+        @Mock
+        val typingIndicatorSenderHandler: TypingIndicatorSenderHandler = mock(TypingIndicatorSenderHandler::class)
+
+        fun withTypingIndicatorStatus(enabled: Boolean = true) = apply {
+            given(userPropertyRepository)
+                .suspendFunction(userPropertyRepository::getTypingIndicatorStatus)
+                .whenInvoked()
+                .thenReturn(enabled)
+        }
+
+        fun withSenderHandlerCall() = apply {
+            given(typingIndicatorSenderHandler)
+                .function(typingIndicatorSenderHandler::sendStartedAndEnqueueStoppingEvent)
+                .whenInvokedWith(any())
+                .thenReturn(Unit)
+        }
+
+        fun arrange() = this to TypingIndicatorOutgoingRepositoryImpl(
+            userPropertyRepository = userPropertyRepository,
+            typingIndicatorSenderHandler = typingIndicatorSenderHandler
+        )
+    }
+
+    private companion object {
+        val conversationOne = TestConversation.ID
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/SendTypingEventUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/SendTypingEventUseCaseTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.TypingIndicatorOutgoingRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SendTypingEventUseCaseTest {
+
+    @Test
+    fun givenATypingEvent_whenCallingSendSucceed_thenReturnSuccess() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withTypingIndicatorStatusAndResult(Conversation.TypingIndicatorMode.STOPPED)
+            .arrange()
+
+        useCase(TestConversation.ID, Conversation.TypingIndicatorMode.STOPPED)
+
+        verify(arrangement.typingIndicatorRepository)
+            .suspendFunction(arrangement.typingIndicatorRepository::sendTypingIndicatorStatus)
+            .with(eq(TestConversation.ID), eq(Conversation.TypingIndicatorMode.STOPPED))
+            .wasInvoked()
+    }
+
+    @Test
+    fun givenATypingEvent_whenCallingSendFails_thenReturnIgnoringFailure() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withTypingIndicatorStatusAndResult(
+                Conversation.TypingIndicatorMode.STARTED,
+                Either.Left(CoreFailure.Unknown(RuntimeException("Some error")))
+            )
+            .arrange()
+
+        val result = useCase(TestConversation.ID, Conversation.TypingIndicatorMode.STARTED)
+
+        verify(arrangement.typingIndicatorRepository)
+            .suspendFunction(arrangement.typingIndicatorRepository::sendTypingIndicatorStatus)
+            .with(eq(TestConversation.ID), eq(Conversation.TypingIndicatorMode.STARTED))
+            .wasInvoked()
+        assertEquals(Unit, result)
+    }
+
+    private class Arrangement {
+        @Mock
+        val typingIndicatorRepository: TypingIndicatorOutgoingRepository = mock(TypingIndicatorOutgoingRepository::class)
+
+        fun withTypingIndicatorStatusAndResult(
+            typingMode: Conversation.TypingIndicatorMode,
+            result: Either<CoreFailure, Unit> = Either.Right(Unit)
+        ) = apply {
+            given(typingIndicatorRepository)
+                .suspendFunction(typingIndicatorRepository::sendTypingIndicatorStatus)
+                .whenInvokedWith(any(), eq(typingMode))
+                .thenReturn(result)
+        }
+
+        fun arrange() = this to SendTypingEventUseCaseImpl(
+            typingIndicatorRepository
+        )
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Refactor and split repositories, and create a periodic cleanup of orphaned typing indicators, so we clean those after some time.

Needs releases with:

- https://github.com/wireapp/kalium/pull/2121

### Testing

#### Test Coverage (Optional)

Coverage for PR

- https://github.com/wireapp/kalium/pull/2121

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
