### PR TITLE
fix: E2EI enrolling grace period reseting issue RC

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.persistence.config.IsFileSharingEnabledEntity
 import com.wire.kalium.persistence.config.TeamSettingsSelfDeletionStatusEntity
 import com.wire.kalium.persistence.config.UserConfigStorage
 import com.wire.kalium.persistence.dao.unread.UserConfigDAO
+import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
@@ -233,10 +234,8 @@ internal class UserConfigDataSource internal constructor(
 
     override fun snoozeE2EINotification(duration: Duration): Either<StorageFailure, Unit> =
         wrapStorageRequest {
-            getE2EINotificationTimeOrNull()?.let { current ->
-                val notifyUserAfterMs = current.plus(duration.inWholeMilliseconds)
-                userConfigStorage.updateE2EINotificationTime(notifyUserAfterMs)
-            }
+            val notifyUserAfterMs = DateTimeUtil.currentInstant().toEpochMilliseconds().plus(duration.inWholeMilliseconds)
+            userConfigStorage.updateE2EINotificationTime(notifyUserAfterMs)
         }
 
     override suspend fun clearE2EISettings() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetE2EICertificateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/GetE2EICertificateUseCase.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.e2ei.usecase
 
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.feature.e2ei.CertificateStatusMapper
@@ -37,7 +38,8 @@ class GetE2eiCertificateUseCaseImpl internal constructor(
     override suspend operator fun invoke(clientId: ClientId): GetE2EICertificateUseCaseResult =
         mlsConversationRepository.getClientIdentity(clientId).fold(
             {
-                GetE2EICertificateUseCaseResult.Failure
+                if (it is StorageFailure.DataNotFound) GetE2EICertificateUseCaseResult.NotActivated
+                else GetE2EICertificateUseCaseResult.Failure
             },
             {
                 it?.let {


### PR DESCRIPTION
# What's new in this PR?

### Issues

Re-opening the app re-write E2EI gracePeriod. 

### Causes (Optional)

After recent changes `E2EIConfigHandler$handle` is called not only when the E2EI settings changed but in `SyncFeatureConfigsUseCase` too (on every app launch). As far as the gracePeriod is calculated locally in E2EIConfigHandler it was "resetting" gracePeriod on every app launch.

### Solutions

in `E2EIConfigHandler` add checking if the new settings that we are going to set are the same (except gracePeriod end) as already saved one -> do nothing. If it's different -> set it.


