### PR TITLE
feat(monkeys): Improve docker to allow running external monkeys in it [WPB-6471]

### DIFF
--- a/monkeys/README.md
+++ b/monkeys/README.md
@@ -7,10 +7,12 @@ This application enables the creation of stress tests in clients and in the back
 To build, run:
 
 ```bash
-./gradlew :monkeys:build
+./gradlew :monkeys:assembleDist
 ```
 
-A jar file will be created inside `./monkeys/build/libs` called `monkeys.jar`.
+A zip and tar files will be created inside `./monkeys/build/distributions`. In the uncompressed
+folder, you'll see a folder called bin which contains 3 scripts to start the monkeys, the replayer
+and the monkey-server.
 
 ### Docker
 
@@ -21,7 +23,8 @@ folder, run:
 docker compose up
 ```
 
-By default, it will search for a config named `config.json` inside the `monkeys/docker/config` folder. To change
+By default, it will search for a config named `config.json` inside the `monkeys/docker/config`
+folder. To change
 which
 config file to load simply set the environment variable `CONFIG`:
 
@@ -44,13 +47,13 @@ port [3000](http://localhost:3000/) and prometheus on the port [9090](http://loc
 Create a configuration and execute:
 
 ```bash
-java -jar monkeys.jar config.json
+./bin/monkeys config.json
 ```
 
 For a list of the possible options and parameters run:
 
 ```bash
-java -jar monkeys.jar --help
+./bin/monkeys --help
 ```
 
 An [example](example.json) config is in this repo and the schema can be seen [here](schema.json).
@@ -58,13 +61,52 @@ An [example](example.json) config is in this repo and the schema can be seen [he
 When creating teams and users automatically through Infinite Monkeys, remember to set the `authUser`
 and `authPassword` with the credentials for the internal API of the respective backend.
 
+### Running each monkey in detached mode
+
+It is possible to split each monkey from the main application and that can improve performance and
+scalability. To do that you need to specify a command to start each monkey and an address to resolve
+them. Both the `startCommand` and the `addressTemplate` are templated string the following variables
+will be replaced at runtime:
+
+* teamName: the name of the team that the user belongs to
+* email: the email of the user
+* userId: the id of the user (without the domain)
+* teamId: the id of the team that the user belongs to
+* monkeyIndex: a unique identifier within the app for each monkey (it is numeric starting from 0)
+* monkeyClientId: a unique identifier for each client within the app (it is numeric)
+
+Example:
+
+```json
+{
+    "externalMonkey": {
+        "startCommand": "./monkeys/bin/monkey-server -p 50{{monkeyIndex}}",
+        "addressTemplate": "http://localhost:50{{monkeyIndex}}",
+        "waitTime": 3
+    }
+}
+```
+
+It is also possible to run this inside docker. Here's an example (the `--platform` option is only
+needed on non x86_64 CPUs):
+
+```json
+{
+    "externalMonkey": {
+        "startCommand": "docker run --platform linux/amd64 --network docker_monkeys --hostname monkey-{{monkeyIndex}} monkeys /opt/app/bin/monkey-server",
+        "addressTemplate": "http://monkey-{{monkeyIndex}}:8080",
+        "waitTime": 3
+    }
+}
+```
+
+The `waitTime` field is optional and determines how long (in seconds) it will wait until it proceeds to start the
+next monkey. This can be important because the next step in the app is assigning each to a user and
+the app must be ready to respond.
+
 ## Current Limitations (to be fixed in the future)
 
-* The `SIGINT` signal is not being correctly processed by the app.
 * The application should run until it receives a `SIGINT` (Ctrl+C) signal. There should be a
   configuration to finish the test run
 * Tests need to be implemented
-* Tracing and replaying a test run. For this the order is the important factor, so when replayed it
-  won't be executed in parallel.
-* Clean-up the data created during the tests
 * Randomising times for action execution

--- a/monkeys/README.md
+++ b/monkeys/README.md
@@ -104,6 +104,10 @@ The `waitTime` field is optional and determines how long (in seconds) it will wa
 next monkey. This can be important because the next step in the app is assigning each to a user and
 the app must be ready to respond.
 
+**Note**: setting environment variables prior to the command is is not supported. Ex: 
+`INDEX={{monkeyIndex}} ./monkeys/bin/monkey-server -p 50$INDEX`. This is a limitation of the JVM's system command
+runner.
+
 ## Current Limitations (to be fixed in the future)
 
 * The application should run until it receives a `SIGINT` (Ctrl+C) signal. There should be a

--- a/monkeys/docker/Dockerfile
+++ b/monkeys/docker/Dockerfile
@@ -6,5 +6,15 @@ RUN tar -xf /kalium/monkeys/build/distributions/monkeys.tar
 
 FROM wirebot/cryptobox:1.4.0
 
+# install docker cli
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+      tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update && apt-get install -y docker-ce-cli
+
 RUN mkdir /opt/app
 COPY --from=jdk-build /monkeys /opt/app

--- a/monkeys/docker/docker-compose.yml
+++ b/monkeys/docker/docker-compose.yml
@@ -1,14 +1,17 @@
 services:
-    monkeys:
+    monkeys-controller:
         platform: linux/amd64
         build:
             context: ../../
             dockerfile: ./monkeys/docker/Dockerfile
         image: monkeys
+        networks:
+            - monkeys
         depends_on:
             - postgres
         volumes:
             - ./config:/config
+            - /var/run/docker.sock:/var/run/docker.sock
         entrypoint:
             - /opt/app/bin/monkeys
         command:
@@ -16,6 +19,8 @@ services:
     postgres:
         image: postgres
         restart: unless-stopped
+        networks:
+            - monkeys
         environment:
             POSTGRES_PASSWORD: monkeys
             POSTGRES_USER: monkeys
@@ -27,6 +32,8 @@ services:
         command:
             - '--config.file=/etc/prometheus/prometheus.yml'
         restart: unless-stopped
+        networks:
+            - monkeys
         ports:
             - 9090:9090
         volumes:
@@ -37,6 +44,8 @@ services:
         ports:
             - 3000:3000
         restart: unless-stopped
+        networks:
+            - monkeys
         environment:
             - GF_SECURITY_ADMIN_USER=admin
             - GF_SECURITY_ADMIN_PASSWORD=grafana
@@ -55,3 +64,5 @@ services:
             - ./grafana/dashboards:/var/lib/grafana/dashboards
 volumes:
     prom_data:
+networks:
+    monkeys:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This improves the execution of the monkeys inside docker. Allowing to run the app with external monkeys in a docker network.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
