### PR TITLE
chore: architectural fitness functions - use case implementation visibility pt1. (ACOL-123)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/UpdateAssetMessageDownloadStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/UpdateAssetMessageDownloadStatusUseCase.kt
@@ -41,7 +41,7 @@ interface UpdateAssetMessageDownloadStatusUseCase {
     ): UpdateDownloadStatusResult
 }
 
-class UpdateAssetMessageDownloadStatusUseCaseImpl(
+internal class UpdateAssetMessageDownloadStatusUseCaseImpl(
     private val messageRepository: MessageRepository
 ) : UpdateAssetMessageDownloadStatusUseCase {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCase.kt
@@ -17,7 +17,7 @@ interface EndCallOnConversationChangeUseCase {
     suspend operator fun invoke()
 }
 
-class EndCallOnConversationChangeUseCaseImpl(
+internal class EndCallOnConversationChangeUseCaseImpl(
     private val callRepository: CallRepository,
     private val conversationRepository: ConversationRepository,
     private val endCallUseCase: EndCallUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
@@ -43,7 +43,7 @@ interface EndCallUseCase {
 /**
  * This use case is responsible for ending a call.
  */
-class EndCallUseCaseImpl(
+internal class EndCallUseCaseImpl(
     private val callManager: Lazy<CallManager>,
     private val callRepository: CallRepository,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/UnMuteCallUseCase.kt
@@ -32,7 +32,7 @@ interface UnMuteCallUseCase {
     )
 }
 
-class UnMuteCallUseCaseImpl(
+internal class UnMuteCallUseCaseImpl(
     private val callManager: Lazy<CallManager>,
     private val callRepository: CallRepository
 ) : UnMuteCallUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/CleareNewClientsForUser.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/CleareNewClientsForUser.kt
@@ -28,7 +28,7 @@ interface ClearNewClientsForUserUseCase {
     suspend operator fun invoke(userId: UserId)
 }
 
-class ClearNewClientsForUserUseCaseImpl(private val userSessionScopeProvider: UserSessionScopeProvider) : ClearNewClientsForUserUseCase {
+internal class ClearNewClientsForUserUseCaseImpl(private val userSessionScopeProvider: UserSessionScopeProvider) : ClearNewClientsForUserUseCase {
     override suspend fun invoke(userId: UserId) {
         userSessionScopeProvider.getOrCreate(userId)
             .clientRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/CleareNewClientsForUser.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/CleareNewClientsForUser.kt
@@ -28,7 +28,8 @@ interface ClearNewClientsForUserUseCase {
     suspend operator fun invoke(userId: UserId)
 }
 
-internal class ClearNewClientsForUserUseCaseImpl(private val userSessionScopeProvider: UserSessionScopeProvider) : ClearNewClientsForUserUseCase {
+internal class ClearNewClientsForUserUseCaseImpl(private val userSessionScopeProvider: UserSessionScopeProvider) :
+    ClearNewClientsForUserUseCase {
     override suspend fun invoke(userId: UserId) {
         userSessionScopeProvider.getOrCreate(userId)
             .clientRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/FetchSelfClientsFromRemoteUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/FetchSelfClientsFromRemoteUseCase.kt
@@ -37,7 +37,7 @@ interface FetchSelfClientsFromRemoteUseCase {
     suspend operator fun invoke(): SelfClientsResult
 }
 
-class FetchSelfClientsFromRemoteUseCaseImpl(
+internal class FetchSelfClientsFromRemoteUseCaseImpl(
     private val clientRepository: ClientRepository,
     private val provideClientId: CurrentClientIdProvider,
 ) : FetchSelfClientsFromRemoteUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCase.kt
@@ -38,7 +38,7 @@ interface GetOrRegisterClientUseCase {
 }
 
 @Suppress("LongParameterList")
-class GetOrRegisterClientUseCaseImpl(
+internal class GetOrRegisterClientUseCaseImpl(
     private val clientRepository: ClientRepository,
     private val pushTokenRepository: PushTokenRepository,
     private val logoutRepository: LogoutRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
@@ -36,7 +36,7 @@ interface IsAllowedToRegisterMLSClientUseCase {
 }
 
 @OptIn(DelicateKaliumApi::class)
-class IsAllowedToRegisterMLSClientUseCaseImpl(
+internal class IsAllowedToRegisterMLSClientUseCaseImpl(
     private val featureSupport: FeatureSupport,
     private val mlsPublicKeysRepository: MLSPublicKeysRepository,
 ) : IsAllowedToRegisterMLSClientUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCase.kt
@@ -32,7 +32,7 @@ interface NeedsToRegisterClientUseCase {
     suspend operator fun invoke(): Boolean
 }
 
-class NeedsToRegisterClientUseCaseImpl(
+internal class NeedsToRegisterClientUseCaseImpl(
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val sessionRepository: SessionRepository,
     private val proteusClientProvider: ProteusClientProvider,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ObserveClientDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ObserveClientDetailsUseCase.kt
@@ -40,7 +40,7 @@ interface ObserveClientDetailsUseCase {
     suspend operator fun invoke(userId: UserId, clientId: ClientId): Flow<GetClientDetailsResult>
 }
 
-class ObserveClientDetailsUseCaseImpl(
+internal class ObserveClientDetailsUseCaseImpl(
     private val clientRepository: ClientRepository,
     private val provideClientId: CurrentClientIdProvider
 ) : ObserveClientDetailsUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterMLSClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterMLSClientUseCase.kt
@@ -35,7 +35,7 @@ interface RegisterMLSClientUseCase {
     suspend operator fun invoke(clientId: ClientId): Either<CoreFailure, Unit>
 }
 
-class RegisterMLSClientUseCaseImpl(
+internal class RegisterMLSClientUseCaseImpl(
     private val mlsClientProvider: MLSClientProvider,
     private val clientRepository: ClientRepository,
     private val keyPackageRepository: KeyPackageRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt
@@ -41,7 +41,7 @@ interface AddMemberToConversationUseCase {
     }
 }
 
-class AddMemberToConversationUseCaseImpl(
+internal class AddMemberToConversationUseCaseImpl(
     private val conversationGroupRepository: ConversationGroupRepository
 ) : AddMemberToConversationUseCase {
     override suspend fun invoke(conversationId: ConversationId, userIdList: List<UserId>): AddMemberToConversationUseCase.Result {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationUnreadEventsCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationUnreadEventsCountUseCase.kt
@@ -35,7 +35,7 @@ interface GetConversationUnreadEventsCountUseCase {
     }
 }
 
-class GetConversationUnreadEventsCountUseCaseImpl(
+internal class GetConversationUnreadEventsCountUseCaseImpl(
     private val conversationRepository: ConversationRepository
 ) : GetConversationUnreadEventsCountUseCase {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/LeaveConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/LeaveConversationUseCase.kt
@@ -34,7 +34,7 @@ interface LeaveConversationUseCase {
     suspend operator fun invoke(conversationId: ConversationId): RemoveMemberFromConversationUseCase.Result
 }
 
-class LeaveConversationUseCaseImpl(
+internal class LeaveConversationUseCaseImpl(
     private val conversationGroupRepository: ConversationGroupRepository,
     private val selfUserId: UserId,
 ) : LeaveConversationUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/LeaveSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/LeaveSubconversationUseCase.kt
@@ -41,7 +41,7 @@ interface LeaveSubconversationUseCase {
     suspend operator fun invoke(conversationId: ConversationId, subconversationId: SubconversationId): Either<CoreFailure, Unit>
 }
 
-class LeaveSubconversationUseCaseImpl(
+internal class LeaveSubconversationUseCaseImpl(
     val conversationApi: ConversationApi,
     val mlsClientProvider: MLSClientProvider,
     val subconversationRepository: SubconversationRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveArchivedUnreadConversationsCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveArchivedUnreadConversationsCountUseCase.kt
@@ -28,7 +28,7 @@ interface ObserveArchivedUnreadConversationsCountUseCase {
     suspend operator fun invoke(): Flow<Long>
 }
 
-class ObserveArchivedUnreadConversationsCountUseCaseImpl(
+internal class ObserveArchivedUnreadConversationsCountUseCaseImpl(
     private val conversationRepository: ConversationRepository
 ) : ObserveArchivedUnreadConversationsCountUseCase {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RemoveMemberFromConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RemoveMemberFromConversationUseCase.kt
@@ -41,7 +41,7 @@ interface RemoveMemberFromConversationUseCase {
     }
 }
 
-class RemoveMemberFromConversationUseCaseImpl(
+internal class RemoveMemberFromConversationUseCaseImpl(
     private val conversationGroupRepository: ConversationGroupRepository
 ) : RemoveMemberFromConversationUseCase {
     override suspend fun invoke(conversationId: ConversationId, userIdToRemove: UserId): RemoveMemberFromConversationUseCase.Result {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCase.kt
@@ -40,7 +40,7 @@ interface UpdateKeyingMaterialsUseCase {
     suspend operator fun invoke(): UpdateKeyingMaterialsResult
 }
 
-class UpdateKeyingMaterialsUseCaseImpl(
+internal class UpdateKeyingMaterialsUseCaseImpl(
     val mlsConversationRepository: MLSConversationRepository,
     private val updateKeyingMaterialThresholdProvider: UpdateKeyingMaterialThresholdProvider
 ) : UpdateKeyingMaterialsUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
@@ -33,7 +33,7 @@ interface MLSKeyPackageCountUseCase {
     suspend operator fun invoke(fromAPI: Boolean = true): MLSKeyPackageCountResult
 }
 
-class MLSKeyPackageCountUseCaseImpl(
+internal class MLSKeyPackageCountUseCaseImpl(
     private val keyPackageRepository: KeyPackageRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
@@ -44,7 +44,7 @@ interface RefillKeyPackagesUseCase {
 
 }
 
-class RefillKeyPackagesUseCaseImpl(
+internal class RefillKeyPackagesUseCaseImpl(
     private val keyPackageRepository: KeyPackageRepository,
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider,
     private val currentClientIdProvider: CurrentClientIdProvider,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/rootDetection/CheckSystemIntegrityUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/rootDetection/CheckSystemIntegrityUseCase.kt
@@ -46,7 +46,7 @@ interface CheckSystemIntegrityUseCase {
     suspend fun invoke(): Result
 }
 
-class CheckSystemIntegrityUseCaseImpl(
+internal class CheckSystemIntegrityUseCaseImpl(
     private val kaliumConfigs: KaliumConfigs,
     private val rootDetector: RootDetector,
     private val sessionRepository: SessionRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/PersistNewSelfDeletionTimerUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/PersistNewSelfDeletionTimerUseCase.kt
@@ -33,7 +33,7 @@ interface PersistNewSelfDeletionTimerUseCase {
     suspend operator fun invoke(conversationId: ConversationId, newSelfDeletionTimer: SelfDeletionTimer)
 }
 
-class PersistNewSelfDeletionTimerUseCaseImpl(
+class PersistNewSelfDeletionTimerUseCaseImpl internal constructor(
     private val conversationRepository: ConversationRepository
 ) : PersistNewSelfDeletionTimerUseCase {
     override suspend fun invoke(conversationId: ConversationId, newSelfDeletionTimer: SelfDeletionTimer) =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DeregisterTokenUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DeregisterTokenUseCase.kt
@@ -42,7 +42,7 @@ interface DeregisterTokenUseCase {
     }
 }
 
-class DeregisterTokenUseCaseImpl(
+internal class DeregisterTokenUseCaseImpl(
     private val clientRepository: ClientRepository,
     private val notificationTokenRepository: NotificationTokenRepository
 ) : DeregisterTokenUseCase {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsFileSharingEnabledUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsFileSharingEnabledUseCase.kt
@@ -31,7 +31,7 @@ interface IsFileSharingEnabledUseCase {
     operator fun invoke(): FileSharingStatus
 }
 
-class IsFileSharingEnabledUseCaseImpl(
+internal class IsFileSharingEnabledUseCaseImpl(
     private val userConfigRepository: UserConfigRepository
 ) : IsFileSharingEnabledUseCase {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/MarkSelfDeletionStatusAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/MarkSelfDeletionStatusAsNotifiedUseCase.kt
@@ -27,7 +27,7 @@ interface MarkSelfDeletionStatusAsNotifiedUseCase {
     suspend operator fun invoke()
 }
 
-class MarkSelfDeletionStatusAsNotifiedUseCaseImpl(
+internal class MarkSelfDeletionStatusAsNotifiedUseCaseImpl(
     private val userConfigRepository: UserConfigRepository
 ) : MarkSelfDeletionStatusAsNotifiedUseCase {
     override suspend operator fun invoke() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveFileSharingStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveFileSharingStatusUseCase.kt
@@ -35,7 +35,8 @@ interface ObserveFileSharingStatusUseCase {
     operator fun invoke(): Flow<FileSharingStatus>
 }
 
-internal class ObserveFileSharingStatusUseCaseImpl(private val userConfigRepository: UserConfigRepository) : ObserveFileSharingStatusUseCase {
+internal class ObserveFileSharingStatusUseCaseImpl(private val userConfigRepository: UserConfigRepository) :
+    ObserveFileSharingStatusUseCase {
     override operator fun invoke(): Flow<FileSharingStatus> =
         userConfigRepository.isFileSharingEnabledFlow().map { fileSharingStatusFlow ->
             fileSharingStatusFlow.fold({
@@ -44,6 +45,7 @@ internal class ObserveFileSharingStatusUseCaseImpl(private val userConfigReposit
                         kaliumLogger.e("Data not found in ObserveFileSharingStatusUseCase")
                         FileSharingStatus(FileSharingStatus.Value.Disabled, false)
                     }
+
                     is StorageFailure.Generic -> {
                         kaliumLogger.e("Storage Error : ${it.rootCause} in ObserveFileSharingStatusUseCase", it.rootCause)
                         FileSharingStatus(FileSharingStatus.Value.Disabled, false)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveFileSharingStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveFileSharingStatusUseCase.kt
@@ -35,7 +35,7 @@ interface ObserveFileSharingStatusUseCase {
     operator fun invoke(): Flow<FileSharingStatus>
 }
 
-class ObserveFileSharingStatusUseCaseImpl(private val userConfigRepository: UserConfigRepository) : ObserveFileSharingStatusUseCase {
+internal class ObserveFileSharingStatusUseCaseImpl(private val userConfigRepository: UserConfigRepository) : ObserveFileSharingStatusUseCase {
     override operator fun invoke(): Flow<FileSharingStatus> =
         userConfigRepository.isFileSharingEnabledFlow().map { fileSharingStatusFlow ->
             fileSharingStatusFlow.fold({

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsAndResolveOneOnOnesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsAndResolveOneOnOnesUseCase.kt
@@ -36,7 +36,7 @@ interface UpdateSupportedProtocolsAndResolveOneOnOnesUseCase {
     suspend operator fun invoke(synchroniseUsers: Boolean): Either<CoreFailure, Unit>
 }
 
-class UpdateSupportedProtocolsAndResolveOneOnOnesUseCaseImpl(
+internal class UpdateSupportedProtocolsAndResolveOneOnOnesUseCaseImpl(
     private val updateSupportedProtocols: UpdateSupportedProtocolsUseCase,
     private val oneOnOneResolver: OneOnOneResolver
 ) : UpdateSupportedProtocolsAndResolveOneOnOnesUseCase {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have failing tests for use case visibility after introducing `Konsist` in: 
- https://github.com/wireapp/kalium/pull/2133

### Causes (Optional)

Use case implementations can be instantiated from the outside world.

### Solutions

Mark them as internal when possible or make their constructor internal to adhere to the rule.
Some tests will still fail, so I need to raise a part 2, or 3 after this.

### Needs release 

- https://github.com/wireapp/kalium/pull/2133

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


#### How to test

Tests for the following checks, should NOT fail.

`useCaseImplementationsShouldBeInternalOrHaveInternalConstructor[jvm] - com.wire.kalium.logic.architecture.UseCaseRulesTest -`

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
