### PR TITLE
refactor: unify access token refreshing logic [WPB-5038]

### DIFF
--- a/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
+++ b/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
@@ -124,7 +124,7 @@ class MainActivity : ComponentActivity() {
             addAuthenticatedAccount(
                 serverConfigId = result.serverConfigId,
                 ssoId = result.ssoID,
-                authTokens = result.authData,
+                accountTokens = result.authData,
                 proxyCredentials = null
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
@@ -36,14 +36,14 @@ internal interface LoginRepository {
         label: String?,
         shouldPersistClient: Boolean,
         secondFactorVerificationCode: String? = null,
-    ): Either<NetworkFailure, Pair<AuthTokens, SsoId?>>
+    ): Either<NetworkFailure, Pair<AccountTokens, SsoId?>>
 
     suspend fun loginWithHandle(
         handle: String,
         password: String,
         label: String?,
         shouldPersistClient: Boolean
-    ): Either<NetworkFailure, Pair<AuthTokens, SsoId?>>
+    ): Either<NetworkFailure, Pair<AccountTokens, SsoId?>>
 }
 
 internal class LoginRepositoryImpl internal constructor(
@@ -58,7 +58,7 @@ internal class LoginRepositoryImpl internal constructor(
         label: String?,
         shouldPersistClient: Boolean,
         secondFactorVerificationCode: String?,
-    ): Either<NetworkFailure, Pair<AuthTokens, SsoId?>> =
+    ): Either<NetworkFailure, Pair<AccountTokens, SsoId?>> =
         login(
             LoginApi.LoginParam.LoginWithEmail(email, password, label, secondFactorVerificationCode),
             shouldPersistClient
@@ -69,7 +69,7 @@ internal class LoginRepositoryImpl internal constructor(
         password: String,
         label: String?,
         shouldPersistClient: Boolean,
-    ): Either<NetworkFailure, Pair<AuthTokens, SsoId?>> =
+    ): Either<NetworkFailure, Pair<AccountTokens, SsoId?>> =
         login(
             LoginApi.LoginParam.LoginWithHandle(handle, password, label),
             shouldPersistClient
@@ -78,7 +78,7 @@ internal class LoginRepositoryImpl internal constructor(
     private suspend fun login(
         loginParam: LoginApi.LoginParam,
         persistClient: Boolean
-    ): Either<NetworkFailure, Pair<AuthTokens, SsoId?>> = wrapApiRequest {
+    ): Either<NetworkFailure, Pair<AccountTokens, SsoId?>> = wrapApiRequest {
         loginApi.login(param = loginParam, persist = persistClient)
     }.map {
         Pair(sessionMapper.fromSessionDTO(it.first), idMapper.toSsoId(it.second.ssoID))

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepository.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
@@ -42,7 +42,7 @@ internal interface RegisterAccountRepository {
         name: String,
         password: String,
         cookieLabel: String?
-    ): Either<NetworkFailure, Pair<SsoId?, AuthTokens>>
+    ): Either<NetworkFailure, Pair<SsoId?, AccountTokens>>
 
     @Suppress("LongParameterList")
     suspend fun registerTeamWithEmail(
@@ -53,7 +53,7 @@ internal interface RegisterAccountRepository {
         teamName: String,
         teamIcon: String,
         cookieLabel: String?
-    ): Either<NetworkFailure, Pair<SsoId?, AuthTokens>>
+    ): Either<NetworkFailure, Pair<SsoId?, AccountTokens>>
 }
 
 internal class RegisterAccountDataSource internal constructor(
@@ -76,7 +76,7 @@ internal class RegisterAccountDataSource internal constructor(
         name: String,
         password: String,
         cookieLabel: String?
-    ): Either<NetworkFailure, Pair<SsoId?, AuthTokens>> =
+    ): Either<NetworkFailure, Pair<SsoId?, AccountTokens>> =
         register(
             RegisterApi.RegisterParam.PersonalAccount(
                 email = email,
@@ -95,7 +95,7 @@ internal class RegisterAccountDataSource internal constructor(
         teamName: String,
         teamIcon: String,
         cookieLabel: String?
-    ): Either<NetworkFailure, Pair<SsoId?, AuthTokens>> =
+    ): Either<NetworkFailure, Pair<SsoId?, AccountTokens>> =
         register(
             RegisterApi.RegisterParam.TeamAccount(
                 email = email,
@@ -115,7 +115,7 @@ internal class RegisterAccountDataSource internal constructor(
     private suspend fun activateUser(param: RegisterApi.ActivationParam): Either<NetworkFailure, Unit> =
         wrapApiRequest { registerApi.activate(param) }
 
-    private suspend fun register(param: RegisterApi.RegisterParam): Either<NetworkFailure, Pair<SsoId?, AuthTokens>> =
+    private suspend fun register(param: RegisterApi.RegisterParam): Either<NetworkFailure, Pair<SsoId?, AccountTokens>> =
         wrapApiRequest { registerApi.register(param) }.map {
             Pair(idMapper.toSsoId(it.first.ssoID), sessionMapper.fromSessionDTO(it.second))
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
@@ -66,8 +66,8 @@ internal class SessionMapperImpl(
         SessionDTO(
             userId = userId.toApi(),
             tokenType = tokenType,
-            accessToken = accessToken,
-            refreshToken = refreshToken,
+            accessToken = accessToken.value,
+            refreshToken = refreshToken.value,
             cookieLabel = cookieLabel
         )
     }
@@ -115,8 +115,8 @@ internal class SessionMapperImpl(
     override fun toAuthTokensEntity(authSession: AccountTokens): AuthTokenEntity = with(authSession) {
         AuthTokenEntity(
             userId = userId.toDao(),
-            accessToken = accessToken,
-            refreshToken = refreshToken,
+            accessToken = accessToken.value,
+            refreshToken = refreshToken.value,
             tokenType = tokenType,
             cookieLabel = cookieLabel
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.feature.auth.AccountInfo
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.logic.feature.auth.PersistentWebSocketStatus
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
@@ -39,13 +39,13 @@ import com.wire.kalium.persistence.model.LogoutReason as LogoutReasonEntity
 
 @Suppress("TooManyFunctions")
 interface SessionMapper {
-    fun toSessionDTO(authSession: AuthTokens): SessionDTO
+    fun toSessionDTO(authSession: AccountTokens): SessionDTO
     fun fromEntityToSessionDTO(authTokenEntity: AuthTokenEntity): SessionDTO
-    fun fromSessionDTO(sessionDTO: SessionDTO): AuthTokens
+    fun fromSessionDTO(sessionDTO: SessionDTO): AccountTokens
     fun fromAccountInfoEntity(accountInfoEntity: AccountInfoEntity): AccountInfo
     fun toLogoutReasonEntity(reason: LogoutReason): LogoutReasonEntity
     fun toSsoIdEntity(ssoId: SsoId?): SsoIdEntity?
-    fun toAuthTokensEntity(authSession: AuthTokens): AuthTokenEntity
+    fun toAuthTokensEntity(authSession: AccountTokens): AuthTokenEntity
     fun fromSsoIdEntity(ssoIdEntity: SsoIdEntity?): SsoId?
     fun toLogoutReason(reason: LogoutReasonEntity): LogoutReason
     fun fromEntityToProxyCredentialsDTO(proxyCredentialsEntity: ProxyCredentialsEntity): ProxyCredentialsDTO
@@ -62,7 +62,7 @@ internal class SessionMapperImpl(
     private val idMapper: IdMapper
 ) : SessionMapper {
 
-    override fun toSessionDTO(authSession: AuthTokens): SessionDTO = with(authSession) {
+    override fun toSessionDTO(authSession: AccountTokens): SessionDTO = with(authSession) {
         SessionDTO(
             userId = userId.toApi(),
             tokenType = tokenType,
@@ -82,8 +82,8 @@ internal class SessionMapperImpl(
         )
     }
 
-    override fun fromSessionDTO(sessionDTO: SessionDTO): AuthTokens = with(sessionDTO) {
-        AuthTokens(
+    override fun fromSessionDTO(sessionDTO: SessionDTO): AccountTokens = with(sessionDTO) {
+        AccountTokens(
             userId = userId.toModel(),
             accessToken = accessToken,
             refreshToken = refreshToken,
@@ -112,7 +112,7 @@ internal class SessionMapperImpl(
     override fun toSsoIdEntity(ssoId: SsoId?): SsoIdEntity? =
         ssoId?.let { SsoIdEntity(scimExternalId = it.scimExternalId, subject = it.subject, tenant = it.tenant) }
 
-    override fun toAuthTokensEntity(authSession: AuthTokens): AuthTokenEntity = with(authSession) {
+    override fun toAuthTokensEntity(authSession: AccountTokens): AuthTokenEntity = with(authSession) {
         AuthTokenEntity(
             userId = userId.toDao(),
             accessToken = accessToken,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.auth.Account
 import com.wire.kalium.logic.feature.auth.AccountInfo
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.logic.feature.auth.PersistentWebSocketStatus
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
@@ -54,7 +54,7 @@ interface SessionRepository {
     suspend fun storeSession(
         serverConfigId: String,
         ssoId: SsoId?,
-        authTokens: AuthTokens,
+        accountTokens: AccountTokens,
         proxyCredentials: ProxyCredentials?
     ): Either<StorageFailure, Unit>
 
@@ -93,12 +93,12 @@ internal class SessionDataSource(
     override suspend fun storeSession(
         serverConfigId: String,
         ssoId: SsoId?,
-        authTokens: AuthTokens,
+        accountTokens: AccountTokens,
         proxyCredentials: ProxyCredentials?
     ): Either<StorageFailure, Unit> =
         wrapStorageRequest {
             accountsDAO.insertOrReplace(
-                authTokens.userId.toDao(),
+                accountTokens.userId.toDao(),
                 sessionMapper.toSsoIdEntity(ssoId),
                 serverConfigId,
                 isPersistentWebSocketEnabled = kaliumConfigs.isWebSocketEnabledByDefault
@@ -106,7 +106,7 @@ internal class SessionDataSource(
         }.flatMap {
             wrapStorageRequest {
                 authTokenStorage.addOrReplace(
-                    sessionMapper.toAuthTokensEntity(authTokens),
+                    sessionMapper.toAuthTokensEntity(accountTokens),
                     proxyCredentials?.let { sessionMapper.fromModelToProxyCredentialsEntity(it) }
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/token/AccessToken.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/token/AccessToken.kt
@@ -47,14 +47,12 @@ internal sealed interface AccessTokenRefreshResult {
  * Represents an access token, which is used for authentication and authorization purposes.
  *
  * @property value The value of the access token.
- * @property expiresIn The time in seconds until the access token expires.
  * @property tokenType The type of the access token. _e.g._ "Bearer"
  */
-internal data class AccessToken(
+data class AccessToken(
     val value: String,
-    val expiresIn: Int,
     val tokenType: String
 )
 
 @JvmInline
-internal value class RefreshToken(val value: String)
+value class RefreshToken(val value: String)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/token/AccessToken.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/token/AccessToken.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.session.token
+
+import kotlin.jvm.JvmInline
+
+internal sealed interface AccessTokenRefreshResult {
+    val accessToken: AccessToken
+
+    /**
+     * Represents a result of an access token refresh, where the refresh token remains the same.
+     *
+     * @param accessToken The new access token.
+     */
+    data class SameRefreshToken(
+        override val accessToken: AccessToken
+    ) : AccessTokenRefreshResult
+
+    /**
+     * Represents a new refresh token along with the corresponding access token.
+     *
+     * @property accessToken The new access token.
+     * @property refreshToken The new refresh token.
+     */
+    data class NewRefreshToken(
+        override val accessToken: AccessToken,
+        val refreshToken: RefreshToken
+    ) : AccessTokenRefreshResult
+}
+
+/**
+ * Represents an access token, which is used for authentication and authorization purposes.
+ *
+ * @property value The value of the access token.
+ * @property expiresIn The time in seconds until the access token expires.
+ * @property tokenType The type of the access token. _e.g._ "Bearer"
+ */
+internal data class AccessToken(
+    val value: String,
+    val expiresIn: Int,
+    val tokenType: String
+)
+
+@JvmInline
+internal value class RefreshToken(val value: String)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/token/AccessTokenRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/token/AccessTokenRepository.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.session.token
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
+import com.wire.kalium.persistence.client.AuthTokenStorage
+
+internal interface AccessTokenRepository {
+    /**
+     * Retrieves a new access token using the provided refresh token and client ID.
+     *
+     * If provided, the new token will be associated with this client ID.
+     * If the client is remotely removed by the user, the tokens will be invalidated.
+     * Future refreshes will keep the previously associated client ID.
+     * _i.e._ after the first refresh, the client ID doesn't need to be provided anymore.
+     *
+     * @param refreshToken The refresh token to use for obtaining a new access token.
+     * @param clientId The optional client ID.
+     * @return Either a network failure or the new access token.
+     */
+    suspend fun getNewAccessToken(
+        refreshToken: String,
+        clientId: String? = null
+    ): Either<NetworkFailure, AccessToken>
+}
+
+internal class AccessTokenRepositoryImpl(
+    private val accessTokenApi: AccessTokenApi,
+    private val authTokenStorage: AuthTokenStorage,
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/token/AccessTokenRepositoryFactory.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/token/AccessTokenRepositoryFactory.kt
@@ -17,23 +17,23 @@
  */
 package com.wire.kalium.logic.data.session.token
 
-import kotlin.jvm.JvmInline
-
-internal data class AccessTokenRefreshResult(
-    val accessToken: AccessToken,
-    val refreshToken: RefreshToken
-)
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
+import com.wire.kalium.persistence.client.AuthTokenStorage
 
 /**
- * Represents an access token, which is used for authentication and authorization purposes.
- *
- * @property value The value of the access token.
- * @property tokenType The type of the access token. _e.g._ "Bearer"
+ * Interface for creating an [AccessTokenRepository] instance.
+ * Allows intaking a dynamic [AccessTokenApi] for its construction.
  */
-data class AccessToken(
-    val value: String,
-    val tokenType: String
-)
+internal interface AccessTokenRepositoryFactory {
+    fun create(tokenApi: AccessTokenApi): AccessTokenRepository
+}
 
-@JvmInline
-value class RefreshToken(val value: String)
+internal class AccessTokenRepositoryFactoryImpl(
+    private val userId: UserId,
+    private val tokenStorage: AuthTokenStorage
+) : AccessTokenRepositoryFactory {
+    override fun create(tokenApi: AccessTokenApi): AccessTokenRepository {
+        return AccessTokenRepositoryImpl(userId, tokenApi, tokenStorage)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
@@ -46,16 +46,16 @@ class AddAuthenticatedUserUseCase internal constructor(
     suspend operator fun invoke(
         serverConfigId: String,
         ssoId: SsoId?,
-        accountTokens: AccountTokens,
+        authTokens: AccountTokens,
         proxyCredentials: ProxyCredentials?,
         replace: Boolean = false
-    ): Result = sessionRepository.doesValidSessionExist(accountTokens.userId).fold(
+    ): Result = sessionRepository.doesValidSessionExist(authTokens.userId).fold(
             {
                 Result.Failure.Generic(it)
             }, { doesValidSessionExist ->
                 when (doesValidSessionExist) {
-                    true -> onUserExist(serverConfigId, ssoId, accountTokens, proxyCredentials, replace)
-                    false -> storeUser(serverConfigId, ssoId, accountTokens, proxyCredentials)
+                    true -> onUserExist(serverConfigId, ssoId, authTokens, proxyCredentials, replace)
+                    false -> storeUser(serverConfigId, ssoId, authTokens, proxyCredentials)
                 }
             }
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
@@ -46,16 +46,16 @@ class AddAuthenticatedUserUseCase internal constructor(
     suspend operator fun invoke(
         serverConfigId: String,
         ssoId: SsoId?,
-        authTokens: AuthTokens,
+        accountTokens: AccountTokens,
         proxyCredentials: ProxyCredentials?,
         replace: Boolean = false
-    ): Result = sessionRepository.doesValidSessionExist(authTokens.userId).fold(
+    ): Result = sessionRepository.doesValidSessionExist(accountTokens.userId).fold(
             {
                 Result.Failure.Generic(it)
             }, { doesValidSessionExist ->
                 when (doesValidSessionExist) {
-                    true -> onUserExist(serverConfigId, ssoId, authTokens, proxyCredentials, replace)
-                    false -> storeUser(serverConfigId, ssoId, authTokens, proxyCredentials)
+                    true -> onUserExist(serverConfigId, ssoId, accountTokens, proxyCredentials, replace)
+                    false -> storeUser(serverConfigId, ssoId, accountTokens, proxyCredentials)
                 }
             }
         )
@@ -63,28 +63,28 @@ class AddAuthenticatedUserUseCase internal constructor(
     private suspend fun storeUser(
         serverConfigId: String,
         ssoId: SsoId?,
-        authTokens: AuthTokens,
+        accountTokens: AccountTokens,
         proxyCredentials: ProxyCredentials?
     ): Result =
-        sessionRepository.storeSession(serverConfigId, ssoId, authTokens, proxyCredentials)
+        sessionRepository.storeSession(serverConfigId, ssoId, accountTokens, proxyCredentials)
             .onSuccess {
-                sessionRepository.updateCurrentSession(authTokens.userId)
+                sessionRepository.updateCurrentSession(accountTokens.userId)
             }.fold(
                 { Result.Failure.Generic(it) },
-                { Result.Success(authTokens.userId) }
+                { Result.Success(accountTokens.userId) }
             )
 
     // In case of the new session have a different server configurations the new session should not be added
     private suspend fun onUserExist(
         newServerConfigId: String,
         ssoId: SsoId?,
-        newAuthTokens: AuthTokens,
+        newAccountTokens: AccountTokens,
         proxyCredentials: ProxyCredentials?,
         replace: Boolean
     ): Result =
         when (replace) {
             true -> {
-                sessionRepository.fullAccountInfo(newAuthTokens.userId).fold(
+                sessionRepository.fullAccountInfo(newAccountTokens.userId).fold(
                     { Result.Failure.Generic(it) },
                     { oldSession ->
                         val newServerConfig =
@@ -93,7 +93,7 @@ class AddAuthenticatedUserUseCase internal constructor(
                             storeUser(
                                 serverConfigId = newServerConfigId,
                                 ssoId = ssoId,
-                                authTokens = newAuthTokens,
+                                accountTokens = newAccountTokens,
                                 proxyCredentials = proxyCredentials
                             )
                         } else Result.Failure.UserAlreadyExists

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthSession.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthSession.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.feature.auth
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.session.token.AccessToken
+import com.wire.kalium.logic.data.session.token.RefreshToken
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserId
 import kotlin.contracts.ExperimentalContracts
@@ -57,12 +58,24 @@ data class Account(
 )
 
 /**
- * Represents the authentication tokens received from the server, and the associated user id.
+ * Holds information about the user ID, and the associated user id.
  */
-data class AuthTokens(
+data class AccountTokens(
     val userId: UserId,
-    val accessToken: String,
-    val refreshToken: String,
-    val tokenType: String,
+    val accessToken: AccessToken,
+    val refreshToken: RefreshToken,
     val cookieLabel: String?
-)
+) {
+    constructor(
+        userId: UserId,
+        accessToken: String,
+        refreshToken: String,
+        tokenType: String,
+        cookieLabel: String?
+    ) : this(userId, AccessToken(accessToken, tokenType), RefreshToken(refreshToken), cookieLabel)
+
+    val tokenType: String
+        get() = accessToken.tokenType
+
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthSession.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthSession.kt
@@ -77,5 +77,4 @@ data class AccountTokens(
     val tokenType: String
         get() = accessToken.tokenType
 
-
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthSession.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthSession.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.feature.auth
 
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.session.token.AccessToken
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserId
 import kotlin.contracts.ExperimentalContracts
@@ -55,6 +56,9 @@ data class Account(
     val ssoId: SsoId?
 )
 
+/**
+ * Represents the authentication tokens received from the server, and the associated user id.
+ */
 data class AuthTokens(
     val userId: UserId,
     val accessToken: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -37,7 +37,7 @@ import com.wire.kalium.network.exceptions.isInvalidCredentials
 
 sealed class AuthenticationResult {
     data class Success(
-        val authData: AuthTokens,
+        val authData: AccountTokens,
         val ssoID: SsoId?,
         val serverConfigId: String,
         val proxyCredentials: ProxyCredentials?

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/GetSSOLoginSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/GetSSOLoginSessionUseCase.kt
@@ -32,7 +32,11 @@ import com.wire.kalium.network.exceptions.KaliumException
 import io.ktor.http.HttpStatusCode
 
 sealed class SSOLoginSessionResult {
-    data class Success(val accountTokens: AccountTokens, val ssoId: SsoId?, val proxyCredentials: ProxyCredentials?) : SSOLoginSessionResult()
+    data class Success(
+        val accountTokens: AccountTokens,
+        val ssoId: SsoId?,
+        val proxyCredentials: ProxyCredentials?
+    ) : SSOLoginSessionResult()
 
     sealed class Failure : SSOLoginSessionResult() {
         object InvalidCookie : Failure()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/GetSSOLoginSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/GetSSOLoginSessionUseCase.kt
@@ -26,13 +26,13 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.network.exceptions.KaliumException
 import io.ktor.http.HttpStatusCode
 
 sealed class SSOLoginSessionResult {
-    data class Success(val authTokens: AuthTokens, val ssoId: SsoId?, val proxyCredentials: ProxyCredentials?) : SSOLoginSessionResult()
+    data class Success(val accountTokens: AccountTokens, val ssoId: SsoId?, val proxyCredentials: ProxyCredentials?) : SSOLoginSessionResult()
 
     sealed class Failure : SSOLoginSessionResult() {
         object InvalidCookie : Failure()
@@ -67,7 +67,7 @@ internal class GetSSOLoginSessionUseCaseImpl(
             SSOLoginSessionResult.Failure.Generic(it)
         }, {
             SSOLoginSessionResult.Success(
-                authTokens = sessionMapper.fromSessionDTO(it.sessionDTO),
+                accountTokens = sessionMapper.fromSessionDTO(it.sessionDTO),
                 ssoId = idMapper.toSsoId(it.userDTO.ssoID),
                 proxyCredentials = proxyCredentials
             )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.DelicateKaliumApi
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -60,6 +61,19 @@ class SendTextMessageUseCase internal constructor(
     private val scope: CoroutineScope
 ) {
 
+    suspend operator fun invoke(
+        conversationReference: String,
+        text: String,
+        mentions: List<MessageMention> = emptyList(),
+        quotedMessageId: String? = null
+    ): Either<CoreFailure, Unit> = invoke(
+        ConversationId(conversationReference, conversationReference),
+        text,
+        mentions,
+        quotedMessageId
+    )
+
+    @DelicateKaliumApi("This method is not stable and can be changed in the future")
     suspend operator fun invoke(
         conversationId: ConversationId,
         text: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.util.DateTimeUtil
-import com.wire.kalium.util.DelicateKaliumApi
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -61,19 +60,6 @@ class SendTextMessageUseCase internal constructor(
     private val scope: CoroutineScope
 ) {
 
-    suspend operator fun invoke(
-        conversationReference: String,
-        text: String,
-        mentions: List<MessageMention> = emptyList(),
-        quotedMessageId: String? = null
-    ): Either<CoreFailure, Unit> = invoke(
-        ConversationId(conversationReference, conversationReference),
-        text,
-        mentions,
-        quotedMessageId
-    )
-
-    @DelicateKaliumApi("This method is not stable and can be changed in the future")
     suspend operator fun invoke(
         conversationId: ConversationId,
         text: String,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCase.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.login.ProxyCredentials
 import com.wire.kalium.logic.data.register.RegisterAccountRepository
 import com.wire.kalium.logic.data.user.SsoId
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.network.exceptions.KaliumException
@@ -138,7 +138,7 @@ class RegisterAccountUseCase internal constructor(
 
 sealed class RegisterResult {
     data class Success(
-        val authData: AuthTokens,
+        val authData: AccountTokens,
         val ssoID: SsoId?,
         val serverConfigId: String,
         val proxyCredentials: ProxyCredentials?

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/UpgradeCurrentSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/UpgradeCurrentSessionUseCase.kt
@@ -20,12 +20,11 @@ package com.wire.kalium.logic.feature.session
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.feature.session.token.AccessTokenRefresher
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
-import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.network.session.SessionManager
 
@@ -36,20 +35,16 @@ interface UpgradeCurrentSessionUseCase {
     suspend operator fun invoke(clientId: ClientId): Either<CoreFailure, Unit>
 }
 
-class UpgradeCurrentSessionUseCaseImpl(
+internal class UpgradeCurrentSessionUseCaseImpl(
     private val authenticatedNetworkContainer: AuthenticatedNetworkContainer,
-    private val accessTokenApi: AccessTokenApi,
+    private val accessTokenRefresher: AccessTokenRefresher,
     private val sessionManager: SessionManager
 ) : UpgradeCurrentSessionUseCase {
     override suspend operator fun invoke(clientId: ClientId): Either<CoreFailure, Unit> =
         wrapStorageRequest { sessionManager.session()?.refreshToken }
-            .flatMap { refreshToken ->
-                wrapApiRequest {
-                    accessTokenApi.getToken(refreshToken, clientId.value)
-                }.flatMap {
-                    wrapStorageRequest { sessionManager.updateLoginSession(it.first, it.second) }
-                }.map {
-                    authenticatedNetworkContainer.clearCachedToken()
-                }
+            .flatMap { currentRefreshToken ->
+                accessTokenRefresher.refreshTokenAndPersistSession(currentRefreshToken, clientId.value)
+            }.map {
+                authenticatedNetworkContainer.clearCachedToken()
             }
-    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresher.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresher.kt
@@ -1,0 +1,64 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.session.token
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.session.token.AccessTokenRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.auth.AccountTokens
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.map
+
+internal interface AccessTokenRefresher {
+    /**
+     * Refreshes the access token using the provided refresh token and persists the session in the repository.
+     *
+     * @param currentRefreshToken The refresh token to use for obtaining a new access token.
+     * @param clientId The optional client ID associated with the new token.
+     * @return Either a [CoreFailure] if the operation fails, or the [AccountTokens] with the new access token and refresh token.
+     */
+    suspend fun refreshTokenAndPersistSession(
+        currentRefreshToken: String,
+        clientId: String? = null,
+    ): Either<CoreFailure, AccountTokens>
+}
+
+internal class AccessTokenRefresherImpl(
+    private val userId: UserId,
+    private val repository: AccessTokenRepository,
+) : AccessTokenRefresher {
+    override suspend fun refreshTokenAndPersistSession(
+        currentRefreshToken: String,
+        clientId: String?
+    ): Either<CoreFailure, AccountTokens> {
+        return repository.getNewAccessToken(
+            refreshToken = currentRefreshToken,
+            clientId = clientId
+        ).flatMap { result ->
+            repository.persistTokens(result.accessToken, result.refreshToken).map {
+                AccountTokens(
+                    userId = userId,
+                    accessToken = result.accessToken,
+                    refreshToken = result.refreshToken,
+                    cookieLabel = null
+                )
+            }
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresherFactory.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresherFactory.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.session.token
+
+import com.wire.kalium.logic.data.session.token.AccessTokenRepositoryImpl
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
+import com.wire.kalium.persistence.client.AuthTokenStorage
+
+/**
+ * Represents a factory for creating instances of [AccessTokenRefresher].
+ * Allows taking a dynamic [AccessTokenApi] for its construction.
+ */
+internal interface AccessTokenRefresherFactory {
+    fun create(accessTokenApi: AccessTokenApi): AccessTokenRefresher
+}
+
+internal class AccessTokenRefresherFactoryImpl(
+    private val userId: UserId,
+    private val tokenStorage: AuthTokenStorage
+) : AccessTokenRefresherFactory {
+    override fun create(accessTokenApi: AccessTokenApi): AccessTokenRefresher {
+        return AccessTokenRefresherImpl(
+            userId = userId,
+            repository = AccessTokenRepositoryImpl(
+                userId = userId,
+                accessTokenApi = accessTokenApi,
+                authTokenStorage = tokenStorage
+            )
+        )
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -22,26 +22,26 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.server.ServerConfigMapper
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.feature.session.token.AccessTokenRefresherFactory
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.nullableFold
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
-import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
-import com.wire.kalium.network.api.base.model.RefreshTokenDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isUnknownClient
+import com.wire.kalium.network.session.FailureToRefreshTokenException
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.tools.ServerConfigDTO
 import com.wire.kalium.persistence.client.AuthTokenStorage
@@ -55,6 +55,7 @@ import kotlin.coroutines.CoroutineContext
 @Suppress("LongParameterList")
 class SessionManagerImpl internal constructor(
     private val sessionRepository: SessionRepository,
+    private val accessTokenRefresherFactory: AccessTokenRefresherFactory,
     private val userId: QualifiedID,
     private val tokenStorage: AuthTokenStorage,
     private val logout: suspend (LogoutReason) -> Unit,
@@ -88,44 +89,37 @@ class SessionManagerImpl internal constructor(
             .onSuccess { serverConfig = it }
             .fold({ error("use serverConfig is missing or an error while reading local storage") }, { it })
         serverConfig!!
-    }!!
+    }
 
-    suspend fun updateLoginSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO =
-        wrapStorageRequest {
-            tokenStorage.updateToken(
-                userId = userId.toDao(),
-                accessToken = newAccessTokenDTO.value,
-                tokenType = newAccessTokenDTO.tokenType,
-                refreshToken = newRefreshTokenDTO?.value
+    override suspend fun updateToken(
+        accessTokenApi: AccessTokenApi,
+        oldAccessToken: String,
+        oldRefreshToken: String
+    ): SessionDTO {
+        val refresher = accessTokenRefresherFactory.create(accessTokenApi)
+        return withContext(coroutineContext) {
+            refresher.refreshTokenAndPersistSession(oldRefreshToken).onFailure {
+                if (it is NetworkFailure.ServerMiscommunication) {
+                    onServerMissCommunication(it)
+                }
+            }
+        }.map { refreshResult ->
+            SessionDTO(
+                userId = userId.toApi(),
+                tokenType = refreshResult.accessToken.tokenType,
+                accessToken = refreshResult.accessToken.value,
+                refreshToken = refreshResult.refreshToken.value,
+                cookieLabel = null
             )
-        }.map {
-            sessionMapper.fromEntityToSessionDTO(it)
-        }.onSuccess {
-            session = it
-        }.nullableFold({
-            null
+        }.fold({
+            val message = "Failure during auth token refresh. " +
+                    "A network request is failing because of this. " +
+                    "Future requests should reattempt to refresh the token. Failure='$it'"
+            kaliumLogger.w(message)
+            throw FailureToRefreshTokenException(message)
         }, {
             it
         })
-
-    override suspend fun updateToken(accessTokenApi: AccessTokenApi, oldAccessToken: String, oldRefreshToken: String): SessionDTO {
-        return withContext(coroutineContext) {
-            wrapApiRequest { accessTokenApi.getToken(oldRefreshToken) }.nullableFold({
-                if(it is NetworkFailure.ServerMiscommunication){
-                    onServerMissCommunication(it)
-                }
-                when (it) {
-                    is NetworkFailure.ServerMiscommunication,
-                    is NetworkFailure.NoNetworkConnection,
-                    is NetworkFailure.ProxyError,
-                    is NetworkFailure.FederatedBackendFailure -> {
-                        throw KaliumException()
-                    }
-                }
-            }, {
-                updateLoginSession(it.first, it.second)
-            })
-        }
     }
 
     private suspend fun onServerMissCommunication(serverMiscommunication: NetworkFailure.ServerMiscommunication) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/register/RegisterAccountRepositoryTest.kt
@@ -23,12 +23,11 @@ import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.session.SessionMapper
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
-import com.wire.kalium.network.api.base.model.UserDTO
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.utils.NetworkResponse
 import io.mockative.Mock
@@ -138,8 +137,8 @@ class RegisterAccountRepositoryTest {
             this?.let { SsoId(scimExternalId = it.scimExternalId, subject = it.subject, tenant = it.tenant) }
         }
         val cookieLabel = "COOKIE_LABEL"
-        val authTokens = with(SESSION) {
-            AuthTokens(
+        val accountTokens = with(SESSION) {
+            AccountTokens(
                 userId = UserId(userId.value, userId.domain),
                 accessToken = accessToken,
                 refreshToken = refreshToken,
@@ -147,7 +146,7 @@ class RegisterAccountRepositoryTest {
                 cookieLabel = cookieLabel
             )
         }
-        val expected = Pair(ssoId, authTokens)
+        val expected = Pair(ssoId, accountTokens)
 
         given(registerApi).coroutine {
             register(
@@ -161,7 +160,7 @@ class RegisterAccountRepositoryTest {
             )
         }.then { NetworkResponse.Success(Pair(TEST_USER, SESSION), mapOf(), 200) }
         given(idMapper).invocation { toSsoId(TEST_USER.ssoID) }.then { ssoId }
-        given(sessionMapper).invocation { fromSessionDTO(SESSION) }.then { authTokens }
+        given(sessionMapper).invocation { fromSessionDTO(SESSION) }.then { accountTokens }
 
         val actual = registerAccountRepository.registerPersonalAccountWithEmail(
             email = email,
@@ -171,7 +170,7 @@ class RegisterAccountRepositoryTest {
             cookieLabel = cookieLabel
         )
 
-        assertIs<Either.Right<Pair<SsoId?, AuthTokens>>>(actual)
+        assertIs<Either.Right<Pair<SsoId?, AccountTokens>>>(actual)
         assertEquals(expected, actual.value)
 
         verify(registerApi).coroutine {
@@ -203,9 +202,9 @@ class RegisterAccountRepositoryTest {
         val ssoId = with(TEST_USER.ssoID) {
             this?.let { SsoId(scimExternalId = it.scimExternalId, subject = it.subject, tenant = it.tenant) }
         }
-        val authTokens =
+        val accountTokens =
             with(SESSION) {
-                AuthTokens(
+                AccountTokens(
                     userId = UserId(userId.value, userId.domain),
                     accessToken = accessToken,
                     refreshToken = refreshToken,
@@ -213,7 +212,7 @@ class RegisterAccountRepositoryTest {
                     cookieLabel = cookieLabel
                 )
             }
-        val expected = Pair(ssoId, authTokens)
+        val expected = Pair(ssoId, accountTokens)
 
         given(registerApi).coroutine {
             register(
@@ -231,7 +230,7 @@ class RegisterAccountRepositoryTest {
         given(idMapper).invocation { toSsoId(TEST_USER.ssoID) }.then { ssoId }
         given(sessionMapper)
             .invocation { fromSessionDTO(SESSION) }
-            .then { authTokens }
+            .then { accountTokens }
 
         val actual = registerAccountRepository.registerTeamWithEmail(
             email = email,
@@ -243,7 +242,7 @@ class RegisterAccountRepositoryTest {
             cookieLabel = cookieLabel
         )
 
-        assertIs<Either.Right<Pair<SsoId?, AuthTokens>>>(actual)
+        assertIs<Either.Right<Pair<SsoId?, AccountTokens>>>(actual)
         assertEquals(expected, actual.value)
 
         verify(registerApi).coroutine {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionMapperTest.kt
@@ -56,8 +56,8 @@ class SessionMapperTest {
                 SessionDTO(
                     UserIdDTO(userId.value, userId.domain),
                     tokenType,
-                    accessToken,
-                    refreshToken,
+                    accessToken.value,
+                    refreshToken.value,
                     cookieLabel
                 )
             }
@@ -76,8 +76,8 @@ class SessionMapperTest {
             AuthTokenEntity(
                 userId = UserIDEntity(userId.value, userId.domain),
                 tokenType = tokenType,
-                accessToken = accessToken,
-                refreshToken = refreshToken,
+                accessToken = accessToken.value,
+                refreshToken = refreshToken.value,
                 cookieLabel = cookieLabel
             )
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionMapperTest.kt
@@ -21,7 +21,7 @@ package com.wire.kalium.logic.data.session
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.network.api.base.model.SessionDTO
 import com.wire.kalium.persistence.client.AuthTokenEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -49,7 +49,7 @@ class SessionMapperTest {
 
     @Test
     fun givenAnAuthTokens_whenMappingToSessionCredentials_thenValuesAreMappedCorrectly() {
-        val authSession: AuthTokens = TEST_AUTH_TOKENS
+        val authSession: AccountTokens = TEST_AUTH_TOKENS
 
         val acuteValue: SessionDTO =
             with(authSession) {
@@ -68,7 +68,7 @@ class SessionMapperTest {
 
     @Test
     fun givenAnAuthTokens_whenMappingToPersistenceAuthTokens_thenValuesAreMappedCorrectly() {
-        val authSession: AuthTokens = TEST_AUTH_TOKENS
+        val authSession: AccountTokens = TEST_AUTH_TOKENS
 
         given(idMapper).invocation { idMapper.toSsoIdEntity(TEST_SSO_ID) }.then { TEST_SSO_ID_ENTITY }
 
@@ -89,7 +89,7 @@ class SessionMapperTest {
     private companion object {
         val userId = UserId("user_id", "user.domain.io")
 
-        val TEST_AUTH_TOKENS = AuthTokens(
+        val TEST_AUTH_TOKENS = AccountTokens(
             userId = userId,
             tokenType = "Bearer",
             accessToken = "access_token",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCaseTest.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.auth.login.ProxyCredentials
 import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.session.token.AccessToken
+import com.wire.kalium.logic.data.session.token.RefreshToken
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
@@ -33,12 +35,10 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertIs
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AddAuthenticatedUserUseCaseTest {
 
     @Test
@@ -100,10 +100,16 @@ class AddAuthenticatedUserUseCaseTest {
 
     @Test
     fun givenUserWithAlreadyStoredSession_whenInvokedWithReplaceAndServerConfigAreTheSame_thenSuccessReturned() = runTest {
-        val oldSession = TEST_AUTH_TOKENS.copy(accessToken = "oldAccessToken", refreshToken = "oldRefreshToken")
+        val oldSession = TEST_AUTH_TOKENS.copy(
+            accessToken = AccessToken("oldAccessToken", TEST_AUTH_TOKENS.tokenType),
+            refreshToken = RefreshToken("oldRefreshToken")
+        )
         val oldSessionFullInfo = Account(AccountInfo.Valid(oldSession.userId), TEST_SERVER_CONFIG, TEST_SSO_ID)
 
-        val newSession = TEST_AUTH_TOKENS.copy(accessToken = "newAccessToken", refreshToken = "newRefreshToken")
+        val newSession = TEST_AUTH_TOKENS.copy(
+            accessToken = AccessToken("newAccessToken", TEST_AUTH_TOKENS.tokenType),
+            refreshToken = RefreshToken("newRefreshToken")
+        )
 
         val proxyCredentials = PROXY_CREDENTIALS
 
@@ -146,10 +152,16 @@ class AddAuthenticatedUserUseCaseTest {
 
     @Test
     fun givenUserWithAlreadyStoredSessionWithDifferentServerConfig_whenInvokedWithReplace_thenUserAlreadyExistsReturned() = runTest {
-        val oldSession = TEST_AUTH_TOKENS.copy(accessToken = "oldAccessToken", refreshToken = "oldRefreshToken")
+        val oldSession = TEST_AUTH_TOKENS.copy(
+            accessToken = AccessToken("oldAccessToken", TEST_AUTH_TOKENS.tokenType),
+            refreshToken = RefreshToken("oldRefreshToken")
+        )
         val oldSessionServer = newServerConfig(id = 11)
 
-        val newSession = TEST_AUTH_TOKENS.copy(accessToken = "newAccessToken", refreshToken = "newRefreshToken")
+        val newSession = TEST_AUTH_TOKENS.copy(
+            accessToken = AccessToken("newAccessToken", TEST_AUTH_TOKENS.tokenType),
+            refreshToken = RefreshToken("newRefreshToken")
+        )
         val newSessionServer = newServerConfig(id = 22)
 
         val proxyCredentials = PROXY_CREDENTIALS

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCaseTest.kt
@@ -191,7 +191,7 @@ class AddAuthenticatedUserUseCaseTest {
     private companion object {
         val TEST_USERID = UserId("user_id", "domain.de")
         val TEST_SERVER_CONFIG: ServerConfig = newServerConfig(1)
-        val TEST_AUTH_TOKENS = AuthTokens(
+        val TEST_AUTH_TOKENS = AccountTokens(
             TEST_USERID,
             "access-token",
             "refresh-token",
@@ -246,11 +246,11 @@ class AddAuthenticatedUserUseCaseTest {
         suspend fun withStoreSessionResult(
             serverConfigId: String,
             ssoId: SsoId?,
-            authTokens: AuthTokens,
+            accountTokens: AccountTokens,
             proxyCredentials: ProxyCredentials?,
             result: Either<StorageFailure, Unit>
         ) = apply {
-            given(sessionRepository).coroutine { storeSession(serverConfigId, ssoId, authTokens, proxyCredentials) }.then { result }
+            given(sessionRepository).coroutine { storeSession(serverConfigId, ssoId, accountTokens, proxyCredentials) }.then { result }
         }
 
         suspend fun withUpdateCurrentSessionResult(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -499,14 +499,14 @@ class LoginUseCaseTest {
                 .thenReturn(handleValidationResult)
         }
 
-        fun withLoginUsingEmailResulting(result: Either<NetworkFailure, Pair<AuthTokens, SsoId?>>) = apply {
+        fun withLoginUsingEmailResulting(result: Either<NetworkFailure, Pair<AccountTokens, SsoId?>>) = apply {
             given(loginRepository)
                 .suspendFunction(loginRepository::loginWithEmail)
                 .whenInvokedWith(any(), any(), any(), any(), anything())
                 .thenReturn(result)
         }
 
-        fun withLoginUsingHandleResulting(result: Either<NetworkFailure, Pair<AuthTokens, SsoId?>>) = apply {
+        fun withLoginUsingHandleResulting(result: Either<NetworkFailure, Pair<AccountTokens, SsoId?>>) = apply {
             given(loginRepository)
                 .suspendFunction(loginRepository::loginWithHandle)
                 .whenInvokedWith(any(), any(), any(), any())
@@ -534,7 +534,7 @@ class LoginUseCaseTest {
         // TODO: Remove random value from tests
         val TEST_PERSIST_CLIENT = Random.nextBoolean()
         val TEST_SERVER_CONFIG: ServerConfig = newTestServer(1)
-        val TEST_AUTH_TOKENS = AuthTokens(
+        val TEST_AUTH_TOKENS = AccountTokens(
             userId = UserId("user_id", "domain.de"),
             accessToken = "access_token",
             refreshToken = "refresh_token",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCaseTest.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.auth.AuthTokens
+import com.wire.kalium.logic.feature.auth.AccountTokens
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.stubs.newServerConfig
@@ -216,7 +216,7 @@ class RegisterAccountUseCaseTest {
             completePicture = null,
             availabilityStatus = UserAvailabilityStatus.NONE
         )
-        val TEST_AUTH_TOKENS = AuthTokens(
+        val TEST_AUTH_TOKENS = AccountTokens(
             accessToken = "access_token",
             refreshToken = "refresh_token",
             tokenType = "token_type",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresherTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresherTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.session.token
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.session.token.AccessToken
+import com.wire.kalium.logic.data.session.token.AccessTokenRefreshResult
+import com.wire.kalium.logic.data.session.token.AccessTokenRepository
+import com.wire.kalium.logic.data.session.token.RefreshToken
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AccessTokenRefresherTest {
+
+    @Test
+    fun givenRefreshFails_whenRefreshing_thenShouldPropagateFailureAndNotPersist(): TestResult = runTest {
+        val failure = NetworkFailure.NoNetworkConnection(null)
+        val (arrangement, accessTokenRefresher) = arrange {
+            withRefreshTokenReturning(Either.Left(failure))
+        }
+
+        accessTokenRefresher.refreshTokenAndPersistSession("egal")
+            .shouldFail {
+                assertEquals(failure, it)
+            }
+        verify(arrangement.repository)
+            .suspendFunction(arrangement.repository::persistTokens)
+            .with(anything())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenPersistFails_whenRefreshing_thenShouldPropagateFailure(): TestResult = runTest {
+        val failure = StorageFailure.DataNotFound
+        val (_, accessTokenRefresher) = arrange {
+            withRefreshTokenReturning(
+                Either.Right(
+                    AccessTokenRefreshResult(
+                        AccessToken("access", "refresh"),
+                        RefreshToken("hey")
+                    )
+                )
+            )
+            withPersistReturning(Either.Left(failure))
+        }
+
+        accessTokenRefresher.refreshTokenAndPersistSession("egal")
+            .shouldFail {
+                assertEquals(failure, it)
+            }
+    }
+
+    @Test
+    fun givenSuccessfulRefresh_whenRefreshing_thenShouldPersistResultCorrectly(): TestResult = runTest {
+        val (arrangement, accessTokenRefresher) = arrange {
+            withRefreshTokenReturning(Either.Right(TEST_REFRESH_RESULT))
+            withPersistReturning(Either.Right(Unit))
+        }
+
+        accessTokenRefresher.refreshTokenAndPersistSession("egal")
+        verify(arrangement.repository)
+            .suspendFunction(arrangement.repository::persistTokens)
+            .with(eq(TEST_REFRESH_RESULT.accessToken), eq(TEST_REFRESH_RESULT.refreshToken))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenEverythingSucceeds_whenRefreshing_thenShouldPropagateSuccess(): TestResult = runTest {
+        val (_, accessTokenRefresher) = arrange {
+            withRefreshTokenReturning(Either.Right(TEST_REFRESH_RESULT))
+            withPersistReturning(Either.Right(Unit))
+        }
+
+        accessTokenRefresher.refreshTokenAndPersistSession("egal").shouldSucceed { }
+    }
+
+    private class Arrangement(private val configure: Arrangement.() -> Unit) {
+
+        val userId = TestUser.USER_ID
+
+        @Mock
+        val repository = mock(AccessTokenRepository::class)
+
+        fun arrange(): Pair<Arrangement, AccessTokenRefresher> = run {
+            configure()
+            this@Arrangement to AccessTokenRefresherImpl(userId, repository)
+        }
+
+        fun withRefreshTokenReturning(result: Either<NetworkFailure, AccessTokenRefreshResult>) {
+            given(repository)
+                .suspendFunction(repository::getNewAccessToken)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(result)
+        }
+
+        fun withPersistReturning(result: Either<StorageFailure, Unit>) {
+            given(repository)
+                .suspendFunction(repository::persistTokens)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(result)
+        }
+    }
+
+    private companion object {
+        fun arrange(configure: Arrangement.() -> Unit) = Arrangement(configure).arrange()
+
+        val TEST_REFRESH_RESULT = AccessTokenRefreshResult(
+            AccessToken("access", "refresh"),
+            RefreshToken("hey")
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/SessionManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/SessionManagerTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.network
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.configuration.server.ServerConfigMapper
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.session.SessionMapper
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.feature.auth.AccountTokens
+import com.wire.kalium.logic.feature.session.token.AccessTokenRefresher
+import com.wire.kalium.logic.feature.session.token.AccessTokenRefresherFactory
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
+import com.wire.kalium.network.session.FailureToRefreshTokenException
+import com.wire.kalium.network.session.SessionManager
+import com.wire.kalium.persistence.client.AuthTokenStorage
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class SessionManagerTest {
+
+    @Test
+    fun givenFailureOnRefresh_whenRefreshingToken_thenShouldThrowException() = runTest {
+        val failure = NetworkFailure.NoNetworkConnection(null)
+        val (arrangement, sessionManager) = arrange {
+            withTokenRefresherResult(Either.Left(failure))
+        }
+
+        assertFailsWith<FailureToRefreshTokenException> {
+            sessionManager.updateToken(arrangement.accessTokenApi, "egal", "egal")
+        }
+    }
+
+    private class Arrangement(private val configure: Arrangement.() -> Unit) {
+
+        @Mock
+        private val sessionRepository = mock(SessionRepository::class)
+
+        // Unused, but necessary when updating tokens
+        @Mock
+        val accessTokenApi = mock(AccessTokenApi::class)
+
+        @Mock
+        private val accessTokenRefresher = mock(AccessTokenRefresher::class)
+        private val accessTokenRefresherFactory = object : AccessTokenRefresherFactory {
+            override fun create(accessTokenApi: AccessTokenApi): AccessTokenRefresher {
+                return accessTokenRefresher
+            }
+        }
+        private val userId = TestUser.USER_ID
+
+        @Mock
+        private val tokenStorage = mock(AuthTokenStorage::class)
+
+        private val logout = { _: LogoutReason -> }
+
+        @Mock
+        private val serverConfigMapper = mock(ServerConfigMapper::class)
+
+        @Mock
+        private val sessionMapper = mock(SessionMapper::class)
+
+        fun arrange(): Pair<Arrangement, SessionManager> = run {
+            configure()
+            this@Arrangement to SessionManagerImpl(
+                sessionRepository = sessionRepository,
+                accessTokenRefresherFactory = accessTokenRefresherFactory,
+                userId = userId,
+                tokenStorage = tokenStorage,
+                logout = logout,
+                serverConfigMapper = serverConfigMapper,
+                sessionMapper = sessionMapper,
+                coroutineContext = EmptyCoroutineContext
+            )
+        }
+
+        fun withTokenRefresherResult(result: Either<CoreFailure, AccountTokens>) = apply {
+            given(accessTokenRefresher)
+                .suspendFunction(accessTokenRefresher::refreshTokenAndPersistSession)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(result)
+        }
+    }
+
+    private companion object {
+        fun arrange(configure: Arrangement.() -> Unit) = Arrangement(configure).arrange()
+    }
+}

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
@@ -82,7 +82,7 @@ class Monkey(val user: UserData) {
             val storeResult = addAuthenticatedAccount(
                 serverConfigId = loginResult.serverConfigId,
                 ssoId = loginResult.ssoID,
-                authTokens = loginResult.authData,
+                accountTokens = loginResult.authData,
                 proxyCredentials = loginResult.proxyCredentials,
                 replace = true
             )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/Tokens.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/Tokens.kt
@@ -22,6 +22,14 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
+/**
+ * Represents an access token received from an authentication server.
+ *
+ * @property userId The ID of the user associated with the access token.
+ * @property value The access token value.
+ * @property expiresIn The duration in seconds until the token expires.
+ * @property tokenType The type of the token. _e.g._ "Bearer"
+ */
 @Serializable
 data class AccessTokenDTO(
     @SerialName("user") val userId: NonQualifiedUserId,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -189,11 +189,10 @@ internal class AuthenticatedHttpClientProviderImpl(
         BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
     }
 
-    private val refreshToken: suspend RefreshTokensParams.() -> BearerTokens? = {
+    private val refreshToken: suspend RefreshTokensParams.() -> BearerTokens = {
+        // TODO: Add logs for when the `oldTokens` are null just to make it easier to find in logs if it ever happens
         val newSession = sessionManager.updateToken(accessTokenApi(client), oldTokens!!.accessToken, oldTokens!!.refreshToken)
-        newSession?.let {
-            BearerTokens(accessToken = it.accessToken, refreshToken = it.refreshToken)
-        }
+        BearerTokens(accessToken =  newSession.accessToken, refreshToken =  newSession.refreshToken)
     }
 
     private val bearerAuthProvider: BearerAuthProvider = BearerAuthProvider(refreshToken, loadToken, { true }, null)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/FailureToRefreshTokenException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/FailureToRefreshTokenException.kt
@@ -15,16 +15,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+package com.wire.kalium.network.session
 
-package com.wire.kalium.network.api.base.authenticated
-
-import com.wire.kalium.network.api.base.model.AccessTokenDTO
-import com.wire.kalium.network.api.base.model.RefreshTokenDTO
-import com.wire.kalium.network.utils.NetworkResponse
-
-interface AccessTokenApi {
-    suspend fun getToken(
-        refreshToken: String,
-        clientId: String? = null
-    ): NetworkResponse<Pair<AccessTokenDTO, RefreshTokenDTO?>>
-}
+/**
+ * Exception thrown when a token refresh fails.
+ * Could be caused by anything, including network errors, invalid credentials, etc.
+ *
+ * @param message The detail message.
+ * @param cause The cause of the exception.
+ */
+class FailureToRefreshTokenException(
+    message: String,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -19,9 +19,7 @@
 package com.wire.kalium.network.session
 
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
-import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
-import com.wire.kalium.network.api.base.model.RefreshTokenDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
 import com.wire.kalium.network.tools.ServerConfigDTO
 import io.ktor.client.HttpClient
@@ -45,13 +43,15 @@ interface SessionManager {
     fun serverConfig(): ServerConfigDTO
 
     /**
-     * Updates the access token and refresh token in the session.
+     * Updates the access token and (possibly) the refresh token for the session.
      *
+     * In case of failure to refresh the access token, an exception can be thrown.
      *
      * @param accessTokenApi The AccessTokenApi interface used to retrieve the new access token.
      * @param oldAccessToken The old access token to be replaced.
      * @param oldRefreshToken The old refresh token to be replaced.
      * @return The updated SessionDTO object.
+     * @see FailureToRefreshTokenException
      */
     suspend fun updateToken(accessTokenApi: AccessTokenApi, oldAccessToken: String, oldRefreshToken: String): SessionDTO
     fun proxyCredentials(): ProxyCredentialsDTO?

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -43,8 +43,17 @@ import kotlin.coroutines.CoroutineContext
 interface SessionManager {
     suspend fun session(): SessionDTO?
     fun serverConfig(): ServerConfigDTO
-    suspend fun updateToken(accessTokenApi: AccessTokenApi, oldAccessToken: String, oldRefreshToken: String): SessionDTO?
-    suspend fun updateLoginSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO?
+
+    /**
+     * Updates the access token and refresh token in the session.
+     *
+     *
+     * @param accessTokenApi The AccessTokenApi interface used to retrieve the new access token.
+     * @param oldAccessToken The old access token to be replaced.
+     * @param oldRefreshToken The old refresh token to be replaced.
+     * @return The updated SessionDTO object.
+     */
+    suspend fun updateToken(accessTokenApi: AccessTokenApi, oldAccessToken: String, oldRefreshToken: String): SessionDTO
     fun proxyCredentials(): ProxyCredentialsDTO?
 }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -65,8 +65,12 @@ internal abstract class ApiTest {
 
     private val refreshToken: suspend RefreshTokensParams.() -> BearerTokens?
         get() = {
-            val newSession = TEST_SESSION_MANAGER.updateToken(AccessTokenApiV0(client), oldTokens!!.accessToken, oldTokens!!.refreshToken)
-            newSession?.let {
+            val newSession = TEST_SESSION_MANAGER.updateToken(
+                accessTokenApi = AccessTokenApiV0(client),
+                oldAccessToken = oldTokens!!.accessToken,
+                oldRefreshToken = oldTokens!!.refreshToken
+            )
+            newSession.let {
                 BearerTokens(accessToken = it.accessToken, refreshToken = it.refreshToken)
             }
         }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/TestSessionManagerV0.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/TestSessionManagerV0.kt
@@ -20,9 +20,7 @@ package com.wire.kalium.api
 
 import com.wire.kalium.api.json.model.testCredentials
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
-import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
-import com.wire.kalium.network.api.base.model.RefreshTokenDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.tools.ServerConfigDTO
@@ -33,18 +31,13 @@ class TestSessionManagerV0 : SessionManager {
 
     override suspend fun session(): SessionDTO = session
     override fun serverConfig(): ServerConfigDTO = serverConfig
-    override suspend fun updateToken(accessTokenApi: AccessTokenApi, oldAccessToken: String, oldRefreshToken: String): SessionDTO {
+    override suspend fun updateToken(
+        accessTokenApi: AccessTokenApi,
+        oldAccessToken: String,
+        oldRefreshToken: String
+    ): SessionDTO {
         TODO("Not yet implemented")
     }
-
-    override suspend fun updateLoginSession(newAccessTokenDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?) =
-        SessionDTO(
-            session.userId,
-            newAccessTokenDTO.tokenType,
-            newAccessTokenDTO.value,
-            newRefreshTokenDTO?.value ?: session.refreshToken,
-            session.cookieLabel
-        )
 
     override fun proxyCredentials(): ProxyCredentialsDTO? =
         ProxyCredentialsDTO("username", "password")

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/TestSessionManagerV0.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/TestSessionManagerV0.kt
@@ -33,7 +33,7 @@ class TestSessionManagerV0 : SessionManager {
 
     override suspend fun session(): SessionDTO = session
     override fun serverConfig(): ServerConfigDTO = serverConfig
-    override suspend fun updateToken(accessTokenApi: AccessTokenApi, oldAccessToken: String, oldRefreshToken: String): SessionDTO? {
+    override suspend fun updateToken(accessTokenApi: AccessTokenApi, oldAccessToken: String, oldRefreshToken: String): SessionDTO {
         TODO("Not yet implemented")
     }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerIntegrationTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerIntegrationTest.kt
@@ -230,6 +230,7 @@ class SessionManagerIntegrationTest {
             mockEngine,
             sessionManager.serverConfig(),
             bearerAuthProvider,
+            kaliumLogger,
             false
         )
         val assetApi = AssetApiV0(client)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerIntegrationTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerIntegrationTest.kt
@@ -23,17 +23,17 @@ import com.wire.kalium.api.TestNetworkStateObserver.Companion.DEFAULT_TEST_NETWO
 import com.wire.kalium.api.json.model.testCredentials
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
-import com.wire.kalium.network.api.base.model.AccessTokenDTO
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
-import com.wire.kalium.network.api.base.model.RefreshTokenDTO
 import com.wire.kalium.network.api.base.model.SessionDTO
 import com.wire.kalium.network.api.v0.authenticated.AccessTokenApiV0
 import com.wire.kalium.network.api.v0.authenticated.AssetApiV0
+import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.kaliumLogger
 import com.wire.kalium.network.networkContainer.KaliumUserAgentProvider
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.session.installAuth
 import com.wire.kalium.network.tools.ServerConfigDTO
+import com.wire.kalium.network.utils.NetworkResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respondError
@@ -44,30 +44,39 @@ import io.ktor.client.plugins.auth.providers.RefreshTokensParams
 import io.ktor.client.request.get
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
-class SessionManagerTest {
+/**
+ * Tests how our [SessionManager] integrates with the internals of Ktor.
+ * For example, making sure that when we throw an exception during token refresh,
+ * Ktor will catch it, and we will be able to return a [NetworkResponse.Error] with the exception.
+ */
+class SessionManagerIntegrationTest {
 
     @Test
     fun givenClientWithAuth_whenServerReturns401_thenShouldTryAgainWithNewToken() = runTest {
         val sessionManager = createFakeSessionManager()
 
         val loadToken: suspend () -> BearerTokens? = {
-            val session = sessionManager.session() ?: error("missing user session")
+            val session = sessionManager.session()
             BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
         }
 
         val refreshToken: suspend RefreshTokensParams.() -> BearerTokens? = {
-            val newSession = sessionManager.updateToken(AccessTokenApiV0(client), oldTokens!!.accessToken, oldTokens!!.refreshToken)
-            newSession?.let {
+            val newSession = sessionManager.updateToken(
+                accessTokenApi = AccessTokenApiV0(client),
+                oldAccessToken = oldTokens!!.accessToken,
+                oldRefreshToken = oldTokens!!.refreshToken
+            )
+            newSession.let {
                 BearerTokens(accessToken = it.accessToken, refreshToken = it.refreshToken)
             }
         }
@@ -76,7 +85,7 @@ class SessionManagerTest {
 
         var callCount = 0
         var didFail = false
-        val mockEngine = MockEngine() {
+        val mockEngine = MockEngine {
             callCount++
             // Fail only the first time, so the test can
             // proceed when sessionManager is called again
@@ -104,20 +113,24 @@ class SessionManagerTest {
         val sessionManager = createFakeSessionManager()
 
         val loadToken: suspend () -> BearerTokens? = {
-            val session = sessionManager.session() ?: error("missing user session")
+            val session = sessionManager.session()
             BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
         }
 
         val refreshToken: suspend RefreshTokensParams.() -> BearerTokens? = {
-            val newSession = sessionManager.updateToken(AccessTokenApiV0(client), oldTokens!!.accessToken, oldTokens!!.refreshToken)
-            newSession?.let {
+            val newSession = sessionManager.updateToken(
+                accessTokenApi = AccessTokenApiV0(client),
+                oldAccessToken = oldTokens!!.accessToken,
+                oldRefreshToken = oldTokens!!.refreshToken
+            )
+            newSession.let {
                 BearerTokens(accessToken = it.accessToken, refreshToken = it.refreshToken)
             }
         }
 
         val bearerAuthProvider = BearerAuthProvider(refreshToken, loadToken, { true }, null)
 
-        val mockEngine = MockEngine() {
+        val mockEngine = MockEngine {
             respondOk()
         }
 
@@ -139,13 +152,17 @@ class SessionManagerTest {
         val sessionManager = createFakeSessionManager()
 
         val loadToken: suspend () -> BearerTokens? = {
-            val session = sessionManager.session() ?: error("missing user session")
+            val session = sessionManager.session()
             BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
         }
 
         val refreshToken: suspend RefreshTokensParams.() -> BearerTokens? = {
-            val newSession = sessionManager.updateToken(AccessTokenApiV0(client), oldTokens!!.accessToken, oldTokens!!.refreshToken)
-            newSession?.let {
+            val newSession = sessionManager.updateToken(
+                AccessTokenApiV0(client),
+                oldTokens!!.accessToken,
+                oldTokens!!.refreshToken
+            )
+            newSession.let {
                 BearerTokens(accessToken = it.accessToken, refreshToken = it.refreshToken)
             }
         }
@@ -154,7 +171,7 @@ class SessionManagerTest {
 
         var callCount = 0
         var didFail = false
-        val mockEngine = MockEngine() {
+        val mockEngine = MockEngine {
             callCount++
             // Fail only the first time, so the test can
             // proceed when sessionManager is called again
@@ -169,7 +186,12 @@ class SessionManagerTest {
         }
 
         val client = AuthenticatedNetworkClient(
-            DEFAULT_TEST_NETWORK_STATE_OBSERVER, mockEngine, sessionManager.serverConfig(), bearerAuthProvider, kaliumLogger, false
+            DEFAULT_TEST_NETWORK_STATE_OBSERVER,
+            mockEngine,
+            sessionManager.serverConfig(),
+            bearerAuthProvider,
+            kaliumLogger,
+            false
         )
         val assetApi = AssetApiV0(client)
         val kaliumFileSystem: FileSystem = FakeFileSystem()
@@ -178,6 +200,49 @@ class SessionManagerTest {
 
         assetApi.downloadAsset("asset_id", "asset_domain", null, tempFileSink = tempOutputSink)
         assertEquals(2, callCount)
+    }
+
+    @Test
+    fun givenRefreshTokenThrows_whenServerSignalTokenRefreshIsNeeded_thenShouldReturnFailure() = runTest {
+        KaliumUserAgentProvider.setUserAgent("KaliumTest")
+        val sessionManager = createFakeSessionManager()
+
+        val loadToken: suspend () -> BearerTokens? = {
+            val session = sessionManager.session()
+            BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
+        }
+
+        val expectedCause = Exception("Refresh token failed")
+        var isThrowing = false
+        val refreshToken: suspend RefreshTokensParams.() -> BearerTokens? = {
+            isThrowing = true
+            throw expectedCause
+        }
+
+        val bearerAuthProvider = BearerAuthProvider(refreshToken, loadToken, { true }, null)
+
+        val mockEngine = MockEngine {
+            respondError(status = HttpStatusCode.Unauthorized)
+        }
+
+        val client = AuthenticatedNetworkClient(
+            DEFAULT_TEST_NETWORK_STATE_OBSERVER,
+            mockEngine,
+            sessionManager.serverConfig(),
+            bearerAuthProvider,
+            false
+        )
+        val assetApi = AssetApiV0(client)
+        val kaliumFileSystem: FileSystem = FakeFileSystem()
+        val tempPath = "some-dummy-path".toPath()
+        val tempOutputSink = kaliumFileSystem.sink(tempPath)
+
+        val result = assetApi.downloadAsset("asset_id", "asset_domain", null, tempFileSink = tempOutputSink)
+        assertIs<NetworkResponse.Error>(result)
+        val exception = result.kException
+        assertIs<KaliumException.GenericError>(exception)
+        assertEquals(expectedCause.message, exception.cause.message)
+        assertTrue(isThrowing)
     }
 
     private companion object {
@@ -192,9 +257,6 @@ class SessionManagerTest {
             oldAccessToken: String,
             oldRefreshToken: String
         ): SessionDTO = testCredentials.copy(accessToken = UPDATED_ACCESS_TOKEN)
-
-        override suspend fun updateLoginSession(newAccessTokeDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO? =
-            testCredentials
 
         override fun proxyCredentials(): ProxyCredentialsDTO? = ProxyCredentialsDTO("username", "password")
     }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerTest.kt
@@ -191,7 +191,7 @@ class SessionManagerTest {
             accessTokenApi: AccessTokenApi,
             oldAccessToken: String,
             oldRefreshToken: String
-        ): SessionDTO? = testCredentials.copy(accessToken = UPDATED_ACCESS_TOKEN)
+        ): SessionDTO = testCredentials.copy(accessToken = UPDATED_ACCESS_TOKEN)
 
         override suspend fun updateLoginSession(newAccessTokeDTO: AccessTokenDTO, newRefreshTokenDTO: RefreshTokenDTO?): SessionDTO? =
             testCredentials

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.kmmSettings
 
 import android.content.Context
 import com.wire.kalium.persistence.client.AuthTokenStorage
+import com.wire.kalium.persistence.client.AuthTokenStorageImpl
 import com.wire.kalium.persistence.client.TokenStorage
 import com.wire.kalium.persistence.client.TokenStorageImpl
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorage
@@ -32,7 +33,7 @@ actual class GlobalPrefProvider(context: Context, shouldEncryptData: Boolean = t
     )
 
     actual val authTokenStorage: AuthTokenStorage
-        get() = AuthTokenStorage(encryptedSettingsHolder)
+        get() = AuthTokenStorageImpl(encryptedSettingsHolder)
     actual val passphraseStorage: PassphraseStorage
         get() = PassphraseStorageImpl(encryptedSettingsHolder)
     actual val tokenStorage: TokenStorage

--- a/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.persistence.kmmSettings
 
 import com.wire.kalium.persistence.client.AuthTokenStorage
+import com.wire.kalium.persistence.client.AuthTokenStorageImpl
 import com.wire.kalium.persistence.client.TokenStorage
 import com.wire.kalium.persistence.client.TokenStorageImpl
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorage
@@ -37,7 +38,7 @@ actual class GlobalPrefProvider(
         )
 
     actual val authTokenStorage: AuthTokenStorage
-        get() = AuthTokenStorage(kaliumPref)
+        get() = AuthTokenStorageImpl(kaliumPref)
     actual val passphraseStorage: PassphraseStorage
         get() = PassphraseStorageImpl(kaliumPref)
     actual val tokenStorage: TokenStorage

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/AuthTokenStorageTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/client/AuthTokenStorageTest.kt
@@ -37,7 +37,7 @@ class AuthTokenStorageTest {
     @BeforeTest
     fun setup() {
         mockSettings.clear()
-        authTokenStorage = AuthTokenStorage(kaliumPreferences)
+        authTokenStorage = AuthTokenStorageImpl(kaliumPreferences)
     }
 
     @Test
@@ -68,7 +68,6 @@ class AuthTokenStorageTest {
 
         assertFails {
             authTokenStorage.updateToken(expected.userId, "access_token", "token_type", "refresh_token")
-
         }
     }
 

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.persistence.kmmSettings
 
 import com.wire.kalium.persistence.client.AuthTokenStorage
+import com.wire.kalium.persistence.client.AuthTokenStorageImpl
 import com.wire.kalium.persistence.client.TokenStorage
 import com.wire.kalium.persistence.client.TokenStorageImpl
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorage
@@ -37,7 +38,7 @@ actual class GlobalPrefProvider(
         )
 
     actual val authTokenStorage: AuthTokenStorage
-        get() = AuthTokenStorage(kaliumPref)
+        get() = AuthTokenStorageImpl(kaliumPref)
     actual val passphraseStorage: PassphraseStorage
         get() = PassphraseStorageImpl(kaliumPref)
     actual val tokenStorage: TokenStorage


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users are sometimes reporting being stuck in connecting / decrypting messages and they can only recover after killing and restarting the app.

### Causes

When a token refresh is needed (backend returns a 401), Ktor will give us the tokens currently being used and ask for new tokens.
In case of failure by _any reason_ during the refresh, we should throw an exception. **But instead**, for some reason, we're actually returning _null_ in Ktor's [`refreshToken` function](https://ktor.io/docs/bearer-client.html#step9).

This makes it so Ktor will actually try to use these `null` tokens in the next requests. And the backend will again return `401`. Looping back to the token refresh function, that will now throw a `NullPointerException` because we double-bang the `oldTokens`.

The flow pretty much was:

```mermaid
sequenceDiagram
    loop Invalid tokens
    Kalium->>Ktor: Original Request with expired or null tokens
    Ktor->>Server: Forwarding
    Server->>Ktor: 401
    critical Token Refreshing
    Ktor->>Kalium: "Please refresh the tokens"
    Kalium->>Kalium: New tokens request fail
    Kalium->>Ktor: Take these "Null" tokens
    end
    end
```

### Solutions

#### Unify the access token refreshing
The refreshing is currently being done by two entities (`SessionManagerImpl` and `UpgradeUserSessionUseCase`), that are directly accessing the token API.

- Added a `AccessTokenRepository` to mask the storage and APIs, handling source-specific errors, and also making sure the refresh token is always present to keep consistency.
- Added a specialised `AccessTokenRefresher` that is solely responsible for grabing a new token and storing it.
- Removed dependencies to `AccessTokenApi` and `AuthTokenStorage` from the `SessionManagerImpl` and `UpgradeUserSessionUseCase`, going straight to the `AccessTokenRefresher` for token-refresh purposes.

#### Stop mapping failures to `null`

- It's alright to throw exceptions. Ktor will swallow them and we will catch them, mapping it to a `NetworkFailure`.

So the flow becomes:

```mermaid
sequenceDiagram
    Kalium->>Ktor: Original Request with expired or null tokens
    Ktor->>Server: Forwarding
    Server->>Ktor: 401
    critical Token Refreshing
    Ktor->>Kalium: "Please refresh the tokens"
    Kalium->>Kalium: New tokens request fail
    Kalium->>Ktor: Exception!
    Ktor->>Kalium: Your request failed :(
    end
```

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
