### PR TITLE
fix: retain user info after deleting

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -37,24 +37,31 @@ deleteUser:
 DELETE FROM User WHERE qualified_id = ?;
 
 insertUser:
-INSERT INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service, deleted, incomplete_metadata, expires_at, supported_protocols, active_one_on_one_conversation_id)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO User(
+    qualified_id, name, handle, email, phone, accent_id, team, connection_status,
+    preview_asset_id, complete_asset_id, user_type, bot_service, deleted,
+    incomplete_metadata, expires_at, supported_protocols, active_one_on_one_conversation_id
+)
+VALUES(
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
 ON CONFLICT(qualified_id) DO UPDATE SET
-name = excluded.name,
-handle = excluded.handle,
-email = excluded.email,
-phone = excluded.phone,
-accent_id = excluded.accent_id,
-team = excluded.team,
-preview_asset_id = excluded.preview_asset_id,
-complete_asset_id = excluded.complete_asset_id,
-user_type = excluded.user_type,
-bot_service = excluded.bot_service,
-deleted = excluded.deleted,
-incomplete_metadata = excluded.incomplete_metadata,
-expires_at = excluded.expires_at,
-defederated = 0,
-supported_protocols = excluded.supported_protocols;
+    name = CASE WHEN excluded.deleted = 1 THEN name ELSE excluded.name END,
+    handle = CASE WHEN excluded.deleted = 1 THEN handle ELSE excluded.handle END,
+    email = CASE WHEN excluded.deleted = 1 THEN email ELSE excluded.email END,
+    phone = CASE WHEN excluded.deleted = 1 THEN phone ELSE excluded.phone END,
+    accent_id = CASE WHEN excluded.deleted = 1 THEN accent_id ELSE excluded.accent_id END,
+    team = CASE WHEN excluded.deleted = 1 THEN NULL ELSE excluded.team END,
+    preview_asset_id = CASE WHEN excluded.deleted = 1 THEN NULL ELSE excluded.preview_asset_id END,
+    complete_asset_id = CASE WHEN excluded.deleted = 1 THEN NULL ELSE excluded.complete_asset_id END,
+    user_type = excluded.user_type,
+    bot_service = CASE WHEN excluded.deleted = 1 THEN bot_service ELSE excluded.bot_service END,
+    deleted = excluded.deleted,
+    incomplete_metadata = CASE WHEN excluded.deleted = 1 THEN incomplete_metadata ELSE excluded.incomplete_metadata END,
+    expires_at = CASE WHEN excluded.deleted = 1 THEN expires_at ELSE excluded.expires_at END,
+    defederated = 0,
+    supported_protocols = CASE WHEN excluded.deleted = 1 THEN supported_protocols ELSE excluded.supported_protocols END,
+    active_one_on_one_conversation_id = CASE WHEN excluded.deleted = 1 THEN active_one_on_one_conversation_id ELSE excluded.active_one_on_one_conversation_id END;
 
 insertOrIgnoreUser:
 INSERT OR IGNORE INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service, deleted, incomplete_metadata, expires_at, supported_protocols)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a user id deleted from the team are displayed in the UI

### Solutions

only mark the user as deleted when and retain info

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
