### PR TITLE
fix: Ignore ConnectionRequest on backend disabled RC [WPB-7087]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -42,7 +42,9 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.failure.InvalidMappingFailure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.isRight
+import com.wire.kalium.logic.functional.left
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
@@ -75,6 +77,7 @@ interface ConnectionRepository {
     suspend fun setConnectionAsNotified(userId: UserId)
     suspend fun setAllConnectionsAsNotified()
     suspend fun deleteConnection(connection: Connection): Either<StorageFailure, Unit>
+    suspend fun ignoreConnectionRequest(userId: UserId): Either<CoreFailure, Unit>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -125,22 +128,36 @@ internal class ConnectionDataSource(
         }.map { }
     }
 
-    override suspend fun updateConnectionStatus(userId: UserId, connectionState: ConnectionState): Either<CoreFailure, Connection> {
+    private suspend fun updateRemoteConnectionStatus(userId: UserId, connectionState: ConnectionState): Either<CoreFailure, ConnectionDTO> {
         val isValidConnectionState = isValidConnectionState(connectionState)
         val newConnectionStatus = connectionStatusMapper.toApiModel(connectionState)
         if (!isValidConnectionState || newConnectionStatus == null) {
             return Either.Left(InvalidMappingFailure)
         }
 
-        return wrapApiRequest {
-            connectionApi.updateConnection(userId.toApi(), newConnectionStatus)
-        }.map { connectionDTO ->
-            val connectionStatus = connectionDTO.copy(status = newConnectionStatus)
+        return wrapApiRequest { connectionApi.updateConnection(userId.toApi(), newConnectionStatus) }
+    }
+
+    override suspend fun updateConnectionStatus(userId: UserId, connectionState: ConnectionState): Either<CoreFailure, Connection> =
+        updateRemoteConnectionStatus(userId, connectionState).map { connectionDTO ->
+            val connectionStatus = connectionDTO.copy(status = connectionStatusMapper.toApiModel(connectionState)!!)
             val connectionModel = connectionMapper.fromApiToModel(connectionDTO)
             handleUserConnectionStatusPersistence(connectionMapper.fromApiToModel(connectionStatus))
             connectionModel
         }
-    }
+
+    override suspend fun ignoreConnectionRequest(userId: UserId): Either<CoreFailure, Unit> =
+        updateRemoteConnectionStatus(userId, IGNORED)
+            .flatMapLeft {
+                if (it is NetworkFailure.FederatedBackendFailure.FailedDomains)
+                    wrapStorageRequest { connectionDAO.getConnectionByUser(userId.toDao()) }
+                        .map { connectionEntity ->
+                            val updatedConnection = connectionMapper.fromDaoToModel(connectionEntity).copy(status = IGNORED)
+                            handleUserConnectionStatusPersistence(updatedConnection)
+                        }
+                else it.left()
+            }
+            .map { Unit }
 
     /**
      * Check if we can transition to the correct connection status

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCase.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.feature.connection
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.connection.ConnectionRepository
-import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.kaliumLogger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCase.kt
@@ -43,7 +43,7 @@ internal class IgnoreConnectionRequestUseCaseImpl(
 ) : IgnoreConnectionRequestUseCase {
 
     override suspend fun invoke(userId: UserId): IgnoreConnectionRequestUseCaseResult {
-        return connectionRepository.updateConnectionStatus(userId, ConnectionState.IGNORED)
+        return connectionRepository.ignoreConnectionRequest(userId)
             .fold({
                 kaliumLogger.e("An error occurred when ignoring the connection request to $userId")
                 IgnoreConnectionRequestUseCaseResult.Failure(it)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCaseTest.kt
@@ -52,9 +52,9 @@ class IgnoreConnectionRequestUseCaseTest {
     fun givenAConnectionRequest_whenInvokingIgnoreConnectionRequestAndOk_thenShouldReturnsASuccessResult() = runTest {
         // given
         given(connectionRepository)
-            .suspendFunction(connectionRepository::updateConnectionStatus)
-            .whenInvokedWith(eq(userId), eq(ConnectionState.IGNORED))
-            .thenReturn(Either.Right(connection))
+            .suspendFunction(connectionRepository::ignoreConnectionRequest)
+            .whenInvokedWith(eq(userId))
+            .thenReturn(Either.Right(Unit))
 
         // when
         val resultOk = ignoreConnectionRequestUseCase(userId)
@@ -62,8 +62,8 @@ class IgnoreConnectionRequestUseCaseTest {
         // then
         assertEquals(IgnoreConnectionRequestUseCaseResult.Success, resultOk)
         verify(connectionRepository)
-            .suspendFunction(connectionRepository::updateConnectionStatus)
-            .with(eq(userId), eq(ConnectionState.IGNORED))
+            .suspendFunction(connectionRepository::ignoreConnectionRequest)
+            .with(eq(userId))
             .wasInvoked(once)
     }
 
@@ -71,8 +71,8 @@ class IgnoreConnectionRequestUseCaseTest {
     fun givenAConnectionRequest_whenInvokingIgnoreConnectionRequestAndFails_thenShouldReturnsAFailureResult() = runTest {
         // given
         given(connectionRepository)
-            .suspendFunction(connectionRepository::updateConnectionStatus)
-            .whenInvokedWith(eq(userId), eq(ConnectionState.IGNORED))
+            .suspendFunction(connectionRepository::ignoreConnectionRequest)
+            .whenInvokedWith(eq(userId))
             .thenReturn(Either.Left(CoreFailure.Unknown(RuntimeException("Some error"))))
 
         // when
@@ -81,8 +81,8 @@ class IgnoreConnectionRequestUseCaseTest {
         // then
         assertEquals(IgnoreConnectionRequestUseCaseResult.Failure::class, resultFailure::class)
         verify(connectionRepository)
-            .suspendFunction(connectionRepository::updateConnectionStatus)
-            .with(eq(userId), eq(ConnectionState.IGNORED))
+            .suspendFunction(connectionRepository::ignoreConnectionRequest)
+            .with(eq(userId))
             .wasInvoked(once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConnectionRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConnectionRepositoryArrangement.kt
@@ -37,6 +37,7 @@ internal interface ConnectionRepositoryArrangement {
     fun withDeleteConnection(result: Either<StorageFailure, Unit>, connection: Matcher<Connection> = any())
     fun withConnectionList(connectionsFlow: Flow<List<ConversationDetails>>)
     fun withUpdateConnectionStatus(result: Either<CoreFailure, Connection>)
+    fun withIgnoreConnectionRequest(result: Either<CoreFailure, Unit>)
 }
 
 internal open class ConnectionRepositoryArrangementImpl : ConnectionRepositoryArrangement {
@@ -73,6 +74,13 @@ internal open class ConnectionRepositoryArrangementImpl : ConnectionRepositoryAr
         given(connectionRepository)
             .suspendFunction(connectionRepository::updateConnectionStatus)
             .whenInvokedWith(any(), any())
+            .thenReturn(result)
+    }
+
+    override fun withIgnoreConnectionRequest(result: Either<CoreFailure, Unit>) {
+        given(connectionRepository)
+            .suspendFunction(connectionRepository::ignoreConnectionRequest)
+            .whenInvokedWith(any())
             .thenReturn(result)
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConnectionApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConnectionApiV4.kt
@@ -20,6 +20,8 @@ package com.wire.kalium.network.api.v4.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionDTO
+import com.wire.kalium.network.api.base.authenticated.connection.ConnectionStateDTO
+import com.wire.kalium.network.api.base.authenticated.connection.UpdateConnectionRequest
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v3.authenticated.ConnectionApiV3
 import com.wire.kalium.network.exceptions.KaliumException
@@ -27,6 +29,8 @@ import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapFederationResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
 import io.ktor.utils.io.errors.IOException
 
 internal open class ConnectionApiV4 internal constructor(
@@ -40,4 +44,15 @@ internal open class ConnectionApiV4 internal constructor(
     } catch (e: IOException) {
         NetworkResponse.Error(KaliumException.GenericError(e))
     }
+
+    override suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStateDTO): NetworkResponse<ConnectionDTO> =
+        try {
+            httpClient.put("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}") {
+                setBody(UpdateConnectionRequest(connectionStatus))
+            }.let { response ->
+                wrapFederationResponse(response) { wrapKaliumResponse { response } }
+            }
+        } catch (e: IOException) {
+            NetworkResponse.Error(KaliumException.GenericError(e))
+        }
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Connections.sq
@@ -53,3 +53,6 @@ SELECT * FROM Connection LEFT JOIN User ON Connection.qualified_to == User.quali
 
 selectConnectionsForNotification:
 SELECT * FROM Connection LEFT JOIN User ON Connection.qualified_to == User.qualified_id WHERE status = 'PENDING' AND should_notify = 1;
+
+selectConnectionRequestByUser:
+SELECT * FROM Connection LEFT JOIN User ON Connection.qualified_to == User.qualified_id WHERE Connection.qualified_to = :user_id;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAO.kt
@@ -70,4 +70,5 @@ interface ConnectionDAO {
     suspend fun getConnectionRequestsForNotification(): Flow<List<ConnectionEntity>>
     suspend fun updateNotificationFlag(flag: Boolean, userId: QualifiedIDEntity)
     suspend fun setAllConnectionsAsNotified()
+    suspend fun getConnectionByUser(userId: QualifiedIDEntity): ConnectionEntity?
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/ConnectionDAOImpl.kt
@@ -183,4 +183,10 @@ class ConnectionDAOImpl(
     override suspend fun setAllConnectionsAsNotified() = withContext(queriesContext) {
         connectionsQueries.setAllConnectionsAsNotified()
     }
+
+    override suspend fun getConnectionByUser(userId: QualifiedIDEntity): ConnectionEntity? {
+        return withContext(queriesContext) {
+            connectionsQueries.selectConnectionRequestByUser(userId, connectionMapper::toModel).executeAsOneOrNull()
+        }
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

### Issues

When user is trying to ignore the Connection request from the user whose backend is unavailable - Error is displayed.
Igrnoring the ConnectionRequest should be available even in that case.

### Causes (Optional)

It was not implemented (quit a tricky case that nobody think about)

### Solutions

Update ConnectionRepository by adding a separate fun for ignoring the connection request. 
In case of `FederatedBackendFailure.FailedDomains` request is still marked as "Ignored" localy. 


