### PR TITLE
fix: team event manual sync was not being reflected in db (WPB-5516)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -19,12 +19,12 @@
 package com.wire.kalium.logic.data.team
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapper
 import com.wire.kalium.logic.data.event.EventMapper
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.service.ServiceMapper
+import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.di.MapperProvider
@@ -54,8 +54,7 @@ interface TeamRepository {
     suspend fun fetchMembersByTeamId(teamId: TeamId, userDomain: String): Either<CoreFailure, Unit>
     suspend fun getTeam(teamId: TeamId): Flow<Team?>
     suspend fun deleteConversation(conversationId: ConversationId, teamId: TeamId): Either<CoreFailure, Unit>
-    suspend fun updateMemberRole(teamId: String, userId: String, permissionCode: Int?): Either<CoreFailure, Unit>
-    suspend fun updateTeam(team: Team): Either<CoreFailure, Unit>
+    suspend fun syncTeam(teamId: TeamId): Either<CoreFailure, Team>
     suspend fun syncServices(teamId: TeamId): Either<CoreFailure, Unit>
     suspend fun approveLegalHoldRequest(teamId: TeamId, password: String?): Either<CoreFailure, Unit>
     suspend fun fetchLegalHoldStatus(teamId: TeamId): Either<CoreFailure, LegalHoldStatus>
@@ -136,19 +135,15 @@ internal class TeamDataSource(
         }
     }
 
-    override suspend fun updateMemberRole(teamId: String, userId: String, permissionCode: Int?): Either<CoreFailure, Unit> {
-        return wrapStorageRequest {
-            userDAO.upsertTeamMemberUserTypes(
-                mapOf(
-                    QualifiedIDEntity(userId, selfUserId.domain) to userTypeEntityTypeMapper.teamRoleCodeToUserType(permissionCode)
-                )
-            )
-        }
-    }
-
-    override suspend fun updateTeam(team: Team): Either<CoreFailure, Unit> {
-        return wrapStorageRequest {
-            teamDAO.updateTeam(teamMapper.fromModelToEntity(team))
+    override suspend fun syncTeam(teamId: TeamId): Either<CoreFailure, Team> = wrapApiRequest {
+        teamsApi.getTeamInfo(teamId = teamId.value)
+    }.map { teamDTO ->
+        teamMapper.fromDtoToEntity(teamDTO)
+    }.flatMap { teamEntity ->
+        wrapStorageRequest {
+            teamDAO.updateTeam(teamEntity)
+        }.map {
+            teamMapper.fromDaoModelToTeam(teamEntity)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/GetUpdatedSelfTeamUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/GetUpdatedSelfTeamUseCase.kt
@@ -34,7 +34,7 @@ class GetUpdatedSelfTeamUseCase internal constructor(
 
     suspend operator fun invoke(): Either<CoreFailure, Team?> {
         return selfTeamIdProvider().flatMap { teamId ->
-            teamId?.let { teamRepository.fetchTeamById(it) }
+            teamId?.let { teamRepository.syncTeam(it) }
                 ?: Either.Right(null)
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -384,9 +384,7 @@ class TeamRepositoryTest {
             .suspendFunction(arrangement.teamDAO::updateTeam)
             .with(eq(TestTeam.TEAM_ENTITY))
             .wasInvoked(exactly = once)
-
     }
-
 
     private class Arrangement {
         @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -20,8 +20,8 @@ package com.wire.kalium.logic.data.team
 
 import app.cash.turbine.test
 import com.wire.kalium.logic.NetworkFailure
-import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestTeam
@@ -34,7 +34,6 @@ import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientIdDTO
 import com.wire.kalium.network.api.base.authenticated.keypackage.LastPreKeyDTO
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.base.model.ErrorResponse
 import com.wire.kalium.network.api.base.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.base.model.LegalHoldStatusResponse
@@ -60,13 +59,11 @@ import io.mockative.mock
 import io.mockative.once
 import io.mockative.oneOf
 import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class TeamRepositoryTest {
     @Test
     fun givenSelfUserExists_whenFetchingTeamInfo_thenTeamInfoShouldBeSuccessful() = runTest {
@@ -329,23 +326,23 @@ class TeamRepositoryTest {
 
     @Test
     fun givenTeamIdAndUserIdAndStatusEnabled_whenFetchingLegalHoldStatus_thenItShouldSucceedAndHandleEnabledLegalHold() =
-    testFetchingLegalHoldStatus(
-    response = LegalHoldStatusResponse(LegalHoldStatusDTO.ENABLED, null, null),
-    expected = LegalHoldStatus.ENABLED,
-    ) { arrangement ->
-        verify(arrangement.legalHoldHandler)
-            .suspendFunction(arrangement.legalHoldHandler::handleEnable)
-            .with(any())
-            .wasInvoked()
-        verify(arrangement.legalHoldHandler)
-            .suspendFunction(arrangement.legalHoldHandler::handleDisable)
-            .with(any())
-            .wasNotInvoked()
-        verify(arrangement.legalHoldRequestHandler)
-            .suspendFunction(arrangement.legalHoldRequestHandler::handle)
-            .with(any())
-            .wasNotInvoked()
-    }
+        testFetchingLegalHoldStatus(
+            response = LegalHoldStatusResponse(LegalHoldStatusDTO.ENABLED, null, null),
+            expected = LegalHoldStatus.ENABLED,
+        ) { arrangement ->
+            verify(arrangement.legalHoldHandler)
+                .suspendFunction(arrangement.legalHoldHandler::handleEnable)
+                .with(any())
+                .wasInvoked()
+            verify(arrangement.legalHoldHandler)
+                .suspendFunction(arrangement.legalHoldHandler::handleDisable)
+                .with(any())
+                .wasNotInvoked()
+            verify(arrangement.legalHoldRequestHandler)
+                .suspendFunction(arrangement.legalHoldRequestHandler::handle)
+                .with(any())
+                .wasNotInvoked()
+        }
 
     @Test
     fun givenTeamIdAndUserIdAndStatusDisabled_whenFetchingLegalHoldStatus_thenItShouldSucceedAndHandleDisabledLegalHold() =
@@ -366,6 +363,30 @@ class TeamRepositoryTest {
                 .with(any())
                 .wasNotInvoked()
         }
+
+    @Test
+    fun givenSelfUserExists_whenSyncingTeam_thenTeamInfoShouldBeUpdatedSuccessful() = runTest {
+        // given
+        val (arrangement, teamRepository) = Arrangement()
+            .withApiGetTeamInfoSuccess(TestTeam.TEAM_DTO)
+            .arrange()
+
+        // when
+        val result = teamRepository.syncTeam(teamId = TeamId(TestTeam.TEAM_ID.value))
+
+        // then
+        result.shouldSucceed { returnTeam -> assertEquals(TestTeam.TEAM, returnTeam) }
+        verify(arrangement.teamsApi)
+            .suspendFunction(arrangement.teamsApi::getTeamInfo)
+            .with(any())
+            .wasInvoked(exactly = once)
+        verify(arrangement.teamDAO)
+            .suspendFunction(arrangement.teamDAO::updateTeam)
+            .with(eq(TestTeam.TEAM_ENTITY))
+            .wasInvoked(exactly = once)
+
+    }
+
 
     private class Arrangement {
         @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/team/GetUpdatedSelfTeamUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/team/GetUpdatedSelfTeamUseCaseTest.kt
@@ -42,7 +42,7 @@ class GetUpdatedSelfTeamUseCaseTest {
         // given
         val (arrangement, sut) = Arrangement()
             .withSelfTeamIdProvider(Either.Right(null))
-            .withFetchingIdReturning(Either.Right(TestTeam.TEAM))
+            .withSyncingByIdReturning(Either.Right(TestTeam.TEAM))
             .arrange()
 
         // when
@@ -61,7 +61,7 @@ class GetUpdatedSelfTeamUseCaseTest {
         // given
         val (arrangement, sut) = Arrangement()
             .withSelfTeamIdProvider(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
-            .withFetchingIdReturning(Either.Right(TestTeam.TEAM))
+            .withSyncingByIdReturning(Either.Right(TestTeam.TEAM))
             .arrange()
 
         // when
@@ -80,7 +80,7 @@ class GetUpdatedSelfTeamUseCaseTest {
         // given
         val (arrangement, sut) = Arrangement()
             .withSelfTeamIdProvider(Either.Right(TestTeam.TEAM_ID))
-            .withFetchingIdReturning(Either.Right(TestTeam.TEAM))
+            .withSyncingByIdReturning(Either.Right(TestTeam.TEAM))
             .arrange()
 
         // when
@@ -89,7 +89,7 @@ class GetUpdatedSelfTeamUseCaseTest {
         // then
         result.shouldSucceed()
         verify(arrangement.teamRepository)
-            .suspendFunction(arrangement.teamRepository::fetchTeamById)
+            .suspendFunction(arrangement.teamRepository::syncTeam)
             .with(eq(TestTeam.TEAM_ID))
             .wasInvoked()
     }
@@ -109,9 +109,9 @@ class GetUpdatedSelfTeamUseCaseTest {
                 .thenReturn(result)
         }
 
-        fun withFetchingIdReturning(result: Either<CoreFailure, Team>) = apply {
+        fun withSyncingByIdReturning(result: Either<CoreFailure, Team>) = apply {
             given(teamRepository)
-                .suspendFunction(teamRepository::fetchTeamById)
+                .suspendFunction(teamRepository::syncTeam)
                 .whenInvokedWith(any())
                 .thenReturn(result)
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Team changes while fetching was not reflected in DB.

### Causes (Optional)

We were not updating the info because of incorrect query call.

### Solutions

Call the existing update team query to reflect the changes from remote into local db.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
