### PR TITLE
fix: missing json value pagingState when getting team member by ID

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -111,7 +111,7 @@ class TeamRepositoryTest {
             nonQualifiedUserId = "teamMember1"
         )
 
-        val teamMembersList = TeamsApi.TeamMemberList(
+        val teamMembersList = TeamsApi.TeamMemberListPaginated(
             hasMore = false,
             members = listOf(
                 teamMember
@@ -173,7 +173,7 @@ class TeamRepositoryTest {
             nonQualifiedUserId = "teamMember1"
         )
 
-        val teamMembersList = TeamsApi.TeamMemberList(
+        val teamMembersList = TeamsApi.TeamMemberListPaginated(
             hasMore = true,
             members = listOf(
                 teamMember
@@ -523,7 +523,7 @@ class TeamRepositoryTest {
                 .thenReturn(Either.Right(Unit))
         }
 
-        fun withGetTeamMembers(result: NetworkResponse<TeamsApi.TeamMemberList>) = apply {
+        fun withGetTeamMembers(result: NetworkResponse<TeamsApi.TeamMemberListPaginated>) = apply {
             given(teamsApi)
                 .suspendFunction(teamsApi::getTeamMembers)
                 .whenInvokedWith(any(), any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -848,7 +848,7 @@ class UserRepositoryTest {
             given(teamsApi)
                 .suspendFunction(teamsApi::getTeamMembersByIds)
                 .whenInvokedWith(any(), any())
-                .thenReturn(NetworkResponse.Success(TeamsApi.TeamMemberList(false, result, "A=="), mapOf(), 200))
+                .thenReturn(NetworkResponse.Success(TeamsApi.TeamMemberListNonPaginated(false, result), mapOf(), 200))
         }
 
         fun withSuccessfulGetUsersByQualifiedIdList(knownUserEntities: List<UserDetailsEntity>) = apply {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
@@ -32,12 +32,20 @@ import kotlinx.serialization.Serializable
 interface TeamsApi {
 
     @Serializable
-    data class TeamMemberList(
+    data class TeamMemberListPaginated(
         // Please note that this is intentionally cased differently form the has_more in TeamsResponse
         // because the backend response contains a different casing
         @SerialName("hasMore") val hasMore: Boolean,
         val members: List<TeamMemberDTO>,
-        @SerialName("pagingState") val pagingState: String
+        @SerialName("pagingState") val pagingState: String? = null
+    )
+
+    @Serializable
+    data class TeamMemberListNonPaginated(
+        // Please note that this is intentionally cased differently form the has_more in TeamsResponse
+        // because the backend response contains a different casing
+        @SerialName("hasMore") val hasMore: Boolean,
+        val members: List<TeamMemberDTO>
     )
 
     @Serializable
@@ -90,8 +98,8 @@ interface TeamsApi {
 
     suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): NetworkResponse<Unit>
 
-    suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String? = null): NetworkResponse<TeamMemberList>
-    suspend fun getTeamMembersByIds(teamId: TeamId, teamMemberIdList: TeamMemberIdList): NetworkResponse<TeamMemberList>
+    suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String? = null): NetworkResponse<TeamMemberListPaginated>
+    suspend fun getTeamMembersByIds(teamId: TeamId, teamMemberIdList: TeamMemberIdList): NetworkResponse<TeamMemberListNonPaginated>
     suspend fun getTeamMember(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<TeamMemberDTO>
     suspend fun getTeamInfo(teamId: TeamId): NetworkResponse<TeamDTO>
     suspend fun whiteListedServices(teamId: TeamId, size: Int = DEFAULT_SERVICES_SIZE): NetworkResponse<ServiceDetailResponse>

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
@@ -58,7 +58,11 @@ internal open class TeamsApiV0 internal constructor(
         }
     }
 
-    override suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String?): NetworkResponse<TeamsApi.TeamMemberListPaginated> =
+    override suspend fun getTeamMembers(
+        teamId: TeamId,
+        limitTo: Int?,
+        pagingState: String?
+    ): NetworkResponse<TeamsApi.TeamMemberListPaginated> =
         wrapKaliumResponse<TeamsApi.TeamMemberListPaginated> {
             httpClient.get("$PATH_TEAMS/$teamId/$PATH_MEMBERS") {
                 limitTo?.let { parameter("maxResults", it) }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
@@ -58,8 +58,8 @@ internal open class TeamsApiV0 internal constructor(
         }
     }
 
-    override suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String?): NetworkResponse<TeamsApi.TeamMemberList> =
-        wrapKaliumResponse {
+    override suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String?): NetworkResponse<TeamsApi.TeamMemberListPaginated> =
+        wrapKaliumResponse<TeamsApi.TeamMemberListPaginated> {
             httpClient.get("$PATH_TEAMS/$teamId/$PATH_MEMBERS") {
                 limitTo?.let { parameter("maxResults", it) }
                 pagingState?.let { parameter("pagingState", it) }
@@ -69,7 +69,7 @@ internal open class TeamsApiV0 internal constructor(
     override suspend fun getTeamMembersByIds(
         teamId: TeamId,
         teamMemberIdList: TeamsApi.TeamMemberIdList
-    ): NetworkResponse<TeamsApi.TeamMemberList> = wrapKaliumResponse {
+    ): NetworkResponse<TeamsApi.TeamMemberListNonPaginated> = wrapKaliumResponse {
         httpClient.post("$PATH_TEAMS/$teamId/$PATH_MEMBERS_BY_IDS") {
             setBody(teamMemberIdList)
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the changes in https://github.com/wireapp/kalium/pull/2573 added 2 issues
1. the added paging state value is present only in API version => 4
2. the. same data class is used or other endpoints and they are not paginated

### Solutions

1. add a default null value for when paging state is missing.
2. split the data class into 2 paginated and not paginated response

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
