### PR TITLE
feat(mls): handle unsupported protocol for conversation [WPB-5047]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -138,7 +138,7 @@ class ConversationScope internal constructor(
         get() = ObserveIsSelfUserMemberUseCaseImpl(conversationRepository, selfUserId)
 
     val observeConversationInteractionAvailabilityUseCase: ObserveConversationInteractionAvailabilityUseCase
-        get() = ObserveConversationInteractionAvailabilityUseCase(conversationRepository)
+        get() = ObserveConversationInteractionAvailabilityUseCase(conversationRepository, userRepository)
 
     val deleteTeamConversation: DeleteTeamConversationUseCase
         get() = DeleteTeamConversationUseCaseImpl(selfTeamIdProvider, teamRepository, conversationRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
@@ -19,29 +19,52 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 /**
- * Use case that check if self user is able to interact in conversation
- * @param conversationId the id of the conversation where user checks his interaction availability
- * @return an [IsInteractionAvailableResult] containing Success or Failure cases
+ * Use case that check if self user is able to interact in conversation.
+ *
+ * To interact with a conversation means to be able to send messages. This includes non-standalone messages,
+ * like [MessageContent.Reaction], [MessageContent.ButtonAction], etc.
+ *
+ * @see InteractionAvailability
  */
 class ObserveConversationInteractionAvailabilityUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
-    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
+    private val userRepository: UserRepository,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) {
+
+    /**
+     * @param conversationId the id of the conversation where user checks his interaction availability
+     * @return an [IsInteractionAvailableResult] containing Success or Failure cases
+     */
     suspend operator fun invoke(conversationId: ConversationId): Flow<IsInteractionAvailableResult> = withContext(dispatcher.io) {
-        conversationRepository.observeConversationDetailsById(conversationId).map { eitherConversation ->
+        conversationRepository.observeConversationDetailsById(conversationId).combine(
+            userRepository.observeSelfUser()
+        ) { conversation, selfUser ->
+            conversation to selfUser
+        }.map { (eitherConversation, selfUser) ->
             eitherConversation.fold({ failure -> IsInteractionAvailableResult.Failure(failure) }, { conversationDetails ->
+                val isProtocolSupported = doesUserSupportConversationProtocol(conversationDetails, selfUser)
+                if (!isProtocolSupported) { // short-circuit to Unsupported Protocol if it's the case
+                    return@fold IsInteractionAvailableResult.Success(InteractionAvailability.UNSUPPORTED_PROTOCOL)
+                }
                 val availability = when (conversationDetails) {
                     is ConversationDetails.Connection -> InteractionAvailability.DISABLED
                     is ConversationDetails.Group -> {
@@ -66,6 +89,23 @@ class ObserveConversationInteractionAvailabilityUseCase internal constructor(
             })
         }
     }
+
+    private fun doesUserSupportConversationProtocol(
+        conversationDetails: ConversationDetails,
+        selfUser: SelfUser
+    ): Boolean {
+        val protocolInfo = conversationDetails.conversation.protocol
+        val acceptableProtocols = when (protocolInfo) {
+            is Conversation.ProtocolInfo.MLS -> setOf(SupportedProtocol.MLS)
+            // Messages in mixed conversations are sent through Proteus
+            is Conversation.ProtocolInfo.Mixed -> setOf(SupportedProtocol.PROTEUS)
+            Conversation.ProtocolInfo.Proteus -> setOf(SupportedProtocol.PROTEUS)
+        }
+        val isProtocolSupported = selfUser.supportedProtocols?.any { supported ->
+            acceptableProtocols.contains(supported)
+        } ?: false
+        return isProtocolSupported
+    }
 }
 
 sealed class IsInteractionAvailableResult {
@@ -85,6 +125,11 @@ enum class InteractionAvailability {
 
     /**Other team member or public user has been removed */
     DELETED_USER,
+
+    /**
+     * This indicates that the conversation is using a protocol that self user does not support.
+     */
+    UNSUPPORTED_PROTOCOL,
 
     /**Conversation type doesn't support messaging */
     DISABLED

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
@@ -20,17 +20,18 @@ package com.wire.kalium.logic.feature.conversation
 
 import app.cash.turbine.test
 import com.wire.kalium.logic.StorageFailure
-import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversationDetails
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
-import io.mockative.Mock
-import io.mockative.any
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import io.mockative.eq
-import io.mockative.given
-import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.flow.flowOf
@@ -45,9 +46,9 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenUserIsAGroupMember_whenInvokingInteractionForConversation_thenInteractionShouldBeEnabled() = runTest {
         val conversationId = TestConversation.ID
 
-        val (arrangement, observeConversationInteractionAvailability) = Arrangement()
-            .withGroupConversation(isMember = true)
-            .arrange()
+        val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withSelfUserBeingMemberOfConversation(isMember = true)
+        }
 
         observeConversationInteractionAvailability(conversationId).test {
             val interactionResult = awaitItem()
@@ -67,9 +68,9 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenUserIsNoLongerAGroupMember_whenInvokingInteractionForConversation_thenInteractionShouldBeEnabled() = runTest {
         val conversationId = TestConversation.ID
 
-        val (arrangement, observeConversationInteractionAvailability) = Arrangement()
-            .withGroupConversation(isMember = false)
-            .arrange()
+        val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withSelfUserBeingMemberOfConversation(isMember = false)
+        }
 
         observeConversationInteractionAvailability(conversationId).test {
             val interactionResult = awaitItem()
@@ -89,9 +90,9 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenGroupDetailsReturnsError_whenInvokingInteractionForConversation_thenInteractionShouldReturnFailure() = runTest {
         val conversationId = TestConversation.ID
 
-        val (arrangement, observeConversationInteractionAvailability) = Arrangement()
-            .withGroupConversationError()
-            .arrange()
+        val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withGroupConversationError()
+        }
 
         observeConversationInteractionAvailability(conversationId).test {
             val interactionResult = awaitItem()
@@ -111,9 +112,9 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenOtherUserIsBlocked_whenInvokingInteractionForConversation_thenInteractionShouldBeDisabled() = runTest {
         val conversationId = TestConversation.ID
 
-        val (arrangement, observeConversationInteractionAvailability) = Arrangement()
-            .withBlockedUserConversation()
-            .arrange()
+        val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withBlockedUserConversation()
+        }
 
         observeConversationInteractionAvailability(conversationId).test {
             val interactionResult = awaitItem()
@@ -133,9 +134,9 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenOtherUserIsDeleted_whenInvokingInteractionForConversation_thenInteractionShouldBeDisabled() = runTest {
         val conversationId = TestConversation.ID
 
-        val (arrangement, observeConversationInteractionAvailability) = Arrangement()
-            .withDeletedUserConversation()
-            .arrange()
+        val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withDeletedUserConversation()
+        }
 
         observeConversationInteractionAvailability(conversationId).test {
             val interactionResult = awaitItem()
@@ -148,64 +149,143 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
 
             awaitComplete()
         }
-
     }
 
-    private class Arrangement {
-        @Mock
-        val conversationRepository = mock(ConversationRepository::class)
+    @Test
+    fun givenProteusConversationAndUserSupportsOnlyMLS_whenObserving_thenShouldReturnUnsupportedProtocol() = runTest {
+        testProtocolSupport(
+            conversationProtocolInfo = Conversation.ProtocolInfo.Proteus,
+            userSupportedProtocols = setOf(SupportedProtocol.MLS),
+            expectedResult = InteractionAvailability.UNSUPPORTED_PROTOCOL
+        )
+    }
 
-        val observeConversationInteractionAvailability: ObserveConversationInteractionAvailabilityUseCase =
-            ObserveConversationInteractionAvailabilityUseCase(conversationRepository)
+    @Test
+    fun givenMLSConversationAndUserSupportsOnlyMLS_whenObserving_thenShouldReturnUnsupportedProtocol() = runTest {
+        testProtocolSupport(
+            conversationProtocolInfo = TestConversation.MLS_PROTOCOL_INFO,
+            userSupportedProtocols = setOf(SupportedProtocol.PROTEUS),
+            expectedResult = InteractionAvailability.UNSUPPORTED_PROTOCOL
+        )
+    }
 
-        fun withGroupConversation(isMember: Boolean) = apply {
-            given(conversationRepository)
-                .suspendFunction(conversationRepository::observeConversationDetailsById)
-                .whenInvokedWith(any())
-                .thenReturn(flowOf(Either.Right(TestConversationDetails.CONVERSATION_GROUP.copy(isSelfUserMember = isMember))))
+    @Test
+    fun givenMixedConversationAndUserSupportsOnlyMLS_whenObserving_thenShouldReturnUnsupportedProtocol() = runTest {
+        testProtocolSupport(
+            conversationProtocolInfo = TestConversation.MIXED_PROTOCOL_INFO,
+            userSupportedProtocols = setOf(SupportedProtocol.PROTEUS),
+            expectedResult = InteractionAvailability.ENABLED
+        )
+    }
+
+    @Test
+    fun givenMixedConversationAndUserSupportsProteus_whenObserving_thenShouldReturnEnabled() = runTest {
+        testProtocolSupport(
+            conversationProtocolInfo = TestConversation.MIXED_PROTOCOL_INFO,
+            userSupportedProtocols = setOf(SupportedProtocol.PROTEUS),
+            expectedResult = InteractionAvailability.ENABLED
+        )
+    }
+
+    @Test
+    fun givenMLSConversationAndUserSupportsMLS_whenObserving_thenShouldReturnEnabled() = runTest {
+        testProtocolSupport(
+            conversationProtocolInfo = TestConversation.MLS_PROTOCOL_INFO,
+            userSupportedProtocols = setOf(SupportedProtocol.MLS),
+            expectedResult = InteractionAvailability.ENABLED
+        )
+    }
+
+    @Test
+    fun givenProteusConversationAndUserSupportsProteus_whenObserving_thenShouldReturnEnabled() = runTest {
+        testProtocolSupport(
+            conversationProtocolInfo = TestConversation.PROTEUS_PROTOCOL_INFO,
+            userSupportedProtocols = setOf(SupportedProtocol.PROTEUS),
+            expectedResult = InteractionAvailability.ENABLED
+        )
+    }
+
+    private suspend fun testProtocolSupport(
+        conversationProtocolInfo: Conversation.ProtocolInfo,
+        userSupportedProtocols: Set<SupportedProtocol>,
+        expectedResult: InteractionAvailability
+    ) {
+        val convId = TestConversationDetails.CONVERSATION_GROUP.conversation.id
+        val (_, observeConversationInteractionAvailabilityUseCase) = arrange {
+            val proteusGroupDetails = TestConversationDetails.CONVERSATION_GROUP.copy(
+                conversation = TestConversationDetails.CONVERSATION_GROUP.conversation.copy(
+                    protocol = conversationProtocolInfo
+                )
+            )
+            withObserveConversationDetailsByIdReturning(Either.Right(proteusGroupDetails))
+            withObservingSelfUserReturning(flowOf(TestUser.SELF.copy(supportedProtocols = userSupportedProtocols)))
         }
 
-        fun withGroupConversationError() = apply {
-            given(conversationRepository)
-                .suspendFunction(conversationRepository::observeConversationDetailsById)
-                .whenInvokedWith(any())
-                .thenReturn(flowOf(Either.Left(StorageFailure.DataNotFound)))
+        observeConversationInteractionAvailabilityUseCase(convId).test {
+            val result = awaitItem()
+            assertIs<IsInteractionAvailableResult.Success>(result)
+            assertEquals(expectedResult, result.interactionAvailability)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class Arrangement(
+        private val configure: Arrangement.() -> Unit
+    ) : UserRepositoryArrangement by UserRepositoryArrangementImpl(),
+        ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl() {
+
+        init {
+            withObservingSelfUserReturning(
+                flowOf(
+                    TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS))
+                )
+            )
+        }
+
+        fun withSelfUserBeingMemberOfConversation(isMember: Boolean) = apply {
+            withObserveConversationDetailsByIdReturning(
+                Either.Right(TestConversationDetails.CONVERSATION_GROUP.copy(isSelfUserMember = isMember))
+            )
+        }
+
+        fun withGroupConversationError() {
+            withObserveConversationDetailsByIdReturning(Either.Left(StorageFailure.DataNotFound))
         }
 
         fun withBlockedUserConversation() = apply {
-            given(conversationRepository)
-                .suspendFunction(conversationRepository::observeConversationDetailsById)
-                .whenInvokedWith(any())
-                .thenReturn(
-                    flowOf(
-                        Either.Right(
-                            TestConversationDetails.CONVERSATION_ONE_ONE.copy(
-                                otherUser = TestUser.OTHER.copy(
-                                    connectionStatus = ConnectionState.BLOCKED
-                                )
-                            )
+            withObserveConversationDetailsByIdReturning(
+                Either.Right(
+                    TestConversationDetails.CONVERSATION_ONE_ONE.copy(
+                        otherUser = TestUser.OTHER.copy(
+                            connectionStatus = ConnectionState.BLOCKED
                         )
                     )
                 )
+            )
         }
 
         fun withDeletedUserConversation() = apply {
-            given(conversationRepository)
-                .suspendFunction(conversationRepository::observeConversationDetailsById)
-                .whenInvokedWith(any())
-                .thenReturn(
-                    flowOf(
-                        Either.Right(
-                            TestConversationDetails.CONVERSATION_ONE_ONE.copy(
-                                otherUser = TestUser.OTHER.copy(
-                                    deleted = true
-                                )
-                            )
+            withObserveConversationDetailsByIdReturning(
+                Either.Right(
+                    TestConversationDetails.CONVERSATION_ONE_ONE.copy(
+                        otherUser = TestUser.OTHER.copy(
+                            deleted = true
                         )
                     )
                 )
+            )
         }
 
-        fun arrange() = this to observeConversationInteractionAvailability
+        fun arrange(): Pair<Arrangement, ObserveConversationInteractionAvailabilityUseCase> = run {
+            configure()
+            this@Arrangement to ObserveConversationInteractionAvailabilityUseCase(
+                conversationRepository = conversationRepository,
+                userRepository = userRepository
+            )
+        }
+    }
+
+    private companion object {
+        fun arrange(configure: Arrangement.() -> Unit) = Arrangement(configure).arrange()
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
@@ -58,6 +58,8 @@ internal interface UserRepositoryArrangement {
 
     fun withSelfUserReturning(selfUser: SelfUser?)
 
+    fun withObservingSelfUserReturning(selfUserFlow: Flow<SelfUser>)
+
     fun withUserByIdReturning(result: Either<CoreFailure, OtherUser>)
 
     fun withUpdateOneOnOneConversationReturning(result: Either<CoreFailure, Unit>)
@@ -143,6 +145,13 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
             .suspendFunction(userRepository::getSelfUser)
             .whenInvoked()
             .thenReturn(selfUser)
+    }
+
+    override fun withObservingSelfUserReturning(selfUserFlow: Flow<SelfUser>) {
+        given(userRepository)
+            .suspendFunction(userRepository::observeSelfUser)
+            .whenInvoked()
+            .thenReturn(selfUserFlow)
     }
 
     override fun withUserByIdReturning(result: Either<CoreFailure, OtherUser>) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

During MLS migration, it is possible that some users have only access to MLS or Proteus protocol, and the conversation/other user, is using another protocol.

We need to be able to identify this on the UI-level and show something to the user.

### Solutions

Add a new possible result for `InteractionAvailability`, called `UNSUPPORTED_PROTOCOL`, that indicates this scenario.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
