### PR TITLE
chore: add waitUntilCompletes option to LogoutUseCase

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -43,9 +43,10 @@ import kotlinx.coroutines.launch
 interface LogoutUseCase {
     /**
      * @param reason the reason for the logout performed
+     * @param waitUntilCompletes if true, the logout suspend fun will wait until all the logout operations are completed
      * @see [LogoutReason]
      */
-    suspend operator fun invoke(reason: LogoutReason)
+    suspend operator fun invoke(reason: LogoutReason, waitUntilCompletes: Boolean = false)
 }
 
 internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
@@ -68,7 +69,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
     //                 Perhaps [UserSessionScope] (or another specialised class) can observe
     //                 the [LogoutRepository.observeLogout] and invalidating everything in [CoreLogic] level.
 
-    override suspend operator fun invoke(reason: LogoutReason) {
+    override suspend operator fun invoke(reason: LogoutReason, waitUntilCompletes: Boolean) {
         globalCoroutineScope.launch {
             deregisterTokenUseCase()
 
@@ -90,6 +91,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
                         wipeTokenAndMetadata()
                     }
                 }
+
                 LogoutReason.SESSION_EXPIRED -> {
                     if (kaliumConfigs.wipeOnCookieInvalid) {
                         wipeAllData()
@@ -97,12 +99,13 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
                         clearCurrentClientIdAndFirebaseTokenFlag()
                     }
                 }
+
                 LogoutReason.SELF_SOFT_LOGOUT -> clearCurrentClientIdAndFirebaseTokenFlag()
             }
 
             userSessionScopeProvider.get(userId)?.cancel()
             userSessionScopeProvider.delete(userId)
-        }
+        }.let { if (waitUntilCompletes) it.join() else it }
     }
 
     private suspend fun clearCurrentClientIdAndFirebaseTokenFlag() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently logout is executed in a new coroutine scoped to the `globalCoroutineScope` so calling logout just creates and executes this coroutine but does not wait until all required logout-related actions are completed. Because of that, it's possible that some other actions that should happen after the logout is completed are actually executed when logout is not yet done and for instance the app can get the info that the session is still valid.

### Solutions

Provide an optional parameter `waitUntilCompletes` - if true, then this suspend fun waits until all required actions are completed.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
