### PR TITLE
fix: incorrect url when checking crl

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepository.kt
@@ -86,12 +86,11 @@ internal class CertificateRevocationListRepositoryDataSource(
     }
 
     override suspend fun getCurrentClientCrlUrl(): Either<CoreFailure, String> =
-
         userConfigRepository.getE2EISettings()
             .flatMap {
                 if (!it.isRequired) E2EIFailure.Disabled.left()
                 else if (it.discoverUrl == null) E2EIFailure.MissingDiscoveryUrl.left()
-                else Url(it.discoverUrl).authority.right()
+                else Url("${it.discoverUrl}/$PATH_CRL").authority.right()
             }
 
     override suspend fun getClientDomainCRL(url: String): Either<CoreFailure, ByteArray> =
@@ -101,5 +100,6 @@ internal class CertificateRevocationListRepositoryDataSource(
 
     companion object {
         const val CRL_LIST_KEY = "crl_list_key"
+        const val PATH_CRL = "crl"
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepository.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.persistence.config.CRLUrlExpirationList
 import com.wire.kalium.persistence.config.CRLWithExpiration
 import com.wire.kalium.persistence.dao.MetadataDAO
 import io.ktor.http.URLBuilder
-import io.ktor.http.Url
 import io.ktor.http.authority
 
 interface CertificateRevocationListRepository {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/CertificateRevocationListCheckWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/CertificateRevocationListCheckWorker.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.feature.e2ei.usecase.CheckRevocationListUseCase
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.filter
 import kotlinx.datetime.Clock
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
@@ -170,7 +170,7 @@ class ACMEApiImpl internal constructor(
 
     override suspend fun getClientDomainCRL(url: String): NetworkResponse<ByteArray> =
         wrapKaliumResponse {
-            clearTextTrafficHttpClient.get("$HTTP$url/$PATH_CRL")
+            clearTextTrafficHttpClient.get(url)
         }
 
     private companion object {
@@ -179,7 +179,5 @@ class ACMEApiImpl internal constructor(
 
         const val NONCE_HEADER_KEY = "Replay-Nonce"
         const val LOCATION_HEADER_KEY = "location"
-        const val HTTP = "http://"
-        const val PATH_CRL = "crl"
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
 
invalid endpoint when checking crl.

```
2024-03-01 13:53:32.225 17773-18238 Network                 com.waz.zclient.dev.debug            V  REQUEST: {"method":"GET","endpoint":"http///acme.elna.wire.link/crl/crl"
```

### Causes (Optional)

Corecrypto is returing a valid crl, while for current client are adding the path to the url. 
This leads to get a wrong url format that are returned from CC

### Solutions

Add the `PATH` when getting current client url and not when calling api.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
