### PR TITLE
fix: legal hold disabled info is shown right after logging in [W-4870]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
@@ -49,8 +49,11 @@ internal class LegalHoldHandlerImpl internal constructor(
         val userHasBeenUnderLegalHold = isUserUnderLegalHold(legalHoldEnabled.userId)
         // fetch and persist current clients for the given user
         processEvent(selfUserId, legalHoldEnabled.userId)
-        // create system messages only if legal hold status has changed for the given user
+        // create system messages and notify only if legal hold status has changed for the given user
         if (!userHasBeenUnderLegalHold) {
+            if (selfUserId == legalHoldEnabled.userId) { // notify only for self user
+                userConfigRepository.setLegalHoldChangeNotified(false)
+            }
             legalHoldSystemMessagesHandler.handleEnable(legalHoldEnabled.userId)
         }
 
@@ -63,8 +66,11 @@ internal class LegalHoldHandlerImpl internal constructor(
         val userHasBeenUnderLegalHold = isUserUnderLegalHold(legalHoldDisabled.userId)
         // fetch and persist current clients for the given user
         processEvent(selfUserId, legalHoldDisabled.userId)
-        // create system messages only if legal hold status has changed for the given user
+        // create system messages and notify only if legal hold status has changed for the given user
         if (userHasBeenUnderLegalHold) {
+            if (selfUserId == legalHoldDisabled.userId) { // notify only for self user
+                userConfigRepository.setLegalHoldChangeNotified(false)
+            }
             legalHoldSystemMessagesHandler.handleDisable(legalHoldDisabled.userId)
         }
 
@@ -75,7 +81,6 @@ internal class LegalHoldHandlerImpl internal constructor(
         if (selfUserId == userId) {
             userConfigRepository.deleteLegalHoldRequest()
             fetchSelfClientsFromRemote()
-            userConfigRepository.setLegalHoldChangeNotified(false)
         } else {
             persistOtherUserClients(userId)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
@@ -97,6 +97,22 @@ class LegalHoldHandlerTest {
     }
 
     @Test
+    fun givenUserLegalHoldDisabled_whenHandlingEnable_thenCreateOrUpdateSystemMessages() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Disabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .arrange()
+        // when
+        handler.handleEnable(legalHoldEventEnabled)
+        // then
+        verify(arrangement.legalHoldSystemMessagesHandler)
+            .suspendFunction(arrangement.legalHoldSystemMessagesHandler::handleEnable)
+            .with(any())
+            .wasInvoked()
+    }
+
+    @Test
     fun givenUserLegalHoldEnabled_whenHandlingEnable_thenDoNotCreateOrUpdateSystemMessages() = runTest {
         // given
         val (arrangement, handler) = Arrangement()
@@ -113,6 +129,22 @@ class LegalHoldHandlerTest {
     }
 
     @Test
+    fun givenUserLegalHoldEnabled_whenHandlingDisable_thenCreateOrUpdateSystemMessages() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Enabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .arrange()
+        // when
+        handler.handleDisable(legalHoldEventDisabled)
+        // then
+        verify(arrangement.legalHoldSystemMessagesHandler)
+            .suspendFunction(arrangement.legalHoldSystemMessagesHandler::handleDisable)
+            .with(any())
+            .wasInvoked()
+    }
+
+    @Test
     fun givenUserLegalHoldDisabled_whenHandlingDisable_thenDoNotCreateOrUpdateSystemMessages() = runTest {
         // given
         val (arrangement, handler) = Arrangement()
@@ -123,6 +155,102 @@ class LegalHoldHandlerTest {
         // then
         verify(arrangement.legalHoldSystemMessagesHandler)
             .suspendFunction(arrangement.legalHoldSystemMessagesHandler::handleDisable)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenUserLegalHoldEnabled_whenHandlingEnable_thenDoNotSetLegalHoldChangeNotified() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Enabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .arrange()
+        // when
+        handler.handleEnable(legalHoldEventEnabled)
+        // then
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::setLegalHoldChangeNotified)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenUserLegalHoldDisabled_whenHandlingEnableForSelf_thenSetLegalHoldChangeNotifiedAsFalse() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Disabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .arrange()
+        // when
+        handler.handleEnable(legalHoldEventEnabled.copy(userId = TestUser.SELF.id))
+        // then
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::setLegalHoldChangeNotified)
+            .with(eq(false))
+            .wasInvoked()
+    }
+
+    @Test
+    fun givenUserLegalHoldDisabled_whenHandlingEnableForOther_thenDoNotSetLegalHoldChangeNotified() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Disabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .arrange()
+        // when
+        handler.handleEnable(legalHoldEventEnabled.copy(userId = TestUser.OTHER_USER_ID))
+        // then
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::setLegalHoldChangeNotified)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenUserLegalHoldDisabled_whenHandlingDisable_thenDoNotSetLegalHoldChangeNotified() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Disabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .arrange()
+        // when
+        handler.handleDisable(legalHoldEventDisabled)
+        // then
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::setLegalHoldChangeNotified)
+            .with(any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenUserLegalHoldEnabled_whenHandlingDisableForSelf_thenSetLegalHoldChangeNotifiedAsFalse() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Enabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .arrange()
+        // when
+        handler.handleDisable(legalHoldEventDisabled.copy(userId = TestUser.SELF.id))
+        // then
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::setLegalHoldChangeNotified)
+            .with(eq(false))
+            .wasInvoked()
+    }
+
+    @Test
+    fun givenUserLegalHoldEnabled_whenHandlingDisableForOther_thenDoNotSetLegalHoldChangeNotified() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Enabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .arrange()
+        // when
+        handler.handleDisable(legalHoldEventDisabled.copy(userId = TestUser.OTHER_USER_ID))
+        // then
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::setLegalHoldChangeNotified)
             .with(any())
             .wasNotInvoked()
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user isn’t under legal hold, he gets the “no longer under legal hold” dialog message right after logging in.

### Causes (Optional)

Status whether the user has been notified about the legal hold change is updated every time legal hold event is handled, so during the slow sync, even if there hasn't been any change to the legal hold status for the user.

### Solutions

Update this flag only when legal hold status changes for the current user.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Login with account that isn't under legal hold and see if the dialog informing about legal hold disabled is shown right after logging in.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
