### PR TITLE
fix: No audio/video when in MLS call (WPB-6984)

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -420,12 +420,14 @@ class CallManagerImpl internal constructor(
         conversationId: ConversationId,
         clients: String
     ) {
-        withCalling {
-            wcall_set_clients_for_conv(
-                it,
-                federatedIdMapper.parseToFederatedId(conversationId),
-                clients
-            )
+        if (callRepository.getCallMetadataProfile()[conversationId]?.protocol is Conversation.ProtocolInfo.Proteus) {
+            withCalling {
+                wcall_set_clients_for_conv(
+                    it,
+                    federatedIdMapper.parseToFederatedId(conversationId),
+                    clients
+                )
+            }
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When in MLS call we would still call `wcall_set_clients_for_conv`

### Causes (Optional)

`wcall_set_clients_for_conv` should be called only when conversation is `Proteus`

### Solutions

Wrap calling of `wcall_set_clients_for_conv` only when conversation protocol is `Proteus`

### Testing

#### How to Test

- Have 2 accounts with E2EI + MLS enabled
- Have a group with both accounts
- Start a call
- Accept/Join call from another user
- Enable mic/video and everything should be working as expected.
