### PR TITLE
refactor: decouple event content and origin (WPB-6435)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/CommitBundleEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/CommitBundleEventReceiver.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.MLSFailure
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.EventReceiver
@@ -33,7 +34,7 @@ internal class CommitBundleEventReceiverImpl(
     private val memberJoinEventHandler: MemberJoinEventHandler,
     private val memberLeaveEventHandler: MemberLeaveEventHandler
 ) : CommitBundleEventReceiver {
-    override suspend fun onEvent(event: Event.Conversation): Either<CoreFailure, Unit> {
+    override suspend fun onEvent(event: Event.Conversation, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> {
         return when (event) {
             is Event.Conversation.MemberJoin -> memberJoinEventHandler.handle(event)
             is Event.Conversation.MemberLeave -> memberLeaveEventHandler.handle(event)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -289,8 +289,6 @@ internal class ConversationGroupRepositoryImpl(
                                     eventMapper.conversationMemberJoin(
                                         LocalId.generate(),
                                         response.event,
-                                        true,
-                                        false
                                     )
                                 )
                             }
@@ -329,7 +327,7 @@ internal class ConversationGroupRepositoryImpl(
         conversationId: ConversationId
     ) = if (apiResult.value is ConversationMemberAddedResponse.Changed) {
         memberJoinEventHandler.handle(
-            eventMapper.conversationMemberJoin(LocalId.generate(), apiResult.value.event, true, false)
+            eventMapper.conversationMemberJoin(LocalId.generate(), apiResult.value.event)
         ).flatMap {
             if (failedUsersList.isNotEmpty()) {
                 newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(conversationId, failedUsersList)
@@ -404,7 +402,7 @@ internal class ConversationGroupRepositoryImpl(
         if (response is ConversationMemberAddedResponse.Changed) {
             val conversationId = response.event.qualifiedConversation.toModel()
 
-            memberJoinEventHandler.handle(eventMapper.conversationMemberJoin(LocalId.generate(), response.event, true, false))
+            memberJoinEventHandler.handle(eventMapper.conversationMemberJoin(LocalId.generate(), response.event))
                 .flatMap {
                     wrapStorageRequest { conversationDAO.getConversationProtocolInfo(conversationId.toDao()) }
                         .flatMap { protocol ->
@@ -452,8 +450,6 @@ internal class ConversationGroupRepositoryImpl(
                     eventMapper.conversationMemberLeave(
                         LocalId.generate(),
                         response.event,
-                        false,
-                        false
                     )
                 )
             }
@@ -492,8 +488,6 @@ internal class ConversationGroupRepositoryImpl(
                     eventMapper.conversationMessageTimerUpdate(
                         LocalId.generate(),
                         it,
-                        true,
-                        false
                     )
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.Event.Conversation.MLSWelcome
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
@@ -58,6 +59,7 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -377,9 +379,9 @@ internal class MLSConversationDataSource(
 
     private suspend fun processCommitBundleEvents(events: List<EventContentDTO>) {
         events.forEach { eventContentDTO ->
-            val event = MapperProvider.eventMapper(selfUserId).fromEventContentDTO(LocalId.generate(), eventContentDTO, true, false)
+            val event = MapperProvider.eventMapper(selfUserId).fromEventContentDTO(LocalId.generate(), eventContentDTO)
             if (event is Event.Conversation) {
-                commitBundleEventReceiver.onEvent(event)
+                commitBundleEventReceiver.onEvent(event, EventDeliveryInfo(isTransient = true, source = EventSource.LIVE))
             }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -45,12 +45,42 @@ import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.logStructuredJson
+import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.serialization.json.JsonNull
 
-sealed class Event(open val id: String, open val transient: Boolean, open val live: Boolean) {
+/**
+ * A wrapper that joins [Event] with its [EventDeliveryInfo].
+ */
+data class EventEnvelope(
+    val event: Event,
+    val deliveryInfo: EventDeliveryInfo,
+)
+
+/**
+ * Data class representing information about the delivery of an event.
+ *
+ * @property isTransient Specifies whether the event is transient.
+ * Transient events are events that only matter if the user is online/active. For example "user is typing",
+ * and call signaling (mute/unmute), which are irrelevant after a few minutes. These are likely to not even
+ * be stored in the backend.
+ * @property source The source of the event.
+ * @see EventSource
+ */
+data class EventDeliveryInfo(
+    val isTransient: Boolean,
+    val source: EventSource,
+)
+
+/**
+ * Represents an event.
+ *
+ * @property id The ID of the event. As of Jan 2024, the ID used by the backend is
+ * _not_ guaranteed to be unique, so comparing the full object might be necessary.
+ */
+sealed class Event(open val id: String) {
 
     private companion object {
         const val typeKey = "type"
@@ -74,18 +104,14 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
     sealed class Conversation(
         id: String,
-        override val transient: Boolean,
-        override val live: Boolean,
         open val conversationId: ConversationId
-    ) : Event(id, transient, live) {
+    ) : Event(id) {
         data class AccessUpdate(
             override val id: String,
             override val conversationId: ConversationId,
             val data: ConversationResponse,
             val qualifiedFrom: UserId,
-            override val transient: Boolean,
-            override val live: Boolean
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.AccessUpdate",
@@ -98,14 +124,12 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class NewMessage(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val senderUserId: UserId,
             val senderClientId: ClientId,
             val timestampIso: String,
             val content: String,
             val encryptedExternalContent: EncryptedData?
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.NewMessage",
@@ -120,13 +144,11 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class NewMLSMessage(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val subconversationId: SubconversationId?,
             val senderUserId: UserId,
             val timestampIso: String,
             val content: String
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.NewMLSMessage",
@@ -140,12 +162,10 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class NewConversation(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val senderUserId: UserId,
             val timestampIso: String,
             val conversation: ConversationResponse
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.NewConversation",
@@ -158,12 +178,10 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class MemberJoin(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val addedBy: UserId,
             val members: List<Member>,
             val timestampIso: String
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.MemberJoin",
@@ -178,13 +196,11 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class MemberLeave(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val removedBy: UserId,
             val removedList: List<UserId>,
             val timestampIso: String,
             val reason: MemberLeaveReason
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.MemberLeave",
@@ -199,17 +215,13 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
             override val id: String,
             override val conversationId: ConversationId,
             open val timestampIso: String,
-            override val transient: Boolean,
-            override val live: Boolean,
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
             class MemberChangedRole(
                 override val id: String,
                 override val conversationId: ConversationId,
                 override val timestampIso: String,
-                override val transient: Boolean,
-                override val live: Boolean,
                 val member: Member?,
-            ) : MemberChanged(id, conversationId, timestampIso, transient, live) {
+            ) : MemberChanged(id, conversationId, timestampIso) {
 
                 override fun toLogMap(): Map<String, Any?> = mapOf(
                     typeKey to "Conversation.MemberChangedRole",
@@ -224,11 +236,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
                 override val id: String,
                 override val conversationId: ConversationId,
                 override val timestampIso: String,
-                override val transient: Boolean,
-                override val live: Boolean,
                 val mutedConversationStatus: MutedConversationStatus,
                 val mutedConversationChangedTime: String
-            ) : MemberChanged(id, conversationId, timestampIso, transient, live) {
+            ) : MemberChanged(id, conversationId, timestampIso) {
 
                 override fun toLogMap(): Map<String, Any?> = mapOf(
                     typeKey to "Conversation.MemberMutedStatusChanged",
@@ -244,11 +254,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
                 override val id: String,
                 override val conversationId: ConversationId,
                 override val timestampIso: String,
-                override val transient: Boolean,
-                override val live: Boolean,
                 val archivedConversationChangedTime: String,
                 val isArchiving: Boolean
-            ) : MemberChanged(id, conversationId, timestampIso, transient, live) {
+            ) : MemberChanged(id, conversationId, timestampIso) {
 
                 override fun toLogMap(): Map<String, Any?> = mapOf(
                     typeKey to "Conversation.MemberArchivedStatusChanged",
@@ -263,9 +271,7 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
             data class IgnoredMemberChanged(
                 override val id: String,
                 override val conversationId: ConversationId,
-                override val transient: Boolean,
-                override val live: Boolean,
-            ) : MemberChanged(id, conversationId, "", transient, live) {
+            ) : MemberChanged(id, conversationId, "") {
 
                 override fun toLogMap(): Map<String, Any?> = mapOf(
                     typeKey to "Conversation.IgnoredMemberChanged",
@@ -278,12 +284,10 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class MLSWelcome(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val senderUserId: UserId,
             val message: String,
             val timestampIso: String = DateTimeUtil.currentIsoDateTimeString()
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.MLSWelcome",
                 idKey to id.obfuscateId(),
@@ -296,11 +300,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class DeletedConversation(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val senderUserId: UserId,
             val timestampIso: String,
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.DeletedConversation",
@@ -314,12 +316,10 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class RenamedConversation(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val conversationName: String,
             val senderUserId: UserId,
             val timestampIso: String,
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.RenamedConversation",
                 idKey to id.obfuscateId(),
@@ -333,11 +333,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class ConversationReceiptMode(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val receiptMode: ReceiptMode,
             val senderUserId: UserId
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap() = mapOf(
                 typeKey to "Conversation.ConversationReceiptMode",
@@ -351,12 +349,10 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class ConversationMessageTimer(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val messageTimer: Long?,
             val senderUserId: UserId,
             val timestampIso: String
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
 
             override fun toLogMap() = mapOf(
                 typeKey to "Conversation.ConversationMessageTimer",
@@ -371,34 +367,28 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class CodeUpdated(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val key: String,
             val code: String,
             val uri: String,
             val isPasswordProtected: Boolean,
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(typeKey to "Conversation.CodeUpdated")
         }
 
         data class CodeDeleted(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(typeKey to "Conversation.CodeDeleted")
         }
 
         data class TypingIndicator(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val senderUserId: UserId,
             val timestampIso: String,
             val typingIndicatorMode: TypingIndicatorMode,
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.TypingIndicator",
                 conversationIdKey to conversationId.toLogString(),
@@ -411,11 +401,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         data class ConversationProtocol(
             override val id: String,
             override val conversationId: ConversationId,
-            override val transient: Boolean,
-            override val live: Boolean,
             val protocol: Protocol,
             val senderUserId: UserId
-        ) : Conversation(id, transient, live, conversationId) {
+        ) : Conversation(id, conversationId) {
             override fun toLogMap() = mapOf(
                 typeKey to "Conversation.ConversationProtocol",
                 idKey to id.obfuscateId(),
@@ -429,18 +417,14 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
     sealed class Team(
         id: String,
         open val teamId: String,
-        transient: Boolean,
-        live: Boolean,
-    ) : Event(id, transient, live) {
+    ) : Event(id) {
 
         data class MemberLeave(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             override val teamId: String,
             val memberId: String,
             val timestampIso: String,
-        ) : Team(id, teamId, transient, live) {
+        ) : Team(id, teamId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Team.MemberLeave",
                 idKey to id.obfuscateId(),
@@ -453,15 +437,11 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
     sealed class FeatureConfig(
         id: String,
-        transient: Boolean,
-        live: Boolean,
-    ) : Event(id, transient, live) {
+    ) : Event(id) {
         data class FileSharingUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: ConfigsStatusModel
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.FileSharingUpdated",
                 idKey to id.obfuscateId(),
@@ -471,10 +451,8 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class MLSUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: MLSModel
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.MLSUpdated",
                 idKey to id.obfuscateId(),
@@ -485,10 +463,8 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class MLSMigrationUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: MLSMigrationModel
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.MLSUpdated",
                 idKey to id.obfuscateId(),
@@ -500,10 +476,8 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class ClassifiedDomainsUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: ClassifiedDomainsModel,
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.ClassifiedDomainsUpdated",
                 idKey to id.obfuscateId(),
@@ -514,10 +488,8 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class ConferenceCallingUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: ConferenceCallingModel,
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap() = mapOf(
                 typeKey to "FeatureConfig.ConferenceCallingUpdated",
                 idKey to id.obfuscateId(),
@@ -527,10 +499,8 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class GuestRoomLinkUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: ConfigsStatusModel,
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.GuestRoomLinkUpdated",
                 idKey to id.obfuscateId(),
@@ -540,10 +510,8 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class SelfDeletingMessagesConfig(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: SelfDeletingMessagesModel,
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.SelfDeletingMessagesConfig",
                 idKey to id.obfuscateId(),
@@ -554,10 +522,8 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class MLSE2EIUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: E2EIModel
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.MLSE2EIUpdated",
                 idKey to id.obfuscateId(),
@@ -568,10 +534,8 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class AppLockUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val model: AppLockModel
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.AppLockUpdated",
                 idKey to id.obfuscateId(),
@@ -582,9 +546,7 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
         data class UnknownFeatureUpdated(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
-        ) : FeatureConfig(id, transient, live) {
+        ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.UnknownFeatureUpdated",
                 idKey to id.obfuscateId(),
@@ -594,14 +556,10 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
     sealed class User(
         id: String,
-        transient: Boolean,
-        live: Boolean,
-    ) : Event(id, transient, live) {
+    ) : Event(id) {
 
         data class Update(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val userId: UserId,
             val accentId: Int?,
             val ssoIdDeleted: Boolean?,
@@ -611,7 +569,7 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
             val previewAssetId: String?,
             val completeAssetId: String?,
             val supportedProtocols: Set<SupportedProtocol>?
-        ) : User(id, transient, live) {
+        ) : User(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.Update",
                 idKey to id.obfuscateId(),
@@ -620,11 +578,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         }
 
         data class NewConnection(
-            override val transient: Boolean,
-            override val live: Boolean,
             override val id: String,
             val connection: Connection
-        ) : User(id, transient, live) {
+        ) : User(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.NewConnection",
                 idKey to id.obfuscateId(),
@@ -633,11 +589,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         }
 
         data class ClientRemove(
-            override val transient: Boolean,
-            override val live: Boolean,
             override val id: String,
             val clientId: ClientId
-        ) : User(id, transient, live) {
+        ) : User(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.ClientRemove",
                 idKey to id.obfuscateId(),
@@ -646,12 +600,10 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         }
 
         data class UserDelete(
-            override val transient: Boolean,
-            override val live: Boolean,
             override val id: String,
             val userId: UserId,
             val timestampIso: String = DateTimeUtil.currentIsoDateTimeString() // TODO we are not receiving it from API
-        ) : User(id, transient, live) {
+        ) : User(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.UserDelete",
                 idKey to id.obfuscateId(),
@@ -661,11 +613,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         }
 
         data class NewClient(
-            override val transient: Boolean,
-            override val live: Boolean,
             override val id: String,
             val client: Client,
-        ) : User(id, transient, live) {
+        ) : User(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.NewClient",
                 idKey to id.obfuscateId(),
@@ -680,46 +630,37 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
         }
 
         data class LegalHoldRequest(
-            override val transient: Boolean,
-            override val live: Boolean,
             override val id: String,
             val clientId: ClientId,
             val lastPreKey: LastPreKey,
             val userId: UserId
-        ) : User(id, transient, live) {
+        ) : User(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.LegalHold-request",
                 idKey to id.obfuscateId(),
-                "transient" to "$transient",
                 "clientId" to clientId.value.obfuscateId(),
                 "userId" to userId.toLogString(),
             )
         }
 
         data class LegalHoldEnabled(
-            override val transient: Boolean,
-            override val live: Boolean,
             override val id: String,
             val userId: UserId
-        ) : User(id, transient, live) {
+        ) : User(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.LegalHold-enabled",
                 idKey to id.obfuscateId(),
-                "transient" to "$transient",
                 "userId" to userId.toLogString()
             )
         }
 
         data class LegalHoldDisabled(
-            override val transient: Boolean,
-            override val live: Boolean,
             override val id: String,
             val userId: UserId
-        ) : User(id, transient, live) {
+        ) : User(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.LegalHold-disabled",
                 idKey to id.obfuscateId(),
-                "transient" to "$transient",
                 "userId" to userId.toLogString()
             )
         }
@@ -727,34 +668,26 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
     sealed class UserProperty(
         id: String,
-        transient: Boolean,
-        live: Boolean,
-    ) : Event(id, transient, live) {
+    ) : Event(id) {
 
         data class ReadReceiptModeSet(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val value: Boolean,
-        ) : UserProperty(id, transient, live) {
+        ) : UserProperty(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.UserProperty.ReadReceiptModeSet",
                 idKey to id.obfuscateId(),
-                "transient" to "$transient",
                 "value" to "$value"
             )
         }
 
         data class TypingIndicatorModeSet(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val value: Boolean,
-        ) : UserProperty(id, transient, live) {
+        ) : UserProperty(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "User.UserProperty.TypingIndicatorModeSet",
                 idKey to id.obfuscateId(),
-                "transient" to "$transient",
                 "value" to "$value"
             )
         }
@@ -762,11 +695,9 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
     data class Unknown(
         override val id: String,
-        override val transient: Boolean,
-        override val live: Boolean,
         val unknownType: String,
         val cause: String? = null
-    ) : Event(id, transient, live) {
+    ) : Event(id) {
         override fun toLogMap(): Map<String, Any?> = mapOf(
             typeKey to "User.UnknownEvent",
             idKey to id.obfuscateId(),
@@ -777,34 +708,26 @@ sealed class Event(open val id: String, open val transient: Boolean, open val li
 
     sealed class Federation(
         id: String,
-        override val transient: Boolean,
-        override val live: Boolean,
-    ) : Event(id, transient, live) {
+    ) : Event(id) {
 
         data class Delete(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val domain: String,
-        ) : Federation(id, transient, live) {
+        ) : Federation(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Federation.Delete",
                 idKey to id.obfuscateId(),
-                "transient" to "$transient",
                 "domain" to domain
             )
         }
 
         data class ConnectionRemoved(
             override val id: String,
-            override val transient: Boolean,
-            override val live: Boolean,
             val domains: List<String>,
-        ) : Federation(id, transient, live) {
+        ) : Federation(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Federation.ConnectionRemoved",
                 idKey to id.obfuscateId(),
-                "transient" to "$transient",
                 "domains" to domains
             )
         }
@@ -845,12 +768,6 @@ internal fun KaliumLogger.logEventProcessing(
             val finalMap = logMap.toMutableMap()
             finalMap["outcome"] = "skipped"
             logStructuredJson(KaliumLogLevel.WARN, "Skipped handling event", finalMap)
-        }
-
-        else -> {
-            val finalMap = logMap.toMutableMap()
-            finalMap["outcome"] = "unknown"
-            logStructuredJson(KaliumLogLevel.WARN, "Unknown outcome of event handling", finalMap)
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -57,7 +57,18 @@ import kotlinx.serialization.json.JsonNull
 data class EventEnvelope(
     val event: Event,
     val deliveryInfo: EventDeliveryInfo,
-)
+) {
+    override fun toString(): String {
+        return super.toString()
+    }
+
+    fun toLogString(): String = toLogMap().toJsonElement().toString()
+
+    fun toLogMap(): Map<String, Any?> = mapOf(
+        "event" to event.toLogMap(),
+        "deliveryInfo" to deliveryInfo.toLogMap()
+    )
+}
 
 /**
  * Data class representing information about the delivery of an event.
@@ -72,7 +83,12 @@ data class EventEnvelope(
 data class EventDeliveryInfo(
     val isTransient: Boolean,
     val source: EventSource,
-)
+) {
+    fun toLogMap(): Map<String, Any?> = mapOf(
+        "isTransient" to isTransient,
+        "source" to source.name
+    )
+}
 
 /**
  * Represents an event.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -32,13 +32,13 @@ import com.wire.kalium.logic.data.event.Event.UserProperty.ReadReceiptModeSet
 import com.wire.kalium.logic.data.event.Event.UserProperty.TypingIndicatorModeSet
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
-import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.legalhold.LastPreKey
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.toModel
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.logic.util.Base64
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
@@ -64,80 +64,73 @@ class EventMapper(
     private val selfUserId: UserId,
     private val receiptModeMapper: ReceiptModeMapper = MapperProvider.receiptModeMapper(),
     private val clientMapper: ClientMapper = MapperProvider.clientMapper(),
-    private val qualifiedIdMapper: QualifiedIdMapper = QualifiedIdMapperImpl(selfUserId)
+    private val qualifiedIdMapper: QualifiedIdMapper = MapperProvider.qualifiedIdMapper(selfUserId)
 ) {
-    fun fromDTO(eventResponse: EventResponse, live: Boolean = false): List<Event> {
+    fun fromDTO(eventResponse: EventResponse, isLive: Boolean): List<EventEnvelope> {
         // TODO(edge-case): Multiple payloads in the same event have the same ID, is this an issue when marking lastProcessedEventId?
         val id = eventResponse.id
+        val source = if(isLive) EventSource.LIVE else EventSource.PENDING
         return eventResponse.payload?.map { eventContentDTO ->
-            fromEventContentDTO(id, eventContentDTO, eventResponse.transient, live)
+            EventEnvelope(fromEventContentDTO(id, eventContentDTO), EventDeliveryInfo(eventResponse.transient, source))
         } ?: listOf()
     }
 
     @Suppress("ComplexMethod")
-    fun fromEventContentDTO(id: String, eventContentDTO: EventContentDTO, transient: Boolean, live: Boolean): Event =
+    fun fromEventContentDTO(id: String, eventContentDTO: EventContentDTO): Event =
         when (eventContentDTO) {
-            is EventContentDTO.Conversation.NewMessageDTO -> newMessage(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.NewConversationDTO -> newConversation(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.MemberJoinDTO -> conversationMemberJoin(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.MemberLeaveDTO -> conversationMemberLeave(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.MemberUpdateDTO -> memberUpdate(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.MLSWelcomeDTO -> welcomeMessage(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.NewMLSMessageDTO -> newMLSMessage(id, eventContentDTO, transient, live)
-            is EventContentDTO.User.NewConnectionDTO -> connectionUpdate(id, eventContentDTO, transient, live)
-            is EventContentDTO.User.ClientRemoveDTO -> clientRemove(id, eventContentDTO, transient, live)
-            is EventContentDTO.User.UserDeleteDTO -> userDelete(id, eventContentDTO, transient, live)
-            is EventContentDTO.User.NewClientDTO -> newClient(id, eventContentDTO, transient, live)
-            is EventContentDTO.User.NewLegalHoldRequestDTO -> legalHoldRequest(id, transient, live, eventContentDTO)
-            is EventContentDTO.User.LegalHoldEnabledDTO -> legalHoldEnabled(id, transient, live, eventContentDTO)
-            is EventContentDTO.User.LegalHoldDisabledDTO -> legalHoldDisabled(id, transient, live, eventContentDTO)
-            is EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO -> featureConfig(id, eventContentDTO, transient, live)
-            is EventContentDTO.Unknown -> unknown(id, transient, live, eventContentDTO)
-            is EventContentDTO.Conversation.AccessUpdate -> unknown(id, transient, live, eventContentDTO)
-            is EventContentDTO.Conversation.DeletedConversationDTO -> conversationDeleted(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.ConversationRenameDTO -> conversationRenamed(id, eventContentDTO, transient, live)
-            is EventContentDTO.Team.MemberLeave -> teamMemberLeft(id, eventContentDTO, transient, live)
-            is EventContentDTO.User.UpdateDTO -> userUpdate(id, eventContentDTO, transient, live)
-            is EventContentDTO.UserProperty.PropertiesSetDTO -> updateUserProperties(id, eventContentDTO, transient, live)
-            is EventContentDTO.UserProperty.PropertiesDeleteDTO -> deleteUserProperties(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.ReceiptModeUpdate -> conversationReceiptModeUpdate(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.MessageTimerUpdate -> conversationMessageTimerUpdate(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.CodeDeleted -> conversationCodeDeleted(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.CodeUpdated -> conversationCodeUpdated(id, eventContentDTO, transient, live)
-            is EventContentDTO.Federation -> federationTerminated(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.ConversationTypingDTO -> conversationTyping(id, eventContentDTO, transient, live)
-            is EventContentDTO.Conversation.ProtocolUpdate -> conversationProtocolUpdate(id, eventContentDTO, transient, live)
+            is EventContentDTO.Conversation.NewMessageDTO -> newMessage(id, eventContentDTO)
+            is EventContentDTO.Conversation.NewConversationDTO -> newConversation(id, eventContentDTO)
+            is EventContentDTO.Conversation.MemberJoinDTO -> conversationMemberJoin(id, eventContentDTO)
+            is EventContentDTO.Conversation.MemberLeaveDTO -> conversationMemberLeave(id, eventContentDTO)
+            is EventContentDTO.Conversation.MemberUpdateDTO -> memberUpdate(id, eventContentDTO)
+            is EventContentDTO.Conversation.MLSWelcomeDTO -> welcomeMessage(id, eventContentDTO)
+            is EventContentDTO.Conversation.NewMLSMessageDTO -> newMLSMessage(id, eventContentDTO)
+            is EventContentDTO.User.NewConnectionDTO -> connectionUpdate(id, eventContentDTO)
+            is EventContentDTO.User.ClientRemoveDTO -> clientRemove(id, eventContentDTO)
+            is EventContentDTO.User.UserDeleteDTO -> userDelete(id, eventContentDTO)
+            is EventContentDTO.User.NewClientDTO -> newClient(id, eventContentDTO)
+            is EventContentDTO.User.NewLegalHoldRequestDTO -> legalHoldRequest(id, eventContentDTO)
+            is EventContentDTO.User.LegalHoldEnabledDTO -> legalHoldEnabled(id, eventContentDTO)
+            is EventContentDTO.User.LegalHoldDisabledDTO -> legalHoldDisabled(id, eventContentDTO)
+            is EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO -> featureConfig(id, eventContentDTO)
+            is EventContentDTO.Unknown -> unknown(id, eventContentDTO)
+            is EventContentDTO.Conversation.AccessUpdate -> unknown(id, eventContentDTO)
+            is EventContentDTO.Conversation.DeletedConversationDTO -> conversationDeleted(id, eventContentDTO)
+            is EventContentDTO.Conversation.ConversationRenameDTO -> conversationRenamed(id, eventContentDTO)
+            is EventContentDTO.Team.MemberLeave -> teamMemberLeft(id, eventContentDTO)
+            is EventContentDTO.User.UpdateDTO -> userUpdate(id, eventContentDTO)
+            is EventContentDTO.UserProperty.PropertiesSetDTO -> updateUserProperties(id, eventContentDTO)
+            is EventContentDTO.UserProperty.PropertiesDeleteDTO -> deleteUserProperties(id, eventContentDTO)
+            is EventContentDTO.Conversation.ReceiptModeUpdate -> conversationReceiptModeUpdate(id, eventContentDTO)
+            is EventContentDTO.Conversation.MessageTimerUpdate -> conversationMessageTimerUpdate(id, eventContentDTO)
+            is EventContentDTO.Conversation.CodeDeleted -> conversationCodeDeleted(id, eventContentDTO)
+            is EventContentDTO.Conversation.CodeUpdated -> conversationCodeUpdated(id, eventContentDTO)
+            is EventContentDTO.Federation -> federationTerminated(id, eventContentDTO)
+            is EventContentDTO.Conversation.ConversationTypingDTO -> conversationTyping(id, eventContentDTO)
+            is EventContentDTO.Conversation.ProtocolUpdate -> conversationProtocolUpdate(id, eventContentDTO)
         }
 
     private fun conversationTyping(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.ConversationTypingDTO,
-        transient: Boolean,
-        live: Boolean
     ): Event =
         Event.Conversation.TypingIndicator(
             id,
             eventContentDTO.qualifiedConversation.toModel(),
-            transient,
-            live,
             eventContentDTO.qualifiedFrom.toModel(),
             eventContentDTO.time,
             eventContentDTO.status.status.toModel()
         )
 
-    private fun federationTerminated(id: String, eventContentDTO: EventContentDTO.Federation, transient: Boolean, live: Boolean): Event =
+    private fun federationTerminated(id: String, eventContentDTO: EventContentDTO.Federation): Event =
         when (eventContentDTO) {
             is EventContentDTO.Federation.FederationConnectionRemovedDTO -> Event.Federation.ConnectionRemoved(
                 id,
-                transient,
-                live,
                 eventContentDTO.domains
             )
 
             is EventContentDTO.Federation.FederationDeleteDTO -> Event.Federation.Delete(
                 id,
-                transient,
-                live,
                 eventContentDTO.domain
             )
         }
@@ -145,20 +138,14 @@ class EventMapper(
     private fun conversationCodeDeleted(
         id: String,
         event: EventContentDTO.Conversation.CodeDeleted,
-        transient: Boolean,
-        live: Boolean
     ): Event.Conversation.CodeDeleted = Event.Conversation.CodeDeleted(
         id = id,
-        transient = transient,
-        live = live,
         conversationId = event.qualifiedConversation.toModel()
     )
 
     private fun conversationCodeUpdated(
         id: String,
         event: EventContentDTO.Conversation.CodeUpdated,
-        transient: Boolean,
-        live: Boolean
     ): Event.Conversation.CodeUpdated = Event.Conversation.CodeUpdated(
         id = id,
         key = event.data.key,
@@ -166,21 +153,15 @@ class EventMapper(
         uri = event.data.uri,
         isPasswordProtected = event.data.hasPassword,
         conversationId = event.qualifiedConversation.toModel(),
-        transient = transient,
-        live = live,
     )
 
     @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
     fun unknown(
         id: String,
-        transient: Boolean,
-        live: Boolean,
         eventContentDTO: EventContentDTO,
         cause: String? = null
     ): Event.Unknown = Event.Unknown(
         id = id,
-        transient = transient,
-        live = live,
         unknownType = when (eventContentDTO) {
             is EventContentDTO.Unknown -> eventContentDTO.type
             else -> try {
@@ -195,13 +176,9 @@ class EventMapper(
     private fun conversationProtocolUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.ProtocolUpdate,
-        transient: Boolean,
-        live: Boolean
     ): Event = Event.Conversation.ConversationProtocol(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
-        transient = transient,
-        live = live,
         protocol = eventContentDTO.data.protocol.toModel(),
         senderUserId = eventContentDTO.qualifiedFrom.toModel()
     )
@@ -209,13 +186,9 @@ class EventMapper(
     fun conversationMessageTimerUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MessageTimerUpdate,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.ConversationMessageTimer(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
-        transient = transient,
-        live = live,
         messageTimer = eventContentDTO.data.messageTimer,
         senderUserId = eventContentDTO.qualifiedFrom.toModel(),
         timestampIso = eventContentDTO.time
@@ -224,13 +197,9 @@ class EventMapper(
     private fun conversationReceiptModeUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.ReceiptModeUpdate,
-        transient: Boolean,
-        live: Boolean
     ): Event = Event.Conversation.ConversationReceiptMode(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
-        transient = transient,
-        live = live,
         receiptMode = receiptModeMapper.fromApiToModel(eventContentDTO.data.receiptMode),
         senderUserId = eventContentDTO.qualifiedFrom.toModel()
     )
@@ -238,8 +207,6 @@ class EventMapper(
     private fun updateUserProperties(
         id: String,
         eventContentDTO: EventContentDTO.UserProperty.PropertiesSetDTO,
-        transient: Boolean,
-        live: Boolean
     ): Event {
         val fieldKeyValue = eventContentDTO.value
         val key = eventContentDTO.key
@@ -248,22 +215,16 @@ class EventMapper(
                 when (key) {
                     WIRE_RECEIPT_MODE.key -> ReadReceiptModeSet(
                         id,
-                        transient,
-                        live,
                         fieldKeyValue.value == 1
                     )
 
                     WIRE_TYPING_INDICATOR_MODE.key -> TypingIndicatorModeSet(
                         id,
-                        transient,
-                        live,
                         fieldKeyValue.value != 0
                     )
 
                     else -> unknown(
                         id = id,
-                        transient = transient,
-                        live = live,
                         eventContentDTO = eventContentDTO,
                         cause = "Unknown key: $key "
                     )
@@ -272,8 +233,6 @@ class EventMapper(
 
             else -> unknown(
                 id = id,
-                transient = transient,
-                live = live,
                 eventContentDTO = eventContentDTO,
                 cause = "Unknown value type for key: ${eventContentDTO.key} "
             )
@@ -283,16 +242,12 @@ class EventMapper(
     private fun deleteUserProperties(
         id: String,
         eventContentDTO: EventContentDTO.UserProperty.PropertiesDeleteDTO,
-        transient: Boolean,
-        live: Boolean
     ): Event {
         return when (eventContentDTO.key) {
-            WIRE_RECEIPT_MODE.key -> ReadReceiptModeSet(id, transient, live, false)
-            WIRE_TYPING_INDICATOR_MODE.key -> TypingIndicatorModeSet(id, transient, live, true)
+            WIRE_RECEIPT_MODE.key -> ReadReceiptModeSet(id, false)
+            WIRE_TYPING_INDICATOR_MODE.key -> TypingIndicatorModeSet(id, true)
             else -> unknown(
                 id = id,
-                transient = transient,
-                live = live,
                 eventContentDTO = eventContentDTO,
                 cause = "Unknown key: ${eventContentDTO.key} "
             )
@@ -302,13 +257,10 @@ class EventMapper(
     private fun welcomeMessage(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MLSWelcomeDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.MLSWelcome(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
-        transient,
-        live,
+
         eventContentDTO.qualifiedFrom.toModel(),
         eventContentDTO.message,
     )
@@ -316,13 +268,9 @@ class EventMapper(
     private fun newMessage(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.NewMessageDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.NewMessage(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
-        transient,
-        live,
         eventContentDTO.qualifiedFrom.toModel(),
         ClientId(eventContentDTO.data.sender),
         eventContentDTO.time,
@@ -335,13 +283,9 @@ class EventMapper(
     private fun newMLSMessage(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.NewMLSMessageDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.NewMLSMessage(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
-        transient,
-        live,
         eventContentDTO.subconversation?.let { SubconversationId(it) },
         eventContentDTO.qualifiedFrom.toModel(),
         eventContentDTO.time,
@@ -351,24 +295,16 @@ class EventMapper(
     private fun connectionUpdate(
         id: String,
         eventConnectionDTO: EventContentDTO.User.NewConnectionDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.User.NewConnection(
-        transient,
-        live,
         id,
         connectionMapper.fromApiToModel(eventConnectionDTO.connection)
     )
 
     internal fun legalHoldRequest(
         id: String,
-        transient: Boolean,
-        live: Boolean,
         eventContentDTO: EventContentDTO.User.NewLegalHoldRequestDTO
     ): Event.User.LegalHoldRequest {
         return Event.User.LegalHoldRequest(
-            transient = transient,
-            live = live,
             id = id,
             clientId = ClientId(eventContentDTO.clientId.clientId),
             lastPreKey = LastPreKey(eventContentDTO.lastPreKey.id, eventContentDTO.lastPreKey.key),
@@ -378,13 +314,9 @@ class EventMapper(
 
     internal fun legalHoldEnabled(
         id: String,
-        transient: Boolean,
-        live: Boolean,
         eventContentDTO: EventContentDTO.User.LegalHoldEnabledDTO
     ): Event.User.LegalHoldEnabled {
         return Event.User.LegalHoldEnabled(
-            transient,
-            live,
             id,
             qualifiedIdMapper.fromStringToQualifiedID(eventContentDTO.id)
         )
@@ -392,13 +324,9 @@ class EventMapper(
 
     internal fun legalHoldDisabled(
         id: String,
-        transient: Boolean,
-        live: Boolean,
         eventContentDTO: EventContentDTO.User.LegalHoldDisabledDTO
     ): Event.User.LegalHoldDisabled {
         return Event.User.LegalHoldDisabled(
-            transient,
-            live,
             id,
             qualifiedIdMapper.fromStringToQualifiedID(eventContentDTO.id)
         )
@@ -407,30 +335,22 @@ class EventMapper(
     private fun userDelete(
         id: String,
         eventUserDelete: EventContentDTO.User.UserDeleteDTO,
-        transient: Boolean,
-        live: Boolean
     ): Event.User.UserDelete {
-        return Event.User.UserDelete(transient, live, id, eventUserDelete.userId.toModel())
+        return Event.User.UserDelete(id, eventUserDelete.userId.toModel())
     }
 
     private fun clientRemove(
         id: String,
         eventClientRemove: EventContentDTO.User.ClientRemoveDTO,
-        transient: Boolean,
-        live: Boolean
     ): Event.User.ClientRemove {
-        return Event.User.ClientRemove(transient, live, id, ClientId(eventClientRemove.client.clientId))
+        return Event.User.ClientRemove(id, ClientId(eventClientRemove.client.clientId))
     }
 
     private fun newClient(
         id: String,
         eventNewClient: EventContentDTO.User.NewClientDTO,
-        transient: Boolean,
-        live: Boolean
     ): Event.User.NewClient {
         return Event.User.NewClient(
-            transient = transient,
-            live = live,
             id = id,
             client = clientMapper.fromClientDto(eventNewClient.client)
         )
@@ -439,13 +359,9 @@ class EventMapper(
     private fun newConversation(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.NewConversationDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.NewConversation(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
-        transient,
-        live,
         eventContentDTO.qualifiedFrom.toModel(),
         eventContentDTO.time,
         eventContentDTO.data
@@ -454,39 +370,29 @@ class EventMapper(
     fun conversationMemberJoin(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MemberJoinDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.MemberJoin(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         addedBy = eventContentDTO.qualifiedFrom.toModel(),
         members = eventContentDTO.members.users.map { memberMapper.fromApiModel(it) },
         timestampIso = eventContentDTO.time,
-        transient = transient,
-        live = live,
     )
 
     fun conversationMemberLeave(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MemberLeaveDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.MemberLeave(
         id = id,
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         removedBy = eventContentDTO.qualifiedFrom.toModel(),
         removedList = eventContentDTO.removedUsers.qualifiedUserIds.map { it.toModel() },
         timestampIso = eventContentDTO.time,
-        transient = transient,
-        live = live,
         reason = eventContentDTO.removedUsers.reason.toModel()
     )
 
     private fun memberUpdate(
         id: String,
         eventContentDTO: EventContentDTO.Conversation.MemberUpdateDTO,
-        transient: Boolean,
-        live: Boolean
     ): Event.Conversation.MemberChanged {
         return when {
             eventContentDTO.roleChange.role?.isNotEmpty() == true -> {
@@ -494,8 +400,6 @@ class EventMapper(
                     id = id,
                     conversationId = eventContentDTO.qualifiedConversation.toModel(),
                     timestampIso = eventContentDTO.time,
-                    transient = transient,
-                    live = live,
                     member = Conversation.Member(
                         id = eventContentDTO.roleChange.qualifiedUserId.toModel(),
                         role = roleMapper.fromApi(eventContentDTO.roleChange.role.orEmpty())
@@ -509,8 +413,6 @@ class EventMapper(
                     conversationId = eventContentDTO.qualifiedConversation.toModel(),
                     timestampIso = eventContentDTO.time,
                     mutedConversationChangedTime = eventContentDTO.roleChange.mutedRef.orEmpty(),
-                    transient = transient,
-                    live = live,
                     mutedConversationStatus = mapConversationMutedStatus(eventContentDTO.roleChange.mutedStatus)
                 )
             }
@@ -520,8 +422,6 @@ class EventMapper(
                     id = id,
                     conversationId = eventContentDTO.qualifiedConversation.toModel(),
                     timestampIso = eventContentDTO.time,
-                    transient = transient,
-                    live = live,
                     archivedConversationChangedTime = eventContentDTO.roleChange.archivedRef.orEmpty(),
                     isArchiving = eventContentDTO.roleChange.isArchiving ?: false
                 )
@@ -531,8 +431,6 @@ class EventMapper(
                 Event.Conversation.MemberChanged.IgnoredMemberChanged(
                     id,
                     eventContentDTO.qualifiedConversation.toModel(),
-                    transient,
-                    live
                 )
             }
         }
@@ -550,69 +448,49 @@ class EventMapper(
     private fun featureConfig(
         id: String,
         featureConfigUpdatedDTO: EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO,
-        transient: Boolean,
-        live: Boolean
     ) = when (featureConfigUpdatedDTO.data) {
         is FeatureConfigData.FileSharing -> Event.FeatureConfig.FileSharingUpdated(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.FileSharing)
         )
 
         is FeatureConfigData.SelfDeletingMessages -> Event.FeatureConfig.SelfDeletingMessagesConfig(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.SelfDeletingMessages)
         )
 
         is FeatureConfigData.MLS -> Event.FeatureConfig.MLSUpdated(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.MLS)
         )
 
         is FeatureConfigData.MLSMigration -> Event.FeatureConfig.MLSMigrationUpdated(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.MLSMigration)
         )
 
         is FeatureConfigData.ClassifiedDomains -> Event.FeatureConfig.ClassifiedDomainsUpdated(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.ClassifiedDomains)
         )
 
         is FeatureConfigData.ConferenceCalling -> Event.FeatureConfig.ConferenceCallingUpdated(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.ConferenceCalling)
         )
 
         is FeatureConfigData.ConversationGuestLinks -> Event.FeatureConfig.GuestRoomLinkUpdated(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.ConversationGuestLinks)
         )
 
         is FeatureConfigData.E2EI -> Event.FeatureConfig.MLSE2EIUpdated(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.E2EI)
         )
 
         is FeatureConfigData.AppLock -> Event.FeatureConfig.AppLockUpdated(
             id,
-            transient,
-            live,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.AppLock)
         )
 
@@ -622,57 +500,43 @@ class EventMapper(
         is FeatureConfigData.SearchVisibility,
         is FeatureConfigData.SecondFactorPasswordChallenge,
         is FeatureConfigData.Unknown,
-        is FeatureConfigData.ValidateSAMLEmails -> Event.FeatureConfig.UnknownFeatureUpdated(id, transient, live)
+        is FeatureConfigData.ValidateSAMLEmails -> Event.FeatureConfig.UnknownFeatureUpdated(id)
     }
 
     private fun conversationDeleted(
         id: String,
         deletedConversationDTO: EventContentDTO.Conversation.DeletedConversationDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.DeletedConversation(
         id = id,
         conversationId = deletedConversationDTO.qualifiedConversation.toModel(),
         senderUserId = deletedConversationDTO.qualifiedFrom.toModel(),
-        transient = transient,
-        live = live,
         timestampIso = deletedConversationDTO.time
     )
 
     fun conversationRenamed(
         id: String,
         event: EventContentDTO.Conversation.ConversationRenameDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Conversation.RenamedConversation(
         id = id,
         conversationId = event.qualifiedConversation.toModel(),
         senderUserId = event.qualifiedFrom.toModel(),
         conversationName = event.updateNameData.conversationName,
-        transient = transient,
-        live = live,
         timestampIso = event.time,
     )
 
     private fun teamMemberLeft(
         id: String,
         event: EventContentDTO.Team.MemberLeave,
-        transient: Boolean,
-        live: Boolean
     ) = Event.Team.MemberLeave(
         id = id,
         teamId = event.teamId,
         memberId = event.teamMember.nonQualifiedUserId,
-        transient = transient,
-        live = live,
         timestampIso = event.time
     )
 
     private fun userUpdate(
         id: String,
         event: EventContentDTO.User.UpdateDTO,
-        transient: Boolean,
-        live: Boolean
     ) = Event.User.Update(
         id = id,
         userId = UserId(event.userData.nonQualifiedUserId, selfUserId.domain),
@@ -682,8 +546,6 @@ class EventMapper(
         handle = event.userData.handle,
         email = event.userData.email,
         previewAssetId = event.userData.assets?.getPreviewAssetOrNull()?.key,
-        transient = transient,
-        live = live,
         completeAssetId = event.userData.assets?.getCompleteAssetOrNull()?.key,
         supportedProtocols = event.userData.supportedProtocols?.toModel()
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -69,7 +69,7 @@ class EventMapper(
     fun fromDTO(eventResponse: EventResponse, isLive: Boolean): List<EventEnvelope> {
         // TODO(edge-case): Multiple payloads in the same event have the same ID, is this an issue when marking lastProcessedEventId?
         val id = eventResponse.id
-        val source = if(isLive) EventSource.LIVE else EventSource.PENDING
+        val source = if (isLive) EventSource.LIVE else EventSource.PENDING
         return eventResponse.payload?.map { eventContentDTO ->
             EventEnvelope(fromEventContentDTO(id, eventContentDTO), EventDeliveryInfo(eventResponse.transient, source))
         } ?: listOf()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -130,7 +130,9 @@ class EventDataSource(
                 hasMore = notificationsPageResult.value.hasMore
                 lastFetchedNotificationId = notificationsPageResult.value.notifications.lastOrNull()?.id
 
-                notificationsPageResult.value.notifications.flatMap{eventMapper.fromDTO(it, isLive = false)}.forEach { event ->
+                notificationsPageResult.value.notifications.flatMap {
+                    eventMapper.fromDTO(it, isLive = false)
+                }.forEach { event ->
                     if (!coroutineContext.isActive) {
                         return@flow
                     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -47,8 +47,8 @@ import kotlinx.coroutines.isActive
 import kotlin.coroutines.coroutineContext
 
 interface EventRepository {
-    suspend fun pendingEvents(): Flow<Either<CoreFailure, Event>>
-    suspend fun liveEvents(): Either<CoreFailure, Flow<WebSocketEvent<Event>>>
+    suspend fun pendingEvents(): Flow<Either<CoreFailure, EventEnvelope>>
+    suspend fun liveEvents(): Either<CoreFailure, Flow<WebSocketEvent<EventEnvelope>>>
     suspend fun updateLastProcessedEventId(eventId: String): Either<StorageFailure, Unit>
 
     /**
@@ -87,13 +87,13 @@ class EventDataSource(
 ) : EventRepository {
 
     // TODO(edge-case): handle Missing notification response (notify user that some messages are missing)
-    override suspend fun pendingEvents(): Flow<Either<CoreFailure, Event>> =
+    override suspend fun pendingEvents(): Flow<Either<CoreFailure, EventEnvelope>> =
         currentClientId().fold({ flowOf(Either.Left(it)) }, { clientId -> pendingEventsFlow(clientId) })
 
-    override suspend fun liveEvents(): Either<CoreFailure, Flow<WebSocketEvent<Event>>> =
+    override suspend fun liveEvents(): Either<CoreFailure, Flow<WebSocketEvent<EventEnvelope>>> =
         currentClientId().flatMap { clientId -> liveEventsFlow(clientId) }
 
-    private suspend fun liveEventsFlow(clientId: ClientId): Either<NetworkFailure, Flow<WebSocketEvent<Event>>> =
+    private suspend fun liveEventsFlow(clientId: ClientId): Either<NetworkFailure, Flow<WebSocketEvent<EventEnvelope>>> =
         wrapApiRequest { notificationApi.listenToLiveEvents(clientId.value) }.map {
             it.map { webSocketEvent ->
                 when (webSocketEvent) {
@@ -102,7 +102,7 @@ class EventDataSource(
                     }
 
                     is WebSocketEvent.NonBinaryPayloadReceived -> {
-                        flowOf(WebSocketEvent.NonBinaryPayloadReceived<Event>(webSocketEvent.payload))
+                        flowOf(WebSocketEvent.NonBinaryPayloadReceived<EventEnvelope>(webSocketEvent.payload))
                     }
 
                     is WebSocketEvent.Close -> {
@@ -118,7 +118,7 @@ class EventDataSource(
 
     private suspend fun pendingEventsFlow(
         clientId: ClientId
-    ) = flow<Either<CoreFailure, Event>> {
+    ) = flow<Either<CoreFailure, EventEnvelope>> {
 
         var hasMore = true
         var lastFetchedNotificationId = metadataDAO.valueByKey(LAST_PROCESSED_EVENT_ID_KEY)
@@ -130,7 +130,7 @@ class EventDataSource(
                 hasMore = notificationsPageResult.value.hasMore
                 lastFetchedNotificationId = notificationsPageResult.value.notifications.lastOrNull()?.id
 
-                notificationsPageResult.value.notifications.flatMap(eventMapper::fromDTO).forEach { event ->
+                notificationsPageResult.value.notifications.flatMap{eventMapper.fromDTO(it, isLive = false)}.forEach { event ->
                     if (!coroutineContext.isActive) {
                         return@flow
                     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -171,8 +171,6 @@ internal class TeamDataSource(
         legalHoldHandler.handleEnable(
             eventMapper.legalHoldEnabled(
                 id = LocalId.generate(),
-                transient = true,
-                live = false,
                 eventContentDTO = EventContentDTO.User.LegalHoldEnabledDTO(id = selfUserId.toString())
             )
         )
@@ -187,8 +185,6 @@ internal class TeamDataSource(
             LegalHoldStatusDTO.ENABLED -> legalHoldHandler.handleEnable(
                 eventMapper.legalHoldEnabled(
                     id = LocalId.generate(),
-                    transient = true,
-                    live = false,
                     eventContentDTO = EventContentDTO.User.LegalHoldEnabledDTO(id = selfUserId.toString())
                 )
             )
@@ -196,8 +192,6 @@ internal class TeamDataSource(
             LegalHoldStatusDTO.DISABLED -> legalHoldHandler.handleDisable(
                 eventMapper.legalHoldDisabled(
                     id = LocalId.generate(),
-                    transient = true,
-                    live = false,
                     eventContentDTO = EventContentDTO.User.LegalHoldDisabledDTO(id = selfUserId.toString())
                 )
             )
@@ -206,8 +200,6 @@ internal class TeamDataSource(
                 legalHoldRequestHandler.handle(
                     eventMapper.legalHoldRequest(
                         id = LocalId.generate(),
-                        transient = true,
-                        live = false,
                         eventContentDTO = EventContentDTO.User.NewLegalHoldRequestDTO(
                             clientId = response.clientId!!,
                             lastPreKey = response.lastPreKey!!,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCase.kt
@@ -55,7 +55,7 @@ internal class RenameConversationUseCaseImpl(
             .onSuccess { response ->
                 if (response is ConversationRenameResponse.Changed)
                     renamedConversationEventHandler.handle(
-                        eventMapper.conversationRenamed(LocalId.generate(), response.event, true, false)
+                        eventMapper.conversationRenamed(LocalId.generate(), response.event)
                     )
             }
             .fold({

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/guestroomlink/GenerateGuestRoomLinkUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/guestroomlink/GenerateGuestRoomLinkUseCase.kt
@@ -50,8 +50,6 @@ class GenerateGuestRoomLinkUseCaseImpl internal constructor(
                     code = it.data.code,
                     id = uuid4().toString(),
                     isPasswordProtected = it.data.hasPassword,
-                    transient = false,
-                    live = false,
                     key = it.data.key,
                     uri = it.data.uri
                 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -22,7 +22,7 @@ import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventEnvelope
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.sync.ConnectionPolicy
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
@@ -68,7 +68,7 @@ internal interface EventGatherer {
      *
      * Will stop or keep gathering accordingly to the current [ConnectionPolicy]
      */
-    suspend fun gatherEvents(): Flow<Event>
+    suspend fun gatherEvents(): Flow<EventEnvelope>
 
     val currentSource: StateFlow<EventSource>
 }
@@ -79,12 +79,13 @@ internal class EventGathererImpl(
 ) : EventGatherer {
 
     private val _currentSource = MutableStateFlow(EventSource.PENDING)
+    // TODO: Refactor so currentSource is emitted through the gatherEvents flow, instead of having two separated flows
     override val currentSource: StateFlow<EventSource> get() = _currentSource.asStateFlow()
 
     private val offlineEventBuffer = PendingEventsBuffer()
     private val logger = kaliumLogger.withFeatureId(SYNC)
 
-    override suspend fun gatherEvents(): Flow<Event> = flow {
+    override suspend fun gatherEvents(): Flow<EventEnvelope> = flow {
         offlineEventBuffer.clear()
         _currentSource.value = EventSource.PENDING
         eventRepository.lastProcessedEventId().flatMap {
@@ -99,8 +100,8 @@ internal class EventGathererImpl(
         _currentSource.value = EventSource.PENDING
     }
 
-    private suspend fun FlowCollector<Event>.handleWebSocketEventsWhilePolicyAllows(
-        webSocketEventFlow: Flow<WebSocketEvent<Event>>
+    private suspend fun FlowCollector<EventEnvelope>.handleWebSocketEventsWhilePolicyAllows(
+        webSocketEventFlow: Flow<WebSocketEvent<EventEnvelope>>
     ) = webSocketEventFlow.combine(incrementalSyncRepository.connectionPolicyState)
         .buffer(Channel.UNLIMITED)
         .transformWhile { (webSocketEvent, policy) ->
@@ -118,14 +119,16 @@ internal class EventGathererImpl(
         .cancellable()
         .collect { handleWebsocketEvent(it) }
 
-    private suspend fun FlowCollector<Event>.handleWebsocketEvent(webSocketEvent: WebSocketEvent<Event>) = when (webSocketEvent) {
+    private suspend fun FlowCollector<EventEnvelope>.handleWebsocketEvent(
+        webSocketEvent: WebSocketEvent<EventEnvelope>
+    ) = when (webSocketEvent) {
         is WebSocketEvent.Open -> onWebSocketOpen()
         is WebSocketEvent.BinaryPayloadReceived -> onWebSocketEventReceived(webSocketEvent)
         is WebSocketEvent.Close -> handleWebSocketClosure(webSocketEvent)
         is WebSocketEvent.NonBinaryPayloadReceived -> logger.w("Non binary event received on Websocket")
     }
 
-    private fun handleWebSocketClosure(webSocketEvent: WebSocketEvent.Close<Event>) =
+    private fun handleWebSocketClosure(webSocketEvent: WebSocketEvent.Close<EventEnvelope>) =
         when (val cause = webSocketEvent.cause) {
             null -> logger.i("Websocket closed normally")
             is IOException ->
@@ -135,38 +138,41 @@ internal class EventGathererImpl(
                 throw KaliumSyncException("Unknown Websocket error: $cause, message: ${cause.message}", CoreFailure.Unknown(cause))
         }
 
-    private suspend fun FlowCollector<Event>.onWebSocketEventReceived(webSocketEvent: WebSocketEvent.BinaryPayloadReceived<Event>) {
+    private suspend fun FlowCollector<EventEnvelope>.onWebSocketEventReceived(
+        webSocketEvent: WebSocketEvent.BinaryPayloadReceived<EventEnvelope>
+    ) {
         logger.i("Websocket Received binary payload")
-        val event = webSocketEvent.payload
-        if (offlineEventBuffer.contains(event)) {
-            if (offlineEventBuffer.clearBufferIfLastEventEquals(event)) {
+        val envelope = webSocketEvent.payload
+        val obfuscatedId = envelope.event.id.obfuscateId()
+        if (offlineEventBuffer.contains(envelope.event)) {
+            if (offlineEventBuffer.clearBufferIfLastEventEquals(envelope.event)) {
                 // Really live
-                logger.d("Removed most recent event from offlineEventBuffer: '${event.id.obfuscateId()}'")
+                logger.d("Removed most recent event from offlineEventBuffer: '$obfuscatedId'")
             } else {
                 // Really live
-                logger.d("Removing event from offlineEventBuffer: ${event.id.obfuscateId()}")
-                offlineEventBuffer.remove(event)
+                logger.d("Removing event from offlineEventBuffer: $obfuscatedId")
+                offlineEventBuffer.remove(envelope.event)
             }
             logger
-                .d("Skipping emit of event from WebSocket because already emitted as offline event ${event.id.obfuscateId()}")
+                .d("Skipping emit of event from WebSocket because already emitted as offline event $obfuscatedId")
         } else {
-            logger.d("Event never seen before ${event.id.obfuscateId()} - We are live")
-            emit(event)
+            logger.d("Event never seen before $obfuscatedId - We are live")
+            emit(envelope)
         }
     }
 
-    private suspend fun FlowCollector<Event>.onWebSocketOpen() {
+    private suspend fun FlowCollector<EventEnvelope>.onWebSocketOpen() {
         logger.i("Websocket Open")
         eventRepository
             .pendingEvents()
             .onEach { result ->
                 result.onFailure(::throwPendingEventException)
             }
-            .filterIsInstance<Either.Right<Event>>()
+            .filterIsInstance<Either.Right<EventEnvelope>>()
             .map { offlineEvent -> offlineEvent.value }
             .collect {
-                logger.i("Collecting offline event: ${it.id.obfuscateId()}")
-                offlineEventBuffer.add(it)
+                logger.i("Collecting offline event: ${it.event.id.obfuscateId()}")
+                offlineEventBuffer.add(it.event)
                 emit(it)
             }
         logger.i("Offline events collection finished. Collecting Live events.")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -56,7 +56,7 @@ internal class IncrementalSyncWorkerImpl(
         launch {
             eventGatherer.gatherEvents().cancellable().collect {
                 // TODO make sure that event process is not cancel in a midway
-                eventProcessor.processEvent(it.event, it.deliveryInfo).onFailure { failure ->
+                eventProcessor.processEvent(it).onFailure { failure ->
                     throw KaliumSyncException("Failed to process event. Aborting Sync for a retry", failure)
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -56,7 +56,7 @@ internal class IncrementalSyncWorkerImpl(
         launch {
             eventGatherer.gatherEvents().cancellable().collect {
                 // TODO make sure that event process is not cancel in a midway
-                eventProcessor.processEvent(it).onFailure { failure ->
+                eventProcessor.processEvent(it.event, it.deliveryInfo).onFailure { failure ->
                     throw KaliumSyncException("Failed to process event. Aborting Sync for a retry", failure)
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.sync.receiver
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.receiver.conversation.ConversationMessageTimerEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.DeletedConversationEventHandler
@@ -57,19 +58,19 @@ internal class ConversationEventReceiverImpl(
     private val typingIndicatorHandler: TypingIndicatorHandler,
     private val protocolUpdateEventHandler: ProtocolUpdateEventHandler
 ) : ConversationEventReceiver {
-    override suspend fun onEvent(event: Event.Conversation): Either<CoreFailure, Unit> {
+    override suspend fun onEvent(event: Event.Conversation, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> {
         // TODO: Make sure errors are accounted for by each handler.
         //       onEvent now requires Either, so we can propagate errors,
         //       but not all handlers are using it yet.
         //       Returning Either.Right is the equivalent of how it was originally working.
         return when (event) {
             is Event.Conversation.NewMessage -> {
-                newMessageHandler.handleNewProteusMessage(event)
+                newMessageHandler.handleNewProteusMessage(event, deliveryInfo)
                 Either.Right(Unit)
             }
 
             is Event.Conversation.NewMLSMessage -> {
-                newMessageHandler.handleNewMLSMessage(event)
+                newMessageHandler.handleNewMLSMessage(event, deliveryInfo)
                 Either.Right(Unit)
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/EventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/EventReceiver.kt
@@ -20,8 +20,9 @@ package com.wire.kalium.logic.sync.receiver
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.functional.Either
 
 internal fun interface EventReceiver<T : Event> {
-    suspend fun onEvent(event: T): Either<CoreFailure, Unit>
+    suspend fun onEvent(event: T, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit>
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.sync.receiver
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.feature.featureConfig.handler.AppLockConfigHandler
@@ -51,7 +52,7 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
     private val appLockConfigHandler: AppLockConfigHandler
 ) : FeatureConfigEventReceiver {
 
-    override suspend fun onEvent(event: Event.FeatureConfig): Either<CoreFailure, Unit> =
+    override suspend fun onEvent(event: Event.FeatureConfig, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> =
         handleFeatureConfigEvent(event)
             .onSuccess {
                 kaliumLogger.logEventProcessing(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiver.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.id.ConversationId
@@ -59,7 +60,7 @@ class FederationEventReceiverImpl internal constructor(
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) : FederationEventReceiver {
 
-    override suspend fun onEvent(event: Event.Federation): Either<CoreFailure, Unit> {
+    override suspend fun onEvent(event: Event.Federation, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> {
         when (event) {
             is Event.Federation.Delete -> handleDeleteEvent(event)
             is Event.Federation.ConnectionRemoved -> handleConnectionRemovedEvent(event)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.sync.receiver
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
@@ -37,7 +38,7 @@ internal class TeamEventReceiverImpl(
     private val selfUserId: UserId,
 ) : TeamEventReceiver {
 
-    override suspend fun onEvent(event: Event.Team): Either<CoreFailure, Unit> {
+    override suspend fun onEvent(event: Event.Team, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> {
         when {
             event is Event.Team.MemberLeave -> handleMemberLeave(event)
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
@@ -40,6 +41,7 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldRequestHandler
 import kotlin.time.Duration.Companion.ZERO
@@ -61,9 +63,9 @@ internal class UserEventReceiverImpl internal constructor(
     private val legalHoldHandler: LegalHoldHandler
 ) : UserEventReceiver {
 
-    override suspend fun onEvent(event: Event.User): Either<CoreFailure, Unit> {
+    override suspend fun onEvent(event: Event.User, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> {
         return when (event) {
-            is Event.User.NewConnection -> handleNewConnection(event)
+            is Event.User.NewConnection -> handleNewConnection(event, deliveryInfo)
             is Event.User.ClientRemove -> handleClientRemove(event)
             is Event.User.UserDelete -> handleUserDelete(event)
             is Event.User.Update -> handleUserUpdate(event)
@@ -101,7 +103,7 @@ internal class UserEventReceiverImpl internal constructor(
                 }
             }
 
-    private suspend fun handleNewConnection(event: Event.User.NewConnection): Either<CoreFailure, Unit> =
+    private suspend fun handleNewConnection(event: Event.User.NewConnection, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> =
         userRepository.fetchUserInfo(event.connection.qualifiedToId)
             .flatMap {
                 connectionRepository.insertConnectionFromEvent(event)
@@ -109,7 +111,7 @@ internal class UserEventReceiverImpl internal constructor(
                         if (event.connection.status == ConnectionState.ACCEPTED) {
                             oneOnOneResolver.scheduleResolveOneOnOneConversationWithUserId(
                                 event.connection.qualifiedToId,
-                                delay = if (event.live) 3.seconds else ZERO
+                                delay = if (deliveryInfo.source == EventSource.LIVE) 3.seconds else ZERO
                             )
                             newGroupConversationSystemMessagesCreator.value.conversationStartedUnverifiedWarning(
                                 event.connection.qualifiedConversationId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiver.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.sync.receiver
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.functional.Either
@@ -34,7 +35,7 @@ internal class UserPropertiesEventReceiverImpl internal constructor(
     private val userConfigRepository: UserConfigRepository
 ) : UserPropertiesEventReceiver {
 
-    override suspend fun onEvent(event: Event.UserProperty): Either<CoreFailure, Unit> {
+    override suspend fun onEvent(event: Event.UserProperty, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> {
         return when (event) {
             is Event.UserProperty.ReadReceiptModeSet -> {
                 handleReadReceiptMode(event)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.ProteusFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.id.ConversationId
@@ -33,13 +34,14 @@ import com.wire.kalium.logic.feature.message.StaleEpochVerifier
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.toInstant
 
 internal interface NewMessageEventHandler {
-    suspend fun handleNewProteusMessage(event: Event.Conversation.NewMessage)
-    suspend fun handleNewMLSMessage(event: Event.Conversation.NewMLSMessage)
+    suspend fun handleNewProteusMessage(event: Event.Conversation.NewMessage, deliveryInfo: EventDeliveryInfo)
+    suspend fun handleNewMLSMessage(event: Event.Conversation.NewMLSMessage, deliveryInfo: EventDeliveryInfo)
 }
 
 @Suppress("LongParameterList")
@@ -55,7 +57,7 @@ internal class NewMessageEventHandlerImpl(
 
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
 
-    override suspend fun handleNewProteusMessage(event: Event.Conversation.NewMessage) {
+    override suspend fun handleNewProteusMessage(event: Event.Conversation.NewMessage, deliveryInfo: EventDeliveryInfo) {
         proteusMessageUnpacker.unpackProteusMessage(event)
             .onFailure {
                 val logMap = mapOf(
@@ -87,7 +89,7 @@ internal class NewMessageEventHandlerImpl(
             }.onSuccess {
                 if (it is MessageUnpackResult.ApplicationMessage) {
                     if (it.content.legalHoldStatus != Conversation.LegalHoldStatus.UNKNOWN) {
-                        legalHoldHandler.handleNewMessage(it, event.live)
+                        legalHoldHandler.handleNewMessage(it, isLive = deliveryInfo.source == EventSource.LIVE)
                     }
                     handleSuccessfulResult(it)
                     onMessageInserted(it)
@@ -100,7 +102,7 @@ internal class NewMessageEventHandlerImpl(
             }
     }
 
-    override suspend fun handleNewMLSMessage(event: Event.Conversation.NewMLSMessage) {
+    override suspend fun handleNewMLSMessage(event: Event.Conversation.NewMLSMessage, deliveryInfo: EventDeliveryInfo) {
         mlsMessageUnpacker.unpackMlsMessage(event)
             .onFailure {
                 val logMap = mapOf(
@@ -141,7 +143,7 @@ internal class NewMessageEventHandlerImpl(
                 it.forEach {
                     if (it is MessageUnpackResult.ApplicationMessage) {
                         if (it.content.legalHoldStatus != Conversation.LegalHoldStatus.UNKNOWN) {
-                            legalHoldHandler.handleNewMessage(it, event.live)
+                            legalHoldHandler.handleNewMessage(it, isLive = deliveryInfo.source == EventSource.LIVE)
                         }
                         handleSuccessfulResult(it)
                         onMessageInserted(it)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -127,8 +127,6 @@ class ConversationRepositoryTest {
         val event = Event.Conversation.NewConversation(
             "id",
             TestConversation.ID,
-            false,
-            false,
             TestUser.SELF.id,
             "time",
             CONVERSATION_RESPONSE
@@ -158,8 +156,6 @@ class ConversationRepositoryTest {
             val event = Event.Conversation.NewConversation(
                 "id",
                 TestConversation.ID,
-                false,
-                false,
                 TestUser.SELF.id,
                 "time",
                 CONVERSATION_RESPONSE
@@ -190,8 +186,6 @@ class ConversationRepositoryTest {
             val event = Event.Conversation.NewConversation(
                 "id",
                 TestConversation.ID,
-                false,
-                false,
                 TestUser.SELF.id,
                 "time",
                 CONVERSATION_RESPONSE
@@ -222,8 +216,6 @@ class ConversationRepositoryTest {
             val event = Event.Conversation.NewConversation(
                 "id",
                 TestConversation.ID,
-                false,
-                false,
                 TestUser.SELF.id,
                 "time",
                 CONVERSATION_RESPONSE.copy(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1837,8 +1837,6 @@ class MLSConversationRepositoryTest {
             val WELCOME_EVENT = Event.Conversation.MLSWelcome(
                 "eventId",
                 TestConversation.ID,
-                false,
-                false,
                 TestUser.USER_ID,
                 WELCOME.encodeBase64(),
                 timestampIso = "2022-03-30T15:36:00.000Z"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -72,7 +72,7 @@ class EventRepositoryTest {
 
         eventRepository.pendingEvents().test {
             awaitItem().shouldSucceed {
-                assertEquals(pendingEvent.id, it.id)
+                assertEquals(pendingEvent.id, it.event.id)
             }
             awaitComplete()
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -24,12 +24,15 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
+import com.wire.kalium.logic.data.event.EventEnvelope
 import com.wire.kalium.logic.data.event.MemberLeaveReason
 import com.wire.kalium.logic.data.featureConfig.AppLockModel
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import io.ktor.util.encodeBase64
 import kotlinx.datetime.Instant
@@ -39,8 +42,6 @@ object TestEvent {
     fun memberJoin(eventId: String = "eventId", members: List<Member> = listOf()) = Event.Conversation.MemberJoin(
         eventId,
         TestConversation.ID,
-        false,
-        false,
         TestUser.USER_ID,
         members,
         "2022-03-30T15:36:00.000Z"
@@ -49,8 +50,6 @@ object TestEvent {
     fun memberLeave(eventId: String = "eventId", members: List<Member> = listOf()) = Event.Conversation.MemberLeave(
         eventId,
         TestConversation.ID,
-        false,
-        false,
         TestUser.USER_ID,
         listOf(),
         "2022-03-30T15:36:00.000Z",
@@ -61,8 +60,6 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         "2022-03-30T15:36:00.000Z",
-        false,
-        false,
         member
     )
 
@@ -70,8 +67,6 @@ object TestEvent {
         eventId,
         TestConversation.ID,
         "2022-03-30T15:36:00.000Z",
-        false,
-        false,
         MutedConversationStatus.AllAllowed,
         "2022-03-30T15:36:00.000Zp"
     )
@@ -81,8 +76,6 @@ object TestEvent {
             eventId,
             TestConversation.ID,
             "2022-03-30T15:36:00.000Z",
-            false,
-            false,
             "2022-03-31T16:36:00.000Zp",
             isArchiving,
         )
@@ -90,24 +83,28 @@ object TestEvent {
     fun memberChangeIgnored(eventId: String = "eventId") = Event.Conversation.MemberChanged.IgnoredMemberChanged(
         eventId,
         TestConversation.ID,
-        false,
-        false
     )
 
-    fun clientRemove(eventId: String = "eventId", clientId: ClientId) = Event.User.ClientRemove(false, false, eventId, clientId)
-    fun userDelete(eventId: String = "eventId", userId: UserId) = Event.User.UserDelete(false, false, eventId, userId)
+    fun clientRemove(eventId: String = "eventId", clientId: ClientId) = Event.User.ClientRemove(eventId, clientId)
+    fun userDelete(eventId: String = "eventId", userId: UserId) = Event.User.UserDelete(eventId, userId)
     fun updateUser(eventId: String = "eventId", userId: UserId) = Event.User.Update(
-        eventId,
-        false, false, userId, null, false, "newName", null, null, null, null, null
+        id = eventId,
+        userId = userId,
+        accentId = null,
+        ssoIdDeleted = false,
+        name = "newName",
+        handle = null,
+        email = null,
+        previewAssetId = null,
+        completeAssetId = null,
+        supportedProtocols = null
     )
 
     fun newClient(eventId: String = "eventId", clientId: ClientId = ClientId("client")) = Event.User.NewClient(
-        false, false, eventId, TestClient.CLIENT
+        eventId, TestClient.CLIENT
     )
 
     fun newConnection(eventId: String = "eventId", status: ConnectionState = ConnectionState.PENDING) = Event.User.NewConnection(
-        false,
-        false,
         eventId,
         Connection(
             conversationId = "conversationId",
@@ -123,8 +120,6 @@ object TestEvent {
     fun deletedConversation(eventId: String = "eventId") = Event.Conversation.DeletedConversation(
         eventId,
         TestConversation.ID,
-        false,
-        false,
         TestUser.USER_ID,
         "2022-03-30T15:36:00.000Z"
     )
@@ -132,8 +127,6 @@ object TestEvent {
     fun renamedConversation(eventId: String = "eventId") = Event.Conversation.RenamedConversation(
         eventId,
         TestConversation.ID,
-        false,
-        false,
         "newName",
         TestUser.USER_ID,
         "2022-03-30T15:36:00.000Z"
@@ -142,8 +135,6 @@ object TestEvent {
     fun receiptModeUpdate(eventId: String = "eventId") = Event.Conversation.ConversationReceiptMode(
         eventId,
         TestConversation.ID,
-        false,
-        false,
         receiptMode = Conversation.ReceiptMode.ENABLED,
         senderUserId = TestUser.USER_ID
     )
@@ -153,15 +144,11 @@ object TestEvent {
         teamId = "teamId",
         memberId = "memberId",
         timestampIso = "2022-03-30T15:36:00.000Z",
-        transient = false,
-        live = false
     )
 
     fun timerChanged(eventId: String = "eventId") = Event.Conversation.ConversationMessageTimer(
         id = eventId,
         conversationId = TestConversation.ID,
-        transient = false,
-        live = false,
         messageTimer = 3000,
         senderUserId = TestUser.USER_ID,
         timestampIso = "2022-03-30T15:36:00.000Z"
@@ -169,8 +156,6 @@ object TestEvent {
 
     fun userPropertyReadReceiptMode(eventId: String = "eventId") = Event.UserProperty.ReadReceiptModeSet(
         id = eventId,
-        transient = false,
-        live = false,
         value = true
     )
 
@@ -181,8 +166,6 @@ object TestEvent {
     ) = Event.Conversation.NewMessage(
         "eventId",
         TestConversation.ID,
-        false,
-        false,
         senderUserId,
         TestClient.CLIENT_ID,
         "time",
@@ -195,8 +178,6 @@ object TestEvent {
     ) = Event.Conversation.NewMLSMessage(
         "eventId",
         TestConversation.ID,
-        false,
-        false,
         null,
         TestUser.USER_ID,
         timestamp.toIsoDateTimeString(),
@@ -206,8 +187,6 @@ object TestEvent {
     fun newConversationEvent() = Event.Conversation.NewConversation(
         id = "eventId",
         conversationId = TestConversation.ID,
-        transient = false,
-        live = false,
         timestampIso = "timestamp",
         conversation = TestConversation.CONVERSATION_RESPONSE,
         senderUserId = TestUser.SELF.id
@@ -216,8 +195,6 @@ object TestEvent {
     fun newMLSWelcomeEvent() = Event.Conversation.MLSWelcome(
         "eventId",
         TestConversation.ID,
-        false,
-        false,
         TestUser.USER_ID,
         "dummy-message",
         timestampIso = "2022-03-30T15:36:00.000Z"
@@ -228,15 +205,11 @@ object TestEvent {
         conversationId = TestConversation.ID,
         data = TestConversation.CONVERSATION_RESPONSE,
         qualifiedFrom = TestUser.USER_ID,
-        transient = false,
-        live = false
     )
 
     fun codeUpdated() = Event.Conversation.CodeUpdated(
         id = "eventId",
         conversationId = TestConversation.ID,
-        transient = false,
-        live = false,
         code = "code",
         key = "key",
         uri = "uri",
@@ -246,15 +219,11 @@ object TestEvent {
     fun codeDeleted() = Event.Conversation.CodeDeleted(
         id = "eventId",
         conversationId = TestConversation.ID,
-        transient = false,
-        live = false
     )
 
     fun typingIndicator(typingIndicatorMode: Conversation.TypingIndicatorMode) = Event.Conversation.TypingIndicator(
         id = "eventId",
         conversationId = TestConversation.ID,
-        transient = true,
-        live = false,
         senderUserId = TestUser.OTHER_USER_ID,
         timestampIso = "2022-03-30T15:36:00.000Z",
         typingIndicatorMode = typingIndicatorMode
@@ -263,16 +232,12 @@ object TestEvent {
     fun newConversationProtocolEvent() = Event.Conversation.ConversationProtocol(
         id = "eventId",
         conversationId = TestConversation.ID,
-        transient = false,
-        live = false,
         protocol = Conversation.Protocol.MIXED,
         senderUserId = TestUser.OTHER_USER_ID
     )
 
     fun newFeatureConfigEvent() = Event.FeatureConfig.AppLockUpdated(
         id = "eventId",
-        transient = false,
-        live = false,
         model = AppLockModel(
             inactivityTimeoutSecs = 60,
             status = Status.ENABLED
@@ -281,7 +246,12 @@ object TestEvent {
 
     fun newUnknownFeatureUpdate() = Event.FeatureConfig.UnknownFeatureUpdated(
         id = "eventId",
-        transient = false,
-        live = false
     )
+
+    fun Event.wrapInEnvelope(isTransient: Boolean = false, source: EventSource = EventSource.LIVE): EventEnvelope {
+        return EventEnvelope(this, EventDeliveryInfo(isTransient, source))
+    }
+
+    val liveDeliveryInfo = EventDeliveryInfo(false, EventSource.LIVE)
+    val nonLiveDeliveryInfo = EventDeliveryInfo(false, EventSource.PENDING)
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.framework.TestEvent
+import com.wire.kalium.logic.framework.TestEvent.wrapInEnvelope
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.receiver.ConversationEventReceiver
 import com.wire.kalium.logic.sync.receiver.FederationEventReceiver
@@ -55,7 +56,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
 
         // Then
         verify(arrangement.eventRepository)
@@ -74,7 +75,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
 
         // Then
         verify(arrangement.conversationEventReceiver)
@@ -95,7 +96,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
             .shouldFail { assertEquals(failure, it) }
 
         // Then
@@ -115,7 +116,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
 
         // Then
         verify(arrangement.userEventReceiver)
@@ -136,7 +137,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
             .shouldFail { assertEquals(failure, it) }
 
         // Then
@@ -149,32 +150,32 @@ class EventProcessorTest {
     @Test
     fun givenNonTransientEvent_whenProcessingEvent_thenLastProcessedEventIdIsUpdated() = runTest {
         // Given
-        val event = TestEvent.newConnection().copy(transient = false)
+        val envelope = TestEvent.newConnection().wrapInEnvelope(isTransient = false)
 
         val (arrangement, eventProcessor) = Arrangement()
-            .withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
+            .withUpdateLastProcessedEventId(envelope.event.id, Either.Right(Unit))
             .arrange()
 
         // When
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(envelope.event, TestEvent.liveDeliveryInfo)
 
         // Then
         verify(arrangement.eventRepository)
             .suspendFunction(arrangement.eventRepository::updateLastProcessedEventId)
-            .with(eq(event.id))
+            .with(eq(envelope.event.id))
             .wasInvoked(exactly = once)
     }
 
     @Test
     fun givenTransientEvent_whenProcessingEvent_thenLastProcessedEventIdIsNotUpdated() = runTest {
         // Given
-        val event = TestEvent.newConnection().copy(transient = true)
+        val event = TestEvent.newConnection()
 
         val (arrangement, eventProcessor) = Arrangement()
             .arrange()
 
         // When
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo.copy(isTransient = true))
 
         // Then
         verify(arrangement.eventRepository)
@@ -192,7 +193,7 @@ class EventProcessorTest {
             .withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
             .arrange()
 
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.userPropertiesEventReceiver)
             .suspendFunction(arrangement.userPropertiesEventReceiver::onEvent)
@@ -212,7 +213,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event)
+        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
             .shouldFail { assertEquals(failure, it) }
 
         // Then

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
@@ -56,7 +56,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
+        eventProcessor.processEvent(event.wrapInEnvelope())
 
         // Then
         verify(arrangement.eventRepository)
@@ -75,7 +75,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
+        eventProcessor.processEvent(event.wrapInEnvelope())
 
         // Then
         verify(arrangement.conversationEventReceiver)
@@ -96,7 +96,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
+        eventProcessor.processEvent(event.wrapInEnvelope())
             .shouldFail { assertEquals(failure, it) }
 
         // Then
@@ -116,7 +116,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
+        eventProcessor.processEvent(event.wrapInEnvelope())
 
         // Then
         verify(arrangement.userEventReceiver)
@@ -137,7 +137,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
+        eventProcessor.processEvent(event.wrapInEnvelope())
             .shouldFail { assertEquals(failure, it) }
 
         // Then
@@ -157,7 +157,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(envelope.event, TestEvent.liveDeliveryInfo)
+        eventProcessor.processEvent(envelope.event.wrapInEnvelope())
 
         // Then
         verify(arrangement.eventRepository)
@@ -169,13 +169,13 @@ class EventProcessorTest {
     @Test
     fun givenTransientEvent_whenProcessingEvent_thenLastProcessedEventIdIsNotUpdated() = runTest {
         // Given
-        val event = TestEvent.newConnection()
+        val event = TestEvent.newConnection().wrapInEnvelope(isTransient = true)
 
         val (arrangement, eventProcessor) = Arrangement()
             .arrange()
 
         // When
-        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo.copy(isTransient = true))
+        eventProcessor.processEvent(event)
 
         // Then
         verify(arrangement.eventRepository)
@@ -193,7 +193,7 @@ class EventProcessorTest {
             .withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
             .arrange()
 
-        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
+        eventProcessor.processEvent(event.wrapInEnvelope())
 
         verify(arrangement.userPropertiesEventReceiver)
             .suspendFunction(arrangement.userPropertiesEventReceiver::onEvent)
@@ -213,7 +213,7 @@ class EventProcessorTest {
             .arrange()
 
         // When
-        eventProcessor.processEvent(event, TestEvent.liveDeliveryInfo)
+        eventProcessor.processEvent(event.wrapInEnvelope())
             .shouldFail { assertEquals(failure, it) }
 
         // Then

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
@@ -21,8 +21,9 @@ package com.wire.kalium.logic.sync.incremental
 import app.cash.turbine.test
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventEnvelope
 import com.wire.kalium.logic.framework.TestEvent
+import com.wire.kalium.logic.framework.TestEvent.wrapInEnvelope
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.KaliumSyncException
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
@@ -50,10 +51,10 @@ class IncrementalSyncWorkerTest {
     @Test
     fun givenGathererEmitsEvent_whenPerformingIncrementalSync_thenProcessorShouldReceiveTheEvent() = runTest(TestKaliumDispatcher.default) {
         // Given
-        val event = TestEvent.memberJoin()
+        val envelope = TestEvent.memberJoin().wrapInEnvelope()
         val (arrangement, worker) = Arrangement()
             .withEventGathererSourceReturning(MutableStateFlow(EventSource.LIVE))
-            .withEventGathererReturning(flowOf(event))
+            .withEventGathererReturning(flowOf(envelope))
             .arrange()
 
         // When
@@ -62,7 +63,7 @@ class IncrementalSyncWorkerTest {
         // Then
         verify(arrangement.eventProcessor)
             .suspendFunction(arrangement.eventProcessor::processEvent)
-            .with(eq(event))
+            .with(eq(envelope.event), eq(envelope.deliveryInfo))
             .wasInvoked(exactly = once)
     }
 
@@ -70,7 +71,7 @@ class IncrementalSyncWorkerTest {
     fun givenGathererEmitsEventDuringLiveSource_whenPerformingIncrementalSync_thenWorkerShouldEmitLiveSource() =
         runTest(TestKaliumDispatcher.default) {
             // Given
-            val event = TestEvent.memberJoin()
+            val event = TestEvent.memberJoin().wrapInEnvelope()
             val (_, worker) = Arrangement()
                 .withEventGathererReturning(flowOf(event))
                 .withEventGathererSourceReturning(MutableStateFlow(EventSource.LIVE))
@@ -88,7 +89,7 @@ class IncrementalSyncWorkerTest {
     fun givenGathererEmitsEventDuringPendingSource_whenPerformingIncrementalSync_thenWorkerShouldEmitPendingSource() =
         runTest(TestKaliumDispatcher.default) {
             // Given
-            val event = TestEvent.memberJoin()
+            val event = TestEvent.memberJoin().wrapInEnvelope()
             val (_, worker) = Arrangement()
                 .withEventGathererReturning(flowOf(event))
                 .withEventGathererSourceReturning(MutableStateFlow(EventSource.PENDING))
@@ -125,7 +126,7 @@ class IncrementalSyncWorkerTest {
         val coreFailureCause = NetworkFailure.NoNetworkConnection(null)
         val (_, worker) = Arrangement()
             .withEventGathererSourceReturning(MutableStateFlow(EventSource.PENDING))
-            .withEventGathererReturning(flowOf(TestEvent.memberJoin()))
+            .withEventGathererReturning(flowOf(TestEvent.memberJoin().wrapInEnvelope()))
             .withEventProcessorFailingWith(coreFailureCause)
             .arrange()
 
@@ -148,7 +149,7 @@ class IncrementalSyncWorkerTest {
             withEventProcessorSucceeding()
         }
 
-        fun withEventGathererReturning(eventFlow: Flow<Event>) = apply {
+        fun withEventGathererReturning(eventFlow: Flow<EventEnvelope>) = apply {
             given(eventGatherer)
                 .suspendFunction(eventGatherer::gatherEvents)
                 .whenInvoked()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
@@ -63,7 +63,7 @@ class IncrementalSyncWorkerTest {
         // Then
         verify(arrangement.eventProcessor)
             .suspendFunction(arrangement.eventProcessor::processEvent)
-            .with(eq(envelope.event), eq(envelope.deliveryInfo))
+            .with(eq(envelope))
             .wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -60,7 +60,7 @@ class ConversationEventReceiverTest {
 
         val (arrangement, featureConfigEventReceiver) = Arrangement().arrange()
 
-        val result = featureConfigEventReceiver.onEvent(newMessageEvent)
+        val result = featureConfigEventReceiver.onEvent(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.newMessageEventHandler)
             .suspendFunction(arrangement.newMessageEventHandler::handleNewProteusMessage)
@@ -76,7 +76,7 @@ class ConversationEventReceiverTest {
 
         val (arrangement, featureConfigEventReceiver) = Arrangement().arrange()
 
-        val result = featureConfigEventReceiver.onEvent(newMLSMessageEvent)
+        val result = featureConfigEventReceiver.onEvent(newMLSMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.newMessageEventHandler)
             .suspendFunction(arrangement.newMessageEventHandler::handleNewMLSMessage)
@@ -92,7 +92,7 @@ class ConversationEventReceiverTest {
 
         val (arrangement, featureConfigEventReceiver) = Arrangement().arrange()
 
-        val result = featureConfigEventReceiver.onEvent(newConversationEvent)
+        val result = featureConfigEventReceiver.onEvent(newConversationEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.newConversationEventHandler)
             .suspendFunction(arrangement.newConversationEventHandler::handle)
@@ -108,7 +108,7 @@ class ConversationEventReceiverTest {
 
         val (arrangement, featureConfigEventReceiver) = Arrangement().arrange()
 
-        val result = featureConfigEventReceiver.onEvent(deletedConversationEvent)
+        val result = featureConfigEventReceiver.onEvent(deletedConversationEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.deletedConversationEventHandler)
             .suspendFunction(arrangement.deletedConversationEventHandler::handle)
@@ -126,7 +126,7 @@ class ConversationEventReceiverTest {
             .withMemberJoinSucceeded()
             .arrange()
 
-        val result = featureConfigEventReceiver.onEvent(memberJoinEvent)
+        val result = featureConfigEventReceiver.onEvent(memberJoinEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.memberJoinEventHandler)
             .suspendFunction(arrangement.memberJoinEventHandler::handle)
@@ -144,7 +144,7 @@ class ConversationEventReceiverTest {
             .withMemberLeaveSucceeded()
             .arrange()
 
-        val result = featureConfigEventReceiver.onEvent(memberLeaveEvent)
+        val result = featureConfigEventReceiver.onEvent(memberLeaveEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.memberLeaveEventHandler)
             .suspendFunction(arrangement.memberLeaveEventHandler::handle)
@@ -161,7 +161,7 @@ class ConversationEventReceiverTest {
 
         val (arrangement, featureConfigEventReceiver) = Arrangement().arrange()
 
-        val result = featureConfigEventReceiver.onEvent(memberChangeEvent)
+        val result = featureConfigEventReceiver.onEvent(memberChangeEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.memberChangeEventHandler)
             .suspendFunction(arrangement.memberChangeEventHandler::handle)
@@ -178,7 +178,7 @@ class ConversationEventReceiverTest {
             .withMLSWelcomeEventSucceeded()
             .arrange()
 
-        val result = featureConfigEventReceiver.onEvent(mlsWelcomeEvent)
+        val result = featureConfigEventReceiver.onEvent(mlsWelcomeEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.mlsWelcomeEventHandler)
             .suspendFunction(arrangement.mlsWelcomeEventHandler::handle)
@@ -193,7 +193,7 @@ class ConversationEventReceiverTest {
 
         val (arrangement, featureConfigEventReceiver) = Arrangement().arrange()
 
-        val result = featureConfigEventReceiver.onEvent(renamedConversationEvent)
+        val result = featureConfigEventReceiver.onEvent(renamedConversationEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.renamedConversationEventHandler)
             .suspendFunction(arrangement.renamedConversationEventHandler::handle)
@@ -209,7 +209,7 @@ class ConversationEventReceiverTest {
 
             val (arrangement, featureConfigEventReceiver) = Arrangement().arrange()
 
-            val result = featureConfigEventReceiver.onEvent(receiptModeUpdateEvent)
+            val result = featureConfigEventReceiver.onEvent(receiptModeUpdateEvent, TestEvent.liveDeliveryInfo)
 
             verify(arrangement.receiptModeUpdateEventHandler)
                 .suspendFunction(arrangement.receiptModeUpdateEventHandler::handle)
@@ -224,7 +224,7 @@ class ConversationEventReceiverTest {
 
         val (_, featureConfigEventReceiver) = Arrangement().arrange()
 
-        val result = featureConfigEventReceiver.onEvent(accessUpdateEvent)
+        val result = featureConfigEventReceiver.onEvent(accessUpdateEvent, TestEvent.liveDeliveryInfo)
 
         result.shouldSucceed()
     }
@@ -238,7 +238,7 @@ class ConversationEventReceiverTest {
                 .withConversationMessageTimerFailed()
                 .arrange()
 
-            val result = featureConfigEventReceiver.onEvent(conversationMessageTimerEvent)
+            val result = featureConfigEventReceiver.onEvent(conversationMessageTimerEvent, TestEvent.liveDeliveryInfo)
 
             verify(arrangement.conversationMessageTimerEventHandler)
                 .suspendFunction(arrangement.conversationMessageTimerEventHandler::handle)
@@ -257,7 +257,7 @@ class ConversationEventReceiverTest {
                 withHandleCodeUpdatedEvent(Either.Right(Unit))
             }
 
-        val result = featureConfigEventReceiver.onEvent(codeUpdatedEvent)
+        val result = featureConfigEventReceiver.onEvent(codeUpdatedEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.codeUpdatedHandler)
             .suspendFunction(arrangement.codeUpdatedHandler::handle)
@@ -277,7 +277,7 @@ class ConversationEventReceiverTest {
                 withHandleCodeUpdatedEvent(Either.Left(StorageFailure.DataNotFound))
             }
 
-        val result = featureConfigEventReceiver.onEvent(codeUpdatedEvent)
+        val result = featureConfigEventReceiver.onEvent(codeUpdatedEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.codeUpdatedHandler)
             .suspendFunction(arrangement.codeUpdatedHandler::handle)
@@ -297,7 +297,7 @@ class ConversationEventReceiverTest {
                 withHandleCodeDeleteEvent(Either.Right(Unit))
             }
 
-        val result = featureConfigEventReceiver.onEvent(codeUpdatedEvent)
+        val result = featureConfigEventReceiver.onEvent(codeUpdatedEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.codeDeletedHandler)
             .suspendFunction(arrangement.codeDeletedHandler::handle)
@@ -317,7 +317,7 @@ class ConversationEventReceiverTest {
                 withHandleCodeDeleteEvent(Either.Left(StorageFailure.DataNotFound))
             }
 
-        val result = featureConfigEventReceiver.onEvent(codeUpdatedEvent)
+        val result = featureConfigEventReceiver.onEvent(codeUpdatedEvent, TestEvent.liveDeliveryInfo)
 
 
         verify(arrangement.codeDeletedHandler)
@@ -335,7 +335,7 @@ class ConversationEventReceiverTest {
             .withConversationTypingEventSucceeded(Either.Right(Unit))
             .arrange()
 
-        val result = handler.onEvent(typingStarted)
+        val result = handler.onEvent(typingStarted, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.typingIndicatorHandler)
             .suspendFunction(arrangement.typingIndicatorHandler::handle)
@@ -351,7 +351,7 @@ class ConversationEventReceiverTest {
             .withConversationTypingEventSucceeded(Either.Left(StorageFailure.Generic(RuntimeException("some error"))))
             .arrange()
 
-        val result = handler.onEvent(typingStarted)
+        val result = handler.onEvent(typingStarted, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.typingIndicatorHandler)
             .suspendFunction(arrangement.typingIndicatorHandler::handle)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.feature.featureConfig.handler.FileSharingConfigHand
 import com.wire.kalium.logic.feature.featureConfig.handler.GuestRoomConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSMigrationConfigHandler
-import com.wire.kalium.logic.feature.featureConfig.handler.SecondFactorPasswordChallengeConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
 import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
 import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
@@ -44,7 +43,6 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.any
@@ -69,7 +67,10 @@ class FeatureConfigEventReceiverTest {
             .withIsFileSharingEnabled(Either.Right(FileSharingStatus(state = FileSharingStatus.Value.Disabled, isStatusChanged = false)))
             .arrange()
 
-        featureConfigEventReceiver.onEvent(arrangement.newFileSharingUpdatedEvent(ConfigsStatusModel(Status.ENABLED)))
+        featureConfigEventReceiver.onEvent(
+            event = arrangement.newFileSharingUpdatedEvent(ConfigsStatusModel(Status.ENABLED)),
+            deliveryInfo = TestEvent.liveDeliveryInfo
+        )
 
         verify(arrangement.userConfigRepository)
             .function(arrangement.userConfigRepository::setFileSharingStatus)
@@ -85,7 +86,8 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            arrangement.newFileSharingUpdatedEvent(ConfigsStatusModel(Status.DISABLED))
+            event = arrangement.newFileSharingUpdatedEvent(ConfigsStatusModel(Status.DISABLED)),
+            deliveryInfo = TestEvent.liveDeliveryInfo
         )
 
         verify(arrangement.userConfigRepository)
@@ -102,9 +104,10 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            arrangement.newFileSharingUpdatedEvent(ConfigsStatusModel(Status.DISABLED))
+            event = arrangement.newFileSharingUpdatedEvent(ConfigsStatusModel(Status.DISABLED)),
+            deliveryInfo = TestEvent.liveDeliveryInfo
         )
-
+        
         verify(arrangement.userConfigRepository)
             .function(arrangement.userConfigRepository::setFileSharingStatus)
             .with(eq(false), eq(false))
@@ -118,7 +121,8 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            arrangement.newConferenceCallingUpdatedEvent(ConferenceCallingModel(Status.ENABLED))
+            arrangement.newConferenceCallingUpdatedEvent(ConferenceCallingModel(Status.ENABLED)),
+            TestEvent.liveDeliveryInfo
         )
 
         verify(arrangement.userConfigRepository)
@@ -134,9 +138,8 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            arrangement.newConferenceCallingUpdatedEvent(
-                ConferenceCallingModel(Status.DISABLED)
-            )
+            event = arrangement.newConferenceCallingUpdatedEvent(ConferenceCallingModel(Status.DISABLED)),
+            deliveryInfo = TestEvent.liveDeliveryInfo
         )
 
         verify(arrangement.userConfigRepository)
@@ -160,7 +163,10 @@ class FeatureConfigEventReceiverTest {
             .withSelfDeletingMessages(currentSelfDeletingMessagesStatus)
             .arrange()
 
-        featureConfigEventReceiver.onEvent(arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel))
+        featureConfigEventReceiver.onEvent(
+            arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+            TestEvent.liveDeliveryInfo
+        )
 
         verify(arrangement.userConfigRepository)
             .suspendFunction(arrangement.userConfigRepository::setTeamSettingsSelfDeletionStatus)
@@ -184,7 +190,10 @@ class FeatureConfigEventReceiverTest {
                 .withSelfDeletingMessages(currentSelfDeletingMessagesStatus)
                 .arrange()
 
-            featureConfigEventReceiver.onEvent(arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel))
+            featureConfigEventReceiver.onEvent(
+                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+                TestEvent.liveDeliveryInfo
+            )
 
             verify(arrangement.userConfigRepository)
                 .suspendFunction(arrangement.userConfigRepository::setTeamSettingsSelfDeletionStatus)
@@ -209,7 +218,10 @@ class FeatureConfigEventReceiverTest {
                 .withSelfDeletingMessages(currentSelfDeletingMessagesStatus)
                 .arrange()
 
-            featureConfigEventReceiver.onEvent(arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel))
+            featureConfigEventReceiver.onEvent(
+                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+                TestEvent.liveDeliveryInfo
+            )
 
             verify(arrangement.userConfigRepository)
                 .suspendFunction(arrangement.userConfigRepository::setTeamSettingsSelfDeletionStatus)
@@ -231,7 +243,10 @@ class FeatureConfigEventReceiverTest {
                 .withStoredTeamSettingsSelfDeletionStatusError()
                 .arrange()
 
-            featureConfigEventReceiver.onEvent(arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel))
+            featureConfigEventReceiver.onEvent(
+                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+                TestEvent.liveDeliveryInfo
+            )
 
             verify(arrangement.userConfigRepository)
                 .suspendFunction(arrangement.userConfigRepository::setTeamSettingsSelfDeletionStatus)
@@ -252,7 +267,10 @@ class FeatureConfigEventReceiverTest {
                 .withStoredTeamSettingsSelfDeletionStatusError()
                 .arrange()
 
-            featureConfigEventReceiver.onEvent(arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel))
+            featureConfigEventReceiver.onEvent(
+                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+                TestEvent.liveDeliveryInfo
+            )
 
             verify(arrangement.userConfigRepository)
                 .function(arrangement.userConfigRepository::setTeamSettingsSelfDeletionStatus)
@@ -272,7 +290,10 @@ class FeatureConfigEventReceiverTest {
             .withDisabledKaliumConfigFlag()
             .arrange()
 
-        featureConfigEventReceiver.onEvent(arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel))
+        featureConfigEventReceiver.onEvent(
+            event = arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel),
+            deliveryInfo = TestEvent.liveDeliveryInfo
+        )
 
         verify(arrangement.userConfigRepository)
             .function(arrangement.userConfigRepository::setTeamSettingsSelfDeletionStatus)
@@ -288,7 +309,7 @@ class FeatureConfigEventReceiverTest {
         val (_, handler) = Arrangement()
             .arrange()
 
-        handler.onEvent(newUnknownFeatureUpdate).shouldSucceed()
+        handler.onEvent(newUnknownFeatureUpdate, TestEvent.liveDeliveryInfo).shouldSucceed()
     }
 
     private class Arrangement {
@@ -368,15 +389,15 @@ class FeatureConfigEventReceiverTest {
 
         fun newFileSharingUpdatedEvent(
             model: ConfigsStatusModel
-        ) = Event.FeatureConfig.FileSharingUpdated("eventId", false, false, model)
+        ) = Event.FeatureConfig.FileSharingUpdated("eventId", model)
 
         fun newConferenceCallingUpdatedEvent(
             model: ConferenceCallingModel
-        ) = Event.FeatureConfig.ConferenceCallingUpdated("eventId", false, false, model)
+        ) = Event.FeatureConfig.ConferenceCallingUpdated("eventId", model)
 
         fun newSelfDeletingMessagesUpdatedEvent(
             model: SelfDeletingMessagesModel
-        ) = Event.FeatureConfig.SelfDeletingMessagesConfig("eventId", false, false, model)
+        ) = Event.FeatureConfig.SelfDeletingMessagesConfig("eventId", model)
 
         fun arrange() = this to featureConfigEventReceiver
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiverTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestConnection
 import com.wire.kalium.logic.framework.TestConversationDetails
+import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
@@ -107,13 +108,11 @@ class FederationEventReceiverTest {
         // When
         val event = Event.Federation.Delete(
             "id",
-            true,
-            false,
             defederatedDomain
         )
 
         // Then
-        useCase.onEvent(event).shouldSucceed()
+        useCase.onEvent(event, TestEvent.liveDeliveryInfo).shouldSucceed()
 
         verify(arrangement.connectionRepository)
             .suspendFunction(arrangement.connectionRepository::deleteConnection)
@@ -178,13 +177,11 @@ class FederationEventReceiverTest {
             // When
             val event = Event.Federation.ConnectionRemoved(
                 "id",
-                true,
-                false,
                 listOf(defederatedDomain, defederatedDomainTwo)
             )
 
             // Then
-            useCase.onEvent(event).shouldSucceed()
+            useCase.onEvent(event, TestEvent.liveDeliveryInfo).shouldSucceed()
 
             verify(arrangement.memberDAO)
                 .suspendFunction(arrangement.memberDAO::deleteMembersByQualifiedID)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiverTest.kt
@@ -49,7 +49,7 @@ class TeamEventReceiverTest {
                 withPersistMessageSuccess()
             }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.persistMessageUseCase)
             .suspendFunction(arrangement.persistMessageUseCase::invoke)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -64,7 +64,7 @@ class UserEventReceiverTest {
             withLogoutUseCaseSucceed()
         }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.logoutUseCase)
             .suspendFunction(arrangement.logoutUseCase::invoke)
@@ -80,7 +80,7 @@ class UserEventReceiverTest {
             withLogoutUseCaseSucceed()
         }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.logoutUseCase)
             .suspendFunction(arrangement.logoutUseCase::invoke)
@@ -95,7 +95,7 @@ class UserEventReceiverTest {
             withLogoutUseCaseSucceed()
         }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.logoutUseCase)
             .suspendFunction(arrangement.logoutUseCase::invoke)
@@ -113,7 +113,7 @@ class UserEventReceiverTest {
             )
         }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.userRepository)
             .suspendFunction(
@@ -131,7 +131,7 @@ class UserEventReceiverTest {
             withUpdateUserSuccess()
         }
 
-        val result = eventReceiver.onEvent(event)
+        val result = eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         assertIs<Either.Right<Unit>>(result)
         verify(arrangement.userRepository)
@@ -147,7 +147,7 @@ class UserEventReceiverTest {
             withUpdateUserFailure(StorageFailure.DataNotFound)
         }
 
-        val result = eventReceiver.onEvent(event)
+        val result = eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         assertIs<Either.Right<Unit>>(result)
     }
@@ -159,7 +159,7 @@ class UserEventReceiverTest {
             withUpdateUserFailure(StorageFailure.Generic(Throwable("error")))
         }
 
-        val result = eventReceiver.onEvent(event)
+        val result = eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         assertIs<Either.Left<StorageFailure.Generic>>(result)
     }
@@ -169,7 +169,7 @@ class UserEventReceiverTest {
         val event = TestEvent.newClient()
         val (arrangement, eventReceiver) = arrange { }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.clientRepository)
             .suspendFunction(arrangement.clientRepository::saveNewClientEvent)
@@ -186,7 +186,7 @@ class UserEventReceiverTest {
             withPersistUnverifiedWarningMessageSuccess()
         }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.connectionRepository)
             .suspendFunction(arrangement.connectionRepository::insertConnectionFromEvent)
@@ -203,7 +203,7 @@ class UserEventReceiverTest {
             withPersistUnverifiedWarningMessageSuccess()
         }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.oneOnOneResolver)
             .suspendFunction(arrangement.oneOnOneResolver::resolveOneOnOneConversationWithUser)
@@ -212,8 +212,8 @@ class UserEventReceiverTest {
     }
 
     @Test
-    fun givenNewConnectionEventWithStatusAccepted_thenResolveActiveOneOnOneConversationIsScheduled() = runTest {
-        val event = TestEvent.newConnection(status = ConnectionState.ACCEPTED).copy()
+    fun givenNonLiveNewConnectionEventWithStatusAccepted_thenResolveActiveOneOnOneConversationIsScheduled() = runTest {
+        val event = TestEvent.newConnection(status = ConnectionState.ACCEPTED)
         val (arrangement, eventReceiver) = arrange {
             withFetchUserInfoReturning(Either.Right(Unit))
             withInsertConnectionFromEventSucceeding()
@@ -221,7 +221,7 @@ class UserEventReceiverTest {
             withPersistUnverifiedWarningMessageSuccess()
         }
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.nonLiveDeliveryInfo)
 
         verify(arrangement.oneOnOneResolver)
             .suspendFunction(arrangement.oneOnOneResolver::scheduleResolveOneOnOneConversationWithUserId)
@@ -233,7 +233,7 @@ class UserEventReceiverTest {
     @Test
     fun givenLiveNewConnectionEventWithStatusAccepted_thenResolveActiveOneOnOneConversationIsScheduledWithDelay() =
         runTest(TestKaliumDispatcher.default) {
-            val event = TestEvent.newConnection(status = ConnectionState.ACCEPTED).copy(live = true)
+            val event = TestEvent.newConnection(status = ConnectionState.ACCEPTED)
             val (arrangement, eventReceiver) = arrange {
                 withFetchUserInfoReturning(Either.Right(Unit))
                 withInsertConnectionFromEventSucceeding()
@@ -241,7 +241,7 @@ class UserEventReceiverTest {
                 withPersistUnverifiedWarningMessageSuccess()
             }
 
-            eventReceiver.onEvent(event)
+            eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
             advanceUntilIdle()
 
             verify(arrangement.oneOnOneResolver)
@@ -262,7 +262,7 @@ class UserEventReceiverTest {
                 withPersistUnverifiedWarningMessageSuccess()
             }
             // when
-            eventReceiver.onEvent(event)
+            eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
             // then
             verify(arrangement.newGroupConversationSystemMessagesCreator)
                 .suspendFunction(arrangement.newGroupConversationSystemMessagesCreator::conversationStartedUnverifiedWarning)
@@ -282,7 +282,7 @@ class UserEventReceiverTest {
                 withPersistUnverifiedWarningMessageSuccess()
             }
             // when
-            eventReceiver.onEvent(event)
+            eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
             // then
             verify(arrangement.newGroupConversationSystemMessagesCreator)
                 .suspendFunction(arrangement.newGroupConversationSystemMessagesCreator::conversationStartedUnverifiedWarning)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiverTest.kt
@@ -40,7 +40,7 @@ class UserPropertiesEventReceiverTest {
             .withUpdateReadReceiptsSuccess()
             .arrange()
 
-        eventReceiver.onEvent(event)
+        eventReceiver.onEvent(event, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.userConfigRepository)
             .function(arrangement.userConfigRepository::setReadReceiptsStatus)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/CodeDeletedHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/CodeDeletedHandlerTest.kt
@@ -41,8 +41,6 @@ class CodeDeletedHandlerTest {
         val event = Event.Conversation.CodeDeleted(
             conversationId = ConversationId("conversationId", "domain"),
             id = "event-id",
-            transient = false,
-            live = false
         )
 
         handler.handle(event)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/CodeUpdateHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/CodeUpdateHandlerTest.kt
@@ -45,8 +45,6 @@ class CodeUpdateHandlerTest {
             code = "code",
             key = "key",
             id = "event-id",
-            transient = false,
-            live = false
         )
 
         handler.handle(event)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -340,8 +340,6 @@ class MLSWelcomeEventHandlerTest {
         val WELCOME_EVENT = Event.Conversation.MLSWelcome(
             "eventId",
             CONVERSATION_ID,
-            false,
-            false,
             TestUser.USER_ID,
             WELCOME.encodeBase64(),
             timestampIso = "2022-03-30T15:36:00.000Z"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
@@ -218,8 +218,6 @@ class MemberLeaveEventHandlerTest {
         fun memberLeaveEvent(reason: MemberLeaveReason) = Event.Conversation.MemberLeave(
             id = "id",
             conversationId = conversationId,
-            transient = false,
-            live = false,
             removedBy = userId,
             removedList = listOf(userId),
             timestampIso = "timestampIso",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -421,8 +421,6 @@ class NewConversationEventHandlerTest {
         ) = Event.Conversation.NewConversation(
             id = "eventId",
             conversationId = TestConversation.ID,
-            transient = false,
-            live = false,
             timestampIso = "timestamp",
             conversation = conversation,
             senderUserId = TestUser.SELF.id

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -59,7 +59,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
 
-        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.proteusMessageUnpacker)
             .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
@@ -84,7 +84,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
 
-        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.proteusMessageUnpacker)
             .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
@@ -114,7 +114,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
 
-        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.proteusMessageUnpacker)
             .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
@@ -135,7 +135,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant())
 
-        newMessageEventHandler.handleNewMLSMessage(newMessageEvent)
+        newMessageEventHandler.handleNewMLSMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.mlsMessageUnpacker)
             .suspendFunction(arrangement.mlsMessageUnpacker::unpackMlsMessage)
@@ -162,7 +162,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant())
 
-        newMessageEventHandler.handleNewMLSMessage(newMessageEvent)
+        newMessageEventHandler.handleNewMLSMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.legalHoldHandler)
             .suspendFunction(arrangement.legalHoldHandler::handleNewMessage)
@@ -184,7 +184,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant())
 
-        newMessageEventHandler.handleNewMLSMessage(newMessageEvent)
+        newMessageEventHandler.handleNewMLSMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.mlsMessageUnpacker)
             .suspendFunction(arrangement.mlsMessageUnpacker::unpackMlsMessage)
@@ -216,7 +216,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
 
-        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.proteusMessageUnpacker)
             .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
@@ -243,7 +243,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
 
-        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.proteusMessageUnpacker)
             .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
@@ -278,7 +278,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
 
-        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.proteusMessageUnpacker)
             .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
@@ -300,7 +300,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
 
-        newMessageEventHandler.handleNewProteusMessage(newMessageEvent)
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.proteusMessageUnpacker)
             .suspendFunction(arrangement.proteusMessageUnpacker::unpackProteusMessage)
@@ -332,7 +332,7 @@ class NewMessageEventHandlerTest {
 
         val newMessageEvent = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant())
 
-        newMessageEventHandler.handleNewMLSMessage(newMessageEvent)
+        newMessageEventHandler.handleNewMLSMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         verify(arrangement.staleEpochVerifier)
             .suspendFunction(arrangement.staleEpochVerifier::verifyEpoch)
@@ -350,7 +350,7 @@ class NewMessageEventHandlerTest {
 
             val newMessageEvent = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant())
 
-            newMessageEventHandler.handleNewMLSMessage(newMessageEvent)
+            newMessageEventHandler.handleNewMLSMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
             verify(arrangement.applicationMessageHandler)
                 .suspendFunction(arrangement.applicationMessageHandler::handleDecryptionError)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
@@ -754,14 +754,10 @@ class LegalHoldHandlerTest {
     companion object {
         private val testDispatchers: KaliumDispatcher = TestKaliumDispatcher
         private val legalHoldEventEnabled = Event.User.LegalHoldEnabled(
-            transient = false,
-            live = false,
             id = "id-1",
             userId = TestUser.SELF.id,
         )
         private val legalHoldEventDisabled = Event.User.LegalHoldDisabled(
-            transient = false,
-            live = false,
             id = "id-2",
             userId = TestUser.OTHER_USER_ID
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldRequestHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldRequestHandlerTest.kt
@@ -87,16 +87,12 @@ class LegalHoldRequestHandlerTest {
 
     companion object {
         private val legalHoldRequestSelfUser = Event.User.LegalHoldRequest(
-            transient = false,
-            live = false,
             id = "event-id",
             clientId = ClientId("client-id"),
             lastPreKey = LastPreKey(3, "key"),
             userId = TestUser.SELF.id
         )
         private val legalHoldRequestOtherUser = Event.User.LegalHoldRequest(
-            transient = false,
-            live = false,
             id = "event-id",
             clientId = ClientId("client-id"),
             lastPreKey = LastPreKey(3, "key"),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. Events are being processed twice when they are received through the PendingEvents flow and also in the LiveEvents flow
2. `live` and `transient` flags are being passed all around the code

### Causes

The `Event` class has `live` and `transient` flags mixed with the content of the event.
In `PendingEventsBuffer`, when calling `contains`, the event was not being found, because the flag `live` was different, so the `equals` result was "wrong".

### Solutions

Separate the content of the event and the information about the event's origin.

This is two-fold:
1. Cleans up a bit of code, as live/transient were being passed everywhere.
2. Makes sure that when comparing events, their origin won't matter, as we can easily call `equals` between two Events without having `transient` and `live` in the middle

### Testing

#### Test Coverage

The compiler does the job in this case. There's no difference between a Pending and a Live event, the content is exactly the same.

I'll try to add a couple of integration tests for this later, as I also plan to change `PendingEventsBuffer` to increase its performance.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
