### PR TITLE
fix: Respect MLS and E2EI Enabled on User Identity (WPB-6807)

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -307,11 +307,12 @@ class MLSClientImpl(
     }
 
     override suspend fun registerCrl(url: String, crl: JsonRawData): CrlRegistration {
-        return toCrlRegistration(coreCrypto.e2eiRegisterCrl(url, crl))
+        return CrlRegistration(false,1000000UL)
+        //return toCrlRegistration(coreCrypto.e2eiRegisterCrl(url, crl))
     }
 
     override suspend fun registerIntermediateCa(pem: CertificateChain) {
-        coreCrypto.e2eiRegisterIntermediateCa(pem)
+        //coreCrypto.e2eiRegisterIntermediateCa(pem)
     }
 
     companion object {

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -307,12 +307,11 @@ class MLSClientImpl(
     }
 
     override suspend fun registerCrl(url: String, crl: JsonRawData): CrlRegistration {
-        return CrlRegistration(false,1000000UL)
-        //return toCrlRegistration(coreCrypto.e2eiRegisterCrl(url, crl))
+        return toCrlRegistration(coreCrypto.e2eiRegisterCrl(url, crl))
     }
 
     override suspend fun registerIntermediateCa(pem: CertificateChain) {
-        //coreCrypto.e2eiRegisterIntermediateCa(pem)
+        coreCrypto.e2eiRegisterIntermediateCa(pem)
     }
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1859,7 +1859,10 @@ class UserSessionScope internal constructor(
         get() = MarkFileSharingChangeAsNotifiedUseCase(userConfigRepository)
 
     val isMLSEnabled: IsMLSEnabledUseCase get() = IsMLSEnabledUseCaseImpl(featureSupport, userConfigRepository)
-    val isE2EIEnabled: IsE2EIEnabledUseCase get() = IsE2EIEnabledUseCaseImpl(userConfigRepository)
+    val isE2EIEnabled: IsE2EIEnabledUseCase get() = IsE2EIEnabledUseCaseImpl(
+        userConfigRepository,
+        isMLSEnabled
+    )
 
     val getDefaultProtocol: GetDefaultProtocolUseCase
         get() = GetDefaultProtocolUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1777,7 +1777,8 @@ class UserSessionScope internal constructor(
             clientRepository,
             joinExistingMLSConversations,
             refreshUsersWithoutMetadata,
-            userScopedLogger,
+            isE2EIEnabled,
+            userScopedLogger
         )
 
     val search: SearchScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EIAllCertificatesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EIAllCertificatesUseCase.kt
@@ -41,12 +41,12 @@ class GetUserE2eiCertificatesUseCaseImpl internal constructor(
 ) : GetUserE2eiCertificatesUseCase {
     override suspend operator fun invoke(userId: UserId): Map<String, E2eiCertificate> =
         if (isE2EIEnabledUseCase()) {
-        mlsConversationRepository.getUserIdentity(userId).map { identities ->
-            val result = mutableMapOf<String, E2eiCertificate>()
-            identities.forEach {
-                result[it.clientId.value] = pemCertificateDecoder.decode(it.certificate, it.status)
-            }
-            result
-        }.getOrElse(mapOf())
+            mlsConversationRepository.getUserIdentity(userId).map { identities ->
+                val result = mutableMapOf<String, E2eiCertificate>()
+                identities.forEach {
+                    result[it.clientId.value] = pemCertificateDecoder.decode(it.certificate, it.status)
+                }
+                result
+            }.getOrElse(mapOf())
         } else mapOf()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EIAllCertificatesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EIAllCertificatesUseCase.kt
@@ -17,13 +17,14 @@
  */
 package com.wire.kalium.logic.feature.e2ei.usecase
 
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.e2ei.E2eiCertificate
 import com.wire.kalium.logic.feature.e2ei.PemCertificateDecoder
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.functional.getOrElse
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.data.conversation.ClientId
 
 /**
  * This use case is used to get all e2ei certificates of the user.
@@ -35,9 +36,11 @@ interface GetUserE2eiCertificatesUseCase {
 
 class GetUserE2eiCertificatesUseCaseImpl internal constructor(
     private val mlsConversationRepository: MLSConversationRepository,
-    private val pemCertificateDecoder: PemCertificateDecoder
+    private val pemCertificateDecoder: PemCertificateDecoder,
+    private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : GetUserE2eiCertificatesUseCase {
     override suspend operator fun invoke(userId: UserId): Map<String, E2eiCertificate> =
+        if (isE2EIEnabledUseCase()) {
         mlsConversationRepository.getUserIdentity(userId).map { identities ->
             val result = mutableMapOf<String, E2eiCertificate>()
             identities.forEach {
@@ -45,4 +48,5 @@ class GetUserE2eiCertificatesUseCaseImpl internal constructor(
             }
             result
         }.getOrElse(mapOf())
+        } else mapOf()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EICertificateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EICertificateUseCase.kt
@@ -38,16 +38,16 @@ class GetUserE2eiCertificateStatusUseCaseImpl internal constructor(
 ) : GetUserE2eiCertificateStatusUseCase {
     override suspend operator fun invoke(userId: UserId): GetUserE2eiCertificateStatusResult =
         if (isE2EIEnabledUseCase()) {
-        mlsConversationRepository.getUserIdentity(userId).fold(
-            {
-                GetUserE2eiCertificateStatusResult.Failure.NotActivated
-            },
-            { identities ->
-                identities.getUserCertificateStatus(pemCertificateDecoder)?.let {
-                    GetUserE2eiCertificateStatusResult.Success(it)
-                } ?: GetUserE2eiCertificateStatusResult.Failure.NotActivated
-            }
-        )
+            mlsConversationRepository.getUserIdentity(userId).fold(
+                {
+                    GetUserE2eiCertificateStatusResult.Failure.NotActivated
+                },
+                { identities ->
+                    identities.getUserCertificateStatus(pemCertificateDecoder)?.let {
+                        GetUserE2eiCertificateStatusResult.Success(it)
+                    } ?: GetUserE2eiCertificateStatusResult.Failure.NotActivated
+                }
+            )
         } else {
             GetUserE2eiCertificateStatusResult.Failure.NotActivated
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EICertificateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetUserE2EICertificateUseCase.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.e2ei.CertificateStatus
 import com.wire.kalium.logic.feature.e2ei.PemCertificateDecoder
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.functional.fold
 
 /**
@@ -32,9 +33,11 @@ interface GetUserE2eiCertificateStatusUseCase {
 
 class GetUserE2eiCertificateStatusUseCaseImpl internal constructor(
     private val mlsConversationRepository: MLSConversationRepository,
-    private val pemCertificateDecoder: PemCertificateDecoder
+    private val pemCertificateDecoder: PemCertificateDecoder,
+    private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : GetUserE2eiCertificateStatusUseCase {
     override suspend operator fun invoke(userId: UserId): GetUserE2eiCertificateStatusResult =
+        if (isE2EIEnabledUseCase()) {
         mlsConversationRepository.getUserIdentity(userId).fold(
             {
                 GetUserE2eiCertificateStatusResult.Failure.NotActivated
@@ -45,6 +48,9 @@ class GetUserE2eiCertificateStatusUseCaseImpl internal constructor(
                 } ?: GetUserE2eiCertificateStatusResult.Failure.NotActivated
             }
         )
+        } else {
+            GetUserE2eiCertificateStatusResult.Failure.NotActivated
+        }
 }
 
 sealed class GetUserE2eiCertificateStatusResult {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsE2EIEnabledUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsE2EIEnabledUseCase.kt
@@ -32,13 +32,14 @@ interface IsE2EIEnabledUseCase {
 }
 
 internal class IsE2EIEnabledUseCaseImpl(
-    private val userConfigRepository: UserConfigRepository
+    private val userConfigRepository: UserConfigRepository,
+    private val isMLSEnabledUseCase: IsMLSEnabledUseCase
 ) : IsE2EIEnabledUseCase {
 
     override operator fun invoke(): Boolean =
         userConfigRepository.getE2EISettings().fold({
             false
         }, {
-            it.isRequired
+            it.isRequired && isMLSEnabledUseCase()
         })
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsE2EIEnabledUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsE2EIEnabledUseCase.kt
@@ -22,11 +22,11 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.functional.fold
 
 /**
- * Checks if the current user's team has enabled E2EI .
+ * Checks if the current user's team has enabled E2EI and MLS.
  */
 interface IsE2EIEnabledUseCase {
     /**
-     * @return true if E2EI is enabled, false otherwise.
+     * @return true if E2EI and MLS is enabled, false otherwise.
      */
     operator fun invoke(): Boolean
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -104,6 +104,7 @@ class UserScope internal constructor(
     private val clientRepository: ClientRepository,
     private val joinExistingMLSConversationsUseCase: JoinExistingMLSConversationsUseCase,
     val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
+    private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase,
     private val userScoppedLogger: KaliumLogger
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
@@ -129,12 +130,14 @@ class UserScope internal constructor(
     val getUserE2eiCertificateStatus: GetUserE2eiCertificateStatusUseCase
         get() = GetUserE2eiCertificateStatusUseCaseImpl(
             mlsConversationRepository = mlsConversationRepository,
-            pemCertificateDecoder = pemCertificateDecoderImpl
+            pemCertificateDecoder = pemCertificateDecoderImpl,
+            isE2EIEnabledUseCase = isE2EIEnabledUseCase
         )
     val getUserE2eiCertificates: GetUserE2eiCertificatesUseCase
         get() = GetUserE2eiCertificatesUseCaseImpl(
             mlsConversationRepository = mlsConversationRepository,
-            pemCertificateDecoder = pemCertificateDecoderImpl
+            pemCertificateDecoder = pemCertificateDecoderImpl,
+            isE2EIEnabledUseCase = isE2EIEnabledUseCase
         )
     val getMembersE2EICertificateStatuses: GetMembersE2EICertificateStatusesUseCase
         get() = GetMembersE2EICertificateStatusesUseCaseImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/IsE2EIEnabledUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/IsE2EIEnabledUseCaseArrangement.kt
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.mls
+
+import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
+import io.mockative.Mock
+import io.mockative.given
+import io.mockative.mock
+
+
+interface IsE2EIEnabledUseCaseArrangement {
+    val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
+
+    fun withE2EIEnabledAndMLSEnabled(result: Boolean)
+}
+
+class IsE2EIEnabledUseCaseArrangementImpl : IsE2EIEnabledUseCaseArrangement {
+    @Mock
+    override val isE2EIEnabledUseCase: IsE2EIEnabledUseCase = mock(IsE2EIEnabledUseCase::class)
+
+    override fun withE2EIEnabledAndMLSEnabled(result: Boolean) {
+        given(isE2EIEnabledUseCase)
+            .function(isE2EIEnabledUseCase::invoke)
+            .whenInvoked()
+            .thenReturn(result)
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In `OtherUserProfileScreenViewModel` we are calling `getUserE2eiCertificateStatus` on init and are not verifying if E2EI is enabled (and not also MLS) thus leading to a problem when they are disabled.

### Causes (Optional)

Not prior verification if E2EI and MLS is enabled before calling its functions.

### Solutions

Add `isMLSEnabledUseCase` to `IsE2EIEnabledUseCase` and  add its usage in:
- `GetUserE2eiCertificateStatusUseCase`
- `GetUserE2eiCertificatesUseCase`

So whenever they are called, we verify if they are enabled and can continue or just return an emptyMap or Failure.NotActivated (depending from where it is being called).


### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution
