### PR TITLE
fix: failure to parse lack of supported protocols

### DIFF
--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/SupportedProtocolSetAdapter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/SupportedProtocolSetAdapter.kt
@@ -22,7 +22,11 @@ import com.wire.kalium.persistence.dao.SupportedProtocolEntity
 
 internal object SupportedProtocolSetAdapter : ColumnAdapter<Set<SupportedProtocolEntity>, String> {
     override fun decode(databaseValue: String): Set<SupportedProtocolEntity> {
-        return databaseValue.split(SEPARATOR).map { SupportedProtocolEntity.valueOf(it) }.toSet()
+        return if(databaseValue.isBlank()) {
+            emptySet()
+        } else {
+            databaseValue.split(SEPARATOR).map { SupportedProtocolEntity.valueOf(it) }.toSet()
+        }
     }
 
     override fun encode(value: Set<SupportedProtocolEntity>): String {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/SupportedProtocolSetAdapter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/adapter/SupportedProtocolSetAdapter.kt
@@ -22,7 +22,7 @@ import com.wire.kalium.persistence.dao.SupportedProtocolEntity
 
 internal object SupportedProtocolSetAdapter : ColumnAdapter<Set<SupportedProtocolEntity>, String> {
     override fun decode(databaseValue: String): Set<SupportedProtocolEntity> {
-        return if(databaseValue.isBlank()) {
+        return if (databaseValue.isBlank()) {
             emptySet()
         } else {
             databaseValue.split(SEPARATOR).map { SupportedProtocolEntity.valueOf(it) }.toSet()

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/adapter/SupportedProtocolSetAdapterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/adapter/SupportedProtocolSetAdapterTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.persistence.adapter
+
+import com.wire.kalium.persistence.dao.SupportedProtocolEntity
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SupportedProtocolSetAdapterTest {
+
+    private val adapter = SupportedProtocolSetAdapter
+
+    @Test
+    fun givenEmptySet_whenEncodingAndDecoding_thenShouldReturnEmptySet() {
+        val encoded = adapter.encode(emptySet())
+        val decoded = adapter.decode(encoded)
+
+        assertTrue(decoded.isEmpty())
+    }
+
+    @Test
+    fun givenEmptyString_whenDecodingAndEncoding_thenShouldReturnEmptyString() {
+        val decoded = adapter.decode("")
+        val encoded = adapter.encode(decoded)
+
+        assertTrue(encoded.isEmpty())
+    }
+
+    @Test
+    fun givenProteus_whenEncodingAndDecoding_thenShouldReturnProteus() {
+        val encoded = adapter.encode(setOf(SupportedProtocolEntity.PROTEUS))
+        val decoded = adapter.decode(encoded)
+
+        assertEquals(1, decoded.size)
+        assertContains(decoded, SupportedProtocolEntity.PROTEUS)
+    }
+
+    @Test
+    fun givenMLSAndProteus_whenEncodingAndDecoding_thenShouldReturnMLSAndProteus() {
+        val encoded = adapter.encode(setOf(SupportedProtocolEntity.MLS, SupportedProtocolEntity.PROTEUS))
+        val decoded = adapter.decode(encoded)
+
+        assertEquals(2, decoded.size)
+        assertContains(decoded, SupportedProtocolEntity.MLS)
+        assertContains(decoded, SupportedProtocolEntity.PROTEUS)
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Exception during parsing of `SupportedProtocol`:

```
java.lang.IllegalArgumentException: No enum constant com.wire.kalium.persistence.dao.SupportedProtocolEntity.
```

### Causes

We're not considering the possibility of empty string `""`

### Solutions

Return `emptySet()` when the string is empty. This means that the client has not set supported protocols for a user yet.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
