### PR TITLE
fix: Crash while getting users mls verification status (WPB-6125)

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -383,7 +383,7 @@ ORDER BY Conversation.type DESC LIMIT 1;
 getMLSGroupIdByUserId:
 SELECT Conversation.mls_group_id FROM Member
 JOIN Conversation ON Conversation.qualified_id = Member.conversation
-WHERE Conversation.mls_group_id IS NOT NULL AND Member.user = :userId;
+WHERE Conversation.mls_group_id IS NOT NULL AND Member.user = :userId LIMIT 1;
 
 getMLSGroupIdByConversationId:
 SELECT Conversation.mls_group_id FROM Conversation


### PR DESCRIPTION
# What's new in this PR?

### Issues

Crash on opening other user profile

### Causes (Optional)

When opening Other user profile app trying to get MLS status of that user, for that app search for the mls_groupd_id by UserId. The problem is that the DB-query could return more then one result but DAO method uses `executeAsOneOrNull()` so if there are more then one result -> crash. 

### Solutions

Add `LIMIT 1` into a query to get only 1 query result (it doesn't meter which we'll get)

