### PR TITLE
fix: wrong conversation type when resolving 1on1 after receiving new conversation event [WPB-5551]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -196,6 +196,33 @@ class ConversationMapperTest {
         assertEquals(ConversationEntity.Type.GROUP, result.type)
     }
 
+    @Test
+    fun givenAFakeTeamOneOnOneConversationResponse_whenMappingFromConversationResponseToDaoType_thenShouldMapToOneOnOneType() {
+        val response = CONVERSATION_RESPONSE.copy(
+            // Looks like a Group
+            type = ConversationResponse.Type.GROUP,
+            // No Name
+            name = null,
+            // Only one other participant
+            members = CONVERSATION_RESPONSE.members.copy(otherMembers = listOf(OTHER_MEMBERS.first())),
+            // Same team as user
+            teamId = SELF_USER_TEAM_ID.value
+        )
+        val result = response.toConversationType(SELF_USER_TEAM_ID)
+        assertEquals(ConversationEntity.Type.ONE_ON_ONE, result)
+    }
+
+    @Test
+    fun givenAGroupConversationResponseWithoutName_whenMappingFromConversationResponseToDaoType_thenShouldMapToGroupType() {
+        val response = CONVERSATION_RESPONSE.copy(
+            type = ConversationResponse.Type.GROUP,
+            name = null,
+            teamId = null
+        )
+        val result = response.toConversationType(SELF_USER_TEAM_ID)
+        assertEquals(ConversationEntity.Type.GROUP, result)
+    }
+
     private companion object {
         val ORIGINAL_CONVERSATION_ID = ConversationId("original", "oDomain")
         val SELF_USER_TEAM_ID = TeamId("teamID")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationResponse.kt
@@ -54,6 +54,13 @@ data class ConversationResponse(
     @SerialName("epoch")
     val epoch: ULong?,
 
+    @Deprecated(
+        "For team 1on1 it can be a false group type",
+        ReplaceWith(
+            "this.toConversationType(selfUserTeamId)",
+            "com.wire.kalium.logic.data.conversation.toConversationType",
+        )
+    )
     @Serializable(with = ConversationTypeSerializer::class)
     val type: Type,
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

New team 1on1 conversations are still not visible on conversation list.

### Causes (Optional)

When handling new conversation event, if a conversation is a team 1on1, the app can receive a false `GROUP` type for such conversation instead of `ONE_TO_ONE`. We handle that case when persisting conversation already but shouldn't use `type` field directly anywhere because of that.

### Solutions

Use mapping function from `ConversationMapper` to get the proper type when handling new conversation event.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

user A and B have no conversation
user A and B use Proteus protocol and at least one does not support MLS protocol (so that MLS can't be used for their 1on1 conversation)
**user A and B are in the same team** (this assertion was missing in the previous fix)
user B finds user A, opens 1on1 conversation with user A and sends a message
user A can see this new 1on1 conversation on the conversation list even before he/she writes anything in this conversation

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
