### PR TITLE
fix(applock): team app lock dialog displayed when changing timeout

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/AppLockConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/AppLockConfigHandler.kt
@@ -24,7 +24,6 @@ import com.wire.kalium.logic.data.featureConfig.AppLockModel
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.nullableFold
-import kotlin.time.Duration.Companion.seconds
 
 class AppLockConfigHandler(
     private val userConfigRepository: UserConfigRepository
@@ -37,8 +36,8 @@ class AppLockConfigHandler(
             },
             {
                 val newStatus = appLockConfig.status == Status.ENABLED
-                ((it.isEnabled != newStatus) ||
-                        (newStatus && it.timeout != appLockConfig.inactivityTimeoutSecs.seconds))
+                if (it.isEnabled != newStatus) true
+                else it.isStatusChanged
             }
         )
         return userConfigRepository.setAppLockStatus(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/AppLockConfigHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/AppLockConfigHandlerTest.kt
@@ -82,7 +82,7 @@ class AppLockConfigHandlerTest {
     }
 
     @Test
-    fun givenNewStatusSameAsCurrent_whenHandlingTheEvent_ThenSetAppLockWithStatusChangedFalse() {
+    fun givenNewStatusSameAsCurrent_whenHandlingTheEvent_ThenSetAppLockWithOldStatusChangedValue() {
         val appLockModel = AppLockModel(Status.ENABLED, 44)
         val (arrangement, appLockConfigHandler) = Arrangement()
             .withAppLocked()
@@ -99,30 +99,7 @@ class AppLockConfigHandlerTest {
             .with(
                 eq(appLockModel.status.toBoolean()),
                 eq(appLockModel.inactivityTimeoutSecs),
-                eq(false)
-            )
-            .wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenStatusEnabledAndTimeoutDifferentFromCurrent_whenHandlingTheEvent_ThenSetAppLockWithStatusChangedTrue() {
-        val appLockModel = AppLockModel(Status.ENABLED, 20)
-        val (arrangement, appLockConfigHandler) = Arrangement()
-            .withAppLocked()
-            .arrange()
-
-        appLockConfigHandler.handle(appLockModel)
-
-        verify(arrangement.userConfigRepository)
-            .function(arrangement.userConfigRepository::isTeamAppLockEnabled)
-            .wasInvoked(exactly = once)
-
-        verify(arrangement.userConfigRepository)
-            .function(arrangement.userConfigRepository::setAppLockStatus)
-            .with(
-                eq(appLockModel.status.toBoolean()),
-                eq(appLockModel.inactivityTimeoutSecs),
-                eq(true)
+                eq(appLockTeamConfigEnabled.isStatusChanged)
             )
             .wasInvoked(exactly = once)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On Client side, team app lock dialog is displayed when changing timeout from team console.

### Causes (Optional)

Wrong logic for setting `isStatusChanged` value

### Solutions

Use last saved value of `isStatusChanged`, if the status is the same as current

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
