### PR TITLE
feat(jvm): Add support for in-memory user storage

### DIFF
--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -40,7 +40,8 @@ import java.io.File
 actual class CoreLogic(
     rootPath: String,
     kaliumConfigs: KaliumConfigs,
-    userAgent: String
+    userAgent: String,
+    useInMemoryStorage: Boolean = false,
 ) : CoreLogicCommon(
     rootPath = rootPath, kaliumConfigs = kaliumConfigs, userAgent = userAgent
 ) {
@@ -75,7 +76,8 @@ actual class CoreLogic(
             globalCallManager,
             userStorageProvider,
             networkStateObserver,
-            userAgent
+            userAgent,
+            useInMemoryStorage
         )
     }
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/di/PlatformUserStorageProperties.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/di/PlatformUserStorageProperties.kt
@@ -18,7 +18,15 @@
 
 package com.wire.kalium.logic.di
 
+import java.io.File
+
 actual class PlatformUserStorageProperties internal constructor(
     val rootPath: String,
-    val rootStoragePath: String
+    val databaseInfo: DatabaseStorageType
 )
+
+sealed interface DatabaseStorageType {
+    data class FiledBacked(val filePath: File) : DatabaseStorageType
+
+    data object InMemory : DatabaseStorageType
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/di/PlatformUserStorageProvider.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/di/PlatformUserStorageProvider.kt
@@ -21,22 +21,36 @@ package com.wire.kalium.logic.di
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.persistence.db.PlatformDatabaseData
+import com.wire.kalium.persistence.db.inMemoryDatabase
 import com.wire.kalium.persistence.db.userDatabaseBuilder
 import com.wire.kalium.persistence.kmmSettings.UserPrefBuilder
 import com.wire.kalium.util.KaliumDispatcherImpl
-import java.io.File
 
 internal actual class PlatformUserStorageProvider : UserStorageProvider() {
-    override fun create(userId: UserId, shouldEncryptData: Boolean, platformProperties: PlatformUserStorageProperties): UserStorage {
+    override fun create(
+        userId: UserId,
+        shouldEncryptData: Boolean,
+        platformProperties: PlatformUserStorageProperties
+    ): UserStorage {
         val userIdEntity = userId.toDao()
         val pref = UserPrefBuilder(userIdEntity, platformProperties.rootPath, shouldEncryptData)
-        val database = userDatabaseBuilder(
-            platformDatabaseData = PlatformDatabaseData(File(platformProperties.rootStoragePath)),
-            userId = userIdEntity,
-            passphrase = null,
-            dispatcher = KaliumDispatcherImpl.io,
-            enableWAL = false
-        )
+
+        val databaseInfo = platformProperties.databaseInfo
+        val database = when (databaseInfo) {
+            is DatabaseStorageType.FiledBacked -> {
+                userDatabaseBuilder(
+                    platformDatabaseData = PlatformDatabaseData(databaseInfo.filePath),
+                    userId = userIdEntity,
+                    passphrase = null,
+                    dispatcher = KaliumDispatcherImpl.io,
+                    enableWAL = false
+                )
+            }
+
+            else -> {
+                inMemoryDatabase(userIdEntity, KaliumDispatcherImpl.io)
+            }
+        }
         return UserStorage(database, pref)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Infinite Monkeys and other short-lived applications using Kalium can get sub-optimal performance when running multiple clients/accounts as Kalium relies on file-based persistence.

### Solutions

The user storage creation process is refactored to support both file-based and in-memory databases. This involves changes in the `PlatformUserStorageProvider`, `CoreLogic`, and `UserSessionScopeProviderImpl` classes. An optional flag is added to the `CoreLogic` constructor to indicate whether to use in-memory storage.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
