### PR TITLE
refactor: remove duplicated legalHoldStatus field from ConversationDetails [WPB-4568]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.message.MessagePreview
 import com.wire.kalium.logic.data.message.UnreadEventType
-import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
@@ -288,7 +287,6 @@ sealed class ConversationDetails(open val conversation: Conversation) {
     data class OneOne(
         override val conversation: Conversation,
         val otherUser: OtherUser,
-        val legalHoldStatus: LegalHoldStatus,
         val userType: UserType,
         val unreadEventCount: UnreadEventCount,
         val lastMessage: MessagePreview?
@@ -296,7 +294,6 @@ sealed class ConversationDetails(open val conversation: Conversation) {
 
     data class Group(
         override val conversation: Conversation,
-        val legalHoldStatus: LegalHoldStatus,
         val hasOngoingCall: Boolean = false,
         val unreadEventCount: UnreadEventCount,
         val lastMessage: MessagePreview?,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.data.message.MessagePreview
 import com.wire.kalium.logic.data.user.AvailabilityStatusMapper
 import com.wire.kalium.logic.data.user.BotService
 import com.wire.kalium.logic.data.user.Connection
-import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.toModel
@@ -220,7 +219,6 @@ internal class ConversationMapperImpl(
                             supportedProtocols = userSupportedProtocols?.map { it.toModel() }?.toSet(),
                             activeOneOnOneConversationId = userActiveOneOnOneConversationId?.toModel()
                         ),
-                        legalHoldStatus = LegalHoldStatus.DISABLED,
                         userType = domainUserTypeMapper.fromUserTypeEntity(userType),
                         unreadEventCount = unreadEventCount ?: mapOf(),
                         lastMessage = lastMessage
@@ -230,7 +228,6 @@ internal class ConversationMapperImpl(
                 ConversationEntity.Type.GROUP -> {
                     ConversationDetails.Group(
                         conversation = fromDaoModel(daoModel),
-                        legalHoldStatus = LegalHoldStatus.DISABLED,
                         hasOngoingCall = callStatus != null, // todo: we can do better!
                         unreadEventCount = unreadEventCount ?: mapOf(),
                         lastMessage = lastMessage,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -29,7 +29,8 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.user.LegalHoldStatus
+import com.wire.kalium.logic.data.conversation.JoinSubconversationUseCase
+import com.wire.kalium.logic.data.conversation.LeaveSubconversationUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.SubconversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -45,8 +46,6 @@ import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.logic.data.conversation.JoinSubconversationUseCase
-import com.wire.kalium.logic.data.conversation.LeaveSubconversationUseCase
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestTeam
 import com.wire.kalium.logic.framework.TestUser
@@ -172,7 +171,6 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            LegalHoldStatus.ENABLED,
                             false,
                             lastMessage = null,
                             isSelfUserMember = true,
@@ -214,7 +212,6 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            LegalHoldStatus.ENABLED,
                             lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
@@ -271,7 +268,6 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            LegalHoldStatus.ENABLED,
                             lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
@@ -317,7 +313,6 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            LegalHoldStatus.ENABLED,
                             lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
@@ -377,7 +372,6 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            LegalHoldStatus.ENABLED,
                             lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
@@ -1742,7 +1736,6 @@ class CallRepositoryTest {
             val oneOnOneConversationDetails = ConversationDetails.OneOne(
                 conversation = oneOnOneConversation,
                 otherUser = TestUser.OTHER,
-                legalHoldStatus = LegalHoldStatus.ENABLED,
                 userType = UserType.INTERNAL,
                 lastMessage = null,
                 unreadEventCount = emptyMap()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -1,9 +1,10 @@
 package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
-import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
@@ -14,8 +15,6 @@ import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.logic.data.call.Call
-import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.arrangement.repository.CallRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.CallRepositoryArrangementImpl
@@ -242,7 +241,6 @@ class EndCallOnConversationChangeUseCaseTest {
 
         private val groupConversationDetail = ConversationDetails.Group(
             conversation = conversation,
-            legalHoldStatus = LegalHoldStatus.ENABLED,
             hasOngoingCall = true,
             unreadEventCount = mapOf(),
             lastMessage = null,
@@ -253,7 +251,6 @@ class EndCallOnConversationChangeUseCaseTest {
 
         private val oneOnOneConversationDetail = ConversationDetails.OneOne(
             conversation = conversation,
-            legalHoldStatus = LegalHoldStatus.ENABLED,
             otherUser = otherUser,
             unreadEventCount = mapOf(),
             lastMessage = null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -77,7 +76,6 @@ class ObserveConversationDetailsUseCaseTest {
             Either.Right(
                 ConversationDetails.Group(
                     conversation,
-                    LegalHoldStatus.DISABLED,
                     lastMessage = null,
                     isSelfUserMember = true,
                     isSelfUserCreator = true,
@@ -88,7 +86,6 @@ class ObserveConversationDetailsUseCaseTest {
             Either.Right(
                 ConversationDetails.Group(
                     conversation.copy(name = "New Name"),
-                    LegalHoldStatus.DISABLED,
                     lastMessage = null,
                     isSelfUserMember = true,
                     isSelfUserCreator = true,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.framework.TestConversation
@@ -65,7 +64,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails =
             ConversationDetails.Group(
                 groupConversation,
-                LegalHoldStatus.DISABLED,
                 lastMessage = null,
                 isSelfUserMember = true,
                 isSelfUserCreator = true,
@@ -102,7 +100,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails1 =
             ConversationDetails.Group(
                 groupConversation1,
-                LegalHoldStatus.DISABLED,
                 lastMessage = null,
                 isSelfUserMember = true,
                 isSelfUserCreator = true,
@@ -112,7 +109,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails2 =
             ConversationDetails.Group(
                 groupConversation2,
-                LegalHoldStatus.DISABLED,
                 lastMessage = null,
                 isSelfUserMember = true,
                 isSelfUserCreator = true,
@@ -149,7 +145,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val selfConversationDetails = ConversationDetails.Self(selfConversation)
         val groupConversationDetails = ConversationDetails.Group(
             conversation = groupConversation,
-            legalHoldStatus = LegalHoldStatus.DISABLED,
             lastMessage = null,
             isSelfUserMember = true,
             isSelfUserCreator = true,
@@ -187,7 +182,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationUpdates = listOf(
             ConversationDetails.Group(
                 groupConversation,
-                LegalHoldStatus.DISABLED,
                 lastMessage = null,
                 isSelfUserMember = true,
                 isSelfUserCreator = true,
@@ -199,7 +193,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val firstOneOnOneDetails = ConversationDetails.OneOne(
             oneOnOneConversation,
             TestUser.OTHER,
-            LegalHoldStatus.ENABLED,
             UserType.INTERNAL,
             lastMessage = null,
             unreadEventCount = emptyMap()
@@ -207,7 +200,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val secondOneOnOneDetails = ConversationDetails.OneOne(
             oneOnOneConversation,
             TestUser.OTHER.copy(name = "New User Name"),
-            LegalHoldStatus.DISABLED,
             UserType.INTERNAL,
             lastMessage = null,
             unreadEventCount = emptyMap()
@@ -244,7 +236,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val fetchArchivedConversations = false
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
-            LegalHoldStatus.DISABLED,
             lastMessage = null,
             isSelfUserMember = true,
             isSelfUserCreator = true,
@@ -282,7 +273,6 @@ class ObserveConversationListDetailsUseCaseTest {
         val fetchArchivedConversations = false
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
-            LegalHoldStatus.DISABLED,
             lastMessage = null,
             isSelfUserMember = true,
             isSelfUserCreator = true,
@@ -314,7 +304,6 @@ class ObserveConversationListDetailsUseCaseTest {
 
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
-            LegalHoldStatus.DISABLED,
             lastMessage = null,
             isSelfUserMember = true,
             isSelfUserCreator = true,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.logic.framework
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.ConversationDetails
-import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.user.type.UserType
 
 object TestConversationDetails {
@@ -40,7 +39,6 @@ object TestConversationDetails {
     val CONVERSATION_ONE_ONE = ConversationDetails.OneOne(
         TestConversation.ONE_ON_ONE(),
         TestUser.OTHER,
-        LegalHoldStatus.DISABLED,
         UserType.EXTERNAL,
         lastMessage = null,
         unreadEventCount = emptyMap()
@@ -48,7 +46,6 @@ object TestConversationDetails {
 
     val CONVERSATION_GROUP = ConversationDetails.Group(
         conversation = TestConversation.GROUP(),
-        legalHoldStatus = LegalHoldStatus.ENABLED,
         lastMessage = null,
         isSelfUserCreator = true,
         isSelfUserMember = true,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There were duplicated fields related to legal hold status for conversation - one in `Conversation` data, which is persisted in the DB and also redundant one added to the `ConversationDetails.OneOne` and `ConversaionDetails.Group`.

### Solutions

Remove the `legalHoldStatus` field from `ConversationDetails.OneOne` and `ConversationDetails.Group` because it already contains `Conversation` data which has `legalHoldStatus` for conversation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
