### PR TITLE
fix: location replies not displayed (WPB-5951)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/MessageContentEncoder.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/MessageContentEncoder.kt
@@ -80,8 +80,8 @@ class MessageContentEncoder {
     }
 
     private fun encodeLocationCoordinates(latitude: Float, longitude: Float, messageTimeStampInMillis: Long): EncodedMessageContent {
-        val latitudeBEBytes = (latitude * 1000).roundToLong().toByteArray()
-        val longitudeBEBytes = (longitude * 1000).roundToLong().toByteArray()
+        val latitudeBEBytes = (latitude * COORDINATES_ROUNDING).roundToLong().toByteArray()
+        val longitudeBEBytes = (longitude * COORDINATES_ROUNDING).roundToLong().toByteArray()
 
         return EncodedMessageContent(latitudeBEBytes + longitudeBEBytes + encodeMessageTimeStampInMillis(messageTimeStampInMillis))
     }
@@ -94,6 +94,7 @@ class MessageContentEncoder {
 
     private companion object {
         const val MILLIS_IN_SEC = 1000
+        const val COORDINATES_ROUNDING = 1000
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/MessageContentEncoder.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/MessageContentEncoder.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.util.DateTimeUtil.toEpochMillis
 import com.wire.kalium.util.long.toByteArray
 import com.wire.kalium.util.string.toHexString
 import com.wire.kalium.util.string.toUTF16BEByteArray
+import kotlin.math.roundToLong
 
 class MessageContentEncoder {
     fun encodeMessageContent(messageDate: String, messageContent: MessageContent): EncodedMessageContent? {
@@ -40,6 +41,14 @@ class MessageContentEncoder {
                     messageTimeStampInMillis = messageDate.toEpochMillis(),
                     messageTextBody = messageContent.value
                 )
+
+            is MessageContent.Location -> with(messageContent) {
+                encodeLocationCoordinates(
+                    latitude = latitude,
+                    longitude = longitude,
+                    messageTimeStampInMillis = messageDate.toEpochMillis()
+                )
+            }
 
             else -> {
                 kaliumLogger.w("Attempting to encode message with unsupported content type")
@@ -68,6 +77,13 @@ class MessageContentEncoder {
         val messageTimeStampInSec = messageTimeStampInMillis / MILLIS_IN_SEC
 
         return messageTimeStampInSec.toByteArray()
+    }
+
+    private fun encodeLocationCoordinates(latitude: Float, longitude: Float, messageTimeStampInMillis: Long): EncodedMessageContent {
+        val latitudeBEBytes = (latitude * 1000).roundToLong().toByteArray()
+        val longitudeBEBytes = (longitude * 1000).roundToLong().toByteArray()
+
+        return EncodedMessageContent(latitudeBEBytes + longitudeBEBytes + encodeMessageTimeStampInMillis(messageTimeStampInMillis))
     }
 
     private fun wrapIntoResult(messageTimeStampByteArray: ByteArray, messageTextBodyUTF16BE: ByteArray): EncodedMessageContent {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/MessageContentEncoderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/MessageContentEncoderTest.kt
@@ -126,6 +126,19 @@ class MessageContentEncoderTest {
         assertEquals(result.sha256Digest.toHexString(), markDown.second.second)
     }
 
+    @Test
+    fun givenALocationMessage_whenEncoding_ThenResultHasExpectedSHA256HashResult() = runTest {
+        val (locationMessage, messageDate, expectedHash) = location
+        val result = messageContentEncoder.encodeMessageContent(
+            messageDate = messageDate,
+            messageContent = locationMessage
+        )
+
+        // then
+        assertNotNull(result)
+        assertEquals(expectedHash, result.sha256Digest.toHexString())
+    }
+
     private companion object TestData {
         val textWithEmoji =
             (
@@ -165,5 +178,11 @@ class MessageContentEncoderTest {
                 "0005bcdcccd" to
                 "f25a925d55116800e66872d2a82d8292adf1d4177195703f976bc884d32b5c94"
                 )
+
+        val location = Triple(
+            MessageContent.Location(52.516666f, 13.4f, "someLocation", 10),
+            "2018-10-22T15:09:29.000+02:00",
+            "56a5fa30081bc16688574fdfbbe96c2eee004d1fb37dc714eec6efb340192816"
+        )
     }
 }

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/long/toByteArray.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/long/toByteArray.kt
@@ -18,6 +18,9 @@
 
 package com.wire.kalium.util.long
 
+/**
+ * Converts a Long into a Byte Array Big Endian.
+ */
 @Suppress("MagicNumber")
 fun Long.toByteArray(): ByteArray {
     val result = ByteArray(Long.SIZE_BYTES)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Location replies not displayed with data.

### Causes (Optional)

Hash encoded verification for location messages, not implemented.

### Solutions

Implement according to [docs](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/157221847/Use+case+Generate+the+hash+of+a+quote#Location-message).

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
