### PR TITLE
fix: persisting team members connection state (RC) [WPB-5338]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -63,7 +63,7 @@ WHERE qualified_id = ?;
 
 updateTeamMemberUser:
 UPDATE User
-SET name = ?, handle = ?, email = ?, phone = ?, accent_id = ?, team = ?, preview_asset_id = ?, complete_asset_id = ?, bot_service = ?, incomplete_metadata = 0
+SET name = ?, handle = ?, email = ?, phone = ?, accent_id = ?, team = ?, connection_status = ?, preview_asset_id = ?, complete_asset_id = ?, bot_service = ?, incomplete_metadata = 0
 WHERE qualified_id = ?;
 
 updateTeamMemberType:

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -58,27 +58,57 @@ VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateUser:
 UPDATE User
-SET name = ?, handle = ?, email = ?, phone = ?, accent_id = ?, team = ?, preview_asset_id = ?, complete_asset_id = ?, user_type = ?, bot_service = ?, incomplete_metadata = ?, expires_at = ?
+SET name = ?,
+    handle = ?,
+    email = ?,
+    phone = ?,
+    accent_id = ?,
+    team = ?,
+    preview_asset_id = ?,
+    complete_asset_id = ?,
+    user_type = ?,
+    bot_service = ?,
+    incomplete_metadata = ?,
+    expires_at = ?
 WHERE qualified_id = ?;
 
 updateTeamMemberUser:
 UPDATE User
-SET name = ?, handle = ?, email = ?, phone = ?, accent_id = ?, team = ?, connection_status = ?, preview_asset_id = ?, complete_asset_id = ?, bot_service = ?, incomplete_metadata = 0
+SET name = ?,
+    handle = ?,
+    email = ?,
+    phone = ?,
+    accent_id = ?,
+    team = ?,
+    connection_status = ?,
+    preview_asset_id = ?,
+    complete_asset_id = ?,
+    bot_service = ?,
+    incomplete_metadata = 0
 WHERE qualified_id = ?;
 
 updateTeamMemberType:
 UPDATE User
-SET team = ?, connection_status = ?, user_type = ?
+SET team = ?,
+    connection_status = ?,
+    user_type = ?
 WHERE qualified_id = ?;
 
 markUserAsDeleted:
 UPDATE User
-SET team = NULL , preview_asset_id = NULL, complete_asset_id = NULL, user_type = ?, deleted = 1
+SET team = NULL ,
+    preview_asset_id = NULL,
+    complete_asset_id = NULL,
+    user_type = ?,
+    deleted = 1
 WHERE qualified_id = ?;
 
 markUserAsDefederated:
 UPDATE User
-SET team = NULL , preview_asset_id = NULL, complete_asset_id = NULL, defederated = 1
+SET team = NULL,
+    preview_asset_id = NULL,
+    complete_asset_id = NULL,
+    defederated = 1
 WHERE qualified_id = ?;
 
 insertOrIgnoreUserId:
@@ -87,7 +117,12 @@ VALUES(?, 1);
 
 updateSelfUser:
 UPDATE User
-SET name = ?, handle = ?, email = ?, accent_id = ?, preview_asset_id = ?, complete_asset_id = ?
+SET name = ?,
+    handle = ?,
+    email = ?,
+    accent_id = ?,
+    preview_asset_id = ?,
+    complete_asset_id = ?
 WHERE qualified_id = ?;
 
 insertOrIgnoreUserIdWithConnectionStatus:
@@ -136,7 +171,10 @@ updateUserhandle:
 UPDATE User SET handle = ? WHERE qualified_id = ?;
 
 updateUserAsset:
-UPDATE User SET complete_asset_id = ?, preview_asset_id = ? WHERE complete_asset_id = ?;
+UPDATE User
+SET complete_asset_id = ?,
+    preview_asset_id = ?
+WHERE complete_asset_id = ?;
 
 selectChanges:
 SELECT changes();

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -164,7 +164,14 @@ interface UserDAO {
     suspend fun upsertTeamMembersTypes(users: List<UserEntity>)
 
     /**
-     * This will update all columns, except [UserEntity.userType] or insert a new record with default values
+     * This will update all columns, except:
+     * - [UserEntity.availabilityStatus]
+     * - [UserEntity.userType]
+     * - [UserEntity.deleted]
+     * - [UserEntity.hasIncompleteMetadata]
+     * - [UserEntity.expiresAt]
+     * - [UserEntity.defederated]
+     * or insert a new record with default values
      * An upsert operation is a one that tries to update a record and if fails (not rows affected by change) inserts instead.
      * In this case as the transaction can be executed many times, we need to take care for not deleting old data.
      */

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -185,6 +185,7 @@ class UserDAOImpl internal constructor(
                     phone = user.phone,
                     accent_id = user.accentId,
                     team = user.team,
+                    connection_status = user.connectionStatus,
                     preview_asset_id = user.previewAssetId,
                     complete_asset_id = user.completeAssetId,
                     bot_service = user.botService,

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -34,6 +34,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -804,25 +805,23 @@ class UserDAOTest : BaseDatabaseTest() {
         )
         db.userDAO.upsertTeamMembers(listOf(updatedTeamMemberUser))
         val result = db.userDAO.getUserByQualifiedID(user1.id).first()
-        assertTrue {
-            result != null &&
-            result.name == updatedTeamMemberUser.name &&
-            result.handle == updatedTeamMemberUser.handle &&
-            result.email == updatedTeamMemberUser.email &&
-            result.phone == updatedTeamMemberUser.phone &&
-            result.accentId == updatedTeamMemberUser.accentId &&
-            result.team == updatedTeamMemberUser.team &&
-            result.connectionStatus == updatedTeamMemberUser.connectionStatus &&
-            result.previewAssetId == updatedTeamMemberUser.previewAssetId &&
-            result.completeAssetId == updatedTeamMemberUser.completeAssetId &&
-            result.availabilityStatus != updatedTeamMemberUser.availabilityStatus && // should not be updated
-            result.userType != updatedTeamMemberUser.userType && // should not be updated
-            result.botService == updatedTeamMemberUser.botService &&
-            result.deleted != updatedTeamMemberUser.deleted && // should not be updated
-            result.hasIncompleteMetadata != updatedTeamMemberUser.hasIncompleteMetadata && // should not be updated
-            result.expiresAt != updatedTeamMemberUser.expiresAt && // should not be updated
-            result.defederated != updatedTeamMemberUser.defederated // should not be updated
-        }
+        assertNotNull(result)
+        assertEquals(updatedTeamMemberUser.name, result.name)
+        assertEquals(updatedTeamMemberUser.handle, result.handle)
+        assertEquals(updatedTeamMemberUser.email, result.email)
+        assertEquals(updatedTeamMemberUser.phone, result.phone)
+        assertEquals(updatedTeamMemberUser.accentId, result.accentId)
+        assertEquals(updatedTeamMemberUser.team, result.team)
+        assertEquals(updatedTeamMemberUser.connectionStatus, result.connectionStatus)
+        assertEquals(updatedTeamMemberUser.previewAssetId, result.previewAssetId)
+        assertEquals(updatedTeamMemberUser.completeAssetId, result.completeAssetId)
+        assertEquals(updatedTeamMemberUser.botService, result.botService)
+        assertNotEquals(updatedTeamMemberUser.availabilityStatus, result.availabilityStatus)
+        assertNotEquals(updatedTeamMemberUser.userType, result.userType)
+        assertNotEquals(updatedTeamMemberUser.deleted, result.deleted)
+        assertNotEquals(updatedTeamMemberUser.hasIncompleteMetadata, result.hasIncompleteMetadata)
+        assertNotEquals(updatedTeamMemberUser.expiresAt, result.expiresAt)
+        assertNotEquals(updatedTeamMemberUser.defederated, result.defederated)
     }
 
     private companion object {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -764,7 +764,7 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingTeamMemberUser_whenUpdatingIt_thenAllImportantFieldsAreProperlyUpdated() = runTest(dispatcher) {
+    fun givenExistingTeamMemberUser_whenUpsertingIt_thenAllImportantFieldsAreProperlyUpdated() = runTest(dispatcher) {
         val user = user1.copy(
             name = "Name",
             handle = "Handle",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After fresh login, if user already has some conversations with other team members, when opening other conversation member profile, the app shows “connect” button so the user appears as not connected, but this user is from the same team.

### Solutions

Update also connection status for team members.

According to the documentation for the `upsertTeamMembers` function: 
>This will update all columns, except [UserEntity.userType] 

so it looks like an oversight and it should also update connection status.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
