### PR TITLE
refactor: create a new okhttp client for each user on jvm target

### DIFF
--- a/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
+++ b/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
@@ -24,15 +24,17 @@ import java.util.concurrent.TimeUnit
 fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpSingleton.createNew(block)
 
 private object OkHttpSingleton {
-    private val sharedClient = OkHttpClient.Builder().apply {
-        // OkHttp doesn't support configuring ping intervals dynamically,
-        // so they must be set when creating the Engine
-        // See https://youtrack.jetbrains.com/issue/KTOR-4752
-        pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS)
-            .connectTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
-            .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
-            .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
-    }.connectionSpecs(supportedConnectionSpecs()).build()
+    private val sharedClient by lazy {
+        OkHttpClient.Builder().apply {
+            // OkHttp doesn't support configuring ping intervals dynamically,
+            // so they must be set when creating the Engine
+            // See https://youtrack.jetbrains.com/issue/KTOR-4752
+            pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS)
+                .connectTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+        }.connectionSpecs(supportedConnectionSpecs()).build()
+    }
 
     fun createNew(block: OkHttpClient.Builder.() -> Unit): OkHttpClient {
         return sharedClient.newBuilder().apply(block).build()

--- a/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
+++ b/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
@@ -20,7 +20,9 @@ package com.wire.kalium.network
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
-fun OkhttpClientfactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpSingleton.createNew(block)
+@Suppress("FunctionName")
+fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpSingleton.createNew(block)
+
 private object OkHttpSingleton {
     private val sharedClient = OkHttpClient.Builder().apply {
         // OkHttp doesn't support configuring ping intervals dynamically,

--- a/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientfactory.kt
+++ b/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientfactory.kt
@@ -1,0 +1,38 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network
+
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+fun OkhttpClientfactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpSingleton.createNew(block)
+private object OkHttpSingleton {
+    private val sharedClient = OkHttpClient.Builder().apply {
+        // OkHttp doesn't support configuring ping intervals dynamically,
+        // so they must be set when creating the Engine
+        // See https://youtrack.jetbrains.com/issue/KTOR-4752
+        pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS)
+            .connectTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+            .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+            .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+    }.connectionSpecs(supportedConnectionSpecs()).build()
+
+    fun createNew(block: OkHttpClient.Builder.() -> Unit): OkHttpClient {
+        return sharedClient.newBuilder().apply(block).build()
+    }
+}

--- a/network/src/androidUnitTest/kotlin/com/wire/kalium/api/tools/HttpClientConnectionSpecsTest.kt
+++ b/network/src/androidUnitTest/kotlin/com/wire/kalium/api/tools/HttpClientConnectionSpecsTest.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium
+package com.wire.kalium.api.tools
 
 import com.wire.kalium.network.OkhttpClientFactory
 import okhttp3.CipherSuite

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -35,7 +35,6 @@ import java.net.PasswordAuthentication
 import java.net.Proxy
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
-import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
@@ -46,7 +45,7 @@ actual fun defaultHttpEngine(
     ignoreSSLCertificates: Boolean,
     certificatePinning: CertificatePinning
 ): HttpClientEngine = OkHttp.create {
-    OkhttpClientfactory {
+    OkhttpClientFactory {
         if (certificatePinning.isNotEmpty()) {
             val certPinner = CertificatePinner.Builder().apply {
                 certificatePinning.forEach { (cert, hosts) ->

--- a/network/src/jvmMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
+++ b/network/src/jvmMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
@@ -20,16 +20,16 @@ package com.wire.kalium.network
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
-fun OkhttpClientfactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpClient.Builder()
+@Suppress("FunctionName")
+fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpClient.Builder()
     .apply(block)
     .apply {
 
-    // OkHttp doesn't support configuring ping intervals dynamically,
-    // so they must be set when creating the Engine
-    // See https://youtrack.jetbrains.com/issue/KTOR-4752
-    pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS)
-        .connectTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
-        .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
-        .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
-}.connectionSpecs(supportedConnectionSpecs()).build()
-
+        // OkHttp doesn't support configuring ping intervals dynamically,
+        // so they must be set when creating the Engine
+        // See https://youtrack.jetbrains.com/issue/KTOR-4752
+        pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS)
+            .connectTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+            .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+            .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+    }.connectionSpecs(supportedConnectionSpecs()).build()

--- a/network/src/jvmMain/kotlin/com/wire/kalium/network/OkhttpClientfactory.kt
+++ b/network/src/jvmMain/kotlin/com/wire/kalium/network/OkhttpClientfactory.kt
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network
+
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+fun OkhttpClientfactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpClient.Builder()
+    .apply(block)
+    .apply {
+
+    // OkHttp doesn't support configuring ping intervals dynamically,
+    // so they must be set when creating the Engine
+    // See https://youtrack.jetbrains.com/issue/KTOR-4752
+    pingInterval(WEBSOCKET_PING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS)
+        .connectTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+        .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+        .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
+}.connectionSpecs(supportedConnectionSpecs()).build()
+


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

test services are limited on the number of web socket connection that can be created

### Solutions

it was solved temporary by reverting the commit only for the test service branch, but now this is a permanent fix, that refactor the way Okhttp client are created bu using a Singleton in Android and createing a new one each time on jvm

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
