### PR TITLE
fix: update user connection status after cancelling request

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiver.kt
@@ -76,7 +76,7 @@ class FederationEventReceiverImpl internal constructor(
                     if (conversationDetails is ConversationDetails.Connection
                         && conversationDetails.otherUser?.id?.domain == event.domain
                     ) {
-                        connectionRepository.deleteConnection(conversationDetails.conversationId)
+                        connectionRepository.deleteConnection(conversationDetails.connection)
                     }
                 }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConnectionRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConnectionRepositoryArrangement.kt
@@ -21,14 +21,10 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationDetails
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.Connection
-import com.wire.kalium.logic.data.user.ConnectionState
-import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCaseTest
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
 import io.mockative.any
-import io.mockative.eq
 import io.mockative.given
 import io.mockative.matchers.Matcher
 import io.mockative.mock
@@ -38,7 +34,7 @@ internal interface ConnectionRepositoryArrangement {
     val connectionRepository: ConnectionRepository
 
     fun withGetConnections(result: Either<StorageFailure, Flow<List<ConversationDetails>>>)
-    fun withDeleteConnection(result: Either<StorageFailure, Unit>, conversationId: Matcher<ConversationId> = any())
+    fun withDeleteConnection(result: Either<StorageFailure, Unit>, connection: Matcher<Connection> = any())
     fun withConnectionList(connectionsFlow: Flow<List<ConversationDetails>>)
     fun withUpdateConnectionStatus(result: Either<CoreFailure, Connection>)
 }
@@ -58,11 +54,11 @@ internal open class ConnectionRepositoryArrangementImpl : ConnectionRepositoryAr
 
     override fun withDeleteConnection(
         result: Either<StorageFailure, Unit>,
-        conversationId: Matcher<ConversationId>,
+        connection: Matcher<Connection>,
     ) {
         given(connectionRepository)
             .suspendFunction(connectionRepository::deleteConnection)
-            .whenInvokedWith(conversationId)
+            .whenInvokedWith(connection)
             .thenReturn(result)
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After sending a request and cancelling, the button still shows "cancel request" and clicking again just returns the info that cancelling is not possible, so it stays in this state forever and user cannot send a request.

### Causes (Optional)

After cancelling, the connection row in DB is removed but user's field `connection_status` is not updated - it's still `SENT`.
Cancelling a request is the only state change when the user's `connection_status` isn't updated.

### Solutions

Update user's `connection_status` field as well when cancelling a connection request.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Send a connection request and then cancel it.

### Attachments (Optional)

#### Before

https://github.com/wireapp/kalium/assets/30429749/e05cb47f-4165-456f-9366-9c6388661e6c

#### After

https://github.com/wireapp/kalium/assets/30429749/ee3f1ef2-405b-448e-9336-a2ce21339eea

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
