### PR TITLE
fix: upgraded tokens not being used

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -69,16 +69,17 @@ class SessionManagerImpl internal constructor(
     override suspend fun session(): SessionDTO = withContext(coroutineContext) {
         wrapStorageRequest { tokenStorage.getToken(userId.toDao()) }
             .map { sessionMapper.fromEntityToSessionDTO(it) }
-            .fold({
-                error(
-                    """SESSION MANAGER: 
+            .fold(
+                {
+                    error(
+                        """SESSION MANAGER: 
                     |"error": "missing user session",
                     |"cause": "$it" """.trimMargin()
-                )
-            }, { session ->
-                kaliumLogger.i("_TOKEN_ FOUND SESSION = $session")
-                session
-            }
+                    )
+                }, { session ->
+                    kaliumLogger.i("_TOKEN_ FOUND SESSION = $session")
+                    session
+                }
             )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/SessionManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/SessionManagerTest.kt
@@ -39,8 +39,10 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.anything
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
+import io.mockative.verify
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
@@ -86,42 +88,18 @@ class SessionManagerTest {
     }
 
     @Test
-    fun givenInitialSessionIsUpdated_whenFetchingSession_thenSessionShouldBeUpdatedProperly() = runTest {
-        val expectedData = TEST_ACCOUNT_TOKENS
-        val (arrangement, sessionManager) = arrange {
-            withCurrentTokenResult(
-                AuthTokenEntity(
-                    userId = UserIDEntity("potato", "potahto"),
-                    accessToken = "aToken",
-                    refreshToken = "rToken",
-                    tokenType = "tType",
-                    cookieLabel = "cLabel"
-                )
-            )
-            withTokenRefresherResult(Either.Right(expectedData))
-        }
-
-        sessionManager.session()
-        sessionManager.updateToken(arrangement.accessTokenApi, "egal", "egal")
-        val result = sessionManager.session()
-        assertNotNull(result)
-        assertEquals(expectedData.userId.value, result.userId.value)
-        assertEquals(expectedData.userId.domain, result.userId.domain)
-        assertEquals(expectedData.accessToken.value, result.accessToken)
-        assertEquals(expectedData.refreshToken.value, result.refreshToken)
-        assertEquals(expectedData.tokenType, result.tokenType)
-        assertEquals(expectedData.cookieLabel, result.cookieLabel)
-    }
-
-    @Test
-    fun givenTokenWasUpdated_whenGettingSession_thenItShouldBeUpdatedAsWell() = runTest {
+    fun givenSuccess_whenUpdatingToken_thenItShouldCallTokenRefresherCorrectly() = runTest {
         val (arrangement, sessionManager) = arrange {
             withTokenRefresherResult(Either.Right(TEST_ACCOUNT_TOKENS))
         }
 
-        sessionManager.updateToken(arrangement.accessTokenApi, "egal", "egal")
+        val accessToken = "egal"
+        val refreshToken = "refreshToken"
+        sessionManager.updateToken(arrangement.accessTokenApi, accessToken, refreshToken)
 
-        assertEquals(TEST_SESSION_DTO, sessionManager.session())
+        verify(arrangement.accessTokenRefresher)
+            .suspendFunction(arrangement.accessTokenRefresher::refreshTokenAndPersistSession)
+            .with(eq(accessToken), eq(refreshToken))
     }
 
     @Test
@@ -134,8 +112,12 @@ class SessionManagerTest {
             tokenType = "tType",
             cookieLabel = "cLabel"
         )
-        val updatedTokens = originalTokens.copy(
-            accessToken = "a completely different token"
+        val updatedTokens = AuthTokenEntity(
+            userId = UserIDEntity("updated userId", "updated userDomain"),
+            accessToken = "a completely different token",
+            refreshToken = "a completely different refresh token",
+            tokenType = "updated tType",
+            cookieLabel = "updated cLabel"
         )
         val (_, sessionManager) = arrange {
             withCurrentTokenReturning {
@@ -148,11 +130,16 @@ class SessionManagerTest {
             }
         }
 
-        val firstResult = sessionManager.session()
-        val secondResult = sessionManager.session()
+        val firstResult = sessionManager.session()!!
+        val secondResult = sessionManager.session()!!
 
-        assertEquals(originalTokens.accessToken, firstResult!!.accessToken)
-        assertEquals(updatedTokens.accessToken, secondResult!!.accessToken)
+        assertEquals(originalTokens.accessToken, firstResult.accessToken)
+        assertEquals(updatedTokens.accessToken, secondResult.accessToken)
+        assertEquals(updatedTokens.refreshToken, secondResult.refreshToken)
+        assertEquals(updatedTokens.userId.value, secondResult.userId.value)
+        assertEquals(updatedTokens.userId.domain, secondResult.userId.domain)
+        assertEquals(updatedTokens.tokenType, secondResult.tokenType)
+        assertEquals(updatedTokens.cookieLabel, secondResult.cookieLabel)
     }
 
     private class Arrangement(private val configure: Arrangement.() -> Unit) {
@@ -165,7 +152,7 @@ class SessionManagerTest {
         val accessTokenApi = mock(AccessTokenApi::class)
 
         @Mock
-        private val accessTokenRefresher = mock(AccessTokenRefresher::class)
+        val accessTokenRefresher = mock(AccessTokenRefresher::class)
         private val accessTokenRefresherFactory = object : AccessTokenRefresherFactory {
             override fun create(accessTokenApi: AccessTokenApi): AccessTokenRefresher {
                 return accessTokenRefresher


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Tokens that are result of token-upgrading (_i.e._ associating a client ID with the tokens), are not being used right after they are acquired.

### Causes

In the previous implementation, the `SessionManagerImpl` was not properly utilizing updated tokens causing session issues.

It was keeping a `session` in memory and using it. So when other entities would modify the `session` directly in storage, it would not be updated.

### Solutions

There was no reason to keep the `session` in memory, as it's something that is rarely used. And as long as the `SessionManager` is atomic in its operations, it won't race with itself.

The code has been updated to not retain the first session instance but fetch a new one each time, hence always using the newest token. Tests have been added to verify the proper functioning of this feature.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
