### PR TITLE
fix: improve pending events check performance

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -145,7 +145,7 @@ internal class EventGathererImpl(
         val envelope = webSocketEvent.payload
         val obfuscatedId = envelope.event.id.obfuscateId()
         if (offlineEventBuffer.contains(envelope.event)) {
-            if (offlineEventBuffer.clearBufferIfLastEventEquals(envelope.event)) {
+            if (offlineEventBuffer.clearHistoryIfLastEventEquals(envelope.event)) {
                 // Really live
                 logger.d("Removed most recent event from offlineEventBuffer: '$obfuscatedId'")
             } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -82,7 +82,7 @@ internal class EventGathererImpl(
     // TODO: Refactor so currentSource is emitted through the gatherEvents flow, instead of having two separated flows
     override val currentSource: StateFlow<EventSource> get() = _currentSource.asStateFlow()
 
-    private val offlineEventBuffer = PendingEventsBuffer()
+    private val offlineEventBuffer = EventProcessingHistory()
     private val logger = kaliumLogger.withFeatureId(SYNC)
 
     override suspend fun gatherEvents(): Flow<EventEnvelope> = flow {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessingHistory.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessingHistory.kt
@@ -23,19 +23,21 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /**
- * Stores pending events as they are collected, used to
- * check if an event was already collected (duplicated, present in both pending and live sources).
+ * In-memory event storage, used to check if an event was already
+ * dealt with and avoid duplication. _i.e._ present in both pending and live sources.
  *
  * All operations are thread-safe.
  */
-internal class PendingEventsBuffer {
-    private val events = mutableListOf<Event>()
+internal class EventProcessingHistory {
+    private val events = hashSetOf<Event>()
+    private var lastAddedEvent: Event? = null
     private val mutex = Mutex()
 
     /**
      * Adds an [event] to the end of this storage.
      */
     suspend fun add(event: Event) = mutex.withLock {
+        lastAddedEvent = event
         events.add(event)
     }
 
@@ -60,8 +62,9 @@ internal class PendingEventsBuffer {
      *         False otherwise.
      */
     suspend fun clearBufferIfLastEventEquals(event: Event): Boolean = mutex.withLock {
-        if (events.last() == event) {
+        if (event == lastAddedEvent) {
             events.clear()
+            lastAddedEvent = null
             true
         } else {
             false
@@ -72,6 +75,7 @@ internal class PendingEventsBuffer {
      * Clears the storage, removes every previously added [Event].
      */
     suspend fun clear() = mutex.withLock {
+        lastAddedEvent = null
         events.clear()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessingHistory.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessingHistory.kt
@@ -61,7 +61,7 @@ internal class EventProcessingHistory {
      * @return True if this [event] was the one added most recently and the storage was cleared.
      *         False otherwise.
      */
-    suspend fun clearBufferIfLastEventEquals(event: Event): Boolean = mutex.withLock {
+    suspend fun clearHistoryIfLastEventEquals(event: Event): Boolean = mutex.withLock {
         if (event == lastAddedEvent) {
             events.clear()
             lastAddedEvent = null

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessingHistoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessingHistoryTest.kt
@@ -93,7 +93,7 @@ class EventProcessingHistoryTest {
         eventsBuffer.add(event1)
         eventsBuffer.add(event2)
 
-        val result = eventsBuffer.clearBufferIfLastEventEquals(event2)
+        val result = eventsBuffer.clearHistoryIfLastEventEquals(event2)
 
         assertTrue(result)
     }
@@ -105,7 +105,7 @@ class EventProcessingHistoryTest {
         eventsBuffer.add(event1)
         eventsBuffer.add(event2)
 
-        eventsBuffer.clearBufferIfLastEventEquals(event2)
+        eventsBuffer.clearHistoryIfLastEventEquals(event2)
 
         assertFalse { eventsBuffer.contains(event1) }
         assertFalse { eventsBuffer.contains(event2) }
@@ -131,7 +131,7 @@ class EventProcessingHistoryTest {
         eventsBuffer.add(event1)
         eventsBuffer.add(event2)
 
-        val result = eventsBuffer.clearBufferIfLastEventEquals(event1)
+        val result = eventsBuffer.clearHistoryIfLastEventEquals(event1)
 
         assertFalse(result)
     }
@@ -143,7 +143,7 @@ class EventProcessingHistoryTest {
         eventsBuffer.add(event1)
         eventsBuffer.add(event2)
 
-        eventsBuffer.clearBufferIfLastEventEquals(event1)
+        eventsBuffer.clearHistoryIfLastEventEquals(event1)
 
         assertTrue { eventsBuffer.contains(event1) }
         assertTrue { eventsBuffer.contains(event2) }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the device goes offline for an extended amount of time, the list of pending events will grow, which makes the current `PendingEventBuffer` slow when calling `contains`, as it is backed by an `ArrayList`.

### Solutions

Rename `PendingEventBuffer` to `EventProcessingHistory` so it's easier to understand its purpose, as it doesn't quite work as a _buffer_, but rather a "look back into history" thing.

Just replace the list with a `hashSet` for constant-time lookup.
- Add a `lastAddedEvent` for internal usage, in order to keep `clearHistoryIfLastEventEquals` working.

### Dependencies

Contains changes of the PR:
- #2459

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

### Attachments

Although we're mostly expecting to have up to a handful of thousand events in "normal" scenarios. Having 10k or so events isn't that hard in bigger teams.

Although this benchmark is quite extreme and unrealistic, we can see that the overhead can be bigger once the 10k point is reached, especially on mobile.

When running 100k events, it timed-out on 100s.

-----
        // Before change / Ryzen 9 7950X
        // Time taken to check 1_000 events: 8.503900ms
        // Time taken to check 5_000 events: 48.001100ms
        // Time taken to check 10_000 events: 123.374ms
        // Time taken to check 100_000 events: 8.805900200s
        // Time taken to check 200_000 events: 39.982060600s

        // Before change / Pixel 7 Pro
        // Time taken to check 1_000 events: 87.146607ms
        // Time taken to check 5_000 events: 1.556234091s
        // Time taken to check 10_000 events: 6.036795251s
        // Time taken to check 100_000 events: Timeout (100+ seconds)

-----

        // After change / Ryzen 9 7950X
        // Time taken to check 1_000 events: 3.728200ms
        // Time taken to check 5_000 events: 5.591400ms
        // Time taken to check 10_000 events: 7.627500ms
        // Time taken to check 100_000 events: 29.892500ms
        // Time taken to check 200_000 events: 45.879800ms

        // After change / Pixel 7 Pro
        // Time taken to check 1_000 events: 32.855021ms / Pixel 7 Pro
        // Time taken to check 5_000 events: 157.673747ms / Pixel 7 Pro
        // Time taken to check 10_000 events: 297.535115ms / Pixel 7 Pro
        // Time taken to check 100_000 events: 1.185030315s / Pixel 7 Pro
        // Time taken to check 200_000 events: 1.616787842s / Pixel 7 Pro

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
