### PR TITLE
chore: Add Technolinator config for dependencytrack, setting the correct java version (SEC-598)

### DIFF
--- a/.github/technolinator.yml
+++ b/.github/technolinator.yml
@@ -1,0 +1,14 @@
+# whether Technolinator does analysis at all; default: true
+enable: true
+# whether Technolinator shall comment vulnerability reports to pull-requests
+enablePullRequestReport: false
+analysis:
+    # whether cdxgen should scan for projects recursively in 'location' or only 'location' itself; default: true
+    recursive: true
+    # include only 'required' scoped dependencies to created BOM
+    requiredScopeOnly: false
+    # create sbom with evidence (slows down the process)
+    evidence: true
+jdk:
+    # select JDK version used by cdxgen on JVM based projects (see below)
+    version: 17

--- a/.github/technolinator.yml
+++ b/.github/technolinator.yml
@@ -10,5 +10,5 @@ analysis:
     # create sbom with evidence (slows down the process)
     evidence: true
 jdk:
-    # select JDK version used by cdxgen on JVM based projects (see below)
+    # select JDK version used by cdxgen on JVM based projects
     version: 17


### PR DESCRIPTION
Issues

CDXgen was not able to get the correct dependency tree for kalium previously, because it used java21 internally. This config sets the java version to 17 and enables cdxgen to create a dependency tree and push it to dependency track.

How to Test

No need, this change is transparent for devs and only pertains to security tooling and should have no visible effect at all.