### PR TITLE
feat(monkeys): Add support for 2FA during login [WPB-6289]

### DIFF
--- a/monkeys/README.md
+++ b/monkeys/README.md
@@ -32,7 +32,7 @@ config file to load simply set the environment variable `CONFIG`:
 env CONFIG=example.json docker compose up
 ```
 
-*Note*: the file must be located inside the config folder.
+_Note_: the file must be located inside the config folder.
 
 If the host is not an ARM based platform, the `--platform` parameter can be omitted. If building on
 MacOs ARM computers, be sure to disable Rosetta emulation and containerd support in the settings
@@ -68,12 +68,13 @@ scalability. To do that you need to specify a command to start each monkey and a
 them. Both the `startCommand` and the `addressTemplate` are templated string the following variables
 will be replaced at runtime:
 
-* teamName: the name of the team that the user belongs to
-* email: the email of the user
-* userId: the id of the user (without the domain)
-* teamId: the id of the team that the user belongs to
-* monkeyIndex: a unique identifier within the app for each monkey (it is numeric starting from 0)
-* monkeyClientId: a unique identifier for each client within the app (it is numeric)
+- teamName: the name of the team that the user belongs to
+- email: the email of the user
+- userId: the id of the user (without the domain)
+- teamId: the id of the team that the user belongs to
+- monkeyIndex: a unique identifier within the app for each monkey (it is numeric starting from 0)
+- monkeyClientId: a unique identifier for each client within the app (it is numeric)
+- code: the 2FA code that can be reused until expired.
 
 Example:
 
@@ -100,17 +101,29 @@ needed on non x86_64 CPUs):
 }
 ```
 
+Or on swarm mode:
+
+```json
+{
+    "externalMonkey": {
+        "startCommand": "docker service create --hostname monkey-{{monkeyIndex}} --name monkey-{{monkeyIndex}}-{{teamName}} --network infinite-monkeys_monkeys --restart-condition none monkeys /opt/app/bin/monkey-server",
+        "addressTemplate": "http://monkey-{{monkeyIndex}}:8080",
+        "waitTime": 3
+    }
+}
+```
+
 The `waitTime` field is optional and determines how long (in seconds) it will wait until it proceeds to start the
 next monkey. This can be important because the next step in the app is assigning each to a user and
 the app must be ready to respond.
 
-**Note**: setting environment variables prior to the command is is not supported. Ex: 
+**Note**: setting environment variables prior to the command is is not supported. Ex:
 `INDEX={{monkeyIndex}} ./monkeys/bin/monkey-server -p 50$INDEX`. This is a limitation of the JVM's system command
 runner.
 
 ## Current Limitations (to be fixed in the future)
 
-* The application should run until it receives a `SIGINT` (Ctrl+C) signal. There should be a
-  configuration to finish the test run
-* Tests need to be implemented
-* Randomising times for action execution
+- The application should run until it receives a `SIGINT` (Ctrl+C) signal. There should be a
+    configuration to finish the test run
+- Tests need to be implemented
+- Randomising times for action execution

--- a/monkeys/schema.json
+++ b/monkeys/schema.json
@@ -18,7 +18,7 @@
             ],
             "properties": {
                 "startCommand": {
-                    "description": "The command to start the process. For example kubectl to start a pod or docker to start a container. It can be templated with the following fields: teamName, email, userId, teamId, monkeyIndex, monkeyClientId, internalUser, internalPassword",
+                    "description": "The command to start the process. For example kubectl to start a pod or docker to start a container. It can be templated with the following fields: teamName, email, userId, teamId, monkeyIndex, monkeyClientId",
                     "type": "string",
                     "examples": [
                         "/opt/app/monkeys/bin/monkey-server -p 80{{monkeyIndex}}",
@@ -26,7 +26,7 @@
                     ]
                 },
                 "addressTemplate": {
-                    "description": "The template to resolve the address of the individual monkey. It can be templated with the following fields: teamName, email, userId, teamId, monkeyIndex, monkeyClientId, internalUser, internalPassword",
+                    "description": "The template to resolve the address of the individual monkey. It can be templated with the following fields: teamName, email, userId, teamId, monkeyIndex, monkeyClientId",
                     "type": "string",
                     "examples": [
                         "http://localhost:80{{monkeyIndex}}",
@@ -147,8 +147,7 @@
                     "domain",
                     "authUser",
                     "authPassword",
-                    "userCount",
-                    "2FAEnabled"
+                    "userCount"
                 ],
                 "properties": {
                     "api": {
@@ -200,7 +199,7 @@
                         "type": "integer"
                     },
                     "2FAEnabled": {
-                        "description": "Does this server required 2FA authentication?",
+                        "description": "Does this server require 2FA authentication?",
                         "type": "boolean",
                         "default": false
                     },

--- a/monkeys/schema.json
+++ b/monkeys/schema.json
@@ -18,7 +18,7 @@
             ],
             "properties": {
                 "startCommand": {
-                    "description": "The command to start the process. For example kubectl to start a pod or docker to start a container. It can be templated with the following fields: teamName, email, userId, teamId, monkeyIndex, monkeyClientId",
+                    "description": "The command to start the process. For example kubectl to start a pod or docker to start a container. It can be templated with the following fields: teamName, email, userId, teamId, monkeyIndex, monkeyClientId, internalUser, internalPassword",
                     "type": "string",
                     "examples": [
                         "/opt/app/monkeys/bin/monkey-server -p 80{{monkeyIndex}}",
@@ -26,7 +26,7 @@
                     ]
                 },
                 "addressTemplate": {
-                    "description": "The template to resolve the address of the individual monkey. It can be templated with the following fields: teamName, email, userId, teamId, monkeyIndex, monkeyClientId",
+                    "description": "The template to resolve the address of the individual monkey. It can be templated with the following fields: teamName, email, userId, teamId, monkeyIndex, monkeyClientId, internalUser, internalPassword",
                     "type": "string",
                     "examples": [
                         "http://localhost:80{{monkeyIndex}}",
@@ -147,7 +147,8 @@
                     "domain",
                     "authUser",
                     "authPassword",
-                    "userCount"
+                    "userCount",
+                    "2FAEnabled"
                 ],
                 "properties": {
                     "api": {
@@ -197,6 +198,11 @@
                     "userCount": {
                         "description": "How many users should be created in this team",
                         "type": "integer"
+                    },
+                    "2FAEnabled": {
+                        "description": "Does this server required 2FA authentication?",
+                        "type": "boolean",
+                        "default": false
                     },
                     "dumpUsers": {
                         "description": "Should the application dump the users created into a file",

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/Utils.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/Utils.kt
@@ -35,4 +35,5 @@ fun String.renderMonkeyTemplate(userData: UserData, monkeyId: MonkeyId): String 
     return this.replace("{{teamName}}", userData.team.name).replace("{{email}}", userData.email)
         .replace("{{userId}}", userData.userId.value).replace("{{teamId}}", userData.team.id)
         .replace("{{monkeyIndex}}", monkeyId.index.toString()).replace("{{monkeyClientId}}", monkeyId.clientId.toString())
+        .replace("{{code}}", userData.oldCode.orEmpty())
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/LocalMonkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/LocalMonkey.kt
@@ -192,7 +192,10 @@ class LocalMonkey(monkeyType: MonkeyType, internalId: MonkeyId) : Monkey(monkeyT
     }
 
     override suspend fun createConversation(
-        name: String, monkeyList: List<Monkey>, protocol: ConversationOptions.Protocol, isDestroyable: Boolean
+        name: String,
+        monkeyList: List<Monkey>,
+        protocol: ConversationOptions.Protocol,
+        isDestroyable: Boolean
     ): MonkeyConversation {
         val self = this
         return this.monkeyState.readyThen {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/LocalMonkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/LocalMonkey.kt
@@ -64,10 +64,14 @@ class LocalMonkey(monkeyType: MonkeyType, internalId: MonkeyId) : Monkey(monkeyT
      * Logs user in and register client (if not registered)
      */
     override suspend fun login(coreLogic: CoreLogic, callback: (Monkey) -> Unit) {
-        val authScope = getAuthScope(coreLogic, this.monkeyType.userData().team.backend)
-        val email = this.monkeyType.userData().email
-        val password = this.monkeyType.userData().password
-        val loginResult = authScope.login(email, password, false)
+        val userData = this.monkeyType.userData()
+        val secondFactor = userData.request2FA()
+        val authScope = getAuthScope(coreLogic, userData.team.backend)
+        val email = userData.email
+        val password = userData.password
+        val loginResult = authScope.login(
+            userIdentifier = email, password = password, shouldPersistClient = false, secondFactorVerificationCode = secondFactor
+        )
         if (loginResult !is AuthenticationResult.Success) {
             error("User creds didn't work ($email, $password)")
         }
@@ -86,7 +90,10 @@ class LocalMonkey(monkeyType: MonkeyType, internalId: MonkeyId) : Monkey(monkeyT
         }
         val sessionScope = coreLogic.getSessionScope(loginResult.authData.userId)
         val registerClientParam = RegisterClientUseCase.RegisterClientParam(
-            password = this.monkeyType.userData().password, capabilities = emptyList(), clientType = ClientType.Temporary
+            password = userData.password,
+            capabilities = emptyList(),
+            clientType = ClientType.Temporary,
+            secondFactorVerificationCode = secondFactor
         )
         val registerResult = sessionScope.client.getOrRegister(registerClientParam)
         if (registerResult is RegisterClientResult.Failure) {
@@ -185,10 +192,7 @@ class LocalMonkey(monkeyType: MonkeyType, internalId: MonkeyId) : Monkey(monkeyT
     }
 
     override suspend fun createConversation(
-        name: String,
-        monkeyList: List<Monkey>,
-        protocol: ConversationOptions.Protocol,
-        isDestroyable: Boolean
+        name: String, monkeyList: List<Monkey>, protocol: ConversationOptions.Protocol, isDestroyable: Boolean
     ): MonkeyConversation {
         val self = this
         return this.monkeyState.readyThen {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestData.kt
@@ -188,6 +188,7 @@ data class BackendConfig(
     @SerialName("authUser") val authUser: String,
     @SerialName("authPassword") val authPassword: String,
     @SerialName("userCount") val userCount: ULong,
+    @SerialName("2FAEnabled") val secondFactorAuth : Boolean = false,
     @SerialName("dumpUsers") val dumpUsers: Boolean = false,
     @SerialName("presetTeam") val presetTeam: TeamConfig? = null
 )

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestData.kt
@@ -188,7 +188,7 @@ data class BackendConfig(
     @SerialName("authUser") val authUser: String,
     @SerialName("authPassword") val authPassword: String,
     @SerialName("userCount") val userCount: ULong,
-    @SerialName("2FAEnabled") val secondFactorAuth : Boolean = false,
+    @SerialName("2FAEnabled") val secondFactorAuth: Boolean = false,
     @SerialName("dumpUsers") val dumpUsers: Boolean = false,
     @SerialName("presetTeam") val presetTeam: TeamConfig? = null
 )

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestDataImporter.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestDataImporter.kt
@@ -46,6 +46,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -162,7 +163,7 @@ private suspend fun HttpClient.createTeam(backendConfig: BackendConfig): Team {
         ownerId = UserId(userId, backend.domain),
         client = this
     )
-    login(team.owner.email, team.owner.password)
+    login(team.owner.email, team.owner.password, team.owner.request2FA())
 
     put("self/handle") { setBody(mapOf("handle" to ownerId).toJsonObject()) }
     logger.i("Owner $email (id $userId) of team ${backendConfig.teamName} (id: $teamId) in backend ${backendConfig.domain}")
@@ -172,7 +173,8 @@ private suspend fun HttpClient.createTeam(backendConfig: BackendConfig): Team {
 private suspend fun setUserHandle(backendConfig: BackendConfig, userData: UserData) {
     lateinit var token: BearerTokens
     val httpClient = httpClient(backendConfig) { token }
-    httpClient.login(userData.email, userData.password) { accessToken ->
+    val secondFactor = httpClient.request2FA(userData.email, userData.userId)
+    httpClient.login(userData.email, userData.password, secondFactor) { accessToken ->
         token = BearerTokens(accessToken, "")
     }
     httpClient.put("self/handle") { setBody(mapOf("handle" to "monkey-${userData.userId.value}").toJsonObject()) }
@@ -198,6 +200,7 @@ private suspend fun HttpClient.createUser(i: Int, team: Team, userPassword: Stri
 private suspend fun HttpClient.login(
     email: String,
     password: String,
+    secondFactor: String?,
     tokenProvider: (accessToken: String) -> Unit = { accessToken ->
         token = BearerTokens(accessToken, "")
     }
@@ -205,7 +208,7 @@ private suspend fun HttpClient.login(
     val response = post("login") {
         setBody(
             mapOf(
-                "email" to email, "password" to password, "label" to ""
+                "email" to email, "password" to password, "label" to "", "verification_code" to secondFactor
             ).toJsonObject()
         )
     }.body<JsonObject>()
@@ -214,11 +217,22 @@ private suspend fun HttpClient.login(
 }
 
 internal suspend fun HttpClient.teamParticipants(team: Team): List<UserId> {
-    this.login(team.owner.email, team.owner.password)
+    this.login(team.owner.email, team.owner.password, team.owner.request2FA())
     val members = get("teams/${team.id}/members").body<JsonObject>()
     return members["members"]!!.jsonArray.map { member ->
         UserId(member.jsonObject["user"]!!.jsonPrimitive.content, team.backend.domain)
     }
+}
+
+suspend fun HttpClient.request2FA(email: String, userId: UserId): String {
+    this.post("v3/verification-code/send") {
+        setBody(
+            mapOf(
+                "action" to "login", "email" to email
+            ).toJsonObject()
+        )
+    }
+    return this.get("i/users/${userId.value}/verification-code/login").body<JsonPrimitive>().content
 }
 
 private suspend fun HttpClient.invite(teamId: String, email: String, name: String): String {
@@ -234,7 +248,7 @@ private suspend fun HttpClient.invite(teamId: String, email: String, name: Strin
 }
 
 internal fun httpClient(backendConfig: BackendConfig, tokenProvider: () -> BearerTokens? = { token }) = HttpClient(OkHttp.create()) {
-    val excludedPaths = listOf("register", "login", "activate")
+    val excludedPaths = listOf("v3", "register", "login", "activate")
     defaultRequest {
         url(backendConfig.api)
         contentType(ContentType.Application.Json)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestDataImporter.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestDataImporter.kt
@@ -173,7 +173,7 @@ private suspend fun HttpClient.createTeam(backendConfig: BackendConfig): Team {
 private suspend fun setUserHandle(backendConfig: BackendConfig, userData: UserData) {
     lateinit var token: BearerTokens
     val httpClient = httpClient(backendConfig) { token }
-    val secondFactor = httpClient.request2FA(userData.email, userData.userId)
+    val secondFactor = if (backendConfig.secondFactorAuth) httpClient.request2FA(userData.email, userData.userId) else null
     httpClient.login(userData.email, userData.password, secondFactor) { accessToken ->
         token = BearerTokens(accessToken, "")
     }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/UserData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/UserData.kt
@@ -23,7 +23,11 @@ import io.ktor.client.plugins.ClientRequestException
 import io.ktor.http.HttpStatusCode
 
 data class UserData(
-    val email: String, val password: String, val userId: UserId, val team: Team, var oldCode: String?
+    val email: String,
+    val password: String,
+    val userId: UserId,
+    val team: Team,
+    var oldCode: String?
 ) {
     fun backendConfig() = BackendConfig(
         this.team.backend.api,

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/MonkeyServer.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/MonkeyServer.kt
@@ -49,6 +49,7 @@ class MonkeyServer : CliktCommand() {
     private val port by option("-p", "--port", help = "Port to bind the http server").int().default(DEFAULT_PORT)
     private val logLevel by option("-l", "--log-level", help = "log level").enum<KaliumLogLevel>().default(KaliumLogLevel.INFO)
     private val logOutputFile by option("-o", "--log-file", help = "output file for logs")
+    private val oldCode by option("-c", "--code", help = "Current 2FA code to use until a new one can be generated")
     private val fileLogger: LogWriter by lazy { fileLogger(logOutputFile ?: "kalium.log") }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -72,11 +73,11 @@ class MonkeyServer : CliktCommand() {
         } else {
             CoreLogger.init(KaliumLogger.Config(logLevel))
         }
-        backendConfig?.let { initMonkey(it) }
+        backendConfig?.let { initMonkey(it, oldCode) }
         embeddedServer(Netty, port = port, host = "0.0.0.0", module = {
             configureMonitoring()
             configureAdministration()
-            configureRoutes(coreLogic)
+            configureRoutes(coreLogic, oldCode)
         }).start(wait = true)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This adds support to 2FA in the login of the monkeys. A new flag was added in the backend configuration to indicate the need for it during authentication.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
