### PR TITLE
chore: add logs to lifecycle executors

### DIFF
--- a/logger/src/commonMain/kotlin/com/wire/kalium/logger/KaliumLogger.kt
+++ b/logger/src/commonMain/kotlin/com/wire/kalium/logger/KaliumLogger.kt
@@ -112,10 +112,19 @@ class KaliumLogger(
      * In this case it will become "featureId:featureName[userId|clientId]".
      * When current type of tag is [Tag.Text], then it will just replace it with the new one: "featureId:featureName".
      */
-    @Suppress("unused")
-    fun withFeatureId(featureId: ApplicationFlow): KaliumLogger = KaliumLogger(
+    fun withFeatureId(featureId: ApplicationFlow): KaliumLogger = withTextTag(
+        featureId.name.lowercase()
+    )
+
+    /**
+     * Creates a new logger with a custom tag that replaces the old tag.
+     *
+     * @param textTag The text tag to be added to the logger.
+     * @return Returns a new instance of KaliumLogger with the updated tag.
+     */
+    fun withTextTag(textTag: String): KaliumLogger = KaliumLogger(
         config = config,
-        tag = "featureId:${featureId.name.lowercase()}".let {
+        tag = "featureId:$textTag".let {
             when (tag) {
                 is Tag.Text -> Tag.Text(it)
                 is Tag.UserClientText -> Tag.UserClientText(it, tag.data)
@@ -129,7 +138,6 @@ class KaliumLogger(
      * and if it contained already some text tag prefix part, then the same prefix will be also included in the new one,
      * to keep the standard pattern of the tag: "tag[userId|clientId]".
      */
-    @Suppress("unused")
     fun withUserDeviceData(data: () -> UserClientData): KaliumLogger = KaliumLogger(
         config = config,
         tag = when (tag) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
@@ -61,7 +61,7 @@ object CoreLogger {
 internal fun KaliumLogger.logStructuredJson(
     level: KaliumLogLevel,
     leadingMessage: String,
-    jsonStringKeyValues: Map<String, Any>
+    jsonStringKeyValues: Map<String, Any?>
 ) {
     val logJson = jsonStringKeyValues.toJsonElement()
     val sanitizedLeadingMessage = if (leadingMessage.endsWith(":")) leadingMessage else "$leadingMessage:"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageLimitsProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageLimitsProvider.kt
@@ -33,7 +33,9 @@ class KeyPackageLimitsProviderImpl(
 ) : KeyPackageLimitsProvider {
 
     private val keyPackageUploadLimit: Int
-        get() = if (kaliumConfigs.lowerKeyPackageLimits) KEY_PACKAGE_LIMIT_LOW else KEY_PACKAGE_LIMIT
+        get() = if (kaliumConfigs.lowerKeyPackageLimits) {
+            KEY_PACKAGE_LIMIT_LOW
+        } else KEY_PACKAGE_LIMIT
 
     private val keyPackageUploadThreshold: Float
         get() = KEY_PACKAGE_THRESHOLD
@@ -46,7 +48,7 @@ class KeyPackageLimitsProviderImpl(
 
     companion object {
         internal const val KEY_PACKAGE_LIMIT = 100
-        internal const val KEY_PACKAGE_LIMIT_LOW = 10
-        internal const val KEY_PACKAGE_THRESHOLD = 0.5F
+        internal const val KEY_PACKAGE_LIMIT_LOW = 1
+        internal const val KEY_PACKAGE_THRESHOLD = 1F
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageLimitsProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageLimitsProvider.kt
@@ -33,9 +33,7 @@ class KeyPackageLimitsProviderImpl(
 ) : KeyPackageLimitsProvider {
 
     private val keyPackageUploadLimit: Int
-        get() = if (kaliumConfigs.lowerKeyPackageLimits) {
-            KEY_PACKAGE_LIMIT_LOW
-        } else KEY_PACKAGE_LIMIT
+        get() = if (kaliumConfigs.lowerKeyPackageLimits) KEY_PACKAGE_LIMIT_LOW else KEY_PACKAGE_LIMIT
 
     private val keyPackageUploadThreshold: Float
         get() = KEY_PACKAGE_THRESHOLD
@@ -48,7 +46,7 @@ class KeyPackageLimitsProviderImpl(
 
     companion object {
         internal const val KEY_PACKAGE_LIMIT = 100
-        internal const val KEY_PACKAGE_LIMIT_LOW = 1
-        internal const val KEY_PACKAGE_THRESHOLD = 1F
+        internal const val KEY_PACKAGE_LIMIT_LOW = 10
+        internal const val KEY_PACKAGE_THRESHOLD = 0.5F
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1052,7 +1052,8 @@ class UserSessionScope internal constructor(
             incrementalSyncRepository,
             clientRepository,
             recoverMLSConversationsUseCase,
-            slowSyncRepository
+            slowSyncRepository,
+            userScopedLogger
         )
     }
 
@@ -1060,7 +1061,8 @@ class UserSessionScope internal constructor(
         ConversationsRecoveryManagerImpl(
             incrementalSyncRepository,
             addSystemMessageToAllConversationsUseCase,
-            slowSyncRepository
+            slowSyncRepository,
+            userScopedLogger
         )
     }
 
@@ -1454,7 +1456,8 @@ class UserSessionScope internal constructor(
             clientRemoteRepository = clientRemoteRepository,
             userConfigRepository = userConfigRepository,
             selfClientIdProvider = clientIdProvider,
-            incrementalSyncRepository = incrementalSyncRepository
+            incrementalSyncRepository = incrementalSyncRepository,
+            kaliumLogger = userScopedLogger,
         )
 
     private val legalHoldHandler = LegalHoldHandlerImpl(
@@ -1567,7 +1570,8 @@ class UserSessionScope internal constructor(
         ProteusSyncWorkerImpl(
             incrementalSyncRepository = incrementalSyncRepository,
             proteusPreKeyRefiller = proteusPreKeyRefiller,
-            preKeyRepository = preKeyRepository
+            preKeyRepository = preKeyRepository,
+            kaliumLogger = userScopedLogger,
         )
     }
 
@@ -1576,6 +1580,7 @@ class UserSessionScope internal constructor(
             certificateRevocationListRepository = certificateRevocationListRepository,
             incrementalSyncRepository = incrementalSyncRepository,
             checkRevocationList = checkRevocationList,
+            kaliumLogger = userScopedLogger,
         )
     }
 
@@ -1583,6 +1588,7 @@ class UserSessionScope internal constructor(
         FeatureFlagSyncWorkerImpl(
             incrementalSyncRepository = incrementalSyncRepository,
             syncFeatureConfigs = syncFeatureConfigsUseCase,
+            kaliumLogger = userScopedLogger,
         )
     }
 
@@ -1602,7 +1608,8 @@ class UserSessionScope internal constructor(
     private val avsSyncStateReporter: AvsSyncStateReporter by lazy {
         AvsSyncStateReporterImpl(
             callManager = callManager,
-            observeSyncStateUseCase = observeSyncState
+            observeSyncStateUseCase = observeSyncState,
+            kaliumLogger = userScopedLogger,
         )
     }
 
@@ -1625,7 +1632,10 @@ class UserSessionScope internal constructor(
         )
 
     private val acmeCertificatesSyncWorker: ACMECertificatesSyncWorker by lazy {
-        ACMECertificatesSyncWorkerImpl(e2eiRepository)
+        ACMECertificatesSyncWorkerImpl(
+            e2eiRepository = e2eiRepository,
+            kaliumLogger = userScopedLogger,
+        )
     }
 
     private val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase
@@ -1711,7 +1721,8 @@ class UserSessionScope internal constructor(
             staleEpochVerifier,
             eventProcessor,
             legalHoldHandler,
-            this
+            this,
+            userScopedLogger,
         )
     val messages: MessageScope
         get() = MessageScope(
@@ -1741,7 +1752,8 @@ class UserSessionScope internal constructor(
             messageMetadataRepository,
             staleEpochVerifier,
             legalHoldHandler,
-            this
+            this,
+            userScopedLogger,
         )
     val users: UserScope
         get() = UserScope(
@@ -1767,7 +1779,8 @@ class UserSessionScope internal constructor(
             updateSupportedProtocols,
             clientRepository,
             joinExistingMLSConversations,
-            refreshUsersWithoutMetadata
+            refreshUsersWithoutMetadata,
+            userScopedLogger,
         )
 
     val search: SearchScope
@@ -1959,12 +1972,17 @@ class UserSessionScope internal constructor(
             persistMessage,
             conversationVerificationStatusChecker,
             epochChangesObserver,
-            userId
+            userId,
+            userScopedLogger,
         )
     }
 
     private val typingIndicatorSyncManager: TypingIndicatorSyncManager =
-        TypingIndicatorSyncManager(lazy { conversations.typingIndicatorIncomingRepository }, observeSyncState)
+        TypingIndicatorSyncManager(
+            typingIndicatorIncomingRepository = lazy { conversations.typingIndicatorIncomingRepository },
+            observeSyncStateUseCase = observeSyncState,
+            kaliumLogger = userScopedLogger,
+        )
 
     init {
         launch {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationsRecoveryManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationsRecoveryManager.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.conversation
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
@@ -31,15 +32,20 @@ internal class ConversationsRecoveryManagerImpl(
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val addSystemMessageToAllConversationsUseCase: AddSystemMessageToAllConversationsUseCase,
     private val slowSyncRepository: SlowSyncRepository,
+    kaliumLogger: KaliumLogger
 ) : ConversationsRecoveryManager {
+
+    private val logger = kaliumLogger.withTextTag("ConversationsRecoveryManager")
 
     @Suppress("ComplexCondition")
     override suspend fun invoke() {
+        logger.d("Starting to monitor")
         // wait until incremental sync is done
         incrementalSyncRepository.incrementalSyncState.collect { syncState ->
             if (syncState is IncrementalSyncStatus.Live &&
                 slowSyncRepository.needsToPersistHistoryLostMessage()
             ) {
+                logger.i("Persisting history lost message and marking it as no longer needed")
                 addSystemMessageToAllConversationsUseCase.invoke()
                 slowSyncRepository.setNeedsToPersistHistoryLostMessage(false)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManager.kt
@@ -18,14 +18,15 @@
 
 package com.wire.kalium.logic.feature.conversation
 
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.functional.getOrElse
-import com.wire.kalium.logic.kaliumLogger
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.wire.kalium.logic.logStructuredJson
 
 internal interface MLSConversationsRecoveryManager {
     suspend fun invoke()
@@ -37,18 +38,34 @@ internal class MLSConversationsRecoveryManagerImpl(
     private val clientRepository: ClientRepository,
     private val recoverMLSConversationsUseCase: RecoverMLSConversationsUseCase,
     private val slowSyncRepository: SlowSyncRepository,
+    kaliumLogger: KaliumLogger
 ) : MLSConversationsRecoveryManager {
 
+    private val logger = kaliumLogger.withTextTag("MLSConversationRecoveryManager")
+
     @Suppress("ComplexCondition")
-    @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun invoke() {
         // wait until incremental sync is done
+        logger.v("Starting to observe for matching requirements")
         incrementalSyncRepository.incrementalSyncState.collect { syncState ->
+            val isMlsSupported = featureSupport.isMLSSupported
+            val hasRegisteredMLSClient = clientRepository.hasRegisteredMLSClient().getOrElse(false)
+            val needsToRecoverMLSGroups = slowSyncRepository.needsToRecoverMLSGroups()
+            logger.logStructuredJson(
+                level = KaliumLogLevel.DEBUG,
+                leadingMessage = "SyncState updated",
+                jsonStringKeyValues = mapOf(
+                    "isMlsSupported" to isMlsSupported,
+                    "hasRegisteredMLSClient" to hasRegisteredMLSClient,
+                    "needsToRecoverMLSGroups" to needsToRecoverMLSGroups
+                )
+            )
             if (syncState is IncrementalSyncStatus.Live &&
-                featureSupport.isMLSSupported &&
-                clientRepository.hasRegisteredMLSClient().getOrElse(false) &&
-                slowSyncRepository.needsToRecoverMLSGroups()
+                isMlsSupported &&
+                hasRegisteredMLSClient &&
+                needsToRecoverMLSGroups
             ) {
+                logger.i("Recovering MLS Conversations")
                 recoverMLSConversations()
             }
         }
@@ -58,9 +75,12 @@ internal class MLSConversationsRecoveryManagerImpl(
         recoverMLSConversationsUseCase.invoke().let { result ->
             when (result) {
                 is RecoverMLSConversationsResult.Failure ->
-                    kaliumLogger.w("Error while recovering MLS conversations: ${result.failure}")
-                is RecoverMLSConversationsResult.Success ->
+                    logger.w("Error while recovering MLS conversations: ${result.failure}")
+
+                is RecoverMLSConversationsResult.Success -> {
+                    logger.i("Successfully recovered MLS Conversations")
                     slowSyncRepository.setNeedsToRecoverMLSGroups(false)
+                }
             }
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandler.kt
@@ -18,6 +18,8 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.benasher44.uuid.uuid4
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation.VerificationStatus
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -28,10 +30,12 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.mls.ConversationVerificationStatusChecker
 import com.wire.kalium.logic.feature.conversation.mls.EpochChangesObserver
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onlyRight
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onEach
 
 /**
  * Observes all the MLS Conversations Verification status.
@@ -47,17 +51,31 @@ internal class MLSConversationsVerificationStatusesHandlerImpl(
     private val conversationVerificationStatusChecker: ConversationVerificationStatusChecker,
     private val epochChangesObserver: EpochChangesObserver,
     private val selfUserId: UserId,
+    kaliumLogger: KaliumLogger
 ) : MLSConversationsVerificationStatusesHandler {
 
-    override suspend fun invoke() =
-        epochChangesObserver.observe().mapLatest { groupId -> conversationVerificationStatusChecker.check(groupId).map { groupId to it } }
+    private val logger = kaliumLogger.withTextTag("MLSConversationsVerificationStatusesHandler")
+
+    override suspend fun invoke() {
+        logger.d("Starting to monitor")
+        epochChangesObserver.observe()
+            .mapLatest { groupId -> conversationVerificationStatusChecker.check(groupId).map { groupId to it } }
+            .onEach {
+                if (it is Either.Left) {
+                    val failure = it.value
+                    val throwable = if (failure is CoreFailure.Unknown) failure.rootCause else null
+                    logger.w("Error while checking conversation verification status: ${it.value}", throwable)
+                }
+            }
             .onlyRight()
             .collect { (groupId, newStatus) ->
                 conversationRepository.getConversationDetailsByMLSGroupId(groupId)
                     .map { conversation -> updateStatusAndNotifyUserIfNeeded(newStatus, conversation) }
             }
+    }
 
     private suspend fun updateStatusAndNotifyUserIfNeeded(newStatusFromCC: VerificationStatus, conversation: ConversationDetails) {
+        logger.i("Updating verification status and notifying user if needed")
         val currentStatus = conversation.conversation.mlsVerificationStatus
         val newStatus = getActualNewStatus(newStatusFromCC, currentStatus)
 
@@ -92,6 +110,7 @@ internal class MLSConversationsVerificationStatusesHandlerImpl(
         conversationId: ConversationId,
         updatedStatus: VerificationStatus
     ) {
+        logger.i("Notifying user about state changes")
         val content = if (updatedStatus == VerificationStatus.VERIFIED) MessageContent.ConversationVerifiedMLS
         else MessageContent.ConversationDegradedMLS
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/TypingIndicatorSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/TypingIndicatorSyncManager.kt
@@ -17,22 +17,25 @@
  */
 package com.wire.kalium.logic.feature.conversation
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.conversation.TypingIndicatorIncomingRepository
-import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 internal class TypingIndicatorSyncManager(
     private val typingIndicatorIncomingRepository: Lazy<TypingIndicatorIncomingRepository>,
-    private val observeSyncStateUseCase: ObserveSyncStateUseCase
+    private val observeSyncStateUseCase: ObserveSyncStateUseCase,
+    kaliumLogger: KaliumLogger
 ) {
+    private val logger = kaliumLogger.withTextTag("TypingIndicatorSyncManager")
     /**
      * Periodically clears and drop orphaned typing indicators, so we don't keep them forever.
      */
     suspend fun execute() {
+        logger.d("Starting to monitor")
         observeSyncStateUseCase().distinctUntilChanged().collectLatest {
-            kaliumLogger.d("Starting clear of orphaned typing indicators...")
+            logger.d("Starting clear of orphaned typing indicators...")
             typingIndicatorIncomingRepository.value.clearExpiredTypingIndicators()
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.debug
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientRepository
@@ -85,7 +86,8 @@ class DebugScope internal constructor(
     private val eventProcessor: EventProcessor,
     private val legalHoldHandler: LegalHoldHandler,
     private val scope: CoroutineScope,
-    internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
+    private val logger: KaliumLogger,
+    internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) {
 
     val breakSession: BreakSessionUseCase
@@ -188,6 +190,7 @@ class DebugScope internal constructor(
             messageRepository = messageRepository,
             deleteEphemeralMessageForSelfUserAsReceiver = deleteEphemeralMessageForSelfUserAsReceiver,
             deleteEphemeralMessageForSelfUserAsSender = deleteEphemeralMessageForSelfUserAsSender,
-            selfUserId = userId
+            selfUserId = userId,
+            kaliumLogger = logger
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/ACMECertificatesSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/ACMECertificatesSyncWorker.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.e2ei
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.e2ei.E2EIRepository
 import com.wire.kalium.logic.functional.intervalFlow
 import kotlin.time.Duration
@@ -31,12 +32,17 @@ internal interface ACMECertificatesSyncWorker {
 
 internal class ACMECertificatesSyncWorkerImpl(
     private val e2eiRepository: E2EIRepository,
-    private val syncInterval: Duration = DEFAULT_SYNC_INTERVAL
+    private val syncInterval: Duration = DEFAULT_SYNC_INTERVAL,
+    kaliumLogger: KaliumLogger
 ) : ACMECertificatesSyncWorker {
 
+    private val logger = kaliumLogger.withTextTag("ACMECertificatesSyncWorker")
+
     override suspend fun execute() {
+        logger.d("Starting to monitor")
         intervalFlow(syncInterval.inWholeMilliseconds)
             .collect {
+                logger.i("Fetching federation certificates")
                 e2eiRepository.fetchFederationCertificates()
             }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/CertificateRevocationListCheckWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/CertificateRevocationListCheckWorker.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.e2ei
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
@@ -44,14 +45,18 @@ internal interface CertificateRevocationListCheckWorker {
 internal class CertificateRevocationListCheckWorkerImpl(
     private val certificateRevocationListRepository: CertificateRevocationListRepository,
     private val incrementalSyncRepository: IncrementalSyncRepository,
-    private val checkRevocationList: CheckRevocationListUseCase
+    private val checkRevocationList: CheckRevocationListUseCase,
+    kaliumLogger: KaliumLogger
 ) : CertificateRevocationListCheckWorker {
 
+    private val logger = kaliumLogger.withTextTag("CertificateRevocationListCheckWorker")
+
     override suspend fun execute() {
+        logger.d("Starting to monitor")
         incrementalSyncRepository.incrementalSyncState
             .filter { it is IncrementalSyncStatus.Live }
             .collect {
-                kaliumLogger.i("Checking certificate revocation list (CRL)..")
+                logger.i("Checking certificate revocation list (CRL)..")
                 certificateRevocationListRepository.getCRLs()?.cRLWithExpirationList?.forEach { crl ->
                     if (crl.expiration < Clock.System.now().epochSeconds.toULong()) {
                         checkRevocationList(crl.url).map { newExpirationTime ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/FeatureFlagsSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/FeatureFlagsSyncWorker.kt
@@ -17,8 +17,11 @@
  */
 package com.wire.kalium.logic.feature.featureConfig
 
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.logStructuredJson
 import kotlinx.coroutines.flow.filter
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -35,13 +38,16 @@ internal interface FeatureFlagsSyncWorker {
 internal class FeatureFlagSyncWorkerImpl(
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val syncFeatureConfigs: SyncFeatureConfigsUseCase,
+    kaliumLogger: KaliumLogger,
     private val minIntervalBetweenPulls: Duration = MIN_INTERVAL_BETWEEN_PULLS,
     private val clock: Clock = Clock.System
 ) : FeatureFlagsSyncWorker {
 
     private var lastPullInstant: Instant? = null
+    private val logger = kaliumLogger.withTextTag("FeatureFlagSyncWorker")
 
     override suspend fun execute() {
+        logger.d("Starting to monitor")
         incrementalSyncRepository.incrementalSyncState.filter {
             it is IncrementalSyncStatus.Live
         }.collect {
@@ -54,7 +60,16 @@ internal class FeatureFlagSyncWorkerImpl(
         val wasLastPullRecent = lastPullInstant?.let { lastPull ->
             lastPull + minIntervalBetweenPulls > now
         } ?: false
+        logger.logStructuredJson(
+            level = KaliumLogLevel.INFO,
+            leadingMessage = "syncFeatureFlagsIfNeeded",
+            jsonStringKeyValues = mapOf(
+                "lastPullInstant" to lastPullInstant,
+                "wasLastPullRecent" to wasLastPullRecent
+            )
+        )
         if (!wasLastPullRecent) {
+            logger.i("Synching feature configs and updating lastPullInstant")
             syncFeatureConfigs()
             lastPullInstant = now
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
@@ -55,14 +55,15 @@ internal class RefillKeyPackagesUseCaseImpl(
             //       and fetch from local instead of remote
             keyPackageRepository.getAvailableKeyPackageCount(selfClientId)
                 .flatMap {
+                    kaliumLogger.i("Key packages: Found ${it.count} available key packages")
                     if (keyPackageLimitsProvider.needsRefill(it.count)) {
-                        kaliumLogger.i("Refilling key packages...")
+                        kaliumLogger.i("Key packages: Refilling key packages...")
                         val amount = keyPackageLimitsProvider.refillAmount()
                         keyPackageRepository.uploadNewKeyPackages(selfClientId, amount).flatMap {
                             Either.Right(Unit)
                         }
                     } else {
-                        kaliumLogger.i("Key packages didn't need refilling")
+                        kaliumLogger.i("Key packages: Refill not needed")
                         Either.Right(Unit)
                     }
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.client.ClientRepository
@@ -103,6 +104,7 @@ class MessageScope internal constructor(
     private val staleEpochVerifier: StaleEpochVerifier,
     private val legalHoldHandler: LegalHoldHandler,
     private val scope: CoroutineScope,
+    private val kaliumLogger: KaliumLogger,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
     private val legalHoldStatusMapper: LegalHoldStatusMapper = LegalHoldStatusMapperImpl
 ) {
@@ -148,7 +150,8 @@ class MessageScope internal constructor(
             messageRepository = messageRepository,
             deleteEphemeralMessageForSelfUserAsReceiver = deleteEphemeralMessageForSelfUserAsReceiver,
             deleteEphemeralMessageForSelfUserAsSender = deleteEphemeralMessageForSelfUserAsSender,
-            selfUserId = selfUserId
+            selfUserId = selfUserId,
+            kaliumLogger = kaliumLogger
         )
 
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger.kt
@@ -17,19 +17,19 @@
  */
 package com.wire.kalium.logic.feature.message.ephemeral
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
 
-internal object SelfDeletionEventLogger {
+internal class SelfDeletionEventLogger(private val logger: KaliumLogger) {
     fun log(
         loggingSelfDeletionEvent: LoggingSelfDeletionEvent
     ) {
-        kaliumLogger.i(loggingSelfDeletionEvent.toJson())
+        logger.i(loggingSelfDeletionEvent.toJson())
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -19,6 +19,7 @@
 
 package com.wire.kalium.logic.feature.user
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.asset.AssetRepository
@@ -102,7 +103,8 @@ class UserScope internal constructor(
     private val updateSelfUserSupportedProtocolsUseCase: UpdateSelfUserSupportedProtocolsUseCase,
     private val clientRepository: ClientRepository,
     private val joinExistingMLSConversationsUseCase: JoinExistingMLSConversationsUseCase,
-    val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase
+    val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
+    private val userScoppedLogger: KaliumLogger
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
     val getSelfUser: GetSelfUserUseCase get() = GetSelfUserUseCaseImpl(userRepository)
@@ -196,6 +198,7 @@ class UserScope internal constructor(
         get() = ObserveCertificateRevocationForSelfClientUseCaseImpl(
             userConfigRepository = userConfigRepository,
             currentClientIdProvider = clientIdProvider,
-            getE2eiCertificate = getE2EICertificate
+            getE2eiCertificate = getE2EICertificate,
+            kaliumLogger = userScoppedLogger,
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Flow.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/functional/Flow.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.functional
 
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -42,7 +41,6 @@ suspend inline fun <A, B> Collection<A>.flatMapFromIterable(
 
 fun <T1, T2> Flow<T1>.combine(flow: Flow<T2>): Flow<Pair<T1, T2>> = combine(flow) { t1, t2 -> t1 to t2 }
 
-@OptIn(FlowPreview::class)
 fun <T> Flow<List<T>>.flatten() = flatMapConcat { it.asFlow() }
 
 fun <T> Flow<T>.distinct(): Flow<T> {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManagerTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManagerTests.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
 import io.mockative.Mock
 import io.mockative.anything
 import io.mockative.classOf
@@ -192,7 +193,8 @@ class MLSConversationsRecoveryManagerTests {
             incrementalSyncRepository,
             clientRepository,
             recoverMLSConversationsUseCase,
-            slowSyncRepository
+            slowSyncRepository,
+            kaliumLogger
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandlerTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversationDetails
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.MLSConversationRepositoryArrangement
@@ -216,7 +217,8 @@ class MLSConversationsVerificationStatusesHandlerTest {
                 persistMessage = persistMessageUseCase,
                 conversationVerificationStatusChecker = conversationVerificationStatusChecker,
                 epochChangesObserver = epochChangesObserver,
-                selfUserId = TestUser.USER_ID
+                selfUserId = TestUser.USER_ID,
+                kaliumLogger = kaliumLogger
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/ACMECertificatesSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/ACMECertificatesSyncWorkerTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.e2ei
 
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.arrangement.repository.E2EIRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.E2EIRepositoryArrangementImpl
 import io.mockative.twice
@@ -54,7 +55,11 @@ class ACMECertificatesSyncWorkerTest {
 
         fun arrange(): Pair<Arrangement, ACMECertificatesSyncWorker> = run {
             configure()
-            this@Arrangement to ACMECertificatesSyncWorkerImpl(e2eiRepository = e2eiRepository, syncInterval = syncInterval)
+            this@Arrangement to ACMECertificatesSyncWorkerImpl(
+                e2eiRepository = e2eiRepository,
+                syncInterval = syncInterval,
+                kaliumLogger = kaliumLogger
+            )
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/CertificateRevocationListCheckTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/CertificateRevocationListCheckTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.feature.e2ei.usecase.CheckRevocationListUseCase
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.persistence.config.CRLUrlExpirationList
 import com.wire.kalium.persistence.config.CRLWithExpiration
 import io.mockative.Mock
@@ -77,7 +78,7 @@ class CertificateRevocationListCheckTest {
         val checkRevocationList = mock(classOf<CheckRevocationListUseCase>())
 
         fun arrange() = this to CertificateRevocationListCheckWorkerImpl(
-            certificateRevocationListRepository, incrementalSyncRepository, checkRevocationList
+            certificateRevocationListRepository, incrementalSyncRepository, checkRevocationList, kaliumLogger
         )
 
         fun withNoCRL() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/FeatureFlagSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/FeatureFlagSyncWorkerTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.feature.featureConfig
 
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangementImpl
 import io.mockative.Mock
@@ -148,7 +149,8 @@ class FeatureFlagSyncWorkerTest {
                 incrementalSyncRepository = incrementalSyncRepository,
                 syncFeatureConfigs = syncFeatureConfigsUseCase,
                 minIntervalBetweenPulls = minimumIntervalBetweenPulls,
-                clock = clock
+                clock = clock,
+                kaliumLogger = kaliumLogger
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/UpdateSelfClientCapabilityToLegalHoldConsentUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/UpdateSelfClientCapabilityToLegalHoldConsentUseCaseTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.anything
@@ -120,7 +121,8 @@ class UpdateSelfClientCapabilityToLegalHoldConsentUseCaseTest {
                 clientRemoteRepository = clientRemoteRepository,
                 userConfigRepository = userConfigRepository,
                 selfClientIdProvider = selfClientIdProvider,
-                incrementalSyncRepository = incrementalSyncRepository
+                incrementalSyncRepository = incrementalSyncRepository,
+                kaliumLogger = kaliumLogger
             )
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/ephemeral/EphemeralMessageDeletionHandlerTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import io.mockative.Mock
 import io.mockative.Times
@@ -829,7 +830,8 @@ class EphemeralMessageDeletionHandlerTest {
             dispatcher,
             deleteEphemeralMessageForSelfUserAsReceiver,
             deleteEphemeralMessageForSelfUserAsSender,
-            coroutineScope
+            kaliumLogger,
+            coroutineScope,
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/proteus/ProteusSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/proteus/ProteusSyncWorkerTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.feature.proteus
 
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.PreKeyRepositoryArrangement
@@ -123,7 +124,8 @@ class ProteusSyncWorkerTest {
                 incrementalSyncRepository = incrementalSyncRepository,
                 proteusPreKeyRefiller = proteusPreKeyRefiller,
                 preKeyRepository = preKeyRepository,
-                minIntervalBetweenRefills = minIntervalBetweenRefills
+                minIntervalBetweenRefills = minIntervalBetweenRefills,
+                kaliumLogger = kaliumLogger
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/AvsSyncStateReporterTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/AvsSyncStateReporterTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.sync
 
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.kaliumLogger
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
@@ -85,7 +86,8 @@ class AvsSyncStateReporterTest {
 
         fun arrange() = this to AvsSyncStateReporterImpl(
             callManager = lazy { callManager },
-            observeSyncStateUseCase = observeSyncStateUseCase
+            observeSyncStateUseCase = observeSyncStateUseCase,
+            kaliumLogger = kaliumLogger
         )
 
         fun withGatheringEventsSyncState() = apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Many of our "lifecycle executors" A.K.A. _things that run when the app is launched while the user is logged in_ don't have enough logs to figure out what is going on when failures happen.

### Solutions

Add more logs.
Bonus: use `UserScopedLogger` to make it easier to distinguish if the device has multiple users signed in.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
