### PR TITLE
fix: E2EI required: grace period in seconds (WPB-5771)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -134,7 +134,7 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
         E2EIModel(
             E2EIConfigModel(
                 data?.config?.url ?: "",
-                data?.config?.verificationExpirationNS ?: 0L
+                data?.config?.verificationExpirationSeconds ?: 0L
             ),
             fromDTO(data?.status ?: FeatureFlagStatusDTO.DISABLED)
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -100,5 +100,5 @@ data class E2EIModel(
 
 data class E2EIConfigModel(
     val discoverUrl: String,
-    val verificationExpirationNS: Long
+    val verificationExpirationSeconds: Long
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/E2EIConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/E2EIConfigHandler.kt
@@ -24,7 +24,6 @@ import com.wire.kalium.logic.data.featureConfig.E2EIModel
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.util.DateTimeUtil
-import kotlinx.datetime.Instant
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -32,12 +31,13 @@ class E2EIConfigHandler(
     private val userConfigRepository: UserConfigRepository,
 ) {
     fun handle(e2eiConfig: E2EIModel): Either<CoreFailure, Unit> {
-        val gracePeriodEndMs = e2eiConfig.config.verificationExpirationNS.toDuration(DurationUnit.NANOSECONDS).inWholeMilliseconds
+        val gracePeriodEnd = DateTimeUtil.currentInstant()
+            .plus(e2eiConfig.config.verificationExpirationSeconds.toDuration(DurationUnit.SECONDS))
         userConfigRepository.setE2EISettings(
             E2EISettings(
                 isRequired = e2eiConfig.status == Status.ENABLED,
                 discoverUrl = e2eiConfig.config.discoverUrl,
-                gracePeriodEnd = Instant.fromEpochMilliseconds(gracePeriodEndMs)
+                gracePeriodEnd = gracePeriodEnd
             )
         )
         return userConfigRepository.setE2EINotificationTime(DateTimeUtil.currentInstant())

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -117,7 +117,7 @@ data class E2EIConfigDTO(
     @SerialName("acmeDiscoveryUrl")
     val url: String?,
     @SerialName("verificationExpiration")
-    val verificationExpirationNS: Long = 0L
+    val verificationExpirationSeconds: Long = 0L
 )
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
@@ -458,7 +458,7 @@ class UserConfigStorageImpl(
             E2EI_NOTIFICATION_TIME,
             timeStamp
         ).also {
-            e2EIFlow.tryEmit(Unit)
+            e2EINotificationFlow.tryEmit(Unit)
         }
     }
 


### PR DESCRIPTION
# What's new in this PR?

### Issues

in `E2EIConfig` API response we were expecting that field `verificationExpiration` is timestamp of the end of the grace period in nano-seconds. In fact it's amount of seconds that left till the end of grace period (stating from the moment when we receive that info). So needed to update `E2EIConfigHandler`

### Causes (Optional)

It wasn't documented well.

### Solutions

Update `E2EIConfigHandler` and tests.

