### PR TITLE
fix: MLS log spam with NPE [WPB-6222]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -575,7 +575,7 @@ internal class MLSConversationDataSource(
         userIds: List<UserId>
     ): Either<CoreFailure, Map<UserId, List<WireIdentity>>> =
         wrapStorageRequest {
-            conversationDAO.getMLSGroupIdByConversationId(conversationId.toDao())!!
+            conversationDAO.getMLSGroupIdByConversationId(conversationId.toDao())
         }.flatMap { mlsGroupId ->
             mlsClientProvider.getMLSClient().flatMap { mlsClient ->
                 wrapMLSRequest {


### PR DESCRIPTION
# What's new in this PR?

### Issues

`NullPointerException ` log is spammed when doing user search even on non MLS enabled enviroments

### Causes (Optional)

redundant `!!` in storage request for getting MLSGroupId. It's not needed there as `wrapStorageRequest` already handles the case when the result is `null` and returns `Either.Left(StorageFailure.DataNotFound)`.

### Solutions

remove `!!`

