### PR TITLE
fix(events): stuck on processing calling events

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnConfigRequest.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnConfigRequest.kt
@@ -41,7 +41,17 @@ class OnConfigRequest(
             callRepository.getCallConfigResponse(limit = null)
                 .fold({
                     callingLogger.i("[OnConfigRequest] - Error: $it")
-                    // TODO: Add a better way to handle the Core Failure?
+                    // We can call config_update with an error if there was a connectivity issue
+                    // AVS will eventually ask us again for the config
+                    // TODO(improvement): We can retry it ourselves and improve the app responsiveness.
+                    //                    Maybe add a retry mechanism that listens for the network state
+                    //                    Caches the config string and exposes a "invalidate" function
+                    //                    That we could call when AVS requests new config.
+                    calling.wcall_config_update(
+                        inst = inst,
+                        error = 1,
+                        jsonString = ""
+                    )
                 }, { config ->
                     calling.wcall_config_update(
                         inst = inst,

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnConfigRequest.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnConfigRequest.kt
@@ -40,7 +40,7 @@ class OnConfigRequest(
         callingScope.launch {
             callRepository.getCallConfigResponse(limit = null)
                 .fold({
-                    callingLogger.i("[OnConfigRequest] - Error: $it")
+                    callingLogger.w("[OnConfigRequest] - Error: $it")
                     // We can call config_update with an error if there was a connectivity issue
                     // AVS will eventually ask us again for the config
                     // TODO(improvement): We can retry it ourselves and improve the app responsiveness.
@@ -55,7 +55,7 @@ class OnConfigRequest(
                 }, { config ->
                     calling.wcall_config_update(
                         inst = inst,
-                        error = 0, // TODO(calling): http error from internal json
+                        error = 0,
                         jsonString = config
                     )
                     callingLogger.i("[OnConfigRequest] - wcall_config_update()")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some users are stuck in `Waiting for Connection` or `Decrypting Messages` for ever.

### Causes

If there's any error while we're fetching AVS Config, we don't ever let AVS know, and it will forever keep waiting for the configs.

### Solutions

Let AVS know that there has been an error. AVS will eventually (every 60s) ask us to try again.

> **Note**
> In the future we can make our own retry mechanism for calling config, so it can be more responsive than just "once every 60s".

### Testing

Tested manually by changing the success code to also simulate an error and check that AVS asks us to try again.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
