### PR TITLE
fix: skip updating supported protocols when mls is not supported

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -907,7 +907,8 @@ class UserSessionScope internal constructor(
         get() = UpdateSupportedProtocolsUseCaseImpl(
             clientRepository,
             userRepository,
-            userConfigRepository
+            userConfigRepository,
+            featureSupport
         )
 
     private val updateSupportedProtocolsAndResolveOneOnOnes: UpdateSupportedProtocolsAndResolveOneOnOnesUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandler.kt
@@ -41,6 +41,10 @@ class MLSConfigHandler(
 
         return userConfigRepository.setMLSEnabled(mlsEnabled && selfUserIsWhitelisted)
             .flatMap {
+                userConfigRepository.setDefaultProtocol(if (mlsEnabled) mlsConfig.defaultProtocol else SupportedProtocol.PROTEUS)
+            }.flatMap {
+                userConfigRepository.setSupportedProtocols(mlsConfig.supportedProtocols)
+            }.flatMap {
                 if (supportedProtocolsHasChanged) {
                     updateSupportedProtocolsAndResolveOneOnOnes(
                         synchroniseUsers = !duringSlowSync
@@ -48,11 +52,6 @@ class MLSConfigHandler(
                 } else {
                     Either.Right(Unit)
                 }
-            }
-            .flatMap {
-                userConfigRepository.setDefaultProtocol(if (mlsEnabled) mlsConfig.defaultProtocol else SupportedProtocol.PROTEUS)
-            }.flatMap {
-                userConfigRepository.setSupportedProtocols(mlsConfig.supportedProtocols)
             }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Slow sync fails when MLS is not supported / configured

### Causes

This was failing at multiple levels:

1. We were attempting to update self supported protocols before we've persisted the protocols which the team supports. This resulted in a `StorageFailure.DataNotFound`
2. There's no guarantee that the team has configured its supported protocols

### Solutions

1. Persist supported protocol before attempting to update supported protocols
2. If MLS is not supported skip updating supported protocols completely.
3. if MLS is supported but supported protocols are not configured also skip updating supported protocols.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
