### PR TITLE
fix: changing profile avatar doesn't reflect update (WPB-5494)

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -60,7 +60,7 @@ insertOrIgnoreUser:
 INSERT OR IGNORE INTO User(qualified_id, name, handle, email, phone, accent_id, team, connection_status, preview_asset_id, complete_asset_id, user_type, bot_service, deleted, incomplete_metadata, expires_at, supported_protocols)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
-updateUser {
+updateUser:
 UPDATE User
 SET
 name = coalesce(:name, name),
@@ -71,8 +71,6 @@ preview_asset_id = :preview_asset_id, preview_asset_id = coalesce(:preview_asset
 complete_asset_id = :complete_asset_id, complete_asset_id = coalesce(:complete_asset_id, complete_asset_id),
 supported_protocols = :supported_protocols, supported_protocols = coalesce(:supported_protocols, supported_protocols)
 WHERE qualified_id = ?;
-SELECT changes();
-}
 
 updatePartialUserInformation:
 UPDATE User

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -193,16 +193,19 @@ class UserDAOImpl internal constructor(
     }
 
     override suspend fun updateUser(update: PartialUserEntity) = withContext(queriesContext) {
-        userQueries.updateUser(
-            name = update.name,
-            handle = update.handle,
-            email = update.email,
-            accent_id = update.accentId?.toLong(),
-            preview_asset_id = update.previewAssetId,
-            complete_asset_id = update.completeAssetId,
-            supported_protocols = update.supportedProtocols,
-            update.id
-        ).executeAsOne() > 0
+        userQueries.transactionWithResult {
+            userQueries.updateUser(
+                name = update.name,
+                handle = update.handle,
+                email = update.email,
+                accent_id = update.accentId?.toLong(),
+                preview_asset_id = update.previewAssetId,
+                complete_asset_id = update.completeAssetId,
+                supported_protocols = update.supportedProtocols,
+                update.id
+            )
+            userQueries.selectChanges().executeAsOne() > 0
+        }
     }
 
     override suspend fun updateUser(users: List<PartialUserEntity>) = withContext(queriesContext) {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -57,6 +57,44 @@ class UserDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenUser_whenUpdatingProfileAvatar_thenChangesAreEmittedCorrectly() = runTest(dispatcher) {
+        //given
+        val updatedUser = PartialUserEntity(
+            id = user1.id,
+            name = "newName",
+            handle = user1.handle,
+            email = user1.email,
+            accentId = user1.accentId,
+            previewAssetId = UserAssetIdEntity(
+                value ="newAvatar",
+                domain = "newAvatarDomain"
+            ),
+            completeAssetId = UserAssetIdEntity(
+                value ="newAvatar",
+                domain = "newAvatarDomain"
+            ),
+            supportedProtocols = user1.supportedProtocols
+        )
+
+        db.userDAO.upsertUser(user1)
+
+        db.userDAO.observeUserDetailsByQualifiedID(user1.id).test {
+            assertEquals(user1, (awaitItem() as UserDetailsEntity).toSimpleEntity())
+
+            // when
+
+            val userIsUpdated = db.userDAO.updateUser(updatedUser)
+
+            // then
+            val newItem = (awaitItem() as UserDetailsEntity)
+            assertEquals(true, userIsUpdated)
+            assertEquals(updatedUser.previewAssetId, newItem.previewAssetId)
+            assertEquals(updatedUser.completeAssetId, newItem.completeAssetId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun givenUser_ThenUserCanBeInserted() = runTest(dispatcher) {
         db.userDAO.upsertUser(user1)
         val result = db.userDAO.observeUserDetailsByQualifiedID(user1.id).first()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When changing user profile avatar it wasn't being reflected in other screens in the app

### Causes (Optional)

the query `updateUser` was a transaction returning `SELECT changes()`, thus sqldelight not emitting the update on the table.

### Solutions

Remove transaction and `SELECT changes()` from the query and add `transactionWithResult` on the DAOImpl to properly reflect the changes upwards when needed.

### Testing

#### How to Test

- Use this branch on AR
- Open Profile Screen and change profile avatar
- go back and check that profile avatar change is reflected across other screens

### Notes (Optional)

@vitorhugods opened an issue on SQLDelight : https://github.com/cashapp/sqldelight/issues/5001
