### PR TITLE
fix: crash when answering a call (WPB-6183)

### DIFF
--- a/.github/workflows/gradle-android-instrumented-tests.yml
+++ b/.github/workflows/gradle-android-instrumented-tests.yml
@@ -25,12 +25,6 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            -   name: Enable KVM group perms # For a faster emulator
-                run: |
-                    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-                    sudo udevadm control --reload-rules
-                    sudo udevadm trigger --name-match=kvm
-
             -   name: Set up JDK
                 uses: actions/setup-java@v4
                 with:

--- a/.github/workflows/gradle-android-instrumented-tests.yml
+++ b/.github/workflows/gradle-android-instrumented-tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: ./.github/workflows/codestyle.yml
     gradle-run-tests:
         needs: [ detekt ]
-        runs-on: ubuntu-22.04
+        runs-on: buildjet-4vcpu-ubuntu-2204
         strategy:
             matrix:
                 api-level: [ 30 ]
@@ -26,7 +26,7 @@ jobs:
                     fetch-depth: 0
 
             -   name: Set up JDK
-                uses: actions/setup-java@v4
+                uses: buildjet/setup-java@v3
                 with:
                     java-version: '17'
                     distribution: 'temurin'
@@ -42,37 +42,36 @@ jobs:
                 run: |
                     ./gradlew :samples:compileDebugSources
 
-            -   name: AVD cache
-                uses: actions/cache@v4
-                id: avd-cache
-                with:
-                    path: |
-                        ~/.android/avd/*
-                        ~/.android/adb*
-                    key: avd-${{ matrix.api-level }}
+            # - name: AVD cache
+            #   uses: actions/cache@v3
+            #   id: avd-cache
+            #   with:
+            #       path: |
+            #           ~/.android/avd/*
+            #           ~/.android/adb*
+            #       key: avd-${{ matrix.api-level }}
 
-            -   name: Create AVD and generate snapshot for caching
-                if: steps.avd-cache.outputs.cache-hit != 'true'
-                uses: reactivecircus/android-emulator-runner@v2
-                with:
-                    api-level: ${{ matrix.api-level }}
-                    force-avd-creation: false
-                    target: google_apis
-                    emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                    cores: 2
-                    ram-size: 4096M
-                    heap-size: 2048M
-                    disable-animations: false
-                    script: echo "Generated AVD snapshot for caching."
+            # - name: Create AVD and generate snapshot for caching
+            #   if: steps.avd-cache.outputs.cache-hit != 'true'
+            #   uses: reactivecircus/android-emulator-runner@v2.27.0
+            #   with:
+            #       api-level: ${{ matrix.api-level }}
+            #       force-avd-creation: false
+            #       target: google_apis
+            #       emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+            #       cores: 4
+            #       ram-size: 4096M
+            #       heap-size: 2048M
+            #       disable-animations: false
+            #       script: echo "Generated AVD snapshot for caching."
 
             -   name: Android Instrumentation Tests
-                uses: reactivecircus/android-emulator-runner@v2
+                uses: reactivecircus/android-emulator-runner@v2.27.0
                 with:
                     api-level: ${{ matrix.api-level }}
-                    force-avd-creation: false
                     target: google_apis
                     emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                    cores: 2
+                    cores: 4
                     ram-size: 4096M
                     heap-size: 2048M
                     script: ./gradlew connectedAndroidOnlyAffectedTest
@@ -82,14 +81,14 @@ jobs:
 
             -   name: Archive Test Reports
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v3
                 with:
                     name: test-reports
                     path: ./**/build/reports/tests/**
 
             -   name: Archive Test Results
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v3
                 with:
                     name: test-results
                     path: |
@@ -105,7 +104,7 @@ jobs:
                         **/build/outputs/androidTest-results/**/*.xml
 
             -   name: Cleanup Gradle Cache
-                  # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+                # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
                 # Restoring these files from a GitHub Actions cache might cause problems for future builds.
                 run: |
                     rm -f ~/.gradle/caches/modules-2/modules-2.lock
@@ -118,7 +117,7 @@ jobs:
 
         steps:
             -   name: Download tests results
-                uses: actions/download-artifact@v4
+                uses: actions/download-artifact@v3
                 continue-on-error: true
                 with:
                     name: test-results

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -28,9 +28,10 @@ import com.wire.kalium.logic.data.call.Participant
 import com.wire.kalium.logic.data.call.mapper.ParticipantMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 @Suppress("LongParameterList")
@@ -53,13 +54,15 @@ class OnParticipantListChanged internal constructor(
             participantsChange.members.map { member ->
                 val participant = participantMapper.fromCallMemberToParticipant(member)
                 val userId = qualifiedIdMapper.fromStringToQualifiedID(member.userId)
-                userRepository.getKnownUserMinimized(userId).also {
+                userRepository.getKnownUserMinimized(userId).onSuccess {
                     val updatedParticipant = participant.copy(
-                        name = it?.name!!,
+                        name = it.name,
                         avatarAssetId = it.completePicture,
                         userType = it.userType
                     )
                     participants.add(updatedParticipant)
+                }.onFailure {
+                    participants.add(participant)
                 }
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/Participant.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/Participant.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.data.user.type.UserType
 data class Participant(
     val id: QualifiedID,
     val clientId: String,
-    val name: String = "",
+    val name: String? = null,
     val isMuted: Boolean,
     val isCameraOn: Boolean,
     val isSpeaking: Boolean = false,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/ParticipantsOrderByName.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/ParticipantsOrderByName.kt
@@ -23,5 +23,5 @@ interface ParticipantsOrderByName {
 }
 
 class ParticipantsOrderByNameImpl : ParticipantsOrderByName {
-    override fun sortItems(participants: List<Participant>) = participants.sortedBy { it.name.uppercase() }
+    override fun sortItems(participants: List<Participant>) = participants.sortedBy { it.name?.uppercase() }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -101,7 +101,7 @@ interface UserRepository {
     suspend fun getSelfUser(): SelfUser?
     suspend fun observeAllKnownUsers(): Flow<Either<StorageFailure, List<OtherUser>>>
     suspend fun getKnownUser(userId: UserId): Flow<OtherUser?>
-    suspend fun getKnownUserMinimized(userId: UserId): OtherUserMinimized?
+    suspend fun getKnownUserMinimized(userId: UserId): Either<StorageFailure, OtherUserMinimized>
     suspend fun getUsersWithOneOnOneConversation(): List<OtherUser>
     suspend fun observeUser(userId: UserId): Flow<User?>
     suspend fun userById(userId: UserId): Either<CoreFailure, OtherUser>
@@ -426,10 +426,12 @@ internal class UserDataSource internal constructor(
             }
     }
 
-    override suspend fun getKnownUserMinimized(userId: UserId) = userDAO.getUserMinimizedByQualifiedID(
-        qualifiedID = userId.toDao()
-    )?.let {
-        userMapper.fromUserEntityToOtherUserMinimized(it)
+    override suspend fun getKnownUserMinimized(userId: UserId) = wrapStorageRequest {
+        userDAO.getUserMinimizedByQualifiedID(
+            qualifiedID = userId.toDao()
+        )?.let {
+            userMapper.fromUserEntityToOtherUserMinimized(it)
+        }
     }
 
     override suspend fun observeUser(userId: UserId): Flow<User?> =


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App could crash when user's name is null. 

### Causes (Optional)

It may happens when there is no conversation in common between some call members.

### Solutions

In kalium side if there is no user yet available we just return a null as value and it's up to UI to display a default value in this case.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
