### PR TITLE
feat: handle legal hold failure result when sending connection [WPB-4395]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/SendConnectionRequestUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/SendConnectionRequestUseCase.kt
@@ -63,17 +63,17 @@ internal class SendConnectionRequestUseCaseImpl(
         })
     }
 
-    private fun handleServerMissCommunicationError(coreFailure: NetworkFailure.ServerMiscommunication): SendConnectionRequestResult.Failure =
-        when (coreFailure.kaliumException) {
+    private fun handleServerMissCommunicationError(failure: NetworkFailure.ServerMiscommunication): SendConnectionRequestResult.Failure =
+        when (failure.kaliumException) {
             is KaliumException.InvalidRequestError -> {
-                with(coreFailure.kaliumException) {
+                with(failure.kaliumException) {
                     when {
                         isMissingLegalHoldConsent() -> SendConnectionRequestResult.Failure.MissingLegalHoldConsent
-                        else -> SendConnectionRequestResult.Failure.GenericFailure(coreFailure)
+                        else -> SendConnectionRequestResult.Failure.GenericFailure(failure)
                     }
                 }
             }
-            else -> SendConnectionRequestResult.Failure.GenericFailure(coreFailure)
+            else -> SendConnectionRequestResult.Failure.GenericFailure(failure)
         }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/SendConnectionRequestUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/SendConnectionRequestUseCase.kt
@@ -26,6 +26,8 @@ import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isMissingLegalHoldConsent
 
 /**
  * Use Case that allows a user send a connection request to connect with another User
@@ -53,13 +55,26 @@ internal class SendConnectionRequestUseCaseImpl(
             when (coreFailure) {
                 is NetworkFailure.FederatedBackendFailure.FederationDenied ->
                     SendConnectionRequestResult.Failure.FederationDenied
-
+                is NetworkFailure.ServerMiscommunication -> handleServerMissCommunicationError(coreFailure)
                 else -> SendConnectionRequestResult.Failure.GenericFailure(coreFailure)
             }
         }, {
             SendConnectionRequestResult.Success
         })
     }
+
+    private fun handleServerMissCommunicationError(coreFailure: NetworkFailure.ServerMiscommunication): SendConnectionRequestResult.Failure =
+        when (coreFailure.kaliumException) {
+            is KaliumException.InvalidRequestError -> {
+                with(coreFailure.kaliumException) {
+                    when {
+                        isMissingLegalHoldConsent() -> SendConnectionRequestResult.Failure.MissingLegalHoldConsent
+                        else -> SendConnectionRequestResult.Failure.GenericFailure(coreFailure)
+                    }
+                }
+            }
+            else -> SendConnectionRequestResult.Failure.GenericFailure(coreFailure)
+        }
 }
 
 sealed class SendConnectionRequestResult {
@@ -68,6 +83,7 @@ sealed class SendConnectionRequestResult {
     sealed class Failure : SendConnectionRequestResult() {
         class GenericFailure(val coreFailure: CoreFailure) : Failure()
         data object FederationDenied : Failure()
+        data object MissingLegalHoldConsent : Failure()
     }
 
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_EMAIL
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_HANDLE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.KEY_EXISTS
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MISSING_AUTH
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.MISSING_LEGALHOLD_CONSENT
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_CLIENT_MISMATCH
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_COMMIT_MISSING_REFERENCES
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_MISSING_GROUP_INFO
@@ -231,3 +232,4 @@ val KaliumException.InvalidRequestError.authenticationCodeFailure: Authenticatio
 
 fun KaliumException.FederationError.isFederationDenied() = errorResponse.label == FEDERATION_DENIED
 fun KaliumException.FederationError.isFederationNotEnabled() = errorResponse.label == FEDERATION_NOT_ENABLED
+fun KaliumException.InvalidRequestError.isMissingLegalHoldConsent(): Boolean = errorResponse.label == MISSING_LEGALHOLD_CONSENT

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -49,6 +49,7 @@ internal object NetworkErrorLabel {
     const val ACCESS_DENIED = "access-denied"
     const val WRONG_CONVERSATION_PASSWORD = "invalid-conversation-password"
     const val NOT_FOUND = "not-found"
+    const val MISSING_LEGALHOLD_CONSENT = "missing-legalhold-consent"
 
     // Federation
     const val FEDERATION_FAILURE = "federation-remote-error"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we're not taking legal hold into account when sending connection requests which results in request not being completed without any explanation. 

### Solutions

Handle `missing-legalhold-consent` response label and return new type of failed result in `SendConnectionRequestUseCase`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Send a connection request to a person which is under legal hold or send a connection request to anyone while you are under legal hold.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
