### PR TITLE
feat(monkeys): Add flag to disable 2FA in the team and force sequential warmup

### DIFF
--- a/monkeys/schema.json
+++ b/monkeys/schema.json
@@ -198,6 +198,11 @@
                         "type": "integer",
                         "default": 10
                     },
+                    "disable2FA": {
+                        "description": "Force disable 2FA",
+                        "type": "boolean",
+                        "default": false
+                    },
                     "2FAEnabled": {
                         "description": "Does this server require 2FA authentication?",
                         "type": "boolean",

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
@@ -73,6 +73,7 @@ fun CoroutineScope.stopIM() {
 class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
     private val dataFilePath by argument(help = "path to the test data file")
     private val skipWarmup by option("-s", "--skip-warmup", help = "Should the warmup be skipped?").flag()
+    private val sequentialWarmup by option("-w", "--sequential-warmup", help = "Should the warmup happen sequentially?").flag()
     private val logLevel by option("-l", "--log-level", help = "log level").enum<KaliumLogLevel>().default(KaliumLogLevel.INFO)
     private val logOutputFile by option("-f", "--log-file", help = "output file for logs")
     private val monkeysLogOutputFile by option("-m", "--monkeys-log-file", help = "output file for monkey logs")
@@ -156,7 +157,7 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
             if (index == 0) {
                 if (!this.skipWarmup) {
                     logger.i("Creating initial key packages for clients (logging everyone in and out). This can take a while...")
-                    monkeyPool.warmUp(coreLogic)
+                    monkeyPool.warmUp(coreLogic, sequentialWarmup)
                 }
                 logger.i("Creating prefixed groups")
                 testData.conversationDistribution.forEach { (prefix, config) ->

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestData.kt
@@ -189,6 +189,7 @@ data class BackendConfig(
     @SerialName("authPassword") val authPassword: String,
     @SerialName("userCount") val userCount: ULong = 10u,
     @SerialName("2FAEnabled") val secondFactorAuth: Boolean = false,
+    @SerialName("disable2FA") val forceDisable2fa: Boolean = false,
     @SerialName("dumpUsers") val dumpUsers: Boolean = false,
     @SerialName("presetTeam") val presetTeam: TeamConfig? = null
 )

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestDataImporter.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/TestDataImporter.kt
@@ -103,11 +103,7 @@ object TestDataImporter {
                 )
                 backendConfig.presetTeam.users.map { user ->
                     UserData(
-                        user.email,
-                        backendConfig.passwordForUsers,
-                        UserId(user.unqualifiedId, backendConfig.domain),
-                        team,
-                        null
+                        user.email, backendConfig.passwordForUsers, UserId(user.unqualifiedId, backendConfig.domain), team, null
                     )
                 }
             } else {
@@ -154,6 +150,16 @@ private suspend fun HttpClient.createTeam(backendConfig: BackendConfig): Team {
                 ), "status" to "enabled"
             ).toJsonObject()
         )
+    }
+    if (backendConfig.forceDisable2fa) {
+        put("i/teams/$teamId/features/sndFactorPasswordChallenge/unlocked")
+        put("i/teams/$teamId/features/sndFactorPasswordChallenge") {
+            setBody(
+                mapOf(
+                    "status" to "disabled", "ttl" to "unlimited"
+                ).toJsonObject()
+            )
+        }
     }
 
     val backend = Backend.fromConfig(backendConfig)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/UserData.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/model/UserData.kt
@@ -110,7 +110,7 @@ data class Backend(
 ) {
     companion object {
         fun fromConfig(config: BackendConfig): Backend = with(config) {
-            Backend(api, accounts, webSocket, blackList, teams, website, title, domain, secondFactorAuth, authUser, authPassword)
+            Backend(api, accounts, webSocket, blackList, teams, website, title, domain, !forceDisable2fa && secondFactorAuth, authUser, authPassword)
         }
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/MonkeyPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/MonkeyPool.kt
@@ -96,13 +96,23 @@ class MonkeyPool(users: List<UserData>, testCase: String, config: MonkeyConfig) 
         }.awaitAll()
     }
 
-    suspend fun warmUp(core: CoreLogic) = coroutineScope {
+    suspend fun warmUp(core: CoreLogic, sequentialWarmup: Boolean) = coroutineScope {
         // this is needed to create key packages for clients at least once
-        poolById.values.map {
-            async {
-                it.warmUp(core)
+        if (sequentialWarmup) {
+            poolById.values.forEach {
+                try {
+                    it.warmUp(core)
+                } catch (e: Exception) {
+                    logger.w("Error warming up monkey ${it.monkeyType.userId()}", e)
+                }
             }
-        }.awaitAll()
+        } else {
+            poolById.values.map {
+                async {
+                    it.warmUp(core)
+                }
+            }.awaitAll()
+        }
     }
 
     fun randomMonkeysFromTeam(team: String, userCount: UserCount): List<Monkey> {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This adds a flag to disable the 2FA in the team if its enabled by default in the backend and another one to make the warmup sequential

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
