### PR TITLE
fix: SessionManager missing session error

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -77,7 +77,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
                 endCallUseCase(it.conversationId)
             }
 
-            if(reason != LogoutReason.SESSION_EXPIRED) {
+            if (reason != LogoutReason.SESSION_EXPIRED) {
                 logoutRepository.logout()
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -77,7 +77,10 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
                 endCallUseCase(it.conversationId)
             }
 
-            logoutRepository.logout()
+            if(reason != LogoutReason.SESSION_EXPIRED) {
+                logoutRepository.logout()
+            }
+
             sessionRepository.logout(userId = userId, reason)
             logoutRepository.onLogout(reason)
             userSessionWorkScheduler.cancelScheduledSendingOfPendingMessages()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -82,9 +82,7 @@ class LogoutUseCaseTest {
             verify(arrangement.deregisterTokenUseCase)
                 .suspendFunction(arrangement.deregisterTokenUseCase::invoke)
                 .wasInvoked(exactly = once)
-            verify(arrangement.logoutRepository)
-                .suspendFunction(arrangement.logoutRepository::logout)
-                .wasInvoked(exactly = once)
+
             verify(arrangement.sessionRepository)
                 .suspendFunction(arrangement.sessionRepository::logout)
                 .with(any(), eq(reason))
@@ -211,6 +209,10 @@ class LogoutUseCaseTest {
         logoutUseCase.invoke(reason)
         arrangement.globalTestScope.advanceUntilIdle()
 
+        verify(arrangement.logoutRepository)
+            .suspendFunction(arrangement.logoutRepository::logout)
+            .wasNotInvoked()
+
         verify(arrangement.clearClientDataUseCase)
             .suspendFunction(arrangement.clearClientDataUseCase::invoke)
             .wasInvoked(exactly = once)
@@ -238,9 +240,14 @@ class LogoutUseCaseTest {
             logoutUseCase.invoke(reason)
             arrangement.globalTestScope.advanceUntilIdle()
 
+            verify(arrangement.logoutRepository)
+                .suspendFunction(arrangement.logoutRepository::logout)
+                .wasInvoked(exactly = once)
+
             verify(arrangement.clearClientDataUseCase)
                 .suspendFunction(arrangement.clearClientDataUseCase::invoke)
                 .wasInvoked(exactly = once)
+
             verify(arrangement.clearUserDataUseCase)
                 .suspendFunction(arrangement.clearUserDataUseCase::invoke)
                 .wasNotInvoked()
@@ -270,6 +277,10 @@ class LogoutUseCaseTest {
 
         logoutUseCase.invoke(reason)
         arrangement.globalTestScope.advanceUntilIdle()
+
+        verify(arrangement.logoutRepository)
+            .suspendFunction(arrangement.logoutRepository::logout)
+            .wasInvoked(exactly = once)
 
         verify(arrangement.clearClientDataUseCase)
             .suspendFunction(arrangement.clearClientDataUseCase::invoke)
@@ -306,6 +317,10 @@ class LogoutUseCaseTest {
 
         logoutUseCase.invoke(reason)
         arrangement.globalTestScope.advanceUntilIdle()
+
+        verify(arrangement.logoutRepository)
+            .suspendFunction(arrangement.logoutRepository::logout)
+            .wasInvoked(exactly = once)
 
         verify(arrangement.observeEstablishedCallsUseCase)
             .suspendFunction(arrangement.observeEstablishedCallsUseCase::invoke)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -48,7 +48,6 @@ import com.wire.kalium.network.api.v2.authenticated.networkContainer.Authenticat
 import com.wire.kalium.network.api.v3.authenticated.networkContainer.AuthenticatedNetworkContainerV3
 import com.wire.kalium.network.api.v4.authenticated.networkContainer.AuthenticatedNetworkContainerV4
 import com.wire.kalium.network.api.v5.authenticated.networkContainer.AuthenticatedNetworkContainerV5
-import com.wire.kalium.network.kaliumLogger
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.tools.ServerConfigDTO
@@ -202,8 +201,9 @@ internal class AuthenticatedHttpClientProviderImpl(
     }
 
     private val loadToken: suspend () -> BearerTokens? = {
-        val session = sessionManager.session() ?: error("missing user session")
-        BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
+        sessionManager.session()?.let {session ->
+            BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
+        }
     }
 
     private val refreshToken: suspend RefreshTokensParams.() -> BearerTokens = {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -201,7 +201,7 @@ internal class AuthenticatedHttpClientProviderImpl(
     }
 
     private val loadToken: suspend () -> BearerTokens? = {
-        sessionManager.session()?.let {session ->
+        sessionManager.session()?.let { session ->
             BearerTokens(accessToken = session.accessToken, refreshToken = session.refreshToken)
         }
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/CustomErrors.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/CustomErrors.kt
@@ -23,11 +23,15 @@ import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.NetworkErrorLabel
 
 object CustomErrors {
+
+    private const val MISSING_REFRESH_TOKEN_CODE = -1
+    private const val MISSING_NONCE_CODE = -2
+
     val MISSING_REFRESH_TOKEN =
         NetworkResponse.Error(
             KaliumException.ServerError(
                 ErrorResponse(
-                    -1,
+                    MISSING_REFRESH_TOKEN_CODE,
                     "no cookie was found",
                     NetworkErrorLabel.KaliumCustom.MISSING_REFRESH_TOKEN
                 )
@@ -38,10 +42,11 @@ object CustomErrors {
         NetworkResponse.Error(
             KaliumException.ServerError(
                 ErrorResponse(
-                    -2,
+                    MISSING_NONCE_CODE,
                     "no nonce found",
                     NetworkErrorLabel.KaliumCustom.MISSING_NONCE
                 )
             )
         )
+
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/CustomErrors.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/CustomErrors.kt
@@ -27,7 +27,7 @@ object CustomErrors {
         NetworkResponse.Error(
             KaliumException.ServerError(
                 ErrorResponse(
-                    500,
+                    -1,
                     "no cookie was found",
                     NetworkErrorLabel.KaliumCustom.MISSING_REFRESH_TOKEN
                 )
@@ -38,7 +38,7 @@ object CustomErrors {
         NetworkResponse.Error(
             KaliumException.ServerError(
                 ErrorResponse(
-                    500,
+                    -2,
                     "no nonce found",
                     NetworkErrorLabel.KaliumCustom.MISSING_NONCE
                 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

SessionManager session not found error 

### Causes (Optional)

1. shared preferences write into memory first for speed (this can be changed, but there is no need to).
2. if any app crash happens right after login, the session will not be written into disk
3. Kaboom session not found. 

### Solutions

handle missing session by logging out the user in case of session not found

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
