### PR TITLE
fix: assign proteus as default supported protocol during db migration

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -27,7 +27,7 @@ CREATE TABLE User (
     incomplete_metadata INTEGER AS Boolean NOT NULL DEFAULT 0,
     expires_at INTEGER AS Instant,
     defederated INTEGER AS Boolean NOT NULL DEFAULT 0,
-    supported_protocols TEXT AS Set<SupportedProtocolEntity>,
+    supported_protocols TEXT AS Set<SupportedProtocolEntity> DEFAULT 'PROTEUS',
     active_one_on_one_conversation_id TEXT AS QualifiedIDEntity
 );
 CREATE INDEX user_team_index ON User(team);

--- a/persistence/src/commonMain/db_user/migrations/59.sqm
+++ b/persistence/src/commonMain/db_user/migrations/59.sqm
@@ -1,4 +1,4 @@
-ALTER TABLE User ADD COLUMN supported_protocols TEXT AS Set<SupportedProtocolEntity>;
+ALTER TABLE User ADD COLUMN supported_protocols TEXT AS Set<SupportedProtocolEntity> DEFAULT 'PROTEUS';
 
 DROP VIEW IF EXISTS ConversationDetails;
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After upgrading from old version to a version with 1-1 mls support, resolving the active 1-1 conversation will fail.

### Causes

After upgrading the newly introduced `supported_protocols` field on the self user and other users are null. This makes the 1-1 resolves to think there's no common protocol for your 1-1 contacts. This will hide the 1-1 conversations from the conversation list.

### Solutions

Assign proteus as the default supported protocol on user db migration.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
