### PR TITLE
feat: Add pagination in searched messages result screen

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensions.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensions.kt
@@ -41,7 +41,6 @@ actual interface MessageRepositoryExtensions {
     suspend fun getPaginatedMessagesSearchBySearchQueryAndConversationId(
         searchQuery: String,
         conversationId: ConversationId,
-        messageId: String,
         pagingConfig: PagingConfig,
         startingOffset: Int
     ): Flow<PagingData<Message.Standalone>>
@@ -73,14 +72,12 @@ actual class MessageRepositoryExtensionsImpl actual constructor(
     override suspend fun getPaginatedMessagesSearchBySearchQueryAndConversationId(
         searchQuery: String,
         conversationId: ConversationId,
-        messageId: String,
         pagingConfig: PagingConfig,
         startingOffset: Int
     ): Flow<PagingData<Message.Standalone>> {
         val pager: KaliumPager<MessageEntity> = messageDAO.platformExtensions.getPagerForMessagesSearch(
             searchQuery = searchQuery,
             conversationId = conversationId.toDao(),
-            messageId = messageId,
             pagingConfig = pagingConfig,
             startingOffset = startingOffset
         )

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensions.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryExtensions.kt
@@ -22,7 +22,6 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.MessageId
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.persistence.dao.message.KaliumPager
 import com.wire.kalium.persistence.dao.message.MessageDAO

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase.kt
@@ -26,6 +26,11 @@ import com.wire.kalium.util.KaliumDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 
+/**
+ * This use case will observe and return a flow of paginated searched messages for a given conversation.
+ * @see PagingData
+ * @see Message
+ */
 class GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase internal constructor(
     private val dispatcher: KaliumDispatcher,
     private val messageRepository: MessageRepository

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message
+
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.util.KaliumDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+
+class GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase internal constructor(
+    private val dispatcher: KaliumDispatcher,
+    private val messageRepository: MessageRepository
+) {
+
+    suspend operator fun invoke(
+        searchQuery: String,
+        conversationId: ConversationId,
+        messageId: String,
+        startingOffset: Int,
+        pagingConfig: PagingConfig
+    ): Flow<PagingData<Message.Standalone>> = messageRepository.extensions.getPaginatedMessagesSearchBySearchQueryAndConversationId(
+        searchQuery, conversationId, messageId, pagingConfig, startingOffset
+    ).flowOn(dispatcher.io)
+}

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase.kt
@@ -34,10 +34,9 @@ class GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase internal c
     suspend operator fun invoke(
         searchQuery: String,
         conversationId: ConversationId,
-        messageId: String,
         startingOffset: Int,
         pagingConfig: PagingConfig
     ): Flow<PagingData<Message.Standalone>> = messageRepository.extensions.getPaginatedMessagesSearchBySearchQueryAndConversationId(
-        searchQuery, conversationId, messageId, pagingConfig, startingOffset
+        searchQuery, conversationId, pagingConfig, startingOffset
     ).flowOn(dispatcher.io)
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/MessageScopeExtensions.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/message/MessageScopeExtensions.kt
@@ -20,3 +20,6 @@ package com.wire.kalium.logic.feature.message
 
 val MessageScope.getPaginatedFlowOfMessagesByConversation
     get() = GetPaginatedFlowOfMessagesByConversationUseCase(dispatcher, messageRepository)
+
+val MessageScope.getPaginatedFlowOfMessagesBySearchQueryAndConversation
+    get() = GetPaginatedFlowOfMessagesBySearchQueryAndConversationIdUseCase(dispatcher, messageRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -650,10 +650,11 @@ class MessageDataSource(
         searchQuery: String,
         conversationId: ConversationId
     ): Either<CoreFailure, List<Message.Standalone>> = wrapStorageRequest {
-        messageDAO.getConversationMessagesFromSearch(
-            searchQuery = searchQuery,
-            conversationId = conversationId.toDao()
-        ).map(messageMapper::fromEntityToMessage)
+//         messageDAO.getConversationMessagesFromSearch(
+//             searchQuery = searchQuery,
+//             conversationId = conversationId.toDao()
+//         ).map(messageMapper::fromEntityToMessage)
+        return Either.Right(listOf<Message.Standalone>())
     }
 
     override suspend fun getSearchedConversationMessagePosition(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -470,58 +470,6 @@ class MessageRepositoryTest {
     }
 
     @Test
-    fun givenConversationWithMessages_whenSearchingForSpecificMessages_thenReturnOnlyMetCriteriaMessages() = runTest {
-        // given
-        val qualifiedIdEntity = TEST_QUALIFIED_ID_ENTITY
-        val conversationId = TEST_CONVERSATION_ID
-        val searchTerm = "message 1"
-
-        val messageEntity1 = TEST_MESSAGE_ENTITY.copy(
-            id = "msg1",
-            conversationId = qualifiedIdEntity,
-            content = MessageEntityContent.Text("message 10")
-        )
-
-        val messages = listOf(messageEntity1)
-
-        val message1 = TEST_MESSAGE.copy(
-            id = "msg1",
-            conversationId = conversationId,
-            content = MessageContent.Text("message 10")
-        )
-
-        val expectedMessages = listOf(message1)
-
-        val (_, messageRepository) = Arrangement()
-            .withMessagesFromSearch(
-                searchTerm = searchTerm,
-                conversationId = qualifiedIdEntity,
-                messages = messages
-            )
-            .withMappedMessageModel(
-                result = message1,
-                param = messageEntity1
-            )
-            .arrange()
-
-        // when
-        val result = messageRepository.getConversationMessagesFromSearch(
-            searchQuery = searchTerm,
-            conversationId = conversationId
-        )
-
-        // then
-        assertEquals(
-            expectedMessages.size,
-            (result as Either.Right).value.size
-        )
-        assertEquals(
-            expectedMessages.first().id,
-            (result as Either.Right).value.first().id
-        )
-    }
-
-    @Test
     fun givenSearchedMessages_whenMessageIsSelected_thenReturnMessagePosition() = runTest {
         // given
         val qualifiedIdEntity = TEST_QUALIFIED_ID_ENTITY
@@ -692,17 +640,6 @@ class MessageRepositoryTest {
                 .suspendFunction(messageDAO::moveMessages)
                 .whenInvokedWith(any())
                 .thenThrow(throwable)
-        }
-
-        fun withMessagesFromSearch(
-            searchTerm: String,
-            conversationId: QualifiedIDEntity,
-            messages: List<MessageEntity>
-        ) = apply {
-            given(messageDAO)
-                .suspendFunction(messageDAO::getConversationMessagesFromSearch)
-                .whenInvokedWith(eq(searchTerm), eq(conversationId))
-                .thenReturn(messages)
         }
 
         fun withSelectedMessagePosition(

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/dao/message/MessageExtensions.kt
@@ -36,7 +36,6 @@ actual interface MessageExtensions {
         searchQuery: String,
         conversationId: ConversationIDEntity,
         pagingConfig: PagingConfig,
-        messageId: String,
         startingOffset: Int
     ): KaliumPager<MessageEntity>
 }
@@ -65,13 +64,12 @@ actual class MessageExtensionsImpl actual constructor(
         searchQuery: String,
         conversationId: ConversationIDEntity,
         pagingConfig: PagingConfig,
-        messageId: String,
         startingOffset: Int
     ): KaliumPager<MessageEntity> {
         // We could return a Flow directly, but having the PagingSource is the only way to test this
         return KaliumPager(
-            Pager(pagingConfig) { getMessagesSearchPagingSource(searchQuery, conversationId, messageId, startingOffset) },
-            getMessagesSearchPagingSource(searchQuery, conversationId, messageId, startingOffset),
+            Pager(pagingConfig) { getMessagesSearchPagingSource(searchQuery, conversationId, startingOffset) },
+            getMessagesSearchPagingSource(searchQuery, conversationId, startingOffset),
             coroutineContext
         )
     }
@@ -100,11 +98,10 @@ actual class MessageExtensionsImpl actual constructor(
     private fun getMessagesSearchPagingSource(
         searchQuery: String,
         conversationId: ConversationIDEntity,
-        messageId: String,
         initialOffset: Int
     ) =
         KaliumOffsetQueryPagingSource(
-            countQuery = messagesQueries.selectSearchedConversationMessagePosition(conversationId, messageId).toInt(),
+            countQuery = messagesQueries.countBySearchedMessageAndConversationId(searchQuery, conversationId).toInt(),
             transacter = messagesQueries,
             context = coroutineContext,
             initialOffset = initialOffset,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -518,12 +518,13 @@ WHERE text LIKE ('%' || :searchQuery || '%')
 AND conversationId = :conversationId
 AND contentType = 'TEXT'
 AND expireAfterMillis IS NULL
-ORDER BY date DESC;
+ORDER BY date DESC
+LIMIT :limit
+OFFSET :offset;
 
 selectSearchedConversationMessagePosition:
 SELECT COUNT(*) FROM Message
-WHERE
-conversation_id = :conversationId
+WHERE conversation_id = :conversationId
 AND creation_date >= (SELECT creation_date FROM Message WHERE id = :messageId LIMIT 1)
 AND expire_after_millis IS NULL
 ORDER BY creation_date DESC;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -522,6 +522,14 @@ ORDER BY date DESC
 LIMIT :limit
 OFFSET :offset;
 
+countBySearchedMessageAndConversationId:
+SELECT COUNT(*) FROM MessageDetailsView
+WHERE text LIKE ('%' || :searchQuery || '%')
+AND conversationId = :conversationId
+AND contentType = 'TEXT'
+AND expireAfterMillis IS NULL
+ORDER BY date DESC;
+
 selectSearchedConversationMessagePosition:
 SELECT COUNT(*) FROM Message
 WHERE conversation_id = :conversationId

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -135,10 +135,10 @@ interface MessageDAO {
 
     suspend fun moveMessages(from: ConversationIDEntity, to: ConversationIDEntity)
 
-    suspend fun getConversationMessagesFromSearch(
-        searchQuery: String,
-        conversationId: QualifiedIDEntity
-    ): List<MessageEntity>
+//     suspend fun getConversationMessagesFromSearch(
+//         searchQuery: String,
+//         conversationId: QualifiedIDEntity
+//     ): List<MessageEntity>
 
     suspend fun getSearchedConversationMessagePosition(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -135,11 +135,6 @@ interface MessageDAO {
 
     suspend fun moveMessages(from: ConversationIDEntity, to: ConversationIDEntity)
 
-//     suspend fun getConversationMessagesFromSearch(
-//         searchQuery: String,
-//         conversationId: QualifiedIDEntity
-//     ): List<MessageEntity>
-
     suspend fun getSearchedConversationMessagePosition(
         conversationId: QualifiedIDEntity,
         messageId: String

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -413,16 +413,16 @@ internal class MessageDAOImpl internal constructor(
             .distinctUntilChanged()
     }
 
-    override suspend fun getConversationMessagesFromSearch(
-        searchQuery: String,
-        conversationId: QualifiedIDEntity
-    ): List<MessageEntity> = withContext(coroutineContext) {
-        queries.selectConversationMessagesFromSearch(
-            searchQuery,
-            conversationId,
-            mapper::toEntityMessageFromView
-        ).executeAsList()
-    }
+//     override suspend fun getConversationMessagesFromSearch(
+//         searchQuery: String,
+//         conversationId: QualifiedIDEntity
+//     ): List<MessageEntity> = withContext(coroutineContext) {
+//         queries.selectConversationMessagesFromSearch(
+//             searchQuery,
+//             conversationId,
+//             mapper::toEntityMessageFromView
+//         ).executeAsList()
+//     }
 
     override suspend fun getSearchedConversationMessagePosition(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -413,17 +413,6 @@ internal class MessageDAOImpl internal constructor(
             .distinctUntilChanged()
     }
 
-//     override suspend fun getConversationMessagesFromSearch(
-//         searchQuery: String,
-//         conversationId: QualifiedIDEntity
-//     ): List<MessageEntity> = withContext(coroutineContext) {
-//         queries.selectConversationMessagesFromSearch(
-//             searchQuery,
-//             conversationId,
-//             mapper::toEntityMessageFromView
-//         ).executeAsList()
-//     }
-
     override suspend fun getSearchedConversationMessagePosition(
         conversationId: QualifiedIDEntity,
         messageId: String

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -1764,65 +1764,6 @@ class MessageDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenMessagesAreInserted_whenGettingConversationMessagesFromSearch_thenOnlyRelevantMessagesAreReturned() = runTest {
-        insertInitialData()
-
-        val otherUser = userEntity2
-
-        val expectedMessages = listOf(
-            newRegularMessageEntity(
-                "1",
-                conversationId = conversationEntity1.id,
-                status = MessageEntity.Status.SENT,
-                senderUserId = otherUser.id,
-                senderName = otherUser.name!!,
-                content = MessageEntityContent.Text("message10"),
-                date = Instant.parse("2022-03-30T15:36:00.000Z")
-            ),
-            newRegularMessageEntity(
-                "2",
-                conversationId = conversationEntity1.id,
-                status = MessageEntity.Status.SENT,
-                senderUserId = otherUser.id,
-                senderName = otherUser.name!!,
-                content = MessageEntityContent.Text("message11"),
-                date = Instant.parse("2022-03-30T15:36:01.000Z")
-            )
-        )
-
-        val allMessages = expectedMessages + listOf(
-            newRegularMessageEntity(
-                "3",
-                conversationId = conversationEntity1.id,
-                senderUserId = otherUser.id,
-                senderName = otherUser.name!!,
-                status = MessageEntity.Status.SENT,
-                content = MessageEntityContent.Text("message20"),
-                date = Instant.parse("2022-03-30T15:36:02.000Z")
-            ),
-            newRegularMessageEntity(
-                "4",
-                conversationId = conversationEntity1.id,
-                senderUserId = otherUser.id,
-                senderName = otherUser.name!!,
-                status = MessageEntity.Status.SENT,
-                content = MessageEntityContent.Text("message21"),
-                date = Instant.parse("2022-03-30T15:36:03.000Z")
-            )
-        )
-
-        messageDAO.insertOrIgnoreMessages(allMessages)
-
-        val result = messageDAO.getConversationMessagesFromSearch(
-            searchQuery = "message1",
-            conversationId = conversationEntity1.id
-        )
-
-        assertEquals(expectedMessages.size, result.size)
-        assertContentEquals(expectedMessages.sortedByDescending { it.date }, result)
-    }
-
-    @Test
     fun givenMessagesAreInserted_whenMessageIsSelected_thenReturnMessagePosition() = runTest {
         // given
         insertInitialData()
@@ -1875,66 +1816,6 @@ class MessageDAOTest : BaseDatabaseTest() {
 
         // then
         assertEquals(expectedPosition, result)
-    }
-
-    @Test
-    fun givenMessagesAreInserted_whenGettingConversationMessagesFromSearch_thenNoSelfDeletingMessagesAreReturned() = runTest {
-        insertInitialData()
-
-        val otherUser = userEntity2
-
-        val expectedMessages = listOf(
-            newRegularMessageEntity(
-                "1",
-                conversationId = conversationEntity1.id,
-                status = MessageEntity.Status.SENT,
-                senderUserId = otherUser.id,
-                senderName = otherUser.name!!,
-                content = MessageEntityContent.Text("message10"),
-                date = Instant.parse("2022-03-30T15:36:00.000Z")
-            ),
-            newRegularMessageEntity(
-                "2",
-                conversationId = conversationEntity1.id,
-                status = MessageEntity.Status.SENT,
-                senderUserId = otherUser.id,
-                senderName = otherUser.name!!,
-                content = MessageEntityContent.Text("message11"),
-                date = Instant.parse("2022-03-30T15:36:01.000Z")
-            )
-        )
-
-        val allMessages = expectedMessages + listOf(
-            newRegularMessageEntity(
-                "3",
-                conversationId = conversationEntity1.id,
-                status = MessageEntity.Status.SENT,
-                senderUserId = otherUser.id,
-                senderName = otherUser.name!!,
-                content = MessageEntityContent.Text("message12"),
-                date = Instant.parse("2022-03-30T15:36:02.000Z"),
-                expireAfterMs = 3600000L
-            ),
-            newRegularMessageEntity(
-                "4",
-                conversationId = conversationEntity1.id,
-                senderUserId = otherUser.id,
-                senderName = otherUser.name!!,
-                status = MessageEntity.Status.SENT,
-                content = MessageEntityContent.Text("message20"),
-                date = Instant.parse("2022-03-30T15:36:03.000Z")
-            )
-        )
-
-        messageDAO.insertOrIgnoreMessages(allMessages)
-
-        val result = messageDAO.getConversationMessagesFromSearch(
-            searchQuery = "message1",
-            conversationId = conversationEntity1.id
-        )
-
-        assertEquals(expectedMessages.size, result.size)
-        assertContentEquals(expectedMessages.sortedByDescending { it.date }, result)
     }
 
     private suspend fun insertInitialData() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was a bit of a performance issue when search result was extensive.

### Solutions

Added pagination to search result (now its so blazing fast that sometimes the loading icon doesn't even show 😢 )

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

AR PR will follow and it will be able to test the feature there.

### Notes (Optional)
![djk](https://github.com/wireapp/kalium/assets/5890660/6224bdf6-7dcf-402c-94aa-bfb95bb59a59)

