### PR TITLE
fix: Crash by loop dependence

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -646,7 +646,6 @@ class UserSessionScope internal constructor(
             certificateRevocationListRepository = certificateRevocationListRepository,
             currentClientIdProvider = clientIdProvider,
             mlsClientProvider = mlsClientProvider,
-            mLSConversationsVerificationStatusesHandler = mlsConversationsVerificationStatusesHandler,
             isE2EIEnabledUseCase = isE2EIEnabled
         )
     private val checkRevocationListForCurrentClient: CheckRevocationListForCurrentClientUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCase.kt
@@ -40,7 +40,6 @@ internal class CheckRevocationListUseCaseImpl(
     private val certificateRevocationListRepository: CertificateRevocationListRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val mlsClientProvider: MLSClientProvider,
-    private val mLSConversationsVerificationStatusesHandler: MLSConversationsVerificationStatusesHandler,
     private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 ) : CheckRevocationListUseCase {
     private val logger = kaliumLogger.withTextTag("CheckRevocationListUseCase")
@@ -52,9 +51,6 @@ internal class CheckRevocationListUseCaseImpl(
                     mlsClientProvider.getCoreCrypto(clientId).map { coreCrypto ->
                         logger.i("registering crl..")
                         coreCrypto.registerCrl(url, it).run {
-                            if (dirty) {
-                                mLSConversationsVerificationStatusesHandler()
-                            }
                             this.expiration
                         }
                     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCase.kt
@@ -22,7 +22,6 @@ import com.wire.kalium.logic.E2EIFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
-import com.wire.kalium.logic.data.e2ei.MLSConversationsVerificationStatusesHandler
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCaseTest.kt
@@ -23,8 +23,8 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.E2EIFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.e2ei.MLSConversationsVerificationStatusesHandler
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.functional.Either

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCaseTest.kt
@@ -233,7 +233,6 @@ class CheckRevocationListUseCaseTest {
             certificateRevocationListRepository = certificateRevocationListRepository,
             currentClientIdProvider = currentClientIdProvider,
             mlsClientProvider = mlsClientProvider,
-            mLSConversationsVerificationStatusesHandler = mLSConversationsVerificationStatusesHandler,
             isE2EIEnabledUseCase =  isE2EIEnabledUseCase
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/CheckRevocationListUseCaseTest.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.E2EIFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
-import com.wire.kalium.logic.data.e2ei.MLSConversationsVerificationStatusesHandler
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import com.wire.kalium.logic.framework.TestClient
@@ -175,10 +174,6 @@ class CheckRevocationListUseCaseTest {
                 .suspendFunction(arrangement.coreCrypto::registerCrl)
                 .with(any())
                 .wasInvoked(once)
-
-            verify(arrangement.mLSConversationsVerificationStatusesHandler)
-                .suspendFunction(arrangement.mLSConversationsVerificationStatusesHandler::invoke)
-                .wasInvoked(once)
         }
 
     @Test
@@ -200,10 +195,6 @@ class CheckRevocationListUseCaseTest {
             .suspendFunction(arrangement.coreCrypto::registerCrl)
             .with(any())
             .wasNotInvoked()
-
-        verify(arrangement.mLSConversationsVerificationStatusesHandler)
-            .suspendFunction(arrangement.mLSConversationsVerificationStatusesHandler::invoke)
-            .wasNotInvoked()
     }
 
     internal class Arrangement {
@@ -213,10 +204,6 @@ class CheckRevocationListUseCaseTest {
 
         @Mock
         val coreCrypto = mock(classOf<CoreCryptoCentral>())
-
-        @Mock
-        val mLSConversationsVerificationStatusesHandler =
-            mock(classOf<MLSConversationsVerificationStatusesHandler>())
 
         @Mock
         val currentClientIdProvider =


### PR DESCRIPTION
# What's new in this PR?

### Issues

Crash after login 

### Causes (Optional)

Loop dependency in UserSessionScope : 
- `ConversationRepository` needs `CheckRevocationListUseCaseImpl`
- `CheckRevocationListUseCaseImpl` needs `MLSConversationsVerificationStatusesHandler`
- `MLSConversationsVerificationStatusesHandler` needs `ConversationRepository`

### Solutions

remove `MLSConversationsVerificationStatusesHandler` from `CheckRevocationListUseCaseImpl` as it's not really needed. Handler observes changes infinitely in `UserSessionScope`, so no need to run it again in CheckRevocationListUseCaseImpl. 

