### PR TITLE
fix: persist searched team members [WPB-5262]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
@@ -35,11 +35,17 @@ import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
+import com.wire.kalium.network.api.base.model.isTeamMember
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserDAO
+<<<<<<< HEAD
 import com.wire.kalium.persistence.dao.UserDetailsEntity
+=======
+import com.wire.kalium.persistence.dao.UserEntity
+import com.wire.kalium.persistence.dao.UserTypeEntity
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
@@ -157,8 +163,36 @@ internal class SearchUserRepositoryImpl(
             response.map { userProfileDTOList ->
                 val otherUserList = if (userProfileDTOList.isEmpty()) emptyList() else {
                     val selfUser = getSelfUser()
+<<<<<<< HEAD
                     userProfileDTOList.map { userProfileDTO ->
                         userMapper.fromUserProfileDtoToOtherUser(userProfileDTO, selfUser)
+=======
+                    val (teamMembers, otherUsers) = userProfileDTOList
+                        .partition { it.isTeamMember(selfUser.teamId?.value, selfUser.id.domain) }
+
+                    // We need to store all found team members locally and not return them as they will be "known" users from now on.
+                    userDAO.upsertTeamMembers(
+                        teamMembers.map { userProfileDTO ->
+                            userMapper.fromUserProfileDtoToUserEntity(
+                                userProfile = userProfileDTO,
+                                connectionState = ConnectionEntity.State.ACCEPTED,
+                                userTypeEntity = UserTypeEntity.STANDARD
+                            )
+                        }
+                    )
+
+                    otherUsers.map { userProfileDTO ->
+                        publicUserMapper.fromUserProfileDtoToOtherUser(
+                            userDetailResponse = userProfileDTO,
+                            userType = userTypeMapper.fromTeamAndDomain(
+                                otherUserDomain = userProfileDTO.id.domain,
+                                selfUserTeamId = selfUser.teamId?.value,
+                                otherUserTeamId = userProfileDTO.teamId,
+                                selfUserDomain = selfUser.id.domain,
+                                isService = userProfileDTO.service != null,
+                            )
+                        )
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
                     }
                 }
                 UserSearchResult(otherUserList)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserDataSource
 import com.wire.kalium.logic.data.user.UserMapper
-import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -57,6 +57,7 @@ import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
 import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.UserProfileDTO
+import com.wire.kalium.network.api.base.model.isTeamMember
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -259,11 +260,16 @@ internal class UserDataSource internal constructor(
         val selfUserDomain = selfUserId.domain
         val selfUserTeamId = selfTeamIdProvider().getOrNull()?.value
         val teamMembers = listUserProfileDTO
-            .filter { userProfileDTO -> isTeamMember(selfUserTeamId, userProfileDTO, selfUserDomain) }
+            .filter { userProfileDTO -> userProfileDTO.isTeamMember(selfUserTeamId, selfUserDomain) }
         val otherUsers = listUserProfileDTO
+<<<<<<< HEAD
             .filter { userProfileDTO -> !isTeamMember(selfUserTeamId, userProfileDTO, selfUserDomain) }
 
         userDAO.upsertUsers(
+=======
+            .filter { userProfileDTO -> !userProfileDTO.isTeamMember(selfUserTeamId, selfUserDomain) }
+        userDAO.upsertTeamMembers(
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
             teamMembers.map { userProfileDTO ->
                 userMapper.fromUserProfileDtoToUserEntity(
                     userProfile = userProfileDTO,
@@ -290,14 +296,6 @@ internal class UserDataSource internal constructor(
             }
         )
     }
-
-    private fun isTeamMember(
-        selfUserTeamId: String?,
-        userProfileDTO: UserProfileDTO,
-        selfUserDomain: String?
-    ) = (selfUserTeamId != null &&
-            userProfileDTO.teamId == selfUserTeamId &&
-            userProfileDTO.id.domain == selfUserDomain)
 
     override suspend fun fetchUsersIfUnknownByIds(ids: Set<UserId>): Either<CoreFailure, Unit> = wrapStorageRequest {
         val qualifiedIDList = ids.map { it.toDao() }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -262,14 +262,9 @@ internal class UserDataSource internal constructor(
         val teamMembers = listUserProfileDTO
             .filter { userProfileDTO -> userProfileDTO.isTeamMember(selfUserTeamId, selfUserDomain) }
         val otherUsers = listUserProfileDTO
-<<<<<<< HEAD
-            .filter { userProfileDTO -> !isTeamMember(selfUserTeamId, userProfileDTO, selfUserDomain) }
+            .filter { userProfileDTO -> !userProfileDTO.isTeamMember(selfUserTeamId, selfUserDomain) }
 
         userDAO.upsertUsers(
-=======
-            .filter { userProfileDTO -> !userProfileDTO.isTeamMember(selfUserTeamId, selfUserDomain) }
-        userDAO.upsertTeamMembers(
->>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
             teamMembers.map { userProfileDTO ->
                 userMapper.fromUserProfileDtoToUserEntity(
                     userProfile = userProfileDTO,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.network.api.base.authenticated.search.UserSearchResponse
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.MetadataDAO
@@ -43,14 +44,15 @@ import io.mockative.Times
 import io.mockative.any
 import io.mockative.anything
 import io.mockative.classOf
+import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -61,6 +63,7 @@ import com.wire.kalium.network.api.base.model.UserId as UserIdDTO
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchUserRepositoryTest {
 
+<<<<<<< HEAD
     @Mock
     private val metadataDAO: MetadataDAO = mock(classOf<MetadataDAO>())
 
@@ -103,13 +106,14 @@ class SearchUserRepositoryTest {
         given(domainUserTypeMapper).invocation { external }.then { UserType.EXTERNAL }
     }
 
+=======
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
     @Test
     fun givenContactSearchApiFailure_whenSearchPublicContact_resultIsFailure() = runTest {
         // given
-        given(userSearchApiWrapper)
-            .suspendFunction(userSearchApiWrapper::search)
-            .whenInvokedWith(anything(), anything(), anything(), anything())
-            .thenReturn(Either.Left(TestNetworkResponseError.noNetworkConnection()))
+        val (_, searchUserRepository) = Arrangement()
+            .withSearchResult(Either.Left(TestNetworkResponseError.noNetworkConnection()))
+            .arrange()
 
         // when
         val actual = searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
@@ -121,17 +125,16 @@ class SearchUserRepositoryTest {
     @Test
     fun givenContactSearchApiFailure_whenSearchPublicContact_thenOnlyContactSearchApiISInvoked() = runTest {
         // given
-        given(userSearchApiWrapper)
-            .suspendFunction(userSearchApiWrapper::search)
-            .whenInvokedWith(anything(), anything(), anything(), anything())
-            .thenReturn(Either.Left(TestNetworkResponseError.noNetworkConnection()))
+        val (arrangement, searchUserRepository) = Arrangement()
+            .withSearchResult(Either.Left(TestNetworkResponseError.noNetworkConnection()))
+            .arrange()
 
         // when
         searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
 
         // then
-        verify(userSearchApiWrapper)
-            .suspendFunction(userSearchApiWrapper::search)
+        verify(arrangement.userSearchApiWrapper)
+            .suspendFunction(arrangement.userSearchApiWrapper::search)
             .with(anything(), anything(), anything(), anything())
             .wasInvoked(exactly = once)
     }
@@ -139,21 +142,25 @@ class SearchUserRepositoryTest {
     @Test
     fun givenContactSearchApiFailure_whenSearchPublicContact_thenUserDetailsApiAndPublicUserMapperIsNotInvoked() = runTest {
         // given
-        given(userSearchApiWrapper)
-            .suspendFunction(userSearchApiWrapper::search)
-            .whenInvokedWith(anything(), anything(), anything(), anything())
-            .thenReturn(Either.Left(TestNetworkResponseError.noNetworkConnection()))
+        val (arrangement, searchUserRepository) = Arrangement()
+            .withSearchResult(Either.Left(TestNetworkResponseError.noNetworkConnection()))
+            .arrange()
 
         // when
         searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
         // then
-        verify(userDetailsApi)
-            .suspendFunction(userDetailsApi::getMultipleUsers)
+        verify(arrangement.userDetailsApi)
+            .suspendFunction(arrangement.userDetailsApi::getMultipleUsers)
             .with(any())
             .wasNotInvoked()
 
+<<<<<<< HEAD
         verify(userMapper)
             .function(userMapper::fromUserProfileDtoToOtherUser)
+=======
+        verify(arrangement.publicUserMapper)
+            .function(arrangement.publicUserMapper::fromUserProfileDtoToOtherUser)
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
             .with(any(), any())
             .wasNotInvoked()
     }
@@ -161,15 +168,10 @@ class SearchUserRepositoryTest {
     @Test
     fun givenContactSearchApiSuccessButuserDetailsApiFailure_whenSearchPublicContact_resultIsFailure() = runTest {
         // given
-        given(userSearchApiWrapper)
-            .suspendFunction(userSearchApiWrapper::search)
-            .whenInvokedWith(anything(), anything(), anything(), anything())
-            .thenReturn(Either.Right(CONTACT_SEARCH_RESPONSE))
-
-        given(userDetailsApi)
-            .suspendFunction(userDetailsApi::getMultipleUsers)
-            .whenInvokedWith(any())
-            .thenReturn(TestNetworkResponseError.genericResponseError())
+        val (_, searchUserRepository) = Arrangement()
+            .withSearchResult(Either.Right(CONTACT_SEARCH_RESPONSE))
+            .withGetMultipleUsersResult(TestNetworkResponseError.genericResponseError())
+            .arrange()
 
         // when
         val actual = searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
@@ -181,22 +183,22 @@ class SearchUserRepositoryTest {
     @Test
     fun givenContactSearchApiSuccessButuserDetailsApiFailure_whenSearchPublicContact_ThenPublicUserMapperIsNotInvoked() = runTest {
         // given
-        given(userSearchApiWrapper)
-            .suspendFunction(userSearchApiWrapper::search)
-            .whenInvokedWith(anything(), anything(), anything(), anything())
-            .thenReturn(Either.Right(CONTACT_SEARCH_RESPONSE))
-
-        given(userDetailsApi)
-            .suspendFunction(userDetailsApi::getMultipleUsers)
-            .whenInvokedWith(any())
-            .then { TestNetworkResponseError.genericResponseError() }
+        val (arrangement, searchUserRepository) = Arrangement()
+            .withSearchResult(Either.Right(CONTACT_SEARCH_RESPONSE))
+            .withGetMultipleUsersResult(TestNetworkResponseError.genericResponseError())
+            .arrange()
 
         // when
         searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
 
         // then
+<<<<<<< HEAD
         verify(userMapper)
             .function(userMapper::fromUserProfileDtoToOtherUser)
+=======
+        verify(arrangement.publicUserMapper)
+            .function(arrangement.publicUserMapper::fromUserProfileDtoToOtherUser)
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
             .with(any(), any())
             .wasNotInvoked()
     }
@@ -205,26 +207,22 @@ class SearchUserRepositoryTest {
     fun givenContactSearchApiSuccessButUserDetailsApiFailure_whenSearchPublicContact_ThenContactSearchApiAndUserDetailsApiIsInvoked() =
         runTest {
             // given
-            given(userSearchApiWrapper)
-                .suspendFunction(userSearchApiWrapper::search)
-                .whenInvokedWith(anything(), anything(), anything(), anything())
-                .thenReturn(Either.Right(CONTACT_SEARCH_RESPONSE))
+            val (arrangement, searchUserRepository) = Arrangement()
+                .withSearchResult(Either.Right(CONTACT_SEARCH_RESPONSE))
+                .withGetMultipleUsersResult(TestNetworkResponseError.genericResponseError())
+                .arrange()
 
-            given(userDetailsApi)
-                .suspendFunction(userDetailsApi::getMultipleUsers)
-                .whenInvokedWith(any())
-                .then { TestNetworkResponseError.genericResponseError() }
             // when
             searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
 
             // then
-            verify(userSearchApiWrapper)
-                .suspendFunction(userSearchApiWrapper::search)
+            verify(arrangement.userSearchApiWrapper)
+                .suspendFunction(arrangement.userSearchApiWrapper::search)
                 .with(anything(), anything(), anything(), anything())
                 .wasInvoked(exactly = once)
 
-            verify(userDetailsApi)
-                .suspendFunction(userDetailsApi::getMultipleUsers)
+            verify(arrangement.userDetailsApi)
+                .suspendFunction(arrangement.userDetailsApi::getMultipleUsers)
                 .with(any())
                 .wasInvoked(exactly = once)
         }
@@ -232,6 +230,7 @@ class SearchUserRepositoryTest {
     @Test
     fun givenContactSearchApiAndUserDetailsApiAndPublicUserApiReturnSuccess_WhenSearchPublicContact_ThenResultIsSuccess() = runTest {
         // given
+<<<<<<< HEAD
         given(userSearchApiWrapper)
             .suspendFunction(userSearchApiWrapper::search)
             .whenInvokedWith(anything(), anything(), anything(), anything())
@@ -271,6 +270,17 @@ class SearchUserRepositoryTest {
                     false
                 )
             }.then { UserType.FEDERATED }
+=======
+        val (_, searchUserRepository) = Arrangement()
+            .withSearchResult(Either.Right(CONTACT_SEARCH_RESPONSE))
+            .withGetMultipleUsersResult(NetworkResponse.Success(USER_RESPONSE, mapOf(), 200))
+            .withFromUserProfileDtoToOtherUserResult(PUBLIC_USER)
+            .withValueByKeyFlowResult(flowOf(JSON_QUALIFIED_ID))
+            .withGetUserByQualifiedIdResult(flowOf(USER_ENTITY))
+            .withFromUserEntityToSelfUser(SELF_USER)
+            .withFromTeamAndDomain(UserType.FEDERATED)
+            .arrange()
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
 
         // when
         val actual = searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
@@ -283,6 +293,7 @@ class SearchUserRepositoryTest {
     fun givenContactSearchApiAndUserDetailsApiAndPublicUserApiReturnSuccess_WhenSearchPublicContact_ThenResultIsEqualToExpectedValue() =
         runTest {
             // given
+<<<<<<< HEAD
             given(userSearchApiWrapper)
                 .suspendFunction(userSearchApiWrapper::search)
                 .whenInvokedWith(anything(), anything(), anything(), anything())
@@ -322,6 +333,17 @@ class SearchUserRepositoryTest {
                         false
                     )
                 }.then { UserType.FEDERATED }
+=======
+            val (_, searchUserRepository) = Arrangement()
+                .withSearchResult(Either.Right(CONTACT_SEARCH_RESPONSE))
+                .withGetMultipleUsersResult(NetworkResponse.Success(USER_RESPONSE, mapOf(), 200))
+                .withFromUserProfileDtoToOtherUserResult(PUBLIC_USER)
+                .withValueByKeyFlowResult(flowOf(JSON_QUALIFIED_ID))
+                .withGetUserByQualifiedIdResult(flowOf(USER_ENTITY))
+                .withFromUserEntityToSelfUser(SELF_USER)
+                .withFromTeamAndDomain(UserType.FEDERATED)
+                .arrange()
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
 
             val expectedResult = UserSearchResult(
                 result = listOf(TestUser.OTHER)
@@ -337,6 +359,7 @@ class SearchUserRepositoryTest {
     fun givenAValidUserSearchWithEmptyResults_WhenSearchingSomeText_ThenResultIsAnEmptyList() =
         runTest {
             // given
+<<<<<<< HEAD
             given(userSearchApiWrapper)
                 .suspendFunction(userSearchApiWrapper::search)
                 .whenInvokedWith(anything(), anything(), anything(), anything())
@@ -360,6 +383,15 @@ class SearchUserRepositoryTest {
                 .function(userMapper::fromUserDetailsEntityToSelfUser)
                 .whenInvokedWith(any())
                 .then { TestUser.SELF }
+=======
+            val (_, searchUserRepository) = Arrangement()
+                .withSearchResult(Either.Right(CONTACT_SEARCH_RESPONSE))
+                .withGetMultipleUsersResult(NetworkResponse.Success(USER_RESPONSE.copy(usersFound = emptyList()), mapOf(), 200))
+                .withValueByKeyFlowResult(flowOf(JSON_QUALIFIED_ID))
+                .withGetUserByQualifiedIdResult(flowOf(USER_ENTITY))
+                .withFromUserEntityToSelfUser(SELF_USER)
+                .arrange()
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
 
             val expectedResult = UserSearchResult(
                 result = emptyList()
@@ -375,6 +407,7 @@ class SearchUserRepositoryTest {
     fun givenASearchWithConversationExcludedOption_WhenSearchingUsersByNameOrHandleOrEmail_ThenSearchForUsersNotInTheConversation() =
         runTest {
             // given
+<<<<<<< HEAD
             given(userDAO)
                 .suspendFunction(userDAO::getUsersDetailsNotInConversationByNameOrHandleOrEmail)
                 .whenInvokedWith(anything(), anything())
@@ -384,6 +417,12 @@ class SearchUserRepositoryTest {
                 .suspendFunction(userDAO::getUserDetailsByNameOrHandleOrEmailAndConnectionStates)
                 .whenInvokedWith(anything(), anything())
                 .then { _, _ -> flowOf(listOf()) }
+=======
+            val (arrangement, searchUserRepository) = Arrangement()
+                .withGetUsersNotInConversationByNameOrHandleOrEmailResult(flowOf(listOf()))
+                .withGetUserByNameOrHandleOrEmailAndConnectionStatesResult(flowOf(listOf()))
+                .arrange()
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
 
             // when
             searchUserRepository.searchKnownUsersByNameOrHandleOrEmail(
@@ -396,6 +435,7 @@ class SearchUserRepositoryTest {
                 )
             )
 
+<<<<<<< HEAD
             verify(userDAO)
                 .suspendFunction(userDAO::getUserDetailsByNameOrHandleOrEmailAndConnectionStates)
                 .with(anything(), anything())
@@ -403,6 +443,15 @@ class SearchUserRepositoryTest {
 
             verify(userDAO)
                 .suspendFunction(userDAO::getUsersDetailsNotInConversationByNameOrHandleOrEmail)
+=======
+            verify(arrangement.userDAO)
+                .suspendFunction(arrangement.userDAO::getUserByNameOrHandleOrEmailAndConnectionStates)
+                .with(anything(), anything())
+                .wasNotInvoked()
+
+            verify(arrangement.userDAO)
+                .suspendFunction(arrangement.userDAO::getUsersNotInConversationByNameOrHandleOrEmail)
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
                 .with(anything(), anything())
                 .wasInvoked(Times(1))
         }
@@ -410,6 +459,7 @@ class SearchUserRepositoryTest {
     @Test
     fun givenASearchWithConversationExcludedOption_WhenSearchingUsersByHandle_ThenSearchForUsersNotInTheConversation() = runTest {
         // given
+<<<<<<< HEAD
         given(userDAO)
             .suspendFunction(userDAO::getUserDetailsByHandleAndConnectionStates)
             .whenInvokedWith(anything(), anything())
@@ -419,6 +469,12 @@ class SearchUserRepositoryTest {
             .suspendFunction(userDAO::getUsersDetailsNotInConversationByHandle)
             .whenInvokedWith(anything(), anything())
             .then { _, _ -> flowOf(listOf()) }
+=======
+        val (arrangement, searchUserRepository) = Arrangement()
+            .withGetUserByHandleAndConnectionStatesResult(flowOf(listOf()))
+            .withGetUsersNotInConversationByHandleResult(flowOf(listOf()))
+            .arrange()
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
 
         // when
         searchUserRepository.searchKnownUsersByHandle(
@@ -432,6 +488,7 @@ class SearchUserRepositoryTest {
         )
 
         // then
+<<<<<<< HEAD
         verify(userDAO)
             .suspendFunction(userDAO::getUserDetailsByHandleAndConnectionStates)
             .with(anything(), anything())
@@ -439,6 +496,15 @@ class SearchUserRepositoryTest {
 
         verify(userDAO)
             .suspendFunction(userDAO::getUsersDetailsNotInConversationByHandle)
+=======
+        verify(arrangement.userDAO)
+            .suspendFunction(arrangement.userDAO::getUserByHandleAndConnectionStates)
+            .with(anything(), anything())
+            .wasNotInvoked()
+
+        verify(arrangement.userDAO)
+            .suspendFunction(arrangement.userDAO::getUsersNotInConversationByHandle)
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
             .with(anything(), anything())
             .wasInvoked(exactly = once)
     }
@@ -446,10 +512,9 @@ class SearchUserRepositoryTest {
     @Test
     fun givenContactSearchApiSuccessButListIsEmpty_whenSearchPublicContact_thenReturnEmptyListWithoutCallingUserDetailsApi() = runTest {
         // given
-        given(userSearchApiWrapper)
-            .suspendFunction(userSearchApiWrapper::search)
-            .whenInvokedWith(anything(), anything(), anything(), anything())
-            .thenReturn(Either.Right(CONTACT_SEARCH_RESPONSE_EMPTY))
+        val (arrangement, searchUserRepository) = Arrangement()
+            .withSearchResult(Either.Right(CONTACT_SEARCH_RESPONSE_EMPTY))
+            .arrange()
 
         // when
         val actual = searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
@@ -458,10 +523,178 @@ class SearchUserRepositoryTest {
         assertIs<Either.Right<UserSearchResult>>(actual)
         assertTrue { actual.value.result.isEmpty() }
 
-        verify(userDetailsApi)
-            .suspendFunction(userDetailsApi::getMultipleUsers)
+        verify(arrangement.userDetailsApi)
+            .suspendFunction(arrangement.userDetailsApi::getMultipleUsers)
             .with(any())
             .wasNotInvoked()
+    }
+
+    @Test
+    fun givenContactSearchApiReturnsTeamMembers_whenSearchPublicContact_thenStoreThemLocallyAndExcludeFromResult() = runTest {
+        // given
+        val userListResponse = ListUsersDTO(
+            usersFailed = emptyList(),
+            usersFound = listOf(USER_PROFILE_DTO.copy(id = UserId("teamUser", SELF_USER.id.domain), teamId = SELF_USER.teamId?.value),)
+        )
+        val (arrangement, searchUserRepository) = Arrangement()
+            .withSearchResult(Either.Right(CONTACT_SEARCH_RESPONSE))
+            .withGetMultipleUsersResult(NetworkResponse.Success(userListResponse, mapOf(), 200))
+            .withValueByKeyFlowResult(flowOf(JSON_QUALIFIED_ID))
+            .withGetUserByQualifiedIdResult(flowOf(USER_ENTITY))
+            .withFromUserEntityToSelfUser(SELF_USER)
+            .withUpsertTeamMembersSuccess()
+            .withFromUserProfileDtoToOtherUserResult(PUBLIC_USER)
+            .withFromUserProfileDtoToUserEntityResult(USER_ENTITY)
+            .withFromTeamAndDomain(UserType.FEDERATED)
+            .arrange()
+
+        // when
+        val actual = searchUserRepository.searchUserDirectory(TEST_QUERY, TEST_DOMAIN)
+
+        // then
+        assertIs<Either.Right<UserSearchResult>>(actual)
+        assertTrue { actual.value.result.isEmpty() }
+
+        verify(arrangement.userDAO)
+            .suspendFunction(arrangement.userDAO::upsertTeamMembers)
+            .with(eq(listOf(USER_ENTITY)))
+            .wasInvoked()
+    }
+
+    internal class Arrangement {
+
+        @Mock
+        internal val metadataDAO: MetadataDAO = mock(classOf<MetadataDAO>())
+
+        @Mock
+        internal val userDetailsApi: UserDetailsApi = mock(classOf<UserDetailsApi>())
+
+        @Mock
+        internal val userSearchApiWrapper: UserSearchApiWrapper = mock(classOf<UserSearchApiWrapper>())
+
+        @Mock
+        internal val publicUserMapper: PublicUserMapper = mock(classOf<PublicUserMapper>())
+
+        @Mock
+        internal val userMapper: UserMapper = mock(classOf<UserMapper>())
+
+        @Mock
+        internal val domainUserTypeMapper: DomainUserTypeMapper = mock(classOf<DomainUserTypeMapper>())
+
+        @Mock
+        internal val userDAO: UserDAO = mock(classOf<UserDAO>())
+
+        private val searchUserRepository: SearchUserRepository by lazy {
+            SearchUserRepositoryImpl(
+                userDAO,
+                metadataDAO,
+                userDetailsApi,
+                userSearchApiWrapper,
+                publicUserMapper,
+                userMapper,
+                domainUserTypeMapper
+            )
+        }
+
+        fun arrange() = this to searchUserRepository
+
+        init {
+            given(domainUserTypeMapper).invocation { federated }.then { UserType.FEDERATED }
+            given(domainUserTypeMapper).invocation { guest }.then { UserType.GUEST }
+            given(domainUserTypeMapper).invocation { standard }.then { UserType.INTERNAL }
+            given(domainUserTypeMapper).invocation { external }.then { UserType.EXTERNAL }
+        }
+
+        fun withSearchResult(result: Either<NetworkFailure, UserSearchResponse>) = apply {
+            given(userSearchApiWrapper)
+                .suspendFunction(userSearchApiWrapper::search)
+                .whenInvokedWith(anything(), anything(), anything(), anything())
+                .thenReturn(result)
+        }
+
+        fun withGetMultipleUsersResult(result: NetworkResponse<ListUsersDTO>) = apply {
+            given(userDetailsApi)
+                .suspendFunction(userDetailsApi::getMultipleUsers)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withFromUserProfileDtoToOtherUserResult(result: OtherUser) = apply {
+            given(publicUserMapper)
+                .function(publicUserMapper::fromUserProfileDtoToOtherUser)
+                .whenInvokedWith(any(), any())
+                .thenReturn(result)
+        }
+
+        fun withValueByKeyFlowResult(result: Flow<String?>) = apply {
+            given(metadataDAO)
+                .suspendFunction(metadataDAO::valueByKeyFlow)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withGetUserByQualifiedIdResult(result: Flow<UserEntity?>) = apply {
+            given(userDAO)
+                .suspendFunction(userDAO::getUserByQualifiedID)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withFromUserEntityToSelfUser(result: SelfUser) = apply {
+            given(userMapper)
+                .function(userMapper::fromUserEntityToSelfUser)
+                .whenInvokedWith(any())
+                .thenReturn(result)
+        }
+
+        fun withFromTeamAndDomain(result: UserType) = apply {
+            given(domainUserTypeMapper)
+                .function(domainUserTypeMapper::fromTeamAndDomain)
+                .whenInvokedWith(any(), any(), any(), any(), any())
+                .thenReturn(result)
+        }
+
+        fun withGetUsersNotInConversationByNameOrHandleOrEmailResult(result: Flow<List<UserEntity>>) = apply {
+            given(userDAO)
+                .suspendFunction(userDAO::getUsersNotInConversationByNameOrHandleOrEmail)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(result)
+        }
+
+        fun withGetUserByNameOrHandleOrEmailAndConnectionStatesResult(result: Flow<List<UserEntity>>) = apply {
+            given(userDAO)
+                .suspendFunction(userDAO::getUserByNameOrHandleOrEmailAndConnectionStates)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(result)
+        }
+
+        fun withGetUserByHandleAndConnectionStatesResult(result: Flow<List<UserEntity>>) = apply {
+            given(userDAO)
+                .suspendFunction(userDAO::getUserByHandleAndConnectionStates)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(result)
+        }
+
+        fun withGetUsersNotInConversationByHandleResult(result: Flow<List<UserEntity>>) = apply {
+            given(userDAO)
+                .suspendFunction(userDAO::getUsersNotInConversationByHandle)
+                .whenInvokedWith(anything(), anything())
+                .thenReturn(result)
+        }
+
+        fun withFromUserProfileDtoToUserEntityResult(result: UserEntity) = apply {
+            given(userMapper)
+                .function(userMapper::fromUserProfileDtoToUserEntity)
+                .whenInvokedWith(any(), any(), any())
+                .thenReturn(result)
+        }
+
+        fun withUpsertTeamMembersSuccess() = apply {
+            given(userDAO)
+                .suspendFunction(userDAO::upsertTeamMembers)
+                .whenInvokedWith(anything())
+                .thenReturn(Unit)
+        }
     }
 
     private companion object {
@@ -502,6 +735,7 @@ class SearchUserRepositoryTest {
             took = 0,
         )
 
+<<<<<<< HEAD
         val USER_RESPONSE = ListUsersDTO(
             usersFailed = emptyList(),
             usersFound = listOf(
@@ -521,9 +755,64 @@ class SearchUserRepositoryTest {
                     supportedProtocols = null
                 )
             )
+=======
+        val USER_PROFILE_DTO = UserProfileDTO(
+            accentId = 1,
+            handle = "handle",
+            id = UserIdDTO(value = "value", domain = "domain"),
+            name = "name",
+            legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+            teamId = "team",
+            assets = emptyList(),
+            deleted = null,
+            email = null,
+            expiresAt = null,
+            nonQualifiedId = "value",
+            service = null
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
         )
 
+        val USER_RESPONSE = ListUsersDTO(usersFailed = emptyList(), usersFound = listOf(USER_PROFILE_DTO))
+
         const val JSON_QUALIFIED_ID = """{"value":"test" , "domain":"test" }"""
+<<<<<<< HEAD
+=======
+
+        val USER_ENTITY = UserEntity(
+            id = QualifiedIDEntity("value", "domain"),
+            name = null,
+            handle = null,
+            email = null,
+            phone = null,
+            accentId = 0,
+            team = null,
+            connectionStatus = ConnectionEntity.State.NOT_CONNECTED,
+            previewAssetId = null,
+            completeAssetId = null,
+            availabilityStatus = UserAvailabilityStatusEntity.AVAILABLE,
+            userType = UserTypeEntity.EXTERNAL,
+            botService = null,
+            deleted = false,
+            expiresAt = null,
+            defederated = false
+        )
+
+        val SELF_USER = SelfUser(
+            id = QualifiedID("someValue", "someId"),
+            name = null,
+            handle = null,
+            email = null,
+            phone = null,
+            accentId = 0,
+            teamId = TeamId("someTeamId"),
+            connectionStatus = ConnectionState.NOT_CONNECTED,
+            previewPicture = null,
+            completePicture = null,
+            availabilityStatus = UserAvailabilityStatus.AVAILABLE,
+            expiresAt = null
+        )
+
+>>>>>>> 0df069cb00 (fix: persist searched team members [WPB-5262] (#2179))
     }
 
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/UserDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/UserDTO.kt
@@ -56,6 +56,9 @@ data class UserProfileDTO(
     @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatusResponse,
 ) : UserDTO()
 
+fun UserProfileDTO.isTeamMember(selfUserTeamId: String?, selfUserDomain: String?) =
+    (selfUserTeamId != null && this.teamId == selfUserTeamId && this.id.domain == selfUserDomain)
+
 @Serializable
 data class SelfUserDTO(
     @SerialName("qualified_id") override val id: UserId,


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2179

---- 

 ⚠️ Conflicts during cherry-pick:

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user belongs to a huge team (over 2000 members), then all team members are not fetched and stored during the slow sync and because of that, when searching, the app can't filter out the team members from the public search list and doesn't know the connection status of them.

### Solutions

When handling public search results, extract team members from the result and persist them locally as contacts.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
