### PR TITLE
feat: UseCase for getting all users E2EI certificates

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EIAllCertificatesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EIAllCertificatesUseCase.kt
@@ -23,9 +23,11 @@ import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
 import com.wire.kalium.logic.feature.e2ei.PemCertificateDecoder
 import com.wire.kalium.logic.functional.getOrElse
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.data.conversation.ClientId
 
 /**
- * This use case is used to get the e2ei certificate status of specific user
+ * This use case is used to get all e2ei certificates of the user.
+ * Returns Map<String, E2eiCertificate> where key is value of [ClientId] and [E2eiCertificate] is certificate itself
  */
 interface GetUserE2eiCertificatesUseCase {
     suspend operator fun invoke(userId: UserId): Map<String, E2eiCertificate>

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EIAllCertificatesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EIAllCertificatesUseCase.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.e2ei.usecase
+
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
+import com.wire.kalium.logic.feature.e2ei.PemCertificateDecoder
+import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.functional.map
+
+/**
+ * This use case is used to get the e2ei certificate status of specific user
+ */
+interface GetUserE2eiCertificatesUseCase {
+    suspend operator fun invoke(userId: UserId): Map<String, E2eiCertificate>
+}
+
+class GetUserE2eiCertificatesUseCaseImpl internal constructor(
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val pemCertificateDecoder: PemCertificateDecoder
+) : GetUserE2eiCertificatesUseCase {
+    override suspend operator fun invoke(userId: UserId): Map<String, E2eiCertificate> =
+        mlsConversationRepository.getUserIdentity(userId).map { identities ->
+            val result = mutableMapOf<String, E2eiCertificate>()
+            identities.forEach {
+                result[it.clientId] = pemCertificateDecoder.decode(it.certificate, it.status)
+            }
+            result
+        }.getOrElse(mapOf())
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -50,6 +50,8 @@ import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetE2eiCertificateUseCaseImpl
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMembersE2EICertificateStatusesUseCaseImpl
+import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCaseImpl
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCaseImpl
 import com.wire.kalium.logic.feature.message.MessageSender
@@ -124,6 +126,11 @@ class UserScope internal constructor(
         )
     val getUserE2eiCertificateStatus: GetUserE2eiCertificateStatusUseCase
         get() = GetUserE2eiCertificateStatusUseCaseImpl(
+            mlsConversationRepository = mlsConversationRepository,
+            pemCertificateDecoder = pemCertificateDecoderImpl
+        )
+    val getUserE2eiCertificates: GetUserE2eiCertificatesUseCase
+        get() = GetUserE2eiCertificatesUseCaseImpl(
             mlsConversationRepository = mlsConversationRepository,
             pemCertificateDecoder = pemCertificateDecoderImpl
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetUserE2eiAllCertificateStatusesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetUserE2eiAllCertificateStatusesUseCaseTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.e2ei
+
+import com.wire.kalium.cryptography.CryptoCertificateStatus
+import com.wire.kalium.cryptography.WireIdentity
+import com.wire.kalium.logic.MLSFailure
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCaseImpl
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.mls.PemCertificateDecoderArrangement
+import com.wire.kalium.logic.util.arrangement.mls.PemCertificateDecoderArrangementImpl
+import io.mockative.any
+import io.mockative.eq
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetUserE2eiAllCertificateStatusesUseCaseTest {
+
+    @Test
+    fun givenErrorOnGettingUserIdentity_whenGetUserE2eiAllCertificateStatuses_thenEmptyMapResult() = runTest {
+        val (_, getUserE2eiAllCertificateStatuses) = arrange {
+            withUserIdentity(Either.Left(MLSFailure.WrongEpoch))
+        }
+
+        val result = getUserE2eiAllCertificateStatuses(userId)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenEmptyWireIdentityList_whenGetUserE2eiAllCertificateStatuses_thenEmptyMapResult() = runTest {
+        val (_, getUserE2eiAllCertificateStatuses) = arrange {
+            withUserIdentity(Either.Right(listOf()))
+        }
+
+        val result = getUserE2eiAllCertificateStatuses(userId)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenOneWireIdentityExpired_whenGetUserE2eiAllCertificateStatuses_thenResultCorrectMap() = runTest {
+        val identity1 = WIRE_IDENTITY
+        val identity2 = WIRE_IDENTITY.copy(clientId = "id_2", status = CryptoCertificateStatus.EXPIRED)
+        val identity3 = WIRE_IDENTITY.copy(clientId = "id_3", status = CryptoCertificateStatus.REVOKED)
+        val (_, getUserE2eiAllCertificateStatuses) = arrange {
+            withUserIdentity(Either.Right(listOf(identity1, identity2, identity3)))
+        }
+
+        val result = getUserE2eiAllCertificateStatuses(userId)
+
+        assertEquals(3, result.size)
+        assertEquals(CertificateStatus.VALID, result[identity1.clientId]?.status)
+        assertEquals(CertificateStatus.EXPIRED, result[identity2.clientId]?.status)
+        assertEquals(CertificateStatus.REVOKED, result[identity3.clientId]?.status)
+    }
+
+    private class Arrangement(private val block: Arrangement.() -> Unit) :
+        MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl(),
+        PemCertificateDecoderArrangement by PemCertificateDecoderArrangementImpl() {
+
+        fun arrange() = run {
+            withPemCertificateDecode(E2EI_CERTIFICATE, any(), eq(CryptoCertificateStatus.VALID))
+            withPemCertificateDecode(E2EI_CERTIFICATE.copy(status = CertificateStatus.EXPIRED), any(), eq(CryptoCertificateStatus.EXPIRED))
+            withPemCertificateDecode(E2EI_CERTIFICATE.copy(status = CertificateStatus.REVOKED), any(), eq(CryptoCertificateStatus.REVOKED))
+
+            block()
+            this@Arrangement to GetUserE2eiCertificatesUseCaseImpl(
+                mlsConversationRepository = mlsConversationRepository,
+                pemCertificateDecoder = pemCertificateDecoder
+            )
+        }
+    }
+
+    private companion object {
+        fun arrange(configuration: Arrangement.() -> Unit) = Arrangement(configuration).arrange()
+
+        private val userId = UserId("value", "domain")
+        private val WIRE_IDENTITY =
+            WireIdentity("id", "user_handle", "User Test", "domain.com", "certificate", CryptoCertificateStatus.VALID)
+        private val E2EI_CERTIFICATE =
+            E2eiCertificate(issuer = "issue", status = CertificateStatus.VALID, serialNumber = "number", certificateDetail = "details")
+    }
+}


### PR DESCRIPTION
# What's new in this PR?

### Issues

No any UseCase for getting all the E2EI certs for all users client in one "request" (only one-by-one by ClientId, which is not cool).
Would be useful for UserProfile screen, where we display the list of devices and need to show E2EI statuses for each device.

### Causes (Optional)

Wasn't implemented

### Solutions

Added `GetUserE2eiCertificatesUseCase` for that, where we can get them by `UserId` and tests for that.

