### PR TITLE
feat(e2ei): use refresh token for IDP authorisation (WPB-5880)

### DIFF
--- a/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/E2EIClientImpl.kt
+++ b/cryptography/src/appleMain/kotlin/com/wire/kalium/cryptography/E2EIClientImpl.kt
@@ -87,4 +87,7 @@ class E2EIClientImpl : E2EIClient {
         TODO("Not yet implemented")
     }
 
+    override suspend fun getOAuthRefreshToken(): String? {
+        TODO("Not yet implemented")
+    }
 }

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/E2EIClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/E2EIClientImpl.kt
@@ -79,6 +79,12 @@ class E2EIClientImpl(
     override suspend fun certificateRequest(previousNonce: String) =
         wireE2eIdentity.certificateRequest(previousNonce)
 
+    override suspend fun getOAuthRefreshToken() = try {
+        wireE2eIdentity.getRefreshToken()
+    } catch (e: Exception) {
+        null
+    }
+
     companion object {
         fun toAcmeDirectory(value: com.wire.crypto.AcmeDirectory) = AcmeDirectory(
             value.newNonce, value.newAccount, value.newOrder
@@ -102,3 +108,4 @@ class E2EIClientImpl(
         )
     }
 }
+

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/E2EIClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/E2EIClientImpl.kt
@@ -79,6 +79,7 @@ class E2EIClientImpl(
     override suspend fun certificateRequest(previousNonce: String) =
         wireE2eIdentity.certificateRequest(previousNonce)
 
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun getOAuthRefreshToken() = try {
         wireE2eIdentity.getRefreshToken()
     } catch (e: Exception) {
@@ -108,4 +109,3 @@ class E2EIClientImpl(
         )
     }
 }
-

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/E2EIClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/E2EIClient.kt
@@ -62,5 +62,5 @@ interface E2EIClient {
     suspend fun finalizeRequest(previousNonce: String): JsonRawData
     suspend fun finalizeResponse(finalize: JsonRawData): String
     suspend fun certificateRequest(previousNonce: String): JsonRawData
-    suspend fun getOAuthRefreshToken():String?
+    suspend fun getOAuthRefreshToken(): String?
 }

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/E2EIClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/E2EIClient.kt
@@ -62,4 +62,5 @@ interface E2EIClient {
     suspend fun finalizeRequest(previousNonce: String): JsonRawData
     suspend fun finalizeResponse(finalize: JsonRawData): String
     suspend fun certificateRequest(previousNonce: String): JsonRawData
+    suspend fun getOAuthRefreshToken():String?
 }

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/E2EIClientImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/E2EIClientImpl.kt
@@ -86,4 +86,8 @@ class E2EIClientImpl : E2EIClient {
     override suspend fun certificateRequest(previousNonce: String): JsonRawData {
         TODO("Not yet implemented")
     }
+
+    override suspend fun getOAuthRefreshToken(): String? {
+        TODO("Not yet implemented")
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/E2EIClientProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/E2EIClientProvider.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.withContext
 
 interface E2EIClientProvider {
     suspend fun getE2EIClient(clientId: ClientId? = null): Either<CoreFailure, E2EIClient>
+    suspend fun nuke()
 }
 
 internal class EI2EIClientProviderImpl(
@@ -84,6 +85,10 @@ internal class EI2EIClientProviderImpl(
         return if (selfUser.name == null || selfUser.handle == null)
             Either.Left(E2EIFailure.Generic(IllegalArgumentException(ERROR_NAME_AND_HANDLE_MUST_NOT_BE_NULL)))
         else Either.Right(selfUser)
+    }
+
+    override suspend fun nuke() {
+        e2EIClient = null
     }
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/E2EIRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/E2EIRepository.kt
@@ -46,23 +46,30 @@ interface E2EIRepository {
     suspend fun loadACMEDirectories(): Either<CoreFailure, AcmeDirectory>
     suspend fun getACMENonce(endpoint: String): Either<CoreFailure, String>
     suspend fun createNewAccount(prevNonce: String, createAccountEndpoint: String): Either<CoreFailure, String>
-    suspend fun createNewOrder(prevNonce: String, createOrderEndpoint: String):
-            Either<CoreFailure, Triple<NewAcmeOrder, String, String>>
-    suspend fun createAuthz(prevNonce: String, authzEndpoint: String):
-            Either<CoreFailure, Triple<NewAcmeAuthz, String, String>>
+    suspend fun createNewOrder(prevNonce: String, createOrderEndpoint: String): Either<CoreFailure, Triple<NewAcmeOrder, String, String>>
+    suspend fun createAuthz(prevNonce: String, authzEndpoint: String): Either<CoreFailure, Triple<NewAcmeAuthz, String, String>>
     suspend fun getWireNonce(): Either<CoreFailure, String>
     suspend fun getWireAccessToken(wireNonce: String): Either<CoreFailure, AccessTokenResponse>
     suspend fun getDPoPToken(wireNonce: String): Either<CoreFailure, String>
-    suspend fun validateDPoPChallenge(accessToken: String, prevNonce: String, acmeChallenge: AcmeChallenge):
-            Either<CoreFailure, ChallengeResponse>
-    suspend fun validateOIDCChallenge(idToken: String, refreshToken: String, prevNonce: String, acmeChallenge: AcmeChallenge):
-            Either<CoreFailure, ChallengeResponse>
+    suspend fun validateDPoPChallenge(
+        accessToken: String,
+        prevNonce: String,
+        acmeChallenge: AcmeChallenge
+    ): Either<CoreFailure, ChallengeResponse>
+    suspend fun validateOIDCChallenge(
+        idToken: String,
+        refreshToken: String,
+        prevNonce: String,
+        acmeChallenge: AcmeChallenge
+    ): Either<CoreFailure, ChallengeResponse>
     suspend fun setDPoPChallengeResponse(challengeResponse: ChallengeResponse): Either<CoreFailure, Unit>
     suspend fun setOIDCChallengeResponse(challengeResponse: ChallengeResponse): Either<CoreFailure, Unit>
     suspend fun finalize(location: String, prevNonce: String): Either<CoreFailure, Pair<ACMEResponse, String>>
     suspend fun checkOrderRequest(location: String, prevNonce: String): Either<CoreFailure, Pair<ACMEResponse, String>>
     suspend fun certificateRequest(location: String, prevNonce: String): Either<CoreFailure, ACMEResponse>
     suspend fun rotateKeysAndMigrateConversations(certificateChain: String): Either<CoreFailure, Unit>
+    suspend fun getOAuthRefreshToken(): Either<CoreFailure, String?>
+    suspend fun nukeE2EIClient()
 }
 
 @Suppress("LongParameterList")
@@ -213,6 +220,14 @@ class E2EIRepositoryImpl(
                 mlsConversationRepository.rotateKeysAndMigrateConversations(clientId, e2eiClient, certificateChain)
             }
         }
+
+    override suspend fun getOAuthRefreshToken() = e2EIClientProvider.getE2EIClient().flatMap { e2EIClient ->
+        Either.Right(e2EIClient.getOAuthRefreshToken())
+    }
+
+    override suspend fun nukeE2EIClient() {
+        e2EIClientProvider.nuke()
+    }
 
     companion object {
         // todo: remove after testing e2ei

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/EnrollE2EIUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/EnrollE2EIUseCase.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.E2EIFailure
 import com.wire.kalium.logic.data.e2ei.E2EIRepository
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.getOrFail
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
 
@@ -33,7 +34,7 @@ interface EnrollE2EIUseCase {
     suspend fun initialEnrollment(): Either<CoreFailure, E2EIEnrollmentResult>
     suspend fun finalizeEnrollment(
         idToken: String,
-        refreshToken: String?,
+        oAuthState: String,
         initializationResult: E2EIEnrollmentResult.Initialized
     ): Either<E2EIFailure, E2EIEnrollmentResult>
 }
@@ -71,9 +72,17 @@ class EnrollE2EIUseCaseImpl internal constructor(
         val authzResponse = e2EIRepository.createAuthz(prevNonce, newOrderResponse.first.authorizations[0]).getOrFail {
             return E2EIEnrollmentResult.Failed(E2EIEnrollmentResult.E2EIStep.AcmeNewAuthz, it).toEitherLeft()
         }
+        kaliumLogger.i("getoAuth")
+
+        val oAuthState = e2EIRepository.getOAuthRefreshToken().getOrNull()
+        kaliumLogger.i("oAuthStAte: $oAuthState")
 
         val initializationResult = E2EIEnrollmentResult.Initialized(
-            authzResponse.first.wireOidcChallenge!!.target, authzResponse.first, authzResponse.second, newOrderResponse.third
+            target = authzResponse.first.wireOidcChallenge!!.target,
+            oAuthState = oAuthState,
+            authz = authzResponse.first,
+            lastNonce = authzResponse.second,
+            orderLocation = newOrderResponse.third
         )
 
         kaliumLogger.i("E2EI Enrollment Initialization Result: $initializationResult")
@@ -91,7 +100,7 @@ class EnrollE2EIUseCaseImpl internal constructor(
      */
     override suspend fun finalizeEnrollment(
         idToken: String,
-        refreshToken: String?,
+        oAuthState: String,
         initializationResult: E2EIEnrollmentResult.Initialized
     ): Either<E2EIFailure, E2EIEnrollmentResult> {
 
@@ -120,7 +129,7 @@ class EnrollE2EIUseCaseImpl internal constructor(
         prevNonce = dpopChallengeResponse.nonce
 
         val oidcChallengeResponse = e2EIRepository.validateOIDCChallenge(
-            idToken, refreshToken ?: "", prevNonce, authz.wireOidcChallenge!!
+            idToken, oAuthState, prevNonce, authz.wireOidcChallenge!!
         ).getOrFail {
             return E2EIEnrollmentResult.Failed(E2EIEnrollmentResult.E2EIStep.OIDCChallenge, it).toEitherLeft()
         }
@@ -147,6 +156,8 @@ class EnrollE2EIUseCaseImpl internal constructor(
             return E2EIEnrollmentResult.Failed(E2EIEnrollmentResult.E2EIStep.ConversationMigration, it).toEitherLeft()
         }
 
+        e2EIRepository.nukeE2EIClient()
+
         return Either.Right(E2EIEnrollmentResult.Finalized(certificateRequest.response.decodeToString()))
     }
 
@@ -171,7 +182,13 @@ sealed interface E2EIEnrollmentResult {
         Certificate
     }
 
-    class Initialized(val target: String, val authz: NewAcmeAuthz, val lastNonce: String, val orderLocation: String) : E2EIEnrollmentResult
+    class Initialized(
+        val target: String,
+        val oAuthState: String?,
+        val authz: NewAcmeAuthz,
+        val lastNonce: String,
+        val orderLocation: String
+    ) : E2EIEnrollmentResult
 
     class Finalized(val certificate: String) : E2EIEnrollmentResult
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -505,6 +505,10 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::rotateKeysAndMigrateConversations)
             .with()
             .wasNotInvoked()
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
+            .with()
+            .wasNotInvoked()
     }
 
     @Test
@@ -568,6 +572,10 @@ class EnrollE2EICertificateUseCaseTest {
             .wasNotInvoked()
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::rotateKeysAndMigrateConversations)
+            .with()
+            .wasNotInvoked()
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
             .with()
             .wasNotInvoked()
     }
@@ -634,6 +642,10 @@ class EnrollE2EICertificateUseCaseTest {
             .wasNotInvoked()
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::rotateKeysAndMigrateConversations)
+            .with()
+            .wasNotInvoked()
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
             .with()
             .wasNotInvoked()
     }
@@ -704,6 +716,10 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::rotateKeysAndMigrateConversations)
             .with()
             .wasNotInvoked()
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
+            .with()
+            .wasNotInvoked()
     }
 
     @Test
@@ -733,7 +749,6 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::getWireNonce)
             .with()
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getDPoPToken)
             .with(any<String>())
@@ -768,6 +783,10 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::rotateKeysAndMigrateConversations)
             .with()
             .wasNotInvoked()
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
+            .with()
+            .wasNotInvoked()
     }
 
     @Test
@@ -798,17 +817,14 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::getWireNonce)
             .with()
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getDPoPToken)
             .with(any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireAccessToken)
             .with(any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::validateDPoPChallenge)
             .with(any<String>(), any<String>(), any<AcmeChallenge>())
@@ -817,7 +833,6 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::checkOrderRequest)
             .with(any<String>(), any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::checkOrderRequest)
             .with()
@@ -834,7 +849,10 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::rotateKeysAndMigrateConversations)
             .with()
             .wasNotInvoked()
-
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
+            .with()
+            .wasNotInvoked()
     }
 
     @Test
@@ -866,17 +884,14 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::getWireNonce)
             .with()
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getDPoPToken)
             .with(any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireAccessToken)
             .with(any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::validateDPoPChallenge)
             .with(any<String>(), any<String>(), any<AcmeChallenge>())
@@ -889,12 +904,14 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::finalize)
             .with(any<String>(), any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::certificateRequest)
             .with()
             .wasNotInvoked()
-
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
+            .with()
+            .wasNotInvoked()
     }
 
     @Test
@@ -928,32 +945,26 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::getWireNonce)
             .with()
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getDPoPToken)
             .with(any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireAccessToken)
             .with(any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::validateDPoPChallenge)
             .with(any<String>(), any<String>(), any<AcmeChallenge>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::validateOIDCChallenge)
             .with(any<String>(), any<String>(), any<String>(), any<AcmeChallenge>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::checkOrderRequest)
             .with(any<String>(), any<String>())
             .wasInvoked(exactly = once)
-
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::finalize)
             .with(any<String>(), any<String>())
@@ -962,6 +973,10 @@ class EnrollE2EICertificateUseCaseTest {
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::rotateKeysAndMigrateConversations)
             .with(any<String>())
+            .wasInvoked(exactly = once)
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
+            .with()
             .wasInvoked(exactly = once)
     }
 
@@ -1031,7 +1046,10 @@ class EnrollE2EICertificateUseCaseTest {
             .function(arrangement.e2EIRepository::certificateRequest)
             .with(any<String>(), any<String>())
             .wasInvoked(exactly = once)
-
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
+            .with()
+            .wasInvoked(exactly = once)
     }
 
     @Test
@@ -1104,6 +1122,10 @@ class EnrollE2EICertificateUseCaseTest {
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::rotateKeysAndMigrateConversations)
             .with(any<String>())
+            .wasInvoked(exactly = once)
+        verify(arrangement.e2EIRepository)
+            .function(arrangement.e2EIRepository::nukeE2EIClient)
+            .with()
             .wasInvoked(exactly = once)
     }
 
@@ -1269,10 +1291,10 @@ class EnrollE2EICertificateUseCaseTest {
 
         val INITIALIZATION_RESULT = E2EIEnrollmentResult.Initialized(
             target = ACME_CHALLENGE.target,
-            ACME_AUTHZ,
+            oAuthState = REFRESH_TOKEN,
+            authz = ACME_AUTHZ,
             lastNonce = RANDOM_NONCE,
             orderLocation = RANDOM_LOCATION
         )
-
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -924,6 +924,7 @@ class EnrollE2EICertificateUseCaseTest {
         arrangement.withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
         arrangement.withCreateNewOrderResulting(Either.Right(Triple(ACME_ORDER, RANDOM_NONCE, RANDOM_LOCATION)))
         arrangement.withCreateAuthzResulting(Either.Right(Triple(ACME_AUTHZ, RANDOM_NONCE, RANDOM_LOCATION)))
+        arrangement.withGettingRefreshTokenSucceeding()
         arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
         arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
         arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
@@ -977,7 +978,7 @@ class EnrollE2EICertificateUseCaseTest {
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::nukeE2EIClient)
             .with()
-            .wasInvoked(exactly = once)
+            .wasNotInvoked()
     }
 
     @Test
@@ -990,6 +991,7 @@ class EnrollE2EICertificateUseCaseTest {
         arrangement.withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
         arrangement.withCreateNewOrderResulting(Either.Right(Triple(ACME_ORDER, RANDOM_NONCE, RANDOM_LOCATION)))
         arrangement.withCreateAuthzResulting(Either.Right(Triple(ACME_AUTHZ, RANDOM_NONCE, RANDOM_LOCATION)))
+        arrangement.withGettingRefreshTokenSucceeding()
         arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
         arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
         arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
@@ -1049,7 +1051,7 @@ class EnrollE2EICertificateUseCaseTest {
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::nukeE2EIClient)
             .with()
-            .wasInvoked(exactly = once)
+            .wasNotInvoked()
     }
 
     @Test
@@ -1231,6 +1233,13 @@ class EnrollE2EICertificateUseCaseTest {
                 .suspendFunction(e2EIRepository::certificateRequest)
                 .whenInvokedWith(any(), any())
                 .thenReturn(result)
+        }
+
+        fun withGettingRefreshTokenSucceeding() = apply {
+            given(e2EIRepository)
+                .suspendFunction(e2EIRepository::getOAuthRefreshToken)
+                .whenInvoked()
+                .thenReturn(Either.Right(" "))
         }
 
         fun arrange(): Pair<Arrangement, EnrollE2EIUseCase> = this to EnrollE2EIUseCaseImpl(e2EIRepository)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
With oAuth refresh token, we can get a new id token without forcing the user to login again on the idp, in this PR all the requirements on kalium are considered.

### Dependencies (Optional)

Needs to be merged with AR

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
