### PR TITLE
feat: extended password verification

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidatePasswordUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/ValidatePasswordUseCaseTest.kt
@@ -29,20 +29,40 @@ class ValidatePasswordUseCaseTest {
     @Test
     fun givenAValidatePasswordUseCaseIsInvoked_whenPasswordIsValid_thenReturnTrue() {
         VALID_PASSWORDS.forEach { validPassword ->
-            assertTrue(message = "$validPassword is invalid ") { validatePasswordUseCase(validPassword) }
+            assertTrue(message = "$validPassword is invalid ") { validatePasswordUseCase(validPassword).isValid }
         }
     }
 
     @Test
     fun givenAValidatePasswordUseCaseIsInvoked_whenPasswordIsInvalid_thenReturnFalse() {
         INVALID_PASSWORDS.forEach { invalidPassword ->
-            assertFalse { validatePasswordUseCase(invalidPassword) }
+            assertFalse { validatePasswordUseCase(invalidPassword).isValid }
         }
     }
 
     @Test
     fun givenAValidatePasswordUseCaseIsInvoked_whenPasswordIsShort_thenReturnFalse() {
-        assertFalse { validatePasswordUseCase("1@3.") }
+        assertTrue { validatePasswordUseCase("aA1@3.").let { it is ValidatePasswordResult.Invalid && it.tooShort } }
+    }
+
+    @Test
+    fun givenAValidatePasswordUseCaseIsInvoked_whenPasswordIsMissingUppercase_thenReturnFalse() {
+        assertTrue { validatePasswordUseCase("a1@3.").let { it is ValidatePasswordResult.Invalid && it.missingUppercaseCharacter } }
+    }
+
+    @Test
+    fun givenAValidatePasswordUseCaseIsInvoked_whenPasswordIsMissingLowercase_thenReturnFalse() {
+        assertTrue { validatePasswordUseCase("A1@3.").let { it is ValidatePasswordResult.Invalid && it.missingLowercaseCharacter } }
+    }
+
+    @Test
+    fun givenAValidatePasswordUseCaseIsInvoked_whenPasswordIsMissingSpecialCharacter_thenReturnFalse() {
+        assertTrue { validatePasswordUseCase("aA13").let { it is ValidatePasswordResult.Invalid && it.missingSpecialCharacter } }
+    }
+
+    @Test
+    fun givenAValidatePasswordUseCaseIsInvoked_whenPasswordIsMissingDigit_thenReturnFalse() {
+        assertTrue { validatePasswordUseCase("aA@.").let { it is ValidatePasswordResult.Invalid && it.missingDigit } }
     }
 
     private companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we can only verify if the whole password is valid or not, but some screens require to show which elements are still missing (like "one uppercase character").

### Solutions

Change the use case to return the sealed class where `Invalid` contains multiple fields to know exactly which elements are still missing in the password.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
