### PR TITLE
feat: count searched message position (WPB-4986)

### DIFF
--- a/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensionsTest.kt
+++ b/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensionsTest.kt
@@ -55,6 +55,7 @@ class MessageRepositoryExtensionsTest {
     fun givenParameters_whenPaginatedMessagesByConversation_thenShouldCallDaoExtensionsWithRightParameters() = runTest {
         val pagingConfig = PagingConfig(20)
         val pager = Pager(pagingConfig) { fakePagingSource }
+        val startingOffset = 0
 
         val kaliumPager = KaliumPager(pager, fakePagingSource, StandardTestDispatcher())
         val (arrangement, messageRepositoryExtensions) = Arrangement()
@@ -65,7 +66,8 @@ class MessageRepositoryExtensionsTest {
         messageRepositoryExtensions.getPaginatedMessagesByConversationIdAndVisibility(
             TestConversation.ID,
             visibilities,
-            pagingConfig
+            pagingConfig,
+            startingOffset
         )
 
         verify(arrangement.messageDaoExtensions)

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensions.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensions.kt
@@ -34,6 +34,7 @@ actual interface MessageRepositoryExtensions {
         conversationId: ConversationId,
         visibility: List<Message.Visibility>,
         pagingConfig: PagingConfig,
+        startingOffset: Int
     ): Flow<PagingData<Message.Standalone>>
 }
 
@@ -46,11 +47,13 @@ actual class MessageRepositoryExtensionsImpl actual constructor(
         conversationId: ConversationId,
         visibility: List<Message.Visibility>,
         pagingConfig: PagingConfig,
+        startingOffset: Int
     ): Flow<PagingData<Message.Standalone>> {
         val pager: KaliumPager<MessageEntity> = messageDAO.platformExtensions.getPagerForConversation(
             conversationId.toDao(),
             visibility.map { it.toEntityVisibility() },
-            pagingConfig
+            pagingConfig,
+            startingOffset
         )
 
         return pager.pagingDataFlow.map { pagingData: PagingData<MessageEntity> ->

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesByConversationUseCase.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesByConversationUseCase.kt
@@ -40,8 +40,9 @@ class GetPaginatedFlowOfMessagesByConversationUseCase internal constructor(
     suspend operator fun invoke(
         conversationId: ConversationId,
         visibility: List<Message.Visibility> = Message.Visibility.values().toList(),
+        startingOffset: Int,
         pagingConfig: PagingConfig
     ): Flow<PagingData<Message.Standalone>> = messageRepository.extensions.getPaginatedMessagesByConversationIdAndVisibility(
-        conversationId, visibility, pagingConfig
+        conversationId, visibility, pagingConfig, startingOffset
     ).flowOn(dispatcher.io)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -224,6 +224,11 @@ interface MessageRepository {
         conversationId: ConversationId
     ): Either<CoreFailure, List<Message.Standalone>>
 
+    suspend fun getSearchedConversationMessagePosition(
+        conversationId: ConversationId,
+        messageId: String
+    ): Either<StorageFailure, Long>
+
     val extensions: MessageRepositoryExtensions
 }
 
@@ -650,5 +655,15 @@ class MessageDataSource(
             searchQuery = searchQuery,
             conversationId = conversationId.toDao()
         ).map(messageMapper::fromEntityToMessage)
+    }
+
+    override suspend fun getSearchedConversationMessagePosition(
+        conversationId: ConversationId,
+        messageId: String
+    ): Either<StorageFailure, Long> = wrapStorageRequest {
+        messageDAO.getSearchedConversationMessagePosition(
+            conversationId = conversationId.toDao(),
+            messageId = messageId
+        )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -227,7 +227,7 @@ interface MessageRepository {
     suspend fun getSearchedConversationMessagePosition(
         conversationId: ConversationId,
         messageId: String
-    ): Either<StorageFailure, Long>
+    ): Either<StorageFailure, Int>
 
     val extensions: MessageRepositoryExtensions
 }
@@ -660,7 +660,7 @@ class MessageDataSource(
     override suspend fun getSearchedConversationMessagePosition(
         conversationId: ConversationId,
         messageId: String
-    ): Either<StorageFailure, Long> = wrapStorageRequest {
+    ): Either<StorageFailure, Int> = wrapStorageRequest {
         messageDAO.getSearchedConversationMessagePosition(
             conversationId = conversationId.toDao(),
             messageId = messageId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
@@ -18,7 +18,6 @@
 package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.functional.fold

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
@@ -20,14 +20,20 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
+import com.wire.kalium.logic.functional.fold
 
 interface GetSearchedConversationMessagePositionUseCase {
 
     suspend operator fun invoke(
         conversationId: ConversationId,
         messageId: String
-    ): Either<StorageFailure, Int>
+    ): Result
+
+    sealed class Result {
+        data class Success(val position: Int) : Result()
+        data class Failure(val storageFailure: StorageFailure) : Result()
+    }
 }
 
 internal class GetSearchedConversationMessagePositionUseCaseImpl internal constructor(
@@ -37,9 +43,12 @@ internal class GetSearchedConversationMessagePositionUseCaseImpl internal constr
     override suspend fun invoke(
         conversationId: ConversationId,
         messageId: String
-    ): Either<StorageFailure, Int> = messageRepository
+    ): GetSearchedConversationMessagePositionUseCase.Result = messageRepository
         .getSearchedConversationMessagePosition(
             conversationId = conversationId,
             messageId = messageId
+        ).fold(
+            { GetSearchedConversationMessagePositionUseCase.Result.Failure(it) },
+            { GetSearchedConversationMessagePositionUseCase.Result.Success(it) }
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageRepository
@@ -39,7 +40,7 @@ interface GetSearchedConversationMessagePositionUseCase {
 
     sealed interface Result {
         data class Success(val position: Int) : Result
-        data class Failure(val cause: StorageFailure) : Result
+        data class Failure(val cause: CoreFailure) : Result
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
@@ -20,9 +20,16 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
 import com.wire.kalium.logic.functional.fold
 
+/**
+ * Gets the Selected Message Position from Search
+ *
+ * @param conversationId [ConversationId] the id of the conversation where the search is happening.
+ * @param messageId [String] the id of the selected message from search.
+ *
+ * @result [Result] Success with Int position. Failure with StorageFailure.
+ */
 interface GetSearchedConversationMessagePositionUseCase {
 
     suspend operator fun invoke(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.functional.Either
+
+interface GetSearchedConversationMessagePositionUseCase {
+
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        messageId: String
+    ): Either<StorageFailure, Long>
+}
+
+internal class GetSearchedConversationMessagePositionUseCaseImpl internal constructor(
+    private val messageRepository: MessageRepository
+) : GetSearchedConversationMessagePositionUseCase {
+
+    override suspend fun invoke(
+        conversationId: ConversationId,
+        messageId: String
+    ): Either<StorageFailure, Long> = messageRepository
+        .getSearchedConversationMessagePosition(
+            conversationId = conversationId,
+            messageId = messageId
+        )
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
@@ -37,9 +37,9 @@ interface GetSearchedConversationMessagePositionUseCase {
         messageId: String
     ): Result
 
-    sealed class Result {
-        data class Success(val position: Int) : Result()
-        data class Failure(val storageFailure: StorageFailure) : Result()
+    sealed interface Result {
+        data class Success(val position: Int) : Result
+        data class Failure(val cause: StorageFailure) : Result
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
@@ -27,7 +27,7 @@ interface GetSearchedConversationMessagePositionUseCase {
     suspend operator fun invoke(
         conversationId: ConversationId,
         messageId: String
-    ): Either<StorageFailure, Long>
+    ): Either<StorageFailure, Int>
 }
 
 internal class GetSearchedConversationMessagePositionUseCaseImpl internal constructor(
@@ -37,7 +37,7 @@ internal class GetSearchedConversationMessagePositionUseCaseImpl internal constr
     override suspend fun invoke(
         conversationId: ConversationId,
         messageId: String
-    ): Either<StorageFailure, Long> = messageRepository
+    ): Either<StorageFailure, Int> = messageRepository
         .getSearchedConversationMessagePosition(
             conversationId = conversationId,
             messageId = messageId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -326,4 +326,9 @@ class MessageScope internal constructor(
         get() = GetConversationMessagesFromSearchQueryUseCaseImpl(
             messageRepository = messageRepository
         )
+
+    val getSearchedConversationMessagePosition: GetSearchedConversationMessagePositionUseCase
+        get() = GetSearchedConversationMessagePositionUseCaseImpl(
+            messageRepository = messageRepository
+        )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -521,6 +521,38 @@ class MessageRepositoryTest {
         )
     }
 
+    @Test
+    fun givenSearchedMessages_whenMessageIsSelected_thenReturnMessagePosition() = runTest {
+        // given
+        val qualifiedIdEntity = TEST_QUALIFIED_ID_ENTITY
+        val conversationId = TEST_CONVERSATION_ID
+        val message = TEST_MESSAGE_ENTITY.copy(
+            id = "msg1",
+            conversationId = qualifiedIdEntity,
+            content = MessageEntityContent.Text("message 1")
+        )
+        val expectedResult = 113
+        val (_, messageRepository) = Arrangement()
+            .withSelectedMessagePosition(
+                conversationId = conversationId.toDao(),
+                messageId = message.id,
+                result = expectedResult
+            )
+            .arrange()
+
+        // when
+        val result = messageRepository.getSearchedConversationMessagePosition(
+            conversationId = conversationId,
+            messageId = message.id
+        )
+
+        // then
+        assertEquals(
+            expectedResult,
+            (result as Either.Right).value
+        )
+    }
+
     private class Arrangement {
 
         @Mock
@@ -671,6 +703,17 @@ class MessageRepositoryTest {
                 .suspendFunction(messageDAO::getConversationMessagesFromSearch)
                 .whenInvokedWith(eq(searchTerm), eq(conversationId))
                 .thenReturn(messages)
+        }
+
+        fun withSelectedMessagePosition(
+            conversationId: QualifiedIDEntity,
+            messageId: String,
+            result: Int
+        ) = apply {
+            given(messageDAO)
+                .suspendFunction(messageDAO::getSearchedConversationMessagePosition)
+                .whenInvokedWith(eq(conversationId), eq(messageId))
+                .thenReturn(result)
         }
 
         fun arrange() = this to MessageDataSource(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -531,12 +531,12 @@ class MessageRepositoryTest {
             conversationId = qualifiedIdEntity,
             content = MessageEntityContent.Text("message 1")
         )
-        val expectedResult = 113
+        val expectedMessagePosition = 113
         val (_, messageRepository) = Arrangement()
             .withSelectedMessagePosition(
                 conversationId = conversationId.toDao(),
                 messageId = message.id,
-                result = expectedResult
+                result = expectedMessagePosition
             )
             .arrange()
 
@@ -548,7 +548,7 @@ class MessageRepositoryTest {
 
         // then
         assertEquals(
-            expectedResult,
+            expectedMessagePosition,
             (result as Either.Right).value
         )
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/message/GetSearchedConversationMessagePositionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/message/GetSearchedConversationMessagePositionUseCaseTest.kt
@@ -84,12 +84,12 @@ class GetSearchedConversationMessagePositionUseCaseTest {
 
     @Test
     fun givenRepositorySucceeds_whenInvokingUseCase_thenShouldPropagateTheSuccess() = runTest {
-        val expectedPosition = 113
+        val expectedMessagePosition = 113
         val (_, getSearchedConversationMessagePosition) = Arrangement()
             .withRepositoryMessagePositionReturning(
                 conversationId = CONVERSATION_ID,
                 messageId = MESSAGE_ID,
-                response = Either.Right(expectedPosition)
+                response = Either.Right(expectedMessagePosition)
             )
             .arrange()
 
@@ -99,7 +99,7 @@ class GetSearchedConversationMessagePositionUseCaseTest {
         )
 
         assertIs<GetSearchedConversationMessagePositionUseCase.Result.Success>(result)
-        assertEquals(expectedPosition, result.position)
+        assertEquals(expectedMessagePosition, result.position)
     }
 
     private inner class Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/message/GetSearchedConversationMessagePositionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/message/GetSearchedConversationMessagePositionUseCaseTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.message
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.feature.message.GetSearchedConversationMessagePositionUseCase
+import com.wire.kalium.logic.feature.message.GetSearchedConversationMessagePositionUseCaseImpl
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class GetSearchedConversationMessagePositionUseCaseTest {
+
+    @Test
+    fun givenConversationIdAndMessageId_whenInvokingUseCase_thenShouldCallMessageRepository() = runTest {
+        val (arrangement, getSearchedConversationMessagePosition) = Arrangement()
+            .withRepositoryMessagePositionReturning(
+                conversationId = CONVERSATION_ID,
+                messageId = MESSAGE_ID,
+                response = Either.Left(StorageFailure.DataNotFound)
+            )
+            .arrange()
+
+        getSearchedConversationMessagePosition(
+            conversationId = CONVERSATION_ID,
+            messageId = MESSAGE_ID
+        )
+
+        verify(arrangement.messageRepository)
+            .coroutine {
+                arrangement.messageRepository.getSearchedConversationMessagePosition(
+                    conversationId = CONVERSATION_ID,
+                    messageId = MESSAGE_ID
+                )
+            }
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenRepositoryFails_whenInvokingUseCase_thenShouldPropagateTheFailure() = runTest {
+        val cause = StorageFailure.DataNotFound
+        val (_, getSearchedConversationMessagePosition) = Arrangement()
+            .withRepositoryMessagePositionReturning(
+                conversationId = CONVERSATION_ID,
+                messageId = MESSAGE_ID,
+                response = Either.Left(StorageFailure.DataNotFound)
+            )
+            .arrange()
+
+        val result = getSearchedConversationMessagePosition(
+            conversationId = CONVERSATION_ID,
+            messageId = MESSAGE_ID
+        )
+
+        assertIs<GetSearchedConversationMessagePositionUseCase.Result.Failure>(result)
+        assertEquals(cause, result.cause)
+    }
+
+    @Test
+    fun givenRepositorySucceeds_whenInvokingUseCase_thenShouldPropagateTheSuccess() = runTest {
+        val expectedPosition = 113
+        val (_, getSearchedConversationMessagePosition) = Arrangement()
+            .withRepositoryMessagePositionReturning(
+                conversationId = CONVERSATION_ID,
+                messageId = MESSAGE_ID,
+                response = Either.Right(expectedPosition)
+            )
+            .arrange()
+
+        val result = getSearchedConversationMessagePosition(
+            conversationId = CONVERSATION_ID,
+            messageId = MESSAGE_ID
+        )
+
+        assertIs<GetSearchedConversationMessagePositionUseCase.Result.Success>(result)
+        assertEquals(expectedPosition, result.position)
+    }
+
+    private inner class Arrangement {
+
+        @Mock
+        val messageRepository: MessageRepository = mock(MessageRepository::class)
+
+        private val getSearchedConversationMessagePosition by lazy {
+            GetSearchedConversationMessagePositionUseCaseImpl(messageRepository = messageRepository)
+        }
+
+        suspend fun withRepositoryMessagePositionReturning(
+            conversationId: ConversationId,
+            messageId: String,
+            response: Either<StorageFailure, Int>
+        ) = apply {
+            given(messageRepository)
+                .coroutine {
+                    messageRepository.getSearchedConversationMessagePosition(
+                        conversationId = conversationId,
+                        messageId = messageId
+                    )
+                }
+                .thenReturn(response)
+        }
+
+        fun arrange() = this to getSearchedConversationMessagePosition
+    }
+
+    private companion object {
+        const val MESSAGE_ID = TestMessage.TEST_MESSAGE_ID
+        val MESSAGE = TestMessage.TEXT_MESSAGE
+        val CONVERSATION_ID = TestConversation.ID
+    }
+}

--- a/persistence/src/androidInstrumentedTest/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensionsTest.kt
+++ b/persistence/src/androidInstrumentedTest/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensionsTest.kt
@@ -123,7 +123,8 @@ class MessageExtensionsTest : BaseDatabaseTest() {
     private fun getPager(): KaliumPager<MessageEntity> = messageExtensions.getPagerForConversation(
         conversationId = CONVERSATION_ID,
         visibilities = MessageEntity.Visibility.values().toList(),
-        pagingConfig = PagingConfig(PAGE_SIZE)
+        pagingConfig = PagingConfig(PAGE_SIZE),
+        startingOffset = 0
     )
 
     private suspend fun PagingSource<Int, MessageEntity>.refresh() = load(

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumOffsetQueryPagingSource.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumOffsetQueryPagingSource.kt
@@ -1,0 +1,111 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.persistence.dao.message
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import app.cash.paging.PagingSourceLoadParams
+import app.cash.paging.PagingSourceLoadParamsAppend
+import app.cash.paging.PagingSourceLoadParamsPrepend
+import app.cash.paging.PagingSourceLoadParamsRefresh
+import app.cash.paging.PagingSourceLoadResult
+import app.cash.paging.PagingSourceLoadResultInvalid
+import app.cash.paging.PagingSourceLoadResultPage
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.SuspendingTransacter
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.TransacterBase
+import app.cash.sqldelight.TransactionCallbacks
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.properties.Delegates
+
+internal class KaliumOffsetQueryPagingSource<RowType : Any>(
+    private val queryProvider: (limit: Int, offset: Int) -> Query<RowType>,
+    private val countQuery: Query<Int>,
+    private val transacter: TransacterBase,
+    private val initialOffset: Int,
+    private val context: CoroutineContext,
+) : WireQueryPagingSource<Int, RowType>() {
+    override val jumpingSupported get() = true
+
+    override suspend fun load(
+        params: PagingSourceLoadParams<Int>,
+    ): PagingSourceLoadResult<Int, RowType> = withContext(context) {
+        val key = params.key ?: initialOffset
+        val limit = when (params) {
+            is PagingSourceLoadParamsPrepend<*> -> minOf(key, params.loadSize)
+            else -> params.loadSize
+        }
+        val getPagingSourceLoadResult: TransactionCallbacks.() -> PagingSourceLoadResultPage<Int, RowType> = {
+            val count = countQuery.executeAsOne()
+            val offset = when (params) {
+                is PagingSourceLoadParamsPrepend<*> -> maxOf(0, key - params.loadSize)
+                is PagingSourceLoadParamsAppend<*> -> key
+                is PagingSourceLoadParamsRefresh<*> -> if (key >= count) maxOf(0, count - params.loadSize) else key
+                else -> error("Unknown PagingSourceLoadParams ${params::class}")
+            }
+            val data = queryProvider(limit, offset)
+                .also { currentQuery = it }
+                .executeAsList()
+            val nextPosToLoad = offset + data.size
+            PagingSourceLoadResultPage(
+                data = data,
+                prevKey = offset.takeIf { it > 0 && data.isNotEmpty() },
+                nextKey = nextPosToLoad.takeIf { data.isNotEmpty() && data.size >= limit && it < count },
+                itemsBefore = offset,
+                itemsAfter = maxOf(0, count - nextPosToLoad),
+            )
+        }
+        val loadResult = when (transacter) {
+            is Transacter -> transacter.transactionWithResult(bodyWithReturn = getPagingSourceLoadResult)
+            is SuspendingTransacter -> transacter.transactionWithResult(bodyWithReturn = getPagingSourceLoadResult)
+        }
+        (if (invalid) PagingSourceLoadResultInvalid<Int, RowType>() else loadResult) as PagingSourceLoadResult<Int, RowType>
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, RowType>) =
+        state.anchorPosition?.let { maxOf(0, it - (state.config.initialLoadSize / 2)) }
+}
+
+internal abstract class WireQueryPagingSource<Key : Any, RowType : Any> :
+    PagingSource<Key, RowType>(),
+    Query.Listener {
+    protected var currentQuery: Query<RowType>? by Delegates.observable(null) { _, old, new ->
+        old?.removeListener(this)
+        new?.addListener(this)
+    }
+
+    init {
+        registerInvalidatedCallback {
+            currentQuery?.removeListener(this)
+            currentQuery = null
+        }
+    }
+
+    final override fun queryResultsChanged() = invalidate()
+}
+
+internal fun Query<Long>.toInt(): Query<Int> =
+    object : Query<Int>({ cursor -> mapper(cursor).toInt() }) {
+        override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = this@toInt.execute(mapper)
+        override fun addListener(listener: Listener) = this@toInt.addListener(listener)
+        override fun removeListener(listener: Listener) = this@toInt.removeListener(listener)
+    }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumOffsetQueryPagingSource.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumOffsetQueryPagingSource.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.properties.Delegates
 
+@Suppress("ComplexMethod")
 internal class KaliumOffsetQueryPagingSource<RowType : Any>(
     private val queryProvider: (limit: Int, offset: Int) -> Query<RowType>,
     private val countQuery: Query<Int>,

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumOffsetQueryPagingSource.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumOffsetQueryPagingSource.kt
@@ -37,6 +37,10 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.properties.Delegates
 
+/**
+ * This class is duplicated from sqlDelight []OffsetQueryPagingSource] so we can pass an initial offset instead of depending
+ * only on the offset result coming from the queryProvider callback.
+ */
 @Suppress("ComplexMethod")
 internal class KaliumOffsetQueryPagingSource<RowType : Any>(
     private val queryProvider: (limit: Int, offset: Int) -> Query<RowType>,

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -20,10 +20,8 @@ package com.wire.kalium.persistence.dao.message
 
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
-import app.cash.sqldelight.paging3.QueryPagingSource
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.dao.ConversationIDEntity
-import com.wire.kalium.persistence.kaliumLogger
 import kotlin.coroutines.CoroutineContext
 
 actual interface MessageExtensions {
@@ -58,19 +56,19 @@ actual class MessageExtensionsImpl actual constructor(
     private fun getPagingSource(
         conversationId: ConversationIDEntity,
         visibilities: Collection<MessageEntity.Visibility>,
-        startingOffset: Int
+        initialOffset: Int
     ) =
-        QueryPagingSource(
-            countQuery = messagesQueries.countByConversationIdAndVisibility(conversationId, visibilities),
+        KaliumOffsetQueryPagingSource(
+            countQuery = messagesQueries.countByConversationIdAndVisibility(conversationId, visibilities).toInt(),
             transacter = messagesQueries,
             context = coroutineContext,
+            initialOffset = initialOffset,
             queryProvider = { limit, offset ->
-                kaliumLogger.d("Querying messages for conversation limit=$limit offset=$offset")
                 messagesQueries.selectByConversationIdAndVisibility(
                     conversationId,
                     visibilities,
-                    limit,
-                    offset + startingOffset,
+                    limit.toLong(),
+                    offset.toLong(),
                     messageMapper::toEntityMessageFromView
                 )
             }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -518,3 +518,10 @@ WHERE text LIKE ('%' || :searchQuery || '%')
 AND conversationId = :conversationId
 AND contentType = 'TEXT'
 ORDER BY date DESC;
+
+selectSearchedConversationMessagePosition:
+SELECT COUNT(*) FROM Message
+WHERE
+conversation_id = :conversationId
+AND creation_date >= (SELECT creation_date FROM Message WHERE id = :messageId LIMIT 1)
+ORDER BY creation_date DESC;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -143,7 +143,7 @@ interface MessageDAO {
     suspend fun getSearchedConversationMessagePosition(
         conversationId: QualifiedIDEntity,
         messageId: String
-    ): Long
+    ): Int
 
     val platformExtensions: MessageExtensions
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -140,5 +140,10 @@ interface MessageDAO {
         conversationId: QualifiedIDEntity
     ): List<MessageEntity>
 
+    suspend fun getSearchedConversationMessagePosition(
+        conversationId: QualifiedIDEntity,
+        messageId: String
+    ): Long
+
     val platformExtensions: MessageExtensions
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -427,10 +427,11 @@ internal class MessageDAOImpl internal constructor(
     override suspend fun getSearchedConversationMessagePosition(
         conversationId: QualifiedIDEntity,
         messageId: String
-    ): Long = withContext(coroutineContext) {
+    ): Int = withContext(coroutineContext) {
         queries
             .selectSearchedConversationMessagePosition(conversationId, messageId)
             .executeAsOne()
+            .toInt()
     }
 
     override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, mapper, coroutineContext)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -424,6 +424,15 @@ internal class MessageDAOImpl internal constructor(
         ).executeAsList()
     }
 
+    override suspend fun getSearchedConversationMessagePosition(
+        conversationId: QualifiedIDEntity,
+        messageId: String
+    ): Long = withContext(coroutineContext) {
+        queries
+            .selectSearchedConversationMessagePosition(conversationId, messageId)
+            .executeAsOne()
+    }
+
     override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, mapper, coroutineContext)
 
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -1767,7 +1767,6 @@ class MessageDAOTest : BaseDatabaseTest() {
     fun givenMessagesAreInserted_whenGettingConversationMessagesFromSearch_thenOnlyRelevantMessagesAreReturned() = runTest {
         insertInitialData()
 
-        val userInQuestion = userEntity1
         val otherUser = userEntity2
 
         val expectedMessages = listOf(
@@ -1821,6 +1820,61 @@ class MessageDAOTest : BaseDatabaseTest() {
 
         assertEquals(expectedMessages.size, result.size)
         assertContentEquals(expectedMessages.sortedByDescending { it.date }, result)
+    }
+
+    @Test
+    fun givenMessagesAreInserted_whenMessageIsSelected_thenReturnMessagePosition() = runTest {
+        // given
+        insertInitialData()
+
+        val otherUser = userEntity2
+
+        val expectedPosition = 1
+
+        val message1 = newRegularMessageEntity(
+            "1",
+            conversationId = conversationEntity1.id,
+            status = MessageEntity.Status.SENT,
+            senderUserId = otherUser.id,
+            senderName = otherUser.name!!,
+            content = MessageEntityContent.Text("message1"),
+            date = Instant.parse("2022-03-30T15:36:00.000Z")
+        )
+        val message2 = newRegularMessageEntity(
+            "2",
+            conversationId = conversationEntity1.id,
+            status = MessageEntity.Status.SENT,
+            senderUserId = otherUser.id,
+            senderName = otherUser.name!!,
+            content = MessageEntityContent.Text("message2"),
+            date = Instant.parse("2022-03-30T15:36:01.000Z")
+        )
+        val message3 = newRegularMessageEntity(
+            "3",
+            conversationId = conversationEntity1.id,
+            status = MessageEntity.Status.SENT,
+            senderUserId = otherUser.id,
+            senderName = otherUser.name!!,
+            content = MessageEntityContent.Text("message3"),
+            date = Instant.parse("2022-03-30T15:36:02.000Z")
+        )
+
+        val messages = listOf(
+            message1,
+            message2,
+            message3
+        )
+
+        messageDAO.insertOrIgnoreMessages(messages)
+
+        // when
+        val result = messageDAO.getSearchedConversationMessagePosition(
+            conversationId = conversationEntity1.id,
+            messageId = message3.id
+        )
+
+        // then
+        assertEquals(expectedPosition, result)
     }
 
     private suspend fun insertInitialData() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no way directly from our pager to get the selected searched message position.

### Solutions

This PR aims to add a usecase / repository / DAO to retrieve the message position in DESC order to be used to scroll the user into the right selected message.

There is also the addition of `KaliumOffsetQueryPagingSource` which is an overriden method of `OffsetQueryPagingSource` but with an extra param: `initialOffset` instead of using the given offset provided by :`queryProvider` in order to properly navigate the pager.

### Dependencies (Optional)

AR PR will follow soon.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

No way to test this now, only when AR PR will be created.
