### PR TITLE
fix: Duplicated system message about degraded conversation (WPB-5878)

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -16,6 +16,12 @@ insertMember:
 INSERT OR IGNORE INTO Member(user, conversation, role)
 VALUES (?, ?, ?);
 
+insertOrUpdateMember:
+INSERT INTO Member(user, conversation, role)
+VALUES (?, ?, ?)
+ON CONFLICT(user, conversation) DO UPDATE SET
+role = excluded.role;
+
 deleteMember:
 DELETE FROM Member WHERE conversation = ? AND user = ?;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/member/MemberDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/member/MemberDAO.kt
@@ -182,7 +182,7 @@ internal class MemberDAOImpl internal constructor(
 
                 memberList.forEach { member ->
                     userQueries.insertOrIgnoreUserId(member.user)
-                    memberQueries.insertMember(member.user, conversationID, member.role)
+                    memberQueries.insertOrUpdateMember(member.user, conversationID, member.role)
                 }
 
                 membersToDelete.forEach { member ->


### PR DESCRIPTION
# What's new in this PR?

### Issues

When some other user adds a new client AND conversation with that user was already "proteus-verified", then 3 system messages are added into that conversation: 1. conversation degraded; 2. conversation verified; 3. conversation degraded.

<img width="461" alt="Screenshot 2023-12-14 at 14 13 18" src="https://github.com/wireapp/kalium/assets/6539347/cf642332-7946-48de-919b-2b9e1d84e3aa">


There should be only 1 message "Conversation degraded", as a new client is not verified.

### Causes (Optional)

`MessageSendFailureHandlerImpl` which is called in case when sending message is not prepared for some client (for that new client in our case), calls also `ConversationRepository.fetchConversation()` which calls `MemberDAO.updateFullMemberList`. This `updateFullMemberList` removes all the members from the conversation and adds only the members that should be there. 

But at the moment when all the members are removed from the conversation DB-trigger runs and it "decides" that the conversation is verified as all the members are verified (no members -> no unverified members -> conversation is verified). 
That's why user sees the message "Conversation is verified". 

Then all the valid members are added into the conversation and the same DB-trigger "decides" that conversation is not verified any more -> adds a new system message.

### Solutions

Update `MemberDAO.updateFullMemberList`:
Instead of removing all the members from the conversation before saving only valid - add all the valid members and after that remove only members that should be removed.
