### PR TITLE
feat: e2ei: Respect E2EI creating mls client fixed certificate status

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetUserE2eiAllCertificateStatusesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetUserE2eiAllCertificateStatusesUseCaseTest.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.cryptography.CryptoCertificateStatus
 import com.wire.kalium.cryptography.CryptoQualifiedClientId
 import com.wire.kalium.cryptography.WireIdentity
 import com.wire.kalium.logic.MLSFailure
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.toCrypto
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.e2ei.usecase.GetUserE2eiCertificatesUseCaseImpl
@@ -71,10 +72,9 @@ class GetUserE2eiAllCertificateStatusesUseCaseTest {
 
         val result = getUserE2eiAllCertificateStatuses(USER_ID)
 
-        assertEquals(3, result.size)
-        assertEquals(CertificateStatus.VALID, result[identity1.clientId.value]?.status)
-        assertEquals(CertificateStatus.EXPIRED, result[identity2.clientId.value]?.status)
-        assertEquals(CertificateStatus.REVOKED, result[identity3.clientId.value]?.status)
+        assertEquals(CertificateStatus.VALID, result[ClientId(identity1.clientId.value)]?.status)
+        assertEquals(CertificateStatus.EXPIRED, result[ClientId(identity2.clientId.value)]?.status)
+        assertEquals(CertificateStatus.REVOKED, result[ClientId(identity3.clientId.value)]?.status)
     }
 
     private class Arrangement(private val block: Arrangement.() -> Unit) :


### PR DESCRIPTION
Just a cherry-pick of [closed PR ](https://github.com/wireapp/kalium/pull/2386) . 
Some problems occurred there as original target branch was merged into RC and that one wasn't updated there are a lot of changes and conflics, so it's easier to remove that branch and cherry-pick a new one with only changes that are actually related to the commit message.

# What's new in this PR?

### Issues

Even when the device (client) has E2EI certificates it's displayed as not valid

### Causes (Optional)

`WireIdentity.clientId` that CoreCrypto returns for each Client is not a usual `ClientId` but combination of `ClientId` and `UserId`, so when app was checking if client has a certificate -> there is no certificate for such clientId.

### Solutions

Fix the `GetUserE2eiCertificatesUseCase` to return not just a Map, but a result that allow to get if client has a certificate by our regular `ClientId`.
