### PR TITLE
fix: offload from main thread usecase operations used in conversation screen (WPB-5964)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/UpdateAssetMessageDownloadStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/UpdateAssetMessageDownloadStatusUseCase.kt
@@ -23,6 +23,9 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message.DownloadStatus
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
 
 interface UpdateAssetMessageDownloadStatusUseCase {
     /**
@@ -42,15 +45,16 @@ interface UpdateAssetMessageDownloadStatusUseCase {
 }
 
 internal class UpdateAssetMessageDownloadStatusUseCaseImpl(
-    private val messageRepository: MessageRepository
+    private val messageRepository: MessageRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : UpdateAssetMessageDownloadStatusUseCase {
 
     override suspend operator fun invoke(
         downloadStatus: DownloadStatus,
         conversationId: ConversationId,
         messageId: String
-    ): UpdateDownloadStatusResult {
-        return messageRepository.updateAssetMessageDownloadStatus(downloadStatus, conversationId, messageId).fold({
+    ): UpdateDownloadStatusResult = withContext(dispatcher.io) {
+        messageRepository.updateAssetMessageDownloadStatus(downloadStatus, conversationId, messageId).fold({
             UpdateDownloadStatusResult.Failure(it)
         }, {
             UpdateDownloadStatusResult.Success

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/IsEligibleToStartCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/IsEligibleToStartCallUseCase.kt
@@ -23,6 +23,9 @@ import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
 
 /**
  * @return the [Boolean] for if the user's team has conference calling enabled in its plan.
@@ -33,21 +36,23 @@ interface IsEligibleToStartCallUseCase {
 
 internal class IsEligibleToStartCallUseCaseImpl(
     private val userConfigRepository: UserConfigRepository,
-    private val callRepository: CallRepository
+    private val callRepository: CallRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : IsEligibleToStartCallUseCase {
 
-    override suspend fun invoke(conversationId: ConversationId, conversationType: Conversation.Type): ConferenceCallingResult {
-        val establishedCallConversationId = callRepository.establishedCallConversationId()
+    override suspend fun invoke(conversationId: ConversationId, conversationType: Conversation.Type): ConferenceCallingResult =
+        withContext(dispatcher.io) {
+            val establishedCallConversationId = callRepository.establishedCallConversationId()
 
-        val canStartCall = (conversationType == Conversation.Type.ONE_ON_ONE ||
-                (conversationType == Conversation.Type.GROUP && isConferenceCallingEnabled()))
+            val canStartCall = (conversationType == Conversation.Type.ONE_ON_ONE ||
+                    (conversationType == Conversation.Type.GROUP && isConferenceCallingEnabled()))
 
-        return establishedCallConversationId?.let {
-            callIsEstablished(it, conversationId, canStartCall)
-        } ?: run {
-            if (canStartCall) ConferenceCallingResult.Enabled else ConferenceCallingResult.Disabled.Unavailable
+            establishedCallConversationId?.let {
+                callIsEstablished(it, conversationId, canStartCall)
+            } ?: run {
+                if (canStartCall) ConferenceCallingResult.Enabled else ConferenceCallingResult.Disabled.Unavailable
+            }
         }
-    }
 
     private fun callIsEstablished(
         establishedCallConversationId: ConversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationUnreadEventsCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationUnreadEventsCountUseCase.kt
@@ -21,6 +21,9 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
 
 /**
  * UseCase for getting once the amount of unread events (all: messages, pings, missed calls, etc.) in a specific conversation.
@@ -36,12 +39,15 @@ interface GetConversationUnreadEventsCountUseCase {
 }
 
 internal class GetConversationUnreadEventsCountUseCaseImpl(
-    private val conversationRepository: ConversationRepository
+    private val conversationRepository: ConversationRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : GetConversationUnreadEventsCountUseCase {
 
     override suspend fun invoke(conversationId: ConversationId): GetConversationUnreadEventsCountUseCase.Result =
-        conversationRepository.getConversationUnreadEventsCount(conversationId).fold(
-            { GetConversationUnreadEventsCountUseCase.Result.Failure(it) },
-            { GetConversationUnreadEventsCountUseCase.Result.Success(it) }
-        )
+        withContext(dispatcher.io) {
+            conversationRepository.getConversationUnreadEventsCount(conversationId).fold(
+                { GetConversationUnreadEventsCountUseCase.Result.Failure(it) },
+                { GetConversationUnreadEventsCountUseCase.Result.Success(it) }
+            )
+        }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MembersToMentionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MembersToMentionUseCase.kt
@@ -21,7 +21,10 @@ package com.wire.kalium.logic.feature.conversation
 import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 
 /**
  * This usecase returns a list of members to mention for a given conversation based on a search done with searchQuery
@@ -39,7 +42,8 @@ import kotlinx.coroutines.flow.first
 @Suppress("ReturnCount")
 class MembersToMentionUseCase internal constructor(
     private val observeConversationMembers: ObserveConversationMembersUseCase,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
     /**
      * search for members to mention in a conversation
@@ -47,7 +51,7 @@ class MembersToMentionUseCase internal constructor(
      * @param searchQuery string used to search for members
      * @return a List of [MemberDetails] of a conversation for the given string
      */
-    suspend operator fun invoke(conversationId: ConversationId, searchQuery: String): List<MemberDetails> {
+    suspend operator fun invoke(conversationId: ConversationId, searchQuery: String): List<MemberDetails> = withContext(dispatcher.io) {
         val conversationMembers = observeConversationMembers(conversationId).first()
 
         // TODO apply normalization techniques that are used for other searches to the name (e.g. ö -> oe)
@@ -56,10 +60,10 @@ class MembersToMentionUseCase internal constructor(
             it.user.id != userRepository.getSelfUser()?.id
         }
         if (searchQuery.isEmpty())
-            return usersToSearch
+            return@withContext usersToSearch
 
         if (searchQuery.first().isWhitespace())
-            return listOf()
+            return@withContext listOf()
 
         val rules: List<(MemberDetails) -> Boolean> = listOf(
             { it.user.name?.startsWith(searchQuery, true) == true },
@@ -83,7 +87,7 @@ class MembersToMentionUseCase internal constructor(
             usersToMention += matches
         }
 
-        return usersToMention
+        return@withContext usersToMention
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCase.kt
@@ -23,8 +23,11 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 /**
  * This use case will observe and return the conversation details for a specific conversation.
@@ -32,6 +35,7 @@ import kotlinx.coroutines.flow.map
  */
 class ObserveConversationDetailsUseCase(
     private val conversationRepository: ConversationRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
     sealed class Result {
         data class Success(val conversationDetails: ConversationDetails) : Result()
@@ -42,8 +46,8 @@ class ObserveConversationDetailsUseCase(
      * @param conversationId the id of the conversation to observe
      * @return a flow of [Result] with the [ConversationDetails] of the conversation
      */
-    suspend operator fun invoke(conversationId: ConversationId): Flow<Result> {
-        return conversationRepository.observeConversationDetailsById(conversationId)
+    suspend operator fun invoke(conversationId: ConversationId): Flow<Result> = withContext(dispatcher.io) {
+        conversationRepository.observeConversationDetailsById(conversationId)
             .map { it.fold({ Result.Failure(it) }, { Result.Success(it) }) }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
@@ -24,8 +24,11 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 /**
  * Use case that check if self user is able to interact in conversation
@@ -33,10 +36,11 @@ import kotlinx.coroutines.flow.map
  * @return an [IsInteractionAvailableResult] containing Success or Failure cases
  */
 class ObserveConversationInteractionAvailabilityUseCase internal constructor(
-    private val conversationRepository: ConversationRepository
+    private val conversationRepository: ConversationRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
-    suspend operator fun invoke(conversationId: ConversationId): Flow<IsInteractionAvailableResult> {
-        return conversationRepository.observeConversationDetailsById(conversationId).map { eitherConversation ->
+    suspend operator fun invoke(conversationId: ConversationId): Flow<IsInteractionAvailableResult> = withContext(dispatcher.io) {
+        conversationRepository.observeConversationDetailsById(conversationId).map { eitherConversation ->
             eitherConversation.fold({ failure -> IsInteractionAvailableResult.Failure(failure) }, { conversationDetails ->
                 val availability = when (conversationDetails) {
                     is ConversationDetails.Connection -> InteractionAvailability.DISABLED
@@ -44,15 +48,18 @@ class ObserveConversationInteractionAvailabilityUseCase internal constructor(
                         if (conversationDetails.isSelfUserMember) InteractionAvailability.ENABLED
                         else InteractionAvailability.NOT_MEMBER
                     }
+
                     is ConversationDetails.OneOne -> {
                         when {
                             conversationDetails.otherUser.defederated -> InteractionAvailability.DISABLED
                             conversationDetails.otherUser.deleted -> InteractionAvailability.DELETED_USER
                             conversationDetails.otherUser.connectionStatus == ConnectionState.BLOCKED ->
                                 InteractionAvailability.BLOCKED_USER
+
                             else -> InteractionAvailability.ENABLED
                         }
                     }
+
                     is ConversationDetails.Self, is ConversationDetails.Team -> InteractionAvailability.DISABLED
                 }
                 IsInteractionAvailableResult.Success(availability)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/SendTypingEventUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/SendTypingEventUseCase.kt
@@ -20,6 +20,9 @@ package com.wire.kalium.logic.feature.conversation
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.TypingIndicatorOutgoingRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
 
 /**
  * UseCase for sending a typing event to a specific [ConversationId]
@@ -36,9 +39,12 @@ interface SendTypingEventUseCase {
 }
 
 internal class SendTypingEventUseCaseImpl(
-    private val typingIndicatorRepository: TypingIndicatorOutgoingRepository
+    private val typingIndicatorRepository: TypingIndicatorOutgoingRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : SendTypingEventUseCase {
     override suspend fun invoke(conversationId: ConversationId, typingStatus: Conversation.TypingIndicatorMode) {
-        typingIndicatorRepository.sendTypingIndicatorStatus(conversationId, typingStatus)
+        withContext(dispatcher.io) {
+            typingIndicatorRepository.sendTypingIndicatorStatus(conversationId, typingStatus)
+        }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -25,13 +25,13 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
@@ -40,7 +40,10 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 
 /**
  * Deletes a message from the conversation
@@ -53,7 +56,8 @@ class DeleteMessageUseCase internal constructor(
     private val messageSender: MessageSender,
     private val selfUserId: UserId,
     private val currentClientIdProvider: CurrentClientIdProvider,
-    private val selfConversationIdProvider: SelfConversationIdProvider
+    private val selfConversationIdProvider: SelfConversationIdProvider,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
     /**
@@ -64,41 +68,42 @@ class DeleteMessageUseCase internal constructor(
      * @param deleteForEveryone either delete the message for everyone or just for the current user
      * @return [Either] [CoreFailure] or [Unit] //fixme: we should not return [Either]
      */
-    suspend operator fun invoke(conversationId: ConversationId, messageId: String, deleteForEveryone: Boolean): Either<CoreFailure, Unit> {
-        slowSyncRepository.slowSyncStatus.first {
-            it is SlowSyncStatus.Complete
-        }
+    suspend operator fun invoke(conversationId: ConversationId, messageId: String, deleteForEveryone: Boolean): Either<CoreFailure, Unit> =
+        withContext(dispatcher.io) {
+            slowSyncRepository.slowSyncStatus.first {
+                it is SlowSyncStatus.Complete
+            }
 
-        return messageRepository.getMessageById(conversationId, messageId).map { message ->
-            when (message.status) {
-                // TODO: there is a race condition here where a message can still be marked as Message.Status.FAILED but be sent
-                // better to send the delete message anyway and let it to other clients to ignore it if the message is not sent
-                Message.Status.Failed -> messageRepository.deleteMessage(messageId, conversationId)
-                else -> {
-                    return currentClientIdProvider().flatMap { currentClientId ->
-                        selfConversationIdProvider().flatMap { selfConversationIds ->
-                            selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
-                                val regularMessage = Message.Signaling(
-                                    id = uuid4().toString(),
-                                    content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else
-                                        MessageContent.DeleteForMe(
-                                            messageId,
-                                            conversationId = conversationId
-                                        ),
-                                    conversationId = if (deleteForEveryone) conversationId else selfConversationId,
-                                    date = DateTimeUtil.currentIsoDateTimeString(),
-                                    senderUserId = selfUserId,
-                                    senderClientId = currentClientId,
-                                    status = Message.Status.Pending,
-                                    isSelfMessage = true,
-                                    expirationData = null
-                                )
-                                messageSender.sendMessage(regularMessage)
+            messageRepository.getMessageById(conversationId, messageId).map { message ->
+                return@withContext when (message.status) {
+                    // TODO: there is a race condition here where a message can still be marked as Message.Status.FAILED but be sent
+                    // better to send the delete message anyway and let it to other clients to ignore it if the message is not sent
+                    Message.Status.Failed -> messageRepository.deleteMessage(messageId, conversationId)
+                    else -> {
+                        currentClientIdProvider().flatMap { currentClientId ->
+                            selfConversationIdProvider().flatMap { selfConversationIds ->
+                                selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
+                                    val regularMessage = Message.Signaling(
+                                        id = uuid4().toString(),
+                                        content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else
+                                            MessageContent.DeleteForMe(
+                                                messageId,
+                                                conversationId = conversationId
+                                            ),
+                                        conversationId = if (deleteForEveryone) conversationId else selfConversationId,
+                                        date = DateTimeUtil.currentIsoDateTimeString(),
+                                        senderUserId = selfUserId,
+                                        senderClientId = currentClientId,
+                                        status = Message.Status.Pending,
+                                        isSelfMessage = true,
+                                        expirationData = null
+                                    )
+                                    messageSender.sendMessage(regularMessage)
+                                }
                             }
-                        }
-                    }
-                        .onSuccess { deleteMessageAsset(message) }
-                        .flatMap {
+                        }.onSuccess {
+                            deleteMessageAsset(message)
+                        }.flatMap {
                             // in case of ephemeral message, we want to delete it completely from the device, not just mark it as deleted
                             // as this can only happen when the user decides to delete the message, before the self-deletion timer expired
                             val isEphemeralMessage = message is Message.Regular && message.expirationData != null
@@ -107,17 +112,16 @@ class DeleteMessageUseCase internal constructor(
                             } else {
                                 messageRepository.markMessageAsDeleted(messageId, conversationId)
                             }
-                        }
-                        .onFailure { failure ->
+                        }.onFailure { failure ->
                             kaliumLogger.withFeatureId(MESSAGES).w("delete message failure: $message")
                             if (failure is CoreFailure.Unknown) {
                                 failure.rootCause?.printStackTrace()
                             }
                         }
+                    }
                 }
             }
         }
-    }
 
     private suspend fun deleteMessageAsset(message: Message) {
         (message.content as? MessageContent.Asset)?.value?.remoteData?.let { assetToRemove ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetSearchedConversationMessagePositionUseCase.kt
@@ -20,7 +20,11 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.feature.message.GetSearchedConversationMessagePositionUseCase.Result
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
 
 /**
  * Gets the Selected Message Position from Search
@@ -44,18 +48,21 @@ interface GetSearchedConversationMessagePositionUseCase {
 }
 
 internal class GetSearchedConversationMessagePositionUseCaseImpl internal constructor(
-    private val messageRepository: MessageRepository
+    private val messageRepository: MessageRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : GetSearchedConversationMessagePositionUseCase {
 
     override suspend fun invoke(
         conversationId: ConversationId,
         messageId: String
-    ): GetSearchedConversationMessagePositionUseCase.Result = messageRepository
-        .getSearchedConversationMessagePosition(
-            conversationId = conversationId,
-            messageId = messageId
-        ).fold(
-            { GetSearchedConversationMessagePositionUseCase.Result.Failure(it) },
-            { GetSearchedConversationMessagePositionUseCase.Result.Success(it) }
-        )
+    ): Result = withContext(dispatcher.io) {
+        messageRepository
+            .getSearchedConversationMessagePosition(
+                conversationId = conversationId,
+                messageId = messageId
+            ).fold(
+                { Result.Failure(it) },
+                { Result.Success(it) }
+            )
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -21,19 +21,22 @@ package com.wire.kalium.logic.feature.message
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 import kotlin.time.Duration
 
 @Suppress("LongParameterList")
@@ -47,7 +50,8 @@ class SendKnockUseCase internal constructor(
     private val slowSyncRepository: SlowSyncRepository,
     private val messageSender: MessageSender,
     private val messageSendFailureHandler: MessageSendFailureHandler,
-    private val selfDeleteTimer: ObserveSelfDeletionTimerSettingsForConversationUseCase
+    private val selfDeleteTimer: ObserveSelfDeletionTimerSettingsForConversationUseCase,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
     /**
@@ -57,7 +61,7 @@ class SendKnockUseCase internal constructor(
      * @param hotKnock whether to send this as a hot knock or not @see [MessageContent.Knock]
      * @return [Either] [CoreFailure] or [Unit] //fixme: we should not return [Either]
      */
-    suspend operator fun invoke(conversationId: ConversationId, hotKnock: Boolean): Either<CoreFailure, Unit> {
+    suspend operator fun invoke(conversationId: ConversationId, hotKnock: Boolean): Either<CoreFailure, Unit> = withContext(dispatcher.io) {
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }
@@ -67,7 +71,7 @@ class SendKnockUseCase internal constructor(
             .first()
             .duration
 
-        return currentClientIdProvider().flatMap { currentClientId ->
+        return@withContext currentClientIdProvider().flatMap { currentClientId ->
             val message = Message.Regular(
                 id = generatedMessageUuid,
                 content = MessageContent.Knock(hotKnock),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
@@ -35,7 +35,10 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 
 /**
  * Toggles a reaction on a message.
@@ -46,7 +49,8 @@ class ToggleReactionUseCase internal constructor(
     private val userId: UserId,
     private val slowSyncRepository: SlowSyncRepository,
     private val reactionRepository: ReactionRepository,
-    private val messageSender: MessageSender
+    private val messageSender: MessageSender,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
     /**
      * Operation to toggle a reaction on a message
@@ -60,13 +64,13 @@ class ToggleReactionUseCase internal constructor(
         conversationId: ConversationId,
         messageId: String,
         reaction: String
-    ): Either<CoreFailure, Unit> {
+    ): Either<CoreFailure, Unit> = withContext(dispatcher.io) {
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }
         val date = DateTimeUtil.currentIsoDateTimeString()
 
-        return reactionRepository.getSelfUserReactionsForMessage(messageId, conversationId)
+        return@withContext reactionRepository.getSelfUserReactionsForMessage(messageId, conversationId)
             .flatMap { reactions ->
                 currentClientIdProvider().map { it to reactions }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
@@ -27,8 +27,11 @@ import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.util.isPositiveNotNull
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.withContext
 
 /**
  * When invoked, this use case will start observing on a given conversation, the currently applied [SelfDeletionTimer]
@@ -44,26 +47,29 @@ interface ObserveSelfDeletionTimerSettingsForConversationUseCase {
 
 class ObserveSelfDeletionTimerSettingsForConversationUseCaseImpl internal constructor(
     private val userConfigRepository: UserConfigRepository,
-    private val conversationRepository: ConversationRepository
+    private val conversationRepository: ConversationRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : ObserveSelfDeletionTimerSettingsForConversationUseCase {
 
     override suspend fun invoke(conversationId: ConversationId, considerSelfUserSettings: Boolean): Flow<SelfDeletionTimer> =
-        userConfigRepository.observeTeamSettingsSelfDeletingStatus()
-            .combine(
-                conversationRepository.observeById(conversationId)
-            ) { teamSettings, conversationDetailsEither ->
-                teamSettings.fold({
-                    onTeamEnabled(conversationDetailsEither, considerSelfUserSettings)
-                }, {
-                    when (it.enforcedSelfDeletionTimer) {
-                        TeamSelfDeleteTimer.Disabled -> SelfDeletionTimer.Disabled
-                        TeamSelfDeleteTimer.Enabled -> onTeamEnabled(conversationDetailsEither, considerSelfUserSettings)
-                        is TeamSelfDeleteTimer.Enforced -> SelfDeletionTimer.Enforced.ByTeam(
-                            it.enforcedSelfDeletionTimer.enforcedDuration
-                        )
-                    }
-                })
-            }
+        withContext(dispatcher.io) {
+            userConfigRepository.observeTeamSettingsSelfDeletingStatus()
+                .combine(
+                    conversationRepository.observeById(conversationId)
+                ) { teamSettings, conversationDetailsEither ->
+                    teamSettings.fold({
+                        onTeamEnabled(conversationDetailsEither, considerSelfUserSettings)
+                    }, {
+                        when (it.enforcedSelfDeletionTimer) {
+                            TeamSelfDeleteTimer.Disabled -> SelfDeletionTimer.Disabled
+                            TeamSelfDeleteTimer.Enabled -> onTeamEnabled(conversationDetailsEither, considerSelfUserSettings)
+                            is TeamSelfDeleteTimer.Enforced -> SelfDeletionTimer.Enforced.ByTeam(
+                                it.enforcedSelfDeletionTimer.enforcedDuration
+                            )
+                        }
+                    })
+                }
+        }
 
     private fun onTeamEnabled(conversation: Either<StorageFailure, Conversation>, considerSelfUserSettings: Boolean): SelfDeletionTimer =
         conversation.fold({

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/PersistNewSelfDeletionTimerUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/PersistNewSelfDeletionTimerUseCase.kt
@@ -22,7 +22,10 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import com.wire.kalium.util.serialization.toJsonElement
+import kotlinx.coroutines.withContext
 
 /**
  * Use case to persist the new self deletion timer for a given conversation to memory.
@@ -35,9 +38,10 @@ interface PersistNewSelfDeletionTimerUseCase {
 }
 
 class PersistNewSelfDeletionTimerUseCaseImpl internal constructor(
-    private val conversationRepository: ConversationRepository
+    private val conversationRepository: ConversationRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : PersistNewSelfDeletionTimerUseCase {
-    override suspend fun invoke(conversationId: ConversationId, newSelfDeletionTimer: SelfDeletionTimer) =
+    override suspend fun invoke(conversationId: ConversationId, newSelfDeletionTimer: SelfDeletionTimer) = withContext(dispatcher.io) {
         conversationRepository.updateUserSelfDeletionTimer(conversationId, newSelfDeletionTimer).fold({
             val logMap = mapOf(
                 "value" to newSelfDeletionTimer.toLogString(eventDescription = "Self Deletion User Update Failure"),
@@ -48,4 +52,5 @@ class PersistNewSelfDeletionTimerUseCaseImpl internal constructor(
             val logMap = newSelfDeletionTimer.toLogString(eventDescription = "Self Deletion User Update Success")
             kaliumLogger.d("${SelfDeletionTimer.SELF_DELETION_LOG_TAG}: $logMap")
         })
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
@@ -20,7 +20,10 @@ package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 
 /**
  * This use case is responsible for retrieving the current user.
@@ -35,9 +38,12 @@ interface GetSelfUserUseCase {
 
 }
 
-internal class GetSelfUserUseCaseImpl internal constructor(private val userRepository: UserRepository) : GetSelfUserUseCase {
+internal class GetSelfUserUseCaseImpl internal constructor(
+    private val userRepository: UserRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
+) : GetSelfUserUseCase {
 
-    override suspend operator fun invoke(): Flow<SelfUser> {
-        return userRepository.observeSelfUser()
+    override suspend operator fun invoke(): Flow<SelfUser> = withContext(dispatcher.io) {
+        userRepository.observeSelfUser()
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Many operations (use cases) are being executed on the main thread

### Causes (Optional)

Blocking clients can lead to ANR, i.e. conversation screen makes use of all the use cases changed in this PR.

### Solutions

Move operations to `io` thread when corresponded.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

Current suite should cover and be green.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
