### PR TITLE
feat: configure supported min TLS versions (WPB-1810)

### DIFF
--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -16,6 +16,8 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
+@file:Suppress("MatchingDeclarationName")
+
 package com.wire.kalium.network
 
 import com.wire.kalium.network.api.base.model.ProxyCredentialsDTO
@@ -120,7 +122,7 @@ private fun OkHttpClient.Builder.ignoreAllSSLErrors() {
     hostnameVerifier { _, _ -> true }
 }
 
-internal fun supportedConnectionSpecs(): List<ConnectionSpec> {
+private fun supportedConnectionSpecs(): List<ConnectionSpec> {
     val wireSpec = ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
         .tlsVersions(TlsVersion.TLS_1_2)
         .build()

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -25,7 +25,6 @@ import com.wire.kalium.network.tools.isProxyRequired
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
 import okhttp3.CertificatePinner
-import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import okhttp3.TlsVersion
@@ -122,12 +121,9 @@ private fun OkHttpClient.Builder.ignoreAllSSLErrors() {
 }
 
 internal fun supportedConnectionSpecs(): List<ConnectionSpec> {
-    val spec = ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+    val wireSpec = ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
         .tlsVersions(TlsVersion.TLS_1_2)
-        .cipherSuites(
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-        ).build()
+        .build()
 
-    return listOf(spec, ConnectionSpec.CLEARTEXT)
+    return listOf(wireSpec, ConnectionSpec.CLEARTEXT)
 }

--- a/network/src/jvmTest/kotlin/com/wire/kalium/ClientConnectionSpecsTest.kt
+++ b/network/src/jvmTest/kotlin/com/wire/kalium/ClientConnectionSpecsTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium
+
+import com.wire.kalium.network.OkHttpSingleton
+import junit.framework.TestCase.assertTrue
+import okhttp3.CipherSuite
+import okhttp3.ConnectionSpec
+import okhttp3.TlsVersion
+import kotlin.test.Test
+import kotlin.test.assertContains
+
+class ClientConnectionSpecsTest {
+
+    @Test
+    fun givenTheHttpClientIsCreated_ThenEnsureSupportedSpecsArePresent() {
+        val connectionSpecs = OkHttpSingleton.createNew {}.connectionSpecs
+        with(connectionSpecs[0]) {
+            tlsVersions?.let {
+                assertContains(it, TlsVersion.TLS_1_2)
+                assertContains(it, TlsVersion.TLS_1_3)
+            }
+
+            cipherSuites?.let {
+                assertContains(it, CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+                assertContains(it, CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
+            }
+        }
+
+        assertTrue(connectionSpecs[1] == ConnectionSpec.CLEARTEXT)
+    }
+}

--- a/network/src/jvmTest/kotlin/com/wire/kalium/ClientConnectionSpecsTest.kt
+++ b/network/src/jvmTest/kotlin/com/wire/kalium/ClientConnectionSpecsTest.kt
@@ -18,12 +18,11 @@
 package com.wire.kalium
 
 import com.wire.kalium.network.OkHttpSingleton
+import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
-import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
 import okhttp3.TlsVersion
 import kotlin.test.Test
-import kotlin.test.assertContains
 
 class ClientConnectionSpecsTest {
 
@@ -32,13 +31,8 @@ class ClientConnectionSpecsTest {
         val connectionSpecs = OkHttpSingleton.createNew {}.connectionSpecs
         with(connectionSpecs[0]) {
             tlsVersions?.let {
-                assertContains(it, TlsVersion.TLS_1_2)
-                assertContains(it, TlsVersion.TLS_1_3)
-            }
-
-            cipherSuites?.let {
-                assertContains(it, CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
-                assertContains(it, CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
+                assertTrue(it.contains(TlsVersion.TLS_1_2) && it.contains(TlsVersion.TLS_1_3))
+                assertFalse(it.contains(TlsVersion.TLS_1_1) && it.contains(TlsVersion.TLS_1_0) && it.contains(TlsVersion.SSL_3_0))
             }
         }
 

--- a/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
+++ b/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
@@ -24,10 +24,10 @@ import okhttp3.ConnectionSpec
 import okhttp3.TlsVersion
 import kotlin.test.Test
 
-class ClientConnectionSpecsTest {
+class HttpClientConnectionSpecsTest {
 
     @Test
-    fun givenTheHttpClientIsCreated_ThenEnsureSupportedSpecsArePresent() {
+    fun givenTheHttpClientIsCreated_ThenEnsureOnlySupportedSpecsArePresent() {
         val connectionSpecs = OkHttpSingleton.createNew {}.connectionSpecs
         with(connectionSpecs[0]) {
             tlsVersions?.let {

--- a/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
+++ b/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
@@ -18,11 +18,11 @@
 package com.wire.kalium
 
 import com.wire.kalium.network.OkHttpSingleton
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
 import okhttp3.ConnectionSpec
 import okhttp3.TlsVersion
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class HttpClientConnectionSpecsTest {
 
@@ -32,10 +32,10 @@ class HttpClientConnectionSpecsTest {
         with(connectionSpecs[0]) {
             tlsVersions?.let {
                 assertTrue(it.contains(TlsVersion.TLS_1_2) && it.contains(TlsVersion.TLS_1_3))
-                assertFalse(it.contains(TlsVersion.TLS_1_1) && it.contains(TlsVersion.TLS_1_0) && it.contains(TlsVersion.SSL_3_0))
+                assertTrue(!it.contains(TlsVersion.TLS_1_1) && !it.contains(TlsVersion.TLS_1_0) && !it.contains(TlsVersion.SSL_3_0))
             }
         }
 
-        assertTrue(connectionSpecs[1] == ConnectionSpec.CLEARTEXT)
+        assertEquals(connectionSpecs[1], ConnectionSpec.CLEARTEXT)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to support a minimum stable version of TLS for the `HttpClient` and being able to test it.

### Causes (Optional)

Only default behavior configured as of now.

### Solutions

Configure at the `HttpClient` level the supported versions of TLS that the android client can use.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
