### PR TITLE
feat(monkeys): add timeouts and make the client retry requests

### DIFF
--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MetricsCollector.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MetricsCollector.kt
@@ -32,19 +32,19 @@ import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlin.time.measureTimedValue
 import kotlin.time.toJavaDuration
 
-object MetricsCollector {
-    private val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-
-    fun Application.configureMicrometer(route: String) {
-        install(MicrometerMetrics) {
-            registry = registry
-        }
-        routing {
-            get(route) {
-                call.respond(registry.scrape())
-            }
+fun Application.configureMicrometer(route: String) {
+    install(MicrometerMetrics) {
+        registry = MetricsCollector.registry
+    }
+    routing {
+        get(route) {
+            call.respond(MetricsCollector.registry.scrape())
         }
     }
+}
+
+object MetricsCollector {
+    internal val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
     fun count(key: String, tags: List<Tag>) {
         this.registry.counter(key, tags).increment()

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/MonkeyApplication.kt
@@ -31,7 +31,6 @@ import com.github.ajalt.clikt.parameters.types.long
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreLogger
-import com.wire.kalium.monkeys.MetricsCollector.configureMicrometer
 import com.wire.kalium.monkeys.conversation.RemoteMonkey
 import com.wire.kalium.monkeys.model.Event
 import com.wire.kalium.monkeys.model.EventType

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/RemoteMonkey.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/conversation/RemoteMonkey.kt
@@ -249,7 +249,10 @@ class RemoteMonkey(monkeyConfig: MonkeyConfig.Remote, monkeyType: MonkeyType, in
     }
 
     override suspend fun createConversation(
-        name: String, monkeyList: List<Monkey>, protocol: ConversationOptions.Protocol, isDestroyable: Boolean
+        name: String,
+        monkeyList: List<Monkey>,
+        protocol: ConversationOptions.Protocol,
+        isDestroyable: Boolean
     ): MonkeyConversation {
         val result: ConversationId = post(
             CREATE_CONVERSATION, CreateConversationRequest(name, monkeyList.map { it.monkeyType.userId() }, protocol, isDestroyable)

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/pool/ConversationPool.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.monkeys.MetricsCollector
 import com.wire.kalium.monkeys.conversation.Monkey
 import com.wire.kalium.monkeys.conversation.MonkeyConversation
+import com.wire.kalium.monkeys.logger
 import com.wire.kalium.monkeys.model.ConversationDef
 import com.wire.kalium.monkeys.model.UserCount
 import kotlinx.coroutines.coroutineScope
@@ -65,8 +66,11 @@ class ConversationPool(private val delayPool: Long) {
         return this.pool[conversationId]?.creator
     }
 
-    fun randomConversations(count: UInt): List<MonkeyConversation> {
-        return (1u..count).map { pool.values.random() }
+    fun randomConversations(count: UInt): List<MonkeyConversation> = try {
+        (1u..count).map { pool.values.random() }
+    } catch (_: NoSuchElementException) {
+        logger.w("No conversation is available yet")
+        listOf()
     }
 
     fun randomDynamicConversations(count: Int): List<MonkeyConversation> {

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/routes/Monitoring.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/server/routes/Monitoring.kt
@@ -1,6 +1,6 @@
 package com.wire.kalium.monkeys.server.routes
 
-import com.wire.kalium.monkeys.MetricsCollector.configureMicrometer
+import com.wire.kalium.monkeys.configureMicrometer
 import io.ktor.http.HttpHeaders
 import io.ktor.server.application.Application
 import io.ktor.server.application.install


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Adding possibility to configure timeouts for the communication between controller and monkeys and make the client retry on errors.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
