### PR TITLE
fix: new 1on1 conversation not visible on list [WPB-5551]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1229,7 +1229,8 @@ class UserSessionScope internal constructor(
             conversationRepository,
             userRepository,
             selfTeamId,
-            conversations.newGroupConversationSystemMessagesCreator
+            conversations.newGroupConversationSystemMessagesCreator,
+            oneOnOneResolver,
         )
     private val deletedConversationHandler: DeletedConversationEventHandler
         get() = DeletedConversationEventHandlerImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -18,22 +18,28 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.getOrNull
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.util.DateTimeUtil
+import kotlinx.coroutines.flow.first
 
 interface NewConversationEventHandler {
     suspend fun handle(event: Event.Conversation.NewConversation)
@@ -44,17 +50,21 @@ internal class NewConversationEventHandlerImpl(
     private val userRepository: UserRepository,
     private val selfTeamIdProvider: SelfTeamIdProvider,
     private val newGroupConversationSystemMessagesCreator: NewGroupConversationSystemMessagesCreator,
+    private val oneOnOneResolver: OneOnOneResolver,
 ) : NewConversationEventHandler {
 
     override suspend fun handle(event: Event.Conversation.NewConversation) {
         conversationRepository
             .persistConversation(event.conversation, selfTeamIdProvider().getOrNull()?.value, true)
             .flatMap { isNewUnhandledConversation ->
-                conversationRepository.updateConversationModifiedDate(event.conversationId, DateTimeUtil.currentInstant())
-                Either.Right(isNewUnhandledConversation)
-            }.flatMap { isNewUnhandledConversation ->
-                userRepository.fetchUsersIfUnknownByIds(event.conversation.members.otherMembers.map { it.id.toModel() }.toSet())
-                Either.Right(isNewUnhandledConversation)
+                resolveConversationIfOneOnOne(event.conversationId)
+                    .flatMap {
+                        conversationRepository.updateConversationModifiedDate(event.conversationId, DateTimeUtil.currentInstant())
+                    }
+                    .flatMap {
+                        userRepository.fetchUsersIfUnknownByIds(event.conversation.members.otherMembers.map { it.id.toModel() }.toSet())
+                    }
+                    .map { isNewUnhandledConversation }
             }.onSuccess { isNewUnhandledConversation ->
                 createSystemMessagesForNewConversation(isNewUnhandledConversation, event)
                 kaliumLogger.logEventProcessing(EventLoggingStatus.SUCCESS, event)
@@ -62,6 +72,17 @@ internal class NewConversationEventHandlerImpl(
                 kaliumLogger.logEventProcessing(EventLoggingStatus.FAILURE, event, Pair("errorInfo", "$it"))
             }
     }
+
+    private suspend fun resolveConversationIfOneOnOne(conversationId: ConversationId): Either<CoreFailure, Unit> =
+        conversationRepository.observeConversationDetailsById(conversationId)
+            .first()
+            .flatMap {
+                if (it is ConversationDetails.OneOne) {
+                    oneOnOneResolver.resolveOneOnOneConversationWithUser(it.otherUser).map { Unit }
+                } else {
+                    Either.Right(Unit)
+                }
+            }
 
     /**
      * Creates system messages for new conversation.


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

New 1on1 conversations are not visible on conversation list until the user sends any message.

### Causes (Optional)

After some recent updates with implementing protocols migration, it's now necessary for the user's `active_one_on_one_conversation_id` field to match the 1on1 conversation id, otherwise it's not added to the list.
Resolving 1on1 conversations that executes protocol migration and results in filling in this field is executed when syncing conversations, creating a new one, accepting connection request or handling new connection, receiving MLS `conversation.mls-welcome` event, but has been missing for Proteus `conversation.create` event.
The conversation was appearing after the user sent a message because then it executes `GetOrCreateOneToOneConversation` which also resolves one on one conversation if can't be found (which also means when `active_one_on_one_conversation_id` is not set properly).

### Solutions

Execute `OneOnOneResolver` also when Proteus `conversation.create` event is received.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- user A and B have no conversation
- user A and B use Proteus protocol and at least one does not support MLS protocol (so that MLS can't be used for their 1on1 conversation)
- user B finds user A, opens 1on1 conversation with user A and sends a message
- user A can see this new 1on1 conversation on the conversation list  even before he/she writes anything in this conversation
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
