### PR TITLE
feat: update group legalhold state if needed when adding or removing members [WPB-6809]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1321,11 +1321,20 @@ class UserSessionScope internal constructor(
         )
     private val memberJoinHandler: MemberJoinEventHandler
         get() = MemberJoinEventHandlerImpl(
-            conversationRepository, userRepository, persistMessage, userId
+            conversationRepository = conversationRepository,
+            userRepository = userRepository,
+            persistMessage = persistMessage,
+            legalHoldHandler = legalHoldHandler,
+            selfUserId = userId
         )
     private val memberLeaveHandler: MemberLeaveEventHandler
         get() = MemberLeaveEventHandlerImpl(
-            userStorage.database.memberDAO, userRepository, persistMessage, updateConversationClientsForCurrentCall, selfTeamId
+            memberDAO = userStorage.database.memberDAO,
+            userRepository = userRepository,
+            persistMessage = persistMessage,
+            updateConversationClientsForCurrentCall = updateConversationClientsForCurrentCall,
+            legalHoldHandler = legalHoldHandler,
+            selfTeamIdProvider = selfTeamId
         )
     private val memberChangeHandler: MemberChangeEventHandler
         get() = MemberChangeEventHandlerImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.util.serialization.toJsonElement
 
 interface MemberJoinEventHandler {
@@ -44,6 +45,7 @@ internal class MemberJoinEventHandlerImpl(
     private val conversationRepository: ConversationRepository,
     private val userRepository: UserRepository,
     private val persistMessage: PersistMessageUseCase,
+    private val legalHoldHandler: LegalHoldHandler,
     private val selfUserId: UserId
 ) : MemberJoinEventHandler {
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
@@ -85,6 +87,7 @@ internal class MemberJoinEventHandlerImpl(
                     expirationData = null
                 )
                 persistMessage(message)
+                legalHoldHandler.handleConversationMembersChanged(event.conversationId)
                 kaliumLogger
                     .logEventProcessing(
                         EventLoggingStatus.SUCCESS,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandler.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.persistence.dao.member.MemberDAO
 
@@ -51,6 +52,7 @@ internal class MemberLeaveEventHandlerImpl(
     private val userRepository: UserRepository,
     private val persistMessage: PersistMessageUseCase,
     private val updateConversationClientsForCurrentCall: Lazy<UpdateConversationClientsForCurrentCallUseCase>,
+    private val legalHoldHandler: LegalHoldHandler,
     private val selfTeamIdProvider: SelfTeamIdProvider
 ) : MemberLeaveEventHandler {
 
@@ -84,6 +86,7 @@ internal class MemberLeaveEventHandlerImpl(
                         persistMessage(it)
                     }
                 }
+                legalHoldHandler.handleConversationMembersChanged(event.conversationId)
             }.onSuccess {
                 kaliumLogger
                     .logEventProcessing(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
@@ -58,6 +58,7 @@ internal interface LegalHoldHandler {
         messageTimestampIso: String,
         handleFailure: suspend () -> Either<CoreFailure, Unit>
     ): Either<CoreFailure, Boolean>
+    suspend fun handleConversationMembersChanged(conversationId: ConversationId): Either<CoreFailure, Unit>
 }
 
 @Suppress("LongParameterList")
@@ -157,6 +158,11 @@ internal class LegalHoldHandlerImpl internal constructor(
                 }
             }
         }
+
+    override suspend fun handleConversationMembersChanged(conversationId: ConversationId): Either<CoreFailure, Unit> =
+        membersHavingLegalHoldClient(conversationId)
+            .map { if (it.isEmpty()) Conversation.LegalHoldStatus.DISABLED else Conversation.LegalHoldStatus.ENABLED }
+            .map { newLegalHoldStatusAfterMembersChange -> handleForConversation(conversationId, newLegalHoldStatusAfterMembersChange) }
 
     private suspend fun processEvent(selfUserId: UserId, userId: UserId) {
         if (selfUserId == userId) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When adding or removing a member that’s under legal hold from group, the group legal hold status should be updated to reflect the actual state of its members.

### Solutions

Create a new method in `LegalHoldHandler` to check if the newly added or removed members were under legal hold and if the group after this change contains members under legal hold and change the group's legal hold status if needed. Add it and execute in both `MemberJoinEventHandler` and `MemberLeaveEventHandler`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Add a team member under legal hold to a group which is not yet under legal hold or remove all members under legal hold form a group.

### Attachments (Optional)

https://github.com/wireapp/kalium/assets/30429749/95dfb100-ff32-4394-90e0-3366b3989185

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
