### PR TITLE
fix: first Screenshot taken in the app is sometimes black

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/screenshotCensoring/ObserveScreenshotCensoringConfigUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/screenshotCensoring/ObserveScreenshotCensoringConfigUseCase.kt
@@ -39,10 +39,10 @@ internal class ObserveScreenshotCensoringConfigUseCaseImpl(
     override suspend fun invoke(): Flow<ObserveScreenshotCensoringConfigResult> {
         return combine(
             userConfigRepository.observeScreenshotCensoringConfig()
-                .mapToRightOr(true), // for safety it's set to true if we can't determine it
+                .mapToRightOr(false),
             userConfigRepository.observeTeamSettingsSelfDeletingStatus()
                 .mapRight { it.enforcedSelfDeletionTimer is TeamSelfDeleteTimer.Enforced }
-                .mapToRightOr(true), // for safety it's set to true if we can't determine it
+                .mapToRightOr(false)
         ) { screenshotCensoringEnabled, teamSelfDeletingEnforced ->
             when {
                 teamSelfDeletingEnforced -> ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/screeenshotCensoring/ObserveScreenshotCensoringConfigUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/screeenshotCensoring/ObserveScreenshotCensoringConfigUseCaseTest.kt
@@ -36,6 +36,7 @@ import io.mockative.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -56,7 +57,7 @@ class ObserveScreenshotCensoringConfigUseCaseTest {
 
         result.test {
             val item = awaitItem()
-            assertTrue { item == expectedResult }
+            assertEquals(expectedResult, item)
 
             verify(arrangement.userConfigRepository)
                 .function(arrangement.userConfigRepository::observeScreenshotCensoringConfig)
@@ -89,11 +90,11 @@ class ObserveScreenshotCensoringConfigUseCaseTest {
         )
 
     @Test
-    fun givenSSCensoringDisabledAndTeamSelfDeletingFailure_whenInvoking_thenShouldReturnEnabledEnforcedByTeamSelfDeletingSettings() =
+    fun givenSSCensoringDisabledAndTeamSelfDeletingFailure_whenInvoking_thenShouldReturnDisabled() =
         runTestWithParametersAndExpectedResult(
             observeScreenshotCensoringConfigResult = Either.Right(false),
             observeTeamSelfDeletingStatusResult = Either.Left(StorageFailure.DataNotFound),
-            expectedResult = ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings
+            expectedResult = ObserveScreenshotCensoringConfigResult.Disabled
         )
 
     @Test
@@ -113,19 +114,19 @@ class ObserveScreenshotCensoringConfigUseCaseTest {
         )
 
     @Test
-    fun givenSSCensoringEnabledAndTeamSelfDeletingFailure_whenInvoking_thenShouldReturnEnabledEnforcedByTeamSelfDeletingSettings() =
+    fun givenSSCensoringEnabledAndTeamSelfDeletingFailure_whenInvoking_thenShouldReturnEnabledChosenByUser() =
         runTestWithParametersAndExpectedResult(
             observeScreenshotCensoringConfigResult = Either.Right(true),
             observeTeamSelfDeletingStatusResult = Either.Left(StorageFailure.DataNotFound),
-            expectedResult = ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings
+            expectedResult = ObserveScreenshotCensoringConfigResult.Enabled.ChosenByUser
         )
 
     @Test
-    fun givenSSCensoringFailureAndTeamSelfDeletingNotEnforced_whenInvoking_thenShouldReturnEnabledChosenByUser() =
+    fun givenSSCensoringFailureAndTeamSelfDeletingNotEnforced_whenInvoking_thenShouldReturnDisabled() =
         runTestWithParametersAndExpectedResult(
             observeScreenshotCensoringConfigResult = Either.Left(StorageFailure.DataNotFound),
             observeTeamSelfDeletingStatusResult = Either.Right(TeamSelfDeleteTimer.Enabled),
-            expectedResult = ObserveScreenshotCensoringConfigResult.Enabled.ChosenByUser
+            expectedResult = ObserveScreenshotCensoringConfigResult.Disabled
         )
 
     @Test
@@ -137,11 +138,11 @@ class ObserveScreenshotCensoringConfigUseCaseTest {
         )
 
     @Test
-    fun givenSSCensoringFailureAndTeamSelfDeletingFailure_whenInvoking_thenShouldReturnEnabledEnforcedByTeamSelfDeletingSettings() =
+    fun givenSSCensoringFailureAndTeamSelfDeletingFailure_whenInvoking_thenShouldReturnDisabled() =
         runTestWithParametersAndExpectedResult(
             observeScreenshotCensoringConfigResult = Either.Left(StorageFailure.DataNotFound),
             observeTeamSelfDeletingStatusResult = Either.Left(StorageFailure.DataNotFound),
-            expectedResult = ObserveScreenshotCensoringConfigResult.Enabled.EnforcedByTeamSelfDeletingSettings
+            expectedResult = ObserveScreenshotCensoringConfigResult.Disabled
         )
 
     private class Arrangement {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

first Screenshot taken in the app is sometimes black

### Solutions

before the sync of feature config is complete, the default value for screen censoring is true so now we switch it to false and it is fixed

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
