### PR TITLE
chore(sync): bump slow sync version (WPB-5057)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -152,10 +152,10 @@ internal class SlowSyncManager(
     }
 
     private companion object {
+        const val CURRENT_VERSION = 5 // bump this version to perform slow sync when some new feature flag was added
+
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
         val MIN_TIME_BETWEEN_SLOW_SYNCS = 7.days
     }
 }
-
-const val CURRENT_VERSION = 4 // bump this version to perform slow sync when some new feature flag was added

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -152,7 +152,14 @@ internal class SlowSyncManager(
     }
 
     private companion object {
-        const val CURRENT_VERSION = 5 // bump this version to perform slow sync when some new feature flag was added
+        /**
+         * The current version of Slow Sync.
+         *
+         * By bumping this version, we can force all clients to perform a new Slow Sync.
+         * Useful when a new step is added to Slow Sync, or when we fix some bug in Slow Sync,
+         * and we'd like to get all users to take advantage of the fix.
+         */
+        const val CURRENT_VERSION = 5
 
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes


### PR DESCRIPTION
Now that fetching of users is paginated and errors in this step are properly propagated, we should perform sync again to cover affected users.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Now that fetching users is being paginated
- #2158 

Users in huge teams (1000+ users) can properly fetch all contacts during slow sync. But #2158 doesn't trigger slow sync again.

### Solutions

Bump the SlowSync Version, so Kalium will trigger it again after updating the app.

Also, move it to be private inside the class, as there's no reason to make it publicly available like it was before.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
