### PR TITLE
feat: sending location messages (WPB-1732)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -133,8 +133,26 @@ class ProtoContentMapperImpl(
             is MessageContent.ButtonAction -> packButtonAction(readableContent)
 
             is MessageContent.ButtonActionConfirmation -> TODO()
-            is MessageContent.Location -> TODO("todo, when implementing send location")
+            is MessageContent.Location -> packLocation(readableContent, expectsReadConfirmation, legalHoldStatus)
         }
+    }
+
+    private fun packLocation(
+        readableContent: MessageContent.Location,
+        expectsReadConfirmation: Boolean,
+        legalHoldStatus: Conversation.LegalHoldStatus
+    ): GenericMessage.Content.Location {
+        val protoLegalHoldStatus = toProtoLegalHoldStatus(legalHoldStatus)
+        return GenericMessage.Content.Location(
+            Location(
+                latitude = readableContent.latitude,
+                longitude = readableContent.longitude,
+                name = readableContent.name,
+                zoom = readableContent.zoom,
+                expectsReadConfirmation = expectsReadConfirmation,
+                legalHoldStatus = protoLegalHoldStatus
+            )
+        )
     }
 
     private fun packButtonAction(
@@ -203,7 +221,10 @@ class ProtoContentMapperImpl(
             }
 
             is MessageContent.Location -> {
-                TODO("todo, when implementing send location")
+                val location = packLocation(readableContent, expectsReadConfirmation, legalHoldStatus)
+                Ephemeral.Content.Location(
+                    location.value
+                )
             }
 
             is MessageContent.FailedDecryption,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapper
+import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -44,7 +45,6 @@ import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapperImpl
 import com.wire.kalium.logic.feature.asset.GetImageAssetMessagesForConversationUseCase
 import com.wire.kalium.logic.feature.asset.GetImageAssetMessagesForConversationUseCaseImpl
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
@@ -286,6 +286,17 @@ class MessageScope internal constructor(
 
     val sendKnock: SendKnockUseCase
         get() = SendKnockUseCase(
+            persistMessage,
+            selfUserId,
+            currentClientIdProvider,
+            slowSyncRepository,
+            messageSender,
+            messageSendFailureHandler,
+            observeSelfDeletingMessages
+        )
+
+    val sendLocation: SendLocationUseCase
+        get() = SendLocationUseCase(
             persistMessage,
             selfUserId,
             currentClientIdProvider,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
@@ -1,0 +1,104 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.message
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration
+
+/**
+ * Sending a location message to a conversation
+ */
+@Suppress("LongParameterList")
+class SendLocationUseCase internal constructor(
+    private val persistMessage: PersistMessageUseCase,
+    private val selfUserId: QualifiedID,
+    private val currentClientIdProvider: CurrentClientIdProvider,
+    private val slowSyncRepository: SlowSyncRepository,
+    private val messageSender: MessageSender,
+    private val messageSendFailureHandler: MessageSendFailureHandler,
+    private val selfDeleteTimer: ObserveSelfDeletionTimerSettingsForConversationUseCase,
+    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
+) {
+
+    /**
+     * Operation to send a location message to a conversation.
+
+     * @return [Either] [CoreFailure] or [Unit]
+     */
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        latitude: Float,
+        longitude: Float,
+        name: String?,
+        zoom: Int
+    ): Either<CoreFailure, Unit> = withContext(dispatcher.io) {
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
+
+        val generatedMessageUuid = uuid4().toString()
+        val messageTimer: Duration? = selfDeleteTimer(conversationId, true)
+            .first()
+            .duration
+
+        return@withContext currentClientIdProvider().flatMap { currentClientId ->
+            val message = Message.Regular(
+                id = generatedMessageUuid,
+                content = MessageContent.Location(
+                    name = name,
+                    latitude = latitude,
+                    longitude = longitude,
+                    zoom = zoom
+                ),
+                conversationId = conversationId,
+                date = DateTimeUtil.currentIsoDateTimeString(),
+                senderUserId = selfUserId,
+                senderClientId = currentClientId,
+                status = Message.Status.Pending,
+                editStatus = Message.EditStatus.NotEdited,
+                isSelfMessage = true,
+                expirationData = messageTimer?.let { Message.ExpirationData(it) }
+            )
+            persistMessage(message)
+                .flatMap { messageSender.sendMessage(message) }
+        }.onFailure { messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, generatedMessageUuid, TYPE) }
+    }
+
+    companion object {
+        const val TYPE = "Location"
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
@@ -56,7 +56,13 @@ class SendLocationUseCase internal constructor(
 
     /**
      * Operation to send a location message to a conversation.
-
+     *
+     * @param conversationId the id of the conversation to send the location to
+     * @param latitude the latitude of the location
+     * @param longitude the longitude of the location
+     * @param name the address line or name of the location to send
+     * @param zoom the zoom level of the location
+     *
      * @return [Either] [CoreFailure] or [Unit]
      */
     suspend operator fun invoke(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -239,6 +239,7 @@ class ProtoContentMapperTest {
 
         assertEquals(originalContent, decoded)
     }
+
     @Test
     fun givenReactionContent_whenMappingToProtoAndBack_thenShouldMaintainSameValues() {
         val messageUid = "uid"
@@ -276,6 +277,7 @@ class ProtoContentMapperTest {
 
         assertEquals(originalContent, decoded)
     }
+
     @Test
     fun givenCompositeContent_whenMappingToProtoAndBack_thenShouldMaintainSameValues() {
         val messageUid = "uid"
@@ -407,6 +409,27 @@ class ProtoContentMapperTest {
         assertIs<ProtoContent.Readable>(decoded)
         assertEquals(decoded.expiresAfterMillis, expiresAfterMillis)
         assertEquals(protoContent, decoded)
+    }
+
+    @Test
+    fun givenProtoLocationContent_whenMappingProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
+        val messageContent = MessageContent.Location(
+            latitude = 1.0f,
+            longitude = 2.0f,
+            zoom = 3,
+            name = "name"
+        )
+        val protoContent = ProtoContent.Readable(
+            TEST_MESSAGE_UUID,
+            messageContent,
+            false,
+            Conversation.LegalHoldStatus.DISABLED
+        )
+
+        val encoded = protoContentMapper.encodeToProtobuf(protoContent)
+        val decoded = protoContentMapper.decodeFromProtobuf(encoded)
+
+        assertEquals(decoded, protoContent)
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCaseTest.kt
@@ -1,0 +1,220 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.arrangement.ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement
+import com.wire.kalium.logic.util.arrangement.ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangementImpl
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.configure
+import io.mockative.given
+import io.mockative.matching
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+
+class SendLocationUseCaseTest {
+
+    @Test
+    fun givenAValidSendLocationRequest_whenSendingLocation_thenShouldReturnASuccessResult() = runTest {
+        // Given
+        val conversationId = ConversationId("some-convo-id", "some-domain-id")
+        val (arrangement, sendLocationUseCase) = Arrangement()
+            .withCurrentClientProviderSuccess()
+            .withPersistMessageSuccess()
+            .withSlowSyncStatusComplete()
+            .withSendMessageSuccess()
+            .arrange {
+                withConversationTimer(flowOf(SelfDeletionTimer.Disabled))
+            }
+
+        // When
+        val result = sendLocationUseCase.invoke(conversationId, LATITUDE, LONGITUDE, NAME, ZOOM)
+
+        // Then
+        assertTrue(result is Either.Right)
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(any(), any())
+            .wasInvoked(once)
+        verify(arrangement.messageSendFailureHandler)
+            .suspendFunction(arrangement.messageSendFailureHandler::handleFailureAndUpdateMessageStatus)
+            .with(any(), any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+    @Test
+    fun givenNoNetwork_whenSendingLocation_thenShouldReturnAFailure() = runTest {
+        // Given
+        val conversationId = ConversationId("some-convo-id", "some-domain-id")
+        val (arrangement, sendLocationUseCase) = Arrangement()
+            .withCurrentClientProviderSuccess()
+            .withPersistMessageSuccess()
+            .withSlowSyncStatusComplete()
+            .withSendMessageFailure()
+            .arrange {
+                withConversationTimer(flowOf(SelfDeletionTimer.Disabled))
+            }
+
+        // When
+        val result = sendLocationUseCase.invoke(conversationId, LATITUDE, LONGITUDE, NAME, ZOOM)
+
+        // Then
+        assertTrue(result is Either.Left)
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(any(), any())
+            .wasInvoked(once)
+        verify(arrangement.messageSendFailureHandler)
+            .suspendFunction(arrangement.messageSendFailureHandler::handleFailureAndUpdateMessageStatus)
+            .with(any(), any(), any(), any(), any())
+            .wasInvoked(once)
+    }
+
+    @Test
+    fun givenConversationHasTimer_whenSendingLocation_thenTheTimerIsAdded() = runTest {
+        // Given
+        val expectedDuration = Duration.parse("PT1H")
+        val conversationId = ConversationId("some-convo-id", "some-domain-id")
+        val (arrangement, sendLocationUseCase) = Arrangement()
+            .withCurrentClientProviderSuccess()
+            .withPersistMessageSuccess()
+            .withSlowSyncStatusComplete()
+            .withSendMessageSuccess()
+            .arrange {
+                withConversationTimer(flowOf(SelfDeletionTimer.Enabled(expectedDuration)))
+            }
+
+        // When
+        val result = sendLocationUseCase.invoke(conversationId, LATITUDE, LONGITUDE, NAME, ZOOM)
+
+        // Then
+        assertTrue(result is Either.Right)
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(matching {
+                assertIs<Message.Regular>(it)
+                it.expirationData?.expireAfter == expectedDuration
+            }, any())
+            .wasInvoked(once)
+        verify(arrangement.messageSendFailureHandler)
+            .suspendFunction(arrangement.messageSendFailureHandler::handleFailureAndUpdateMessageStatus)
+            .with(any(), any(), any(), any(), any())
+            .wasNotInvoked()
+    }
+
+
+    private class Arrangement :
+        ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement by ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangementImpl() {
+
+        @Mock
+        private val persistMessage = mock(classOf<PersistMessageUseCase>())
+
+        @Mock
+        val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
+
+        @Mock
+        private val slowSyncRepository = mock(classOf<SlowSyncRepository>())
+
+        @Mock
+        val messageSender = mock(classOf<MessageSender>())
+
+        @Mock
+        val messageSendFailureHandler = configure(mock(classOf<MessageSendFailureHandler>())) { stubsUnitByDefault = true }
+
+
+        fun withSendMessageSuccess() = apply {
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withSendMessageFailure() = apply {
+            given(messageSender)
+                .suspendFunction(messageSender::sendMessage)
+                .whenInvokedWith(any(), any())
+                .thenReturn(Either.Left(NetworkFailure.NoNetworkConnection(null)))
+        }
+
+        fun withCurrentClientProviderSuccess(clientId: ClientId = TestClient.CLIENT_ID) = apply {
+            given(currentClientIdProvider)
+                .suspendFunction(currentClientIdProvider::invoke)
+                .whenInvoked()
+                .thenReturn(Either.Right(clientId))
+        }
+
+        fun withPersistMessageSuccess() = apply {
+            given(persistMessage)
+                .suspendFunction(persistMessage::invoke)
+                .whenInvokedWith(any())
+                .thenReturn(Either.Right(Unit))
+        }
+
+        fun withSlowSyncStatusComplete() = apply {
+            val stateFlow = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
+            given(slowSyncRepository)
+                .getter(slowSyncRepository::slowSyncStatus)
+                .whenInvoked()
+                .thenReturn(stateFlow)
+        }
+
+        fun arrange(block: (Arrangement.() -> Unit) = {}): Pair<Arrangement, SendLocationUseCase> {
+            block()
+            return this to SendLocationUseCase(
+                persistMessage,
+                TestUser.SELF.id,
+                currentClientIdProvider,
+                slowSyncRepository,
+                messageSender,
+                messageSendFailureHandler,
+                observeSelfDeletionTimerSettingsForConversation
+            )
+        }
+    }
+
+    private companion object {
+        const val LATITUDE = 52.0f
+        const val LONGITUDE = 52.0f
+        const val NAME = "Wire HQ, Berlin"
+        const val ZOOM = 20
+    }
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCaseTest.kt
@@ -32,6 +32,8 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.arrangement.ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement
 import com.wire.kalium.logic.util.arrangement.ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangementImpl
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -47,7 +49,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import kotlin.time.Duration
 
 class SendLocationUseCaseTest {
@@ -69,7 +70,7 @@ class SendLocationUseCaseTest {
         val result = sendLocationUseCase.invoke(conversationId, LATITUDE, LONGITUDE, NAME, ZOOM)
 
         // Then
-        assertTrue(result is Either.Right)
+        result.shouldSucceed()
         verify(arrangement.messageSender)
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(any(), any())
@@ -97,7 +98,7 @@ class SendLocationUseCaseTest {
         val result = sendLocationUseCase.invoke(conversationId, LATITUDE, LONGITUDE, NAME, ZOOM)
 
         // Then
-        assertTrue(result is Either.Left)
+        result.shouldFail()
         verify(arrangement.messageSender)
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(any(), any())
@@ -126,7 +127,8 @@ class SendLocationUseCaseTest {
         val result = sendLocationUseCase.invoke(conversationId, LATITUDE, LONGITUDE, NAME, ZOOM)
 
         // Then
-        assertTrue(result is Either.Right)
+
+        result.shouldSucceed()
         verify(arrangement.messageSender)
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(matching {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCaseTest.kt
@@ -127,7 +127,6 @@ class SendLocationUseCaseTest {
         val result = sendLocationUseCase.invoke(conversationId, LATITUDE, LONGITUDE, NAME, ZOOM)
 
         // Then
-
         result.shouldSucceed()
         verify(arrangement.messageSender)
             .suspendFunction(arrangement.messageSender::sendMessage)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We didn't have support for sending location messages.

### Causes (Optional)

Not implemented.

### Solutions

Implement the sending location messages (supporting self deleting as well) 

### Dependencies (Optional)

PR incoming on Android.
- https://github.com/wireapp/wire-android/pull/2582

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
