### PR TITLE
feat: testservice can return message receipts [WPB-7414]

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ConversationResources.kt
@@ -21,12 +21,14 @@ package com.wire.kalium.testservice.api.v1
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.mention.MessageMention
+import com.wire.kalium.logic.data.message.receipt.DetailedReceipt
 import com.wire.kalium.logic.data.message.receipt.ReceiptType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.testservice.managed.ConversationRepository
 import com.wire.kalium.testservice.managed.InstanceService
 import com.wire.kalium.testservice.models.ClearConversationRequest
 import com.wire.kalium.testservice.models.DeleteMessageRequest
+import com.wire.kalium.testservice.models.GetMessageReceiptsRequest
 import com.wire.kalium.testservice.models.GetMessagesRequest
 import com.wire.kalium.testservice.models.SendButtonActionConfirmationRequest
 import com.wire.kalium.testservice.models.SendButtonActionRequest
@@ -129,6 +131,42 @@ class ConversationResources(private val instanceService: InstanceService) {
                 ConversationRepository.getMessages(
                     instance,
                     ConversationId(conversationId, conversationDomain)
+                )
+            }
+        }
+    }
+
+    @POST
+    @Path("/instance/{id}/getMessageReadReceipts")
+    @Operation(summary = "Get all read receipts of a specific message")
+    @Consumes(MediaType.APPLICATION_JSON)
+    fun getMessageReadReceipts(@PathParam("id") id: String, @Valid request: GetMessageReceiptsRequest): List<DetailedReceipt> {
+        val instance = instanceService.getInstanceOrThrow(id)
+        with(request) {
+            return runBlocking {
+                ConversationRepository.getMessageReceipts(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    messageId,
+                    ReceiptType.READ
+                )
+            }
+        }
+    }
+
+    @POST
+    @Path("/instance/{id}/getMessageDeliveryReceipts")
+    @Operation(summary = "Get all delivery receipts of a specific message")
+    @Consumes(MediaType.APPLICATION_JSON)
+    fun getMessageDeliveryReceipts(@PathParam("id") id: String, @Valid request: GetMessageReceiptsRequest): List<DetailedReceipt> {
+        val instance = instanceService.getInstanceOrThrow(id)
+        with(request) {
+            return runBlocking {
+                ConversationRepository.getMessageReceipts(
+                    instance,
+                    ConversationId(conversationId, conversationDomain),
+                    messageId,
+                    ReceiptType.DELIVERED
                 )
             }
         }

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/models/GetMessageReceiptsRequest.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/models/GetMessageReceiptsRequest.kt
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.testservice.models
+
+data class GetMessageReceiptsRequest(
+    val conversationDomain: String = "staging.zinfra.io",
+    val conversationId: String = "",
+    val messageId: String = "",
+)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

A new endpoint needs to be implemented for testservice because read receipts are not found inside the output of getRecentMessages. Instead observeMessageReceipts fromObserveMessageReceiptsUseCase in message scope needs to be used once messageId is known.

This PR implements two endpoints. /getMessageReadReceipts for read receipts and /getMessageDeliveryReceipts for delivery receipts

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
