### PR TITLE
fix: insure that isFederated function will never run on the main thread

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperImpl.kt
@@ -42,7 +42,7 @@ class FederatedIdMapperImpl internal constructor(
     private val sessionRepository: SessionRepository,
 ) : FederatedIdMapper {
 
-    private fun isFederationEnabled() = sessionRepository.isFederated(selfUserId).fold(
+    private suspend fun isFederationEnabled() = sessionRepository.isFederated(selfUserId).fold(
         { false },
         { it }
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
@@ -73,7 +73,7 @@ interface SessionRepository {
     suspend fun ssoId(userId: UserId): Either<StorageFailure, SsoIdEntity?>
     suspend fun updatePersistentWebSocketStatus(userId: UserId, isPersistentWebSocketEnabled: Boolean): Either<StorageFailure, Unit>
     suspend fun updateSsoIdAndScimInfo(userId: UserId, ssoId: SsoId?, managedBy: ManagedByDTO?): Either<StorageFailure, Unit>
-    fun isFederated(userId: UserId): Either<StorageFailure, Boolean>
+    suspend fun isFederated(userId: UserId): Either<StorageFailure, Boolean>
     suspend fun getAllValidAccountPersistentWebSocketStatus(): Either<StorageFailure, Flow<List<PersistentWebSocketStatus>>>
     suspend fun persistentWebSocketStatus(userId: UserId): Either<StorageFailure, Boolean>
     suspend fun cookieLabel(userId: UserId): Either<StorageFailure, String?>
@@ -195,7 +195,7 @@ internal class SessionDataSource internal constructor(
             accountsDAO.updateSsoIdAndScimInfo(userId.toDao(), idMapper.toSsoIdEntity(ssoId), managedBy?.toDao())
         }
 
-    override fun isFederated(userId: UserId): Either<StorageFailure, Boolean> = wrapStorageRequest {
+    override suspend fun isFederated(userId: UserId): Either<StorageFailure, Boolean> = wrapStorageRequest {
         accountsDAO.isFederated(userId.toDao())
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/FederatedIdMapperTest.kt
@@ -35,7 +35,7 @@ import kotlin.test.assertEquals
 
 class FederatedIdMapperTest {
 
-    lateinit var federatedIdMapper: FederatedIdMapper
+    private lateinit var federatedIdMapper: FederatedIdMapper
 
     @Mock
     private val sessionRepository = mock(classOf<SessionRepository>())
@@ -57,7 +57,7 @@ class FederatedIdMapperTest {
     @Test
     fun givenAUserId_whenCurrentEnvironmentIsFederated_thenShouldMapTheValueWithDomain() = runTest {
         given(sessionRepository)
-            .function(sessionRepository::isFederated)
+            .suspendFunction(sessionRepository::isFederated)
             .whenInvokedWith(any())
             .then { Either.Right(true) }
 
@@ -69,7 +69,7 @@ class FederatedIdMapperTest {
     @Test
     fun givenAUserId_whenCurrentEnvironmentIsNotFederated_thenShouldMapTheValueWithoutDomain() = runTest {
         given(sessionRepository)
-            .function(sessionRepository::isFederated)
+            .suspendFunction(sessionRepository::isFederated)
             .whenInvokedWith(any())
             .then { Either.Right(false) }
 
@@ -81,7 +81,7 @@ class FederatedIdMapperTest {
     @Test
     fun givenError_whenGettingUserFederationStatus_thenShouldMapTheValueWithoutDomain() = runTest {
         given(sessionRepository)
-            .function(sessionRepository::isFederated)
+            .suspendFunction(sessionRepository::isFederated)
             .whenInvokedWith(any())
             .then { Either.Left(StorageFailure.Generic(IOException("why are we still here just to suffer!"))) }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/FederatedSearchParserTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/FederatedSearchParserTest.kt
@@ -25,13 +25,14 @@ import io.mockative.any
 import io.mockative.eq
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class FederatedSearchParserTest {
 
     @Test
-    fun givenUserIsNotFederated_whenParsingSearchQuery_thenSearchQueryIsNotModified() {
+    fun givenUserIsNotFederated_whenParsingSearchQuery_thenSearchQueryIsNotModified() = runTest {
         val (arrangement, federatedSearchParser) = Arrangement().arrange {
             withIsFederated(result = false.right(), userId = any())
         }
@@ -49,7 +50,7 @@ class FederatedSearchParserTest {
     }
 
     @Test
-    fun givenUserIsFederated_whenSearchQueryIncludeNoDomain_thenSearchQueryIsNotModified() {
+    fun givenUserIsFederated_whenSearchQueryIncludeNoDomain_thenSearchQueryIsNotModified() = runTest {
         val (arrangement, federatedSearchParser) = Arrangement().arrange {
             withIsFederated(result = true.right(), userId = any())
         }
@@ -67,7 +68,7 @@ class FederatedSearchParserTest {
     }
 
     @Test
-    fun givenUserIsFederated_whenSearchQueryIncludeDomain_thenSearchQueryIsModified() {
+    fun givenUserIsFederated_whenSearchQueryIncludeDomain_thenSearchQueryIsModified() = runTest {
         val (arrangement, federatedSearchParser) = Arrangement().arrange {
             withIsFederated(result = true.right(), userId = any())
         }
@@ -85,7 +86,7 @@ class FederatedSearchParserTest {
     }
 
     @Test
-    fun givenSearchQuery_whenTheParserIsCalledMultibletime_thenIsFederatedIsExecutedOnlyOnce() {
+    fun givenSearchQuery_whenTheParserIsCalledMultibletime_thenIsFederatedIsExecutedOnlyOnce() = runTest {
         val (arrangement, federatedSearchParser) = Arrangement().arrange {
             withIsFederated(result = true.right(), userId = any())
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/SessionRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/SessionRepositoryArrangement.kt
@@ -39,7 +39,7 @@ internal class SessionRepositoryArrangementImpl : SessionRepositoryArrangement {
     override val sessionRepository: SessionRepository = mock(SessionRepository::class)
     override fun withIsFederated(result: Either<StorageFailure, Boolean>, userId: Matcher<UserId>) {
         given(sessionRepository)
-            .function(sessionRepository::isFederated)
+            .suspendFunction(sessionRepository::isFederated)
             .whenInvokedWith(userId)
             .then { result }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/AccountsDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/AccountsDAO.kt
@@ -112,7 +112,7 @@ interface AccountsDAO {
     suspend fun allValidAccountList(): List<AccountInfoEntity>
     fun observerValidAccountList(): Flow<List<AccountInfoEntity>>
     suspend fun observeAllAccountList(): Flow<List<AccountInfoEntity>>
-    fun isFederated(userIDEntity: UserIDEntity): Boolean?
+    suspend fun isFederated(userIDEntity: UserIDEntity): Boolean?
     suspend fun doesValidAccountExists(userIDEntity: UserIDEntity): Boolean
     suspend fun currentAccount(): AccountInfoEntity?
     fun observerCurrentAccount(): Flow<AccountInfoEntity?>
@@ -189,8 +189,10 @@ internal class AccountsDAOImpl internal constructor(
             .flowOn(queriesContext)
             .mapToList()
 
-    override fun isFederated(userIDEntity: UserIDEntity): Boolean? =
-        queries.isFederationEnabled(userIDEntity).executeAsOneOrNull()
+    override suspend fun isFederated(userIDEntity: UserIDEntity): Boolean? =
+        withContext(queriesContext) {
+            queries.isFederationEnabled(userIDEntity).executeAsOneOrNull()
+        }
 
     override suspend fun doesValidAccountExists(userIDEntity: UserIDEntity): Boolean = withContext(queriesContext) {
         queries.doesValidAccountExist(userIDEntity).executeAsOne()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

sessionRepo.isFederated is not main safe

### Solutions

make it main safe

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
