### PR TITLE
fix: handle federation not enabled [WPB-5237]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isFederationDenied
+import com.wire.kalium.network.exceptions.isFederationNotEnabled
 import com.wire.kalium.network.utils.NetworkResponse
 import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.flow.Flow
@@ -154,6 +155,7 @@ sealed class NetworkFailure : CoreFailure {
 
         data class General(val label: String) : FederatedBackendFailure()
         data class FederationDenied(val label: String) : FederatedBackendFailure()
+        data class FederationNotEnabled(val label: String) : FederatedBackendFailure()
 
         data class ConflictingBackends(override val domains: List<String>) : FederatedBackendFailure(), RetryableFailure
 
@@ -221,6 +223,8 @@ internal inline fun <T : Any> wrapApiRequest(networkCall: () -> NetworkResponse<
                 exception is KaliumException.FederationError -> {
                     if (exception.isFederationDenied()) {
                         Either.Left(NetworkFailure.FederatedBackendFailure.FederationDenied(exception.errorResponse.label))
+                    } else if (exception.isFederationNotEnabled()) {
+                        Either.Left(NetworkFailure.FederatedBackendFailure.FederationNotEnabled(exception.errorResponse.label))
                     } else {
                         Either.Left(NetworkFailure.FederatedBackendFailure.General(exception.errorResponse.label))
                     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -18,11 +18,8 @@
 
 package com.wire.kalium.logic.data.user
 
-<<<<<<< HEAD
 import co.touchlab.stately.collections.ConcurrentMutableMap
-=======
 import com.wire.kalium.logger.obfuscateDomain
->>>>>>> 9b8b0e6937 (fix: handle federation not enabled [WPB-5237] (#2189))
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -18,8 +18,13 @@
 
 package com.wire.kalium.logic.data.user
 
+<<<<<<< HEAD
 import co.touchlab.stately.collections.ConcurrentMutableMap
+=======
+import com.wire.kalium.logger.obfuscateDomain
+>>>>>>> 9b8b0e6937 (fix: handle federation not enabled [WPB-5237] (#2189))
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.MemberMapper
 import com.wire.kalium.logic.data.conversation.Recipient
@@ -42,6 +47,7 @@ import com.wire.kalium.logic.failure.SelfUserDeleted
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.getOrNull
@@ -241,6 +247,24 @@ internal class UserDataSource internal constructor(
                             usersFound = (acc.usersFound + it.usersFound).distinct(),
                             usersFailed = (acc.usersFailed + it.usersFailed).distinct(),
                         )
+                    }
+                }
+                .flatMapLeft { error ->
+                    if (error is NetworkFailure.FederatedBackendFailure.FederationNotEnabled) {
+                        val domains = qualifiedUserIdList
+                            .filterNot { it.domain == selfUserId.domain }
+                            .map { it.domain.obfuscateDomain() }
+                            .toSet()
+                        val domainNames = domains.joinToString(separator = ", ")
+                        kaliumLogger.e("User ids contains different domains when federation is not enabled by backend: $domainNames")
+                        wrapApiRequest {
+                            userDetailsApi.getMultipleUsers(
+                                ListUserRequest.qualifiedIds(qualifiedUserIdList.filter { it.domain == selfUserId.domain }
+                                    .map { userId -> userId.toApi() })
+                            )
+                        }
+                    } else {
+                        Either.Left(error)
                     }
                 }
                 .flatMap { listUserProfileDTO ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -36,12 +36,9 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.framework.TestUser.LIST_USERS_DTO
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.getOrNull
-<<<<<<< HEAD
 import com.wire.kalium.logic.test_util.TestNetworkResponseError
-=======
 import com.wire.kalium.logic.sync.receiver.UserEventReceiverTest
 import com.wire.kalium.logic.test_util.TestNetworkException.federationNotEnabled
->>>>>>> 9b8b0e6937 (fix: handle federation not enabled [WPB-5237] (#2189))
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
@@ -130,6 +130,10 @@ object TestNetworkException {
     val guestLinkDisables = KaliumException.InvalidRequestError(
         ErrorResponse(409, "Guest links are disabled", "guest-links-disabled")
     )
+
+    val federationNotEnabled = KaliumException.FederationError(
+        ErrorResponse(400, "no federator configured", "federation-not-enabled")
+    )
 }
 
 object TestNetworkResponseError {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/ErrorResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/ErrorResponse.kt
@@ -28,7 +28,7 @@ data class ErrorResponse(
     @SerialName("label") val label: String,
     @SerialName("data") val cause: Cause? = null,
 ) {
-    fun isFederationError() = cause?.type == "federation"
+    fun isFederationError() = cause?.type == "federation" || label.contains("federation")
 }
 
 @Serializable

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.network.exceptions.NetworkErrorLabel.BLACKLISTED_EMAIL
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.DOMAIN_BLOCKED_FOR_REGISTRATION
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.FEDERATION_DENIED
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.FEDERATION_FAILURE
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.FEDERATION_NOT_ENABLED
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.GUEST_LINKS_DISABLED
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.HANDLE_EXISTS
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_CODE
@@ -224,3 +225,4 @@ val KaliumException.InvalidRequestError.authenticationCodeFailure: Authenticatio
     }
 
 fun KaliumException.FederationError.isFederationDenied() = errorResponse.label == FEDERATION_DENIED
+fun KaliumException.FederationError.isFederationNotEnabled() = errorResponse.label == FEDERATION_NOT_ENABLED

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -42,15 +42,18 @@ internal object NetworkErrorLabel {
     const val MLS_KEY_PACKAGE_REF_NOT_FOUND = "mls-key-package-ref-not-found"
     const val MLS_MISSING_GROUP_INFO = "mls-missing-group-info"
     const val UNKNOWN_CLIENT = "unknown-client"
-    const val FEDERATION_FAILURE = "federation-remote-error"
     const val NOT_TEAM_MEMBER = "no-team-member"
     const val NO_CONVERSATION = "no-conversation"
     const val NO_CONVERSATION_CODE = "no-conversation-code"
     const val GUEST_LINKS_DISABLED = "guest-links-disabled"
     const val ACCESS_DENIED = "access-denied"
     const val WRONG_CONVERSATION_PASSWORD = "invalid-conversation-password"
-    const val FEDERATION_UNREACHABLE_DOMAINS = "federation-unreachable-domains-error"
+
+    // Federation
+    const val FEDERATION_FAILURE = "federation-remote-error"
     const val FEDERATION_DENIED = "federation-denied"
+    const val FEDERATION_NOT_ENABLED = "federation-not-enabled"
+    const val FEDERATION_UNREACHABLE_DOMAINS = "federation-unreachable-domains-error"
 
     object KaliumCustom {
         const val MISSING_REFRESH_TOKEN = "missing-refresh_token"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Cherry-pick from https://github.com/wireapp/kalium/pull/2189

### Issues
One of client servers returns 
```
ErrorResponse(code=400, message=no federator configured, label=federation-not-enabled, cause=null)
```
probably when user tries to fetch other user data with different domain

### Causes (Optional)
Because fetching users is during slow sync, when it returns error the entire slow sync is aborted and user is stuck on connecting


### Solutions
Handle this error and try to fetch again only those users which have the same domain as self user