### PR TITLE
fix: new clients info after logout [WPB-6126]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ObserveNewClientsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ObserveNewClientsUseCase.kt
@@ -29,8 +29,9 @@ import com.wire.kalium.logic.functional.mapToRightOr
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 /**
@@ -38,6 +39,7 @@ import kotlinx.coroutines.flow.map
  * returns [NewClientResult] which may be:
  * [NewClientResult.InCurrentAccount] if new Clients appears for the user that is currently used.
  * [NewClientResult.InOtherAccount] if new Clients appears for the user that is logged in on device, but not currently used.
+ * [NewClientResult.Empty] if there are no new Clients for any of the logged-in Users.
  * [NewClientResult.Error] in case of error, in most cases it means that the user for which new Client appeared
  * is no longer logged it on the device.
  *
@@ -59,6 +61,7 @@ class ObserveNewClientsUseCaseImpl internal constructor(
         .flatMapLatest { validAccs ->
             val users = validAccs.map { it.first }
             observeAllNewClients(users)
+                .map { it.filter { (_, clients) -> clients.isNotEmpty() } }
                 .map { groupByUser ->
                     if (groupByUser.isEmpty()) return@map NewClientResult.Empty
 
@@ -82,12 +85,14 @@ class ObserveNewClientsUseCaseImpl internal constructor(
                     }.getOrElse(NewClientResult.Error)
                 }
         }
-        .filter {
-            // if newClients list is empty mean no NewClients - do not emit anything
-            (it is NewClientResult.InCurrentAccount && it.newClients.isNotEmpty()) ||
-                    (it is NewClientResult.InOtherAccount && it.newClients.isNotEmpty()) ||
-                    it is NewClientResult.Error
+        .map {
+            when {
+                it is NewClientResult.InCurrentAccount && it.newClients.isEmpty() -> NewClientResult.Empty
+                it is NewClientResult.InOtherAccount && it.newClients.isEmpty() -> NewClientResult.Empty
+                else -> it
+            }
         }
+        .distinctUntilChanged()
 
     private suspend fun observeNewClientsForUser(userId: UserId) = clientRepositoryProvider.provide(userId)
         .observeNewClients()
@@ -95,6 +100,8 @@ class ObserveNewClientsUseCaseImpl internal constructor(
         .map { it to userId }
 
     private suspend fun observeAllNewClients(validAccs: List<SelfUser>): Flow<Map<UserId, List<Client>>> {
+        if (validAccs.isEmpty()) return flowOf(emptyMap())
+
         val observeNewClientsFlows = validAccs.map { selfUser -> observeNewClientsForUser(selfUser.id) }
 
         return combine(observeNewClientsFlows) { newClientsListWithUserId ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ObserveNewClientsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ObserveNewClientsUseCaseTest.kt
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2023 Wire Swiss GmbH
+ * Copyright (C) 2024 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,7 +40,10 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -51,7 +54,7 @@ class ObserveNewClientsUseCaseTest {
     @Test
     fun givenNewClientAndCurrentSessionError_thenNewClientErrorResult() = runTest {
         val (_, observeNewClients) = Arrangement()
-            .withoutValidAccounts(listOf(TestUser.SELF to null))
+            .withValidAccounts(listOf(TestUser.SELF to null))
             .withCurrentSession(Either.Left(StorageFailure.DataNotFound))
             .withNewClientsForUser1(listOf(TestClient.CLIENT))
             .arrange()
@@ -65,7 +68,7 @@ class ObserveNewClientsUseCaseTest {
     @Test
     fun givenNewClientForCurrentUser_thenNewClientInCurrentUserResult() = runTest {
         val (_, observeNewClients) = Arrangement()
-            .withoutValidAccounts(listOf(TestUser.SELF to null))
+            .withValidAccounts(listOf(TestUser.SELF to null))
             .withCurrentSession(Either.Right(TEST_ACCOUNT_INFO))
             .withNewClientsForUser1(listOf(TestClient.CLIENT))
             .arrange()
@@ -80,7 +83,7 @@ class ObserveNewClientsUseCaseTest {
     @Test
     fun givenNewClientForOtherUser_thenNewClientInOtherUserResult() = runTest {
         val (arrangement, observeNewClients) = Arrangement()
-            .withoutValidAccounts(listOf(TestUser.SELF to null, TestUser.SELF.copy(id = TestUser.OTHER_USER_ID) to null))
+            .withValidAccounts(listOf(TestUser.SELF to null, TestUser.SELF.copy(id = TestUser.OTHER_USER_ID) to null))
             .withCurrentSession(Either.Right(TEST_ACCOUNT_INFO))
             .withNewClientsForUser1(listOf())
             .withNewClientsForUser2(listOf(TestClient.CLIENT))
@@ -109,7 +112,7 @@ class ObserveNewClientsUseCaseTest {
         val client1 = TestClient.CLIENT
         val client2 = TestClient.CLIENT.copy(id = ClientId("other_client"))
         val (_, observeNewClients) = Arrangement()
-            .withoutValidAccounts(listOf(TestUser.SELF to null, TestUser.SELF.copy(id = TestUser.OTHER_USER_ID) to null))
+            .withValidAccounts(listOf(TestUser.SELF to null, TestUser.SELF.copy(id = TestUser.OTHER_USER_ID) to null))
             .withCurrentSession(Either.Right(TEST_ACCOUNT_INFO))
             .withNewClientsForUser1(listOf(client1))
             .withNewClientsForUser2(listOf(client2))
@@ -127,7 +130,7 @@ class ObserveNewClientsUseCaseTest {
         val client1 = TestClient.CLIENT
         val client2 = TestClient.CLIENT.copy(id = ClientId("other_client"))
         val (_, observeNewClients) = Arrangement()
-            .withoutValidAccounts(listOf(TestUser.SELF to null))
+            .withValidAccounts(listOf(TestUser.SELF to null))
             .withCurrentSession(Either.Right(TEST_ACCOUNT_INFO))
             .withNewClientsForUser1(listOf(client1, client2))
             .arrange()
@@ -136,6 +139,53 @@ class ObserveNewClientsUseCaseTest {
             assertEquals(NewClientResult.InCurrentAccount(listOf(client1, client2), TestUser.USER_ID), awaitItem())
 
             awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenNoNewClients_thenEmptyResult() = runTest {
+        val (_, observeNewClients) = Arrangement()
+            .withValidAccounts(listOf(TestUser.SELF to null))
+            .withCurrentSession(Either.Right(TEST_ACCOUNT_INFO))
+            .withNewClientsForUser1(emptyList())
+            .arrange()
+
+        observeNewClients().test {
+            assertEquals(NewClientResult.Empty, awaitItem())
+
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenNoAccountsLoggedIn_thenEmptyResult() = runTest {
+        val (_, observeNewClients) = Arrangement()
+            .withValidAccounts(emptyList())
+            .arrange()
+
+        observeNewClients().test {
+            assertEquals(NewClientResult.Empty, awaitItem())
+
+            awaitComplete()
+        }
+    }
+    @Test
+    fun givenNewClientForCurrentUser_whenUserIsBeingLoggedOut_thenChangeToEmptyResult() = runTest {
+        val validAccountsFlow = MutableStateFlow(listOf(TestUser.SELF to null))
+        val (_, observeNewClients) = Arrangement()
+            .withValidAccountsFlow(validAccountsFlow)
+            .withCurrentSession(Either.Right(TEST_ACCOUNT_INFO))
+            .withNewClientsForUser1(listOf(TestClient.CLIENT))
+            .arrange()
+
+        observeNewClients().test {
+            assertEquals(NewClientResult.InCurrentAccount(listOf(TestClient.CLIENT), TestUser.USER_ID), awaitItem())
+
+            validAccountsFlow.value = emptyList()
+            advanceUntilIdle()
+            assertEquals(NewClientResult.Empty, awaitItem())
+
+            cancel()
         }
     }
 
@@ -198,11 +248,17 @@ class ObserveNewClientsUseCaseTest {
                 .then { flowOf(Either.Right(result)) }
         }
 
-        fun withoutValidAccounts(result: List<Pair<SelfUser, Team?>>) = apply {
+        fun withValidAccounts(result: List<Pair<SelfUser, Team?>>) = apply {
             given(observeValidAccounts)
                 .function(observeValidAccounts::invoke)
                 .whenInvoked()
                 .thenReturn(flowOf(result))
+        }
+        fun withValidAccountsFlow(flowResult: Flow<List<Pair<SelfUser, Team?>>>) = apply {
+            given(observeValidAccounts)
+                .function(observeValidAccounts::invoke)
+                .whenInvoked()
+                .thenReturn(flowResult)
         }
 
         fun arrange() = this to observeNewClientsUseCase


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the app gets "new client" event and then current account is becomes invalid (for instance when current client is removed and account logged out) then the lat emitted value is still for this already invalid account.

### Causes (Optional)

`Empty` values are filtered out and if there is an empty list of valid accounts then the flow doesn't calculate a new value.

### Solutions

Update the result when there is no valid accounts and emit also `Empty` results.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- login and register client A on device 1
- login and register client B on device 2
- remove client A from device 2
- account on device 1 should be logged out and there should be no info about "new client: B"

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
