### PR TITLE
fix: persisting team members connection state (dev) [WPB-5338]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -195,7 +195,7 @@ internal class ConnectionDataSource(
     private suspend fun persistConnection(connection: Connection) =
         wrapStorageRequest {
             val connectionStatus = connectionStatusMapper.toDaoModel(state = connection.status)
-            userDAO.upsertConnectionStatus(connection.qualifiedToId.toDao(), connectionStatus)
+            userDAO.upsertConnectionStatuses(mapOf(connection.qualifiedToId.toDao() to connectionStatus))
 
             insertConversationFromConnection(connection)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -142,6 +142,7 @@ internal class TeamDataSource(
                             userTypeEntity = userTypeEntityTypeMapper.teamRoleCodeToUserType(member.permissions?.own)
                         )
                         userDAO.upsertUser(userEntity)
+                        userDAO.upsertConnectionStatuses(mapOf(userEntity.id to userEntity.connectionStatus))
                     }
                 }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -276,7 +276,6 @@ internal class UserDataSource internal constructor(
             userDAO.upsertConnectionStatuses(it.associate { it.id to it.connectionStatus })
         }
 
-
         userDAO.upsertUsers(
             otherUsers.map { userProfileDTO ->
                 userMapper.fromUserProfileDtoToUserEntity(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -268,7 +268,7 @@ internal class UserDataSource internal constructor(
             .map { userProfileDTO ->
                 userMapper.fromUserProfileDtoToUserEntity(
                     userProfile = userProfileDTO,
-                    connectionState = ConnectionEntity.State.ACCEPTED,  // this won't be updated, just to avoid a null value
+                    connectionState = ConnectionEntity.State.ACCEPTED, // this won't be updated, just to avoid a null value
                     userTypeEntity = userDAO.observeUserDetailsByQualifiedID(userProfileDTO.id.toDao())
                         .firstOrNull()?.userType ?: UserTypeEntity.STANDARD
                 )

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -53,6 +53,7 @@ bot_service = excluded.bot_service,
 deleted = excluded.deleted,
 incomplete_metadata = excluded.incomplete_metadata,
 expires_at = excluded.expires_at,
+defederated = 0,
 supported_protocols = excluded.supported_protocols;
 
 insertOrIgnoreUser:

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -53,7 +53,6 @@ bot_service = excluded.bot_service,
 deleted = excluded.deleted,
 incomplete_metadata = excluded.incomplete_metadata,
 expires_at = excluded.expires_at,
-defederated = 0,
 supported_protocols = excluded.supported_protocols;
 
 insertOrIgnoreUser:

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -218,8 +218,9 @@ interface UserDAO {
     /**
      * This will update all columns (or insert a new record), except:
      * - [ConnectionEntity.State]
-     * - [UserEntity.userType]
+     * - [UserAvailabilityStatusEntity]
      * - [UserEntity.activeOneOnOneConversationId]
+     * - [UserEntity.defederated]
      *
      * An upsert operation is a one that tries to update a record and if fails (not rows affected by change) inserts instead.
      * In this case as the transaction can be executed many times, we need to take care for not deleting old data.
@@ -229,8 +230,9 @@ interface UserDAO {
     /**
      * This will update all columns (or insert a new record), except:
      * - [ConnectionEntity.State]
-     * - [UserEntity.userType]
+     * - [UserAvailabilityStatusEntity]
      * - [UserEntity.activeOneOnOneConversationId]
+     * - [UserEntity.defederated]
      *
      * An upsert operation is a one that tries to update a record and if fails (not rows affected by change) inserts instead.
      * In this case as the transaction can be executed many times, we need to take care for not deleting old data.
@@ -297,5 +299,5 @@ interface UserDAO {
      */
     suspend fun updateActiveOneOnOneConversation(userId: QualifiedIDEntity, conversationId: QualifiedIDEntity)
 
-    suspend fun upsertConnectionStatus(userId: QualifiedIDEntity, status: ConnectionEntity.State)
+    suspend fun upsertConnectionStatuses(userStatuses: Map<QualifiedIDEntity, ConnectionEntity.State>)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -231,7 +231,7 @@ class UserDAOImpl internal constructor(
         }
     }
 
-    override suspend fun upsertTeamMemberUserTypes(users: Map<QualifiedIDEntity, UserTypeEntity>) {
+    override suspend fun upsertTeamMemberUserTypes(users: Map<QualifiedIDEntity, UserTypeEntity>) = withContext(queriesContext) {
         userQueries.transaction {
             for (user: Map.Entry<QualifiedIDEntity, UserTypeEntity> in users) {
                 userQueries.upsertTeamMemberUserType(user.key, ConnectionEntity.State.ACCEPTED, user.value)
@@ -391,9 +391,13 @@ class UserDAOImpl internal constructor(
             userQueries.updateOneOnOnConversationId(conversationId, userId)
         }
 
-    override suspend fun upsertConnectionStatus(userId: QualifiedIDEntity, status: ConnectionEntity.State) {
+    override suspend fun upsertConnectionStatuses(userStatuses: Map<QualifiedIDEntity, ConnectionEntity.State>) {
         withContext(queriesContext) {
-            userQueries.upsertUserConnectionStatus(userId, status)
+            userQueries.transaction {
+                for (user: Map.Entry<QualifiedIDEntity, ConnectionEntity.State> in userStatuses) {
+                    userQueries.upsertUserConnectionStatus(user.key, user.value)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Copy of [fix: persisting team members connection state (RC) [WPB-5338] #2191](https://github.com/wireapp/kalium/pull/2191)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After fresh login, if user already has some conversations with other team members, when opening other conversation member profile, the app shows “connect” button so the user appears as not connected, but this user is from the same team.

### Solutions

Update also connection status for team members.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[WPB-5338]: https://wearezeta.atlassian.net/browse/WPB-5338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ