### PR TITLE
feat(mls): reevaluate protocol on demand [WPB-5049]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1552,7 +1552,8 @@ class UserSessionScope internal constructor(
             userStorage,
             userPropertyRepository,
             oneOnOneResolver,
-            this
+            this,
+            userScopedLogger
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.feature.conversation
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
@@ -92,7 +93,8 @@ class ConversationScope internal constructor(
     private val userStorage: UserStorage,
     userPropertyRepository: UserPropertyRepository,
     private val oneOnOneResolver: OneOnOneResolver,
-    private val scope: CoroutineScope
+    private val scope: CoroutineScope,
+    private val kaliumLogger: KaliumLogger
 ) {
 
     val getSelfTeamUseCase: GetSelfTeamUseCase
@@ -124,6 +126,13 @@ class ConversationScope internal constructor(
 
     val observeConversationDetails: ObserveConversationDetailsUseCase
         get() = ObserveConversationDetailsUseCase(conversationRepository)
+
+    val notifyConversationIsOpen: NotifyConversationIsOpenUseCase
+        get() = NotifyConversationIsOpenUseCaseImpl(
+            oneOnOneResolver,
+            conversationRepository,
+            kaliumLogger
+        )
 
     val observeIsSelfUserMemberUseCase: ObserveIsSelfUserMemberUseCase
         get() = ObserveIsSelfUserMemberUseCaseImpl(conversationRepository, selfUserId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/NotifyConversationIsOpenUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/NotifyConversationIsOpenUseCase.kt
@@ -48,7 +48,7 @@ internal class NotifyConversationIsOpenUseCaseImpl(
 
     override suspend operator fun invoke(conversationId: ConversationId) {
         kaliumLogger.v(
-            "Notifying that conversation with ID: $conversationId is open"
+            "Notifying that conversation with ID: ${conversationId.toLogString()} is open"
         )
         val conversation = conversationRepository.observeConversationDetailsById(conversationId)
             .filterIsInstance<Either.Right<ConversationDetails>>()
@@ -57,7 +57,7 @@ internal class NotifyConversationIsOpenUseCaseImpl(
 
         if (conversation is ConversationDetails.OneOne) {
             kaliumLogger.v(
-                "Reevaluating protocol for 1:1 conversation with ID: $conversationId"
+                "Reevaluating protocol for 1:1 conversation with ID: ${conversationId.toLogString()}"
             )
             oneOnOneResolver.resolveOneOnOneConversationWithUser(conversation.otherUser)
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/NotifyConversationIsOpenUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/NotifyConversationIsOpenUseCase.kt
@@ -1,0 +1,65 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
+import com.wire.kalium.logic.functional.Either
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+/**
+ * Used by the UI to notify Kalium that a conversation is open.
+ * It's useful so Kalium can lazily perform update operations and make sure
+ * that the conversation is up-to-date when the user opens it.
+ *
+ * One such operation is protocol reevaluation. So we can make sure
+ * that the conversation is using the latest agreed protocol when the user
+ * opens it.
+ */
+interface NotifyConversationIsOpenUseCase {
+    suspend operator fun invoke(conversationId: ConversationId)
+}
+
+internal class NotifyConversationIsOpenUseCaseImpl(
+    private val oneOnOneResolver: OneOnOneResolver,
+    private val conversationRepository: ConversationRepository,
+    private val kaliumLogger: KaliumLogger
+) : NotifyConversationIsOpenUseCase {
+
+    override suspend operator fun invoke(conversationId: ConversationId) {
+        kaliumLogger.v(
+            "Notifying that conversation with ID: $conversationId is open"
+        )
+        val conversation = conversationRepository.observeConversationDetailsById(conversationId)
+            .filterIsInstance<Either.Right<ConversationDetails>>()
+            .map { it.value }
+            .first()
+
+        if (conversation is ConversationDetails.OneOne) {
+            kaliumLogger.v(
+                "Reevaluating protocol for 1:1 conversation with ID: $conversationId"
+            )
+            oneOnOneResolver.resolveOneOnOneConversationWithUser(conversation.otherUser)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/NotifyConversationIsOpenUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/NotifyConversationIsOpenUseCaseTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.framework.TestConversationDetails
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
+import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import io.mockative.any
+import io.mockative.eq
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class NotifyConversationIsOpenUseCaseTest {
+
+    @Test
+    fun givenConversationId_whenInvoking_thenShouldGetDetailsFromRepository() = runTest {
+        val details = TestConversationDetails.CONVERSATION_GROUP
+        val (arrangement, notifyConversationIsOpenUseCase) = arrange {
+            withObserveConversationDetailsByIdReturning(
+                Either.Right(details)
+            )
+        }
+        notifyConversationIsOpenUseCase.invoke(details.conversation.id)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::observeConversationDetailsById)
+            .with(eq(details.conversation.id))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenGroupConversationId_whenInvoking_thenShouldNotUseResolver() = runTest {
+        val details = TestConversationDetails.CONVERSATION_GROUP
+        val (arrangement, notifyConversationIsOpenUseCase) = arrange {
+            withObserveConversationDetailsByIdReturning(
+                Either.Right(details)
+            )
+        }
+        notifyConversationIsOpenUseCase.invoke(details.conversation.id)
+
+        verify(arrangement.oneOnOneResolver)
+            .suspendFunction(arrangement.oneOnOneResolver::resolveOneOnOneConversationWithUser)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenOneOnOneConversationId_whenInvoking_thenShouldResolveProtocolForUser() = runTest {
+        val details = TestConversationDetails.CONVERSATION_ONE_ONE
+        val (arrangement, notifyConversationIsOpenUseCase) = arrange {
+            withObserveConversationDetailsByIdReturning(
+                Either.Right(details)
+            )
+            withResolveOneOnOneConversationWithUserReturning(
+                Either.Right(details.conversation.id)
+            )
+        }
+        notifyConversationIsOpenUseCase.invoke(details.conversation.id)
+
+        verify(arrangement.oneOnOneResolver)
+            .suspendFunction(arrangement.oneOnOneResolver::resolveOneOnOneConversationWithUser)
+            .with(eq(details.otherUser))
+            .wasInvoked(exactly = once)
+    }
+
+    private class Arrangement(
+        private val configure: Arrangement.() -> Unit
+    ) : OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl(),
+        ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl() {
+        fun arrange(): Pair<Arrangement, NotifyConversationIsOpenUseCase> = run {
+            configure()
+            this@Arrangement to NotifyConversationIsOpenUseCaseImpl(
+                oneOnOneResolver = oneOnOneResolver,
+                conversationRepository = conversationRepository,
+                kaliumLogger = kaliumLogger
+            )
+        }
+    }
+
+    private companion object {
+        fun arrange(configure: Arrangement.() -> Unit) = Arrangement(configure).arrange()
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We should have a fallback / safety net for 1:1 migrations.

### Solutions

Expose a way to notify Kalium that a conversation is being displayed to the user.
This way, Kalium can do some sanity checks.

When calling `NotifyConversationIsOpenUseCase`, Kalium can check if the conversation is 1:1 and if its protocol is up-to-date.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
