### PR TITLE
fix(jvm): support logout and login when using in-memory storage

### DIFF
--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/di/PlatformUserStorageProvider.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/di/PlatformUserStorageProvider.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.di
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.persistence.db.PlatformDatabaseData
+import com.wire.kalium.persistence.db.StorageData
 import com.wire.kalium.persistence.db.inMemoryDatabase
 import com.wire.kalium.persistence.db.userDatabaseBuilder
 import com.wire.kalium.persistence.kmmSettings.UserPrefBuilder
@@ -38,8 +39,9 @@ internal actual class PlatformUserStorageProvider : UserStorageProvider() {
         val databaseInfo = platformProperties.databaseInfo
         val database = when (databaseInfo) {
             is DatabaseStorageType.FiledBacked -> {
+                val storageData = StorageData.FileBacked(databaseInfo.filePath)
                 userDatabaseBuilder(
-                    platformDatabaseData = PlatformDatabaseData(databaseInfo.filePath),
+                    platformDatabaseData = PlatformDatabaseData(storageData),
                     userId = userIdEntity,
                     passphrase = null,
                     dispatcher = KaliumDispatcherImpl.io,
@@ -47,7 +49,7 @@ internal actual class PlatformUserStorageProvider : UserStorageProvider() {
                 )
             }
 
-            else -> {
+            is DatabaseStorageType.InMemory -> {
                 inMemoryDatabase(userIdEntity, KaliumDispatcherImpl.io)
             }
         }

--- a/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
+++ b/persistence-test/src/jvmMain/kotlin/com/wire/kalium/persistence/TestDatabaseManipulation.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.GlobalDatabaseProvider
 import com.wire.kalium.persistence.db.inMemoryDatabase
 import com.wire.kalium.persistence.db.UserDatabaseBuilder
+import com.wire.kalium.persistence.db.clearInMemoryDatabase
 import kotlinx.coroutines.test.TestDispatcher
 import java.nio.file.Files
 
@@ -30,7 +31,7 @@ internal actual fun createTestDatabase(userId: UserIDEntity, dispatcher: TestDis
 }
 
 internal actual fun deleteTestDatabase(userId: UserIDEntity) {
-    getTempDatabaseFile(getTempDatabaseFileNameForUser(userId)).delete()
+    clearInMemoryDatabase(userId)
 }
 
 internal actual fun createTestGlobalDatabase(): GlobalDatabaseProvider {

--- a/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -17,6 +17,7 @@
  */
 
 @file:Suppress("MatchingDeclarationName")
+
 package com.wire.kalium.persistence.db
 
 import app.cash.sqldelight.db.SqlDriver

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/InMemoryDatabaseCache.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/InMemoryDatabaseCache.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.persistence.db
+
+import com.wire.kalium.persistence.dao.UserIDEntity
+
+/**
+ * Provides an in-memory cache for in-memory databases.
+ *
+ * Useful to hold a database across logins and logouts without losing the data in between.
+ */
+internal object InMemoryDatabaseCache {
+    private val cache = mutableMapOf<UserIDEntity, UserDatabaseBuilder>()
+
+    fun getOrCreate(
+        userIDEntity: UserIDEntity,
+        create: () -> UserDatabaseBuilder
+    ): UserDatabaseBuilder {
+        return cache.getOrPut(userIDEntity) { create() }
+    }
+
+    /**
+     * Clears an entry from the cache based on the provided [userIDEntity].
+     *
+     * @param userIDEntity The [UserIDEntity] representing the entry to be cleared.
+     * @return `true` if the entry was successfully cleared, `false` if it didn't exist.
+     */
+    fun clearEntry(userIDEntity: UserIDEntity): Boolean {
+        return cache.remove(userIDEntity) != null
+    }
+}

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -30,9 +30,14 @@ import java.util.Properties
 
 private const val DATABASE_NAME = "main.db"
 
-actual class PlatformDatabaseData(
-    val storePath: File
+actual data class PlatformDatabaseData(
+    val storageData: StorageData
 )
+
+sealed interface StorageData {
+    data class FileBacked(val file: File) : StorageData
+    data object InMemory : StorageData
+}
 
 actual fun userDatabaseBuilder(
     platformDatabaseData: PlatformDatabaseData,
@@ -41,15 +46,22 @@ actual fun userDatabaseBuilder(
     dispatcher: CoroutineDispatcher,
     enableWAL: Boolean
 ): UserDatabaseBuilder {
+    val storageData = platformDatabaseData.storageData
+    if (storageData is StorageData.InMemory) {
+        return inMemoryDatabase(userId, dispatcher)
+    }
+    if (storageData !is StorageData.FileBacked) {
+        throw IllegalStateException("Unsupported storage data type: $storageData")
+    }
     if (passphrase != null) {
         throw NotImplementedError("Encrypted DB is not supported on JVM")
     }
 
-    val databasePath = platformDatabaseData.storePath.resolve(DATABASE_NAME)
+    val databasePath = storageData.file.resolve(DATABASE_NAME)
     val databaseExists = databasePath.exists()
 
     // Make sure all intermediate directories exist
-    platformDatabaseData.storePath.mkdirs()
+    storageData.file.mkdirs()
 
     val driver: SqlDriver = sqlDriver("jdbc:sqlite:${databasePath.absolutePath}", enableWAL)
 
@@ -66,6 +78,19 @@ actual fun userDatabaseDriverByPath(
     enableWAL: Boolean
 ): SqlDriver = sqlDriver(path, false)
 
+internal actual fun getDatabaseAbsoluteFileLocation(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity
+): String? {
+    val storageData = platformDatabaseData.storageData
+    if (storageData !is StorageData.FileBacked) {
+        return null
+    }
+    val dbFile = storageData.file.resolve(DATABASE_NAME)
+    return if (dbFile.exists()) dbFile.absolutePath else null
+}
+
+
 private fun sqlDriver(driverUri: String, enableWAL: Boolean): SqlDriver = JdbcSqliteDriver(
     driverUri,
     Properties(1).apply {
@@ -78,21 +103,32 @@ private fun sqlDriver(driverUri: String, enableWAL: Boolean): SqlDriver = JdbcSq
     }
 )
 
-fun inMemoryDatabase(userId: UserIDEntity, dispatcher: CoroutineDispatcher): UserDatabaseBuilder {
+/**
+ * Creates an in-memory user database,
+ * or returns an existing one if it already exists.
+ *
+ * @param userId The ID of the user for whom the database is created.
+ * @param dispatcher The coroutine dispatcher to be used for executing database operations.
+ * @return The user database builder.
+ */
+fun inMemoryDatabase(
+    userId: UserIDEntity,
+    dispatcher: CoroutineDispatcher
+): UserDatabaseBuilder = InMemoryDatabaseCache.getOrCreate(userId) {
     val driver = sqlDriver(JdbcSqliteDriver.IN_MEMORY, false)
     UserDatabase.Schema.create(driver)
-    return UserDatabaseBuilder(userId, driver, dispatcher, PlatformDatabaseData(File("inMemory")), false)
+    val storageData = StorageData.FileBacked(File("inMemory"))
+    UserDatabaseBuilder(userId, driver, dispatcher, PlatformDatabaseData(storageData), false)
+}
+
+fun clearInMemoryDatabase(userId: UserIDEntity) {
+    InMemoryDatabaseCache.clearEntry(userId)
 }
 
 internal actual fun nuke(
     userId: UserIDEntity,
     platformDatabaseData: PlatformDatabaseData
-): Boolean = platformDatabaseData.storePath.resolve(DATABASE_NAME).delete() ?: false
-
-internal actual fun getDatabaseAbsoluteFileLocation(
-    platformDatabaseData: PlatformDatabaseData,
-    userId: UserIDEntity
-): String? {
-    val dbFile = platformDatabaseData.storePath.resolve(DATABASE_NAME)
-    return if (dbFile.exists()) dbFile.absolutePath else null
+): Boolean = when (val storageData = platformDatabaseData.storageData) {
+    StorageData.InMemory -> InMemoryDatabaseCache.clearEntry(userId)
+    is StorageData.FileBacked -> storageData.file.resolve(DATABASE_NAME).delete()
 }

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -121,14 +121,14 @@ fun inMemoryDatabase(
     UserDatabaseBuilder(userId, driver, dispatcher, PlatformDatabaseData(storageData), false)
 }
 
-fun clearInMemoryDatabase(userId: UserIDEntity) {
-    InMemoryDatabaseCache.clearEntry(userId)
+fun clearInMemoryDatabase(userId: UserIDEntity): Boolean {
+    return InMemoryDatabaseCache.clearEntry(userId)
 }
 
 internal actual fun nuke(
     userId: UserIDEntity,
     platformDatabaseData: PlatformDatabaseData
 ): Boolean = when (val storageData = platformDatabaseData.storageData) {
-    StorageData.InMemory -> InMemoryDatabaseCache.clearEntry(userId)
+    StorageData.InMemory -> clearInMemoryDatabase(userId)
     is StorageData.FileBacked -> storageData.file.resolve(DATABASE_NAME).delete()
 }

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -90,7 +90,6 @@ internal actual fun getDatabaseAbsoluteFileLocation(
     return if (dbFile.exists()) dbFile.absolutePath else null
 }
 
-
 private fun sqlDriver(driverUri: String, enableWAL: Boolean): SqlDriver = JdbcSqliteDriver(
     driverUri,
     Properties(1).apply {

--- a/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
+++ b/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/BaseDatabaseTest.kt
@@ -20,22 +20,21 @@ package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.PlatformDatabaseData
+import com.wire.kalium.persistence.db.StorageData
 import com.wire.kalium.persistence.db.UserDBSecret
 import com.wire.kalium.persistence.db.UserDatabaseBuilder
 import com.wire.kalium.persistence.db.userDatabaseBuilder
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import java.io.File
 import java.nio.file.Files
 
-@OptIn(ExperimentalCoroutinesApi::class)
 actual open class BaseDatabaseTest actual constructor() {
 
     protected actual val dispatcher: TestDispatcher = StandardTestDispatcher()
     actual val encryptedDBSecret = UserDBSecret("db_secret".toByteArray())
 
-    val UserIDEntity.databaseFile
+    private val UserIDEntity.databaseFile
         get() = Files.createTempDirectory("test-storage").toFile().resolve("test-$domain-$value.db")
 
     actual fun databasePath(
@@ -66,5 +65,7 @@ actual open class BaseDatabaseTest actual constructor() {
         )
     }
 
-    actual fun platformDBData(userId: UserIDEntity): PlatformDatabaseData = PlatformDatabaseData(userId.databaseFile)
+    actual fun platformDBData(userId: UserIDEntity): PlatformDatabaseData = PlatformDatabaseData(
+        StorageData.FileBacked(userId.databaseFile)
+    )
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When using `inMemoryStorage` for JVM, it's impossible to logout and then login again, as a new instance will be created from scratch, even when using `SELF_SOFT_LOGOUT` LogoutReason.

### Solutions

Introduced the `InMemoryDatabaseCache` to hold a database across logins/logouts without losing the data.
If `nuke` is called, this cache will be cleared too. Which should only happen when there's a hard logout.

Make sure we also clear the cache when running unit tests.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
