### PR TITLE
fix: paginating fetch multiple users request [WPB-4999]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -216,7 +216,7 @@ internal class UserDataSource internal constructor(
             Either.Right(Unit)
         } else {
             qualifiedUserIdList
-                .chunked(500)
+                .chunked(BATCH_SIZE)
                 .foldToEitherWhileRight(ListUsersDTO(emptyList(), emptyList())) { chunk, acc ->
                     wrapApiRequest {
                         kaliumLogger.d("Fetching ${chunk.size} users")
@@ -480,5 +480,6 @@ internal class UserDataSource internal constructor(
     companion object {
         internal const val SELF_USER_ID_KEY = "selfUserID"
         internal val FEDERATED_USER_TTL = 5.minutes
+        internal const val BATCH_SIZE = 500
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.logic.feature.SelfTeamIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.mapRight
@@ -52,6 +53,7 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
+import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
 import com.wire.kalium.network.api.base.model.SelfUserDTO
@@ -74,7 +76,6 @@ import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.datetime.Instant
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.minutes

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -223,7 +223,7 @@ internal class UserDataSource internal constructor(
                             ListUserRequest.qualifiedIds(chunk.map { userId -> userId.toApi() })
                         )
                     }.map {
-                        kaliumLogger.d("Found ${it.usersFound} users and ${it.usersFailed} failed users")
+                        kaliumLogger.d("Found ${it.usersFound.size} users and ${it.usersFailed.size} failed users")
                         acc.copy(
                             usersFound = (acc.usersFound + it.usersFound).distinct(),
                             usersFailed = (acc.usersFailed + it.usersFailed).distinct(),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently when the app needs to fetch multiple users details, it makes a single request with all userIds. When the list contains around 4000 items, the API returns 413 Content Too Large.

### Solutions

Make this request paginated.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
