### PR TITLE
feat: allow http calls when checking Certificate Revocation List (WPB-6493) - cherrypick

### DIFF
--- a/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
+++ b/network/src/androidMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
@@ -17,11 +17,18 @@
  */
 package com.wire.kalium.network
 
+import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
-@Suppress("FunctionName")
-fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpSingleton.createNew(block)
+fun buildOkhttpClient(block: OkHttpClient.Builder.() -> Unit): OkHttpClient =
+    OkHttpSingleton.createNew {
+        connectionSpecs(supportedConnectionSpecs())
+        block()
+    }
+
+fun buildClearTextTrafficOkhttpClient(): OkHttpClient =
+    OkHttpSingleton.createNew { connectionSpecs(listOf(ConnectionSpec.CLEARTEXT)) }
 
 private object OkHttpSingleton {
     private val sharedClient by lazy {
@@ -33,7 +40,7 @@ private object OkHttpSingleton {
                 .connectTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
-        }.connectionSpecs(supportedConnectionSpecs()).build()
+        }.build()
     }
 
     fun createNew(block: OkHttpClient.Builder.() -> Unit): OkHttpClient {

--- a/network/src/androidUnitTest/kotlin/com/wire/kalium/api/tools/HttpClientConnectionSpecsTest.kt
+++ b/network/src/androidUnitTest/kotlin/com/wire/kalium/api/tools/HttpClientConnectionSpecsTest.kt
@@ -17,7 +17,8 @@
  */
 package com.wire.kalium.api.tools
 
-import com.wire.kalium.network.OkhttpClientFactory
+import com.wire.kalium.network.buildClearTextTrafficOkhttpClient
+import com.wire.kalium.network.buildOkhttpClient
 import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
 import okhttp3.TlsVersion
@@ -51,10 +52,12 @@ class HttpClientConnectionSpecsTest {
         )
 
         // when
-        val connectionSpecs = OkhttpClientFactory { }.connectionSpecs
+        val connectionSpecs = buildOkhttpClient {  }.connectionSpecs
 
         // then
         with(connectionSpecs[0]) {
+            assertEquals(ConnectionSpec.RESTRICTED_TLS, this)
+
             tlsVersions?.let {
                 assertTrue { it.containsAll(validTlsVersions) }
                 assertFalse { it.containsAll(notValidTlsVersions) }
@@ -65,6 +68,13 @@ class HttpClientConnectionSpecsTest {
                 assertFalse { it.containsAll(notValidCipherSuites) }
             }
         }
-        assertEquals(connectionSpecs[1], ConnectionSpec.CLEARTEXT)
+    }
+
+    @Test
+    fun givenOkHttpSingleton_whenBuildingClearTextTrafficOkhttpClient_thenEnsureConnectionSpecClearText() {
+
+        val connectionSpecs = buildClearTextTrafficOkhttpClient()
+
+        assertEquals(ConnectionSpec.CLEARTEXT, connectionSpecs.connectionSpecs.first())
     }
 }

--- a/network/src/appleMain/kotlin/com/wire/kalium/network/defaultHttpEngine.kt
+++ b/network/src/appleMain/kotlin/com/wire/kalium/network/defaultHttpEngine.kt
@@ -54,3 +54,5 @@ actual fun defaultHttpEngine(
 
     }
 }
+
+actual fun clearTextTrafficEngine(): HttpClientEngine = Darwin.create()

--- a/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -45,7 +45,9 @@ actual fun defaultHttpEngine(
     ignoreSSLCertificates: Boolean,
     certificatePinning: CertificatePinning
 ): HttpClientEngine = OkHttp.create {
-    OkhttpClientFactory {
+    buildOkhttpClient {
+        connectionSpecs(supportedConnectionSpecs())
+
         if (certificatePinning.isNotEmpty() && !ignoreSSLCertificates) {
             val certPinner = CertificatePinner.Builder().apply {
                 certificatePinning.forEach { (cert, hosts) ->
@@ -103,5 +105,9 @@ private fun OkHttpClient.Builder.ignoreAllSSLErrors() {
 
 fun supportedConnectionSpecs(): List<ConnectionSpec> {
     val wireSpec = ConnectionSpec.Builder(ConnectionSpec.RESTRICTED_TLS).build()
-    return listOf(wireSpec, ConnectionSpec.CLEARTEXT)
+    return listOf(wireSpec)
+}
+
+actual fun clearTextTrafficEngine(): HttpClientEngine = OkHttp.create {
+    buildClearTextTrafficOkhttpClient()
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/HttpEngine.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/HttpEngine.kt
@@ -29,3 +29,5 @@ expect fun defaultHttpEngine(
     ignoreSSLCertificates: Boolean = false,
     certificatePinning: CertificatePinning
 ): HttpClientEngine
+
+expect fun clearTextTrafficEngine(): HttpClientEngine

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/ACMEApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/ACMEApiTest.kt
@@ -25,11 +25,9 @@ import com.wire.kalium.network.api.base.unbound.acme.*
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class ACMEApiTest : ApiTest() {
 
     @Ignore
@@ -46,7 +44,7 @@ internal class ACMEApiTest : ApiTest() {
                 assertNoQueryParams()
             }
         )
-        val acmeApi: ACMEApi = ACMEApiImpl(networkClient)
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
 
         acmeApi.getTrustAnchors(ACME_DISCOVERY_URL).also { actual ->
             assertIs<NetworkResponse.Success<CertificateChain>>(actual)
@@ -67,7 +65,7 @@ internal class ACMEApiTest : ApiTest() {
                 assertNoQueryParams()
             }
         )
-        val acmeApi: ACMEApi = ACMEApiImpl(networkClient)
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
 
         acmeApi.getACMEDirectories(ACME_DISCOVERY_URL).also { actual ->
             assertIs<NetworkResponse.Success<AcmeDirectoriesResponse>>(actual)
@@ -88,7 +86,7 @@ internal class ACMEApiTest : ApiTest() {
                 assertNoQueryParams()
             }
         )
-        val acmeApi: ACMEApi = ACMEApiImpl(networkClient)
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
 
         acmeApi.getACMENonce(ACME_DIRECTORIES_SAMPLE.newNonce).also { actual ->
             assertIs<NetworkResponse.Success<String>>(actual)
@@ -110,7 +108,7 @@ internal class ACMEApiTest : ApiTest() {
                 assertNoQueryParams()
             }
         )
-        val acmeApi: ACMEApi = ACMEApiImpl(networkClient)
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
 
         acmeApi.sendACMERequest("", byteArrayOf(0x12, 0x24, 0x32, 0x42)).also { actual ->
             assertIs<NetworkResponse.Success<ACMEResponse>>(actual)
@@ -134,7 +132,7 @@ internal class ACMEApiTest : ApiTest() {
                 assertNoQueryParams()
             }
         )
-        val acmeApi: ACMEApi = ACMEApiImpl(networkClient)
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
 
         val response = acmeApi.sendACMERequest(ACME_DIRECTORIES_SAMPLE.newNonce)
         assertFalse(response.isSuccessful())
@@ -154,7 +152,7 @@ internal class ACMEApiTest : ApiTest() {
                 assertNoQueryParams()
             }
         )
-        val acmeApi: ACMEApi = ACMEApiImpl(networkClient)
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
 
         acmeApi.sendACMERequest("", byteArrayOf(0x12, 0x24, 0x32, 0x42)).also { actual ->
             assertIs<NetworkResponse.Success<ACMEResponse>>(actual)
@@ -180,7 +178,7 @@ internal class ACMEApiTest : ApiTest() {
                 assertNoQueryParams()
             }
         )
-        val acmeApi: ACMEApi = ACMEApiImpl(networkClient)
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
 
         acmeApi.sendChallengeRequest(RANDOM_CHALLENGE_URL, byteArrayOf(0x12, 0x24, 0x32, 0x42)).also { actual ->
             assertIs<NetworkResponse.Success<ChallengeResponse>>(actual)

--- a/network/src/jvmMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
+++ b/network/src/jvmMain/kotlin/com/wire/kalium/network/OkhttpClientFactory.kt
@@ -17,11 +17,13 @@
  */
 package com.wire.kalium.network
 
+import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
-@Suppress("FunctionName")
-fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = OkHttpClient.Builder()
+fun buildOkhttpClient(
+    block: OkHttpClient.Builder.() -> Unit
+): OkHttpClient = OkHttpClient.Builder()
     .apply(block)
     .apply {
 
@@ -33,3 +35,7 @@ fun OkhttpClientFactory(block: OkHttpClient.Builder.() -> Unit): OkHttpClient = 
             .readTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
             .writeTimeout(WEBSOCKET_TIMEOUT, TimeUnit.MILLISECONDS)
     }.connectionSpecs(supportedConnectionSpecs()).build()
+
+fun buildClearTextTrafficOkhttpClient(): OkHttpClient = OkHttpClient.Builder().apply {
+    connectionSpecs(listOf(ConnectionSpec.CLEARTEXT))
+}.build()

--- a/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
+++ b/network/src/jvmTest/kotlin/com/wire/kalium/HttpClientConnectionSpecsTest.kt
@@ -17,7 +17,8 @@
  */
 package com.wire.kalium
 
-import com.wire.kalium.network.OkhttpClientFactory
+import com.wire.kalium.network.buildClearTextTrafficOkhttpClient
+import com.wire.kalium.network.buildOkhttpClient
 import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
 import okhttp3.TlsVersion
@@ -51,10 +52,11 @@ class HttpClientConnectionSpecsTest {
         )
 
         // when
-        val connectionSpecs = OkhttpClientFactory { }.connectionSpecs
+        val connectionSpecs = buildOkhttpClient { }.connectionSpecs
 
         // then
         with(connectionSpecs[0]) {
+            assertEquals(ConnectionSpec.RESTRICTED_TLS, this)
             tlsVersions?.let {
                 assertTrue { it.containsAll(validTlsVersions) }
                 assertFalse { it.containsAll(notValidTlsVersions) }
@@ -65,6 +67,13 @@ class HttpClientConnectionSpecsTest {
                 assertFalse { it.containsAll(notValidCipherSuites) }
             }
         }
-        assertEquals(connectionSpecs[1], ConnectionSpec.CLEARTEXT)
+    }
+
+    @Test
+    fun givenOkHttpSingleton_whenBuildingClearTextTrafficOkhttpClient_thenEnsureConnectionSpecClearText() {
+
+        val connectionSpecs = buildClearTextTrafficOkhttpClient()
+
+        assertEquals(ConnectionSpec.CLEARTEXT, connectionSpecs.connectionSpecs.first())
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

### Cherrypick of https://github.com/wireapp/kalium/pull/2491


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
