### PR TITLE
fix: disable message composer only for degraded legal hold conversation status

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
@@ -76,9 +76,8 @@ class ObserveConversationInteractionAvailabilityUseCase internal constructor(
                         conversationDetails.otherUser.defederated -> InteractionAvailability.DISABLED
                         conversationDetails.otherUser.deleted -> InteractionAvailability.DELETED_USER
                         conversationDetails.otherUser.connectionStatus == ConnectionState.BLOCKED -> InteractionAvailability.BLOCKED_USER
-                        conversationDetails.conversation.legalHoldStatus in listOf(
-                            Conversation.LegalHoldStatus.ENABLED, Conversation.LegalHoldStatus.DEGRADED
-                        ) -> InteractionAvailability.LEGAL_HOLD
+                        conversationDetails.conversation.legalHoldStatus == Conversation.LegalHoldStatus.DEGRADED ->
+                            InteractionAvailability.LEGAL_HOLD
                         else -> InteractionAvailability.ENABLED
                     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
@@ -230,14 +230,14 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     }
 
     @Test
-    fun givenConversationLegalHoldIsEnabled_whenInvokingInteractionForConversation_thenInteractionShouldBeLegalHold() = runTest {
+    fun givenConversationLegalHoldIsEnabled_whenInvokingInteractionForConversation_thenInteractionShouldBeEnabled() = runTest {
         val conversationId = TestConversation.ID
         val (_, observeConversationInteractionAvailability) = arrange {
             withLegalHoldOneOnOneConversation(Conversation.LegalHoldStatus.ENABLED)
         }
         observeConversationInteractionAvailability(conversationId).test {
             val interactionResult = awaitItem()
-            assertEquals(IsInteractionAvailableResult.Success(InteractionAvailability.LEGAL_HOLD), interactionResult)
+            assertEquals(IsInteractionAvailableResult.Success(InteractionAvailability.ENABLED), interactionResult)
             awaitComplete()
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sending messages is disabled when one of 1:1 conversation members is under legal hold even when both members consent to legal hold.

### Causes (Optional)

Interaction is disabled not only when legal hold status for conversation is `DEGRADED` (it means that the app got connection update with `MISSING_LEGALHOLD_CONSENT` status for this other member) but also when the status is `ENABLED`, but it shouldn't be the case, because `ENABLED` legal hold status can happen only when both consent to legal hold so at this point both are allowed to send messages to each other.

### Solutions

Disable interaction only when legal hold status for 1:1 conversation is `DEGRADED`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have 1:1 conversation with other team member and enable legal hold for that member.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
