### PR TITLE
fix: supported protocols is only available since API v5

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/SelfApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/SelfApiV4.kt
@@ -19,30 +19,10 @@
 package com.wire.kalium.network.api.v4.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.base.authenticated.self.UpdateSupportedProtocolsRequest
-import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.api.v3.authenticated.SelfApiV3
 import com.wire.kalium.network.session.SessionManager
-import com.wire.kalium.network.utils.NetworkResponse
-import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.put
-import io.ktor.client.request.setBody
 
 internal open class SelfApiV4 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient,
     sessionManager: SessionManager
-) : SelfApiV3(authenticatedNetworkClient, sessionManager) {
-
-    override suspend fun updateSupportedProtocols(
-        protocols: List<SupportedProtocolDTO>
-    ): NetworkResponse<Unit> = wrapKaliumResponse {
-        httpClient.put("$PATH_SELF/$PATH_SUPPORTED_PROTOCOLS") {
-            setBody(UpdateSupportedProtocolsRequest(protocols))
-        }
-    }
-
-    companion object {
-        const val PATH_SUPPORTED_PROTOCOLS = "supported-protocols"
-    }
-
-}
+) : SelfApiV3(authenticatedNetworkClient, sessionManager)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/SelfApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/SelfApiV5.kt
@@ -19,10 +19,28 @@
 package com.wire.kalium.network.api.v5.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.self.UpdateSupportedProtocolsRequest
+import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.api.v4.authenticated.SelfApiV4
 import com.wire.kalium.network.session.SessionManager
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
 
 internal open class SelfApiV5 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient,
     sessionManager: SessionManager
-) : SelfApiV4(authenticatedNetworkClient, sessionManager)
+) : SelfApiV4(authenticatedNetworkClient, sessionManager) {
+    override suspend fun updateSupportedProtocols(
+        protocols: List<SupportedProtocolDTO>
+    ): NetworkResponse<Unit> = wrapKaliumResponse {
+        httpClient.put("$PATH_SELF/$PATH_SUPPORTED_PROTOCOLS") {
+            setBody(UpdateSupportedProtocolsRequest(protocols))
+        }
+    }
+
+    companion object {
+        const val PATH_SUPPORTED_PROTOCOLS = "supported-protocols"
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v5/SelfApiV5Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v5/SelfApiV5Test.kt
@@ -16,11 +16,11 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.api.v4.user.self
+package com.wire.kalium.api.v5
 
 import com.wire.kalium.api.ApiTest
 import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
-import com.wire.kalium.network.api.v4.authenticated.SelfApiV4
+import com.wire.kalium.network.api.v5.authenticated.SelfApiV5
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,7 +29,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
-internal class SelfApiV4Test : ApiTest() {
+internal class SelfApiV5Test : ApiTest() {
     @Test
     fun givenValidRequest_whenUpdatingSupportedProtocols_theRequestShouldBeConfiguredCorrectly() =
         runTest {
@@ -42,7 +42,7 @@ internal class SelfApiV4Test : ApiTest() {
                     assertPathEqual("$PATH_SELF/$PATH_SUPPORTED_PROTOCOLS")
                 }
             )
-            val selfApi = SelfApiV4(networkClient, TEST_SESSION_MANAGER)
+            val selfApi = SelfApiV5(networkClient, TEST_SESSION_MANAGER)
             val response = selfApi.updateSupportedProtocols(listOf(SupportedProtocolDTO.MLS))
             assertTrue(response.isSuccessful())
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Supported protocols is only available since API v5

### Solutions

Move it to v5

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
