### PR TITLE
fix: Change return type of getConversationByGroupID to nullable for epoch changes

### DIFF
--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
@@ -313,7 +313,7 @@ private suspend fun getAuthScope(coreLogic: CoreLogic, backend: Backend): Authen
             isOnPremises = true,
             apiProxy = null
         )
-    ).invoke()
+    ).invoke(null)
     if (result !is AutoVersionAuthScopeUseCase.Result.Success) {
         error("Failed getting AuthScope: $result")
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -104,7 +104,7 @@ interface ConversationDAO {
     suspend fun getConversationsWithoutMetadata(): List<QualifiedIDEntity>
     suspend fun clearContent(conversationId: QualifiedIDEntity)
     suspend fun updateMlsVerificationStatus(verificationStatus: ConversationEntity.VerificationStatus, conversationId: QualifiedIDEntity)
-    suspend fun getConversationByGroupID(groupID: String): ConversationViewEntity
+    suspend fun getConversationByGroupID(groupID: String): ConversationViewEntity?
     suspend fun observeUnreadArchivedConversationsCount(): Flow<Long>
     suspend fun observeDegradedConversationNotified(conversationId: QualifiedIDEntity): Flow<Boolean>
     suspend fun updateDegradedConversationNotifiedFlag(conversationId: QualifiedIDEntity, updateFlag: Boolean)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -247,10 +247,10 @@ internal class ConversationDAOImpl internal constructor(
             .map { it?.let { conversationMapper.toModel(it) } }
     }
 
-    override suspend fun getConversationByGroupID(groupID: String): ConversationViewEntity {
+    override suspend fun getConversationByGroupID(groupID: String): ConversationViewEntity? {
         return conversationQueries.selectByGroupId(groupID)
-            .executeAsOne()
-            .let { it.let { conversationMapper.toModel(it) } }
+            .executeAsOneOrNull()
+            ?.let { it.let { conversationMapper.toModel(it) } }
     }
 
     override suspend fun getConversationIdByGroupID(groupID: String) = withContext(coroutineContext) {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -1811,7 +1811,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenSubConversationGroupIdForCall_whenGettingConversationByGroupId_thenReturnNull() = runTest {
+    fun givenInsertedConversations_whenGettingConversationByInexistingGroupId_thenReturnNull() = runTest {
         // given
         val expected = null
         conversationDAO.insertConversation(conversationEntity4)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -1810,6 +1810,22 @@ class ConversationDAOTest : BaseDatabaseTest() {
         )
     }
 
+    @Test
+    fun givenSubConversationGroupIdForCall_whenGettingConversationByGroupId_thenReturnNull() = runTest {
+        // given
+        val expected = null
+        conversationDAO.insertConversation(conversationEntity4)
+
+        // when
+        val result = conversationDAO.getConversationByGroupID("call_subconversation_groupid")
+
+        // then
+        assertEquals(
+            expected,
+            result
+        )
+    }
+
     private fun ConversationEntity.toViewEntity(userEntity: UserEntity? = null): ConversationViewEntity {
         val protocol: ConversationEntity.Protocol
         val mlsGroupId: String?


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X]  is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While observing epoch changes for calls (SubConversation) it would fail and log an error message as it did not find a conversation with its GroupId.

### Causes (Optional)

Calls (SubConversation) on MLS is only stored in memory and not in the DB, thus resulting in an error log when it did not find.

### Solutions

Change return type of `getConversationByGroupID` to be nullable and change its execution to `executeOneOrNull` so it returns null when it doesn't find it as there is no need to observe epoch changes for calls.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Have E2EI + MLS enabled
- Have 2 Users [A, B]
- Have a call between both Users
- Start/Join call and keep an eye on the logs, there should be no error log for:

```
java.lang.NullPointerException: ResultSet returned null for Conversations.sq:selectByGroupId
```
