### PR TITLE
fix: release: Do not show EnrollE2EI dialog after login (WPB-6364)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -134,7 +134,7 @@ interface MLSConversationRepository {
         isNewClient: Boolean = false
     ): Either<CoreFailure, Unit>
 
-    suspend fun getClientIdentity(clientId: ClientId): Either<CoreFailure, WireIdentity>
+    suspend fun getClientIdentity(clientId: ClientId): Either<CoreFailure, WireIdentity?>
     suspend fun getUserIdentity(userId: UserId): Either<CoreFailure, List<WireIdentity>>
     suspend fun getMembersIdentities(
         conversationId: ConversationId,
@@ -586,7 +586,7 @@ internal class MLSConversationDataSource(
                     mlsClient.getDeviceIdentities(
                         it.mlsGroupId,
                         listOf(CryptoQualifiedClientId(it.clientId, it.userId.toModel().toCrypto()))
-                    ).first()
+                    ).firstOrNull()
                 }
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetE2EICertificateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetE2EICertificateUseCase.kt
@@ -37,18 +37,19 @@ class GetE2eiCertificateUseCaseImpl internal constructor(
     override suspend operator fun invoke(clientId: ClientId): GetE2EICertificateUseCaseResult =
         mlsConversationRepository.getClientIdentity(clientId).fold(
             {
-                GetE2EICertificateUseCaseResult.Failure.NotActivated
+                GetE2EICertificateUseCaseResult.Failure
             },
             {
-                val certificate = pemCertificateDecoder.decode(it.certificate, it.status)
-                GetE2EICertificateUseCaseResult.Success(certificate)
+                it?.let {
+                    val certificate = pemCertificateDecoder.decode(it.certificate, it.status)
+                    GetE2EICertificateUseCaseResult.Success(certificate)
+                } ?: GetE2EICertificateUseCaseResult.NotActivated
             }
         )
 }
 
 sealed class GetE2EICertificateUseCaseResult {
     class Success(val certificate: E2eiCertificate) : GetE2EICertificateUseCaseResult()
-    sealed class Failure : GetE2EICertificateUseCaseResult() {
-        data object NotActivated : Failure()
-    }
+    data object NotActivated : GetE2EICertificateUseCaseResult()
+    data object Failure : GetE2EICertificateUseCaseResult()
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -126,35 +126,36 @@ class MLSConversationRepositoryTest {
     }
 
     @Test
-    fun givenCommitMessageWithNewDistributionPoints_whenDecryptingMessage_thenCheckRevocationList() = runTest(TestKaliumDispatcher.default) {
-        val messageWithNewDistributionPoints = Arrangement.DECRYPTED_MESSAGE_BUNDLE.copy(
-            crlNewDistributionPoints = listOf("url")
-        )
-        val (arrangement, mlsConversationRepository) = Arrangement()
-            .withGetMLSClientSuccessful()
-            .withDecryptMLSMessageSuccessful(messageWithNewDistributionPoints)
-            .withCheckRevocationListResult()
-            .arrange()
+    fun givenCommitMessageWithNewDistributionPoints_whenDecryptingMessage_thenCheckRevocationList() =
+        runTest(TestKaliumDispatcher.default) {
+            val messageWithNewDistributionPoints = Arrangement.DECRYPTED_MESSAGE_BUNDLE.copy(
+                crlNewDistributionPoints = listOf("url")
+            )
+            val (arrangement, mlsConversationRepository) = Arrangement()
+                .withGetMLSClientSuccessful()
+                .withDecryptMLSMessageSuccessful(messageWithNewDistributionPoints)
+                .withCheckRevocationListResult()
+                .arrange()
 
-        val epochChange = async(TestKaliumDispatcher.default) {
-            arrangement.epochsFlow.first()
+            val epochChange = async(TestKaliumDispatcher.default) {
+                arrangement.epochsFlow.first()
+            }
+            yield()
+
+            mlsConversationRepository.decryptMessage(Arrangement.COMMIT, Arrangement.GROUP_ID)
+
+            verify(arrangement.checkRevocationList)
+                .suspendFunction(arrangement.checkRevocationList::invoke)
+                .with(any())
+                .wasInvoked(once)
+
+            verify(arrangement.certificateRevocationListRepository)
+                .suspendFunction(arrangement.certificateRevocationListRepository::addOrUpdateCRL)
+                .with(any(), any())
+                .wasInvoked(once)
+
+            assertEquals(Arrangement.GROUP_ID, epochChange.await())
         }
-        yield()
-
-        mlsConversationRepository.decryptMessage(Arrangement.COMMIT, Arrangement.GROUP_ID)
-
-        verify(arrangement.checkRevocationList)
-            .suspendFunction(arrangement.checkRevocationList::invoke)
-            .with(any())
-            .wasInvoked(once)
-
-        verify(arrangement.certificateRevocationListRepository)
-            .suspendFunction(arrangement.certificateRevocationListRepository::addOrUpdateCRL)
-            .with(any(), any())
-            .wasInvoked(once)
-
-        assertEquals(Arrangement.GROUP_ID, epochChange.await())
-    }
 
     @Test
     fun givenSuccessfulResponses_whenCallingEstablishMLSGroup_thenGroupIsCreatedAndCommitBundleIsSentAndAccepted() = runTest {
@@ -1319,14 +1320,14 @@ class MLSConversationRepositoryTest {
     }
 
     @Test
-    fun givenGetClientId_whenGetUserIdentitiesFails_thenReturnsError() = runTest {
+    fun givenGetClientId_whenGetUserIdentitiesEmpty_thenReturnsNull() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetMLSClientSuccessful()
             .withGetDeviceIdentitiesReturn(emptyList())
             .withGetE2EIConversationClientInfoByClientIdReturns(E2EI_CONVERSATION_CLIENT_INFO_ENTITY)
             .arrange()
 
-        mlsConversationRepository.getClientIdentity(TestClient.CLIENT_ID).shouldFail()
+        assertEquals(Either.Right(null), mlsConversationRepository.getClientIdentity(TestClient.CLIENT_ID))
 
         verify(arrangement.mlsClient)
             .suspendFunction(arrangement.mlsClient::getDeviceIdentities)
@@ -1555,11 +1556,13 @@ class MLSConversationRepositoryTest {
                 .whenInvokedWith(anything())
                 .then { Either.Right(keyPackages) }
         }
+
         fun withKeyPackageLimits(refillAmount: Int) = apply {
             given(keyPackageLimitsProvider).function(keyPackageLimitsProvider::refillAmount)
                 .whenInvoked()
                 .thenReturn(refillAmount)
         }
+
         fun withReplaceKeyPackagesReturning(result: Either<CoreFailure, Unit>) = apply {
             given(keyPackageRepository)
                 .suspendFunction(keyPackageRepository::replaceKeyPackages)
@@ -1772,7 +1775,7 @@ class MLSConversationRepositoryTest {
             const val EPOCH = 5UL
             const val RAW_GROUP_ID = "groupId"
             val GROUP_ID = GroupID(RAW_GROUP_ID)
-            val WELCOME_BUNDLE = WelcomeBundle(RAW_GROUP_ID,null)
+            val WELCOME_BUNDLE = WelcomeBundle(RAW_GROUP_ID, null)
             val TIME = DateTimeUtil.currentIsoDateTimeString()
             val INVALID_REQUEST_ERROR = KaliumException.InvalidRequestError(ErrorResponse(405, "", ""))
             val MLS_STALE_MESSAGE_ERROR = KaliumException.InvalidRequestError(ErrorResponse(409, "", "mls-stale-message"))

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
@@ -170,9 +170,10 @@ interface UserConfigStorage {
     fun isGuestRoomLinkEnabledFlow(): Flow<IsGuestRoomLinkEnabledEntity?>
     fun isScreenshotCensoringEnabledFlow(): Flow<Boolean>
     fun persistScreenshotCensoring(enabled: Boolean)
-    fun setE2EINotificationTime(timeStamp: Long)
+    fun setIfAbsentE2EINotificationTime(timeStamp: Long)
     fun getE2EINotificationTime(): Long?
     fun e2EINotificationTimeFlow(): Flow<Long?>
+    fun updateE2EINotificationTime(timeStamp: Long)
 }
 
 @Serializable
@@ -464,13 +465,15 @@ class UserConfigStorageImpl(
         .onStart { emit(getE2EISettings()) }
         .distinctUntilChanged()
 
-    override fun setE2EINotificationTime(timeStamp: Long) {
-        kaliumPreferences.putLong(
-            E2EI_NOTIFICATION_TIME,
-            timeStamp
-        ).also {
-            e2EINotificationFlow.tryEmit(Unit)
+    override fun setIfAbsentE2EINotificationTime(timeStamp: Long) {
+        getE2EINotificationTime()?.let { current ->
+            if (current <= 0)
+                kaliumPreferences.putLong(E2EI_NOTIFICATION_TIME, timeStamp).also { e2EINotificationFlow.tryEmit(Unit) }
         }
+    }
+
+    override fun updateE2EINotificationTime(timeStamp: Long) {
+        kaliumPreferences.putLong(E2EI_NOTIFICATION_TIME, timeStamp).also { e2EINotificationFlow.tryEmit(Unit) }
     }
 
     override fun getE2EINotificationTime(): Long? {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
@@ -466,8 +466,8 @@ class UserConfigStorageImpl(
         .distinctUntilChanged()
 
     override fun setIfAbsentE2EINotificationTime(timeStamp: Long) {
-        getE2EINotificationTime()?.let { current ->
-            if (current <= 0)
+        getE2EINotificationTime().let { current ->
+            if (current == null || current <= 0)
                 kaliumPreferences.putLong(E2EI_NOTIFICATION_TIME, timeStamp).also { e2EINotificationFlow.tryEmit(Unit) }
         }
     }


### PR DESCRIPTION
# What's new in this PR?

### Issues

The are 2 issues: 

1. After login and enrolling the E2EI certificate user still see the "Enroll E2EI" dialog 
2. Grace period for enrolling E2EI certificate resets on every app opening. 

### Causes (Optional)

1. When user logs in, CC returns an error on getMLSClient, app interprets it as "user doesn't have certificate" and asks user to get it.
2. `E2EIConfigHandler` is called in Syncing and on every sync grace period (which app gets as a period, not exact date) resets

### Solutions

1. 
- update `ObserveE2EIRequiredUseCase` so the error while getting the current client certificate means "Something went wrong, don't show the dialog yet"
- update `MLSConversationRepository.getClientIdentity` to return `null` if client has no certificate (not an error).

2. 
Update `UserConfigStorage.setE2EINotificationTime` -> `UserConfigStorage.setIfAbsentE2EINotificationTime` so the end of grace period is updated only when there is no saved date yet 
AND add `UserConfigStorage.updateE2EINotificationTime` for updating that date when user snoozes the E2EI dialog.

