### PR TITLE
fix: renew dialog is displayed when the cert is revoked

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveE2EIRequiredUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveE2EIRequiredUseCase.kt
@@ -96,9 +96,9 @@ internal class ObserveE2EIRequiredUseCaseImpl(
         } ?: E2EIRequiredResult.NoGracePeriod.Create
 
     private fun onUserHasCertificate(certificate: E2eiCertificate) =
-        if (certificate.endAt <= DateTimeUtil.currentInstant() || certificate.status != CertificateStatus.VALID) {
+        if (certificate.status == CertificateStatus.EXPIRED) {
             E2EIRequiredResult.NoGracePeriod.Renew
-        } else if (certificate.shouldRenew()) {
+        } else if (certificate.status == CertificateStatus.VALID && certificate.shouldRenew()) {
             E2EIRequiredResult.WithGracePeriod.Renew(certificate.renewGracePeriodLeft())
         } else {
             E2EIRequiredResult.NotRequired


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

 renew dialog is displayed when the cert is revoked

### Solutions

check if the cert is revoked and return that there is no need to renew

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
