### PR TITLE
test: improve contracts when asserting either result

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -253,7 +253,7 @@ class AssetRepositoryTest {
 
         // Then
         with(arrangement) {
-            assertTrue(result is Either.Right)
+            result.shouldSucceed()
             val expectedPath = fakeKaliumFileSystem.providePersistentAssetPath("${assetKey.value}.${assetName.fileExtension()}")
             val realPath = result.value
             assertEquals(expectedPath, realPath)
@@ -300,7 +300,7 @@ class AssetRepositoryTest {
 
             // Then
             with(arrangement) {
-                assertTrue(result is Either.Left)
+                result.shouldFail()
                 assertIs<StorageFailure.DataNotFound>(result.value)
                 verify(assetDAO).suspendFunction(assetDAO::getAssetByKey)
                     .with(eq(assetKey.value))
@@ -346,7 +346,7 @@ class AssetRepositoryTest {
 
             // Then
             with(arrangement) {
-                assertTrue(result is Either.Right)
+                result.shouldSucceed()
                 assertEquals(assetPath, result.value)
                 verify(assetDAO).suspendFunction(assetDAO::getAssetByKey)
                     .with(eq(assetKey.value))
@@ -397,7 +397,7 @@ class AssetRepositoryTest {
 
         // Then
         with(arrangement) {
-            assertTrue(result is Either.Left)
+            result.shouldFail()
             assertTrue(result.value is EncryptionFailure.WrongAssetHash)
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -51,7 +51,6 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.thenDoNothing
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import okio.Buffer

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
@@ -62,6 +63,8 @@ import io.mockative.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import com.wire.kalium.network.api.base.model.UserId as NetworkUserId
 
 class ConnectionRepositoryTest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -28,7 +28,6 @@ import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
@@ -63,8 +62,6 @@ import io.mockative.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import com.wire.kalium.network.api.base.model.UserId as NetworkUserId
 
 class ConnectionRepositoryTest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -52,7 +52,6 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::loadACMEDirectories)
@@ -129,7 +128,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.initialEnrollment()
 
         // then
-        result.shouldFail()
         result.shouldFail()
 
         verify(arrangement.e2EIRepository)
@@ -209,7 +207,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.initialEnrollment()
 
         // then
-        result.shouldFail()
         result.shouldFail()
 
         verify(arrangement.e2EIRepository)
@@ -291,7 +288,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.initialEnrollment()
 
         // then
-        result.shouldFail()
         result.shouldFail()
 
         verify(arrangement.e2EIRepository)
@@ -375,7 +371,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.initialEnrollment()
 
         // then
-        result.shouldFail()
         result.shouldFail()
 
         verify(arrangement.e2EIRepository)
@@ -462,7 +457,6 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -528,7 +522,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
 
         // then
-        result.shouldFail()
         result.shouldFail()
 
         verify(arrangement.e2EIRepository)
@@ -599,7 +592,6 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -669,7 +661,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
 
         // then
-        result.shouldFail()
         result.shouldFail()
 
         verify(arrangement.e2EIRepository)
@@ -743,7 +734,6 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -811,7 +801,6 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -878,7 +867,6 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -939,7 +927,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
 
         // then
-        result.shouldFail()
         result.shouldFail()
 
         verify(arrangement.e2EIRepository)
@@ -1006,7 +993,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
 
         // then
-        result.shouldFail()
         result.shouldFail()
 
         verify(arrangement.e2EIRepository)
@@ -1078,7 +1064,6 @@ class EnrollE2EICertificateUseCaseTest {
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
 
         // then
-        result.shouldSucceed()
         result.shouldSucceed()
 
         verify(arrangement.e2EIRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -36,7 +36,6 @@ import io.mockative.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class EnrollE2EICertificateUseCaseTest {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -52,7 +52,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::loadACMEDirectories)
@@ -130,7 +130,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::loadACMEDirectories)
@@ -210,7 +210,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::loadACMEDirectories)
@@ -292,7 +292,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::loadACMEDirectories)
@@ -376,7 +376,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::loadACMEDirectories)
@@ -462,7 +462,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -529,7 +529,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -599,7 +599,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -670,7 +670,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -743,7 +743,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -811,7 +811,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -878,7 +878,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -940,7 +940,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -1007,7 +1007,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldFail()
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)
@@ -1079,7 +1079,7 @@ class EnrollE2EICertificateUseCaseTest {
 
         // then
         result.shouldSucceed()
-        assertTrue(result is Either.Right)
+        result.shouldSucceed()
 
         verify(arrangement.e2EIRepository)
             .function(arrangement.e2EIRepository::getWireNonce)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
@@ -52,7 +52,7 @@ class PersistMigratedMessagesUseCaseTest {
         val result = persistMigratedMessages(listOf(arrangement.fakeMigratedMessage()), TestScope())
 
         // Then
-        assertTrue(result is Either.Right)
+        result.shouldSucceed()
     }
 
     private class Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
-import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.persistence.dao.MigrationDAO
 import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.messages.GenericMessage
@@ -32,13 +32,10 @@ import io.mockative.Mock
 import io.mockative.any
 import io.mockative.given
 import io.mockative.mock
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class PersistMigratedMessagesUseCaseTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCaseTest.kt
@@ -67,7 +67,7 @@ class SendEditTextMessageUseCaseTest {
         val result = sendEditTextMessage(TestConversation.ID, originalMessageId, editedMessageText, listOf(), editedMessageId)
 
         // Then
-        assertTrue(result is Either.Right)
+        result.shouldSucceed()
         verify(arrangement.messageRepository)
             .suspendFunction(arrangement.messageRepository::updateTextMessage)
             .with(any(), any(), eq(originalMessageId), any())
@@ -104,7 +104,7 @@ class SendEditTextMessageUseCaseTest {
         val result = sendEditTextMessage(TestConversation.ID, originalMessageId, editedMessageText, listOf(), editedMessageId)
 
         // Then
-        assertTrue(result is Either.Left)
+        result.shouldFail()
         verify(arrangement.messageRepository)
             .suspendFunction(arrangement.messageRepository::updateTextMessage)
             .with(any(), any(), eq(originalMessageId), any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCaseTest.kt
@@ -28,6 +28,8 @@ import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import io.mockative.Mock
 import io.mockative.any
@@ -39,14 +41,11 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SendEditTextMessageUseCaseTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
@@ -71,7 +71,7 @@ class SendKnockUserCaseTest {
         val result = sendKnockUseCase.invoke(conversationId, false)
 
         // Then
-        assertTrue(result is Either.Right)
+        result.shouldSucceed()
         verify(arrangement.messageSender)
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(any(), any())
@@ -99,7 +99,7 @@ class SendKnockUserCaseTest {
         val result = sendKnockUseCase.invoke(conversationId, false)
 
         // Then
-        assertTrue(result is Either.Left)
+        result.shouldFail()
         verify(arrangement.messageSender)
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(any(), any())
@@ -128,7 +128,7 @@ class SendKnockUserCaseTest {
         val result = sendKnockUseCase.invoke(conversationId, false)
 
         // Then
-        assertTrue(result is Either.Right)
+        result.shouldSucceed()
         verify(arrangement.messageSender)
             .suspendFunction(arrangement.messageSender::sendMessage)
             .with(matching {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendKnockUserCaseTest.kt
@@ -32,6 +32,8 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.arrangement.ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangement
 import com.wire.kalium.logic.util.arrangement.ObserveSelfDeletionTimerSettingsForConversationUseCaseArrangementImpl
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -48,10 +50,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import kotlin.time.Duration
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SendKnockUserCaseTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -67,7 +68,7 @@ class SendTextMessageCaseTest {
         val result = sendTextMessage(TestConversation.ID, "some-text")
 
         // Then
-        assertTrue(result is Either.Right)
+        result.shouldSucceed()
 
         verify(arrangement.userPropertyRepository)
             .suspendFunction(arrangement.userPropertyRepository::getReadReceiptsStatus)
@@ -102,7 +103,7 @@ class SendTextMessageCaseTest {
         val result = sendTextMessage(TestConversation.ID, "some-text")
 
         // Then
-        assertTrue(result is Either.Left)
+        result.shouldFail()
 
         verify(arrangement.userPropertyRepository)
             .suspendFunction(arrangement.userPropertyRepository::getReadReceiptsStatus)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.any
@@ -41,15 +42,12 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SendTextMessageCaseTest {
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/EitherAssertions.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/EitherAssertions.kt
@@ -20,14 +20,30 @@ package com.wire.kalium.logic.util
 
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.fold
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 import kotlin.test.fail
 
-inline infix fun <L, R> Either<L, R>.shouldSucceed(crossinline successAssertion: (R) -> Unit) =
+@OptIn(ExperimentalContracts::class)
+inline infix fun <L, R> Either<L, R>.shouldSucceed(crossinline successAssertion: (R) -> Unit) {
+    contract { returns() implies (this@shouldSucceed is Either.Right<R>) }
     this.fold({ fail("Expected a Right value but got Left") }) { successAssertion(it) }
+}
 
-fun <L, R> Either<L, R>.shouldSucceed() = shouldSucceed { }
+@OptIn(ExperimentalContracts::class)
+fun <L, R> Either<L, R>.shouldSucceed() {
+    contract { returns() implies (this@shouldSucceed is Either.Right<R>) }
+    shouldSucceed { }
+}
 
-inline infix fun <L, R> Either<L, R>.shouldFail(crossinline failAssertion: (L) -> Unit): Unit =
+@OptIn(ExperimentalContracts::class)
+inline infix fun <L, R> Either<L, R>.shouldFail(crossinline failAssertion: (L) -> Unit) {
+    contract { returns() implies (this@shouldFail is Either.Left<L>) }
     this.fold({ failAssertion(it) }) { fail("Expected a Left value but got Right") }
+}
 
-fun <L, R> Either<L, R>.shouldFail(): Unit = shouldFail { }
+@OptIn(ExperimentalContracts::class)
+fun <L, R> Either<L, R>.shouldFail() {
+    contract { returns() implies (this@shouldFail is Either.Left<L>) }
+    shouldFail { }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When asserting either results, `either.shouldSucceed()` and `either.shouldFail()` do not have contracts making easy to consume their wrapped result.
Instead, we need to use `assertTrue(result is Either.Left)` which doesn't provide a good exception message, or `assertIs<Either<R>>(result)` which is verbose AF.

### Solutions

Rely on Kotlin contracts to make the best of both worlds.

Now `shouldSucceed` and `shouldFail` will tell the compiler what it needs to know and we can consume their types without further casting.

I found some usages in the code and replaced them

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
