### PR TITLE
fix: release: Remove e2ei settings data on login (WPB-6495)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -238,7 +238,7 @@ internal class UserConfigDataSource internal constructor(
     override suspend fun clearE2EISettings() {
         wrapStorageRequest {
             userConfigStorage.setE2EISettings(null)
-            userConfigStorage.setE2EINotificationTime(0)
+            userConfigStorage.updateE2EINotificationTime(0)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -127,6 +127,7 @@ interface UserConfigRepository {
     suspend fun observeCertificateExpirationTime(url: String): Flow<Either<StorageFailure, ULong>>
     suspend fun setShouldNotifyForRevokedCertificate(shouldNotify: Boolean)
     suspend fun observeShouldNotifyForRevokedCertificate(): Flow<Either<StorageFailure, Boolean>>
+    suspend fun clearE2EISettings()
 }
 
 @Suppress("TooManyFunctions")
@@ -233,6 +234,13 @@ internal class UserConfigDataSource internal constructor(
                 userConfigStorage.setE2EINotificationTime(notifyUserAfterMs)
             }
         }
+
+    override suspend fun clearE2EISettings() {
+        wrapStorageRequest {
+            userConfigStorage.setE2EISettings(null)
+            userConfigStorage.setE2EINotificationTime(0)
+        }
+    }
 
     private fun getE2EINotificationTimeOrNull() =
         wrapStorageRequest { userConfigStorage.getE2EINotificationTime() }.getOrNull()
@@ -449,6 +457,7 @@ internal class UserConfigDataSource internal constructor(
 
     override suspend fun observeCertificateExpirationTime(url: String): Flow<Either<StorageFailure, ULong>> =
         userConfigDAO.observeCertificateExpirationTime(url).wrapStorageRequest()
+
     override suspend fun setShouldNotifyForRevokedCertificate(shouldNotify: Boolean) {
         userConfigDAO.setShouldNotifyForRevokedCertificate(shouldNotify)
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1785,6 +1785,7 @@ class UserSessionScope internal constructor(
             logoutRepository,
             globalScope.sessionRepository,
             clientRepository,
+            userConfigRepository,
             userId,
             client.deregisterNativePushToken,
             client.clearClientData,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.auth
 
+import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.logout.LogoutReason
@@ -53,6 +54,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
     private val logoutRepository: LogoutRepository,
     private val sessionRepository: SessionRepository,
     private val clientRepository: ClientRepository,
+    private val userConfigRepository: UserConfigRepository,
     private val userId: QualifiedID,
     private val deregisterTokenUseCase: DeregisterTokenUseCase,
     private val clearClientDataUseCase: ClearClientDataUseCase,
@@ -106,6 +108,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
                 LogoutReason.SELF_SOFT_LOGOUT -> clearCurrentClientIdAndFirebaseTokenFlag()
             }
 
+            userConfigRepository.clearE2EISettings()
             userSessionScopeProvider.get(userId)?.cancel()
             userSessionScopeProvider.delete(userId)
             logoutCallback(userId, reason)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
@@ -123,7 +123,7 @@ interface UserConfigStorage {
     /**
      * Save MLSE2EISetting
      */
-    fun setE2EISettings(settingEntity: E2EISettingsEntity)
+    fun setE2EISettings(settingEntity: E2EISettingsEntity?)
 
     /**
      * Get MLSE2EISetting
@@ -445,13 +445,17 @@ class UserConfigStorageImpl(
 
     override fun isMLSEnabled(): Boolean = kaliumPreferences.getBoolean(ENABLE_MLS, false)
 
-    override fun setE2EISettings(settingEntity: E2EISettingsEntity) {
-        kaliumPreferences.putSerializable(
-            E2EI_SETTINGS,
-            settingEntity,
-            E2EISettingsEntity.serializer()
-        ).also {
-            e2EIFlow.tryEmit(Unit)
+    override fun setE2EISettings(settingEntity: E2EISettingsEntity?) {
+        if (settingEntity == null) {
+            kaliumPreferences.remove(E2EI_SETTINGS)
+        } else {
+            kaliumPreferences.putSerializable(
+                E2EI_SETTINGS,
+                settingEntity,
+                E2EISettingsEntity.serializer()
+            ).also {
+                e2EIFlow.tryEmit(Unit)
+            }
         }
     }
 


### PR DESCRIPTION
# What's new in this PR?

### Issues

E2EI settings data is not cleared on user logout

### Causes (Optional)

Wasn't implemented

### Solutions

Implement in
