### PR TITLE
ci: preserve Original Author in Cherry-Picked Commits

### DIFF
--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -126,7 +126,9 @@ jobs:
                   git checkout -b ${{ env.newBranchName }}
                   OUTPUT=$(git cherry-pick ${{ env.cherryPickCommit }} || true)
                   
-                  # If conflicts exist, resolve them
+                  # Handle conflicts
+                  CONFLICTED_FILES=$(git diff --name-only --diff-filter=U | awk 'ORS="\\\\n"' | sed 's/\\\\n$/\\n/')
+                  echo "Captured conflicted files: $CONFLICTED_FILES"
                   if [[ "$OUTPUT" == *"CONFLICT"* ]]; then
                       git add .
                       git commit --author "${{ env.originalAuthor }}" -am "Commit with unresolved merge conflicts outside of ${{ env.SUBMODULE_NAME }}"

--- a/.github/workflows/cherry-pick-rc-to-develop.yml
+++ b/.github/workflows/cherry-pick-rc-to-develop.yml
@@ -109,6 +109,14 @@ jobs:
                   CHERRY_PICK_COMMIT=$(git rev-parse HEAD)
                   echo "cherryPickCommit=$CHERRY_PICK_COMMIT" >> $GITHUB_ENV
 
+            - name: Get Original Author
+              id: get-author
+              if: env.shouldCherryPick == 'true'
+              run: |
+                  ORIGINAL_AUTHOR=$(git log -1 --pretty=format:'%an <%ae>' ${{ github.event.pull_request.merge_commit_sha }})
+                  echo "Original author: $ORIGINAL_AUTHOR"
+                  echo "originalAuthor=$ORIGINAL_AUTHOR" >> $GITHUB_ENV
+
             - name: Cherry-pick commits
               id: commit-cherry-pick
               if: env.shouldCherryPick == 'true'
@@ -118,12 +126,12 @@ jobs:
                   git checkout -b ${{ env.newBranchName }}
                   OUTPUT=$(git cherry-pick ${{ env.cherryPickCommit }} || true)
                   
-                  # Handle conflicts
-                  CONFLICTED_FILES=$(git diff --name-only --diff-filter=U | awk 'ORS="\\\\n"' | sed 's/\\\\n$/\\n/')
-                  echo "Captured conflicted files: $CONFLICTED_FILES"
+                  # If conflicts exist, resolve them
                   if [[ "$OUTPUT" == *"CONFLICT"* ]]; then
-                      # Commit the remaining conflicts
-                      git commit -am "Commit with unresolved merge conflicts outside of ${{ env.SUBMODULE_NAME }}"
+                      git add .
+                      git commit --author "${{ env.originalAuthor }}" -am "Commit with unresolved merge conflicts outside of ${{ env.SUBMODULE_NAME }}"
+                  else
+                      git commit --author "${{ env.originalAuthor }}" --amend --no-edit
                   fi
                   
                   # Push branch and remove temp
@@ -132,6 +140,7 @@ jobs:
                   if [[ -n "${{ env.SUBMODULE_NAME }}" ]]; then
                   git branch -D temp-branch-for-cherry-pick
                   fi
+
 
             - name: Create PR
               if: env.shouldCherryPick == 'true'


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the gh action bot is every where in git blame

### Solutions

 preserve Original Author in Cherry-Picked Commits

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
