### PR TITLE
chore: configure and allow cipher suites - negative test checks (WPB-5448)

### DIFF
--- a/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
+++ b/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
@@ -35,12 +35,13 @@ class HttpClientConnectionSpecsTest {
         val connectionSpecs = OkHttpSingleton.createNew {}.connectionSpecs
         with(connectionSpecs[0]) {
             tlsVersions?.let {
-                assertTrue { validTlsVersions.containsAll(it) }
-                assertFalse { notValidTlsVersions.containsAll(it) }
+                assertTrue { it.containsAll(validTlsVersions) }
+                assertFalse { it.containsAll(notValidTlsVersions) }
             }
 
             cipherSuites?.let {
                 assertTrue { it.containsAll(validCipherSuites) }
+                assertFalse { it.containsAll(notValidCipherSuites) }
             }
         }
 
@@ -55,6 +56,16 @@ class HttpClientConnectionSpecsTest {
             CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
             CipherSuite.TLS_AES_128_GCM_SHA256,
             CipherSuite.TLS_AES_256_GCM_SHA384
+        )
+
+        val notValidCipherSuites = listOf(
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA
         )
     }
 }


### PR DESCRIPTION
----

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

https://wearezeta.atlassian.net/browse/WPB-5448
Follow up of #2193  and #2233

### Causes (Optional)

Add required negative check of ciphersuites

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
