### PR TITLE
feat: allow http calls when checking Certificate Revocation List (WPB-6493)

### DIFF
--- a/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
+++ b/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
@@ -17,11 +17,15 @@
  */
 package com.wire.kalium.network
 
+import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
-@Suppress("FunctionName")
-fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpSingleton.createNew(block)
+fun buildOkhttpClient(block: OkHttpClient.Builder.() -> Unit): OkHttpClient =
+    OkHttpSingleton.createNew(block)
+
+fun buildClearTextTrafficOkhttpClient(): OkHttpClient =
+    OkHttpSingleton.createNewClearTextTrafficClient()
 
 private object OkHttpSingleton {
     private val sharedClient by lazy {
@@ -35,8 +39,15 @@ private object OkHttpSingleton {
                 .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
         }.connectionSpecs(supportedConnectionSpecs()).build()
     }
+    private val clearTextTrafficClient by lazy {
+        OkHttpClient.Builder().apply {
+            connectionSpecs(listOf(ConnectionSpec.CLEARTEXT))
+        }.build()
+    }
 
     fun createNew(block: OkHttpClient.Builder.() -> Unit): OkHttpClient {
         return sharedClient.newBuilder().apply(block).build()
     }
+
+    fun createNewClearTextTrafficClient(): OkHttpClient = clearTextTrafficClient
 }

--- a/network/src/androidUnitTest/kotlin/com/wire/kalium/api/tools/HttpClientConnectionSpecsTest.kt
+++ b/network/src/androidUnitTest/kotlin/com/wire/kalium/api/tools/HttpClientConnectionSpecsTest.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.api.tools
 
-import com.wire.kalium.network.OkhttpClientFactory
+import com.wire.kalium.network.buildOkhttpClient
 import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
 import okhttp3.TlsVersion
@@ -51,7 +51,7 @@ class HttpClientConnectionSpecsTest {
         )
 
         // when
-        val connectionSpecs = OkhttpClientFactory { }.connectionSpecs
+        val connectionSpecs = buildOkhttpClient { }.connectionSpecs
 
         // then
         with(connectionSpecs[0]) {

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -45,7 +45,7 @@ actual fun defaultHttpEngine(
     ignoreSSLCertificates: Boolean,
     certificatePinning: CertificatePinning
 ): HttpClientEngine = OkHttp.create {
-    OkhttpClientFactory {
+    buildOkhttpClient {
         if (certificatePinning.isNotEmpty() && !ignoreSSLCertificates) {
             val certPinner = CertificatePinner.Builder().apply {
                 certificatePinning.forEach { (cert, hosts) ->
@@ -103,5 +103,9 @@ private fun OkHttpClient.Builder.ignoreAllSSLErrors() {
 
 fun supportedConnectionSpecs(): List<ConnectionSpec> {
     val wireSpec = ConnectionSpec.Builder(ConnectionSpec.RESTRICTED_TLS).build()
-    return listOf(wireSpec, ConnectionSpec.CLEARTEXT)
+    return listOf(wireSpec)
+}
+
+actual fun clearTextTrafficEngine(): HttpClientEngine = OkHttp.create {
+    buildClearTextTrafficOkhttpClient()
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -29,3 +29,6 @@ expect fun defaultHttpEngine(
     ignoreSSLCertificates: Boolean = false,
     certificatePinning: CertificatePinning
 ): HttpClientEngine
+
+
+expect fun clearTextTrafficEngine(): HttpClientEngine

--- a/network/src/jvmMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
+++ b/network/src/jvmMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
@@ -17,11 +17,13 @@
  */
 package com.wire.kalium.network
 
+import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
-@Suppress("FunctionName")
-fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpClient.Builder()
+fun buildOkhttpClient(
+    block: OkHttpClient.Builder.() -> Unit
+): OkHttpClient = OkHttpClient.Builder()
     .apply(block)
     .apply {
 
@@ -33,3 +35,8 @@ fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = 
             .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
             .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
     }.connectionSpecs(supportedConnectionSpecs()).build()
+
+fun buildClearTextTrafficOkhttpClient(): OkHttpClient = OkHttpClient.Builder().apply {
+    connectionSpecs(listOf(ConnectionSpec.CLEARTEXT))
+}.build()
+

--- a/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
+++ b/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium
 
-import com.wire.kalium.network.OkhttpClientFactory
+import com.wire.kalium.network.buildOkhttpClient
 import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
 import okhttp3.TlsVersion
@@ -51,7 +51,7 @@ class HttpClientConnectionSpecsTest {
         )
 
         // when
-        val connectionSpecs = OkhttpClientFactory { }.connectionSpecs
+        val connectionSpecs = buildOkhttpClient { }.connectionSpecs
 
         // then
         with(connectionSpecs[0]) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to verify certificates by fetching Certificate Revocation List. This CRL can only be called on HTTP, it's already signed by the issuer so there is no security issue.

BUT by default, Android OS does not allow HTTP calls and throw an exception for that.

### Solutions

In AndroidManifest, I allowed `usesCleartextTraffic` and created in a new okhttp client that could be use on HTTP.

Others calls are still called on HTTPS as we `okhttpClient` with `ConnectionSpec.RESTRICTED_TLS`

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
