### PR TITLE
fix(calling): check user role before applying remote mute

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -212,10 +212,13 @@ class CallManagerImpl internal constructor(
         val msg = content.value.toByteArray()
 
         val callingValue = json.decodeFromString<MessageContent.Calling.CallingValue>(content.value)
+        val conversationMembers = conversationRepository.observeConversationMembers(message.conversationId).first()
         val shouldRemoteMute = shouldRemoteMuteChecker.check(
+            senderUserId = message.senderUserId,
             selfUserId = userId.await(),
             selfClientId = clientId.await().value,
-            targets = callingValue.targets
+            targets = callingValue.targets,
+            conversationMembers = conversationMembers
         )
 
         if (callingValue.type != REMOTE_MUTE_TYPE || shouldRemoteMute) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteCheckerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteCheckerTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import kotlin.test.Test
@@ -25,14 +26,32 @@ import kotlin.test.assertEquals
 class ShouldRemoteMuteCheckerTest {
 
     @Test
+    fun givenSenderIsNotAdmin_whenChecking_thenReturnFalse() {
+        val (_, checker) = Arrangement()
+            .arrange()
+
+        val shouldRemoteMute = checker.check(
+            senderUserId = OTHER_USER_ID,
+            selfUserId = SELF_USER_ID,
+            selfClientId = SELF_CLIENT_ID,
+            targets = null,
+            conversationMembers = listOf(conversationMember.copy(role = Conversation.Member.Role.Member))
+        )
+
+        assertEquals(false, shouldRemoteMute)
+    }
+
+    @Test
     fun givenNullTargets_whenChecking_thenReturnTrue() {
         val (_, checker) = Arrangement()
             .arrange()
 
         val shouldRemoteMute = checker.check(
+            senderUserId = OTHER_USER_ID,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = null
+            targets = null,
+            conversationMembers = listOf(conversationMember)
         )
 
         assertEquals(true, shouldRemoteMute)
@@ -44,9 +63,11 @@ class ShouldRemoteMuteCheckerTest {
             .arrange()
 
         val shouldRemoteMute = checker.check(
+            senderUserId = OTHER_USER_ID,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = targetsWithoutCurrentUser
+            targets = targetsWithoutCurrentUser,
+            conversationMembers = listOf(conversationMember)
         )
 
         assertEquals(false, shouldRemoteMute)
@@ -58,9 +79,11 @@ class ShouldRemoteMuteCheckerTest {
             .arrange()
 
         val shouldRemoteMute = checker.check(
+            senderUserId = OTHER_USER_ID,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = targetsWithCurrentUser
+            targets = targetsWithCurrentUser,
+            conversationMembers = listOf(conversationMember)
         )
 
         assertEquals(true, shouldRemoteMute)
@@ -72,9 +95,11 @@ class ShouldRemoteMuteCheckerTest {
             .arrange()
 
         val shouldRemoteMute = checker.check(
+            senderUserId = OTHER_USER_ID,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = targetsWithDifferentClientId
+            targets = targetsWithDifferentClientId,
+            conversationMembers = listOf(conversationMember)
         )
 
         assertEquals(false, shouldRemoteMute)
@@ -119,6 +144,10 @@ class ShouldRemoteMuteCheckerTest {
                     OTHER_USER_ID.value to listOf(OTHER_CLIENT_ID, OTHER_CLIENT_ID)
                 ),
             )
+        )
+
+        val conversationMember = Conversation.Member(
+            OTHER_USER_ID, Conversation.Member.Role.Admin
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to check if the remote mute event is coming from a conversation admin. If not, then we should not apply the remote mute on the call

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
