### PR TITLE
fix: unread self mention [WPB-5786]

### DIFF
--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -343,7 +343,8 @@ internal class MessageDAOImpl internal constructor(
                     user_id = it.userId
                 )
             }
-            val selfMention = newTextContent.mentions.firstNotNullOfOrNull { it.userId == selfUserId }
+
+            val selfMention = newTextContent.mentions.firstOrNull { it.userId == selfUserId }
             if (selfMention != null) {
                 unreadEventsQueries.updateEvent(UnreadEventTypeEntity.MENTION, currentMessageId, conversationId)
             } else {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- updating edited message without self mention caused unread self mention

### Causes (Optional)

- unread mention badge on conversations

### Solutions

- fix check if mentions contains self user id

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

mention cases:

Case 1:

1. send a new message with 2 ppl mentioned
2. only the 2 ppl should see the icon
3. edit the message to remove one mention
4. only 1 person should see the icon

Case 2:

1 . send a message without a mention and then edit to add a mention and everyone will see the icon
