### PR TITLE
feat: handle connection status update when legal hold requested [WPB-5937]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.user.Connection
@@ -75,6 +76,7 @@ interface ConnectionRepository {
     suspend fun setConnectionAsNotified(userId: UserId)
     suspend fun setAllConnectionsAsNotified()
     suspend fun deleteConnection(connection: Connection): Either<StorageFailure, Unit>
+    suspend fun getConnection(conversationId: ConversationId): Either<StorageFailure, ConversationDetails.Connection>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -252,6 +254,10 @@ internal class ConnectionDataSource(
     override suspend fun deleteConnection(connection: Connection) = wrapStorageRequest {
         connectionDAO.deleteConnectionDataAndConversation(connection.qualifiedConversationId.toDao())
         userDAO.upsertConnectionStatuses(mapOf(connection.qualifiedToId.toDao() to ConnectionEntity.State.CANCELLED))
+    }
+
+    override suspend fun getConnection(conversationId: ConversationId) = wrapStorageRequest {
+            connectionDAO.getConnection(conversationId.toDao())?.let { connectionMapper.fromDaoToConversationDetails(it) }
     }
 
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
@@ -72,15 +72,14 @@ class ObserveConversationInteractionAvailabilityUseCase internal constructor(
                         else InteractionAvailability.NOT_MEMBER
                     }
 
-                    is ConversationDetails.OneOne -> {
-                        when {
-                            conversationDetails.otherUser.defederated -> InteractionAvailability.DISABLED
-                            conversationDetails.otherUser.deleted -> InteractionAvailability.DELETED_USER
-                            conversationDetails.otherUser.connectionStatus == ConnectionState.BLOCKED ->
-                                InteractionAvailability.BLOCKED_USER
-
-                            else -> InteractionAvailability.ENABLED
-                        }
+                    is ConversationDetails.OneOne -> when {
+                        conversationDetails.otherUser.defederated -> InteractionAvailability.DISABLED
+                        conversationDetails.otherUser.deleted -> InteractionAvailability.DELETED_USER
+                        conversationDetails.otherUser.connectionStatus == ConnectionState.BLOCKED -> InteractionAvailability.BLOCKED_USER
+                        conversationDetails.conversation.legalHoldStatus in listOf(
+                            Conversation.LegalHoldStatus.ENABLED, Conversation.LegalHoldStatus.DEGRADED
+                        ) -> InteractionAvailability.LEGAL_HOLD
+                        else -> InteractionAvailability.ENABLED
                     }
 
                     is ConversationDetails.Self, is ConversationDetails.Team -> InteractionAvailability.DISABLED
@@ -132,5 +131,11 @@ enum class InteractionAvailability {
     UNSUPPORTED_PROTOCOL,
 
     /**Conversation type doesn't support messaging */
-    DISABLED
+    DISABLED,
+
+    /**
+     * One of conversation members is under legal hold and self user is not able to interact with it.
+     * This applies to 1:1 conversations only when other member is a guest.
+     */
+    LEGAL_HOLD
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -120,6 +120,7 @@ internal class UserEventReceiverImpl internal constructor(
                             Either.Right(Unit)
                         }
                     }
+                    .flatMap { legalHoldHandler.handleNewConnection(event) }
             }
             .onSuccess {
                 kaliumLogger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
@@ -106,6 +107,8 @@ internal class UserEventReceiverImpl internal constructor(
     private suspend fun handleNewConnection(event: Event.User.NewConnection, deliveryInfo: EventDeliveryInfo): Either<CoreFailure, Unit> =
         userRepository.fetchUserInfo(event.connection.qualifiedToId)
             .flatMap {
+                val previousStatus = connectionRepository.getConnection(event.connection.qualifiedConversationId)
+                    .map { it.connection.status }.getOrNull()
                 connectionRepository.insertConnectionFromEvent(event)
                     .flatMap {
                         if (event.connection.status == ConnectionState.ACCEPTED) {
@@ -113,9 +116,11 @@ internal class UserEventReceiverImpl internal constructor(
                                 event.connection.qualifiedToId,
                                 delay = if (deliveryInfo.source == EventSource.LIVE) 3.seconds else ZERO
                             )
-                            newGroupConversationSystemMessagesCreator.value.conversationStartedUnverifiedWarning(
-                                event.connection.qualifiedConversationId
-                            )
+                            if (previousStatus != ConnectionState.MISSING_LEGALHOLD_CONSENT) {
+                                newGroupConversationSystemMessagesCreator.value.conversationStartedUnverifiedWarning(
+                                    event.connection.qualifiedConversationId
+                                )
+                            } else Either.Right(Unit)
                         } else {
                             Either.Right(Unit)
                         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
@@ -134,7 +134,9 @@ internal class LegalHoldHandlerImpl internal constructor(
                     kaliumLogger.i("accepted connection with user ${event.connection.qualifiedToId.toLogString()}" +
                             "who is ${if (isUnderLegalHold) "" else "not"} under legal hold")
                     val newStatus = if (isUnderLegalHold) Conversation.LegalHoldStatus.ENABLED else Conversation.LegalHoldStatus.DISABLED
-                    handleForConversation(event.connection.qualifiedConversationId, newStatus)
+                    if (newStatus != Conversation.LegalHoldStatus.UNKNOWN) {
+                        conversationRepository.updateLegalHoldStatus(event.connection.qualifiedConversationId, newStatus)
+                    }
                 }
             }
             else -> { /* do nothing */ }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
@@ -129,7 +129,7 @@ internal class LegalHoldHandlerImpl internal constructor(
                 kaliumLogger.i("missing legal hold consent for connection with user ${event.connection.qualifiedToId.toLogString()}")
                 handleForConversation(event.connection.qualifiedConversationId, Conversation.LegalHoldStatus.DEGRADED)
             }
-            ConnectionState.ACCEPTED -> { // TODO: check if user has a legal hold device ?
+            ConnectionState.ACCEPTED -> {
                 isUserUnderLegalHold(event.connection.qualifiedToId).let { isUnderLegalHold ->
                     kaliumLogger.i("accepted connection with user ${event.connection.qualifiedToId.toLogString()}" +
                             "who is ${if (isUnderLegalHold) "" else "not"} under legal hold")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandler.kt
@@ -134,9 +134,7 @@ internal class LegalHoldHandlerImpl internal constructor(
                     kaliumLogger.i("accepted connection with user ${qualifiedToId.toLogString()}" +
                             "who is ${if (isUnderLegalHold) "" else "not"} under legal hold")
                     val newStatus = if (isUnderLegalHold) Conversation.LegalHoldStatus.ENABLED else Conversation.LegalHoldStatus.DISABLED
-                    if (newStatus != Conversation.LegalHoldStatus.UNKNOWN) {
-                        conversationRepository.updateLegalHoldStatus(qualifiedConversationId, newStatus)
-                    }
+                    conversationRepository.updateLegalHoldStatus(qualifiedConversationId, newStatus)
                 }
             }
             else -> { /* do nothing */ }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
@@ -229,6 +229,31 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         }
     }
 
+    @Test
+    fun givenConversationLegalHoldIsEnabled_whenInvokingInteractionForConversation_thenInteractionShouldBeLegalHold() = runTest {
+        val conversationId = TestConversation.ID
+        val (_, observeConversationInteractionAvailability) = arrange {
+            withLegalHoldOneOnOneConversation(Conversation.LegalHoldStatus.ENABLED)
+        }
+        observeConversationInteractionAvailability(conversationId).test {
+            val interactionResult = awaitItem()
+            assertEquals(IsInteractionAvailableResult.Success(InteractionAvailability.LEGAL_HOLD), interactionResult)
+            awaitComplete()
+        }
+    }
+    @Test
+    fun givenConversationLegalHoldIsDegraded_whenInvokingInteractionForConversation_thenInteractionShouldBeLegalHold() = runTest {
+        val conversationId = TestConversation.ID
+        val (_, observeConversationInteractionAvailability) = arrange {
+            withLegalHoldOneOnOneConversation(Conversation.LegalHoldStatus.DEGRADED)
+        }
+        observeConversationInteractionAvailability(conversationId).test {
+            val interactionResult = awaitItem()
+            assertEquals(IsInteractionAvailableResult.Success(InteractionAvailability.LEGAL_HOLD), interactionResult)
+            awaitComplete()
+        }
+    }
+
     private class Arrangement(
         private val configure: Arrangement.() -> Unit
     ) : UserRepositoryArrangement by UserRepositoryArrangementImpl(),
@@ -271,6 +296,16 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
                         otherUser = TestUser.OTHER.copy(
                             deleted = true
                         )
+                    )
+                )
+            )
+        }
+
+        fun withLegalHoldOneOnOneConversation(legalHoldStatus: Conversation.LegalHoldStatus) = apply {
+            withObserveConversationDetailsByIdReturning(
+                Either.Right(
+                    TestConversationDetails.CONVERSATION_ONE_ONE.copy(
+                        conversation = TestConversation.ONE_ON_ONE().copy(legalHoldStatus = legalHoldStatus)
                     )
                 )
             )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.sync.SyncState
+import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.client.FetchSelfClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
@@ -34,6 +35,7 @@ import com.wire.kalium.logic.feature.legalhold.LegalHoldState
 import com.wire.kalium.logic.feature.legalhold.MembersHavingLegalHoldClientUseCase
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForUserUseCase
 import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
@@ -691,6 +693,49 @@ class LegalHoldHandlerTest {
             legalHoldStatusForConversationChanged = false,
             handleEnabledForConversationInvoked = false,
             handleDisabledForConversationInvoked = false,
+        )
+
+    private fun testHandlingNewConnection(
+        userLegalHoldStatus: LegalHoldState,
+        connectionStatus: ConnectionState,
+        expectedConversationLegalHoldStatus: Conversation.LegalHoldStatus,
+    ) = runTest {
+        // given
+        val newConnectionEvent = TestEvent.newConnection(status = connectionStatus)
+        val (arrangement, handler) = Arrangement()
+            .withObserveLegalHoldStateForUserSuccess(userLegalHoldStatus)
+            .withUpdateLegalHoldStatusSuccess(isChanged = true)
+            .arrange()
+        // when
+        val result = handler.handleNewConnection(newConnectionEvent)
+        // then
+        result.shouldSucceed()
+        verify(arrangement.conversationRepository)
+            .suspendFunction(arrangement.conversationRepository::updateLegalHoldStatus)
+            .with(eq(newConnectionEvent.connection.qualifiedConversationId), eq(expectedConversationLegalHoldStatus))
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenNewConnectionMissingLegalHoldConsent_whenHandling_thenUpdateConversationLegalHoldStatusToDegraded() =
+        testHandlingNewConnection(
+            userLegalHoldStatus = LegalHoldState.Disabled,
+            connectionStatus = ConnectionState.MISSING_LEGALHOLD_CONSENT,
+            expectedConversationLegalHoldStatus = Conversation.LegalHoldStatus.DEGRADED,
+        )
+    @Test
+    fun givenNewConnectionAcceptedAndUserUnderLegalHold_whenHandling_thenUpdateConversationLegalHoldStatusToEnabled() =
+        testHandlingNewConnection(
+            userLegalHoldStatus = LegalHoldState.Enabled,
+            connectionStatus = ConnectionState.ACCEPTED,
+            expectedConversationLegalHoldStatus = Conversation.LegalHoldStatus.ENABLED,
+        )
+    @Test
+    fun givenNewConnectionAcceptedAndUserNotUnderLegalHold_whenHandling_thenUpdateConversationLegalHoldStatusToDisabled() =
+        testHandlingNewConnection(
+            userLegalHoldStatus = LegalHoldState.Disabled,
+            connectionStatus = ConnectionState.ACCEPTED,
+            expectedConversationLegalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
         )
 
     private class Arrangement {

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
@@ -53,3 +53,6 @@ SELECT * FROM Connection LEFT JOIN User ON Connection.qualified_to == User.quali
 
 selectConnectionsForNotification:
 SELECT * FROM Connection LEFT JOIN User ON Connection.qualified_to == User.qualified_id WHERE status = 'PENDING' AND should_notify = 1;
+
+selectConnection:
+SELECT * FROM Connection WHERE qualified_conversation = ?;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -438,7 +438,6 @@ updateLegalHoldStatus {
 UPDATE Conversation
 SET legal_hold_status = :legal_hold_status
 WHERE qualified_id = :qualified_id AND legal_hold_status != :legal_hold_status;
-SELECT changes();
 }
 
 upsertLegalHoldStatusChangeNotified {
@@ -447,7 +446,6 @@ VALUES (:conversationId, :notified)
 ON CONFLICT(conversation_id) DO UPDATE SET
     legal_hold_status_change_notified = excluded.legal_hold_status_change_notified
     WHERE legal_hold_status_change_notified != excluded.legal_hold_status_change_notified;
-SELECT changes();
 }
 
 selectLegalHoldStatus:

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
@@ -70,4 +70,5 @@ interface ConnectionDAO {
     suspend fun getConnectionRequestsForNotification(): Flow<List<ConnectionEntity>>
     suspend fun updateNotificationFlag(flag: Boolean, userId: QualifiedIDEntity)
     suspend fun setAllConnectionsAsNotified()
+    suspend fun getConnection(id: ConversationIDEntity): ConnectionEntity?
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
@@ -123,6 +123,10 @@ class ConnectionDAOImpl(
             .map { it.map(connectionMapper::toModel) }
     }
 
+    override suspend fun getConnection(conversationId: QualifiedIDEntity): ConnectionEntity? = withContext(queriesContext) {
+        connectionsQueries.selectConnection(conversationId).executeAsOneOrNull()?.let { connectionMapper.toModel(it) }
+    }
+
     override suspend fun getConnectionRequests(): Flow<List<ConnectionEntity>> {
         return connectionsQueries.selectConnectionRequests(connectionMapper::toModel)
             .asFlow()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -416,12 +416,19 @@ internal class ConversationDAOImpl internal constructor(
         conversationId: QualifiedIDEntity,
         legalHoldStatus: ConversationEntity.LegalHoldStatus
     ) = withContext(coroutineContext) {
-        conversationQueries.updateLegalHoldStatus(legalHoldStatus, conversationId).executeAsOne() > 0
+        conversationQueries.transactionWithResult {
+            conversationQueries.updateLegalHoldStatus(legalHoldStatus, conversationId)
+            conversationQueries.selectChanges().executeAsOne() > 0
+        }
+
     }
 
     override suspend fun updateLegalHoldStatusChangeNotified(conversationId: QualifiedIDEntity, notified: Boolean) =
         withContext(coroutineContext) {
-            conversationQueries.upsertLegalHoldStatusChangeNotified(conversationId, notified).executeAsOne() > 0
+            conversationQueries.transactionWithResult {
+                conversationQueries.upsertLegalHoldStatusChangeNotified(conversationId, notified)
+                conversationQueries.selectChanges().executeAsOne() > 0
+            }
         }
 
     override suspend fun observeLegalHoldStatus(conversationId: QualifiedIDEntity) =

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -197,7 +197,7 @@ internal class MessageDAOImpl internal constructor(
             messagesQuery
                 .executeAsList()
                 .firstOrNull {
-                    when (messageContent) {
+                    LocalId.check(it.id) && when (messageContent) {
                         is MessageEntityContent.MemberChange ->
                             messageContent.memberChangeType == it.memberChangeType &&
                                     it.memberChangeList?.toSet() == messageContent.memberUserIdList.toSet()
@@ -214,7 +214,7 @@ internal class MessageDAOImpl internal constructor(
                     }
                 }?.let {
                     // The message already exists in the local DB, if its id is different then just update id.
-                    if (LocalId.check(it.id) && it.id != message.id) queries.updateMessageId(message.id, it.id, message.conversationId)
+                    if (it.id != message.id) queries.updateMessageId(message.id, it.id, message.conversationId)
                     true
                 }
         } ?: false

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -197,7 +197,7 @@ internal class MessageDAOImpl internal constructor(
             messagesQuery
                 .executeAsList()
                 .firstOrNull {
-                    LocalId.check(it.id) && when (messageContent) {
+                    when (messageContent) {
                         is MessageEntityContent.MemberChange ->
                             messageContent.memberChangeType == it.memberChangeType &&
                                     it.memberChangeList?.toSet() == messageContent.memberUserIdList.toSet()
@@ -214,7 +214,7 @@ internal class MessageDAOImpl internal constructor(
                     }
                 }?.let {
                     // The message already exists in the local DB, if its id is different then just update id.
-                    if (it.id != message.id) queries.updateMessageId(message.id, it.id, message.conversationId)
+                    if (LocalId.check(it.id) && it.id != message.id) queries.updateMessageId(message.id, it.id, message.conversationId)
                     true
                 }
         } ?: false

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConnectionDaoTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConnectionDaoTest.kt
@@ -83,6 +83,19 @@ class ConnectionDaoTest : BaseDatabaseTest() {
         assertEquals(false, result[1].shouldNotify)
     }
 
+    @Test
+    fun givenConnectionExists_WhenGettingConnection_ThenItIsReturned() = runTest {
+        db.connectionDAO.insertConnection(connection1)
+        val result = db.connectionDAO.getConnection(connection1.qualifiedConversationId)
+        assertEquals(connection1, result)
+    }
+
+    @Test
+    fun givenConnectionNotExists_WhenGettingConnection_ThenNullIsReturned() = runTest {
+        val result = db.connectionDAO.getConnection(connection1.qualifiedConversationId)
+        assertEquals(null, result)
+    }
+
     companion object {
         val OTHER_USER_ID = QualifiedIDEntity("me", "wire.com")
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When other user from 1:1 conversation receives a legal hold request, the app gets `NewConnection` event for that user with status `MISSING_LEGALHOLD_STATUS` - the app is not handling that at all so it's not possible to disable sending messages in that case (it shouldn't be possible if the user doesn't give consent; the conversation's legal hold status should be `DEGRADED` then).
When the app receives these statuses, it creates `ConversationStartedUnverifiedWarning` again so it can be added multiple times.

### Solutions

Provide new status type for interaction availability for the legal hold and return it when the conversation's legal hold is in `ENABLED` or `DEGRADED` state.
Handle legal hold status update if needed when `NewConnection` event is received - when `MISSING_LEGALHOLD_CONSENT` then `DEGRADED`, when `ACCEPTED` then check the current user's legal hold status.
Do not create `ConversationStartedUnverifiedWarning` when connection already exists in the database and it is switching status from `MISSING_LEGALHOLD_CONSENT` to `ACCEPTED`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Wile being logged in as a guest, have a 1:1 conversation with some team member and request legal hold for that team member - the conversation should be degraded and sending messages should be disabled.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
