### PR TITLE
fix: team mates are displayed under pulic wire in search list

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserMapper.kt
@@ -333,7 +333,11 @@ internal class UserMapperImpl(
             phone = null,
             accentId = userProfile.accentId,
             teamId = userProfile.teamId?.let { TeamId(it) },
-            connectionStatus = connectionStateMapper.fromDaoConnectionStateToUser(connectionState = ConnectionEntity.State.ACCEPTED),
+            connectionStatus = if (selfTeamId != null && selfTeamId.value == userProfile.teamId) {
+                ConnectionState.ACCEPTED
+            } else {
+                ConnectionState.NOT_CONNECTED
+            },
             previewPicture = userProfile.assets.getPreviewAssetOrNull()
                 ?.let { QualifiedIDEntity(it.key, userProfile.id.domain) }?.toModel(),
             completePicture = userProfile.assets.getCompleteAssetOrNull()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1429,7 +1429,6 @@ class UserSessionScope internal constructor(
         get() = UserEventReceiverImpl(
             clientRepository,
             connectionRepository,
-            conversationRepository,
             userRepository,
             logout,
             oneOnOneResolver,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUsersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUsersUseCase.kt
@@ -56,7 +56,7 @@ class SearchUsersUseCase internal constructor(
         excludingConversation: ConversationId?,
         customDomain: String?
     ): Result = coroutineScope {
-        val cleanSearchQuery = searchQuery.lowercase()
+        val cleanSearchQuery = searchQuery.trim().lowercase()
 
         val remoteResultsDeferred = async {
             searchUserRepository.searchUserRemoteDirectory(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -22,7 +22,6 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
-import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
@@ -52,7 +51,6 @@ internal interface UserEventReceiver : EventReceiver<Event.User>
 internal class UserEventReceiverImpl internal constructor(
     private val clientRepository: ClientRepository,
     private val connectionRepository: ConnectionRepository,
-    private val conversationRepository: ConversationRepository,
     private val userRepository: UserRepository,
     private val logout: LogoutUseCase,
     private val oneOnOneResolver: OneOnOneResolver,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUseCaseTest.kt
@@ -182,7 +182,7 @@ class SearchUseCaseTest {
     @Test
     fun givenSearchQuery_whenDoingSearch_thenCallTheSearchFunctionsWithCleanQuery() = runTest {
             val searchQuery = "    search Query     "
-            val cleanQuery = "search Query"
+            val cleanQuery = "search query"
             val (arrangement, searchUseCase) = Arrangement().arrange {
                 withSearchUserRemoteDirectory(
                     result = UserSearchResult(emptyList()).right(),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUseCaseTest.kt
@@ -179,6 +179,40 @@ class SearchUseCaseTest {
             .wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenSearchQuery_whenDoingSearch_thenCallTheSearchFunctionsWithCleanQuery() = runTest {
+            val searchQuery = "    search Query     "
+            val cleanQuery = "search Query"
+            val (arrangement, searchUseCase) = Arrangement().arrange {
+                withSearchUserRemoteDirectory(
+                    result = UserSearchResult(emptyList()).right(),
+                    searchQuery = eq(cleanQuery),
+                )
+                withSearchLocalByName(
+                    result = emptyList<UserSearchDetails>().right(),
+                    searchQuery = eq(cleanQuery),
+                )
+            }
+
+            val result = searchUseCase(
+                searchQuery = searchQuery,
+                excludingMembersOfConversation = null,
+                customDomain = null
+            )
+
+            assertEquals(
+                expected = emptyList<UserSearchDetails>(),
+                actual = result.connected
+            )
+            verify(arrangement.searchUserRepository)
+                .suspendFunction(arrangement.searchUserRepository::searchUserRemoteDirectory)
+                .with(eq(cleanQuery), any(), any(), any())
+                .wasInvoked(exactly = once)
+            verify(arrangement.searchUserRepository)
+                .suspendFunction(arrangement.searchUserRepository::searchLocalByName)
+                .with(eq(cleanQuery), anything())
+                .wasInvoked(exactly = once)
+    }
 
     private companion object {
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUseCaseTest.kt
@@ -118,7 +118,7 @@ class SearchUseCaseTest {
         )
         verify(arrangement.searchUserRepository)
             .suspendFunction(arrangement.searchUserRepository::searchUserRemoteDirectory)
-            .with(eq("searchQuery"), any(), any(), any())
+            .with(eq("searchquery"), any(), any(), any())
             .wasInvoked(exactly = once)
     }
 
@@ -127,7 +127,10 @@ class SearchUseCaseTest {
 
         val remoteSearchResult = listOf(
             newOtherUser("remoteAndLocalUser1").copy(name = "updatedNewName"),
-            newOtherUser("remoteUser2"),
+            newOtherUser("remoteUser2").copy(
+                teamId = TeamId("otherTeamId"),
+                connectionStatus = ConnectionState.PENDING
+            ),
         )
 
         val localSearchResult = listOf(
@@ -141,18 +144,18 @@ class SearchUseCaseTest {
                 newUserSearchDetails("localUser2")
             ),
             notConnected = listOf(
-                newUserSearchDetails("remoteUser2")
+                newUserSearchDetails("remoteUser2").copy(connectionStatus = ConnectionState.PENDING),
             )
         )
 
         val (arrangement, searchUseCase) = Arrangement().arrange {
             withSearchUserRemoteDirectory(
                 result = UserSearchResult(remoteSearchResult).right(),
-                searchQuery = eq("searchQuery"),
+                searchQuery = eq("searchquery"),
             )
             withSearchLocalByName(
                 result = localSearchResult.right(),
-                searchQuery = eq("searchQuery"),
+                searchQuery = eq("searchquery"),
             )
         }
 
@@ -168,15 +171,18 @@ class SearchUseCaseTest {
         )
         verify(arrangement.searchUserRepository)
             .suspendFunction(arrangement.searchUserRepository::searchUserRemoteDirectory)
-            .with(eq("searchQuery"), any(), any(), any())
+            .with(eq("searchquery"), any(), any(), any())
             .wasInvoked(exactly = once)
         verify(arrangement.searchUserRepository)
             .suspendFunction(arrangement.searchUserRepository::searchLocalByName)
-            .with(eq("searchQuery"), anything())
+            .with(eq("searchquery"), anything())
             .wasInvoked(exactly = once)
     }
 
+
     private companion object {
+
+        val selfUserID = UserId("searchUserID", "searchUserDomain")
 
         fun newOtherUser(id: String) = OtherUser(
             UserId(id, "otherDomain"),
@@ -211,7 +217,6 @@ class SearchUseCaseTest {
 
     private class Arrangement : SearchRepositoryArrangement by SearchRepositoryArrangementImpl() {
 
-        val selfUserID = UserId("searchUserID", "searchUserDomain")
         private val searchUseCase: SearchUsersUseCase = SearchUsersUseCase(
             searchUserRepository = searchUserRepository,
             selfUserId = selfUserID

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -113,7 +113,6 @@ class UserEventReceiverTest {
             withMarkUserAsDeletedAndRemoveFromGroupConversationsSuccess(
                 userIdMatcher = any<UserId>()
             )
-            withConversationsByUserId(listOf(TestConversation.CONVERSATION))
         }
 
         eventReceiver.onEvent(event)
@@ -303,9 +302,6 @@ class UserEventReceiverTest {
         val logoutUseCase = mock(classOf<LogoutUseCase>())
 
         @Mock
-        val conversationRepository = mock(classOf<ConversationRepository>())
-
-        @Mock
         private val currentClientIdProvider = mock(classOf<CurrentClientIdProvider>())
 
         @Mock
@@ -323,7 +319,6 @@ class UserEventReceiverTest {
         private val userEventReceiver: UserEventReceiver = UserEventReceiverImpl(
             clientRepository,
             connectionRepository,
-            conversationRepository,
             userRepository,
             logoutUseCase,
             oneOnOneResolver,
@@ -368,11 +363,6 @@ class UserEventReceiverTest {
 
         fun withLogoutUseCaseSucceed() = apply {
             given(logoutUseCase).suspendFunction(logoutUseCase::invoke).whenInvokedWith(any()).thenReturn(Unit)
-        }
-
-        fun withConversationsByUserId(conversationIds: List<Conversation>) = apply {
-            given(conversationRepository).suspendFunction(conversationRepository::getConversationsByUserId)
-                .whenInvokedWith(any()).thenReturn(Either.Right(conversationIds))
         }
 
         fun arrange() = run {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

not connected teammates are displayed under public wire in search

### Solutions

filter the search results correctly according to the user team id

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
