### PR TITLE
chore: bring back architecture test after being ignored

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+@file:Suppress("konsist.repositoriesShouldNotAccessFeaturePackageClasses")
 
 package com.wire.kalium.logic.data.call
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+@file:Suppress("konsist.repositoriesShouldNotAccessFeaturePackageClasses")
 
 package com.wire.kalium.logic.data.conversation
 
@@ -121,6 +122,7 @@ interface MLSConversationRepository {
         certificateChain: String,
         isNewClient: Boolean = false
     ): Either<CoreFailure, Unit>
+
     suspend fun getClientIdentity(clientId: ClientId): Either<CoreFailure, WireIdentity>
     suspend fun getUserIdentity(userId: UserId): Either<CoreFailure, List<WireIdentity>>
     suspend fun getMembersIdentities(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/E2EIRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/E2EIRepository.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-@file:Suppress("TooManyFunctions")
+@file:Suppress("konsist.repositoriesShouldNotAccessFeaturePackageClasses", "TooManyFunctions")
 
 package com.wire.kalium.logic.data.e2ei
 

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/architecture/LayerAccessRulesTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/architecture/LayerAccessRulesTest.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.architecture
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withPackage
 import com.lemonappdev.konsist.api.verify.assertFalse
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 class LayerAccessRulesTest {
@@ -31,8 +30,6 @@ class LayerAccessRulesTest {
         val importsFromNetworkLayer = ".*?(\\.|)network(\\..*|\\n)".toRegex()
     }
 
-    //todo: fix later
-    @Ignore
     @Test
     fun repositoriesShouldNotAccessFeaturePackageClasses() {
         Konsist.scopeFromProduction()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Architecture tests are ignored

### Causes (Optional)

Circular dependencies, and other code smells, are not being caught.

### Solutions

Renable, and supress (for now) failed tests. 

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

Tickets are going to be created as tech debt to be solved, at least for develop as a last resort.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
