### PR TITLE
fix: handle with scheme and domain from corecrypto [WPB-7084]

### DIFF
--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/IDs.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/IDs.kt
@@ -72,7 +72,7 @@ data class CryptoQualifiedClientId(
 
 data class WireIdentity(
     val clientId: CryptoQualifiedClientId,
-    val handle: String,
+    val handle: String, // handle format is "{scheme}%40{handle}@{domain}", example: "wireapp://%40hans.wurst@elna.wire.link"
     val displayName: String,
     val domain: String,
     val certificate: String,
@@ -80,7 +80,10 @@ data class WireIdentity(
     val thumbprint: String,
     val serialNumber: String,
     val endTimestamp: Long
-)
+) {
+    val handleWithoutSchemeAtSignAndDomain: String
+        get() = handle.substringAfter("://%40").removeSuffix("@$domain")
+}
 
 enum class CryptoCertificateStatus {
     VALID, EXPIRED, REVOKED;

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/MLSConversationsVerificationStatusesHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/MLSConversationsVerificationStatusesHandler.kt
@@ -123,7 +123,7 @@ internal class MLSConversationsVerificationStatusesHandlerImpl(
                     val isUserVerified = wireIdentity.firstOrNull {
                         it.status != CryptoCertificateStatus.VALID ||
                                 it.displayName != persistedMemberInfo?.name ||
-                                it.handle != persistedMemberInfo.handle
+                                it.handleWithoutSchemeAtSignAndDomain != persistedMemberInfo.handle
                     } == null
                     if (!isUserVerified) {
                         newStatus = VerificationStatus.NOT_VERIFIED


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When getting user identities from core crypto, `handle` field has a different format because it contains also scheme and domain.

### Solutions

Provide another property that returns only the core handle without scheme, `%40` at sign and domain.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create a new MLS group with all users verified - it should have a badge.

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
