### PR TITLE
feat: Testservice can send typing events [WPB-6841]

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.testservice.models.SendLocationRequest
 import com.wire.kalium.testservice.models.SendPingRequest
 import com.wire.kalium.testservice.models.SendReactionRequest
 import com.wire.kalium.testservice.models.SendTextRequest
+import com.wire.kalium.testservice.models.SendTypingRequest
 import com.wire.kalium.testservice.models.UpdateTextRequest
 import io.swagger.v3.oas.annotations.Operation
 import kotlinx.coroutines.runBlocking
@@ -297,8 +298,6 @@ class ConversationResources(private val instanceService: InstanceService) {
         }
     }
 
-    // POST /api/v1/instance/{instanceId}/sendButtonAction
-    // Send a button action to a poll.
     @POST
     @Path("/instance/{id}/sendButtonAction")
     @Operation(summary = "Send a button action to a poll.")
@@ -426,6 +425,20 @@ class ConversationResources(private val instanceService: InstanceService) {
         }
     }
 
-    // POST /api/v1/instance/{instanceId}/sendTyping
-    // Send a typing indicator to a conversation.
+    @POST
+    @Path("/instance/{id}/sendTyping")
+    @Operation(summary = "Send a typing indicator to a conversation")
+    @Consumes(MediaType.APPLICATION_JSON)
+    fun sendTyping(@PathParam("id") id: String, @Valid request: SendTypingRequest): Response {
+        val instance = instanceService.getInstanceOrThrow(id)
+        return with(request) {
+            runBlocking {
+                ConversationRepository.sendTyping(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    status
+                )
+            }
+        }
+    }
 }

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendTypingRequest.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/SendTypingRequest.kt
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.testservice.models
+
+data class SendTypingRequest(
+    val conversationDomain: String = "staging.zinfra.io",
+    val conversationId: String = "",
+    val status: String = ""
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

The testservice implements a new endpoint /sendTyping which mirrors the old endpoint in ETS. This was successfully tested against the automatic test case C1220500.