### PR TITLE
fix: missing ServerConfig crashes after session expired / logout [WPB-5960]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -57,7 +57,7 @@ abstract class CoreLogicCommon internal constructor(
     protected val authenticationScopeProvider: AuthenticationScopeProvider =
         AuthenticationScopeProvider(userAgent)
 
-    fun getGlobalScope(): GlobalKaliumScope =
+    private val globalKaliumScope by lazy {
         GlobalKaliumScope(
             userAgent,
             globalDatabase,
@@ -67,6 +67,8 @@ abstract class CoreLogicCommon internal constructor(
             authenticationScopeProvider,
             networkStateObserver
         )
+    }
+    fun getGlobalScope(): GlobalKaliumScope = globalKaliumScope
 
     @Suppress("MemberVisibilityCanBePrivate") // Can be used by other targets like iOS and JS
     fun getAuthenticationScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -31,6 +31,8 @@ import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUse
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCaseImpl
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationScopeProvider
+import com.wire.kalium.logic.feature.auth.LogoutCallbackManager
+import com.wire.kalium.logic.feature.auth.LogoutCallbackManagerImpl
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCaseImpl
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
@@ -191,4 +193,6 @@ class GlobalKaliumScope internal constructor(
 
     val observeIsAppLockEditableUseCase: ObserveIsAppLockEditableUseCase
         get() = ObserveIsAppLockEditableUseCaseImpl(userSessionScopeProvider.value, sessionRepository)
+
+    val logoutCallbackManager: LogoutCallbackManager = LogoutCallbackManagerImpl()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1578,6 +1578,7 @@ class UserSessionScope internal constructor(
             userSessionWorkScheduler,
             calls.establishedCall,
             calls.endCall,
+            globalScope.logoutCallbackManager,
             kaliumConfigs
         )
     val persistPersistentWebSocketConnectionStatus: PersistPersistentWebSocketConnectionStatusUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutCallbackManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutCallbackManager.kt
@@ -34,4 +34,4 @@ class LogoutCallbackManagerImpl : LogoutCallbackManager {
     override suspend fun logout(userId: UserId, reason: LogoutReason) { callbacks.forEach { it(userId, reason) } }
 }
 
-typealias LogoutCallback = (userId: UserId, reason: LogoutReason) -> Unit
+typealias LogoutCallback = suspend (userId: UserId, reason: LogoutReason) -> Unit

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutCallbackManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutCallbackManager.kt
@@ -34,6 +34,4 @@ class LogoutCallbackManagerImpl : LogoutCallbackManager {
     override suspend fun logout(userId: UserId, reason: LogoutReason) { callbacks.forEach { it(userId, reason) } }
 }
 
-interface LogoutCallback {
-    suspend operator fun invoke(userId: UserId, reason: LogoutReason)
-}
+typealias LogoutCallback = (userId: UserId, reason: LogoutReason) -> Unit

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutCallbackManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutCallbackManager.kt
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.auth
+
+import co.touchlab.stately.collections.ConcurrentMutableList
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.user.UserId
+
+interface LogoutCallbackManager {
+    fun register(callback: LogoutCallback)
+    fun unregister(callback: LogoutCallback)
+    suspend fun logout(userId: UserId, reason: LogoutReason)
+}
+
+class LogoutCallbackManagerImpl : LogoutCallbackManager {
+    private val callbacks = ConcurrentMutableList<LogoutCallback>()
+    override fun register(callback: LogoutCallback) { callbacks.add(callback) }
+    override fun unregister(callback: LogoutCallback) { callbacks.remove(callback) }
+    override suspend fun logout(userId: UserId, reason: LogoutReason) { callbacks.forEach { it(userId, reason) } }
+}
+
+interface LogoutCallback {
+    suspend operator fun invoke(userId: UserId, reason: LogoutReason)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionFlowUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionFlowUseCase.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 /**
@@ -40,5 +41,5 @@ class CurrentSessionFlowUseCase(private val sessionRepository: SessionRepository
             }, {
                 CurrentSessionResult.Success(it)
             })
-        }
+        }.distinctUntilChanged()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncCriteriaProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncCriteriaProvider.kt
@@ -44,7 +44,7 @@ internal interface SyncCriteriaResolution {
     /**
      * At least a criterion is not satisfied
      */
-    class MissingRequirement(val cause: String) : SyncCriteriaResolution
+    data class MissingRequirement(val cause: String) : SyncCriteriaResolution
 }
 
 /**

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -22,6 +22,7 @@ package com.wire.kalium.logic.feature.auth
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -29,9 +30,9 @@ import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.logout.LogoutRepository
 import com.wire.kalium.logic.data.notification.PushTokenRepository
 import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.UserSessionScopeProvider
-import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.client.ClearClientDataUseCase
@@ -79,10 +80,6 @@ class LogoutUseCaseTest {
             logoutUseCase.invoke(reason)
             arrangement.globalTestScope.advanceUntilIdle()
 
-            verify(arrangement.deregisterTokenUseCase)
-                .suspendFunction(arrangement.deregisterTokenUseCase::invoke)
-                .wasInvoked(exactly = once)
-
             verify(arrangement.sessionRepository)
                 .suspendFunction(arrangement.sessionRepository::logout)
                 .with(any(), eq(reason))
@@ -107,6 +104,10 @@ class LogoutUseCaseTest {
                     .with(eq(true))
                     .wasInvoked(exactly = once)
             }
+            verify(arrangement.logoutCallbackManager)
+                .function(arrangement.logoutCallbackManager::logout)
+                .with(any<UserId>(), eq(reason))
+                .wasInvoked()
         }
     }
 
@@ -209,6 +210,9 @@ class LogoutUseCaseTest {
         logoutUseCase.invoke(reason)
         arrangement.globalTestScope.advanceUntilIdle()
 
+        verify(arrangement.deregisterTokenUseCase)
+            .suspendFunction(arrangement.deregisterTokenUseCase::invoke)
+            .wasNotInvoked()
         verify(arrangement.logoutRepository)
             .suspendFunction(arrangement.logoutRepository::logout)
             .wasNotInvoked()
@@ -240,6 +244,9 @@ class LogoutUseCaseTest {
             logoutUseCase.invoke(reason)
             arrangement.globalTestScope.advanceUntilIdle()
 
+            verify(arrangement.deregisterTokenUseCase)
+                .suspendFunction(arrangement.deregisterTokenUseCase::invoke)
+                .wasInvoked(exactly = once)
             verify(arrangement.logoutRepository)
                 .suspendFunction(arrangement.logoutRepository::logout)
                 .wasInvoked(exactly = once)
@@ -278,6 +285,9 @@ class LogoutUseCaseTest {
         logoutUseCase.invoke(reason)
         arrangement.globalTestScope.advanceUntilIdle()
 
+        verify(arrangement.deregisterTokenUseCase)
+            .suspendFunction(arrangement.deregisterTokenUseCase::invoke)
+            .wasInvoked(exactly = once)
         verify(arrangement.logoutRepository)
             .suspendFunction(arrangement.logoutRepository::logout)
             .wasInvoked(exactly = once)
@@ -318,6 +328,9 @@ class LogoutUseCaseTest {
         logoutUseCase.invoke(reason)
         arrangement.globalTestScope.advanceUntilIdle()
 
+        verify(arrangement.deregisterTokenUseCase)
+            .suspendFunction(arrangement.deregisterTokenUseCase::invoke)
+            .wasInvoked(exactly = once)
         verify(arrangement.logoutRepository)
             .suspendFunction(arrangement.logoutRepository::logout)
             .wasInvoked(exactly = once)
@@ -365,6 +378,9 @@ class LogoutUseCaseTest {
         @Mock
         val endCall = configure(mock(EndCallUseCase::class)) { stubsUnitByDefault = true }
 
+        @Mock
+        val logoutCallbackManager = configure(mock(classOf<LogoutCallbackManager>())) { stubsUnitByDefault = true }
+
         var kaliumConfigs = KaliumConfigs()
 
         val globalTestScope = TestScope()
@@ -384,6 +400,7 @@ class LogoutUseCaseTest {
                 userSessionWorkScheduler,
                 observeEstablishedCallsUseCase,
                 endCall,
+                logoutCallbackManager,
                 kaliumConfigs
             )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionFlowUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/CurrentSessionFlowUseCaseTest.kt
@@ -80,6 +80,27 @@ class CurrentSessionFlowUseCaseTest {
 
         verify(sessionRepository).invocation { currentSessionFlow() }.wasInvoked(exactly = once)
     }
+    @Test
+    fun givenAUserID_whenCurrentSessionFlowEmitsSameDataAgain_thenDoPropagateTheSameDataAgain() = runTest {
+        val expected: AccountInfo = TEST_ACCOUNT_INFO
+
+        given(sessionRepository).invocation { currentSessionFlow() }.then {
+            flow {
+                emit(Either.Right(expected))
+                emit(Either.Right(expected))
+            }
+        }
+
+        currentSessionFlowUseCase().test {
+            awaitItem().run {
+                assertIs<CurrentSessionResult.Success>(this)
+                assertEquals(expected, this.accountInfo)
+            }
+            awaitComplete()
+        }
+
+        verify(sessionRepository).invocation { currentSessionFlow() }.wasInvoked(exactly = once)
+    }
 
     private companion object {
         val TEST_ACCOUNT_INFO: AccountInfo = AccountInfo.Valid(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Top crashes types currently are the ones related to missing `ServerConfig` when making some actions.

### Causes (Optional)

When session is expired (the app receives 403 when trying to refresh a token) there is an infinite loop, because the app tries to logout - deregister token which results in 401 and it triggers the auth token refresh again resulting in 403 and trying to logout again. After each iteration, `CurrentSessionFlowUseCase` emits the same item again, which triggers multiple actions in the whole app and creates a race condition when logging out (session should be invalid but with all the loop iterations in a fraction of a second the app can still get the previous value).
Some logout actions in Android project are not executed when account is logged out from kalium (when session expires, device is removed from another place or account deleted).

### Solutions

- execute `deregister token` request the same way as `logout` request - only if the logout is not because of the session expiration because otherwise it won't be successful anyway since the app doesn't have a valid token anymore - it prevents from falling into an endless 403-401 loop
- provide a `LogoutCallbackManager` which allows the app to register for logout callbacks and triggered when the logout happens in kalium to execute all other required logout-related actions in Android
- make `GlobalKaliumScope` to not create a new instance every time
- make `CurrentSessionFlow` `distinctUntilChanged` so that it doesn’t re-emit the same items
- make `SyncCriteriaResolution.MissingRequirements` a data class to get the `reason` String in logs as right now it’s not visible and we don’t know what is the reason of failed sync
- provide logs for `AccountSwitchUseCase` ✅

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
