### PR TITLE
chore: architectural fitness functions - inverted layer access msg and conversations pt4. (ACOL-123)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -26,9 +26,9 @@ import com.wire.kalium.logic.data.featureConfig.toModel
 import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.toDao
 import com.wire.kalium.logic.data.user.toModel
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionMapper.toSelfDeletionTimerEntity
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionMapper.toTeamSelfDeleteTimer
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSettingsSelfDeletionStatus
+import com.wire.kalium.logic.data.message.SelfDeletionMapper.toSelfDeletionTimerEntity
+import com.wire.kalium.logic.data.message.SelfDeletionMapper.toTeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.featureFlags.BuildFileRestrictionState
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/UserClientRepositoryProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/UserClientRepositoryProvider.kt
@@ -15,6 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+
+@file:Suppress("konsist.repositoriesShouldNotAccessFeaturePackageClasses")
+
 package com.wire.kalium.logic.data.client
 
 import com.wire.kalium.logic.data.user.UserId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -39,7 +39,7 @@ import com.wire.kalium.logic.data.message.UnreadEventType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SelfDeletionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SelfDeletionMapper.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.logic.feature.selfDeletingMessages
+package com.wire.kalium.logic.data.message
 
 import com.wire.kalium.persistence.config.SelfDeletionTimerEntity
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SelfDeletionTimer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SelfDeletionTimer.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.logic.feature.selfDeletingMessages
+package com.wire.kalium.logic.data.message
 
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.util.serialization.toJsonElement

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/SelfDeletingMessagesConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/SelfDeletingMessagesConfigHandler.kt
@@ -21,8 +21,8 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.Status
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSettingsSelfDeletionStatus
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
@@ -22,6 +22,8 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.util.isPositiveNotNull

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveTeamSettingsSelfDeletingStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveTeamSettingsSelfDeletingStatusUseCase.kt
@@ -18,6 +18,8 @@
 package com.wire.kalium.logic.feature.selfDeletingMessages
 
 import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.Flow

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/PersistNewSelfDeletionTimerUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/PersistNewSelfDeletionTimerUseCase.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.feature.selfDeletingMessages
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.util.serialization.toJsonElement

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/screenshotCensoring/ObserveScreenshotCensoringConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/screenshotCensoring/ObserveScreenshotCensoringConfigUseCase.kt
@@ -19,7 +19,7 @@
 package com.wire.kalium.logic.feature.user.screenshotCensoring
 
 import com.wire.kalium.logic.configuration.UserConfigRepository
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
 import com.wire.kalium.logic.functional.mapRight
 import com.wire.kalium.logic.functional.mapToRightOr
 import kotlinx.coroutines.flow.Flow

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
@@ -39,7 +39,7 @@ import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.framework.TestAsset.dummyUploadedAssetId
 import com.wire.kalium.logic.framework.TestAsset.mockedLongAssetData
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
@@ -42,8 +42,8 @@ import com.wire.kalium.logic.feature.featureConfig.handler.MLSConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSMigrationConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SecondFactorPasswordChallengeConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionMapper.toTeamSelfDeleteTimer
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.SelfDeletionMapper.toTeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneOnOnesUseCase
 import com.wire.kalium.logic.featureFlags.BuildFileRestrictionState
 import com.wire.kalium.logic.featureFlags.KaliumConfigs

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletingMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletingMessagesUseCaseTest.kt
@@ -22,6 +22,10 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.ConversationSelfDeletionStatus
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/screeenshotCensoring/ObserveScreenshotCensoringConfigUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/screeenshotCensoring/ObserveScreenshotCensoringConfigUseCaseTest.kt
@@ -21,8 +21,8 @@ package com.wire.kalium.logic.feature.user.screeenshotCensoring
 import app.cash.turbine.test
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSettingsSelfDeletionStatus
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigResult
 import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotCensoringConfigUseCaseImpl
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -37,8 +37,8 @@ import com.wire.kalium.logic.feature.featureConfig.handler.MLSConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSMigrationConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SecondFactorPasswordChallengeConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSelfDeleteTimer
-import com.wire.kalium.logic.feature.selfDeletingMessages.TeamSettingsSelfDeletionStatus
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneOnOnesUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestUser

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement.kt
@@ -19,10 +19,9 @@ package com.wire.kalium.logic.util.arrangement
 
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import io.mockative.Mock
 import io.mockative.any
-import io.mockative.eq
 import io.mockative.given
 import io.mockative.matchers.Matcher
 import io.mockative.mock

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.feature.asset.ScheduleNewAssetMessageResult
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
 import com.wire.kalium.logic.feature.debug.BrokenState
 import com.wire.kalium.logic.feature.debug.SendBrokenAssetMessageResult
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.onFailure


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

`MESSAGE` and `CONVERSATION` domain classes fix for inverted layer access

### Issues

We have failing tests for inverted dependency access between layers, from bottom to up, after introducing `Konsist` in: 
- https://github.com/wireapp/kalium/pull/2188

### Causes (Optional)

No architecture respected, bottom up access

### Solutions

Move `messages` and `conversation` classes and dtos to provide and adhere to correct layer access.
Some tests will still fail, for other rules.

### Needs release 

- https://github.com/wireapp/kalium/pull/2188

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to test

`AFTER MERGE`, Tests for the following checks, should NOT fail.

`com.wire.kalium.logic.architecture.LayerAccessRulesTest#repositoriesShouldNotAccessFeaturePackageClasses`

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
