### PR TITLE
fix:  legal hold capability not being updated

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -335,7 +335,6 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.network.ApiMigrationManager

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -335,6 +335,7 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.map
+import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.network.ApiMigrationManager
@@ -1448,6 +1449,7 @@ class UserSessionScope internal constructor(
             clientRemoteRepository = clientRemoteRepository,
             userConfigRepository = userConfigRepository,
             selfClientIdProvider = clientIdProvider,
+            incrementalSyncRepository = incrementalSyncRepository
         )
 
     private val legalHoldHandler = LegalHoldHandlerImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/UpdateSelfClientCapabilityToLegalHoldConsentUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/UpdateSelfClientCapabilityToLegalHoldConsentUseCaseTest.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.logic.data.client.UpdateClientCapabilitiesParam
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
 import io.mockative.any
@@ -32,15 +34,30 @@ import io.mockative.given
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
 class UpdateSelfClientCapabilityToLegalHoldConsentUseCaseTest {
 
     @Test
+    fun givenAppSyncing_whenInvokingUseCase_thenDoNotUpdateCapabilities() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSyncOngoing()
+            .arrange()
+
+        useCase.invoke()
+
+        verify(arrangement.userConfigRepository)
+            .suspendFunction(arrangement.userConfigRepository::shouldUpdateClientLegalHoldCapability)
+            .wasNotInvoked()
+    }
+
+    @Test
     fun givenUserConfigRepositoryReturnsFalse_whenInvoking_thenTheClientCapabilitiesShouldNotBeUpdated() =
         runTest {
             val (arrangement, useCase) = Arrangement()
+                .withSyncDone()
                 .withShouldUpdateClientLegalHoldCapabilityResult(false)
                 .arrange()
 
@@ -59,6 +76,7 @@ class UpdateSelfClientCapabilityToLegalHoldConsentUseCaseTest {
         runTest {
             // given
             val (arrangement, useCase) = Arrangement()
+                .withSyncDone()
                 .withShouldUpdateClientLegalHoldCapabilityResult(true)
                 .withClientId()
                 .withUpdateClientCapabilitiesSuccess()
@@ -94,16 +112,33 @@ class UpdateSelfClientCapabilityToLegalHoldConsentUseCaseTest {
         @Mock
         val selfClientIdProvider: CurrentClientIdProvider = mock(CurrentClientIdProvider::class)
 
+        @Mock
+        val incrementalSyncRepository: IncrementalSyncRepository = mock(IncrementalSyncRepository::class)
+
         val useCase: UpdateSelfClientCapabilityToLegalHoldConsentUseCase by lazy {
             UpdateSelfClientCapabilityToLegalHoldConsentUseCaseImpl(
                 clientRemoteRepository = clientRemoteRepository,
                 userConfigRepository = userConfigRepository,
-                selfClientIdProvider = selfClientIdProvider
+                selfClientIdProvider = selfClientIdProvider,
+                incrementalSyncRepository = incrementalSyncRepository
             )
         }
 
         fun arrange() = this to useCase
 
+        fun withSyncOngoing() = apply {
+            given(incrementalSyncRepository)
+                .getter(incrementalSyncRepository::incrementalSyncState)
+                .whenInvoked()
+                .thenReturn(flowOf(IncrementalSyncStatus.FetchingPendingEvents))
+        }
+
+        fun withSyncDone() = apply {
+            given(incrementalSyncRepository)
+                .getter(incrementalSyncRepository::incrementalSyncState)
+                .whenInvoked()
+                .thenReturn(flowOf(IncrementalSyncStatus.Live))
+        }
         fun withShouldUpdateClientLegalHoldCapabilityResult(result: Boolean) = apply {
             given(userConfigRepository)
                 .suspendFunction(userConfigRepository::shouldUpdateClientLegalHoldCapability)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Legal hold consent capability is not updated on app launch.

### Causes (Optional)

`selfClientIdProvider()` in `UpdateSelfClientCapabilityToLegalHoldConsentUseCase` is returning a null value which prevent capability update.

### Solutions

Wait until sync is done and then update the Legal hold consent capability if needed.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
