### PR TITLE
feat: use case to send button action confirmations (WPB-2633)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.messages.Asset
 import com.wire.kalium.protobuf.messages.Button
 import com.wire.kalium.protobuf.messages.ButtonAction
+import com.wire.kalium.protobuf.messages.ButtonActionConfirmation
 import com.wire.kalium.protobuf.messages.Calling
 import com.wire.kalium.protobuf.messages.Cleared
 import com.wire.kalium.protobuf.messages.ClientAction
@@ -132,7 +133,7 @@ class ProtoContentMapperImpl(
             is MessageContent.Composite -> packComposite(readableContent, expectsReadConfirmation, legalHoldStatus)
             is MessageContent.ButtonAction -> packButtonAction(readableContent)
 
-            is MessageContent.ButtonActionConfirmation -> TODO()
+            is MessageContent.ButtonActionConfirmation -> packButtonActionConfirmation(readableContent)
             is MessageContent.Location -> packLocation(readableContent, expectsReadConfirmation, legalHoldStatus)
         }
     }
@@ -160,6 +161,16 @@ class ProtoContentMapperImpl(
     ): GenericMessage.Content.ButtonAction =
         GenericMessage.Content.ButtonAction(
             ButtonAction(
+                buttonId = readableContent.buttonId,
+                referenceMessageId = readableContent.referencedMessageId
+            )
+        )
+
+    private fun packButtonActionConfirmation(
+        readableContent: MessageContent.ButtonActionConfirmation
+    ): GenericMessage.Content.ButtonActionConfirmation =
+        GenericMessage.Content.ButtonActionConfirmation(
+            ButtonActionConfirmation(
                 buttonId = readableContent.buttonId,
                 referenceMessageId = readableContent.referencedMessageId
             )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -55,6 +55,7 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCa
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCaseImpl
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageUploadStatusUseCase
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageUploadStatusUseCaseImpl
+import com.wire.kalium.logic.feature.message.composite.SendButtonActionConfirmationMessageUseCase
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
 import com.wire.kalium.logic.feature.message.composite.SendButtonMessageUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl
@@ -344,6 +345,14 @@ class MessageScope internal constructor(
 
     val resetSession: ResetSessionUseCase
         get() = ResetSessionUseCaseImpl(proteusClientProvider, sessionResetSender, messageRepository)
+
+    val sendButtonActionConfirmationMessage: SendButtonActionConfirmationMessageUseCase
+        get() = SendButtonActionConfirmationMessageUseCase(
+            syncManager = syncManager,
+            messageSender = messageSender,
+            selfUserId = selfUserId,
+            currentClientIdProvider = currentClientIdProvider
+        )
 
     val sendButtonActionMessage: SendButtonActionMessageUseCase
         get() = SendButtonActionMessageUseCase(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageUseCase.kt
@@ -1,0 +1,81 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.composite
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.data.message.MessageTarget
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.util.DateTimeUtil
+
+/**
+ * Use case for sending a button action message.
+ * @param conversationId The conversation id.
+ * @param messageId The id of the message that contains the button.
+ * @param buttonId The id of the button.
+ *
+ * the action message is sent only to the message original sender.
+ */
+class SendButtonActionConfirmationMessageUseCase internal constructor(
+    private val messageSender: MessageSender,
+    private val syncManager: SyncManager,
+    private val currentClientIdProvider: CurrentClientIdProvider,
+    private val selfUserId: UserId
+) {
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        messageId: String,
+        buttonId: String,
+        userIds: List<String>
+    ): Result = syncManager.waitUntilLiveOrFailure().flatMap {
+            currentClientIdProvider().flatMap { currentClientId ->
+                val regularMessage = Message.Signaling(
+                    id = uuid4().toString(),
+                    content = MessageContent.ButtonActionConfirmation(
+                        referencedMessageId = messageId,
+                        buttonId = buttonId
+                    ),
+                    conversationId = conversationId,
+                    date = DateTimeUtil.currentIsoDateTimeString(),
+                    senderUserId = selfUserId,
+                    senderClientId = currentClientId,
+                    status = Message.Status.Pending,
+                    isSelfMessage = true,
+                    expirationData = null
+                )
+                messageSender.sendMessage(regularMessage, messageTarget = MessageTarget.Users(
+                    userIds.map { UserId(it, selfUserId.domain) }
+                ))
+            }
+    }.fold(Result::Failure, { Result.Success })
+
+    sealed interface Result {
+        data object Success : Result
+        data class Failure(
+            val error: CoreFailure
+        ) : Result
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageUseCase.kt
@@ -49,7 +49,7 @@ class SendButtonActionConfirmationMessageUseCase internal constructor(
         conversationId: ConversationId,
         messageId: String,
         buttonId: String,
-        userIds: List<String>
+        userIds: List<UserId>
     ): Result = syncManager.waitUntilLiveOrFailure().flatMap {
             currentClientIdProvider().flatMap { currentClientId ->
                 val regularMessage = Message.Signaling(
@@ -66,9 +66,7 @@ class SendButtonActionConfirmationMessageUseCase internal constructor(
                     isSelfMessage = true,
                     expirationData = null
                 )
-                messageSender.sendMessage(regularMessage, messageTarget = MessageTarget.Users(
-                    userIds.map { UserId(it, selfUserId.domain) }
-                ))
+                messageSender.sendMessage(regularMessage, messageTarget = MessageTarget.Users(userIds))
             }
     }.fold(Result::Failure, { Result.Success })
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.composite
+
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageTarget
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.arrangement.MessageSenderArrangement
+import com.wire.kalium.logic.util.arrangement.MessageSenderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.SyncManagerArrangement
+import com.wire.kalium.logic.util.arrangement.SyncManagerArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangementImpl
+import io.mockative.any
+import io.mockative.matching
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class SendButtonActionConfirmationMessageTest {
+
+    @Test
+    fun givenMessageSendingSuccess_thenMessageIsSentOnlyToOriginalSenderOfTheButtonAction() = runTest {
+        val convId = ConversationId("conversation-id", "conversation-domain")
+        val buttonActionSender = UserId("action-sender-id", "self-user-domain")
+        val (arrangement, useCase) = Arrangement()
+            .arrange {
+                withWaitUntilLiveOrFailure(Either.Right(Unit))
+                withCurrentClientIdSuccess(ClientId("client-id"))
+                withSendMessageSucceed()
+            }
+
+        val result = useCase(
+            conversationId = convId,
+            messageId = "message-id",
+            buttonId = "button-id",
+            userIds = listOf(buttonActionSender.value)
+        )
+
+        assertIs<SendButtonActionConfirmationMessageUseCase.Result.Success>(result)
+
+        verify(arrangement.messageSender)
+            .suspendFunction(arrangement.messageSender::sendMessage)
+            .with(any(), matching {
+                it is MessageTarget.Users && it.userId == listOf(buttonActionSender)
+            })
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.currentClientIdProvider)
+            .suspendFunction(arrangement.currentClientIdProvider::invoke)
+            .wasInvoked(exactly = once)
+
+        verify(arrangement.syncManager)
+            .suspendFunction(arrangement.syncManager::waitUntilLiveOrFailure)
+            .wasInvoked(exactly = once)
+    }
+
+    private companion object {
+        val SELF_USER_ID: UserId = UserId("self-user-id", "self-user-domain")
+    }
+
+    private class Arrangement :
+        MessageSenderArrangement by MessageSenderArrangementImpl(),
+        SyncManagerArrangement by SyncManagerArrangementImpl(),
+        CurrentClientIdProviderArrangement by CurrentClientIdProviderArrangementImpl() {
+
+        private lateinit var useCase: SendButtonActionConfirmationMessageUseCase
+
+        fun arrange(block: Arrangement.() -> Unit): Pair<Arrangement, SendButtonActionConfirmationMessageUseCase> {
+            apply(block)
+            useCase = SendButtonActionConfirmationMessageUseCase(
+                messageSender = messageSender,
+                syncManager = syncManager,
+                currentClientIdProvider = currentClientIdProvider,
+                selfUserId = SELF_USER_ID,
+            )
+
+            return this to useCase
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageTest.kt
@@ -41,7 +41,7 @@ class SendButtonActionConfirmationMessageTest {
     @Test
     fun givenMessageSendingSuccess_thenMessageIsSentOnlyToOriginalSenderOfTheButtonAction() = runTest {
         val convId = ConversationId("conversation-id", "conversation-domain")
-        val buttonActionSender = UserId("action-sender-id", "self-user-domain")
+        val buttonActionSender = UserId("action-sender-id", "action-sender-domain")
         val (arrangement, useCase) = Arrangement()
             .arrange {
                 withWaitUntilLiveOrFailure(Either.Right(Unit))
@@ -53,7 +53,7 @@ class SendButtonActionConfirmationMessageTest {
             conversationId = convId,
             messageId = "message-id",
             buttonId = "button-id",
-            userIds = listOf(buttonActionSender.value)
+            userIds = listOf(buttonActionSender)
         )
 
         assertIs<SendButtonActionConfirmationMessageUseCase.Result.Success>(result)

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -330,7 +330,7 @@ class ConversationResources(private val instanceService: InstanceService) {
                     ConversationId(conversationId, conversationDomain),
                     referenceMessageId,
                     buttonId,
-                    userIds
+                    userIds.map { UserId(it, conversationDomain) }
                 )
             }
         }

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -28,6 +28,8 @@ import com.wire.kalium.testservice.managed.InstanceService
 import com.wire.kalium.testservice.models.ClearConversationRequest
 import com.wire.kalium.testservice.models.DeleteMessageRequest
 import com.wire.kalium.testservice.models.GetMessagesRequest
+import com.wire.kalium.testservice.models.SendButtonActionConfirmationRequest
+import com.wire.kalium.testservice.models.SendButtonActionRequest
 import com.wire.kalium.testservice.models.SendConfirmationReadRequest
 import com.wire.kalium.testservice.models.SendEphemeralConfirmationDeliveredRequest
 import com.wire.kalium.testservice.models.SendFileRequest
@@ -297,9 +299,42 @@ class ConversationResources(private val instanceService: InstanceService) {
 
     // POST /api/v1/instance/{instanceId}/sendButtonAction
     // Send a button action to a poll.
+    @POST
+    @Path("/instance/{id}/sendButtonAction")
+    @Operation(summary = "Send a button action to a poll.")
+    @Consumes(MediaType.APPLICATION_JSON)
+    fun sendButtonActionConfirmation(@PathParam("id") id: String, @Valid request: SendButtonActionRequest): Response {
+        val instance = instanceService.getInstanceOrThrow(id)
+        return with(request) {
+            runBlocking {
+                ConversationRepository.sendButtonAction(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    referenceMessageId,
+                    buttonId
+                )
+            }
+        }
+    }
 
-    // POST /api/v1/instance/{instanceId}/sendButtonActionConfirmation
-    // Send a confirmation to a button action.
+    @POST
+    @Path("/instance/{id}/sendButtonActionConfirmation")
+    @Operation(summary = "Send a confirmation to a button action.")
+    @Consumes(MediaType.APPLICATION_JSON)
+    fun sendButtonActionConfirmation(@PathParam("id") id: String, @Valid request: SendButtonActionConfirmationRequest): Response {
+        val instance = instanceService.getInstanceOrThrow(id)
+        return with(request) {
+            runBlocking {
+                ConversationRepository.sendButtonActionConfirmation(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    referenceMessageId,
+                    buttonId,
+                    userIds
+                )
+            }
+        }
+    }
 
     @POST
     @Path("/instance/{id}/sendReaction")

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCas
 import com.wire.kalium.logic.feature.debug.BrokenState
 import com.wire.kalium.logic.feature.debug.SendBrokenAssetMessageResult
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionConfirmationMessageUseCase
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
@@ -156,7 +157,7 @@ sealed class ConversationRepository {
             conversationId: ConversationId,
             referenceMessageId: String,
             buttonId: String,
-            userIds: List<String>
+            userIds: List<UserId>
         ): Response = instance.coreLogic.globalScope {
             when (val session = session.currentSession()) {
                 is CurrentSessionResult.Success -> {

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/ConversationRepository.kt
@@ -28,6 +28,8 @@ import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCas
 import com.wire.kalium.logic.feature.debug.BrokenState
 import com.wire.kalium.logic.feature.debug.SendBrokenAssetMessageResult
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
+import com.wire.kalium.logic.feature.message.composite.SendButtonActionConfirmationMessageUseCase
+import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.onFailure
@@ -48,6 +50,7 @@ import kotlin.time.toDuration
 
 sealed class ConversationRepository {
 
+    @Suppress("TooManyFunctions")
     companion object {
         private val log = LoggerFactory.getLogger(ConversationRepository::class.java.name)
 
@@ -119,6 +122,67 @@ sealed class ConversationRepository {
                     }
                 }
             }
+
+        suspend fun sendButtonAction(
+            instance: Instance,
+            conversationId: ConversationId,
+            referenceMessageId: String,
+            buttonId: String
+        ): Response = instance.coreLogic.globalScope {
+            when (val session = session.currentSession()) {
+                is CurrentSessionResult.Success -> {
+                    instance.coreLogic.sessionScope(session.accountInfo.userId) {
+                        log.info("Instance ${instance.instanceId}: Send button action for button $buttonId")
+                        when (val result = messages.sendButtonActionMessage(conversationId, referenceMessageId, buttonId)) {
+                            is SendButtonActionMessageUseCase.Result.Failure ->
+                                Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(result).build()
+
+                            else -> {
+                                Response.status(Response.Status.OK)
+                                    .entity(SendTextResponse(instance.instanceId, "", "")).build()
+                            }
+                        }
+                    }
+                }
+
+                is CurrentSessionResult.Failure -> {
+                    Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Session failure").build()
+                }
+            }
+        }
+
+        suspend fun sendButtonActionConfirmation(
+            instance: Instance,
+            conversationId: ConversationId,
+            referenceMessageId: String,
+            buttonId: String,
+            userIds: List<String>
+        ): Response = instance.coreLogic.globalScope {
+            when (val session = session.currentSession()) {
+                is CurrentSessionResult.Success -> {
+                    instance.coreLogic.sessionScope(session.accountInfo.userId) {
+                        log.info("Instance ${instance.instanceId}: Send button action confirmation for button $buttonId")
+                        when (val result = messages.sendButtonActionConfirmationMessage(
+                            conversationId,
+                            referenceMessageId,
+                            buttonId,
+                            userIds
+                        )) {
+                            is SendButtonActionConfirmationMessageUseCase.Result.Failure -> Response
+                                .status(Response.Status.INTERNAL_SERVER_ERROR).entity(result).build()
+
+                            else -> {
+                                Response.status(Response.Status.OK).entity(SendTextResponse(instance.instanceId, "", "")).build()
+                            }
+                        }
+                    }
+                }
+
+                is CurrentSessionResult.Failure -> {
+                    Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Session failure").build()
+                }
+            }
+        }
 
         suspend fun sendReaction(
             instance: Instance,

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendButtonActionConfirmationRequest.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendButtonActionConfirmationRequest.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.testservice.models
+
+data class SendButtonActionConfirmationRequest(
+    val conversationDomain: String = "staging.zinfra.io",
+    val conversationId: String = "",
+    val referenceMessageId: String = "",
+    val buttonId: String = "",
+    val userIds: List<String> = emptyList()
+)

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendButtonActionRequest.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendButtonActionRequest.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.testservice.models
+
+data class SendButtonActionRequest(
+    val conversationDomain: String = "staging.zinfra.io",
+    val conversationId: String = "",
+    val buttonId: String = "",
+    val referenceMessageId: String = ""
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR allows kalium to send confirmations for button actions. Button actions are messages that are send after a user clicked on a poll message button. These messages need a confirmation or their show in the UI as not confirmed and not selected. A button action confirmation is send to the initial sender of the button action. Unfortunately we currently do not have this message in the database and therefor cannot get the user id of the button action sender out of the database. Instead we need to rely on the userId that is provided to the use case. The domain of this user will be set to the domain of the conversation for now because the testservice API was implemented before federation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
