### PR TITLE
refactor: return the same token that was updated from storage

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
@@ -19,7 +19,6 @@
 package com.wire.kalium.logic.data.session
 
 import com.wire.kalium.logic.data.auth.login.ProxyCredentials
-import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionMapper.kt
@@ -46,6 +46,7 @@ interface SessionMapper {
     fun toLogoutReasonEntity(reason: LogoutReason): LogoutReasonEntity
     fun toSsoIdEntity(ssoId: SsoId?): SsoIdEntity?
     fun toAuthTokensEntity(authSession: AccountTokens): AuthTokenEntity
+    fun toAccountTokens(authSession: AuthTokenEntity): AccountTokens
     fun fromSsoIdEntity(ssoIdEntity: SsoIdEntity?): SsoId?
     fun toLogoutReason(reason: LogoutReasonEntity): LogoutReason
     fun fromEntityToProxyCredentialsDTO(proxyCredentialsEntity: ProxyCredentialsEntity): ProxyCredentialsDTO
@@ -58,9 +59,7 @@ interface SessionMapper {
 }
 
 @Suppress("TooManyFunctions")
-internal class SessionMapperImpl(
-    private val idMapper: IdMapper
-) : SessionMapper {
+internal class SessionMapperImpl : SessionMapper {
 
     override fun toSessionDTO(authSession: AccountTokens): SessionDTO = with(authSession) {
         SessionDTO(
@@ -121,6 +120,14 @@ internal class SessionMapperImpl(
             cookieLabel = cookieLabel
         )
     }
+
+    override fun toAccountTokens(authSession: AuthTokenEntity): AccountTokens = AccountTokens(
+        userId = authSession.userId.toModel(),
+        accessToken = authSession.accessToken,
+        refreshToken = authSession.refreshToken,
+        tokenType = authSession.tokenType,
+        cookieLabel = authSession.cookieLabel
+    )
 
     override fun fromSsoIdEntity(ssoIdEntity: SsoIdEntity?): SsoId? =
         ssoIdEntity?.let { SsoId(scimExternalId = it.scimExternalId, subject = it.subject, tenant = it.tenant) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -104,7 +104,7 @@ internal object MapperProvider {
     fun apiVersionMapper(): ApiVersionMapper = ApiVersionMapperImpl()
     fun idMapper(): IdMapper = IdMapperImpl()
     fun serverConfigMapper(): ServerConfigMapper = ServerConfigMapperImpl(apiVersionMapper(), idMapper())
-    fun sessionMapper(): SessionMapper = SessionMapperImpl(idMapper())
+    fun sessionMapper(): SessionMapper = SessionMapperImpl()
     fun availabilityStatusMapper(): AvailabilityStatusMapper = AvailabilityStatusMapperImpl()
     fun connectionStateMapper(): ConnectionStateMapper = ConnectionStateMapperImpl()
     fun userMapper(): UserMapper = UserMapperImpl()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -560,7 +560,6 @@ class UserSessionScope internal constructor(
 
     private val accessTokenRefresher: AccessTokenRefresher
         get() = AccessTokenRefresherImpl(
-            userId = userId,
             repository = accessTokenRepository
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresher.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresher.kt
@@ -19,11 +19,9 @@ package com.wire.kalium.logic.feature.session.token
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.session.token.AccessTokenRepository
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.auth.AccountTokens
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
-import com.wire.kalium.logic.functional.map
 
 internal interface AccessTokenRefresher {
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresher.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresher.kt
@@ -40,7 +40,6 @@ internal interface AccessTokenRefresher {
 }
 
 internal class AccessTokenRefresherImpl(
-    private val userId: UserId,
     private val repository: AccessTokenRepository,
 ) : AccessTokenRefresher {
     override suspend fun refreshTokenAndPersistSession(
@@ -51,14 +50,7 @@ internal class AccessTokenRefresherImpl(
             refreshToken = currentRefreshToken,
             clientId = clientId
         ).flatMap { result ->
-            repository.persistTokens(result.accessToken, result.refreshToken).map {
-                AccountTokens(
-                    userId = userId,
-                    accessToken = result.accessToken,
-                    refreshToken = result.refreshToken,
-                    cookieLabel = null
-                )
-            }
+            repository.persistTokens(result.accessToken, result.refreshToken)
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresherFactory.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresherFactory.kt
@@ -38,7 +38,6 @@ internal class AccessTokenRefresherFactoryImpl(
 ) : AccessTokenRefresherFactory {
     override fun create(accessTokenApi: AccessTokenApi): AccessTokenRefresher {
         return AccessTokenRefresherImpl(
-            userId = userId,
             repository = AccessTokenRepositoryImpl(
                 userId = userId,
                 accessTokenApi = accessTokenApi,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/session/SessionMapperTest.kt
@@ -36,15 +36,11 @@ import kotlin.test.assertEquals
 import com.wire.kalium.network.api.base.model.UserId as UserIdDTO
 
 class SessionMapperTest {
-
-    @Mock
-    val idMapper = mock(classOf<IdMapper>())
-
     private lateinit var sessionMapper: SessionMapper
 
     @BeforeTest
     fun setup() {
-        sessionMapper = SessionMapperImpl(idMapper)
+        sessionMapper = SessionMapperImpl()
     }
 
     @Test
@@ -69,8 +65,6 @@ class SessionMapperTest {
     @Test
     fun givenAnAuthTokens_whenMappingToPersistenceAuthTokens_thenValuesAreMappedCorrectly() {
         val authSession: AccountTokens = TEST_AUTH_TOKENS
-
-        given(idMapper).invocation { idMapper.toSsoIdEntity(TEST_SSO_ID) }.then { TEST_SSO_ID_ENTITY }
 
         val expected: AuthTokenEntity = with(authSession) {
             AuthTokenEntity(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/AuthTokenStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/client/AuthTokenStorage.kt
@@ -77,7 +77,7 @@ internal class AuthTokenStorageImpl(
         val newToken = kaliumPreferences.getSerializable(key, AuthTokenEntity.serializer())
             ?.let {
                 it.copy(accessToken = accessToken, refreshToken = refreshToken ?: it.refreshToken, tokenType = tokenType)
-            } ?: error("No token found for user")
+            } ?: error("No token found for user ${userId.toLogString()}")
 
         kaliumPreferences.putSerializable(
             key,
@@ -102,10 +102,12 @@ internal class AuthTokenStorageImpl(
     override fun proxyCredentials(userId: UserIDEntity): ProxyCredentialsEntity? =
         kaliumPreferences.getSerializable(proxyCredentialsKey(userId), ProxyCredentialsEntity.serializer())
 
+    // DO NOT CHANE THE KEY FORMAT
     private fun tokenKey(userId: UserIDEntity): String {
         return "user_tokens_${userId.value}@${userId.domain}"
     }
 
+    // DO NOT CHANE THE KEY FORMAT
     private fun proxyCredentialsKey(userId: UserIDEntity): String {
         return "proxy_credentials_${userId.value}@${userId.domain}"
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

in token updated we were ignoring the token stored locally and creating a new one with cookieLabel = null 
this should not effect us but it is nice to use the same one that was stored since we do not to set the label to null 

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
