### PR TITLE
revert: mark user as deleted when server response with 404 (#2259)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -49,7 +49,6 @@ import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.mapRight
-import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -62,8 +61,6 @@ import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
 import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.api.base.model.isTeamMember
-import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.network.exceptions.isNotFound
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -229,20 +226,8 @@ internal class UserDataSource internal constructor(
         return fetchUsersByIds(ids)
     }
 
-    /**
-     * Fetches user information for all of users id stored in the DB
-     * and updates the DB with the new information.
-     * If the user is not found on the server, it will be marked as deleted.
-     */
     override suspend fun fetchUserInfo(userId: UserId) =
         wrapApiRequest { userDetailsApi.getUserInfo(userId.toApi()) }
-            .onFailure {
-                if (it is NetworkFailure.ServerMiscommunication &&
-                    it.kaliumException is KaliumException.InvalidRequestError &&
-                    it.kaliumException.isNotFound()) {
-                    wrapStorageRequest { userDAO.markUserAsDeleted(userId.toDao()) }
-                }
-            }
             .flatMap { userProfileDTO ->
                 fetchTeamMembersByIds(listOf(userProfileDTO))
                     .flatMap { persistUsers(listOf(userProfileDTO), it) }
@@ -332,8 +317,8 @@ internal class UserDataSource internal constructor(
                     userProfile = userProfileDTO,
                     connectionState = ConnectionEntity.State.ACCEPTED,
                     userTypeEntity =
-                    if (userProfileDTO.service != null) UserTypeEntity.SERVICE
-                    else userTypeEntityMapper.teamRoleCodeToUserType(mapTeamMemberDTO[userProfileDTO.id.value]?.permissions?.own)
+                        if (userProfileDTO.service != null) UserTypeEntity.SERVICE
+                        else userTypeEntityMapper.teamRoleCodeToUserType(mapTeamMemberDTO[userProfileDTO.id.value]?.permissions?.own)
                 )
             }
         val otherUsers = listUserProfileDTO

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -48,9 +48,7 @@ import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.QualifiedUserIdListRequest
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.authenticated.userDetails.qualifiedIds
-import com.wire.kalium.network.api.base.model.ErrorResponse
 import com.wire.kalium.network.api.base.model.UserProfileDTO
-import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.MetadataDAO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -694,33 +692,6 @@ class UserRepositoryTest {
             .wasNotInvoked()
     }
 
-    @Test
-    fun givenNotFoundError_whenFetchingAUserInfo_thenMarkAsDeleted() = runTest {
-        val (arrangement, userRepository) = Arrangement()
-            .withUserDaoReturning(TestUser.DETAILS_ENTITY.copy(team = TestTeam.TEAM_ID.value))
-            .withErrorGetUsersInfo(
-                NetworkResponse.Error(
-                    KaliumException.InvalidRequestError(
-                        ErrorResponse(404, "Not found", "not-found")
-                    )
-                )
-            )
-            .arrange()
-
-        val result = userRepository.fetchUserInfo(TestUser.USER_ID)
-        result.shouldFail()
-
-        verify(arrangement.userDetailsApi)
-            .suspendFunction(arrangement.userDetailsApi::getUserInfo)
-            .with(any())
-            .wasInvoked(exactly = once)
-
-        verify(arrangement.userDAO)
-            .suspendFunction(arrangement.userDAO::markUserAsDeleted)
-            .with(any())
-            .wasInvoked(exactly = once)
-    }
-
     private class Arrangement {
         @Mock
         val userDAO = configure(mock(classOf<UserDAO>())) { stubsUnitByDefault = true }
@@ -810,13 +781,6 @@ class UserRepositoryTest {
                 .suspendFunction(userDetailsApi::getUserInfo)
                 .whenInvokedWith(any())
                 .thenReturn(NetworkResponse.Success(result, mapOf(), 200))
-        }
-
-        fun withErrorGetUsersInfo(error: NetworkResponse.Error) = apply {
-            given(userDetailsApi)
-                .suspendFunction(userDetailsApi::getUserInfo)
-                .whenInvokedWith(any())
-                .thenReturn(error)
         }
 
         fun withSuccessfulFetchTeamMembersByIds(result: List<TeamsApi.TeamMemberDTO>) = apply {


### PR DESCRIPTION
…59)"

This reverts commit 66585d1b11d6c7e5d9993e1329d345a60d1e9c71.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
after discussing this feature with int the team it is not required, and the use case is updated 

### Solutions
revert the change

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
