### PR TITLE
chore: obfuscate user id in calling logs

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
@@ -36,6 +36,9 @@ class OnNetworkQualityChanged : NetworkQualityChangedHandler {
         arg: Pointer?
     ) {
         // Not yet implemented
-        callingLogger.i("[OnNetworkQualityChanged] - ConversationId: ${conversationId.obfuscateId()} | UserId: ${userId.obfuscateId()} | Quality: $quality")
+        callingLogger.i(
+            "[OnNetworkQualityChanged] - ConversationId: ${conversationId.obfuscateId()}" +
+                    " | UserId: ${userId.obfuscateId()} | Quality: $quality"
+        )
     }
 }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
@@ -38,7 +38,7 @@ class OnNetworkQualityChanged : NetworkQualityChangedHandler {
         // Not yet implemented
         callingLogger.i(
             "[OnNetworkQualityChanged] - ConversationId: ${conversationId.obfuscateId()}" +
-                    " | UserId: ${userId.obfuscateId()} | Quality: $quality"
+                    " | UserId: ${userId?.obfuscateId()} | Quality: $quality"
         )
     }
 }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
@@ -36,6 +36,6 @@ class OnNetworkQualityChanged : NetworkQualityChangedHandler {
         arg: Pointer?
     ) {
         // Not yet implemented
-        callingLogger.i("[OnNetworkQualityChanged] - ConversationId: ${conversationId.obfuscateId()} | UserId: $userId | Quality: $quality")
+        callingLogger.i("[OnNetworkQualityChanged] - ConversationId: ${conversationId.obfuscateId()} | UserId: ${userId.obfuscateId()} | Quality: $quality")
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In NetworkQuality callback userId is logged without being obfuscated

### Causes (Optional)
We missed that

### Solutions

Obfuscate it!

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
