### PR TITLE
feat: fetch legal hold status during the slow sync [WPB-5655]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/LegalHoldStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/LegalHoldStatusMapper.kt
@@ -18,18 +18,18 @@
 
 package com.wire.kalium.logic.data.conversation
 
-import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 
 interface LegalHoldStatusMapper {
-    fun fromApiModel(legalHoldStatusResponse: LegalHoldStatusResponse): LegalHoldStatus
+    fun fromApiModel(legalHoldStatusDTO: LegalHoldStatusDTO): LegalHoldStatus
 }
 
-class LegalHoldStatusMapperImp : LegalHoldStatusMapper {
-    override fun fromApiModel(legalHoldStatusResponse: LegalHoldStatusResponse): LegalHoldStatus =
-        when (legalHoldStatusResponse) {
-            LegalHoldStatusResponse.ENABLED -> LegalHoldStatus.ENABLED
-            LegalHoldStatusResponse.PENDING -> LegalHoldStatus.PENDING
-            LegalHoldStatusResponse.DISABLED -> LegalHoldStatus.DISABLED
-            LegalHoldStatusResponse.NO_CONSENT -> LegalHoldStatus.NO_CONSENT
+class LegalHoldStatusMapperImpl : LegalHoldStatusMapper {
+    override fun fromApiModel(legalHoldStatusDTO: LegalHoldStatusDTO): LegalHoldStatus =
+        when (legalHoldStatusDTO) {
+            LegalHoldStatusDTO.ENABLED -> LegalHoldStatus.ENABLED
+            LegalHoldStatusDTO.PENDING -> LegalHoldStatus.PENDING
+            LegalHoldStatusDTO.DISABLED -> LegalHoldStatus.DISABLED
+            LegalHoldStatusDTO.NO_CONSENT -> LegalHoldStatus.NO_CONSENT
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -362,7 +362,7 @@ class EventMapper(
         connectionMapper.fromApiToModel(eventConnectionDTO.connection)
     )
 
-    private fun legalHoldRequest(
+    internal fun legalHoldRequest(
         id: String,
         transient: Boolean,
         live: Boolean,
@@ -372,13 +372,13 @@ class EventMapper(
             transient = transient,
             live = live,
             id = id,
-            clientId = ClientId(eventContentDTO.id),
+            clientId = ClientId(eventContentDTO.clientId.clientId),
             lastPreKey = LastPreKey(eventContentDTO.lastPreKey.id, eventContentDTO.lastPreKey.key),
             userId = qualifiedIdMapper.fromStringToQualifiedID(eventContentDTO.id)
         )
     }
 
-    private fun legalHoldEnabled(
+    internal fun legalHoldEnabled(
         id: String,
         transient: Boolean,
         live: Boolean,
@@ -392,7 +392,7 @@ class EventMapper(
         )
     }
 
-    private fun legalHoldDisabled(
+    internal fun legalHoldDisabled(
         id: String,
         transient: Boolean,
         live: Boolean,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
@@ -32,6 +32,7 @@ sealed interface SlowSyncStatus {
 }
 
 enum class SlowSyncStep {
+    MIGRATION,
     SELF_USER,
     FEATURE_FLAGS,
     UPDATE_SUPPORTED_PROTOCOLS,
@@ -41,5 +42,5 @@ enum class SlowSyncStep {
     CONTACTS,
     JOINING_MLS_CONVERSATIONS,
     RESOLVE_ONE_ON_ONE_PROTOCOLS,
-    MIGRATION
+    LEGAL_HOLD,
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -19,6 +19,9 @@
 package com.wire.kalium.logic.data.team
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
+import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapper
+import com.wire.kalium.logic.data.event.EventMapper
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.service.ServiceMapper
@@ -29,16 +32,21 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
+import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldRequestHandler
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.ServiceDAO
 import com.wire.kalium.persistence.dao.TeamDAO
 import com.wire.kalium.persistence.dao.UserDAO
+import com.wire.kalium.persistence.dao.message.LocalId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -52,6 +60,7 @@ interface TeamRepository {
     suspend fun updateTeam(team: Team): Either<CoreFailure, Unit>
     suspend fun syncServices(teamId: TeamId): Either<CoreFailure, Unit>
     suspend fun approveLegalHold(teamId: TeamId, password: String?): Either<CoreFailure, Unit>
+    suspend fun fetchLegalHoldStatus(teamId: TeamId): Either<CoreFailure, LegalHoldStatus>
 }
 
 @Suppress("LongParameterList")
@@ -62,10 +71,14 @@ internal class TeamDataSource(
     private val userDetailsApi: UserDetailsApi,
     private val selfUserId: UserId,
     private val serviceDAO: ServiceDAO,
+    private val legalHoldHandler: LegalHoldHandler,
+    private val legalHoldRequestHandler: LegalHoldRequestHandler,
     private val userMapper: UserMapper = MapperProvider.userMapper(),
     private val teamMapper: TeamMapper = MapperProvider.teamMapper(),
     private val serviceMapper: ServiceMapper = MapperProvider.serviceMapper(),
-    private val userTypeEntityTypeMapper: UserEntityTypeMapper = MapperProvider.userTypeEntityMapper()
+    private val userTypeEntityTypeMapper: UserEntityTypeMapper = MapperProvider.userTypeEntityMapper(),
+    private val legalHoldStatusMapper: LegalHoldStatusMapper = MapperProvider.legalHoldStatusMapper(),
+    private val eventMapper: EventMapper = MapperProvider.eventMapper(selfUserId),
 ) : TeamRepository {
 
     override suspend fun fetchTeamById(teamId: TeamId): Either<CoreFailure, Team> = wrapApiRequest {
@@ -152,5 +165,42 @@ internal class TeamDataSource(
     override suspend fun approveLegalHold(teamId: TeamId, password: String?): Either<CoreFailure, Unit> = wrapApiRequest {
         teamsApi.approveLegalHold(teamId.value, selfUserId.value, password)
         // TODO: should we update the legal hold status for the current user in the database?
+    }
+
+    override suspend fun fetchLegalHoldStatus(teamId: TeamId): Either<CoreFailure, LegalHoldStatus> = wrapApiRequest {
+        teamsApi.fetchLegalHoldStatus(teamId.value, selfUserId.value)
+    }.flatMap { response ->
+        when (response.legalHoldStatusDTO) {
+            LegalHoldStatusDTO.ENABLED -> legalHoldHandler.handleEnable(
+                eventMapper.legalHoldEnabled(
+                    id = LocalId.generate(),
+                    transient = true,
+                    live = false,
+                    eventContentDTO = EventContentDTO.User.LegalHoldEnabledDTO(id = selfUserId.toString())
+                )
+            )
+            LegalHoldStatusDTO.DISABLED -> legalHoldHandler.handleDisable(
+                eventMapper.legalHoldDisabled(
+                    id = LocalId.generate(),
+                    transient = true,
+                    live = false,
+                    eventContentDTO = EventContentDTO.User.LegalHoldDisabledDTO(id = selfUserId.toString())
+                )
+            )
+            LegalHoldStatusDTO.PENDING ->
+                legalHoldRequestHandler.handle(
+                    eventMapper.legalHoldRequest(
+                        id = LocalId.generate(),
+                        transient = true,
+                        live = false,
+                        eventContentDTO = EventContentDTO.User.NewLegalHoldRequestDTO(
+                            clientId = response.clientId!!,
+                            lastPreKey = response.lastPreKey!!,
+                            id = selfUserId.toString()
+                        )
+                    )
+                )
+            LegalHoldStatusDTO.NO_CONSENT -> Either.Right(Unit)
+        }.map { legalHoldStatusMapper.fromApiModel(response.legalHoldStatusDTO) }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -39,6 +39,8 @@ import com.wire.kalium.logic.data.conversation.ConversationRoleMapper
 import com.wire.kalium.logic.data.conversation.ConversationRoleMapperImpl
 import com.wire.kalium.logic.data.conversation.ConversationStatusMapper
 import com.wire.kalium.logic.data.conversation.ConversationStatusMapperImpl
+import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapper
+import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.MLSCommitBundleMapper
 import com.wire.kalium.logic.data.conversation.MLSCommitBundleMapperImpl
 import com.wire.kalium.logic.data.conversation.MemberMapper
@@ -168,4 +170,5 @@ internal object MapperProvider {
     fun receiptModeMapper(): ReceiptModeMapper = ReceiptModeMapperImpl()
     fun sendMessagePartialFailureMapper(): SendMessagePartialFailureMapper = SendMessagePartialFailureMapperImpl()
     fun serviceMapper(): ServiceMapper = ServiceMapper()
+    fun legalHoldStatusMapper(): LegalHoldStatusMapper = LegalHoldStatusMapperImpl()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -217,6 +217,8 @@ import com.wire.kalium.logic.feature.featureConfig.handler.SecondFactorPasswordC
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManager
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManagerImpl
+import com.wire.kalium.logic.feature.legalhold.ApproveLegalHoldRequestUseCase
+import com.wire.kalium.logic.feature.legalhold.ApproveLegalHoldRequestUseCaseImpl
 import com.wire.kalium.logic.feature.legalhold.FetchLegalHoldForSelfUserFromRemoteUseCase
 import com.wire.kalium.logic.feature.legalhold.FetchLegalHoldForSelfUserFromRemoteUseCaseImpl
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestUseCase
@@ -1338,6 +1340,18 @@ class UserSessionScope internal constructor(
     val observeLegalHoldForSelfUser: ObserveLegalHoldForSelfUserUseCase
         get() = ObserveLegalHoldForSelfUserUseCaseImpl(userId, observeLegalHoldStateForUser)
 
+    val observeLegalHoldRequestUseCase: ObserveLegalHoldRequestUseCase
+        get() = ObserveLegalHoldRequestUseCaseImpl(
+            userConfigRepository = userConfigRepository,
+            preKeyRepository = preKeyRepository
+        )
+
+    val approveLegalHoldRequestUseCase: ApproveLegalHoldRequestUseCase
+        get() = ApproveLegalHoldRequestUseCaseImpl(
+            teamRepository = teamRepository,
+            selfTeamIdProvider = selfTeamId,
+        )
+
     private val fetchSelfClientsFromRemote: FetchSelfClientsFromRemoteUseCase
         get() = FetchSelfClientsFromRemoteUseCaseImpl(
             clientRepository = clientRepository,
@@ -1759,12 +1773,6 @@ class UserSessionScope internal constructor(
                 it.createDirectories(dataStoragePaths.assetStoragePath.value.toPath())
         }
     }
-
-    val observeLegalHoldRequestUseCase: ObserveLegalHoldRequestUseCase
-        get() = ObserveLegalHoldRequestUseCaseImpl(
-            userConfigRepository = userConfigRepository,
-            preKeyRepository = preKeyRepository
-        )
 
     internal val getProxyCredentials: GetProxyCredentialsUseCase
         get() = GetProxyCredentialsUseCaseImpl(sessionManager)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -217,6 +217,8 @@ import com.wire.kalium.logic.feature.featureConfig.handler.SecondFactorPasswordC
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManager
 import com.wire.kalium.logic.feature.keypackage.KeyPackageManagerImpl
+import com.wire.kalium.logic.feature.legalhold.FetchLegalHoldForSelfUserFromRemoteUseCase
+import com.wire.kalium.logic.feature.legalhold.FetchLegalHoldForSelfUserFromRemoteUseCaseImpl
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestUseCase
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldRequestUseCaseImpl
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldForSelfUserUseCase
@@ -713,7 +715,9 @@ class UserSessionScope internal constructor(
             authenticatedNetworkContainer.teamsApi,
             authenticatedNetworkContainer.userDetailsApi,
             userId,
-            userStorage.database.serviceDAO
+            userStorage.database.serviceDAO,
+            legalHoldHandler,
+            legalHoldRequestHandler,
         )
 
     private val serviceRepository: ServiceRepository
@@ -962,6 +966,7 @@ class UserSessionScope internal constructor(
             syncSelfTeamUseCase,
             syncContacts,
             joinExistingMLSConversations,
+            fetchLegalHoldForSelfUserFromRemoteUseCase,
             oneOnOneResolver
         )
     }
@@ -1350,6 +1355,12 @@ class UserSessionScope internal constructor(
         userConfigRepository = userConfigRepository,
         coroutineContext = coroutineContext
     )
+
+    private val fetchLegalHoldForSelfUserFromRemoteUseCase: FetchLegalHoldForSelfUserFromRemoteUseCase
+        get() = FetchLegalHoldForSelfUserFromRemoteUseCaseImpl(
+            teamRepository = teamRepository,
+            selfTeamIdProvider = selfTeamId,
+        )
 
     private val userEventReceiver: UserEventReceiver
         get() = UserEventReceiverImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1340,13 +1340,13 @@ class UserSessionScope internal constructor(
     val observeLegalHoldForSelfUser: ObserveLegalHoldForSelfUserUseCase
         get() = ObserveLegalHoldForSelfUserUseCaseImpl(userId, observeLegalHoldStateForUser)
 
-    val observeLegalHoldRequestUseCase: ObserveLegalHoldRequestUseCase
+    val observeLegalHoldRequest: ObserveLegalHoldRequestUseCase
         get() = ObserveLegalHoldRequestUseCaseImpl(
             userConfigRepository = userConfigRepository,
             preKeyRepository = preKeyRepository
         )
 
-    val approveLegalHoldRequestUseCase: ApproveLegalHoldRequestUseCase
+    val approveLegalHoldRequest: ApproveLegalHoldRequestUseCase
         get() = ApproveLegalHoldRequestUseCaseImpl(
             teamRepository = teamRepository,
             selfTeamIdProvider = selfTeamId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/legalhold/FetchLegalHoldForSelfUserFromRemoteUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/legalhold/FetchLegalHoldForSelfUserFromRemoteUseCase.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.legalhold
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.team.TeamRepository
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+
+/**
+ * Use case that allows to fetch and persist the legal hold state for the self user.
+ */
+interface FetchLegalHoldForSelfUserFromRemoteUseCase {
+    suspend operator fun invoke(): Either<CoreFailure, LegalHoldStatus>
+}
+
+class FetchLegalHoldForSelfUserFromRemoteUseCaseImpl internal constructor(
+    private val teamRepository: TeamRepository,
+    private val selfTeamIdProvider: SelfTeamIdProvider,
+) : FetchLegalHoldForSelfUserFromRemoteUseCase {
+
+    override suspend fun invoke(): Either<CoreFailure, LegalHoldStatus> =
+        selfTeamIdProvider()
+            .flatMap { if (it == null) Either.Left(StorageFailure.DataNotFound) else Either.Right(it) }
+            .flatMap { teamId -> teamRepository.fetchLegalHoldStatus(teamId) }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/legalhold/FetchLegalHoldForSelfUserFromRemoteUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/legalhold/FetchLegalHoldForSelfUserFromRemoteUseCase.kt
@@ -18,7 +18,6 @@
 package com.wire.kalium.logic.feature.legalhold
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.team.TeamRepository
@@ -39,6 +38,8 @@ class FetchLegalHoldForSelfUserFromRemoteUseCaseImpl internal constructor(
 
     override suspend fun invoke(): Either<CoreFailure, LegalHoldStatus> =
         selfTeamIdProvider()
-            .flatMap { if (it == null) Either.Left(StorageFailure.DataNotFound) else Either.Right(it) }
-            .flatMap { teamId -> teamRepository.fetchLegalHoldStatus(teamId) }
+            .flatMap { teamId ->
+                if (teamId == null) Either.Right(LegalHoldStatus.NO_CONSENT)
+                else teamRepository.fetchLegalHoldStatus(teamId)
+            }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/TeamScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/TeamScope.kt
@@ -19,11 +19,9 @@
 package com.wire.kalium.logic.feature.team
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.data.id.SelfTeamIdProvider
-import com.wire.kalium.logic.feature.legalhold.ApproveLegalHoldRequestUseCase
-import com.wire.kalium.logic.feature.legalhold.ApproveLegalHoldRequestUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCase
 import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCaseImpl
 
@@ -47,9 +45,4 @@ class TeamScope internal constructor(
         )
 
     val isSelfATeamMember: IsSelfATeamMemberUseCase get() = IsSelfATeamMemberUseCaseImpl(selfTeamIdProvider)
-
-    val approveLegalHoldRequestUseCase: ApproveLegalHoldRequestUseCase get() = ApproveLegalHoldRequestUseCaseImpl(
-        teamRepository = teamRepository,
-        selfTeamIdProvider = selfTeamIdProvider,
-    )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.feature.connection.SyncConnectionsUseCase
 import com.wire.kalium.logic.feature.conversation.SyncConversationsUseCase
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
+import com.wire.kalium.logic.feature.legalhold.FetchLegalHoldForSelfUserFromRemoteUseCase
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.SyncContactsUseCase
 import com.wire.kalium.logic.feature.user.SyncSelfUserUseCase
@@ -67,6 +68,7 @@ internal class SlowSyncWorkerImpl(
     private val syncSelfTeam: SyncSelfTeamUseCase,
     private val syncContacts: SyncContactsUseCase,
     private val joinMLSConversations: JoinExistingMLSConversationsUseCase,
+    private val fetchLegalHoldForSelfUserFromRemoteUseCase: FetchLegalHoldForSelfUserFromRemoteUseCase,
     private val oneOnOneResolver: OneOnOneResolver,
 ) : SlowSyncWorker {
 
@@ -97,6 +99,7 @@ internal class SlowSyncWorkerImpl(
             .continueWithStep(SlowSyncStep.CONTACTS, syncContacts::invoke)
             .continueWithStep(SlowSyncStep.JOINING_MLS_CONVERSATIONS, joinMLSConversations::invoke)
             .continueWithStep(SlowSyncStep.RESOLVE_ONE_ON_ONE_PROTOCOLS, oneOnOneResolver::resolveAllOneOnOneConversations)
+            .continueWithStep(SlowSyncStep.LEGAL_HOLD) { fetchLegalHoldForSelfUserFromRemoteUseCase().map { } }
             .flatMap {
                 saveLastProcessedEventIdIfNeeded(lastProcessedEventIdToSaveOnSuccess)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -96,10 +96,10 @@ internal class SlowSyncWorkerImpl(
             .continueWithStep(SlowSyncStep.CONVERSATIONS, syncConversations::invoke)
             .continueWithStep(SlowSyncStep.CONNECTIONS, syncConnections::invoke)
             .continueWithStep(SlowSyncStep.SELF_TEAM, syncSelfTeam::invoke)
+            .continueWithStep(SlowSyncStep.LEGAL_HOLD) { fetchLegalHoldForSelfUserFromRemoteUseCase().map { } }
             .continueWithStep(SlowSyncStep.CONTACTS, syncContacts::invoke)
             .continueWithStep(SlowSyncStep.JOINING_MLS_CONVERSATIONS, joinMLSConversations::invoke)
             .continueWithStep(SlowSyncStep.RESOLVE_ONE_ON_ONE_PROTOCOLS, oneOnOneResolver::resolveAllOneOnOneConversations)
-            .continueWithStep(SlowSyncStep.LEGAL_HOLD) { fetchLegalHoldForSelfUserFromRemoteUseCase().map { } }
             .flatMap {
                 saveLastProcessedEventIdIfNeeded(lastProcessedEventIdToSaveOnSuccess)
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -38,7 +38,7 @@ import com.wire.kalium.network.api.base.authenticated.connection.ConnectionRespo
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionStateDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.model.ConversationId
-import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.UserProfileDTO
 import com.wire.kalium.network.exceptions.KaliumException
@@ -359,7 +359,7 @@ class ConnectionRepositoryTest {
             handle = "handle",
             id = QualifiedID(value = "value", domain = "domain"),
             name = "name",
-            legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+            legalHoldStatus = LegalHoldStatusDTO.ENABLED,
             teamId = "team",
             assets = emptyList(),
             deleted = null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -20,16 +20,24 @@ package com.wire.kalium.logic.data.team
 
 import app.cash.turbine.test
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestTeam
 import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
+import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldRequestHandler
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.client.ClientIdDTO
+import com.wire.kalium.network.api.base.authenticated.keypackage.LastPreKeyDTO
 import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.model.ErrorResponse
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
+import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
 import com.wire.kalium.network.api.base.model.ServiceDetailDTO
 import com.wire.kalium.network.api.base.model.ServiceDetailResponse
 import com.wire.kalium.network.api.base.model.TeamDTO
@@ -45,6 +53,7 @@ import io.mockative.classOf
 import io.mockative.configure
 import io.mockative.eq
 import io.mockative.given
+import io.mockative.matching
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.oneOf
@@ -220,6 +229,108 @@ class TeamRepositoryTest {
         result.shouldSucceed()
     }
 
+    private fun testFetchingLegalHoldStatus(
+        response: LegalHoldStatusResponse,
+        expected: LegalHoldStatus,
+        verification: (Arrangement) -> Unit,
+    ) = runTest {
+        // given
+        val (arrangement, teamRepository) = Arrangement()
+            .withApiFetchLegalHoldStatusSuccess(response)
+            .withHandleLegalHoldSuccesses()
+            .arrange()
+        // when
+        val result = teamRepository.fetchLegalHoldStatus(teamId = TeamId(value = "teamId"))
+        // then
+        result.shouldSucceed() { assertEquals(expected, it) }
+        verification(arrangement)
+    }
+
+    @Test
+    fun givenTeamIdAndUserIdAndStatusNoConsent_whenFetchingLegalHoldStatus_thenItShouldSucceed() =
+        testFetchingLegalHoldStatus(
+            response = LegalHoldStatusResponse(LegalHoldStatusDTO.NO_CONSENT, null, null),
+            expected = LegalHoldStatus.NO_CONSENT,
+        ) { arrangement ->
+            verify(arrangement.legalHoldHandler)
+                .suspendFunction(arrangement.legalHoldHandler::handleEnable)
+                .with(any())
+                .wasNotInvoked()
+            verify(arrangement.legalHoldHandler)
+                .suspendFunction(arrangement.legalHoldHandler::handleDisable)
+                .with(any())
+                .wasNotInvoked()
+            verify(arrangement.legalHoldRequestHandler)
+                .suspendFunction(arrangement.legalHoldRequestHandler::handle)
+                .with(any())
+                .wasNotInvoked()
+        }
+
+    @Test
+    fun givenTeamIdAndUserIdAndStatusPending_whenFetchingLegalHoldStatus_thenItShouldSucceedAndHandlePendingLegalHold() {
+        val clientId = ClientIdDTO("clientId")
+        val lastPreKey = LastPreKeyDTO(1, "key")
+        testFetchingLegalHoldStatus(
+            response = LegalHoldStatusResponse(LegalHoldStatusDTO.PENDING, ClientIdDTO("clientId"), LastPreKeyDTO(1, "key")),
+            expected = LegalHoldStatus.PENDING,
+        ) { arrangement ->
+            verify(arrangement.legalHoldHandler)
+                .suspendFunction(arrangement.legalHoldHandler::handleEnable)
+                .with(any())
+                .wasNotInvoked()
+            verify(arrangement.legalHoldHandler)
+                .suspendFunction(arrangement.legalHoldHandler::handleDisable)
+                .with(any())
+                .wasNotInvoked()
+            verify(arrangement.legalHoldRequestHandler)
+                .suspendFunction(arrangement.legalHoldRequestHandler::handle)
+                .with(matching {
+                    it.clientId.value == clientId.clientId && it.lastPreKey.id == lastPreKey.id && it.lastPreKey.key == lastPreKey.key
+                })
+                .wasInvoked()
+        }
+    }
+
+    @Test
+    fun givenTeamIdAndUserIdAndStatusEnabled_whenFetchingLegalHoldStatus_thenItShouldSucceedAndHandleEnabledLegalHold() =
+    testFetchingLegalHoldStatus(
+    response = LegalHoldStatusResponse(LegalHoldStatusDTO.ENABLED, null, null),
+    expected = LegalHoldStatus.ENABLED,
+    ) { arrangement ->
+        verify(arrangement.legalHoldHandler)
+            .suspendFunction(arrangement.legalHoldHandler::handleEnable)
+            .with(any())
+            .wasInvoked()
+        verify(arrangement.legalHoldHandler)
+            .suspendFunction(arrangement.legalHoldHandler::handleDisable)
+            .with(any())
+            .wasNotInvoked()
+        verify(arrangement.legalHoldRequestHandler)
+            .suspendFunction(arrangement.legalHoldRequestHandler::handle)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenTeamIdAndUserIdAndStatusDisabled_whenFetchingLegalHoldStatus_thenItShouldSucceedAndHandleDisabledLegalHold() =
+        testFetchingLegalHoldStatus(
+            response = LegalHoldStatusResponse(LegalHoldStatusDTO.DISABLED, null, null),
+            expected = LegalHoldStatus.DISABLED,
+        ) { arrangement ->
+            verify(arrangement.legalHoldHandler)
+                .suspendFunction(arrangement.legalHoldHandler::handleEnable)
+                .with(any())
+                .wasNotInvoked()
+            verify(arrangement.legalHoldHandler)
+                .suspendFunction(arrangement.legalHoldHandler::handleDisable)
+                .with(any())
+                .wasInvoked()
+            verify(arrangement.legalHoldRequestHandler)
+                .suspendFunction(arrangement.legalHoldRequestHandler::handle)
+                .with(any())
+                .wasNotInvoked()
+        }
+
     private class Arrangement {
         @Mock
         val teamDAO = configure(mock(classOf<TeamDAO>())) {
@@ -247,6 +358,12 @@ class TeamRepositoryTest {
             stubsUnitByDefault = true
         }
 
+        @Mock
+        val legalHoldHandler = mock(classOf<LegalHoldHandler>())
+
+        @Mock
+        val legalHoldRequestHandler = mock(classOf<LegalHoldRequestHandler>())
+
         val teamRepository: TeamRepository = TeamDataSource(
             teamDAO = teamDAO,
             teamMapper = teamMapper,
@@ -255,7 +372,9 @@ class TeamRepositoryTest {
             userDAO = userDAO,
             userMapper = userMapper,
             selfUserId = TestUser.USER_ID,
-            serviceDAO = serviceDAO
+            serviceDAO = serviceDAO,
+            legalHoldHandler = legalHoldHandler,
+            legalHoldRequestHandler = legalHoldRequestHandler,
         )
 
         fun withApiGetTeamInfoSuccess(teamDTO: TeamDTO) = apply {
@@ -291,6 +410,28 @@ class TeamRepositoryTest {
                 .suspendFunction(teamsApi::approveLegalHold)
                 .whenInvokedWith(any(), any())
                 .thenReturn(NetworkResponse.Success(value = Unit, headers = mapOf(), httpCode = 200))
+        }
+
+        fun withApiFetchLegalHoldStatusSuccess(result: LegalHoldStatusResponse) = apply {
+            given(teamsApi)
+                .suspendFunction(teamsApi::fetchLegalHoldStatus)
+                .whenInvokedWith(any())
+                .thenReturn(NetworkResponse.Success(value = result, headers = mapOf(), httpCode = 200))
+        }
+
+        fun withHandleLegalHoldSuccesses() = apply {
+            given(legalHoldHandler)
+                .suspendFunction(legalHoldHandler::handleEnable)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+            given(legalHoldHandler)
+                .suspendFunction(legalHoldHandler::handleDisable)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+            given(legalHoldRequestHandler)
+                .suspendFunction(legalHoldRequestHandler::handle)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
         }
 
         fun arrange() = this to teamRepository

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/FetchLegalHoldForSelfUserFromRemoteUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/FetchLegalHoldForSelfUserFromRemoteUseCaseTest.kt
@@ -55,7 +55,7 @@ class FetchLegalHoldForSelfUserFromRemoteUseCaseTest {
         useCase.invoke()
         // then
         verify(arrangement.teamRepository)
-            .suspendFunction(arrangement.teamRepository::approveLegalHold)
+            .suspendFunction(arrangement.teamRepository::fetchLegalHoldStatus)
             .with(eq(selfTeamId))
             .wasInvoked(once)
     }
@@ -78,9 +78,23 @@ class FetchLegalHoldForSelfUserFromRemoteUseCaseTest {
     }
 
     @Test
+    fun givenSelfUserIsNotInATeam_whenFetching_thenNoConsentResultShouldBeReturned() = runTest {
+        // given
+        val status = LegalHoldStatus.NO_CONSENT
+        val (_, useCase) = Arrangement()
+            .withGetSelfTeamResult(Either.Right(null))
+            .arrange()
+        // when
+        val result = useCase.invoke()
+        // then
+        result.shouldSucceed() {
+            assertEquals(status, it)
+        }
+    }
+
+    @Test
     fun givenGetSelfTeamIdFailure_whenFetching_thenDataNotFoundErrorShouldBeReturned() = runTest {
         // given
-        val password = "password"
         val (_, useCase) = Arrangement()
             .withGetSelfTeamResult(Either.Left(StorageFailure.DataNotFound))
             .arrange()
@@ -105,7 +119,7 @@ class FetchLegalHoldForSelfUserFromRemoteUseCaseTest {
         val result = useCase()
         // then
         result.shouldFail() {
-            assertEquals(StorageFailure.DataNotFound, it)
+            assertEquals(failure, it)
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/FetchLegalHoldForSelfUserFromRemoteUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/FetchLegalHoldForSelfUserFromRemoteUseCaseTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.legalhold
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.team.TeamRepository
+import com.wire.kalium.logic.framework.TestTeam
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.exceptions.KaliumException
+import io.ktor.utils.io.errors.IOException
+import io.mockative.Mock
+import io.mockative.anything
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FetchLegalHoldForSelfUserFromRemoteUseCaseTest {
+
+    @Test
+    fun givenFetchLegalHoldParams_whenFetching_thenTheRepositoryShouldBeCalledWithCorrectParameters() = runTest {
+        // given
+        val selfTeamId = TeamId(TestTeam.TEAM.id)
+        val (arrangement, useCase) = Arrangement()
+            .withGetSelfTeamResult(Either.Right(selfTeamId))
+            .withFetchLegalHoldStatusResult(Either.Right(LegalHoldStatus.ENABLED))
+            .arrange()
+        // when
+        useCase.invoke()
+        // then
+        verify(arrangement.teamRepository)
+            .suspendFunction(arrangement.teamRepository::approveLegalHold)
+            .with(eq(selfTeamId))
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenASuccess_whenFetching_thenSuccessShouldBeReturned() = runTest {
+        // given
+        val status = LegalHoldStatus.ENABLED
+        val selfTeamId = TeamId(TestTeam.TEAM.id)
+        val (_, useCase) = Arrangement()
+            .withGetSelfTeamResult(Either.Right(selfTeamId))
+            .withFetchLegalHoldStatusResult(Either.Right(status))
+            .arrange()
+        // when
+        val result = useCase()
+        // then
+        result.shouldSucceed {
+            assertEquals(status, it)
+        }
+    }
+
+    @Test
+    fun givenGetSelfTeamIdFailure_whenFetching_thenDataNotFoundErrorShouldBeReturned() = runTest {
+        // given
+        val password = "password"
+        val (_, useCase) = Arrangement()
+            .withGetSelfTeamResult(Either.Left(StorageFailure.DataNotFound))
+            .arrange()
+        // when
+        val result = useCase.invoke()
+        // then
+        result.shouldFail() {
+            assertEquals(StorageFailure.DataNotFound, it)
+        }
+    }
+
+    @Test
+    fun givenAGenericError_whenFetching_thenGenericErrorShouldBeReturned() = runTest {
+        // given
+        val selfTeamId = TeamId(TestTeam.TEAM.id)
+        val failure = NetworkFailure.ServerMiscommunication(KaliumException.GenericError(IOException("no internet")))
+        val (_, useCase) = Arrangement()
+            .withGetSelfTeamResult(Either.Right(selfTeamId))
+            .withFetchLegalHoldStatusResult(Either.Left(failure))
+            .arrange()
+        // when
+        val result = useCase()
+        // then
+        result.shouldFail() {
+            assertEquals(StorageFailure.DataNotFound, it)
+        }
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val teamRepository: TeamRepository = mock(TeamRepository::class)
+        @Mock
+        val selfTeamIdProvider: SelfTeamIdProvider = mock(SelfTeamIdProvider::class)
+        val useCase: FetchLegalHoldForSelfUserFromRemoteUseCase by lazy {
+            FetchLegalHoldForSelfUserFromRemoteUseCaseImpl(teamRepository, selfTeamIdProvider)
+        }
+
+        fun arrange() = this to useCase
+
+        fun withGetSelfTeamResult(result: Either<CoreFailure, TeamId?>) = apply {
+            given(selfTeamIdProvider)
+                .suspendFunction(selfTeamIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(result)
+        }
+        fun withFetchLegalHoldStatusResult(result: Either<CoreFailure, LegalHoldStatus>) = apply {
+            given(teamRepository)
+                .suspendFunction(teamRepository::fetchLegalHoldStatus)
+                .whenInvokedWith(anything())
+                .thenReturn(result)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestTeam.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestTeam.kt
@@ -22,7 +22,7 @@ import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.network.api.base.model.NonQualifiedUserId
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
-import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.base.model.TeamDTO
 import com.wire.kalium.persistence.dao.TeamEntity
 import com.wire.kalium.network.api.base.model.TeamId as TeamIdDTO
@@ -56,7 +56,7 @@ object TestTeam {
     fun memberDTO(
         nonQualifiedUserId: NonQualifiedUserId = "id",
         createdBy: NonQualifiedUserId? = null,
-        legalHoldStatus: LegalHoldStatusResponse? = null,
+        legalHoldStatus: LegalHoldStatusDTO? = null,
         createdAt: String? = null,
         permissions: TeamsApi.Permissions? = null
     ): TeamsApi.TeamMemberDTO = TeamsApi.TeamMemberDTO(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestUser.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
 import com.wire.kalium.network.api.base.model.AssetSizeDTO
-import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.base.model.SelfUserDTO
 import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.api.base.model.UserAssetDTO
@@ -144,7 +144,7 @@ object TestUser {
         handle = "handle",
         email = "email",
         accentId = 0,
-        legalHoldStatus = LegalHoldStatusResponse.DISABLED,
+        legalHoldStatus = LegalHoldStatusDTO.DISABLED,
         teamId = "teamId",
         assets = listOf(
             UserAssetDTO("value1", AssetSizeDTO.PREVIEW, UserAssetTypeDTO.IMAGE),

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.network.api.base.authenticated
 
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
 import com.wire.kalium.network.api.base.model.NonQualifiedConversationId
 import com.wire.kalium.network.api.base.model.NonQualifiedUserId
@@ -42,7 +43,7 @@ interface TeamsApi {
     data class TeamMemberDTO(
         @SerialName("user") val nonQualifiedUserId: NonQualifiedUserId,
         @SerialName("created_by") val createdBy: NonQualifiedUserId?,
-        @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatusResponse?,
+        @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatusDTO?,
         @SerialName("created_at") val createdAt: String?,
         val permissions: Permissions?
     )
@@ -94,6 +95,7 @@ interface TeamsApi {
     suspend fun getTeamInfo(teamId: TeamId): NetworkResponse<TeamDTO>
     suspend fun whiteListedServices(teamId: TeamId, size: Int = DEFAULT_SERVICES_SIZE): NetworkResponse<ServiceDetailResponse>
     suspend fun approveLegalHold(teamId: TeamId, userId: NonQualifiedUserId, password: String?): NetworkResponse<Unit>
+    suspend fun fetchLegalHoldStatus(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<LegalHoldStatusResponse>
 
     companion object {
         const val DEFAULT_SERVICES_SIZE = 100 // this number is copied from the web client

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/LegalHoldStatusResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/LegalHoldStatusResponse.kt
@@ -35,6 +35,7 @@ enum class LegalHoldStatusDTO {
     NO_CONSENT
 }
 
+@Serializable
 data class LegalHoldStatusResponse(
     @SerialName("status") val legalHoldStatusDTO: LegalHoldStatusDTO,
     @SerialName("client") val clientId: ClientIdDTO?,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/LegalHoldStatusResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/LegalHoldStatusResponse.kt
@@ -18,11 +18,13 @@
 
 package com.wire.kalium.network.api.base.model
 
+import com.wire.kalium.network.api.base.authenticated.client.ClientIdDTO
+import com.wire.kalium.network.api.base.authenticated.keypackage.LastPreKeyDTO
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class LegalHoldStatusResponse {
+enum class LegalHoldStatusDTO {
     @SerialName("enabled")
     ENABLED,
     @SerialName("pending")
@@ -32,3 +34,9 @@ enum class LegalHoldStatusResponse {
     @SerialName("no_consent")
     NO_CONSENT
 }
+
+data class LegalHoldStatusResponse(
+    @SerialName("status") val legalHoldStatusDTO: LegalHoldStatusDTO,
+    @SerialName("client") val clientId: ClientIdDTO?,
+    @SerialName("last_prekey") val lastPreKey: LastPreKeyDTO?,
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/UserDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/model/UserDTO.kt
@@ -53,7 +53,7 @@ data class UserProfileDTO(
     @SerialName("id") override val nonQualifiedId: NonQualifiedUserId,
     @SerialName("service") override val service: ServiceDTO?,
     @SerialName("supported_protocols") override val supportedProtocols: List<SupportedProtocolDTO>?,
-    @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatusResponse,
+    @SerialName("legalhold_status") val legalHoldStatus: LegalHoldStatusDTO,
 ) : UserDTO()
 
 fun UserProfileDTO.isTeamMember(selfUserTeamId: String?, selfUserDomain: String?) =

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.network.api.v0.authenticated
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
 import com.wire.kalium.network.api.base.authenticated.client.PasswordRequest
+import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
 import com.wire.kalium.network.api.base.model.NonQualifiedConversationId
 import com.wire.kalium.network.api.base.model.NonQualifiedUserId
 import com.wire.kalium.network.api.base.model.ServiceDetailResponse
@@ -83,6 +84,11 @@ internal open class TeamsApiV0 internal constructor(
             httpClient.put("$PATH_TEAMS/$teamId/$PATH_LEGAL_HOLD/$userId/$PATH_APPROVE") {
                 setBody(PasswordRequest(password))
             }
+        }
+
+    override suspend fun fetchLegalHoldStatus(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<LegalHoldStatusResponse> =
+        wrapKaliumResponse {
+            httpClient.get("$PATH_TEAMS/$teamId/$PATH_LEGAL_HOLD/$userId")
         }
 
     private companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/teams/TeamsApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/teams/TeamsApiV0Test.kt
@@ -149,6 +149,23 @@ internal class TeamsApiV0Test : ApiTest() {
     fun givenAValidTeamIdAndUserIdAndNoPassword_whenApprovingLegalHold_theRequestShouldBeConfiguredCorrectly() =
         testApprovingLegalHold(DUMMY_TEAM_ID, DUMMY_USER_ID, null)
 
+    @Test
+    fun givenAValidTeamIdAndUserId_whenFetchingLegalHoldStatus_thenRequestShouldBeConfiguredCorrectly() = runTest {
+        val teamId = DUMMY_TEAM_ID
+        val userId = DUMMY_USER_ID
+        val networkClient = mockAuthenticatedNetworkClient(
+            "",
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertNoQueryParams()
+                assertPathEqual("/$PATH_TEAMS/$teamId/$PATH_LEGAL_HOLD/$userId")
+            }
+        )
+        val teamsApi: TeamsApi = TeamsApiV0(networkClient)
+        teamsApi.fetchLegalHoldStatus(teamId, userId)
+    }
+
     private companion object {
         const val PATH_TEAMS = "teams"
         const val PATH_CONVERSATIONS = "conversations"

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/ListUsersResponseJson.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
-import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.base.model.UserProfileDTO
@@ -39,7 +39,7 @@ object ListUsersResponseJson {
             name = "usera",
             handle = "user_a",
             accentId = 2147483647,
-            legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+            legalHoldStatus = LegalHoldStatusDTO.ENABLED,
             teamId = null,
             assets = emptyList(),
             deleted = false,
@@ -54,7 +54,7 @@ object ListUsersResponseJson {
             name = "userb",
             handle = "user_b",
             accentId = 2147483647,
-            legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+            legalHoldStatus = LegalHoldStatusDTO.ENABLED,
             teamId = null,
             assets = emptyList(),
             deleted = false,

--- a/tango-tests/src/integrationTest/kotlin/util/ListUsersResponseJson.kt
+++ b/tango-tests/src/integrationTest/kotlin/util/ListUsersResponseJson.kt
@@ -19,7 +19,7 @@
 package util
 
 import com.wire.kalium.network.api.base.authenticated.userDetails.ListUsersDTO
-import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
+import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.base.model.UserProfileDTO
 
@@ -35,7 +35,7 @@ object ListUsersResponseJson {
             name = "usera",
             handle = "user_a",
             accentId = 2147483647,
-            legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+            legalHoldStatus = LegalHoldStatusDTO.ENABLED,
             teamId = null,
             assets = emptyList(),
             deleted = false,
@@ -50,7 +50,7 @@ object ListUsersResponseJson {
             name = "userb",
             handle = "user_b",
             accentId = 2147483647,
-            legalHoldStatus = LegalHoldStatusResponse.ENABLED,
+            legalHoldStatus = LegalHoldStatusDTO.ENABLED,
             teamId = null,
             assets = emptyList(),
             deleted = false,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user has pending legal hold request and logs in on a freshly installed app, the app doesn't receive the legal hold request event.

### Solutions

Make fetching legal hold status to be a step of the slow sync so that the app always knows the proper status of the legal hold.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

On a freshly installed app, log in using the account which has a pending legal hold request.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
