### PR TITLE
fix: SelfDeleting message in MLS conversation [WPB-5301]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
@@ -75,6 +75,7 @@ class MLSMessageCreatorImpl(
                     messageUid = message.id,
                     messageContent = message.content,
                     expectsReadConfirmation = expectsReadConfirmation,
+                    expiresAfterMillis = message.expirationData?.expireAfter?.inWholeMilliseconds,
                     legalHoldStatus = legalHoldStatus
                 )
             )


### PR DESCRIPTION
# What's new in this PR?

### Issues

Self-deleting messages in MLS conversations were sent as regular message. 

### Causes (Optional)

`MLSMessageCreatorImpl` ignores a message timer, guess it happens cause there were no SelfDeleting messages yet, when the creator was developed. 

### Solutions

update `MLSMessageCreatorImpl` to use message timer.
