### PR TITLE
fix: failure fetching federated certificate chain

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/E2EIRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/E2EIRepository.kt
@@ -354,7 +354,7 @@ class E2EIRepositoryImpl(
             })
         }
 
-    private suspend fun E2EIRepositoryImpl.registerIntermediateCAs(data: List<String>) =
+    private suspend fun registerIntermediateCAs(data: List<String>) =
         currentClientIdProvider().fold({
             E2EIFailure.TrustAnchors(it).left()
         }, { clientId ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/EnrollE2EIUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/EnrollE2EIUseCase.kt
@@ -58,6 +58,10 @@ class EnrollE2EIUseCaseImpl internal constructor(
         e2EIRepository.initFreshE2EIClient(isNewClient = isNewClientRegistration)
 
         e2EIRepository.fetchAndSetTrustAnchors()
+        e2EIRepository.fetchFederationCertificates().getOrFail {
+            kaliumLogger.e("Failure fetching federation certificates during E2EI Enrolling!. Failure:$it")
+            return it.left()
+        }
 
         val acmeDirectories = e2EIRepository.loadACMEDirectories().getOrFail {
             return it.left()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -39,7 +39,6 @@ import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.nullableFold
 import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.KaliumSyncException
 import com.wire.kalium.logic.sync.slow.migration.steps.SyncMigrationStep

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -100,10 +100,7 @@ internal class SlowSyncWorkerImpl(
             .continueWithStep(SlowSyncStep.LEGAL_HOLD) { fetchLegalHoldForSelfUserFromRemoteUseCase().map { } }
             .continueWithStep(SlowSyncStep.CONTACTS, syncContacts::invoke)
             .continueWithStep(SlowSyncStep.JOINING_MLS_CONVERSATIONS, joinMLSConversations::invoke)
-            .continueWithStep(SlowSyncStep.RESOLVE_ONE_ON_ONE_PROTOCOLS) {
-                oneOnOneResolver.resolveAllOneOnOneConversations()
-                Unit.right()
-            }
+            .continueWithStep(SlowSyncStep.RESOLVE_ONE_ON_ONE_PROTOCOLS, oneOnOneResolver::resolveAllOneOnOneConversations)
             .flatMap {
                 saveLastProcessedEventIdIfNeeded(lastProcessedEventIdToSaveOnSuccess)
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -63,6 +63,7 @@ class EnrollE2EICertificateUseCaseTest {
         // given
         arrangement.withInitializingE2EIClientSucceed()
         arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
+        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
         arrangement.withLoadACMEDirectoriesResulting(E2EIFailure.AcmeDirectories(TEST_CORE_FAILURE).left())
 
         // when
@@ -144,6 +145,7 @@ class EnrollE2EICertificateUseCaseTest {
         // given
         arrangement.withInitializingE2EIClientSucceed()
         arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
+        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
         arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
         arrangement.withGetACMENonceResulting(E2EIFailure.AcmeNonce(TEST_CORE_FAILURE).left())
 
@@ -224,6 +226,7 @@ class EnrollE2EICertificateUseCaseTest {
         // given
         arrangement.withInitializingE2EIClientSucceed()
         arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
+        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
         arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
         arrangement.withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
         arrangement.withCreateNewAccountResulting(E2EIFailure.AcmeNewAccount(TEST_CORE_FAILURE).left())
@@ -309,6 +312,7 @@ class EnrollE2EICertificateUseCaseTest {
         // given
         arrangement.withInitializingE2EIClientSucceed()
         arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
+        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
         arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
         arrangement.withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
         arrangement.withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
@@ -396,6 +400,7 @@ class EnrollE2EICertificateUseCaseTest {
         // given
         arrangement.withInitializingE2EIClientSucceed()
         arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
+        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
         arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
         arrangement.withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
         arrangement.withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
@@ -487,6 +492,7 @@ class EnrollE2EICertificateUseCaseTest {
         // given
         arrangement.withInitializingE2EIClientSucceed()
         arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
+        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
         arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
         arrangement.withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
         arrangement.withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
@@ -1107,6 +1113,13 @@ class EnrollE2EICertificateUseCaseTest {
         fun withLoadTrustAnchorsResulting(result: Either<E2EIFailure, Unit>) = apply {
             given(e2EIRepository)
                 .suspendFunction(e2EIRepository::fetchAndSetTrustAnchors)
+                .whenInvoked()
+                .thenReturn(result)
+        }
+
+        fun withFetchFederationCertificateChainResulting(result: Either<E2EIFailure, Unit>) = apply {
+            given(e2EIRepository)
+                .suspendFunction(e2EIRepository::fetchFederationCertificates)
                 .whenInvoked()
                 .thenReturn(result)
         }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEResponse.kt
@@ -124,5 +124,11 @@ enum class DtoAuthorizationChallengeType {
     OIDC
 }
 
+@Serializable
+data class FederationCertificateChainResponse(
+    @SerialName("crts")
+    val certificates: List<String>
+)
+
 @JvmInline
 value class CertificateChain(val value: String)

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/ACMEApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/ACMEApiTest.kt
@@ -30,6 +30,27 @@ import kotlin.test.*
 
 internal class ACMEApiTest : ApiTest() {
 
+    @Test
+    fun givingASuccessfulResponse_whenGettingACMEFederationCertificateChain_thenAllCertificatesShouldBeParsed() = runTest {
+        val expected = listOf("a", "b", "potato")
+
+        val networkClient = mockUnboundNetworkClient(
+            responseBody = """
+                 {
+                     "crts": ["a", "b", "potato"]
+                 }
+            """.trimIndent(),
+            statusCode = HttpStatusCode.OK
+        )
+
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
+
+        val result = acmeApi.getACMEFederationCertificateChain("someURL")
+
+        assertTrue(result.isSuccessful())
+        assertContentEquals(expected, result.value)
+    }
+
     @Ignore
     @Test
     fun whenCallingGeTrustAnchorsApi_theResponseShouldBeConfigureCorrectly() = runTest {
@@ -185,6 +206,7 @@ internal class ACMEApiTest : ApiTest() {
             assertEquals(expected, actual.value)
         }
     }
+
     companion object {
         private const val ACME_DISCOVERY_URL = "https://balderdash.hogwash.work:9000/acme/google-android/directory"
         private const val ACME_DIRECTORIES_PATH = "https://balderdash.hogwash.work:9000/acme/google-android/directory"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues


#### Scenario

Given I am a User with E2EI enabled
And I have MLS conversations with federated users
And I get a E2EI certificate during login
When performing Slow Sync


#### What's happening

It fails during `JoinExternalMLSConversations` and `ResolveOneOnOneConversations` because CoreCrypto can't validate the identity of some users.
I get completely stuck in "Waiting for Connection"

#### What should happen

It should join all existing MLS conversations and resolve one on ones.
I should not get stuck

### Causes

1. We were not fetching the federation certificate chain and registering with CoreCrypto when enrolling into E2EI (only on a daily basis)
2. We were not properly parsing the certificate list and passing one at a time to CoreCrypto. We were just passing the whole blob to it.

### Solutions

1. Call `fetchFederationCertificates` during E2EI enrollment
2. Parse the certificates and pass them one at a time to CoreCrypto.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
