### PR TITLE
fix: cert pinning failing for GET:/api-version

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -33,7 +33,7 @@ data class KaliumConfigs(
     val lowerKeyPackageLimits: Boolean = false,
     val lowerKeyingMaterialsUpdateThreshold: Boolean = false,
     val developmentApiEnabled: Boolean = false,
-    val ignoreSSLCertificatesForUnboundCalls: Boolean = true,
+    val ignoreSSLCertificatesForUnboundCalls: Boolean = false,
     val guestRoomLink: Boolean = true,
     val selfDeletingMessages: Boolean = true,
     val wipeOnCookieInvalid: Boolean = false,

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -65,7 +65,7 @@ actual fun defaultHttpEngine(
     certificatePinning: CertificatePinning
 ): HttpClientEngine = OkHttp.create {
     OkHttpSingleton.createNew {
-        if (certificatePinning.isNotEmpty()) {
+        if (certificatePinning.isNotEmpty() && !ignoreSSLCertificates) {
             val certPinner = CertificatePinner.Builder().apply {
                 certificatePinning.forEach { (cert, hosts) ->
                     hosts.forEach { host ->


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

cert pinning failing for GET:/api-version only

### Solutions

there is a flag to ignore ssl cert in unbound network client for e2ei and that flag should be true only in debug mode and it was not, it should not have effected any users in prod 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
