### PR TITLE
fix: showing degradation alert dialog [WPB-6971] [WPB-6972]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandler.kt
@@ -127,6 +127,6 @@ internal class MLSConversationsVerificationStatusesHandlerImpl(
 
         persistMessage(conversationDegradedMessage)
 
-        conversationRepository.setDegradedConversationNotifiedFlag(conversationId, updatedStatus == VerificationStatus.DEGRADED)
+        conversationRepository.setDegradedConversationNotifiedFlag(conversationId, updatedStatus != VerificationStatus.DEGRADED)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsVerificationStatusesHandlerTest.kt
@@ -130,7 +130,7 @@ class MLSConversationsVerificationStatusesHandlerTest {
 
         verify(arrangement.conversationRepository)
             .suspendFunction(arrangement.conversationRepository::setDegradedConversationNotifiedFlag)
-            .with(any(), eq(true))
+            .with(any(), eq(false))
             .wasInvoked(once)
     }
 
@@ -193,7 +193,7 @@ class MLSConversationsVerificationStatusesHandlerTest {
 
         verify(arrangement.conversationRepository)
             .suspendFunction(arrangement.conversationRepository::setDegradedConversationNotifiedFlag)
-            .with(any(), eq(false))
+            .with(any(), eq(true))
             .wasInvoked(once)
     }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -474,6 +474,7 @@ CREATE TRIGGER addMessageAfterProteusVerificationStatusChange
 AFTER UPDATE ON Conversation
 WHEN new.proteus_verification_status != old.proteus_verification_status
 AND (new.proteus_verification_status  = 'VERIFIED' OR old.proteus_verification_status = 'VERIFIED')
+AND new.protocol != 'MLS'
 BEGIN
     INSERT OR IGNORE INTO Message(id, content_type, conversation_id, creation_date, sender_user_id, sender_client_id, status, visibility)
     VALUES(

--- a/persistence/src/commonMain/db_user/migrations/75.sqm
+++ b/persistence/src/commonMain/db_user/migrations/75.sqm
@@ -1,0 +1,27 @@
+CREATE TRIGGER addMessageAfterProteusVerificationStatusChange
+AFTER UPDATE ON Conversation
+WHEN new.proteus_verification_status != old.proteus_verification_status
+AND (new.proteus_verification_status  = 'VERIFIED' OR old.proteus_verification_status = 'VERIFIED')
+AND new.protocol != 'MLS'
+BEGIN
+    INSERT OR IGNORE INTO Message(id, content_type, conversation_id, creation_date, sender_user_id, sender_client_id, status, visibility)
+    VALUES(
+        (SELECT lower(hex(randomblob(4)) || '-' || lower(hex(randomblob(2))) || '-4' ||
+        substr(lower(hex(randomblob(2))),2) || '-a' || substr(lower(hex(randomblob(2))),2)
+        || '-' || lower(hex(randomblob(6))))),
+        (CASE (new.proteus_verification_status)
+            WHEN 'VERIFIED' THEN 'CONVERSATION_VERIFIED_PROTEUS'
+            ELSE 'CONVERSATION_DEGRADED_PROTEUS' END
+        ),
+        new.qualified_id,
+        (SELECT CAST((julianday('now') - 2440587.5) * 86400 * 1000 AS INTEGER)),
+        (SELECT SelfUser.id FROM SelfUser LIMIT 1),
+        (SELECT Client.id FROM Client WHERE Client.user_id = (SELECT SelfUser.id FROM SelfUser LIMIT 1) LIMIT 1),
+        'SENT',
+        'VISIBLE'
+    );
+
+    UPDATE Conversation
+    SET degraded_conversation_notified = (new.proteus_verification_status != 'DEGRADED')
+    WHERE qualified_id = new.qualified_id;
+END;

--- a/persistence/src/commonMain/db_user/migrations/75.sqm
+++ b/persistence/src/commonMain/db_user/migrations/75.sqm
@@ -1,3 +1,5 @@
+DROP TRIGGER IF EXISTS addMessageAfterProteusVerificationStatusChange;
+
 CREATE TRIGGER addMessageAfterProteusVerificationStatusChange
 AFTER UPDATE ON Conversation
 WHEN new.proteus_verification_status != old.proteus_verification_status


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The degradation alert dialog is showing when sending first message in verified conversation but it's not showing when sending messages in a group that's degraded.

### Causes (Optional)

Wrong boolean expression leading to persisting the inverted value.

### Solutions

Invert the boolean expression to `setDegradedConversationNotifiedFlag` when the new status is **not** `DEGRADED`, because if this flag is true it means that the user has been already notified about conversation being degraded or there's no need to inform the user because the conversation is not degraded.
Also added another check in `addMessageAfterProteusVerificationStatusChange` trigger to only change the `degraded_conversation_notified` flag if the proteus verification status changes and the conversation still actually uses proteus, otherwise if only `MLS` protocol is used then `proteus_verification_status` should not trigger degradation alert dialog anymore, only MLS' `verification_status` changes should be taken into account in that case.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have a verified MLS conversation and add new non-verified user (degradation alert dialog should be shown) or send first message in a verified conversation (degradation alert dialog should not be shown).

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
