### PR TITLE
feat: location messages backup (WPB-5826)

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/DumpContent.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/DumpContent.sq
@@ -210,7 +210,6 @@ INSERT INTO Receipt
             OR selfdelete_message_id.conversation_id IS NULL;
 
 INSERT INTO ButtonContent SELECT * FROM local_db.ButtonContent;
-}
 
 WITH selfdelete_message_id AS (
     SELECT local_db.Message.id, local_db.Message.conversation_id
@@ -230,3 +229,5 @@ INSERT INTO MessageConversationLocationContent
           AND local_db.MessageConversationLocationContent.conversation_id = selfdelete_message_id.conversation_id
         WHERE selfdelete_message_id.id IS NULL
            OR selfdelete_message_id.conversation_id IS NULL;
+           
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/DumpContent.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/DumpContent.sq
@@ -211,3 +211,22 @@ INSERT INTO Receipt
 
 INSERT INTO ButtonContent SELECT * FROM local_db.ButtonContent;
 }
+
+WITH selfdelete_message_id AS (
+    SELECT local_db.Message.id, local_db.Message.conversation_id
+        FROM local_db.Message
+        WHERE local_db.Message.expire_after_millis IS NOT NULL
+)
+INSERT INTO MessageConversationLocationContent
+    SELECT local_db.MessageConversationLocationContent.message_id,
+           local_db.MessageConversationLocationContent.conversation_id,
+           local_db.MessageConversationLocationContent.latitude,
+           local_db.MessageConversationLocationContent.longitude,
+           local_db.MessageConversationLocationContent.name,
+           local_db.MessageConversationLocationContent.zoom
+    FROM local_db.MessageConversationLocationContent
+        LEFT JOIN selfdelete_message_id
+           ON local_db.MessageConversationLocationContent.message_id = selfdelete_message_id.id
+          AND local_db.MessageConversationLocationContent.conversation_id = selfdelete_message_id.conversation_id
+        WHERE selfdelete_message_id.id IS NULL
+           OR selfdelete_message_id.conversation_id IS NULL;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ImportContent.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ImportContent.sq
@@ -101,3 +101,6 @@ INSERT OR IGNORE INTO Receipt SELECT * FROM backup_db.Receipt;
 
 importCompositeButtons:
 INSERT OR IGNORE INTO ButtonContent SELECT * FROM backup_db.ButtonContent;
+
+importMessageLocationContentTable:
+INSERT OR IGNORE INTO MessageConversationLocationContent SELECT * FROM backup_db.MessageConversationLocationContent;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -322,6 +322,7 @@ markMessageAsDeleted {
    DELETE FROM MessageMemberChangeContent WHERE message_id = :message_id AND conversation_id = :conversation_id;
    DELETE FROM MessageUnknownContent WHERE message_id = :message_id AND conversation_id = :conversation_id;
    DELETE FROM MessageRestrictedAssetContent WHERE message_id = :message_id AND conversation_id = :conversation_id;
+   DELETE FROM MessageConversationLocationContent WHERE message_id = :message_id AND conversation_id = :conversation_id;
    -- deleted messages will not have a quote 100%
    -- TODO: why inserting a NULL here? Shouldn't we just not insert anything?
    INSERT INTO MessageTextContent(message_id, conversation_id, text_body, is_quoting_self) VALUES(:message_id, :conversation_id, NULL, 0);

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/backup/DatabaseImporter.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/backup/DatabaseImporter.kt
@@ -67,6 +67,7 @@ internal class DatabaseImporterImpl internal constructor(
                 importReactionTable()
                 importReceiptTable()
                 importCompositeButtons()
+                importMessageLocationContentTable()
             }
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Location messages are not included in backups currently.

### Causes (Optional)

Not implemented.

### Solutions

Implement export and import necessary queries.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
