### PR TITLE
fix: null teamId for team member [WPB-5749]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -996,7 +996,7 @@ class UserRepositoryTest {
             given(selfApi)
                 .suspendFunction(selfApi::getSelfInfo)
                 .whenInvoked()
-                .thenReturn(NetworkResponse.Success(TestUser.SELF_USER_DTO, mapOf(), 200))
+                .thenReturn(NetworkResponse.Success(TestUser.SELF_USER_DTO.copy(teamId = TestTeam.TEAM_ID.value), mapOf(), 200))
         }
 
         fun withRemoteGetSelfReturningDeletedUser(): Arrangement = apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After changes from this PR https://github.com/wireapp/kalium/pull/2653, `selfTeamIdProvider` can return null `teamId` even if self user belongs to a team.

### Causes (Optional)

When fetching self team member data, during first slow sync the app will try to get self team id from DB before it's persisted. To insert self user data to the DB it needs to fetch team member data, but to fetch team member data it requires team id which is taken from DB by the `selfTeamIdProvider` - it returns null and this null is then used later on in the app.

### Solutions

Do not use `selfTeamIdProvider` until self user data is synced, instead in this case just use `teamId` from `selfUserDTO`.