### PR TITLE
fix: Show alert message after conversation becomes degraded RC [WPB-6607]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandler.kt
@@ -107,5 +107,7 @@ internal class MLSConversationsVerificationStatusesHandlerImpl(
         )
 
         persistMessage(conversationDegradedMessage)
+
+        conversationRepository.setDegradedConversationNotifiedFlag(conversationId, updatedStatus == VerificationStatus.DEGRADED)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandlerTest.kt
@@ -66,6 +66,11 @@ class MLSConversationsVerificationStatusesHandlerTest {
             .suspendFunction(arrangement.persistMessageUseCase::invoke)
             .with(any())
             .wasNotInvoked()
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::setDegradedConversationNotifiedFlag)
+            .with(any(), any())
+            .wasNotInvoked()
     }
 
     @Test
@@ -88,6 +93,11 @@ class MLSConversationsVerificationStatusesHandlerTest {
         verify(arrangement.persistMessageUseCase)
             .suspendFunction(arrangement.persistMessageUseCase::invoke)
             .with(any())
+            .wasNotInvoked()
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::setDegradedConversationNotifiedFlag)
+            .with(any(), any())
             .wasNotInvoked()
     }
 
@@ -116,6 +126,11 @@ class MLSConversationsVerificationStatusesHandlerTest {
             .suspendFunction(arrangement.persistMessageUseCase::invoke)
             .with(anyInstanceOf(Message.System::class))
             .wasInvoked(once)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::setDegradedConversationNotifiedFlag)
+            .with(any(), eq(true))
+            .wasInvoked(once)
     }
 
     @Test
@@ -141,6 +156,11 @@ class MLSConversationsVerificationStatusesHandlerTest {
         verify(arrangement.persistMessageUseCase)
             .suspendFunction(arrangement.persistMessageUseCase::invoke)
             .with(any())
+            .wasNotInvoked()
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::setDegradedConversationNotifiedFlag)
+            .with(any(), any())
             .wasNotInvoked()
     }
 
@@ -169,6 +189,11 @@ class MLSConversationsVerificationStatusesHandlerTest {
             .suspendFunction(arrangement.persistMessageUseCase::invoke)
             .with(anyInstanceOf(Message.System::class))
             .wasInvoked(once)
+
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::setDegradedConversationNotifiedFlag)
+            .with(any(), eq(false))
+            .wasInvoked(once)
     }
 
     private fun arrange(block: Arrangement.() -> Unit) = Arrangement(block).arrange()
@@ -182,6 +207,7 @@ class MLSConversationsVerificationStatusesHandlerTest {
         init {
             withUpdateVerificationStatus(Either.Right(Unit))
             withPersistingMessage(Either.Right(Unit))
+            withSetDegradedConversationNotifiedFlag(Either.Right(Unit))
         }
 
         fun arrange() = block().run {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
@@ -98,6 +98,8 @@ internal interface ConversationRepositoryArrangement {
             .whenInvokedWith(any(), any())
             .thenReturn(result)
     }
+
+    fun withSetDegradedConversationNotifiedFlag(result: Either<CoreFailure, Unit>)
 }
 
 internal open class ConversationRepositoryArrangementImpl : ConversationRepositoryArrangement {
@@ -248,6 +250,13 @@ internal open class ConversationRepositoryArrangementImpl : ConversationReposito
     override fun withGetConversationByIdReturning(result: Conversation?) {
         given(conversationRepository)
             .suspendFunction(conversationRepository::getConversationById)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
+
+    override fun withSetDegradedConversationNotifiedFlag(result: Either<CoreFailure, Unit>) {
+        given(conversationRepository)
+            .suspendFunction(conversationRepository::setDegradedConversationNotifiedFlag)
             .whenInvokedWith(any())
             .thenReturn(result)
     }


### PR DESCRIPTION
# What's new in this PR?

### Issues

When a conversation becomes degraded, we must show a message to the user when:

Expected:
- they try to send a message
- they try to start a call
- stop the ongoing call

Actual: None of the above happen!

### Causes (Optional)

Dialog showing flag was not updated on MLS status changes

### Solutions

Update dialog showing flag on MLS status changes

