### PR TITLE
refactor: create a dedicated class for WireIdentity handle [WPB-7084]

### DIFF
--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/WireIdentityHandleTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/WireIdentityHandleTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.cryptography
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WireIdentityHandleTest {
+
+    private fun testCreatingWireIdentityHandle(
+        rawValue: String,
+        expectedScheme: String,
+        expectedHandle: String,
+        expectedDomain: String,
+    ) = runTest {
+        val wireIdentityHandle = WireIdentity.Handle.fromString(rawValue, expectedDomain)
+        assertEquals(expectedScheme, wireIdentityHandle.scheme)
+        assertEquals(expectedHandle, wireIdentityHandle.handle)
+        assertEquals(expectedDomain, wireIdentityHandle.domain)
+    }
+
+    @Test
+    fun givenRawHandleWithSchemeAtSignDomain_whenCreatingWireIdentityHandle_thenItIsCorrectlyParsed() =
+        testCreatingWireIdentityHandle(
+            rawValue = "sch.eme://%40han.dle@dom.ain",
+            expectedScheme = "sch.eme",
+            expectedHandle = "han.dle",
+            expectedDomain = "dom.ain"
+        )
+
+    @Test
+    fun givenRawHandleWithSchemeAtSign_whenCreatingWireIdentityHandle_thenItIsCorrectlyParsed() =
+        testCreatingWireIdentityHandle(
+            rawValue = "sch.eme://%40han.dle",
+            expectedScheme = "sch.eme",
+            expectedHandle = "han.dle",
+            expectedDomain = ""
+        )
+
+    @Test
+    fun givenRawHandleWithSchemeDomain_whenCreatingWireIdentityHandle_thenItIsCorrectlyParsed() =
+        testCreatingWireIdentityHandle(
+            rawValue = "sch.eme://han.dle@dom.ain",
+            expectedScheme = "sch.eme",
+            expectedHandle = "han.dle",
+            expectedDomain = "dom.ain"
+        )
+
+    @Test
+    fun givenRawHandleWithScheme_whenCreatingWireIdentityHandle_thenItIsCorrectlyParsed() =
+        testCreatingWireIdentityHandle(
+            rawValue = "sch.eme://han.dle",
+            expectedScheme = "sch.eme",
+            expectedHandle = "han.dle",
+            expectedDomain = ""
+        )
+
+    @Test
+    fun givenRawHandleWithAtSignDomain_whenCreatingWireIdentityHandle_thenItIsCorrectlyParsed() =
+        testCreatingWireIdentityHandle(
+            rawValue = "%40han.dle@dom.ain",
+            expectedScheme = "",
+            expectedHandle = "han.dle",
+            expectedDomain = "dom.ain"
+        )
+
+    @Test
+    fun givenRawHandleWithAtSign_whenCreatingWireIdentityHandle_thenItIsCorrectlyParsed() =
+        testCreatingWireIdentityHandle(
+            rawValue = "%40han.dle",
+            expectedScheme = "",
+            expectedHandle = "han.dle",
+            expectedDomain = ""
+        )
+
+    @Test
+    fun givenRawHandleWithDomain_whenCreatingWireIdentityHandle_thenItIsCorrectlyParsed() =
+        testCreatingWireIdentityHandle(
+            rawValue = "han.dle@dom.ain",
+            expectedScheme = "",
+            expectedHandle = "han.dle",
+            expectedDomain = "dom.ain"
+        )
+
+    @Test
+    fun givenRawHandle_whenCreatingWireIdentityHandle_thenItIsCorrectlyParsed() =
+        testCreatingWireIdentityHandle(
+            rawValue = "han.dle",
+            expectedScheme = "",
+            expectedHandle = "han.dle",
+            expectedDomain = ""
+        )
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/DecryptedMessageBundleMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/DecryptedMessageBundleMapper.kt
@@ -36,7 +36,7 @@ fun com.wire.kalium.cryptography.DecryptedMessageBundle.toModel(groupID: GroupID
         identity?.let { identity ->
             E2EIdentity(
                 identity.clientId,
-                identity.handle,
+                identity.handle.handle,
                 identity.displayName,
                 identity.domain,
                 identity.certificate,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/MLSConversationsVerificationStatusesHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/MLSConversationsVerificationStatusesHandler.kt
@@ -123,7 +123,7 @@ internal class MLSConversationsVerificationStatusesHandlerImpl(
                     val isUserVerified = wireIdentity.firstOrNull {
                         it.status != CryptoCertificateStatus.VALID ||
                                 it.displayName != persistedMemberInfo?.name ||
-                                it.handleWithoutSchemeAtSignAndDomain != persistedMemberInfo.handle
+                                it.handle.handle != persistedMemberInfo.handle
                     } == null
                     if (!isUserVerified) {
                         newStatus = VerificationStatus.NOT_VERIFIED

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1575,36 +1575,44 @@ class MLSConversationRepositoryTest {
         }
 
     @Test
-    fun givenHandleWithSchemeAndDomain_whenGetUserIdentity_thenHandleWithoutSchemeAtSignAndDomainShouldReturnProperValue() = runTest {
+    fun givenHandleWithSchemeAndDomain_whenGetUserIdentity_thenHandleShouldReturnProperValues() = runTest {
         // given
-        val handleWithSchemeAndDomain = "wireapp://%40handle@domain.com"
+        val scheme = "wireapp"
         val handle = "handle"
+        val domain = "domain.com"
+        val handleWithSchemeAndDomain = "$scheme://%40$handle@$domain"
         val groupId = Arrangement.GROUP_ID.value
+        val wireIdentity = WIRE_IDENTITY.copy(handle = WireIdentity.Handle.fromString(handleWithSchemeAndDomain, domain))
         val (_, mlsConversationRepository) = Arrangement()
             .withGetEstablishedSelfMLSGroupIdReturns(groupId)
             .withGetMLSClientSuccessful()
-            .withGetUserIdentitiesReturn(mapOf(groupId to listOf(WIRE_IDENTITY.copy(handle = handleWithSchemeAndDomain))))
+            .withGetUserIdentitiesReturn(mapOf(groupId to listOf(wireIdentity)))
             .arrange()
         // when
         val result = mlsConversationRepository.getUserIdentity(TestUser.USER_ID)
         // then
         result.shouldSucceed() {
             it.forEach {
-                assertEquals(handle, it.handleWithoutSchemeAtSignAndDomain)
+                assertEquals(scheme, it.handle.scheme)
+                assertEquals(handle, it.handle.handle)
+                assertEquals(domain, it.handle.domain)
             }
         }
     }
 
     @Test
-    fun givenHandleWithSchemeAndDomain_whenGetMemberIdentities_thenHandleWithoutSchemeAtSignAndDomainShouldReturnProperValue() = runTest {
+    fun givenHandleWithSchemeAndDomain_whenGetMemberIdentities_thenHandleShouldReturnProperValues() = runTest {
         // given
-        val handleWithSchemeAndDomain = "wireapp://%40handle@domain.com"
+        val scheme = "wireapp"
         val handle = "handle"
+        val domain = "domain.com"
+        val handleWithSchemeAndDomain = "$scheme://%40$handle@$domain"
         val groupId = Arrangement.GROUP_ID.value
+        val wireIdentity = WIRE_IDENTITY.copy(handle = WireIdentity.Handle.fromString(handleWithSchemeAndDomain, domain))
         val (_, mlsConversationRepository) = Arrangement()
             .withGetMLSGroupIdByConversationIdReturns(groupId)
             .withGetMLSClientSuccessful()
-            .withGetUserIdentitiesReturn(mapOf(groupId to listOf(WIRE_IDENTITY.copy(handle = handleWithSchemeAndDomain))))
+            .withGetUserIdentitiesReturn(mapOf(groupId to listOf(wireIdentity)))
             .arrange()
         // when
         val result = mlsConversationRepository.getMembersIdentities(TestConversation.ID, listOf(TestUser.USER_ID))
@@ -1612,7 +1620,9 @@ class MLSConversationRepositoryTest {
         result.shouldSucceed() {
             it.values.forEach {
                 it.forEach {
-                    assertEquals(handle, it.handleWithoutSchemeAtSignAndDomain)
+                    assertEquals(scheme, it.handle.scheme)
+                    assertEquals(handle, it.handle.handle)
+                    assertEquals(domain, it.handle.domain)
                 }
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Right now, after the hotfix https://github.com/wireapp/kalium/pull/2624 the app is able to get the proper handle without scheme or domain (handle format for WireIdentity is `{scheme}%40{username}@{domain}`, example: `wireapp://%40hans.wurst@elna.wire.link`), but it still operates on strings which is error-prone.

### Solutions

Create a dedicated class which defines what this handle consists of and acts as a parser so that we have a single point of failure.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create a new MLS group with all users verified - it should have a badge.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
