### PR TITLE
fix: missing non-mls conversation when app supports MLS but backend doesn't

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
@@ -104,4 +104,4 @@ data class UpdateClientCapabilitiesParam(
  * the `INACTIVE_DURATION`.
  */
 val Client.isActive: Boolean
-    get() = lastActive?.let { (Clock.System.now() - it) < Client.INACTIVE_DURATION } ?: false
+    get() = (lastActive ?: registrationTime)?.let { (Clock.System.now() - it) < Client.INACTIVE_DURATION } ?: false

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1014,7 +1014,8 @@ class UserSessionScope internal constructor(
             clientRepository,
             userRepository,
             userConfigRepository,
-            featureSupport
+            featureSupport,
+            clientIdProvider
         )
 
     private val updateSupportedProtocolsAndResolveOneOnOnes: UpdateSupportedProtocolsAndResolveOneOnOnesUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1015,7 +1015,8 @@ class UserSessionScope internal constructor(
             userRepository,
             userConfigRepository,
             featureSupport,
-            clientIdProvider
+            clientIdProvider,
+            userScopedLogger
         )
 
     private val updateSupportedProtocolsAndResolveOneOnOnes: UpdateSupportedProtocolsAndResolveOneOnOnesUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfUserSupportedProtocolsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfUserSupportedProtocolsUseCase.kt
@@ -59,7 +59,6 @@ internal class UpdateSelfUserSupportedProtocolsUseCaseImpl(
             Either.Right(false)
         } else {
             (userRepository.getSelfUser()?.let { selfUser ->
-                kaliumLogger.d("cccc Updating supported protocols for user = ${selfUser.supportedProtocols}")
                 selfSupportedProtocols().flatMap { newSupportedProtocols ->
                     kaliumLogger.i(
                         "Updating supported protocols = $newSupportedProtocols previously = ${selfUser.supportedProtocols}"
@@ -89,7 +88,13 @@ internal class UpdateSelfUserSupportedProtocolsUseCaseImpl(
         currentClientIdProvider().flatMap { currentClientId ->
             clientsRepository.selfListOfClients().flatMap { selfClients ->
                 userConfigRepository.getMigrationConfiguration()
-                    .flatMapLeft { if (it is StorageFailure.DataNotFound) Either.Right(MIGRATION_CONFIGURATION_DISABLED) else Either.Left(it) }
+                    .flatMapLeft {
+                        if (it is StorageFailure.DataNotFound) {
+                            Either.Right(MIGRATION_CONFIGURATION_DISABLED)
+                        } else {
+                            Either.Left(it)
+                        }
+                    }
                     .flatMap { migrationConfiguration ->
                         userConfigRepository.getSupportedProtocols().map { supportedProtocols ->
                             val selfSupportedProtocols = mutableSetOf<SupportedProtocol>()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientTest.kt
@@ -50,4 +50,31 @@ class ClientTest {
         assertTrue(client.isActive)
     }
 
+    @Test
+    fun givenLastActiveIsNull_whenRegistrationTRimeIsNotOld_thenIsActiveIsTrue() {
+        val client = TestClient.CLIENT.copy(
+            lastActive = null,
+            registrationTime = Clock.System.now() - (Client.INACTIVE_DURATION - 1.days)
+        )
+        assertTrue(client.isActive)
+    }
+
+    @Test
+    fun givenLastActiveIsNull_whenRegistrationTRimeIsOld_thenIsActiveIsFalse() {
+        val client = TestClient.CLIENT.copy(
+            lastActive = null,
+            registrationTime = Clock.System.now() - (Client.INACTIVE_DURATION + 1.days)
+        )
+        assertFalse(client.isActive)
+    }
+
+    @Test
+    fun givenLastActiveIsNull_whenRegistrationTRimeIsNull_thenIsActiveIsFalse() {
+        val client = TestClient.CLIENT.copy(
+            lastActive = null,
+            registrationTime = null
+        )
+        assertFalse(client.isActive)
+    }
+
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.data.user.SupportedProtocol
@@ -32,6 +33,8 @@ import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangementImpl
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.any
@@ -51,8 +54,9 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenMLSIsNotSupported_whenInvokingUseCase_thenSupportedProtocolsAreNotUpdated() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(false)
-            .arrange()
+            .arrange {
+                withIsMLSSupported(false)
+            }
 
         useCase.invoke().shouldSucceed()
 
@@ -65,13 +69,15 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenSupportedProtocolsHasNotChanged_whenInvokingUseCase_thenSupportedProtocolsAreNotUpdated() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.PROTEUS))
-            .withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = emptyList())
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.PROTEUS))
+                withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(clients = emptyList())
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -84,13 +90,15 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenProteusAsSupportedProtocol_whenInvokingUseCase_thenProteusIsIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.PROTEUS))
-            .withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = emptyList())
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.PROTEUS))
+                withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(clients = emptyList())
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -103,13 +111,15 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenProteusIsNotSupportedButMigrationHasNotEnded_whenInvokingUseCase_thenProteusIsIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
-            .withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = emptyList())
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
+                withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(clients = emptyList())
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -122,13 +132,15 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenProteusIsNotSupported_whenInvokingUseCase_thenProteusIsNotIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
-            .withGetMigrationConfigurationSuccessful(COMPLETED_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = emptyList())
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
+                withGetMigrationConfigurationSuccessful(COMPLETED_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(clients = emptyList())
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -141,15 +153,19 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenMlsIsSupportedAndAllActiveClientsAreCapable_whenInvokingUseCase_thenMlsIsIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
-            .withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = listOf(
-                TestClient.CLIENT.copy(isMLSCapable = true, lastActive = Clock.System.now())
-            ))
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
+                withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(
+                    clients = listOf(
+                        TestClient.CLIENT.copy(isMLSCapable = true, lastActive = Clock.System.now())
+                    )
+                )
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -162,16 +178,20 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenMlsIsSupportedAndAnInactiveClientIsNotMlsCapable_whenInvokingUseCase_thenMlsIsIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
-            .withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = listOf(
-                TestClient.CLIENT.copy(isMLSCapable = true, lastActive = Clock.System.now()),
-                TestClient.CLIENT.copy(isMLSCapable = false, lastActive = Instant.DISTANT_PAST)
-            ))
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
+                withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(
+                    clients = listOf(
+                        TestClient.CLIENT.copy(isMLSCapable = true, lastActive = Clock.System.now()),
+                        TestClient.CLIENT.copy(isMLSCapable = false, lastActive = Instant.DISTANT_PAST)
+                    )
+                )
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -184,16 +204,18 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenMlsIsSupportedAndAllActiveClientsAreNotCapable_whenInvokingUseCase_thenMlsIsNotIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
-            .withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = listOf(
-                TestClient.CLIENT.copy(isMLSCapable = true, lastActive = Clock.System.now()),
-                TestClient.CLIENT.copy(isMLSCapable = false, lastActive = Clock.System.now())
-            ))
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
+                withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(clients = listOf(
+                    TestClient.CLIENT.copy(isMLSCapable = true, lastActive = Clock.System.now()),
+                    TestClient.CLIENT.copy(isMLSCapable = false, lastActive = Clock.System.now())
+                ))
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -206,16 +228,20 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenMlsIsSupportedAndMigrationHasEnded_whenInvokingUseCase_thenMlsIsIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
-            .withGetMigrationConfigurationSuccessful(COMPLETED_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = listOf(
-                TestClient.CLIENT.copy(isMLSCapable = true),
-                TestClient.CLIENT.copy(isMLSCapable = false)
-            ))
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.MLS))
+                withGetMigrationConfigurationSuccessful(COMPLETED_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(
+                    clients = listOf(
+                        TestClient.CLIENT.copy(isMLSCapable = true),
+                        TestClient.CLIENT.copy(isMLSCapable = false)
+                    )
+                )
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -228,15 +254,19 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenMigrationIsMissingAndAllClientsAreCapable_whenInvokingUseCase_thenMlsIsIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS))
-            .withGetMigrationConfigurationFailing(StorageFailure.DataNotFound)
-            .withGetSelfClientsSuccessful(clients = listOf(
-                TestClient.CLIENT.copy(isMLSCapable = true)
-            ))
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS))
+                withGetMigrationConfigurationFailing(StorageFailure.DataNotFound)
+                withGetSelfClientsSuccessful(
+                    clients = listOf(
+                        TestClient.CLIENT.copy(isMLSCapable = true)
+                    )
+                )
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -249,15 +279,19 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenMlsIsNotSupportedAndAllClientsAreCapable_whenInvokingUseCase_thenMlsIsNotIncluded() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful()
-            .withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.PROTEUS))
-            .withGetMigrationConfigurationSuccessful(DISABLED_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = listOf(
-                TestClient.CLIENT.copy(isMLSCapable = true)
-            ))
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful()
+                withGetSupportedProtocolsSuccessful(setOf(SupportedProtocol.PROTEUS))
+                withGetMigrationConfigurationSuccessful(DISABLED_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(
+                    clients = listOf(
+                        TestClient.CLIENT.copy(isMLSCapable = true)
+                    )
+                )
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke()
 
@@ -270,13 +304,15 @@ class UpdateSupportedProtocolsUseCaseTest {
     @Test
     fun givenSupportedProtocolsAreNotConfigured_whenInvokingUseCase_thenSupportedProtocolsAreNotUpdated() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withIsMLSSupported(true)
-            .withGetSelfUserSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
-            .withGetSupportedProtocolsFailing(StorageFailure.DataNotFound)
-            .withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
-            .withGetSelfClientsSuccessful(clients = emptyList())
-            .withUpdateSupportedProtocolsSuccessful()
-            .arrange()
+            .arrange {
+                withCurrentClientIdSuccess(ClientId("1"))
+                withIsMLSSupported(true)
+                withGetSelfUserSuccessful(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+                withGetSupportedProtocolsFailing(StorageFailure.DataNotFound)
+                withGetMigrationConfigurationSuccessful(ONGOING_MIGRATION_CONFIGURATION)
+                withGetSelfClientsSuccessful(clients = emptyList())
+                withUpdateSupportedProtocolsSuccessful()
+            }
 
         useCase.invoke().shouldSucceed()
 
@@ -286,13 +322,16 @@ class UpdateSupportedProtocolsUseCaseTest {
             .wasNotInvoked()
     }
 
-    private class Arrangement {
+    private class Arrangement : CurrentClientIdProviderArrangement by CurrentClientIdProviderArrangementImpl() {
         @Mock
         val clientRepository = mock(ClientRepository::class)
+
         @Mock
         val userRepository = mock(UserRepository::class)
+
         @Mock
         val userConfigRepository = mock(UserConfigRepository::class)
+
         @Mock
         val featureSupport = mock(FeatureSupport::class)
 
@@ -306,9 +345,11 @@ class UpdateSupportedProtocolsUseCaseTest {
             given(userRepository)
                 .suspendFunction(userRepository::getSelfUser)
                 .whenInvoked()
-                .thenReturn(TestUser.SELF.copy(
-                    supportedProtocols = supportedProtocols
-                ))
+                .thenReturn(
+                    TestUser.SELF.copy(
+                        supportedProtocols = supportedProtocols
+                    )
+                )
         }
 
         fun withUpdateSupportedProtocolsSuccessful() = apply {
@@ -353,12 +394,15 @@ class UpdateSupportedProtocolsUseCaseTest {
                 .thenReturn(Either.Right(clients))
         }
 
-        fun arrange() = this to UpdateSelfUserSupportedProtocolsUseCaseImpl(
-            clientRepository,
-            userRepository,
-            userConfigRepository,
-            featureSupport
-        )
+        fun arrange(block: (Arrangement.() -> Unit)) = apply(block).let {
+            this to UpdateSelfUserSupportedProtocolsUseCaseImpl(
+                clientRepository,
+                userRepository,
+                userConfigRepository,
+                featureSupport,
+                currentClientIdProvider
+            )
+        }
 
         companion object {
             val ONGOING_MIGRATION_CONFIGURATION = MLSMigrationModel(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.user
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.client.Client
@@ -335,6 +336,8 @@ class UpdateSupportedProtocolsUseCaseTest {
         @Mock
         val featureSupport = mock(FeatureSupport::class)
 
+        private var kaliumLogger = KaliumLogger.disabled()
+
         fun withIsMLSSupported(supported: Boolean) = apply {
             given(featureSupport)
                 .invocation { featureSupport.isMLSSupported }
@@ -400,7 +403,8 @@ class UpdateSupportedProtocolsUseCaseTest {
                 userRepository,
                 userConfigRepository,
                 featureSupport,
-                currentClientIdProvider
+                currentClientIdProvider,
+                kaliumLogger
             )
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

 missing non mls conversation when app supports MLS but backend does not

### Causes (Optional)

keep the folloing in mind
1. kotlin `Collection.all` function will return true if the collection is empty
2. for newly created clients, the lastActive value is return as null from the backend.
3. to check if all of our clients supports MLS we do this
``` kotlin 
        val allSelfClientsAreMLSCapable = selfClients.filter { it.isActive }.all { it.isMLSCapable }
```
4. the result of this is allSelfClientsAreMLSCapable = true and the app will update the supported protocols to include MLS 

### Solutions

1. Consider self client as always active
2. To check if a client is active we check the registration date if the last active date is null

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
