### PR TITLE
fix: observe connections without user metadata [WPB-6247]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -50,6 +50,7 @@ import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.mapRight
+import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
@@ -238,6 +239,9 @@ internal class UserDataSource internal constructor(
             .flatMap { userProfileDTO ->
                 fetchTeamMembersByIds(listOf(userProfileDTO))
                     .flatMap { persistUsers(listOf(userProfileDTO), it) }
+            }
+            .onFailure {
+                userDAO.insertOrIgnoreIncompleteUsers(listOf(userId.toDao()))
             }
 
     override suspend fun fetchUsersByIds(qualifiedUserIdList: Set<UserId>): Either<CoreFailure, Unit> =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.framework.TestUser.LIST_USERS_DTO
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.getOrNull
+import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.test_util.TestNetworkException.federationNotEnabled
 import com.wire.kalium.logic.test_util.TestNetworkResponseError
 import com.wire.kalium.logic.util.shouldFail
@@ -693,6 +694,20 @@ class UserRepositoryTest {
             .wasNotInvoked()
     }
 
+    @Test
+    fun givenUserId_whenFetchingUserInfoFailed_thenItShouldInsertIncompleteUserData() = runTest {
+        val (arrangement, userRepository) = Arrangement()
+            .withFailingGetUserInfo()
+            .arrange()
+
+        userRepository.fetchUserInfo(TestUser.USER_ID)
+
+        verify(arrangement.userDAO)
+            .suspendFunction(arrangement.userDAO::insertOrIgnoreIncompleteUsers)
+            .with(any())
+            .wasInvoked()
+    }
+
     private class Arrangement {
         @Mock
         val userDAO = configure(mock(classOf<UserDAO>())) { stubsUnitByDefault = true }
@@ -782,6 +797,13 @@ class UserRepositoryTest {
                 .suspendFunction(userDetailsApi::getUserInfo)
                 .whenInvokedWith(any())
                 .thenReturn(NetworkResponse.Success(result, mapOf(), 200))
+        }
+
+        fun withFailingGetUserInfo() = apply {
+            given(userDetailsApi)
+                .suspendFunction(userDetailsApi::getUserInfo)
+                .whenInvokedWith(any())
+                .thenReturn(NetworkResponse.Error(TestNetworkException.generic))
         }
 
         fun withSuccessfulFetchTeamMembersByIds(result: List<TeamsApi.TeamMemberDTO>) = apply {
@@ -922,6 +944,13 @@ class UserRepositoryTest {
                 .suspendFunction(userDAO::updateActiveOneOnOneConversation)
                 .whenInvokedWith(any(), any())
                 .thenThrow(exception)
+        }
+
+        fun withInsertOrIgnoreUsers() {
+            given(userDAO)
+                .suspendFunction(userDAO::insertOrIgnoreIncompleteUsers)
+                .whenInvokedWith(any())
+                .thenReturn(Unit)
         }
 
         fun arrange(block: (Arrangement.() -> Unit) = { }): Pair<Arrangement, UserRepository> {

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -266,10 +266,11 @@ selectAllConversationDetails:
 SELECT * FROM ConversationDetails
 WHERE
     type IS NOT 'SELF'
-    AND incomplete_metadata = 0
     AND (
-    type IS 'GROUP' OR (type IS NOT 'GROUP' AND (name IS NOT NULL AND otherUserId IS NOT NULL)) -- show 1:1 convos and connection requests if they have user metadata
-    OR (type IS 'ONE_ON_ONE' AND userDeleted = 1) -- show deleted 1:1 convos, to maintain prev, logic
+    type IS 'GROUP'
+    OR (type IS 'ONE_ON_ONE' AND (name IS NOT NULL AND otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+    OR (type IS 'ONE_ON_ONE' AND userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+    OR (type IS 'CONNECTION_PENDING' AND otherUserId IS NOT NULL) -- show connection requests even without metadata
     )
     AND (protocol IS 'PROTEUS' OR protocol IS 'MIXED' OR (protocol IS 'MLS' AND mls_group_state IS 'ESTABLISHED'))
     AND archived = :fromArchive

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -954,7 +954,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenConnectionRequestAndUserWithoutName_whenSelectingAllConversationDetails_thenShouldNotReturnConnectionRequest() = runTest {
+    fun givenConnectionRequestAndUserWithoutName_whenSelectingAllConversationDetails_thenShouldReturnConnectionRequest() = runTest {
         val fromArchive = false
         val conversationId = QualifiedIDEntity("connection-conversationId", "domain")
         val conversation = conversationEntity1.copy(id = conversationId, type = ConversationEntity.Type.CONNECTION_PENDING)
@@ -973,7 +973,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         connectionDAO.insertConnection(connectionEntity)
 
         conversationDAO.getAllConversationDetails(fromArchive).first().let {
-            assertEquals(0, it.size)
+            assertEquals(1, it.size)
         }
     }
 
@@ -1233,15 +1233,15 @@ class ConversationDAOTest : BaseDatabaseTest() {
     fun givenNoMLSConversationExistsForGivenClients_whenGettingE2EIClientInfoByClientId_thenReturnsNull() = runTest {
         // given
 
-        //insert userA data
+        // insert userA data
         val userA = user1
         val clientCA1 = "clientA1"
         val clientCA2 = "clientA2"
         userDAO.upsertUser(userA)
         clientDao.insertClients(listOf(insertedClient.copy(userA.id, id = clientCA1), insertedClient.copy(userA.id, id = clientCA2)))
 
-        //insert userB data
-        val userB = user1.copy(id = user1.id.copy("b","b.com"))
+        // insert userB data
+        val userB = user1.copy(id = user1.id.copy("b", "b.com"))
         val clientCB1 = "clientB1"
         val clientCB2 = "clientB2"
         userDAO.upsertUser(userB)
@@ -1255,68 +1255,69 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenMLSGroupConversationExistsForGivenClients_whenGettingE2EIClientInfoByClientId_thenReturnsE2EIConversationClientInfo() = runTest {
-        // given
+    fun givenMLSGroupConversationExistsForGivenClients_whenGettingE2EIClientInfoByClientId_thenReturnsE2EIConversationClientInfo() =
+        runTest {
+            // given
 
-        //insert userA data
-        val userA = user1
-        val clientCA1 = "clientA1"
-        val clientCA2 = "clientA2"
-        userDAO.upsertUser(userA)
-        clientDao.insertClients(listOf(insertedClient.copy(userA.id, id = clientCA1), insertedClient.copy(userA.id, id = clientCA2)))
-        conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.SELF))
+            // insert userA data
+            val userA = user1
+            val clientCA1 = "clientA1"
+            val clientCA2 = "clientA2"
+            userDAO.upsertUser(userA)
+            clientDao.insertClients(listOf(insertedClient.copy(userA.id, id = clientCA1), insertedClient.copy(userA.id, id = clientCA2)))
+            conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.SELF))
 
-        //insert userB data
-        val userB = user1.copy(id = user1.id.copy("b","b.com"))
-        val clientCB1 = "clientB1"
-        val clientCB2 = "clientB2"
-        userDAO.upsertUser(userB)
-        clientDao.insertClients(listOf(insertedClient.copy(userB.id, id = clientCB1), insertedClient.copy(userB.id, id = clientCB2)))
+            // insert userB data
+            val userB = user1.copy(id = user1.id.copy("b", "b.com"))
+            val clientCB1 = "clientB1"
+            val clientCB2 = "clientB2"
+            userDAO.upsertUser(userB)
+            clientDao.insertClients(listOf(insertedClient.copy(userB.id, id = clientCB1), insertedClient.copy(userB.id, id = clientCB2)))
 
-        //insert 1:1 proteus between userA and userB
-        conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.ONE_ON_ONE))
+            // insert 1:1 proteus between userA and userB
+            conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.ONE_ON_ONE))
 
-        //insert a group proteus between userA and userB
-        conversationDAO.insertConversation(conversationEntity4)
-        memberDAO.insertMembersWithQualifiedId(
-            listOf(
-                MemberEntity(userA.id, MemberEntity.Role.Member),
-                MemberEntity(userB.id, MemberEntity.Role.Member) // adding SelfUser as a member too
-            ),
-            conversationEntity4.id
-        )
+            // insert a group proteus between userA and userB
+            conversationDAO.insertConversation(conversationEntity4)
+            memberDAO.insertMembersWithQualifiedId(
+                listOf(
+                    MemberEntity(userA.id, MemberEntity.Role.Member),
+                    MemberEntity(userB.id, MemberEntity.Role.Member) // adding SelfUser as a member too
+                ),
+                conversationEntity4.id
+            )
 
-        val expectedUserA = E2EIConversationClientInfoEntity(
-            userId = userA.id,
-            mlsGroupId = (conversationEntity4.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
-            clientId = clientCA1
-        )
-        val expectedUserB = E2EIConversationClientInfoEntity(
-            userId = userB.id,
-            mlsGroupId = (conversationEntity4.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
-            clientId = clientCA1
-        )
+            val expectedUserA = E2EIConversationClientInfoEntity(
+                userId = userA.id,
+                mlsGroupId = (conversationEntity4.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
+                clientId = clientCA1
+            )
+            val expectedUserB = E2EIConversationClientInfoEntity(
+                userId = userB.id,
+                mlsGroupId = (conversationEntity4.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
+                clientId = clientCA1
+            )
 
-        // then
-        assertEquals(
-            expectedUserA.copy(clientId = clientCA1), conversationDAO.getE2EIConversationClientInfoByClientId(clientCA1)
-        )
-        assertEquals(
-            expectedUserA.copy(clientId = clientCA2), conversationDAO.getE2EIConversationClientInfoByClientId(clientCA2)
-        )
-        assertEquals(
-            expectedUserB.copy(clientId = clientCB1), conversationDAO.getE2EIConversationClientInfoByClientId(clientCB1)
-        )
-        assertEquals(
-            expectedUserB.copy(clientId = clientCB2), conversationDAO.getE2EIConversationClientInfoByClientId(clientCB2)
-        )
-    }
+            // then
+            assertEquals(
+                expectedUserA.copy(clientId = clientCA1), conversationDAO.getE2EIConversationClientInfoByClientId(clientCA1)
+            )
+            assertEquals(
+                expectedUserA.copy(clientId = clientCA2), conversationDAO.getE2EIConversationClientInfoByClientId(clientCA2)
+            )
+            assertEquals(
+                expectedUserB.copy(clientId = clientCB1), conversationDAO.getE2EIConversationClientInfoByClientId(clientCB1)
+            )
+            assertEquals(
+                expectedUserB.copy(clientId = clientCB2), conversationDAO.getE2EIConversationClientInfoByClientId(clientCB2)
+            )
+        }
 
     @Test
     fun givenAllTypeOfConversationsForGivenClients_whenGettingE2EIClientInfoByClientId_thenReturnsSelfE2EIInfoFirst() = runTest {
         // given
 
-        //insert userA data
+        // insert userA data
         val userA = user1
         val clientCA1 = "clientA1"
         val clientCA2 = "clientA2"
@@ -1325,21 +1326,27 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.SELF))
         conversationDAO.insertConversation(conversationEntity2.copy(id = userA.id, type = ConversationEntity.Type.SELF))
 
-        //insert userB data
-        val userB = user1.copy(id = user1.id.copy("b","b.com"))
+        // insert userB data
+        val userB = user1.copy(id = user1.id.copy("b", "b.com"))
         val clientCB1 = "clientB1"
         val clientCB2 = "clientB2"
         userDAO.upsertUser(userB)
         clientDao.insertClients(listOf(insertedClient.copy(userB.id, id = clientCB1), insertedClient.copy(userB.id, id = clientCB2)))
 
-        //insert 1:1 proteus between userA and userB
+        // insert 1:1 proteus between userA and userB
         conversationDAO.insertConversation(conversationEntity1.copy(id = userB.id, type = ConversationEntity.Type.ONE_ON_ONE))
 
-        //insert 1:1 mls between userA and userB
+        // insert 1:1 mls between userA and userB
         val protocolInfo = (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).copy(groupId = "groupAB")
-        conversationDAO.insertConversation(conversationEntity2.copy(id = userB.id, type = ConversationEntity.Type.ONE_ON_ONE, protocolInfo = protocolInfo))
+        conversationDAO.insertConversation(
+            conversationEntity2.copy(
+                id = userB.id,
+                type = ConversationEntity.Type.ONE_ON_ONE,
+                protocolInfo = protocolInfo
+            )
+        )
 
-        //insert an MLSGroup between userA and userB
+        // insert an MLSGroup between userA and userB
         conversationDAO.insertConversation(conversationEntity4)
         memberDAO.insertMembersWithQualifiedId(
             listOf(
@@ -1349,7 +1356,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             conversationEntity4.id
         )
 
-        //insert a proteus group between userA and userB
+        // insert a proteus group between userA and userB
         conversationDAO.insertConversation(conversationEntity5)
         memberDAO.insertMembersWithQualifiedId(
             listOf(
@@ -1378,28 +1385,34 @@ class ConversationDAOTest : BaseDatabaseTest() {
     fun givenAllTypeOfConversationsForGivenClientsExceptSelf_whenGettingE2EIClientInfoByClientId_thenReturnsE2EIInfo() = runTest {
         // given
 
-        //insert userA data
+        // insert userA data
         val userA = user1
         val clientCA1 = "clientA1"
         val clientCA2 = "clientA2"
         userDAO.upsertUser(userA)
         clientDao.insertClients(listOf(insertedClient.copy(userA.id, id = clientCA1), insertedClient.copy(userA.id, id = clientCA2)))
 
-        //insert userB data
-        val userB = user1.copy(id = user1.id.copy("b","b.com"))
+        // insert userB data
+        val userB = user1.copy(id = user1.id.copy("b", "b.com"))
         val clientCB1 = "clientB1"
         val clientCB2 = "clientB2"
         userDAO.upsertUser(userB)
         clientDao.insertClients(listOf(insertedClient.copy(userB.id, id = clientCB1), insertedClient.copy(userB.id, id = clientCB2)))
 
-        //insert 1:1 proteus between userA and userB
+        // insert 1:1 proteus between userA and userB
         conversationDAO.insertConversation(conversationEntity1.copy(id = userB.id, type = ConversationEntity.Type.ONE_ON_ONE))
 
-        //insert 1:1 mls between userA and userB
+        // insert 1:1 mls between userA and userB
         val protocolInfo = (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).copy(groupId = "groupAB")
-        conversationDAO.insertConversation(conversationEntity2.copy(id = userB.id, type = ConversationEntity.Type.ONE_ON_ONE, protocolInfo = protocolInfo))
+        conversationDAO.insertConversation(
+            conversationEntity2.copy(
+                id = userB.id,
+                type = ConversationEntity.Type.ONE_ON_ONE,
+                protocolInfo = protocolInfo
+            )
+        )
 
-        //insert an MLSGroup between userA and userB
+        // insert an MLSGroup between userA and userB
         conversationDAO.insertConversation(conversationEntity4)
         memberDAO.insertMembersWithQualifiedId(
             listOf(
@@ -1409,7 +1422,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             conversationEntity4.id
         )
 
-        //insert a proteus group between userA and userB
+        // insert a proteus group between userA and userB
         conversationDAO.insertConversation(conversationEntity5)
         memberDAO.insertMembersWithQualifiedId(
             listOf(
@@ -1435,78 +1448,79 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenMLSGroupsAndProteusGroupsForGivenClients_whenGettingE2EIClientInfoByClientId_thenReturnsE2EIConversationClientInfo() = runTest {
-        // given
+    fun givenMLSGroupsAndProteusGroupsForGivenClients_whenGettingE2EIClientInfoByClientId_thenReturnsE2EIConversationClientInfo() =
+        runTest {
+            // given
 
-        //insert userA data
-        val userA = user1
-        val clientCA1 = "clientA1"
-        val clientCA2 = "clientA2"
-        userDAO.upsertUser(userA)
-        clientDao.insertClients(listOf(insertedClient.copy(userA.id, id = clientCA1), insertedClient.copy(userA.id, id = clientCA2)))
-        conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.SELF))
+            // insert userA data
+            val userA = user1
+            val clientCA1 = "clientA1"
+            val clientCA2 = "clientA2"
+            userDAO.upsertUser(userA)
+            clientDao.insertClients(listOf(insertedClient.copy(userA.id, id = clientCA1), insertedClient.copy(userA.id, id = clientCA2)))
+            conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.SELF))
 
-        //insert userB data
-        val userB = user1.copy(id = user1.id.copy("b","b.com"))
-        val clientCB1 = "clientB1"
-        val clientCB2 = "clientB2"
-        userDAO.upsertUser(userB)
-        clientDao.insertClients(listOf(insertedClient.copy(userB.id, id = clientCB1), insertedClient.copy(userB.id, id = clientCB2)))
+            // insert userB data
+            val userB = user1.copy(id = user1.id.copy("b", "b.com"))
+            val clientCB1 = "clientB1"
+            val clientCB2 = "clientB2"
+            userDAO.upsertUser(userB)
+            clientDao.insertClients(listOf(insertedClient.copy(userB.id, id = clientCB1), insertedClient.copy(userB.id, id = clientCB2)))
 
-        //insert 1:1 proteus between userA and userB
-        conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.ONE_ON_ONE))
+            // insert 1:1 proteus between userA and userB
+            conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.ONE_ON_ONE))
 
-        //insert an MLSGroup between userA and userB
-        conversationDAO.insertConversation(conversationEntity4)
-        memberDAO.insertMembersWithQualifiedId(
-            listOf(
-                MemberEntity(userA.id, MemberEntity.Role.Member),
-                MemberEntity(userB.id, MemberEntity.Role.Member) // adding SelfUser as a member too
-            ),
-            conversationEntity4.id
-        )
+            // insert an MLSGroup between userA and userB
+            conversationDAO.insertConversation(conversationEntity4)
+            memberDAO.insertMembersWithQualifiedId(
+                listOf(
+                    MemberEntity(userA.id, MemberEntity.Role.Member),
+                    MemberEntity(userB.id, MemberEntity.Role.Member) // adding SelfUser as a member too
+                ),
+                conversationEntity4.id
+            )
 
-        //insert a proteus group between userA and userB
-        conversationDAO.insertConversation(conversationEntity5)
-        memberDAO.insertMembersWithQualifiedId(
-            listOf(
-                MemberEntity(userA.id, MemberEntity.Role.Member),
-                MemberEntity(userB.id, MemberEntity.Role.Member) // adding SelfUser as a member too
-            ),
-            conversationEntity5.id
-        )
+            // insert a proteus group between userA and userB
+            conversationDAO.insertConversation(conversationEntity5)
+            memberDAO.insertMembersWithQualifiedId(
+                listOf(
+                    MemberEntity(userA.id, MemberEntity.Role.Member),
+                    MemberEntity(userB.id, MemberEntity.Role.Member) // adding SelfUser as a member too
+                ),
+                conversationEntity5.id
+            )
 
-        val expectedUserA = E2EIConversationClientInfoEntity(
-            userId = userA.id,
-            mlsGroupId = (conversationEntity4.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
-            clientId = clientCA1
-        )
-        val expectedUserB = E2EIConversationClientInfoEntity(
-            userId = userB.id,
-            mlsGroupId = (conversationEntity4.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
-            clientId = clientCA1
-        )
+            val expectedUserA = E2EIConversationClientInfoEntity(
+                userId = userA.id,
+                mlsGroupId = (conversationEntity4.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
+                clientId = clientCA1
+            )
+            val expectedUserB = E2EIConversationClientInfoEntity(
+                userId = userB.id,
+                mlsGroupId = (conversationEntity4.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
+                clientId = clientCA1
+            )
 
-        // then
-        assertEquals(
-            expectedUserA.copy(clientId = clientCA1), conversationDAO.getE2EIConversationClientInfoByClientId(clientCA1)
-        )
-        assertEquals(
-            expectedUserA.copy(clientId = clientCA2), conversationDAO.getE2EIConversationClientInfoByClientId(clientCA2)
-        )
-        assertEquals(
-            expectedUserB.copy(clientId = clientCB1), conversationDAO.getE2EIConversationClientInfoByClientId(clientCB1)
-        )
-        assertEquals(
-            expectedUserB.copy(clientId = clientCB2), conversationDAO.getE2EIConversationClientInfoByClientId(clientCB2)
-        )
-    }
+            // then
+            assertEquals(
+                expectedUserA.copy(clientId = clientCA1), conversationDAO.getE2EIConversationClientInfoByClientId(clientCA1)
+            )
+            assertEquals(
+                expectedUserA.copy(clientId = clientCA2), conversationDAO.getE2EIConversationClientInfoByClientId(clientCA2)
+            )
+            assertEquals(
+                expectedUserB.copy(clientId = clientCB1), conversationDAO.getE2EIConversationClientInfoByClientId(clientCB1)
+            )
+            assertEquals(
+                expectedUserB.copy(clientId = clientCB2), conversationDAO.getE2EIConversationClientInfoByClientId(clientCB2)
+            )
+        }
 
     @Test
     fun givenOnlyProteusConversationExistsForGivenClients_whenGettingE2EIClientInfoByClientId_thenReturnsNull() = runTest {
         // given
 
-        //insert userA data
+        // insert userA data
         val userA = user1
         val clientCA1 = "clientA1"
         val clientCA2 = "clientA2"
@@ -1514,17 +1528,17 @@ class ConversationDAOTest : BaseDatabaseTest() {
         clientDao.insertClients(listOf(insertedClient.copy(userA.id, id = clientCA1), insertedClient.copy(userA.id, id = clientCA2)))
         conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.SELF))
 
-        //insert userB data
-        val userB = user1.copy(id = user1.id.copy("b","b.com"))
+        // insert userB data
+        val userB = user1.copy(id = user1.id.copy("b", "b.com"))
         val clientCB1 = "clientB1"
         val clientCB2 = "clientB2"
         userDAO.upsertUser(userB)
         clientDao.insertClients(listOf(insertedClient.copy(userB.id, id = clientCB1), insertedClient.copy(userB.id, id = clientCB2)))
 
-        //insert 1:1 proteus between userA and userB
+        // insert 1:1 proteus between userA and userB
         conversationDAO.insertConversation(conversationEntity1.copy(id = userA.id, type = ConversationEntity.Type.ONE_ON_ONE))
 
-        //insert a group proteus between userA and userB
+        // insert a group proteus between userA and userB
         conversationDAO.insertConversation(conversationEntity5)
         memberDAO.insertMembersWithQualifiedId(
             listOf(
@@ -1600,6 +1614,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         // then
         assertEquals(true, result)
     }
+
     @Test
     fun givenTheSameLegalHoldStatus_whenUpdating_thenShouldReturnFalse() = runTest {
         // given
@@ -1611,6 +1626,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         // then
         assertEquals(false, result)
     }
+
     @Test
     fun givenNewLegalHoldStatusChangeNotifiedFlag_whenUpdating_thenShouldReturnTrue() = runTest {
         // given
@@ -1622,6 +1638,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         // then
         assertEquals(true, result)
     }
+
     @Test
     fun givenTheSameLegalHoldStatusChangeNotifiedFlag_whenUpdating_thenShouldReturnFalse() = runTest {
         // given
@@ -1633,6 +1650,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         // then
         assertEquals(false, result)
     }
+
     @Test
     fun givenLegalHoldStatus_whenObserving_thenShouldReturnCorrectValue() = runTest {
         // given
@@ -1644,6 +1662,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         // then
         assertEquals(ConversationEntity.LegalHoldStatus.ENABLED, result)
     }
+
     @Test
     fun givenLegalHoldStatusChangeNotified_whenObserving_thenShouldReturnCorrectValue() = runTest {
         // given


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user was offline and started getting events about connection requests, while one of backends is offline then user from connection request is not saved on db.

### Causes (Optional)

We don't have any information in conversation list about pending connection request

### Solutions

If fetching user failed, save incomplete data in db and propagate connection requests with incomplete user metadata

