### PR TITLE
refactor: return partially claimed key packages [WPB-3694][WPB-6646][WPB-6643]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -53,10 +53,13 @@ sealed interface CoreFailure {
     data object MissingClientRegistration : CoreFailure
 
     /**
-     * Key packages requested not available which prevents them from being added
-     * to an existing or new conversation.
+     * Represents a failure indicating that key packages are missing for user IDs.
+     *
+     * @property failedUserIds The set of user IDs for which key packages are missing.
      */
-    data class NoKeyPackagesAvailable(val failedUserIds: Set<UserId>) : CoreFailure
+    data class MissingKeyPackages(
+        val failedUserIds: Set<UserId>
+    ) : CoreFailure
 
     /**
      * It's not allowed to run the application with development API enabled when

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -229,7 +229,7 @@ internal class ConversationGroupRepositoryImpl(
     ): Either<CoreFailure, Unit> {
         return when {
             // claiming key packages offline or out of packages
-            this is CoreFailure.NoKeyPackagesAvailable && remainingAttempts > 0 -> {
+            this is CoreFailure.MissingKeyPackages && remainingAttempts > 0 -> {
                 val (validUsers, failedUsers) = userIdList.partition { !this.failedUserIds.contains(it) }
                 tryAddMembersToMLSGroup(
                     conversationId = conversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -67,7 +67,7 @@ internal class JoinExistingMLSConversationsUseCaseImpl(
                                     )
                                     Either.Left(it)
                                 }
-                                is CoreFailure.NoKeyPackagesAvailable -> {
+                                is CoreFailure.MissingKeyPackages -> {
                                     kaliumLogger.w(
                                         "Failed to establish mls group for ${conversation.id.toLogString()} " +
                                                 "since some participants are out of key packages, skipping."

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -439,7 +439,12 @@ internal class MLSConversationDataSource(
     ): Either<CoreFailure, Unit> = withContext(serialDispatcher) {
         commitPendingProposals(groupID).flatMap {
             retryOnCommitFailure(groupID, retryOnStaleMessage = retryOnStaleMessage) {
-                keyPackageRepository.claimKeyPackages(userIdList).flatMap { keyPackages ->
+                keyPackageRepository.claimKeyPackages(userIdList).flatMap { keyPackageResult ->
+                    val keyPackages = keyPackageResult.successfullyFetchedKeyPackages
+                    val usersMissingKeyPackages = keyPackageResult.usersWithoutKeyPackagesAvailable
+                    if (usersMissingKeyPackages.isNotEmpty()) {
+                        return@retryOnCommitFailure Either.Left(CoreFailure.MissingKeyPackages(usersMissingKeyPackages))
+                    }
                     mlsClientProvider.getMLSClient().flatMap { mlsClient ->
                         val clientKeyPackageList = keyPackages.map { it.keyPackage.decodeBase64Bytes() }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/mls/KeyPackageClaimResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/mls/KeyPackageClaimResult.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation.mls
+
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageDTO
+
+data class KeyPackageClaimResult(
+    val successfullyFetchedKeyPackages: List<KeyPackageDTO>,
+    val usersWithoutKeyPackagesAvailable: Set<UserId>
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.mls.KeyPackageClaimResult
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.user.UserId
@@ -37,7 +38,19 @@ import io.ktor.util.encodeBase64
 
 interface KeyPackageRepository {
 
-    suspend fun claimKeyPackages(userIds: List<UserId>): Either<CoreFailure, List<KeyPackageDTO>>
+    /**
+     * Claims the key packages for the specified user IDs.
+     *
+     * Attempts to fetch key packages from self user will be skipped.
+     * Attempts to fetch _only_ from self user will result in success even though no key packages were actually claimed.
+     *
+     * @param userIds The list of user IDs for which to claim key packages.
+     * @return An [Either] instance representing the result of the operation. If the operation is successful, it will be [Either.Right]
+     * with a [KeyPackageClaimResult] object containing the successfully fetched key packages and the user IDs without key packages
+     * available. If the operation fails, it will be [Either.Left] with a [CoreFailure] object indicating the reason for the failure.
+     * If **no** KeyPackages are available, [CoreFailure.MissingKeyPackages] will be the cause.
+     */
+    suspend fun claimKeyPackages(userIds: List<UserId>): Either<CoreFailure, KeyPackageClaimResult>
 
     suspend fun uploadNewKeyPackages(clientId: ClientId, amount: Int = 100): Either<CoreFailure, Unit>
 
@@ -58,7 +71,7 @@ class KeyPackageDataSource(
     private val selfUserId: UserId,
 ) : KeyPackageRepository {
 
-    override suspend fun claimKeyPackages(userIds: List<UserId>): Either<CoreFailure, List<KeyPackageDTO>> =
+    override suspend fun claimKeyPackages(userIds: List<UserId>): Either<CoreFailure, KeyPackageClaimResult> =
         currentClientIdProvider().flatMap { selfClientId ->
             val failedUsers = mutableSetOf<UserId>()
             val claimedKeyPackages = mutableListOf<KeyPackageDTO>()
@@ -74,10 +87,10 @@ class KeyPackageDataSource(
                 }
             }
 
-            if (failedUsers.isNotEmpty()) {
-                Either.Left(CoreFailure.NoKeyPackagesAvailable(failedUsers))
+            if (claimedKeyPackages.isEmpty() && failedUsers.isNotEmpty()) {
+                Either.Left(CoreFailure.MissingKeyPackages(failedUsers))
             } else {
-                Either.Right(claimedKeyPackages)
+                Either.Right(KeyPackageClaimResult(claimedKeyPackages, failedUsers))
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
@@ -106,7 +106,7 @@ internal class OneOnOneResolverImpl(
         }
 
     private fun handleBatchEntryFailure(it: CoreFailure) = when (it) {
-        is CoreFailure.NoKeyPackagesAvailable,
+        is CoreFailure.MissingKeyPackages,
         is NetworkFailure.ServerMiscommunication,
         is NetworkFailure.FederatedBackendFailure,
         is CoreFailure.NoCommonProtocolFound

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -1801,6 +1801,6 @@ class ConversationGroupRepositoryTest {
             NetworkFailure.FederatedBackendFailure.FailedDomains(domains.toList())
         )
 
-        val KEY_PACKAGES_NOT_AVAILABLE_FAILURE = Either.Left(CoreFailure.NoKeyPackagesAvailable(setOf(TestUser.OTHER_FEDERATED_USER_ID)))
+        val KEY_PACKAGES_NOT_AVAILABLE_FAILURE = Either.Left(CoreFailure.MissingKeyPackages(setOf(TestUser.OTHER_FEDERATED_USER_ID)))
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -227,7 +227,7 @@ class JoinExistingMLSConversationsUseCaseTest {
             given(joinExistingMLSConversationUseCase)
                 .suspendFunction(joinExistingMLSConversationUseCase::invoke)
                 .whenInvokedWith(anything())
-                .then { Either.Left(CoreFailure.NoKeyPackagesAvailable(setOf())) }
+                .then { Either.Left(CoreFailure.MissingKeyPackages(setOf())) }
         }
 
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When _creating_ a conversation, we don't handle properly the possibility of failure during Key Package claiming. We only handle these cases when adding members, etc.

### Solutions

#### Handle these cases, duh.

That's the goal. But it's not so simple.

KeyPackage claiming currently happens _after_ we ask the backend to create a conversation with all the members. This means that if we were to just handle these failures, we would need to also _remove_ the members whose key packages were not available. 

#### Proposal

Claim all the keypackages _before_ asking the backend to create a conversation. This way we can filter users without keypackages, and _then_ we create a new conversation, we also collect the failed users from this step (federation, for example), and in the end we join them all together, warning the user that some users could not be added to the converstion.

#### And this PR?

Make `claimKeyPackages` more flexible to be used by other parts of the application, by returning Success even in partial cases, but also return the failed users in case it happens.

`claimKeyPackages` is currently only used by the `MLSConversationRepository`, which uses it solely to establish MLS groups.

`claimKeyPackages` either returns Success or Failure. There is no "Only a few users failed" case.

Change `MLSConversationRepository` to keep the same behaviour it had before.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
