### PR TITLE
fix: e2ei endpoint is called even when the feature is disabled

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -192,8 +192,8 @@ interface MLSFailure : CoreFailure {
 
 interface E2EIFailure : CoreFailure {
 
-    data object Disabled: E2EIFailure
-    data object MissingDiscoveryUrl: E2EIFailure
+    data object Disabled : E2EIFailure
+    data object MissingDiscoveryUrl : E2EIFailure
     data class FailedInitialization(val step: E2EIEnrollmentResult.E2EIStep) : E2EIFailure
     data class FailedOAuth(val reason: String) : E2EIFailure
     data class FailedFinalization(val step: E2EIEnrollmentResult.E2EIStep) : E2EIFailure

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -191,6 +191,9 @@ interface MLSFailure : CoreFailure {
 }
 
 interface E2EIFailure : CoreFailure {
+
+    data object Disabled: E2EIFailure
+    data object MissingDiscoveryUrl: E2EIFailure
     data class FailedInitialization(val step: E2EIEnrollmentResult.E2EIStep) : E2EIFailure
     data class FailedOAuth(val reason: String) : E2EIFailure
     data class FailedFinalization(val step: E2EIEnrollmentResult.E2EIStep) : E2EIFailure

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/E2EISettings.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/E2EISettings.kt
@@ -22,7 +22,7 @@ import kotlinx.datetime.Instant
 
 data class E2EISettings(
     val isRequired: Boolean,
-    val discoverUrl: String,
+    val discoverUrl: String?,
     val gracePeriodEnd: Instant?
 ) {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepository.kt
@@ -18,7 +18,6 @@
 package com.wire.kalium.logic.data.e2ei
 
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
@@ -45,7 +44,7 @@ interface CertificateRevocationListRepository {
 internal class CertificateRevocationListRepositoryDataSource(
     private val acmeApi: ACMEApi,
     private val metadataDAO: MetadataDAO,
-    private val userConfigRepository: UserConfigRepository
+    private val e2eiRepository: E2EIRepository
 ) : CertificateRevocationListRepository {
     override suspend fun getCRLs(): CRLUrlExpirationList? =
         metadataDAO.getSerializable(CRL_LIST_KEY, CRLUrlExpirationList.serializer())
@@ -83,8 +82,8 @@ internal class CertificateRevocationListRepositoryDataSource(
     }
 
     override suspend fun getCurrentClientCrlUrl(): Either<CoreFailure, String> =
-        userConfigRepository.getE2EISettings().map {
-            (Url(it.discoverUrl).protocolWithAuthority)
+        e2eiRepository.discoveryUrl().map {
+            Url(it).protocolWithAuthority
         }
 
     override suspend fun getClientDomainCRL(url: String): Either<CoreFailure, ByteArray> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/E2EIRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/E2EIRepository.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.cryptography.AcmeDirectory
 import com.wire.kalium.cryptography.NewAcmeAuthz
 import com.wire.kalium.cryptography.NewAcmeOrder
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.E2EIFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.client.E2EIClientProvider
 import com.wire.kalium.logic.data.client.MLSClientProvider
@@ -35,6 +36,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.getOrFail
+import com.wire.kalium.logic.functional.left
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
@@ -91,6 +93,7 @@ interface E2EIRepository {
     suspend fun fetchFederationCertificates(): Either<CoreFailure, Unit>
     suspend fun getCurrentClientCrlUrl(): Either<CoreFailure, String>
     suspend fun getClientDomainCRL(url: String): Either<CoreFailure, ByteArray>
+    fun discoveryUrl(): Either<CoreFailure, String>
 }
 
 @Suppress("LongParameterList")
@@ -116,9 +119,9 @@ class E2EIRepositoryImpl(
         })
     }
 
-    override suspend fun fetchAndSetTrustAnchors(): Either<CoreFailure, Unit> = userConfigRepository.getE2EISettings().flatMap {
+    override suspend fun fetchAndSetTrustAnchors(): Either<CoreFailure, Unit> = discoveryUrl().flatMap {
         wrapApiRequest {
-            acmeApi.getTrustAnchors(Url(it.discoverUrl).protocolWithAuthority)
+            acmeApi.getTrustAnchors(Url(it).protocolWithAuthority)
         }.flatMap { trustAnchors ->
             mlsClientProvider.getMLSClient().flatMap { mlsClient ->
                 wrapE2EIRequest {
@@ -128,9 +131,9 @@ class E2EIRepositoryImpl(
         }
     }
 
-    override suspend fun loadACMEDirectories(): Either<CoreFailure, AcmeDirectory> = userConfigRepository.getE2EISettings().flatMap {
+    override suspend fun loadACMEDirectories(): Either<CoreFailure, AcmeDirectory> = discoveryUrl().flatMap {
         wrapApiRequest {
-            acmeApi.getACMEDirectories(it.discoverUrl)
+            acmeApi.getACMEDirectories(it)
         }.flatMap { directories ->
             e2EIClientProvider.getE2EIClient().flatMap { e2eiClient ->
                 wrapE2EIRequest {
@@ -301,29 +304,37 @@ class E2EIRepositoryImpl(
         Either.Right(e2EIClient.getOAuthRefreshToken())
     }
 
-    override suspend fun fetchFederationCertificates(): Either<CoreFailure, Unit> = userConfigRepository.getE2EISettings().flatMap {
-        wrapApiRequest {
-            acmeApi.getACMEFederation(Url(it.discoverUrl).protocolWithAuthority)
-        }.flatMap { data ->
-            mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-                wrapMLSRequest {
-                    mlsClient.registerIntermediateCa(data)
+    override suspend fun fetchFederationCertificates(): Either<CoreFailure, Unit> = discoveryUrl()
+        .flatMap {
+            wrapApiRequest {
+                acmeApi.getACMEFederation(Url(it).protocolWithAuthority)
+            }.flatMap { data ->
+                mlsClientProvider.getMLSClient().flatMap { mlsClient ->
+                    wrapMLSRequest {
+                        mlsClient.registerIntermediateCa(data)
+                    }
                 }
             }
         }
-    }
+
+    override fun discoveryUrl(): Either<CoreFailure, String> =
+        userConfigRepository.getE2EISettings().flatMap { settings ->
+            when {
+                !settings.isRequired -> E2EIFailure.Disabled.left()
+                settings.discoverUrl == null -> E2EIFailure.MissingDiscoveryUrl.left()
+                else -> Either.Right(settings.discoverUrl)
+            }
+        }
 
     override suspend fun nukeE2EIClient() {
         e2EIClientProvider.nuke()
     }
 
     override suspend fun getCurrentClientCrlUrl(): Either<CoreFailure, String> =
-        userConfigRepository.getE2EISettings().map {
-            (Url(it.discoverUrl).protocolWithAuthority)
-        }
+        discoveryUrl().map { Url(it).protocolWithAuthority }
 
     override suspend fun getClientDomainCRL(url: String): Either<CoreFailure, ByteArray> =
         wrapApiRequest {
             acmeApi.getClientDomainCRL(url)
-         }
+        }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -131,13 +131,22 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
         )
 
     override fun fromDTO(data: FeatureConfigData.E2EI?): E2EIModel =
-        E2EIModel(
+        data?.let {
+            E2EIModel(
+                E2EIConfigModel(
+                    data.config.url,
+                    data.config.verificationExpirationSeconds
+                ),
+                fromDTO(data.status)
+            )
+        } ?: E2EIModel(
             E2EIConfigModel(
-                data?.config?.url ?: "",
-                data?.config?.verificationExpirationSeconds ?: 0L
+                null,
+                0
             ),
-            fromDTO(data?.status ?: FeatureFlagStatusDTO.DISABLED)
+            Status.DISABLED
         )
+
     override fun fromModel(status: Status): FeatureFlagStatusDTO =
         when (status) {
             Status.ENABLED -> FeatureFlagStatusDTO.ENABLED

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -99,6 +99,6 @@ data class E2EIModel(
 )
 
 data class E2EIConfigModel(
-    val discoverUrl: String,
+    val discoverUrl: String?,
     val verificationExpirationSeconds: Long
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1555,7 +1555,7 @@ class UserSessionScope internal constructor(
         get() = CertificateRevocationListRepositoryDataSource(
             acmeApi = globalScope.unboundNetworkContainer.acmeApi,
             metadataDAO = userStorage.database.metadataDAO,
-            userConfigRepository = userConfigRepository
+            e2eiRepository = e2eiRepository
         )
 
     private val proteusPreKeyRefiller: ProteusPreKeyRefiller

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -61,7 +61,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
     private val appLockConfigHandler: AppLockConfigHandler
 ) : SyncFeatureConfigsUseCase {
     override suspend operator fun invoke(): Either<CoreFailure, Unit> =
-        featureConfigRepository.getFeatureConfigs().flatMap {
+        featureConfigRepository.getFeatureConfigs().flatMap { it ->
             // TODO handle other feature flags and after it bump version in [SlowSyncManager.CURRENT_VERSION]
             guestRoomConfigHandler.handle(it.guestRoomLinkModel)
             fileSharingConfigHandler.handle(it.fileSharingModel)
@@ -71,7 +71,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
             conferenceCallingConfigHandler.handle(it.conferenceCallingModel)
             passwordChallengeConfigHandler.handle(it.secondFactorPasswordChallengeModel)
             selfDeletingMessagesConfigHandler.handle(it.selfDeletingMessagesModel)
-            e2EIConfigHandler.handle(it.e2EIModel)
+            it.e2EIModel?.let { e2EIModel -> e2EIConfigHandler.handle(e2EIModel) }
             appLockConfigHandler.handle(it.appLockModel)
             Either.Right(Unit)
         }.onFailure { networkFailure ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/E2EIConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/E2EIConfigHandler.kt
@@ -31,8 +31,12 @@ class E2EIConfigHandler(
     private val userConfigRepository: UserConfigRepository,
 ) {
     fun handle(e2eiConfig: E2EIModel): Either<CoreFailure, Unit> {
-        val gracePeriodEnd = DateTimeUtil.currentInstant()
-            .plus(e2eiConfig.config.verificationExpirationSeconds.toDuration(DurationUnit.SECONDS))
+        val gracePeriodEnd = e2eiConfig.config.verificationExpirationSeconds
+            .toDuration(DurationUnit.SECONDS)
+            .let {
+            DateTimeUtil.currentInstant().plus(it)
+        }
+
         userConfigRepository.setE2EISettings(
             E2EISettings(
                 isRequired = e2eiConfig.status == Status.ENABLED,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepositoryTest.kt
@@ -115,9 +115,9 @@ class CertificateRevocationListRepositoryTest {
         val metadataDAO = mock(classOf<MetadataDAO>())
 
         @Mock
-        val userConfigRepository = mock(classOf<UserConfigRepository>())
+        val e2eiRepository = mock(classOf<E2EIRepository>())
 
-        fun arrange() = this to CertificateRevocationListRepositoryDataSource(acmeApi, metadataDAO, userConfigRepository)
+        fun arrange() = this to CertificateRevocationListRepositoryDataSource(acmeApi, metadataDAO, e2eiRepository)
 
         suspend fun withEmptyList() = apply {
             given(metadataDAO).coroutine {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -117,7 +117,7 @@ data class E2EIConfigDTO(
     @SerialName("acmeDiscoveryUrl")
     val url: String?,
     @SerialName("verificationExpiration")
-    val verificationExpirationSeconds: Long = 0L
+    val verificationExpirationSeconds: Long
 )
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
@@ -35,6 +35,8 @@ import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
+import io.ktor.http.URLBuilder
+import io.ktor.http.URLProtocol
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 
@@ -57,7 +59,12 @@ class ACMEApiImpl internal constructor(
     private val clearTextTrafficHttpClient get() = unboundClearTextTrafficNetworkClient.httpClient
 
     override suspend fun getTrustAnchors(acmeUrl: String): NetworkResponse<ByteArray> = wrapKaliumResponse {
-        httpClient.get("$acmeUrl/$PATH_ACME_ROOTS_PEM")
+        URLBuilder(acmeUrl).apply {
+            protocol = URLProtocol.HTTPS
+            pathSegments = pathSegments + PATH_ACME_ROOTS_PEM
+        }
+            .build()
+            .let { httpClient.get(it) }
     }
 
     override suspend fun getACMEDirectories(discoveryUrl: String): NetworkResponse<AcmeDirectoriesResponse> = wrapKaliumResponse {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
@@ -35,8 +35,6 @@ import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
-import io.ktor.http.URLBuilder
-import io.ktor.http.URLProtocol
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
@@ -59,12 +59,7 @@ class ACMEApiImpl internal constructor(
     private val clearTextTrafficHttpClient get() = unboundClearTextTrafficNetworkClient.httpClient
 
     override suspend fun getTrustAnchors(acmeUrl: String): NetworkResponse<ByteArray> = wrapKaliumResponse {
-        URLBuilder(acmeUrl).apply {
-            protocol = URLProtocol.HTTPS
-            pathSegments = pathSegments + PATH_ACME_ROOTS_PEM
-        }
-            .build()
-            .let { httpClient.get(it) }
+        httpClient.get("$acmeUrl/$PATH_ACME_ROOTS_PEM")
     }
 
     override suspend fun getACMEDirectories(discoveryUrl: String): NetworkResponse<AcmeDirectoriesResponse> = wrapKaliumResponse {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
@@ -203,7 +203,7 @@ data class TeamSettingsSelfDeletionStatusEntity(
 @Serializable
 data class E2EISettingsEntity(
     @SerialName("status") val status: Boolean,
-    @SerialName("discoverUrl") val discoverUrl: String,
+    @SerialName("discoverUrl") val discoverUrl: String?,
     @SerialName("gracePeriodEndMs") val gracePeriodEndMs: Long?,
 )
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

it can happen that e2ei endpoint is called with empty URL when it is disabled

### Solutions

small refactor to make sure it cann't be called when it is not enabled

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
