### PR TITLE
feat(monkeys): Write CC version in logs and allow to skip warmup [WPB-6784]

### DIFF
--- a/monkeys/build.gradle.kts
+++ b/monkeys/build.gradle.kts
@@ -60,9 +60,14 @@ tasks.startScripts {
     dependsOn(serverScripts)
 }
 
+tasks.jar {
+    manifest {
+        attributes["CC-Version"] = libs.coreCrypto.get().version
+    }
+}
+
 sourceSets {
     val main by getting {
-
         dependencies {
             implementation(project(":network"))
             implementation(project(":cryptography"))

--- a/monkeys/schema.json
+++ b/monkeys/schema.json
@@ -146,8 +146,7 @@
                     "passwordForUsers",
                     "domain",
                     "authUser",
-                    "authPassword",
-                    "userCount"
+                    "authPassword"
                 ],
                 "properties": {
                     "api": {
@@ -196,7 +195,8 @@
                     },
                     "userCount": {
                         "description": "How many users should be created in this team",
-                        "type": "integer"
+                        "type": "integer",
+                        "default": 10
                     },
                     "2FAEnabled": {
                         "description": "Does this server require 2FA authentication?",

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
@@ -180,10 +180,12 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
         val isActive = AtomicBoolean(true)
 
         fun getCCVersion(): String {
-            this::class.java.classLoader?.getResources("META-INF/MANIFEST.MF")?.asIterator()?.forEach {
-                val manifest = Manifest(it.openStream())
-                if (manifest.mainAttributes.getValue("CC-Version") != null)
-                    return manifest.mainAttributes.getValue("CC-Version")
+            this::class.java.classLoader?.getResources("META-INF/MANIFEST.MF")?.asIterator()?.forEach { url ->
+                url.openStream().use {
+                    val manifest = Manifest(it)
+                    if (manifest.mainAttributes.getValue("CC-Version") != null)
+                        return manifest.mainAttributes.getValue("CC-Version")
+                }
             }
             return "Not-Found"
         }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
@@ -24,6 +24,7 @@ import co.touchlab.kermit.LogWriter
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.enum
 import com.wire.kalium.logger.KaliumLogLevel
@@ -60,6 +61,7 @@ import sun.misc.SignalHandler
 import java.io.File
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.jar.Manifest
 import kotlin.coroutines.cancellation.CancellationException
 
 fun CoroutineScope.stopIM() {
@@ -70,6 +72,7 @@ fun CoroutineScope.stopIM() {
 
 class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
     private val dataFilePath by argument(help = "path to the test data file")
+    private val skipWarmup by option("-s", "--skip-warmup", help = "Should the warmup be skipped?").flag()
     private val logLevel by option("-l", "--log-level", help = "log level").enum<KaliumLogLevel>().default(KaliumLogLevel.INFO)
     private val logOutputFile by option("-f", "--log-file", help = "output file for logs")
     private val monkeysLogOutputFile by option("-m", "--monkeys-log-file", help = "output file for monkey logs")
@@ -102,7 +105,7 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
                 }
             }.start(false).stopServerOnCancellation()
 
-            logger.i("Initializing Infinite Monkeys")
+            logger.i("Initializing Infinite Monkeys - CC: ${getCCVersion()}")
             val testData = TestDataImporter.importFromFile(dataFilePath)
             val eventProcessor = when (testData.eventStorage) {
                 is com.wire.kalium.monkeys.model.EventStorage.FileStorage -> FileStorage(testData.eventStorage)
@@ -151,8 +154,10 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
             // the first one creates the preset groups and logs everyone in so keypackages are created
             val eventChannel = Channel<Event>(Channel.UNLIMITED)
             if (index == 0) {
-                logger.i("Creating initial key packages for clients (logging everyone in and out). This can take a while...")
-                monkeyPool.warmUp(coreLogic)
+                if (!this.skipWarmup) {
+                    logger.i("Creating initial key packages for clients (logging everyone in and out). This can take a while...")
+                    monkeyPool.warmUp(coreLogic)
+                }
                 logger.i("Creating prefixed groups")
                 testData.conversationDistribution.forEach { (prefix, config) ->
                     ConversationPool.createPrefixedConversations(
@@ -173,5 +178,14 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
     companion object {
         val HOME_DIRECTORY: String = homeDirectory()
         val isActive = AtomicBoolean(true)
+
+        fun getCCVersion(): String {
+            this::class.java.classLoader?.getResources("META-INF/MANIFEST.MF")?.asIterator()?.forEach {
+                val manifest = Manifest(it.openStream())
+                if (manifest.mainAttributes.getValue("CC-Version") != null)
+                    return manifest.mainAttributes.getValue("CC-Version")
+            }
+            return "Not-Found"
+        }
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestData.kt
@@ -187,7 +187,7 @@ data class BackendConfig(
     @SerialName("teamName") val teamName: String,
     @SerialName("authUser") val authUser: String,
     @SerialName("authPassword") val authPassword: String,
-    @SerialName("userCount") val userCount: ULong,
+    @SerialName("userCount") val userCount: ULong = 10u,
     @SerialName("2FAEnabled") val secondFactorAuth: Boolean = false,
     @SerialName("dumpUsers") val dumpUsers: Boolean = false,
     @SerialName("presetTeam") val presetTeam: TeamConfig? = null


### PR DESCRIPTION
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds the possibility to skip the warmup (which can be useful when running with preset users) and writes the CC version in the logs

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
