### PR TITLE
fix: MLS enabling setting [WPB-7097]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/MLSConversationsVerificationStatusesHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/MLSConversationsVerificationStatusesHandler.kt
@@ -49,6 +49,7 @@ import com.wire.kalium.persistence.dao.conversation.EpochChangesDataEntity
 import com.wire.kalium.util.DateTimeUtil
 
 typealias UserToWireIdentity = Map<UserId, List<WireIdentity>>
+
 /**
  * Observes all the MLS Conversations Verification status.
  * Notify user (by adding System message in conversation) if needed about changes.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -472,8 +472,7 @@ sealed class Event(open val id: String) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.MLSUpdated",
                 idKey to id.obfuscateId(),
-                featureStatusKey to model.status.name,
-                "allowedUsers" to model.allowedUsers?.map { it.value.obfuscateId() }
+                featureStatusKey to model.status.name
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -473,7 +473,7 @@ sealed class Event(open val id: String) {
                 typeKey to "FeatureConfig.MLSUpdated",
                 idKey to id.obfuscateId(),
                 featureStatusKey to model.status.name,
-                "allowedUsers" to model.allowedUsers.map { it.value.obfuscateId() }
+                "allowedUsers" to model.allowedUsers?.map { it.value.obfuscateId() }
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.data.featureConfig
 
-import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.toModel
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigData
@@ -77,13 +76,11 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
     override fun fromDTO(data: FeatureConfigData.MLS?): MLSModel =
         data?.let {
             MLSModel(
-                it.config.protocolToggleUsers?.map { userId -> PlainId(userId) },
                 it.config.defaultProtocol.toModel(),
                 it.config.supportedProtocols.map { it.toModel() }.toSet(),
                 fromDTO(it.status)
             )
         } ?: MLSModel(
-            null,
             SupportedProtocol.PROTEUS,
             setOf(SupportedProtocol.PROTEUS),
             Status.DISABLED

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -77,13 +77,13 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
     override fun fromDTO(data: FeatureConfigData.MLS?): MLSModel =
         data?.let {
             MLSModel(
-                it.config.protocolToggleUsers.map { userId -> PlainId(userId) },
+                it.config.protocolToggleUsers?.map { userId -> PlainId(userId) },
                 it.config.defaultProtocol.toModel(),
                 it.config.supportedProtocols.map { it.toModel() }.toSet(),
                 fromDTO(it.status)
             )
         } ?: MLSModel(
-            listOf(),
+            null,
             SupportedProtocol.PROTEUS,
             setOf(SupportedProtocol.PROTEUS),
             Status.DISABLED

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -77,7 +77,7 @@ data class SelfDeletingMessagesConfigModel(
 )
 
 data class MLSModel(
-    val allowedUsers: List<PlainId>,
+    val allowedUsers: List<PlainId>?,
     val defaultProtocol: SupportedProtocol,
     val supportedProtocols: Set<SupportedProtocol>,
     val status: Status

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -77,7 +77,6 @@ data class SelfDeletingMessagesConfigModel(
 )
 
 data class MLSModel(
-    val allowedUsers: List<PlainId>?,
     val defaultProtocol: SupportedProtocol,
     val supportedProtocols: Set<SupportedProtocol>,
     val status: Status

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -18,9 +18,8 @@
 
 package com.wire.kalium.logic.data.featureConfig
 
-import com.wire.kalium.logic.data.id.PlainId
-import com.wire.kalium.util.time.Second
 import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.util.time.Second
 import kotlinx.datetime.Instant
 
 data class FeatureConfigModel(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -61,6 +61,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDataSource
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepositoryImpl
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.EpochChangesObserverImpl
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCaseImpl
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationsUseCase
@@ -81,6 +82,8 @@ import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepositoryDataSource
 import com.wire.kalium.logic.data.e2ei.E2EIRepository
 import com.wire.kalium.logic.data.e2ei.E2EIRepositoryImpl
+import com.wire.kalium.logic.data.e2ei.MLSConversationsVerificationStatusesHandler
+import com.wire.kalium.logic.data.e2ei.MLSConversationsVerificationStatusesHandlerImpl
 import com.wire.kalium.logic.data.event.EventDataSource
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigDataSource
@@ -186,8 +189,6 @@ import com.wire.kalium.logic.feature.conversation.ConversationsRecoveryManager
 import com.wire.kalium.logic.feature.conversation.ConversationsRecoveryManagerImpl
 import com.wire.kalium.logic.feature.conversation.MLSConversationsRecoveryManager
 import com.wire.kalium.logic.feature.conversation.MLSConversationsRecoveryManagerImpl
-import com.wire.kalium.logic.data.e2ei.MLSConversationsVerificationStatusesHandler
-import com.wire.kalium.logic.data.e2ei.MLSConversationsVerificationStatusesHandlerImpl
 import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveOtherUserSecurityClassificationLabelUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.ObserveSecurityClassificationLabelUseCase
@@ -199,7 +200,6 @@ import com.wire.kalium.logic.feature.conversation.SyncConversationsUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.TypingIndicatorSyncManager
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManagerImpl
-import com.wire.kalium.logic.data.conversation.EpochChangesObserverImpl
 import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolver
 import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolverImpl
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneMigrator
@@ -1522,7 +1522,7 @@ class UserSessionScope internal constructor(
         get() = FileSharingConfigHandler(userConfigRepository)
 
     private val mlsConfigHandler
-        get() = MLSConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes, userId)
+        get() = MLSConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes)
 
     private val mlsMigrationConfigHandler
         get() = MLSMigrationConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandler.kt
@@ -35,8 +35,8 @@ class MLSConfigHandler(
 ) {
     suspend fun handle(mlsConfig: MLSModel, duringSlowSync: Boolean): Either<CoreFailure, Unit> {
         val mlsEnabled = mlsConfig.status == Status.ENABLED
-        val isMLSSupported = mlsConfig.supportedProtocols.contains(SupportedProtocol.MLS)
-        val selfUserIsWhitelisted = mlsConfig.allowedUsers.contains(selfUserId.toPlainID())
+        val isMLSSupported = mlsConfig.defaultProtocol == SupportedProtocol.MLS
+        val selfUserIsWhitelisted = mlsConfig.allowedUsers?.contains(selfUserId.toPlainID()) ?: false
         val previousSupportedProtocols = userConfigRepository.getSupportedProtocols().getOrElse(setOf(SupportedProtocol.PROTEUS))
         val supportedProtocolsHasChanged = !previousSupportedProtocols.equals(mlsConfig.supportedProtocols)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandler.kt
@@ -22,7 +22,6 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.data.user.SupportedProtocol
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneOnOnesUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
@@ -30,17 +29,15 @@ import com.wire.kalium.logic.functional.getOrElse
 
 class MLSConfigHandler(
     private val userConfigRepository: UserConfigRepository,
-    private val updateSupportedProtocolsAndResolveOneOnOnes: UpdateSupportedProtocolsAndResolveOneOnOnesUseCase,
-    private val selfUserId: UserId
+    private val updateSupportedProtocolsAndResolveOneOnOnes: UpdateSupportedProtocolsAndResolveOneOnOnesUseCase
 ) {
     suspend fun handle(mlsConfig: MLSModel, duringSlowSync: Boolean): Either<CoreFailure, Unit> {
         val mlsEnabled = mlsConfig.status == Status.ENABLED
-        val isMLSSupported = mlsConfig.defaultProtocol == SupportedProtocol.MLS
-        val selfUserIsWhitelisted = mlsConfig.allowedUsers?.contains(selfUserId.toPlainID()) ?: false
+        val isMLSSupported = mlsConfig.supportedProtocols.contains(SupportedProtocol.MLS)
         val previousSupportedProtocols = userConfigRepository.getSupportedProtocols().getOrElse(setOf(SupportedProtocol.PROTEUS))
         val supportedProtocolsHasChanged = !previousSupportedProtocols.equals(mlsConfig.supportedProtocols)
 
-        return userConfigRepository.setMLSEnabled((mlsEnabled && isMLSSupported) || (selfUserIsWhitelisted && mlsEnabled))
+        return userConfigRepository.setMLSEnabled(mlsEnabled && isMLSSupported)
             .flatMap {
                 userConfigRepository.setDefaultProtocol(if (mlsEnabled) mlsConfig.defaultProtocol else SupportedProtocol.PROTEUS)
             }.flatMap {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -64,7 +64,6 @@ class FeatureConfigMapperTest {
         val model = mapper.fromDTO(arrangement.featureConfigResponse.mls)
 
         assertEquals(Status.ENABLED, model.status)
-        assertEquals(listOf(PlainId("someId")), model.allowedUsers)
     }
 
     @Test
@@ -156,7 +155,6 @@ class FeatureConfigMapperTest {
             FeatureConfigData.ValidateSAMLEmails(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.MLS(
                 MLSConfigDTO(
-                    listOf("someId"),
                     SupportedProtocolDTO.MLS,
                     listOf(SupportedProtocolDTO.MLS),
                     emptyList(),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -75,7 +75,6 @@ class FeatureConfigRepositoryTest {
             ConfigsStatusModel(Status.ENABLED),
             ConfigsStatusModel(Status.ENABLED),
             MLSModel(
-                emptyList(),
                 SupportedProtocol.PROTEUS,
                 setOf(SupportedProtocol.PROTEUS),
                 Status.ENABLED
@@ -158,7 +157,6 @@ class FeatureConfigRepositoryTest {
             FeatureConfigData.ValidateSAMLEmails(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.MLS(
                 MLSConfigDTO(
-                    emptyList(),
                     SupportedProtocolDTO.PROTEUS,
                     listOf(SupportedProtocolDTO.PROTEUS),
                     emptyList(),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
@@ -43,7 +43,7 @@ object FeatureConfigTest {
         secondFactorPasswordChallengeModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         ssoModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         validateSAMLEmailsModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
-        mlsModel: MLSModel = MLSModel(listOf(), SupportedProtocol.PROTEUS, setOf(SupportedProtocol.PROTEUS), Status.ENABLED),
+        mlsModel: MLSModel = MLSModel(SupportedProtocol.PROTEUS, setOf(SupportedProtocol.PROTEUS), Status.ENABLED),
         e2EIModel: E2EIModel = E2EIModel(E2EIConfigModel("url", 10000L), Status.ENABLED),
         mlsMigrationModel: MLSMigrationModel? = MLSMigrationModel(
             Instant.DISTANT_FUTURE,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
@@ -24,14 +24,16 @@ import com.wire.kalium.logic.configuration.UserConfigDataSource
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.featureConfig.ConferenceCallingModel
 import com.wire.kalium.logic.data.featureConfig.ConfigsStatusModel
+import com.wire.kalium.logic.data.featureConfig.E2EIConfigModel
+import com.wire.kalium.logic.data.featureConfig.E2EIModel
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigModel
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigTest
-import com.wire.kalium.logic.data.featureConfig.E2EIConfigModel
-import com.wire.kalium.logic.data.featureConfig.E2EIModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesConfigModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.message.SelfDeletionMapper.toTeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.featureConfig.handler.AppLockConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.ClassifiedDomainsConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.ConferenceCallingConfigHandler
@@ -42,12 +44,9 @@ import com.wire.kalium.logic.feature.featureConfig.handler.MLSConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSMigrationConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SecondFactorPasswordChallengeConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
-import com.wire.kalium.logic.data.message.SelfDeletionMapper.toTeamSelfDeleteTimer
-import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
 import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneOnOnesUseCase
 import com.wire.kalium.logic.featureFlags.BuildFileRestrictionState
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
-import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.shouldSucceed
@@ -733,7 +732,7 @@ class SyncFeatureConfigsUseCaseTest {
                 featureConfigRepository,
                 GuestRoomConfigHandler(userConfigRepository, kaliumConfigs),
                 FileSharingConfigHandler(userConfigRepository),
-                MLSConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes, TestUser.SELF.id),
+                MLSConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes),
                 MLSMigrationConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes),
                 ClassifiedDomainsConfigHandler(userConfigRepository),
                 ConferenceCallingConfigHandler(userConfigRepository),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandlerTest.kt
@@ -105,33 +105,12 @@ class MLSConfigHandlerTest {
 
         handler.handle(MLS_CONFIG.copy(
             status = Status.ENABLED,
-            allowedUsers = listOf(SELF_USER_ID.toPlainID()),
             supportedProtocols = setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS)
         ), duringSlowSync = false)
 
         verify(arrangement.userConfigRepository)
             .suspendFunction(arrangement.userConfigRepository::setMLSEnabled)
             .with(eq(true))
-            .wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenMlsIsEnabledAndSelfUserIsNotWhitelisted_whenSyncing_thenSetMlsDisabled() = runTest {
-        val (arrangement, handler) = arrange {
-            withGetSupportedProtocolsReturning(Either.Right(setOf(SupportedProtocol.PROTEUS)))
-            withSetSupportedProtocolsSuccessful()
-            withSetDefaultProtocolSuccessful()
-            withSetMLSEnabledSuccessful()
-        }
-
-        handler.handle(MLS_CONFIG.copy(
-            status = Status.ENABLED,
-            allowedUsers = listOf(TestUser.OTHER_USER_ID.toPlainID())
-        ), duringSlowSync = false)
-
-        verify(arrangement.userConfigRepository)
-            .suspendFunction(arrangement.userConfigRepository::setMLSEnabled)
-            .with(eq(false))
             .wasInvoked(exactly = once)
     }
 
@@ -214,7 +193,6 @@ class MLSConfigHandlerTest {
 
         val SELF_USER_ID = TestUser.USER_ID
         val MLS_CONFIG = MLSModel(
-            allowedUsers = null,
             defaultProtocol = SupportedProtocol.MLS,
             supportedProtocols = setOf(SupportedProtocol.PROTEUS),
             status = Status.ENABLED

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -27,6 +27,8 @@ import com.wire.kalium.logic.data.featureConfig.ConfigsStatusModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesConfigModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
+import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.feature.featureConfig.handler.AppLockConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.ClassifiedDomainsConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.ConferenceCallingConfigHandler
@@ -36,12 +38,9 @@ import com.wire.kalium.logic.feature.featureConfig.handler.GuestRoomConfigHandle
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSMigrationConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
-import com.wire.kalium.logic.data.message.TeamSelfDeleteTimer
-import com.wire.kalium.logic.data.message.TeamSettingsSelfDeletionStatus
 import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneOnOnesUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestEvent
-import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
@@ -107,7 +106,7 @@ class FeatureConfigEventReceiverTest {
             event = arrangement.newFileSharingUpdatedEvent(ConfigsStatusModel(Status.DISABLED)),
             deliveryInfo = TestEvent.liveDeliveryInfo
         )
-        
+
         verify(arrangement.userConfigRepository)
             .function(arrangement.userConfigRepository::setFileSharingStatus)
             .with(eq(false), eq(false))
@@ -164,7 +163,7 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+            arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel),
             TestEvent.liveDeliveryInfo
         )
 
@@ -191,7 +190,7 @@ class FeatureConfigEventReceiverTest {
                 .arrange()
 
             featureConfigEventReceiver.onEvent(
-                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel),
                 TestEvent.liveDeliveryInfo
             )
 
@@ -219,7 +218,7 @@ class FeatureConfigEventReceiverTest {
                 .arrange()
 
             featureConfigEventReceiver.onEvent(
-                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel),
                 TestEvent.liveDeliveryInfo
             )
 
@@ -244,7 +243,7 @@ class FeatureConfigEventReceiverTest {
                 .arrange()
 
             featureConfigEventReceiver.onEvent(
-                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel),
                 TestEvent.liveDeliveryInfo
             )
 
@@ -268,7 +267,7 @@ class FeatureConfigEventReceiverTest {
                 .arrange()
 
             featureConfigEventReceiver.onEvent(
-                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel), 
+                arrangement.newSelfDeletingMessagesUpdatedEvent(newSelfDeletingEventModel),
                 TestEvent.liveDeliveryInfo
             )
 
@@ -326,7 +325,7 @@ class FeatureConfigEventReceiverTest {
             FeatureConfigEventReceiverImpl(
                 GuestRoomConfigHandler(userConfigRepository, kaliumConfigs),
                 FileSharingConfigHandler(userConfigRepository),
-                MLSConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes, TestUser.SELF.id),
+                MLSConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes),
                 MLSMigrationConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes),
                 ClassifiedDomainsConfigHandler(userConfigRepository),
                 ConferenceCallingConfigHandler(userConfigRepository),

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -84,8 +84,6 @@ data class ClassifiedDomainsConfigDTO(
 
 @Serializable
 data class MLSConfigDTO(
-    @SerialName("protocolToggleUsers")
-    val protocolToggleUsers: List<String>?,
     @SerialName("defaultProtocol")
     val defaultProtocol: SupportedProtocolDTO,
     @SerialName("supportedProtocols")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -85,7 +85,7 @@ data class ClassifiedDomainsConfigDTO(
 @Serializable
 data class MLSConfigDTO(
     @SerialName("protocolToggleUsers")
-    val protocolToggleUsers: List<String>,
+    val protocolToggleUsers: List<String>?,
     @SerialName("defaultProtocol")
     val defaultProtocol: SupportedProtocolDTO,
     @SerialName("supportedProtocols")

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/FeatureConfigJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/FeatureConfigJson.kt
@@ -129,7 +129,7 @@ object FeatureConfigJson {
             SSO(FeatureFlagStatusDTO.ENABLED),
             ValidateSAMLEmails(FeatureFlagStatusDTO.ENABLED),
             MLS(
-                MLSConfigDTO(emptyList(), SupportedProtocolDTO.PROTEUS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
+                MLSConfigDTO(SupportedProtocolDTO.PROTEUS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
                 FeatureFlagStatusDTO.ENABLED
             ),
             FeatureConfigData.E2EI(E2EIConfigDTO("url", 0L), FeatureFlagStatusDTO.ENABLED),

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
@@ -196,7 +196,7 @@ object NotificationEventsResponseJson {
     private val newMlsFeatureConfigUpdate = ValidJsonProvider(
         EventContentDTO.FeatureConfig.FeatureConfigUpdatedDTO(
             MLS(
-                MLSConfigDTO(emptyList(), SupportedProtocolDTO.MLS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
+                MLSConfigDTO(SupportedProtocolDTO.MLS, listOf(SupportedProtocolDTO.PROTEUS), listOf(1), 1),
                 FeatureFlagStatusDTO.ENABLED,
             )
         ),


### PR DESCRIPTION
# What's new in this PR?

### Issues

Wrong calculating if MLS is enabled for user or not. 

### Causes (Optional)

Nobody knows how it should work :) 

### Solutions

Fix it: 
- if the MLS is enabled in settings AND MLS is in the supported protocols list, 
- in all other cases MLS is disabled.

AND 
in `com.wire.kalium.logic.data.featureConfig.MLSModel` make field `allowedUsers` nullable as it might be removed in the future.
