### PR TITLE
fix: Team members API not passing paging state and resulting in infinite loop on teams with more than 200 members

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -108,6 +108,7 @@ internal class TeamDataSource(
         var hasMore = true
         var error: CoreFailure? = null
         var pagesSynced = 0
+        var pagingState: String? = null
         while (
             hasMore &&
             error == null &&
@@ -116,10 +117,12 @@ internal class TeamDataSource(
             wrapApiRequest {
                 teamsApi.getTeamMembers(
                     teamId = teamId.value,
-                    limitTo = pageSize
+                    limitTo = pageSize,
+                    pagingState = pagingState
                 )
             }.onSuccess {
                 hasMore = it.hasMore
+                pagingState = it.pagingState
             }.map {
                 it.members.map { teamMember ->
                     val userId = QualifiedIDEntity(teamMember.nonQualifiedUserId, userDomain)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -115,7 +115,8 @@ class TeamRepositoryTest {
             hasMore = false,
             members = listOf(
                 teamMember
-            )
+            ),
+            pagingState = "A=="
         )
 
         val (arrangement, teamRepository) = Arrangement()
@@ -176,7 +177,8 @@ class TeamRepositoryTest {
             hasMore = true,
             members = listOf(
                 teamMember
-            )
+            ),
+            "A=="
         )
 
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -848,7 +848,7 @@ class UserRepositoryTest {
             given(teamsApi)
                 .suspendFunction(teamsApi::getTeamMembersByIds)
                 .whenInvokedWith(any(), any())
-                .thenReturn(NetworkResponse.Success(TeamsApi.TeamMemberList(false, result), mapOf(), 200))
+                .thenReturn(NetworkResponse.Success(TeamsApi.TeamMemberList(false, result, "A=="), mapOf(), 200))
         }
 
         fun withSuccessfulGetUsersByQualifiedIdList(knownUserEntities: List<UserDetailsEntity>) = apply {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
@@ -36,7 +36,8 @@ interface TeamsApi {
         // Please note that this is intentionally cased differently form the has_more in TeamsResponse
         // because the backend response contains a different casing
         @SerialName("hasMore") val hasMore: Boolean,
-        val members: List<TeamMemberDTO>
+        val members: List<TeamMemberDTO>,
+        @SerialName("pagingState") val pagingState: String
     )
 
     @Serializable
@@ -89,7 +90,7 @@ interface TeamsApi {
 
     suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): NetworkResponse<Unit>
 
-    suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?): NetworkResponse<TeamMemberList>
+    suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String? = null): NetworkResponse<TeamMemberList>
     suspend fun getTeamMembersByIds(teamId: TeamId, teamMemberIdList: TeamMemberIdList): NetworkResponse<TeamMemberList>
     suspend fun getTeamMember(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<TeamMemberDTO>
     suspend fun getTeamInfo(teamId: TeamId): NetworkResponse<TeamDTO>

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
@@ -58,10 +58,11 @@ internal open class TeamsApiV0 internal constructor(
         }
     }
 
-    override suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?): NetworkResponse<TeamsApi.TeamMemberList> =
+    override suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String?): NetworkResponse<TeamsApi.TeamMemberList> =
         wrapKaliumResponse {
             httpClient.get("$PATH_TEAMS/$teamId/$PATH_MEMBERS") {
                 limitTo?.let { parameter("maxResults", it) }
+                pagingState?.let { parameter("pagingState", it) }
             }
         }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/teams/TeamsApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/teams/TeamsApiV0Test.kt
@@ -52,11 +52,30 @@ internal class TeamsApiV0Test : ApiTest() {
                     assertGet()
                     assertQueryExist("maxResults")
                     assertQueryParameter("maxResults", hasValue = "10")
+                    assertQueryDoesNotExist("pagingState")
                     assertPathEqual("/$PATH_TEAMS/$DUMMY_TEAM_ID/$PATH_MEMBERS")
                 }
             )
             val teamsApi: TeamsApi = TeamsApiV0(networkClient)
             teamsApi.getTeamMembers(DUMMY_TEAM_ID, limitTo = 10)
+        }
+
+    @Test
+    fun givenAValidGetTeamsSecondPageRequest_whenGettingTeamsMembers_theRequestShouldBeConfiguredCorrectly() =
+        runTest {
+            val networkClient = mockAuthenticatedNetworkClient(
+                GET_TEAM_MEMBER_CLIENT_RESPONSE.rawJson,
+                statusCode = HttpStatusCode.OK,
+                assertion = {
+                    assertGet()
+                    assertQueryExist("maxResults")
+                    assertQueryParameter("maxResults", hasValue = "10")
+                    assertQueryParameter("pagingState", hasValue = "A==")
+                    assertPathEqual("/$PATH_TEAMS/$DUMMY_TEAM_ID/$PATH_MEMBERS")
+                }
+            )
+            val teamsApi: TeamsApi = TeamsApiV0(networkClient)
+            teamsApi.getTeamMembers(DUMMY_TEAM_ID, limitTo = 10, pagingState = "A==")
         }
 
     @Test


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a team has more than 200 members the `fetchMembersByTeamId` will start an infinite loop because it doesn't send the paging state back to the backend. This results in the backend always returning the first page and the `hasMore` attribute to true.

### Solutions

The `pagingState` is now sent.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
