### PR TITLE
fix(dev): persist proper team members user types [WPB-5343]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
@@ -26,11 +26,13 @@ import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserDataSource
 import com.wire.kalium.logic.data.user.UserMapper
+import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
+import com.wire.kalium.network.api.base.authenticated.TeamsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUserRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
@@ -40,7 +42,6 @@ import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.UserDetailsEntity
-import com.wire.kalium.persistence.dao.UserTypeEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
@@ -92,8 +93,10 @@ internal class SearchUserRepositoryImpl(
     private val userDAO: UserDAO,
     private val metadataDAO: MetadataDAO,
     private val userDetailsApi: UserDetailsApi,
+    private val teamsApi: TeamsApi,
     private val userSearchAPiWrapper: UserSearchApiWrapper,
     private val userMapper: UserMapper = MapperProvider.userMapper(),
+    private val userEntityTypeMapper: UserEntityTypeMapper = MapperProvider.userTypeEntityMapper(),
 ) : SearchUserRepository {
 
     override suspend fun searchKnownUsersByNameOrHandleOrEmail(
@@ -149,35 +152,50 @@ internal class SearchUserRepositoryImpl(
             searchUsersOptions
         ).flatMap {
             val qualifiedIdList = it.documents.map { it.qualifiedID }
-            val response =
+            val usersResponse =
                 if (qualifiedIdList.isEmpty()) Either.Right(listOf())
                 else wrapApiRequest {
                     userDetailsApi.getMultipleUsers(ListUserRequest.qualifiedIds(qualifiedIdList))
                 }.map { listUsersDTO -> listUsersDTO.usersFound }
-            response.map { userProfileDTOList ->
-                val otherUserList = if (userProfileDTOList.isEmpty()) emptyList() else {
-                    val selfUser = getSelfUser()
-                    val (teamMembers, otherUsers) = userProfileDTOList
-                        .partition { it.isTeamMember(selfUser.teamId?.value, selfUser.id.domain) }
 
+            usersResponse.flatMap { userProfileDTOList ->
+                if (userProfileDTOList.isEmpty())
+                    return Either.Right(UserSearchResult(emptyList()))
+
+                val selfUser = getSelfUser()
+                val (teamMembers, otherUsers) = userProfileDTOList
+                    .partition { it.isTeamMember(selfUser.teamId?.value, selfUser.id.domain) }
+
+                val teamMembersResponse =
+                    if (selfUser.teamId == null || teamMembers.isEmpty()) Either.Right(emptyMap())
+                    else wrapApiRequest {
+                        teamsApi.getTeamMembersByIds(selfUser.teamId.value, TeamsApi.TeamMemberIdList(teamMembers.map { it.id.value }))
+                    }.map { teamMemberList -> teamMemberList.members.associateBy { it.nonQualifiedUserId } }
+
+                teamMembersResponse.map { teamMemberMap ->
                     // We need to store all found team members locally and not return them as they will be "known" users from now on.
                     teamMembers.map { userProfileDTO ->
                         userMapper.fromUserProfileDtoToUserEntity(
                             userProfile = userProfileDTO,
                             connectionState = ConnectionEntity.State.ACCEPTED,
-                            userTypeEntity = userDAO.observeUserDetailsByQualifiedID(userProfileDTO.id.toDao())
-                                .firstOrNull()?.userType ?: UserTypeEntity.STANDARD
+                            userTypeEntity = userEntityTypeMapper.teamRoleCodeToUserType(
+                                permissionCode = teamMemberMap[userProfileDTO.id.value]?.permissions?.own,
+                                isService = userProfileDTO.service != null
+                            )
                         )
                     }.let {
-                        userDAO.upsertUsers(it)
-                        userDAO.upsertConnectionStatuses(it.associate { it.id to it.connectionStatus })
+                        if (it.isNotEmpty()) {
+                            userDAO.upsertUsers(it)
+                            userDAO.upsertConnectionStatuses(it.associate { it.id to it.connectionStatus })
+                        }
                     }
 
-                    otherUsers.map { userProfileDTO ->
-                        userMapper.fromUserProfileDtoToOtherUser(userProfileDTO, selfUser)
-                    }
+                    UserSearchResult(
+                        otherUsers.map { userProfileDTO ->
+                            userMapper.fromUserProfileDtoToOtherUser(userProfileDTO, selfUser)
+                        }
+                    )
                 }
-                UserSearchResult(otherUserList)
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -67,7 +67,6 @@ import com.wire.kalium.persistence.dao.UserTypeEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
@@ -291,7 +290,7 @@ internal class UserDataSource internal constructor(
         val mapTeamMemberDTO = listTeamMemberDTO.associateBy { it.nonQualifiedUserId }
         val selfUserTeamId = selfTeamIdProvider().getOrNull()?.value
         val teamMembers = listUserProfileDTO
-            .filter { userProfileDTO ->  mapTeamMemberDTO.containsKey(userProfileDTO.id.value) }
+            .filter { userProfileDTO -> mapTeamMemberDTO.containsKey(userProfileDTO.id.value) }
             .map { userProfileDTO ->
                 userMapper.fromUserProfileDtoToUserEntity(
                     userProfile = userProfileDTO,
@@ -357,7 +356,7 @@ internal class UserDataSource internal constructor(
         }
     }
 
-    @OptIn(FlowPreview::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun observeSelfUserWithTeam(): Flow<Pair<SelfUser, Team?>> {
         return metadataDAO.valueByKeyFlow(SELF_USER_ID_KEY).filterNotNull().flatMapMerge { encodedValue ->
             val selfUserID: QualifiedIDEntity = Json.decodeFromString(encodedValue)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/type/UserTypeMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/type/UserTypeMapper.kt
@@ -129,13 +129,14 @@ interface UserTypeMapper<T> {
 
     private fun selfUserIsTeamMember(selfUserTeamId: String?) = selfUserTeamId != null
 
-    fun teamRoleCodeToUserType(permissionCode: Int?): T = when (permissionCode) {
-        TeamRole.ExternalPartner.value -> external
-        TeamRole.Member.value -> standard
-        TeamRole.Admin.value -> admin
-        TeamRole.Owner.value -> owner
-        null -> standard
-        else -> guest
-    }
-
+    fun teamRoleCodeToUserType(permissionCode: Int?, isService: Boolean = false): T =
+        if (isService) service
+        else when (permissionCode) {
+            TeamRole.ExternalPartner.value -> external
+            TeamRole.Member.value -> standard
+            TeamRole.Admin.value -> admin
+            TeamRole.Owner.value -> owner
+            null -> standard
+            else -> guest
+        }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -675,6 +675,7 @@ class UserSessionScope internal constructor(
         userStorage.database.clientDAO,
         authenticatedNetworkContainer.selfApi,
         authenticatedNetworkContainer.userDetailsApi,
+        authenticatedNetworkContainer.teamsApi,
         globalScope.sessionRepository,
         userId,
         selfTeamId
@@ -728,6 +729,7 @@ class UserSessionScope internal constructor(
             userStorage.database.userDAO,
             userStorage.database.metadataDAO,
             authenticatedNetworkContainer.userDetailsApi,
+            authenticatedNetworkContainer.teamsApi,
             userSearchApiWrapper
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/DomainUserTypeMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/DomainUserTypeMapperTest.kt
@@ -76,6 +76,14 @@ class DomainUserTypeMapperTest {
     }
 
     @Test
+    fun givenServiceTeamMember_whenMappingToConversationDetails_ThenConversationDetailsUserTypeIsService() {
+        // when
+        val result = userTypeMapper.teamRoleCodeToUserType(TeamRole.Member.value, true)
+        // then
+        assertEquals(UserType.SERVICE, result)
+    }
+
+    @Test
     fun givenCommonNotWireDomainAndDifferentTeam_whenMappingToConversationDetails_ThenConversationDetailsUserTypeIsFederated() {
         // given
         val result = userTypeMapper.fromTeamAndDomain(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserEntityTypeMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserEntityTypeMapperTest.kt
@@ -76,6 +76,14 @@ class UserEntityTypeMapperTest {
     }
 
     @Test
+    fun givenServiceTeamMember_whenMappingToConversationDetails_ThenConversationDetailsUserTypeIsService() {
+        // when
+        val result = userTypeMapper.teamRoleCodeToUserType(TeamRole.Member.value, true)
+        // then
+        assertEquals(UserTypeEntity.SERVICE, result)
+    }
+
+    @Test
     fun givenCommonNotTheSameDomainAndDifferentTeam_whenMappingToConversationDetails_ThenConversationDetailsUserTypeIsFederated() {
         // given
         val result = userTypeMapper.fromTeamAndDomain(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
@@ -53,6 +53,11 @@ interface TeamsApi {
         @SerialName("self") val own: Int
     )
 
+    @Serializable
+    data class TeamMemberIdList(
+        @SerialName("user_ids") val userIds: List<NonQualifiedUserId>
+    )
+
     sealed interface GetTeamsOptionsInterface
 
     /**
@@ -80,6 +85,7 @@ interface TeamsApi {
     suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): NetworkResponse<Unit>
 
     suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?): NetworkResponse<TeamMemberList>
+    suspend fun getTeamMembersByIds(teamId: TeamId, teamMemberIdList: TeamMemberIdList): NetworkResponse<TeamMemberList>
     suspend fun getTeamMember(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<TeamMemberDTO>
     suspend fun getTeamInfo(teamId: TeamId): NetworkResponse<TeamDTO>
     suspend fun whiteListedServices(teamId: TeamId, size: Int = DEFAULT_SERVICES_SIZE): NetworkResponse<ServiceDetailResponse>

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
@@ -30,6 +30,8 @@ import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 
 internal open class TeamsApiV0 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient
@@ -60,6 +62,15 @@ internal open class TeamsApiV0 internal constructor(
             }
         }
 
+    override suspend fun getTeamMembersByIds(
+        teamId: TeamId,
+        teamMemberIdList: TeamsApi.TeamMemberIdList
+    ): NetworkResponse<TeamsApi.TeamMemberList> = wrapKaliumResponse {
+        httpClient.post("$PATH_TEAMS/$teamId/$PATH_MEMBERS_BY_IDS") {
+            setBody(teamMemberIdList)
+        }
+    }
+
     override suspend fun getTeamMember(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<TeamsApi.TeamMemberDTO> =
         wrapKaliumResponse {
             httpClient.get("$PATH_TEAMS/$teamId/$PATH_MEMBERS/$userId")
@@ -69,6 +80,7 @@ internal open class TeamsApiV0 internal constructor(
         const val PATH_TEAMS = "teams"
         const val PATH_CONVERSATIONS = "conversations"
         const val PATH_MEMBERS = "members"
+        const val PATH_MEMBERS_BY_IDS = "get-members-by-ids-using-post"
         const val PATH_SERVICES = "services"
         const val PATH_WHITELISTED = "whitelisted"
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -220,7 +220,7 @@ interface UserDAO {
      * - [ConnectionEntity.State]
      * - [UserAvailabilityStatusEntity]
      * - [UserEntity.activeOneOnOneConversationId]
-     * - [UserEntity.defederated]
+     * - [UserEntity.defederated] (this will be set to false)
      *
      * An upsert operation is a one that tries to update a record and if fails (not rows affected by change) inserts instead.
      * In this case as the transaction can be executed many times, we need to take care for not deleting old data.
@@ -232,7 +232,7 @@ interface UserDAO {
      * - [ConnectionEntity.State]
      * - [UserAvailabilityStatusEntity]
      * - [UserEntity.activeOneOnOneConversationId]
-     * - [UserEntity.defederated]
+     * - [UserEntity.defederated] (this will be set to false)
      *
      * An upsert operation is a one that tries to update a record and if fails (not rows affected by change) inserts instead.
      * In this case as the transaction can be executed many times, we need to take care for not deleting old data.


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The only place where the user type for team members was determined and stored was during the slow sync, but for large teams, members list is ignored, not fully fetched and not stored so we were losing this information. 

### Solutions

Fetch member permissions when searching and fetching users when slow syncing and opening profile so that we always store team members with proper user types.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
