### PR TITLE
feat(e2ei): replace keypackages in one api (WPB-5801)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -536,13 +536,8 @@ internal class MLSConversationDataSource(
         }.map { rotateBundle ->
             // todo: make below API calls atomic when the backend does it in one request
             // todo: store keypackages to drop, later drop them again
-            kaliumLogger.w("drop old key packages after conversations migration")
-            keyPackageRepository.deleteKeyPackages(clientId, rotateBundle.keyPackageRefsToRemove).flatMapLeft {
-                return Either.Left(it)
-            }
-
-            kaliumLogger.w("upload new key packages including x509 certificate")
-            keyPackageRepository.uploadKeyPackages(clientId, rotateBundle.newKeyPackages).flatMapLeft {
+            kaliumLogger.w("upload new keypackages and drop old ones")
+            keyPackageRepository.replaceKeyPackages(clientId, rotateBundle.newKeyPackages).flatMapLeft {
                 return Either.Left(it)
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -45,7 +45,7 @@ interface KeyPackageRepository {
 
     suspend fun uploadKeyPackages(clientId: ClientId, keyPackages: List<ByteArray>): Either<CoreFailure, Unit>
 
-    suspend fun deleteKeyPackages(clientId: ClientId, keyPackages: List<ByteArray>): Either<CoreFailure, Unit>
+    suspend fun replaceKeyPackages(clientId: ClientId, keyPackages: List<ByteArray>): Either<CoreFailure, Unit>
 
     suspend fun getAvailableKeyPackageCount(clientId: ClientId): Either<NetworkFailure, KeyPackageCountDTO>
 
@@ -99,12 +99,12 @@ class KeyPackageDataSource(
             keyPackageApi.uploadKeyPackages(clientId.value, keyPackages.map { it.encodeBase64() })
         }
 
-    override suspend fun deleteKeyPackages(
+    override suspend fun replaceKeyPackages(
         clientId: ClientId,
         keyPackages: List<ByteArray>
     ): Either<CoreFailure, Unit> =
         wrapApiRequest {
-            keyPackageApi.deleteKeyPackages(clientId.value, keyPackages.map { it.encodeBase64() })
+            keyPackageApi.replaceKeyPackages(clientId.value, keyPackages.map { it.encodeBase64() })
         }
 
     override suspend fun validKeyPackageCount(clientId: ClientId): Either<CoreFailure, Int> =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1117,8 +1117,7 @@ class MLSConversationRepositoryTest {
             .withGetMLSClientSuccessful()
             .withRotateAllSuccessful()
             .withSendCommitBundleSuccessful()
-            .withUploadKeyPackagesReturning(Either.Right(Unit))
-            .withDeleteKeyPackagesReturning(Either.Right(Unit))
+            .withReplaceKeyPackagesReturning(Either.Right(Unit))
             .arrange()
 
         assertEquals(
@@ -1132,12 +1131,7 @@ class MLSConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(arrangement.keyPackageRepository)
-            .suspendFunction(arrangement.keyPackageRepository::deleteKeyPackages)
-            .with(any(), any())
-            .wasInvoked(once)
-
-        verify(arrangement.keyPackageRepository)
-            .suspendFunction(arrangement.keyPackageRepository::uploadKeyPackages)
+            .suspendFunction(arrangement.keyPackageRepository::replaceKeyPackages)
             .with(any(), any())
             .wasInvoked(once)
 
@@ -1148,12 +1142,11 @@ class MLSConversationRepositoryTest {
     }
 
     @Test
-    fun givenDropKeypackagesFailed_whenRotatingKeysAndMigratingConversation_thenReturnsFailure() = runTest {
+    fun givenReplacingKeypackagesFailed_whenRotatingKeysAndMigratingConversation_thenReturnsFailure() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetMLSClientSuccessful()
             .withRotateAllSuccessful()
-            .withUploadKeyPackagesReturning(Either.Right(Unit))
-            .withDeleteKeyPackagesReturning(TEST_FAILURE)
+            .withReplaceKeyPackagesReturning(TEST_FAILURE)
             .withSendCommitBundleSuccessful()
             .arrange()
 
@@ -1168,48 +1161,7 @@ class MLSConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(arrangement.keyPackageRepository)
-            .suspendFunction(arrangement.keyPackageRepository::deleteKeyPackages)
-            .with(any(), any())
-            .wasInvoked(once)
-
-        verify(arrangement.keyPackageRepository)
-            .suspendFunction(arrangement.keyPackageRepository::uploadKeyPackages)
-            .with(any(), any())
-            .wasNotInvoked()
-
-        verify(arrangement.mlsMessageApi)
-            .suspendFunction(arrangement.mlsMessageApi::sendCommitBundle)
-            .with(anyInstanceOf(MLSMessageApi.CommitBundle::class))
-            .wasNotInvoked()
-    }
-
-    @Test
-    fun givenUploadKeypackagesFailed_whenRotatingKeysAndMigratingConversation_thenReturnsFailure() = runTest {
-        val (arrangement, mlsConversationRepository) = Arrangement()
-            .withGetMLSClientSuccessful()
-            .withRotateAllSuccessful()
-            .withUploadKeyPackagesReturning(TEST_FAILURE)
-            .withDeleteKeyPackagesReturning(Either.Right(Unit))
-            .withSendCommitBundleSuccessful()
-            .arrange()
-
-        assertEquals(
-            TEST_FAILURE,
-            mlsConversationRepository.rotateKeysAndMigrateConversations(TestClient.CLIENT_ID, arrangement.e2eiClient, "")
-        )
-
-        verify(arrangement.mlsClient)
-            .suspendFunction(arrangement.mlsClient::e2eiRotateAll)
-            .with(any(), any(), any())
-            .wasInvoked(once)
-
-        verify(arrangement.keyPackageRepository)
-            .suspendFunction(arrangement.keyPackageRepository::deleteKeyPackages)
-            .with(any(), any())
-            .wasInvoked(once)
-
-        verify(arrangement.keyPackageRepository)
-            .suspendFunction(arrangement.keyPackageRepository::uploadKeyPackages)
+            .suspendFunction(arrangement.keyPackageRepository::replaceKeyPackages)
             .with(any(), any())
             .wasInvoked(once)
 
@@ -1224,8 +1176,7 @@ class MLSConversationRepositoryTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetMLSClientSuccessful()
             .withRotateAllSuccessful()
-            .withUploadKeyPackagesReturning(Either.Right(Unit))
-            .withDeleteKeyPackagesReturning(Either.Right(Unit))
+            .withReplaceKeyPackagesReturning(Either.Right(Unit))
             .withSendCommitBundleFailing(Arrangement.MLS_CLIENT_MISMATCH_ERROR, times = 1)
             .arrange()
 
@@ -1239,12 +1190,7 @@ class MLSConversationRepositoryTest {
             .wasInvoked(once)
 
         verify(arrangement.keyPackageRepository)
-            .suspendFunction(arrangement.keyPackageRepository::deleteKeyPackages)
-            .with(any(), any())
-            .wasInvoked(once)
-
-        verify(arrangement.keyPackageRepository)
-            .suspendFunction(arrangement.keyPackageRepository::uploadKeyPackages)
+            .suspendFunction(arrangement.keyPackageRepository::replaceKeyPackages)
             .with(any(), any())
             .wasInvoked(once)
 
@@ -1392,16 +1338,9 @@ class MLSConversationRepositoryTest {
                 .then { Either.Right(keyPackages) }
         }
 
-        fun withUploadKeyPackagesReturning(result: Either<CoreFailure, Unit>) = apply {
+        fun withReplaceKeyPackagesReturning(result: Either<CoreFailure, Unit>) = apply {
             given(keyPackageRepository)
-                .suspendFunction(keyPackageRepository::uploadKeyPackages)
-                .whenInvokedWith(anything(), anything())
-                .thenReturn(result)
-        }
-
-        fun withDeleteKeyPackagesReturning(result: Either<CoreFailure, Unit>) = apply {
-            given(keyPackageRepository)
-                .suspendFunction(keyPackageRepository::deleteKeyPackages)
+                .suspendFunction(keyPackageRepository::replaceKeyPackages)
                 .whenInvokedWith(anything(), anything())
                 .thenReturn(result)
         }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/keypackage/KeyPackageApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/keypackage/KeyPackageApi.kt
@@ -54,13 +54,13 @@ interface KeyPackageApi {
     suspend fun uploadKeyPackages(clientId: String, keyPackages: List<KeyPackage>): NetworkResponse<Unit>
 
     /**
-     * Delete a batch key packages from the server
+     * Upload and replace a batch fresh key packages from the self client
      *
      * @param clientId client ID
      * @param keyPackages list of key packages
      *
      */
-    suspend fun deleteKeyPackages(clientId: String, keyPackages: List<KeyPackage>): NetworkResponse<Unit>
+    suspend fun replaceKeyPackages(clientId: String, keyPackages: List<KeyPackage>): NetworkResponse<Unit>
 
     /**
      * Get the number of available key packages for the self client

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/KeyPackageApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/KeyPackageApiV0.kt
@@ -39,11 +39,11 @@ internal open class KeyPackageApiV0 internal constructor() : KeyPackageApi {
         APINotSupported("MLS: uploadKeyPackages api is only available on API V5")
     )
 
-    override suspend fun deleteKeyPackages(
+    override suspend fun replaceKeyPackages(
         clientId: String,
         keyPackages: List<KeyPackage>
     ): NetworkResponse<Unit> = NetworkResponse.Error(
-        APINotSupported("MLS: uploadKeyPackages api is only available on API V5")
+        APINotSupported("MLS: replaceKeyPackages api is only available on API V5")
     )
 
     override suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO> =

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
@@ -32,6 +32,7 @@ import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 
 internal open class KeyPackageApiV5 internal constructor(
@@ -60,13 +61,13 @@ internal open class KeyPackageApiV5 internal constructor(
             }
         }
 
-    override suspend fun deleteKeyPackages(
+    override suspend fun replaceKeyPackages(
         clientId: String,
         keyPackages: List<KeyPackage>
     ): NetworkResponse<Unit> =
         wrapKaliumResponse {
-            kaliumLogger.v("Keypackages Count to delete: ${keyPackages.size}")
-            httpClient.delete("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId") {
+            kaliumLogger.v("Keypackages Count to replace: ${keyPackages.size}")
+            httpClient.put("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId") {
                 setBody(KeyPackageList(keyPackages))
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Use one atomic api to replace new keypackages with the old ones.

### Issues

The API wasn't ready, so we had to use two APIs to achieve this! now it's replaced with the atomic one.

### Causes (Optional)

API wasn't ready at the time.

### Solutions

Using the new API.


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
