### PR TITLE
feat:  implement use case to get default conversation creation protocol (WPB-5475)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationOptions.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationOptions.kt
@@ -18,6 +18,8 @@
 
 package com.wire.kalium.logic.data.conversation
 
+import com.wire.kalium.logic.data.user.SupportedProtocol
+
 // TODO(qol): rename to CreateConversationParam
 data class ConversationOptions(
     val access: Set<Conversation.Access>? = null,
@@ -27,6 +29,14 @@ data class ConversationOptions(
     val creatorClientId: ClientId? = null
 ) {
     enum class Protocol {
-        PROTEUS, MLS
+        PROTEUS, MLS;
+
+        companion object {
+            fun fromSupportedProtocolToConversationOptionsProtocol(supportedProtocol: SupportedProtocol): Protocol =
+                when (supportedProtocol) {
+                    SupportedProtocol.MLS -> MLS
+                    SupportedProtocol.PROTEUS -> PROTEUS
+                }
+        }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -293,6 +293,8 @@ import com.wire.kalium.logic.feature.session.token.AccessTokenRefresherImpl
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCase
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCaseImpl
 import com.wire.kalium.logic.feature.team.TeamScope
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
@@ -1848,6 +1850,11 @@ class UserSessionScope internal constructor(
 
     val isMLSEnabled: IsMLSEnabledUseCase get() = IsMLSEnabledUseCaseImpl(featureSupport, userConfigRepository)
     val isE2EIEnabled: IsE2EIEnabledUseCase get() = IsE2EIEnabledUseCaseImpl(userConfigRepository)
+
+    val getDefaultProtocol: GetDefaultProtocolUseCase
+        get() = GetDefaultProtocolUseCaseImpl(
+            userConfigRepository = userConfigRepository
+        )
 
     val observeE2EIRequired: ObserveE2EIRequiredUseCase
         get() = ObserveE2EIRequiredUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetDefaultProtocolUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetDefaultProtocolUseCase.kt
@@ -38,7 +38,7 @@ internal class GetDefaultProtocolUseCaseImpl(
     override fun invoke(): SupportedProtocol =
         userConfigRepository.getDefaultProtocol().fold({
             SupportedProtocol.PROTEUS
-        },{ supportedProtocol ->
+        }, { supportedProtocol ->
             supportedProtocol
         })
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetDefaultProtocolUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetDefaultProtocolUseCase.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.functional.fold
+
+/**
+ * Get the Default Protocol [SupportedProtocol]
+ */
+interface GetDefaultProtocolUseCase {
+    /**
+     * @return [SupportedProtocol.MLS] or [SupportedProtocol.PROTEUS]
+     */
+    operator fun invoke(): SupportedProtocol
+}
+
+internal class GetDefaultProtocolUseCaseImpl(
+    private val userConfigRepository: UserConfigRepository
+) : GetDefaultProtocolUseCase {
+
+    override fun invoke(): SupportedProtocol =
+        userConfigRepository.getDefaultProtocol().fold({
+            SupportedProtocol.PROTEUS
+        },{ supportedProtocol ->
+            supportedProtocol
+        })
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetDefaultProtocolUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/GetDefaultProtocolUseCaseTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GetDefaultProtocolUseCaseTest {
+
+    @Test
+    fun givenGetDefaultProtocolUseCase_whenRequestingDefaultProtocol_thenReturnProteusAsDefaultProtocol() = runTest {
+        // given
+        val (_, useCase) = GetDefaultProtocolUseCaseTestArrangement()
+            .withReturningSuccessProteusProtocol()
+            .arrange()
+
+        // when
+        val result = useCase()
+
+        // then
+        assertEquals(result, SupportedProtocol.PROTEUS)
+    }
+
+    @Test
+    fun givenGetDefaultProtocolUseCase_whenRequestingDefaultProtocol_thenReturnMLSAsDefaultProtocol() = runTest {
+        // given
+        val (_, useCase) = GetDefaultProtocolUseCaseTestArrangement()
+            .withReturningSuccessMLSProtocol()
+            .arrange()
+
+        // when
+        val result = useCase()
+
+        // then
+        assertEquals(result, SupportedProtocol.MLS)
+    }
+
+    @Test
+    fun givenRequestingDefaultProtocol_whenRequestFails_thenReturnProteusAsDefaultProtocol() = runTest {
+        // given
+        val (_, useCase) = GetDefaultProtocolUseCaseTestArrangement()
+            .withReturningError()
+            .arrange()
+
+        // when
+        val result = useCase()
+
+        // then
+        assertEquals(result, SupportedProtocol.PROTEUS)
+    }
+
+    internal class GetDefaultProtocolUseCaseTestArrangement {
+        @Mock
+        val userConfigRepository: UserConfigRepository = mock(UserConfigRepository::class)
+
+        val useCase = GetDefaultProtocolUseCaseImpl(
+            userConfigRepository = userConfigRepository
+        )
+
+        fun withReturningSuccessProteusProtocol() = apply {
+            given(userConfigRepository)
+                .function(userConfigRepository::getDefaultProtocol)
+                .whenInvoked()
+                .thenReturn(Either.Right(SupportedProtocol.PROTEUS))
+        }
+
+        fun withReturningSuccessMLSProtocol() = apply {
+            given(userConfigRepository)
+                .function(userConfigRepository::getDefaultProtocol)
+                .whenInvoked()
+                .thenReturn(Either.Right(SupportedProtocol.MLS))
+        }
+
+        fun withReturningError() = apply {
+            given(userConfigRepository)
+                .function(userConfigRepository::getDefaultProtocol)
+                .whenInvoked()
+                .thenReturn(Either.Left(StorageFailure.Generic(Throwable())))
+        }
+
+        fun arrange() = this to useCase
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no way for getting the default protocol when creating a group.

### Causes (Optional)

Not implemented.

### Solutions

Create a usecase (`GetDefaultProtocolUseCase`) to get default protocol set by the team owner.

### Dependencies (Optional)

Needs releases with:

AR PR will follow as soon as this one is merged.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Only tested in conjunction with AR, steps will be explained in AR PR.
