### PR TITLE
feat: allow configuration to the number of team members fetched during slow sync

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -919,7 +919,7 @@ class UserSessionScope internal constructor(
         get() = SyncSelfTeamUseCaseImpl(
             userRepository = userRepository,
             teamRepository = teamRepository,
-            fetchAllTeamMembersEagerly = kaliumConfigs.fetchAllTeamMembersEagerly
+            fetchedUsersLimit = kaliumConfigs.limitTeamMembersFetchDuringSlowSync
         )
 
     private val joinExistingMLSConversationUseCase: JoinExistingMLSConversationUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCase.kt
@@ -35,7 +35,7 @@ internal interface SyncSelfTeamUseCase {
 internal class SyncSelfTeamUseCaseImpl(
     private val userRepository: UserRepository,
     private val teamRepository: TeamRepository,
-    private val fetchAllTeamMembersEagerly: Boolean
+    private val fetchedUsersLimit: Int?
 ) : SyncSelfTeamUseCase {
 
     override suspend fun invoke(): Either<CoreFailure, Unit> {
@@ -43,15 +43,11 @@ internal class SyncSelfTeamUseCaseImpl(
 
         return user.teamId?.let { teamId ->
             teamRepository.fetchTeamById(teamId = teamId).flatMap {
-                if (fetchAllTeamMembersEagerly) {
-                    kaliumLogger.withFeatureId(SYNC).i("Fetching all team members eagerly")
-                    teamRepository.fetchMembersByTeamId(
-                        teamId = teamId,
-                        userDomain = user.id.domain
-                    )
-                } else {
-                    Either.Right(Unit)
-                }
+                teamRepository.fetchMembersByTeamId(
+                    teamId = teamId,
+                    userDomain = user.id.domain,
+                    fetchedUsersLimit = fetchedUsersLimit
+                )
             }.onSuccess {
                 teamRepository.syncServices(teamId = teamId)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -45,7 +45,10 @@ data class KaliumConfigs(
     val mockNetworkStateObserver: NetworkStateObserver? = null,
     // Interval between attempts to advance the proteus to MLS migration
     val mlsMigrationInterval: Duration = 24.hours,
-    val fetchAllTeamMembersEagerly: Boolean = false,
+    // limit for the number of team members to fetch during slow sync
+    // if null there will be no limit and all team members will be fetched
+    // preferably it should be a multiple of TeamRepository.FETCH_TEAM_MEMBER_PAGE_SIZE
+    val limitTeamMembersFetchDuringSlowSync: Int? = null,
     val maxRemoteSearchResultCount: Int = 30
 )
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

we need to fetch the first 200 team members on android

### Solutions

add configuration to the number of team members fetched during slow sync

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
