### PR TITLE
fix: enable editable app lock toggle (WPB-5610)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/IsAppLockEditableUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/IsAppLockEditableUseCase.kt
@@ -37,7 +37,7 @@ class IsAppLockEditableUseCase internal constructor(
                 accounts.map { session ->
                     userSessionScopeProvider.getOrCreate(session.userId).let { userSessionScope ->
                         userSessionScope.userConfigRepository.isTeamAppLockEnabled().fold({
-                            true
+                            false
                         }, { appLockConfig ->
                             appLockConfig.isEnforced
                         })

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/IsAppLockEditableUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/IsAppLockEditableUseCaseTest.kt
@@ -1,4 +1,0 @@
-package com.wire.kalium.logic.feature.featureConfig
-
-class IsAppLockEditableUseCaseTest {
-}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/IsAppLockEditableUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/IsAppLockEditableUseCaseTest.kt
@@ -1,0 +1,4 @@
+package com.wire.kalium.logic.feature.featureConfig
+
+class IsAppLockEditableUseCaseTest {
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When private users started the app there was no value from `isTeamAppLockEnabled` and was always returning `DataNotFound` thus not enabling the user to toggle `AppLock` in settings

### Solutions

Invert the value provided from the `fold` in the usecase

### Testing

#### How to Test

Testing will be available in AR PR.