### PR TITLE
fix: archived conversation notifications before login (WPB-6127)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase.kt
@@ -19,7 +19,6 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
@@ -76,32 +75,6 @@ internal class UpdateConversationArchivedStatusUseCaseImpl(
                             "status to archived = ($shouldArchiveConversation)"
                 )
 
-                // Now we should make sure the conversation gets muted if it's archived or un-muted if it's unarchived
-                val updatedMutedStatus = if (shouldArchiveConversation) {
-                    MutedConversationStatus.AllMuted
-                } else {
-                    MutedConversationStatus.AllAllowed
-                }
-
-                if (!onlyLocally) {
-                    updateMutedStatusRemotely(conversationId, updatedMutedStatus, archivedStatusTimestamp)
-                } else {
-                    Either.Right(Unit)
-                }
-                    .flatMap {
-                        conversationRepository.updateMutedStatusLocally(conversationId, updatedMutedStatus, archivedStatusTimestamp)
-                    }.fold({
-                        kaliumLogger.e(
-                            "Something went wrong when updating locally the muting status of the convId: " +
-                                    "(${conversationId.toLogString()}) to (${updatedMutedStatus.status}"
-                        )
-                    }, {
-                        kaliumLogger.d(
-                            "Successfully updated locally the muting status of the convId: " +
-                                    "(${conversationId.toLogString()}) to (${updatedMutedStatus.status}"
-                        )
-                    })
-                // Even if the muting status update fails, we should still return success as the archived status update was successful
                 ArchiveStatusUpdateResult.Success
             })
 
@@ -120,24 +93,6 @@ internal class UpdateConversationArchivedStatusUseCaseImpl(
             kaliumLogger.d(
                 "Successfully updated remotely convId (${conversationId.toLogString()}) archiving " +
                         "status to archived = ($shouldArchiveConversation)"
-            )
-        }
-
-    private suspend fun updateMutedStatusRemotely(
-        conversationId: ConversationId,
-        updatedMutedStatus: MutedConversationStatus,
-        archivedStatusTimestamp: Long
-    ) = conversationRepository.updateMutedStatusRemotely(conversationId, updatedMutedStatus, archivedStatusTimestamp)
-        .onFailure {
-            kaliumLogger.e(
-                "Something went wrong when updating remotely the muting status of the convId: " +
-                        "(${conversationId.toLogString()}) to (${updatedMutedStatus.status}"
-            )
-        }
-        .onSuccess {
-            kaliumLogger.d(
-                "Successfully updated remotely the muting status of the convId: " +
-                        "(${conversationId.toLogString()}) to (${updatedMutedStatus.status}"
             )
         }
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
@@ -24,6 +24,7 @@ WHERE
 Message.visibility = 'VISIBLE' AND
 (Message.sender_user_id != SelfUser.id) AND
 (Message.creation_date > IFNULL(Conversation.last_notified_date, 0)) AND
-Conversation.muted_status != 'ALL_MUTED'
+Conversation.muted_status != 'ALL_MUTED' AND
+Conversation.archived == 0
 ORDER BY Message.creation_date DESC;
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -320,6 +320,27 @@ class MessageNotificationsTest : BaseMessageTest() {
         }
     }
 
+    @Test
+    fun givenConversationIsArchived_whenMessageInserted_thenDoNotNotify() = runTest {
+        val message = OTHER_MESSAGE
+        userDAO.upsertUsers(listOf(SELF_USER, OTHER_USER, OTHER_USER_2))
+        conversationDAO.insertConversations(
+            listOf(
+                TEST_CONVERSATION_1.copy(
+                    archived = true
+                ),
+                TEST_CONVERSATION_2
+            )
+        )
+
+        messageDAO.insertOrIgnoreMessage(message)
+
+        messageDAO.getNotificationMessage().test {
+            val notifications = awaitItem()
+            assertTrue { notifications.isEmpty() }
+        }
+    }
+
     private suspend fun doTheTest(
         mutedStatus: ConversationEntity.MutedStatus,
         status: UserAvailabilityStatusEntity,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a conversation is archived before the user logs in on android, he receives notification in this conversation (both for normal and for self deleting messages)

### Causes (Optional)

We were not verifying archived status when getting messages for notifications

### Solutions

- Add `Convesation.archived` verification in getting messages for notification
- Remove manual update of muted status when archiving

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- have 2 clients available, web A  and android B
- archive any conversation C on client A
- login to the app, client B
- see that the conversation is archived (but does not have a mute icon)
- Go back to conversation list
- receive messages in conversation C
- take a look at the notification center
- Conversation should not be muted and user should not receive notifications
