### PR TITLE
fix: potential infinite loop when fetching team members

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -112,8 +112,7 @@ internal class TeamDataSource(
         while (
             hasMore &&
             error == null &&
-            fetchedUsersLimit?.let { limit -> pagesSynced * pageSize >= limit } != true &&
-            !(hasMore && pagingState == null && pagesSynced > 0)
+            fetchedUsersLimit?.let { limit -> pagesSynced * pageSize >= limit } != true
         ) {
             wrapApiRequest {
                 teamsApi.getTeamMembers(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -200,37 +200,6 @@ class TeamRepositoryTest {
     }
 
     @Test
-    fun givenHasMoreIsTruePagingStateIsNullAndWeFetchedMoreThanZeroPages_thenAbort() = runTest {
-        val teamMember = TestTeam.memberDTO(
-            nonQualifiedUserId = "teamMember1"
-        )
-
-        val teamMembersList = TeamsApi.TeamMemberListPaginated(
-            hasMore = true,
-            members = listOf(
-                teamMember
-            ),
-            pagingState = null
-        )
-
-        val pageSize = 100
-        val limit = 200
-
-        val (arrangement, teamRepository) = Arrangement()
-            .withGetTeamMembers(NetworkResponse.Success(teamMembersList, mapOf(), 200))
-            .arrange()
-
-        val result = teamRepository.fetchMembersByTeamId(teamId = TeamId("teamId"), userDomain = "userDomain", limit, pageSize = pageSize)
-
-        result.shouldSucceed()
-
-        verify(arrangement.teamsApi)
-            .suspendFunction(arrangement.teamsApi::getTeamMembers)
-            .with(any(), any())
-            .wasInvoked(exactly = once)
-    }
-
-    @Test
     fun givenSelfUserExists_whenGettingTeamById_thenTeamDataShouldBePassed() = runTest {
         val teamEntity = TeamEntity(id = "teamId", name = "teamName", icon = "icon")
         val team = Team(id = "teamId", name = "teamName", icon = "icon")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

if hasMore == true and the paging state is null then the app can go into infinite loop fetching the first page of team members
in practice this will never be the case since even on older APIs the the backend will send the pagingState (while swagger says it will not send any) i will sleep better at night if this potential error is covered

### Solutions

stop the fetch if we fetched at least 1 page, hasMore is true and paging state is null

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
