### PR TITLE
feat(mls): refill key package on MLS-welcome events

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1232,7 +1232,7 @@ class UserSessionScope internal constructor(
         )
     private val mlsWelcomeHandler: MLSWelcomeEventHandler
         get() = MLSWelcomeEventHandlerImpl(
-            mlsClientProvider, conversationRepository, oneOnOneResolver
+            mlsClientProvider, conversationRepository, oneOnOneResolver, client.refillKeyPackages
         )
     private val renamedConversationHandler: RenamedConversationEventHandler
         get() = RenamedConversationEventHandlerImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
@@ -51,6 +51,8 @@ class RefillKeyPackagesUseCaseImpl(
 ) : RefillKeyPackagesUseCase {
     override suspend operator fun invoke(): RefillKeyPackagesResult =
         currentClientIdProvider().flatMap { selfClientId ->
+            // TODO: Maybe use MLSKeyPackageCountUseCase instead of repository directly,
+            //       and fetch from local instead of remote
             keyPackageRepository.getAvailableKeyPackageCount(selfClientId)
                 .flatMap {
                     if (keyPackageLimitsProvider.needsRefill(it.count)) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, we're only checking if keypackages are running low every 24h. This could lead to keypackages getting exhausted before the next check.

### Solutions

Also check the count and upload new keypackages if needed on each mls-welcome event.

The result of the refilling action is logged.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
