### PR TITLE
feat: Observe self client certificate revocation (WPB-6145) - cherrypick

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -125,6 +125,8 @@ interface UserConfigRepository {
     suspend fun setCRLExpirationTime(url: String, timestamp: ULong)
     suspend fun getCRLExpirationTime(url: String): ULong?
     suspend fun observeCertificateExpirationTime(url: String): Flow<Either<StorageFailure, ULong>>
+    suspend fun setShouldNotifyForRevokedCertificate(shouldNotify: Boolean)
+    suspend fun observeShouldNotifyForRevokedCertificate(): Flow<Either<StorageFailure, Boolean>>
 }
 
 @Suppress("TooManyFunctions")
@@ -447,4 +449,10 @@ internal class UserConfigDataSource internal constructor(
 
     override suspend fun observeCertificateExpirationTime(url: String): Flow<Either<StorageFailure, ULong>> =
         userConfigDAO.observeCertificateExpirationTime(url).wrapStorageRequest()
+    override suspend fun setShouldNotifyForRevokedCertificate(shouldNotify: Boolean) {
+        userConfigDAO.setShouldNotifyForRevokedCertificate(shouldNotify)
+    }
+
+    override suspend fun observeShouldNotifyForRevokedCertificate(): Flow<Either<StorageFailure, Boolean>> =
+        userConfigDAO.observeShouldNotifyForRevokedCertificate().wrapStorageRequest()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -297,6 +297,8 @@ import com.wire.kalium.logic.feature.user.ObserveE2EIRequiredUseCase
 import com.wire.kalium.logic.feature.user.ObserveE2EIRequiredUseCaseImpl
 import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCase
 import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCaseImpl
+import com.wire.kalium.logic.feature.user.e2ei.ObserveShouldNotifyForRevokedCertificateUseCase
+import com.wire.kalium.logic.feature.user.e2ei.ObserveShouldNotifyForRevokedCertificateUseCaseImpl
 import com.wire.kalium.logic.feature.user.SyncContactsUseCase
 import com.wire.kalium.logic.feature.user.SyncContactsUseCaseImpl
 import com.wire.kalium.logic.feature.user.SyncSelfUserUseCase
@@ -306,6 +308,8 @@ import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneO
 import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCase
 import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsUseCaseImpl
 import com.wire.kalium.logic.feature.user.UserScope
+import com.wire.kalium.logic.feature.user.e2ei.MarkNotifyForRevokedCertificateAsNotifiedUseCase
+import com.wire.kalium.logic.feature.user.e2ei.MarkNotifyForRevokedCertificateAsNotifiedUseCaseImpl
 import com.wire.kalium.logic.feature.user.guestroomlink.MarkGuestLinkFeatureFlagAsNotChangedUseCase
 import com.wire.kalium.logic.feature.user.guestroomlink.MarkGuestLinkFeatureFlagAsNotChangedUseCaseImpl
 import com.wire.kalium.logic.feature.user.guestroomlink.ObserveGuestRoomLinkFeatureFlagUseCase
@@ -1676,6 +1680,7 @@ class UserSessionScope internal constructor(
     val users: UserScope
         get() = UserScope(
             userRepository,
+            userConfigRepository,
             accountRepository,
             searchUserRepository,
             syncManager,
@@ -1738,6 +1743,12 @@ class UserSessionScope internal constructor(
     val isFileSharingEnabled: IsFileSharingEnabledUseCase get() = IsFileSharingEnabledUseCaseImpl(userConfigRepository)
     val observeFileSharingStatus: ObserveFileSharingStatusUseCase
         get() = ObserveFileSharingStatusUseCaseImpl(userConfigRepository)
+
+   val observeShouldNotifyForRevokedCertificate: ObserveShouldNotifyForRevokedCertificateUseCase
+         by lazy { ObserveShouldNotifyForRevokedCertificateUseCaseImpl(userConfigRepository) }
+
+   val markNotifyForRevokedCertificateAsNotified: MarkNotifyForRevokedCertificateAsNotifiedUseCase
+         by lazy { MarkNotifyForRevokedCertificateAsNotifiedUseCaseImpl(userConfigRepository) }
 
     val markGuestLinkFeatureFlagAsNotChanged: MarkGuestLinkFeatureFlagAsNotChangedUseCase
         get() = MarkGuestLinkFeatureFlagAsNotChangedUseCaseImpl(userConfigRepository)
@@ -1931,6 +1942,9 @@ class UserSessionScope internal constructor(
 
         launch {
             updateSelfClientCapabilityToLegalHoldConsent()
+        }
+        launch {
+            users.observeCertificateRevocationForSelfClient()
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/ObserveCertificateRevocationForSelfClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/ObserveCertificateRevocationForSelfClientUseCase.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.e2ei.usecase
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.feature.e2ei.CertificateStatus
+import com.wire.kalium.logic.functional.map
+
+/**
+ * Use case to observe certificate revocation for self client.
+ */
+interface ObserveCertificateRevocationForSelfClientUseCase {
+    suspend operator fun invoke()
+}
+
+@Suppress("LongParameterList")
+internal class ObserveCertificateRevocationForSelfClientUseCaseImpl(
+    private val userConfigRepository: UserConfigRepository,
+    private val currentClientIdProvider: CurrentClientIdProvider,
+    private val getE2eiCertificate: GetE2eiCertificateUseCase
+) : ObserveCertificateRevocationForSelfClientUseCase {
+    override suspend fun invoke() {
+        currentClientIdProvider().map { clientId ->
+            getE2eiCertificate(clientId).run {
+                if (this is GetE2EICertificateUseCaseResult.Success && certificate.status == CertificateStatus.REVOKED) {
+                    userConfigRepository.setShouldNotifyForRevokedCertificate(true)
+                }
+            }
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -19,6 +19,7 @@
 
 package com.wire.kalium.logic.feature.user
 
+import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
@@ -54,6 +55,8 @@ import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUs
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificateStatusUseCaseImpl
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCaseImpl
+import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
+import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCaseImpl
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCaseImpl
@@ -75,6 +78,7 @@ import com.wire.kalium.persistence.dao.MetadataDAO
 @Suppress("LongParameterList")
 class UserScope internal constructor(
     private val userRepository: UserRepository,
+    private val userConfigRepository: UserConfigRepository,
     private val accountRepository: AccountRepository,
     private val searchUserRepository: SearchUserRepository,
     private val syncManager: SyncManager,
@@ -176,4 +180,11 @@ class UserScope internal constructor(
     val deleteAccount: DeleteAccountUseCase get() = DeleteAccountUseCase(accountRepository)
 
     val updateSupportedProtocols: UpdateSupportedProtocolsUseCase get() = updateSupportedProtocolsUseCase
+
+    val observeCertificateRevocationForSelfClient: ObserveCertificateRevocationForSelfClientUseCase
+        get() = ObserveCertificateRevocationForSelfClientUseCaseImpl(
+            userConfigRepository = userConfigRepository,
+            currentClientIdProvider = clientIdProvider,
+            getE2eiCertificate = getE2EICertificate
+        )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/e2ei/MarkNotifyForRevokedCertificateAsNotifiedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/e2ei/MarkNotifyForRevokedCertificateAsNotifiedUseCase.kt
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user.e2ei
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+
+/**
+ * Use case that marks that the user should not be notified about revoked E2Ei certificate.
+ */
+interface MarkNotifyForRevokedCertificateAsNotifiedUseCase {
+    suspend operator fun invoke()
+}
+
+internal class MarkNotifyForRevokedCertificateAsNotifiedUseCaseImpl(
+    private val userConfigRepository: UserConfigRepository
+) : MarkNotifyForRevokedCertificateAsNotifiedUseCase {
+    override suspend operator fun invoke() {
+        userConfigRepository.setShouldNotifyForRevokedCertificate(false)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/e2ei/ObserveShouldNotifyForRevokedCertificateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/e2ei/ObserveShouldNotifyForRevokedCertificateUseCase.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user.e2ei
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.functional.fold
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Use case that observes if the user should be notified about revoked E2ei certificate.
+ */
+interface ObserveShouldNotifyForRevokedCertificateUseCase {
+    suspend operator fun invoke(): Flow<Boolean>
+}
+
+internal class ObserveShouldNotifyForRevokedCertificateUseCaseImpl(
+    private val userConfigRepository: UserConfigRepository
+) : ObserveShouldNotifyForRevokedCertificateUseCase {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend operator fun invoke(): Flow<Boolean> =
+        userConfigRepository.observeShouldNotifyForRevokedCertificate().flatMapLatest {
+            it.fold(
+                { flowOf(false) },
+                { shouldNotify ->
+                    flowOf(shouldNotify)
+                }
+            )
+        }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/e2ei/MarkNotifyForRevokedCertificateAsNotifiedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/e2ei/MarkNotifyForRevokedCertificateAsNotifiedUseCaseTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user.e2ei
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class MarkNotifyForRevokedCertificateAsNotifiedUseCaseTest {
+
+    @Test
+    fun givenUserConfigRepository_whenRunningUseCase_thenSetShouldNotifyForRevokedCertificateOnce() =
+        runTest {
+            val (arrangement, markNotifyForRevokedCertificateAsNotified) = Arrangement()
+                .withUserConfigRepository()
+                .arrange()
+
+            markNotifyForRevokedCertificateAsNotified.invoke()
+
+            verify(arrangement.userConfigRepository)
+                .function(arrangement.userConfigRepository::setShouldNotifyForRevokedCertificate)
+                .with(eq(false))
+                .wasInvoked()
+        }
+
+    internal class Arrangement {
+
+        @Mock
+        val userConfigRepository = mock(classOf<UserConfigRepository>())
+
+        fun arrange() = this to MarkNotifyForRevokedCertificateAsNotifiedUseCaseImpl(
+            userConfigRepository = userConfigRepository
+        )
+
+        fun withUserConfigRepository() = apply {
+            given(userConfigRepository)
+                .function(userConfigRepository::setShouldNotifyForRevokedCertificate)
+                .whenInvokedWith(eq(false))
+                .thenReturn(Unit)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/e2ei/ObserveShouldNotifyForRevokedCertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/e2ei/ObserveShouldNotifyForRevokedCertificateUseCaseTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user.e2ei
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObserveShouldNotifyForRevokedCertificateUseCaseTest {
+
+    @Test
+    fun givenUserConfigRepositoryFailure_whenRunningUseCase_thenEmitFalse() = runTest {
+        val (_, observeShouldNotifyForRevokedCertificate) = Arrangement()
+            .withUserConfigRepositoryFailure()
+            .arrange()
+
+        val result = observeShouldNotifyForRevokedCertificate.invoke()
+
+        assertEquals(false, result.first())
+    }
+
+    @Test
+    fun givenUserConfigRepositorySuccess_whenRunningUseCase_thenEmitSameValueOfRepository() =
+        runTest {
+            val (_, observeShouldNotifyForRevokedCertificate) = Arrangement()
+                .withUserConfigRepositorySuccess()
+                .arrange()
+
+            val result = observeShouldNotifyForRevokedCertificate.invoke()
+
+            assertEquals(true, result.first())
+        }
+
+    internal class Arrangement {
+
+        @Mock
+        val userConfigRepository = mock(classOf<UserConfigRepository>())
+
+        fun arrange() = this to ObserveShouldNotifyForRevokedCertificateUseCaseImpl(
+            userConfigRepository = userConfigRepository
+        )
+
+        fun withUserConfigRepositoryFailure() = apply {
+            given(userConfigRepository)
+                .suspendFunction(userConfigRepository::observeShouldNotifyForRevokedCertificate)
+                .whenInvoked()
+                .thenReturn(flowOf(Either.Left(StorageFailure.DataNotFound)))
+        }
+
+        fun withUserConfigRepositorySuccess() = apply {
+            given(userConfigRepository)
+                .suspendFunction(userConfigRepository::observeShouldNotifyForRevokedCertificate)
+                .whenInvoked()
+                .thenReturn(flowOf(Either.Right(true)))
+        }
+    }
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/unread/UserConfigDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/unread/UserConfigDAO.kt
@@ -55,6 +55,8 @@ interface UserConfigDAO {
     suspend fun setCRLExpirationTime(url: String, timestamp: ULong)
     suspend fun getCRLsPerDomain(url: String): ULong?
     suspend fun observeCertificateExpirationTime(url: String): Flow<ULong?>
+    suspend fun setShouldNotifyForRevokedCertificate(shouldNotify: Boolean)
+    suspend fun observeShouldNotifyForRevokedCertificate(): Flow<Boolean?>
 }
 
 @Suppress("TooManyFunctions")
@@ -167,8 +169,16 @@ internal class UserConfigDAOImpl internal constructor(
     override suspend fun observeCertificateExpirationTime(url: String): Flow<ULong?> =
         metadataDAO.valueByKeyFlow(url).map { it?.toULongOrNull() }
 
+    override suspend fun setShouldNotifyForRevokedCertificate(shouldNotify: Boolean) {
+        metadataDAO.insertValue(shouldNotify.toString(), SHOULD_NOTIFY_FOR_REVOKED_CERTIFICATE)
+    }
+
+    override suspend fun observeShouldNotifyForRevokedCertificate(): Flow<Boolean?> =
+        metadataDAO.valueByKeyFlow(SHOULD_NOTIFY_FOR_REVOKED_CERTIFICATE).map { it?.toBoolean() }
+
     private companion object {
         private const val SELF_DELETING_MESSAGES_KEY = "SELF_DELETING_MESSAGES"
+        private const val SHOULD_NOTIFY_FOR_REVOKED_CERTIFICATE = "should_notify_for_revoked_certificate"
         private const val MLS_MIGRATION_KEY = "MLS_MIGRATION"
         private const val SUPPORTED_PROTOCOLS_KEY = "SUPPORTED_PROTOCOLS"
         const val LEGAL_HOLD_REQUEST = "legal_hold_request"


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Cherry pick from the original PR:

https://github.com/wireapp/kalium/pull/2384


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
