### PR TITLE
fix(monkeys): allow to delay conversation to pool to avoid conversation not found errors (WPB-7046)

### DIFF
--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
@@ -27,6 +27,7 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.long
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreLogger
@@ -72,6 +73,12 @@ fun CoroutineScope.stopIM() {
 
 class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
     private val dataFilePath by argument(help = "path to the test data file")
+    @Suppress("MagicNumber")
+    private val delayPool by option(
+        "-d",
+        "--delay-pool",
+        help = "Time in milliseconds it will wait for a conversation to be added to the pool."
+    ).long().default(1000L)
     private val skipWarmup by option("-s", "--skip-warmup", help = "Should the warmup be skipped?").flag()
     private val sequentialWarmup by option("-w", "--sequential-warmup", help = "Should the warmup happen sequentially?").flag()
     private val logLevel by option("-l", "--log-level", help = "log level").enum<KaliumLogLevel>().default(KaliumLogLevel.INFO)
@@ -138,6 +145,7 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
 
     private suspend fun runMonkeys(testData: TestData, eventStorage: EventStorage) {
         val users = TestDataImporter.generateUserData(testData.backends)
+        val conversationPool = ConversationPool(delayPool)
         testData.testCases.forEachIndexed { index, testCase ->
             val monkeyConfig = if (testData.externalMonkey != null) {
                 logger.i("Starting ${users.size} external monkeys")
@@ -161,7 +169,7 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
                 }
                 logger.i("Creating prefixed groups")
                 testData.conversationDistribution.forEach { (prefix, config) ->
-                    ConversationPool.createPrefixedConversations(
+                    conversationPool.createPrefixedConversations(
                         coreLogic, prefix, config.groupCount, config.userCount, config.protocol, monkeyPool
                     ).forEach {
                         eventChannel.send(Event(it.owner, EventType.CreateConversation(it)))
@@ -169,9 +177,9 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
                 }
             }
             logger.i("Running setup for test case ${testCase.name}")
-            runSetup(testCase.setup, coreLogic, monkeyPool, eventChannel)
+            runSetup(testCase.setup, coreLogic, monkeyPool, conversationPool, eventChannel)
             logger.i("Starting actions for test case ${testCase.name}")
-            start(testCase.name, testCase.actions, coreLogic, monkeyPool, eventChannel)
+            start(testCase.name, testCase.actions, coreLogic, monkeyPool, conversationPool, eventChannel)
             eventStorage.processEvents(eventChannel)
         }
     }
@@ -184,8 +192,7 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
             this::class.java.classLoader?.getResources("META-INF/MANIFEST.MF")?.asIterator()?.forEach { url ->
                 url.openStream().use {
                     val manifest = Manifest(it)
-                    if (manifest.mainAttributes.getValue("CC-Version") != null)
-                        return manifest.mainAttributes.getValue("CC-Version")
+                    if (manifest.mainAttributes.getValue("CC-Version") != null) return manifest.mainAttributes.getValue("CC-Version")
                 }
             }
             return "Not-Found"

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
@@ -31,6 +31,7 @@ import com.github.ajalt.clikt.parameters.types.long
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreLogger
+import com.wire.kalium.monkeys.MetricsCollector.configureMicrometer
 import com.wire.kalium.monkeys.conversation.RemoteMonkey
 import com.wire.kalium.monkeys.model.Event
 import com.wire.kalium.monkeys.model.EventType
@@ -43,13 +44,9 @@ import com.wire.kalium.monkeys.storage.DummyEventStorage
 import com.wire.kalium.monkeys.storage.EventStorage
 import com.wire.kalium.monkeys.storage.FileStorage
 import com.wire.kalium.monkeys.storage.PostgresStorage
-import io.ktor.server.application.call
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.engine.stopServerOnCancellation
 import io.ktor.server.netty.Netty
-import io.ktor.server.response.respondText
-import io.ktor.server.routing.get
-import io.ktor.server.routing.routing
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -106,11 +103,7 @@ class MonkeyApplication : CliktCommand(allowMultipleSubcommands = true) {
 
             logger.i("Initializing Metrics Endpoint")
             embeddedServer(Netty, port = 9090) {
-                routing {
-                    get("/") {
-                        call.respondText(MetricsCollector.metrics())
-                    }
-                }
+                configureMicrometer("/")
             }.start(false).stopServerOnCancellation()
 
             logger.i("Initializing Infinite Monkeys - CC: ${getCCVersion()}")

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/Action.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/Action.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.monkeys.model.ActionType
 import com.wire.kalium.monkeys.model.Event
 import com.wire.kalium.monkeys.model.EventType
 import com.wire.kalium.monkeys.model.MonkeyId
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.channels.SendChannel
 
@@ -72,5 +73,5 @@ abstract class Action(val sender: suspend (Event) -> Unit) {
         }
     }
 
-    abstract suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool)
+    abstract suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool)
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/AddUserToConversationAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/AddUserToConversationAction.kt
@@ -27,8 +27,8 @@ import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 open class AddUserToConversationAction(val config: ActionType.AddUsersToConversation, sender: suspend (Event) -> Unit) : Action(sender) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
-        val targets = pickConversations(monkeyPool)
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
+        val targets = pickConversations(monkeyPool, conversationPool)
         targets.forEach { (monkeyConversation, participants) ->
             monkeyConversation.addMonkeys(participants)
             this.sender(
@@ -40,8 +40,11 @@ open class AddUserToConversationAction(val config: ActionType.AddUsersToConversa
         }
     }
 
-    open suspend fun pickConversations(monkeyPool: MonkeyPool): List<Pair<MonkeyConversation, List<Monkey>>> {
-        val targets = ConversationPool.randomDynamicConversations(this.config.countGroups.toInt())
+    open suspend fun pickConversations(
+        monkeyPool: MonkeyPool,
+        conversationPool: ConversationPool
+    ): List<Pair<MonkeyConversation, List<Monkey>>> {
+        val targets = conversationPool.randomDynamicConversations(this.config.countGroups.toInt())
         return targets.map { target ->
             val filterOut = target.membersIds()
             val participants = target.creator.randomPeers(this.config.userCount, monkeyPool, filterOut)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/CreateConversationAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/CreateConversationAction.kt
@@ -25,13 +25,13 @@ import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 open class CreateConversationAction(val config: ActionType.CreateConversation, sender: suspend (Event) -> Unit) : Action(sender) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         if (this.config.team != null) {
             val conversation =
-                ConversationPool.createDynamicConversation(this.config.team, this.config.userCount, this.config.protocol, monkeyPool)
+                conversationPool.createDynamicConversation(this.config.team, this.config.userCount, this.config.protocol, monkeyPool)
             this.sender(Event(conversation.owner, EventType.CreateConversation(conversation)))
         } else {
-            val conversation = ConversationPool.createDynamicConversation(this.config.userCount, this.config.protocol, monkeyPool)
+            val conversation = conversationPool.createDynamicConversation(this.config.userCount, this.config.protocol, monkeyPool)
             this.sender(Event(conversation.owner, EventType.CreateConversation(conversation)))
         }
     }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/DestroyConversationAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/DestroyConversationAction.kt
@@ -26,15 +26,15 @@ import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 open class DestroyConversationAction(val config: ActionType.DestroyConversation, sender: suspend (Event) -> Unit) : Action(sender) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
-        val targets = conversationTargets()
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
+        val targets = conversationTargets(conversationPool)
         targets.forEach {
-            it.destroy()
+            it.destroy(conversationPool::conversationDestroyed)
             this.sender(Event(it.creator.internalId, EventType.DestroyConversation(it.conversationId)))
         }
     }
 
-    open fun conversationTargets(): List<MonkeyConversation> {
-        return ConversationPool.randomDynamicConversations(this.config.count.toInt())
+    open fun conversationTargets(conversationPool: ConversationPool): List<MonkeyConversation> {
+        return conversationPool.randomDynamicConversations(this.config.count.toInt())
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/HandleExternalRequestAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/HandleExternalRequestAction.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.monkeys.actions
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.conversation.Monkey
 import com.wire.kalium.monkeys.model.ActionType
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 private val DIRECT_MESSAGES = arrayOf(
@@ -49,7 +50,7 @@ private val DIRECT_MESSAGES = arrayOf(
 )
 
 class HandleExternalRequestAction(val config: ActionType.HandleExternalRequest) : Action({}) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         val monkeys = monkeyPool.randomMonkeysWithConnectionRequests(config.userCount)
         monkeys.forEach { (monkey, pendingConnections) ->
             if (config.shouldAccept) {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/LoginAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/LoginAction.kt
@@ -23,11 +23,12 @@ import com.wire.kalium.monkeys.logger
 import com.wire.kalium.monkeys.model.ActionType
 import com.wire.kalium.monkeys.model.Event
 import com.wire.kalium.monkeys.model.EventType
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.delay
 
 open class LoginAction(val config: ActionType.Login, sender: suspend (Event) -> Unit) : Action(sender) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         val monkeys = monkeys(monkeyPool)
         logger.i("Logging ${monkeys.count()} monkeys in")
         monkeys.forEach {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/ReconnectAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/ReconnectAction.kt
@@ -23,11 +23,12 @@ import com.wire.kalium.monkeys.logger
 import com.wire.kalium.monkeys.model.ActionType
 import com.wire.kalium.monkeys.model.Event
 import com.wire.kalium.monkeys.model.EventType
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.delay
 
 open class ReconnectAction(val config: ActionType.Reconnect, sender: suspend (Event) -> Unit) : Action(sender) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         val monkeys = monkeys(monkeyPool)
         logger.i("Logging ${monkeys.count()} monkeys out")
         monkeys.forEach {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendExternalRequestAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendExternalRequestAction.kt
@@ -19,10 +19,11 @@ package com.wire.kalium.monkeys.actions
 
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.model.ActionType
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class SendExternalRequestAction(val config: ActionType.SendExternalRequest) : Action({}) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         val monkeys = monkeyPool.randomLoggedInMonkeysFromTeam(config.originTeam, config.userCount)
         val usersFromTeam = monkeyPool.externalUsersFromTeam(config.targetTeam)
         monkeys.forEach { monkey ->

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendRequestAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/SendRequestAction.kt
@@ -21,11 +21,12 @@ import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.model.ActionType
 import com.wire.kalium.monkeys.model.Event
 import com.wire.kalium.monkeys.model.EventType
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.delay
 
 open class SendRequestAction(val config: ActionType.SendRequest, sender: suspend (Event) -> Unit) : Action(sender) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         val monkeys = monkeyPool.randomLoggedInMonkeysFromTeam(this.config.originTeam, this.config.userCount)
         monkeys.forEach { origin ->
             val targets = monkeyPool.randomLoggedInMonkeysFromTeam(this.config.targetTeam, this.config.targetUserCount)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/AddUserToConversationEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/AddUserToConversationEventAction.kt
@@ -29,8 +29,11 @@ import com.wire.kalium.monkeys.pool.MonkeyPool
 class AddUserToConversationEventAction(private val eventConfig: EventType.AddUsersToConversation) :
     AddUserToConversationAction(ActionType.AddUsersToConversation(1u, UserCount.fixed(eventConfig.newMembers.count().toUInt())), {}) {
 
-    override suspend fun pickConversations(monkeyPool: MonkeyPool): List<Pair<MonkeyConversation, List<Monkey>>> {
-        val target = ConversationPool.get(eventConfig.conversationId) ?: error("Could not find conversation")
+    override suspend fun pickConversations(
+        monkeyPool: MonkeyPool,
+        conversationPool: ConversationPool
+    ): List<Pair<MonkeyConversation, List<Monkey>>> {
+        val target = conversationPool.get(eventConfig.conversationId) ?: error("Could not find conversation")
         val members = eventConfig.newMembers.map {
             monkeyPool.getFromTeam(it.team, it.index)
         }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/CreateConversationEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/CreateConversationEventAction.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class CreateConversationEventAction(private val config: EventType.CreateConversation) : Action({}) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
-        ConversationPool.createDynamicConversation(config.conversation, monkeyPool)
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
+        conversationPool.createDynamicConversation(config.conversation, monkeyPool)
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/DestroyConversationEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/DestroyConversationEventAction.kt
@@ -25,8 +25,8 @@ import com.wire.kalium.monkeys.pool.ConversationPool
 
 class DestroyConversationEventAction(private val eventConfig: EventType.DestroyConversation) :
     DestroyConversationAction(ActionType.DestroyConversation(1u), {}) {
-    override fun conversationTargets(): List<MonkeyConversation> {
-        val conversation = ConversationPool.getFromOldId(this.eventConfig.conversationId)
+    override fun conversationTargets(conversationPool: ConversationPool): List<MonkeyConversation> {
+        val conversation = conversationPool.getFromOldId(this.eventConfig.conversationId)
         return listOf(conversation)
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/LeaveConversationEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/LeaveConversationEventAction.kt
@@ -29,8 +29,8 @@ import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class LeaveConversationEventAction(private val leaver: MonkeyId, private val eventConfig: EventType.LeaveConversation) :
     LeaveConversationAction(ActionType.LeaveConversation(1u, UserCount.single()), {}) {
-    override suspend fun leavers(monkeyPool: MonkeyPool): List<Pair<MonkeyConversation, List<Monkey>>> {
-        val conversation = ConversationPool.getFromOldId(this.eventConfig.conversationId)
+    override suspend fun leavers(monkeyPool: MonkeyPool, conversationPool: ConversationPool): List<Pair<MonkeyConversation, List<Monkey>>> {
+        val conversation = conversationPool.getFromOldId(this.eventConfig.conversationId)
         return listOf(Pair(conversation, listOf(monkeyPool.getFromTeam(this.leaver.team, this.leaver.index))))
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/LogoutEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/LogoutEventAction.kt
@@ -20,10 +20,11 @@ package com.wire.kalium.monkeys.actions.replay
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.actions.Action
 import com.wire.kalium.monkeys.model.MonkeyId
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class LogoutEventAction(private val monkey: MonkeyId) : Action({}) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         monkeyPool.getFromTeam(this.monkey.team, this.monkey.index).logout(monkeyPool::loggedOut)
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/RequestResponseEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/RequestResponseEventAction.kt
@@ -21,10 +21,11 @@ import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.actions.Action
 import com.wire.kalium.monkeys.model.EventType
 import com.wire.kalium.monkeys.model.MonkeyId
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class RequestResponseEventAction(private val requester: MonkeyId, private val config: EventType.RequestResponse) : Action({}) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         val sender = monkeyPool.getFromTeam(this.requester.team, this.requester.index)
         val receiver = monkeyPool.getFromTeam(this.config.targetMonkey.team, this.config.targetMonkey.index)
         if (this.config.shouldAccept) {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/SendDirectMessageEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/SendDirectMessageEventAction.kt
@@ -25,13 +25,14 @@ import com.wire.kalium.monkeys.model.ActionType
 import com.wire.kalium.monkeys.model.EventType
 import com.wire.kalium.monkeys.model.MonkeyId
 import com.wire.kalium.monkeys.model.UserCount
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class SendDirectMessageEventAction(private val monkeySender: MonkeyId, private val eventConfig: EventType.SendDirectMessage) :
     SendMessageAction(ActionType.SendMessage(
         UserCount.single(), 1u, 1u
     ), {}) {
-    override suspend fun sendersTargets(monkeyPool: MonkeyPool):
+    override suspend fun sendersTargets(monkeyPool: MonkeyPool, conversationPool: ConversationPool):
             List<Either<List<Pair<Monkey, Monkey>>, List<Pair<MonkeyConversation, List<Monkey>>>>> {
         val sender = monkeyPool.getFromTeam(this.monkeySender.team, this.monkeySender.index)
         val receiver = monkeyPool.getFromTeam(this.eventConfig.targetMonkey.team, this.eventConfig.targetMonkey.index)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/SendMessageEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/SendMessageEventAction.kt
@@ -32,10 +32,10 @@ class SendMessageEventAction(private val monkeySender: MonkeyId, private val eve
     SendMessageAction(ActionType.SendMessage(
         UserCount.single(), 1u, 1u
     ), {}) {
-    override suspend fun sendersTargets(monkeyPool: MonkeyPool):
+    override suspend fun sendersTargets(monkeyPool: MonkeyPool, conversationPool: ConversationPool):
             List<Either<List<Pair<Monkey, Monkey>>, List<Pair<MonkeyConversation, List<Monkey>>>>> {
         val sender = monkeyPool.getFromTeam(this.monkeySender.team, this.monkeySender.index)
-        val receiver = ConversationPool.getFromOldId(this.eventConfig.conversationId)
+        val receiver = conversationPool.getFromOldId(this.eventConfig.conversationId)
         return listOf(Either.Right(listOf(Pair(receiver, listOf(sender)))))
     }
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/SendRequestEventAction.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/actions/replay/SendRequestEventAction.kt
@@ -21,10 +21,11 @@ import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.monkeys.actions.Action
 import com.wire.kalium.monkeys.model.EventType
 import com.wire.kalium.monkeys.model.MonkeyId
+import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 
 class SendRequestEventAction(private val requester: MonkeyId, private val config: EventType.SendRequest) : Action({}) {
-    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool) {
+    override suspend fun execute(coreLogic: CoreLogic, monkeyPool: MonkeyPool, conversationPool: ConversationPool) {
         val sender = monkeyPool.getFromTeam(this.requester.team, this.requester.index)
         val receiver = monkeyPool.getFromTeam(this.config.targetMonkey.team, this.config.targetMonkey.index)
         sender.sendRequest(receiver)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/LocalMonkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/LocalMonkey.kt
@@ -43,7 +43,6 @@ import com.wire.kalium.monkeys.model.Backend
 import com.wire.kalium.monkeys.model.ConversationDef
 import com.wire.kalium.monkeys.model.MonkeyId
 import com.wire.kalium.monkeys.model.UserCount
-import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.MonkeyPool
 import kotlinx.coroutines.flow.first
 
@@ -219,8 +218,8 @@ class LocalMonkey(monkeyType: MonkeyType, internalId: MonkeyId) : Monkey(monkeyT
         }
     }
 
-    override suspend fun leaveConversation(conversationId: ConversationId) {
-        if (this.monkeyType.userId() == ConversationPool.conversationCreator(conversationId)?.monkeyType?.userId()) {
+    override suspend fun leaveConversation(conversationId: ConversationId, creatorId: UserId) {
+        if (this.monkeyType.userId() == creatorId) {
             error("Creator of the group can't leave")
         }
         this.monkeyState.readyThen {
@@ -228,8 +227,8 @@ class LocalMonkey(monkeyType: MonkeyType, internalId: MonkeyId) : Monkey(monkeyT
         }
     }
 
-    override suspend fun destroyConversation(conversationId: ConversationId) {
-        if (this.monkeyType.userId() != ConversationPool.conversationCreator(conversationId)?.monkeyType?.userId()) {
+    override suspend fun destroyConversation(conversationId: ConversationId, creatorId: UserId) {
+        if (this.monkeyType.userId() != creatorId) {
             error("Only the creator can destroy a group")
         }
 

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/Monkey.kt
@@ -58,6 +58,7 @@ abstract class Monkey(val monkeyType: MonkeyType, val internalId: MonkeyId) {
         // MonkeyId is irrelevant for external users as we will never be able to act on their behalf
         fun external(userId: UserId) = LocalMonkey(MonkeyType.External(userId), MonkeyId(-1, "", -1))
         fun internal(user: UserData, monkeyId: MonkeyId) = LocalMonkey(MonkeyType.Internal(user), monkeyId)
+
         fun remote(monkeyConfig: MonkeyConfig.Remote, user: UserData, monkeyId: MonkeyId) =
             RemoteMonkey(monkeyConfig, MonkeyType.Remote(user), monkeyId)
     }
@@ -109,9 +110,9 @@ abstract class Monkey(val monkeyType: MonkeyType, val internalId: MonkeyId) {
         isDestroyable: Boolean = true
     ): MonkeyConversation
 
-    abstract suspend fun leaveConversation(conversationId: ConversationId)
+    abstract suspend fun leaveConversation(conversationId: ConversationId, creatorId: UserId)
 
-    abstract suspend fun destroyConversation(conversationId: ConversationId)
+    abstract suspend fun destroyConversation(conversationId: ConversationId, creatorId: UserId)
 
     abstract suspend fun addMonkeysToConversation(conversationId: ConversationId, monkeys: List<Monkey>)
 

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/MonkeyConversation.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/MonkeyConversation.kt
@@ -21,7 +21,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.monkeys.MetricsCollector
 import com.wire.kalium.monkeys.model.UserCount
-import com.wire.kalium.monkeys.pool.ConversationPool
 import com.wire.kalium.monkeys.pool.resolveUserCount
 import io.micrometer.core.instrument.Tag
 
@@ -63,9 +62,9 @@ class MonkeyConversation(
         this.creator.removeMonkeyFromConversation(conversationId, monkey)
     }
 
-    suspend fun destroy() {
-        this.creator.destroyConversation(this.conversationId)
-        ConversationPool.conversationDestroyed(this.conversationId)
+    suspend fun destroy(callback: (ConversationId) -> Unit) {
+        this.creator.destroyConversation(this.conversationId, this.creator.monkeyType.userId())
+        callback(this.conversationId)
     }
 
     fun membersIds(): List<UserId> {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/RemoteMonkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/RemoteMonkey.kt
@@ -246,11 +246,11 @@ class RemoteMonkey(monkeyConfig: MonkeyConfig.Remote, monkeyType: MonkeyType, in
         return MonkeyConversation(this, result, isDestroyable, monkeyList)
     }
 
-    override suspend fun leaveConversation(conversationId: ConversationId) {
+    override suspend fun leaveConversation(conversationId: ConversationId, creatorId: UserId) {
         postNoBody(LEAVE_CONVERSATION, conversationId)
     }
 
-    override suspend fun destroyConversation(conversationId: ConversationId) {
+    override suspend fun destroyConversation(conversationId: ConversationId, creatorId: UserId) {
         postNoBody(DESTROY_CONVERSATION, conversationId)
     }
 

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/model/ServerModel.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/model/ServerModel.kt
@@ -62,3 +62,10 @@ data class CreateConversationRequest(
     @SerialName("isDestroyable")
     val isDestroyable: Boolean
 )
+@Serializable
+data class ConversationIdRequest(
+    @SerialName("conversationId")
+    val conversationId: ConversationId,
+    @SerialName("creator")
+    val creator: UserId
+)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/routes/Monitoring.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/routes/Monitoring.kt
@@ -1,18 +1,12 @@
 package com.wire.kalium.monkeys.server.routes
 
+import com.wire.kalium.monkeys.MetricsCollector.configureMicrometer
 import io.ktor.http.HttpHeaders
 import io.ktor.server.application.Application
-import io.ktor.server.application.call
 import io.ktor.server.application.install
-import io.ktor.server.metrics.micrometer.MicrometerMetrics
 import io.ktor.server.plugins.callid.CallId
 import io.ktor.server.plugins.callid.callIdMdc
 import io.ktor.server.plugins.callloging.CallLogging
-import io.ktor.server.response.respond
-import io.ktor.server.routing.get
-import io.ktor.server.routing.routing
-import io.micrometer.prometheus.PrometheusConfig
-import io.micrometer.prometheus.PrometheusMeterRegistry
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
 
@@ -28,14 +22,6 @@ fun Application.configureMonitoring() {
             callId.isNotEmpty()
         }
     }
-    val appMicrometerRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
-    install(MicrometerMetrics) {
-        registry = appMicrometerRegistry
-    }
-    routing {
-        get("/metrics") {
-            call.respond(appMicrometerRegistry.scrape())
-        }
-    }
+    configureMicrometer("/metrics")
 }

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/routes/Monkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/routes/Monkey.kt
@@ -1,7 +1,6 @@
 package com.wire.kalium.monkeys.server.routes
 
 import com.wire.kalium.logic.CoreLogic
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.monkeys.conversation.Monkey
 import com.wire.kalium.monkeys.model.Backend
@@ -11,6 +10,7 @@ import com.wire.kalium.monkeys.model.Team
 import com.wire.kalium.monkeys.model.UserData
 import com.wire.kalium.monkeys.model.httpClient
 import com.wire.kalium.monkeys.server.model.AddMonkeysRequest
+import com.wire.kalium.monkeys.server.model.ConversationIdRequest
 import com.wire.kalium.monkeys.server.model.CreateConversationRequest
 import com.wire.kalium.monkeys.server.model.RemoveMonkeyRequest
 import com.wire.kalium.monkeys.server.model.SendDMRequest
@@ -106,13 +106,13 @@ fun Application.configureRoutes(core: CoreLogic, oldCode: String?) {
             call.respond(HttpStatusCode.OK, result.conversationId)
         }
         post("/$LEAVE_CONVERSATION") {
-            val request = call.receive<ConversationId>()
-            monkey.leaveConversation(request)
+            val request = call.receive<ConversationIdRequest>()
+            monkey.leaveConversation(request.conversationId, request.creator)
             call.respond(HttpStatusCode.OK)
         }
         post("/$DESTROY_CONVERSATION") {
-            val request = call.receive<ConversationId>()
-            monkey.destroyConversation(request)
+            val request = call.receive<ConversationIdRequest>()
+            monkey.destroyConversation(request.conversationId, request.creator)
             call.respond(HttpStatusCode.OK)
         }
         post("/$ADD_MONKEY_TO_CONVERSATION") {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
When a conversation is created by the monkeys, it can happen that it gets selected by another monkey to send message there. The monkey might not have received the welcome message yet and this would cause a conversation not found error on the monkey.

Fixed issue with remote monkey where it wouldn't be able to get the conversation creator to leave or remove a member from a conversation.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
