### PR TITLE
fix: SearchUserResult merging local and remote results [WPB-7340]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUserResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUserResult.kt
@@ -32,8 +32,11 @@ data class SearchUserResult(
         ): SearchUserResult {
             val updatedUser = mutableListOf<UserId>()
             remoteSearch.forEach { (userId, remoteUser) ->
-                if ((remoteUser.connectionStatus == ConnectionState.ACCEPTED)) {
+                if (remoteUser.connectionStatus == ConnectionState.ACCEPTED) {
                     localResult[userId] = remoteUser
+                    updatedUser.add(userId)
+                }
+                if (localResult.contains(userId)) {
                     updatedUser.add(userId)
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUserResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUserResult.kt
@@ -34,8 +34,8 @@ data class SearchUserResult(
             remoteSearch.forEach { (userId, remoteUser) ->
                 if (remoteUser.connectionStatus == ConnectionState.ACCEPTED) {
                     localResult[userId] = remoteUser
-                }
-                if (localResult.contains(userId)) {
+                    updatedUser.add(userId)
+                } else if (localResult.contains(userId)) {
                     updatedUser.add(userId)
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUserResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUserResult.kt
@@ -34,7 +34,6 @@ data class SearchUserResult(
             remoteSearch.forEach { (userId, remoteUser) ->
                 if (remoteUser.connectionStatus == ConnectionState.ACCEPTED) {
                     localResult[userId] = remoteUser
-                    updatedUser.add(userId)
                 }
                 if (localResult.contains(userId)) {
                     updatedUser.add(userId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUserResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUserResult.kt
@@ -32,7 +32,7 @@ data class SearchUserResult(
         ): SearchUserResult {
             val updatedUser = mutableListOf<UserId>()
             remoteSearch.forEach { (userId, remoteUser) ->
-                if (localResult.contains(userId) || (remoteUser.connectionStatus == ConnectionState.ACCEPTED)) {
+                if ((remoteUser.connectionStatus == ConnectionState.ACCEPTED)) {
                     localResult[userId] = remoteUser
                     updatedUser.add(userId)
                 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchByHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchByHandleUseCaseTest.kt
@@ -144,10 +144,14 @@ class SearchByHandleUseCaseTest {
     fun givenLocalAndRemoteResult_whenInvokingSearch_thenThereAreNoDuplicatedResult() = runTest {
 
         val remoteSearchResult = listOf(
-            newOtherUser("remoteAndLocalUser1").copy(name = "updatedNewName"),
+            newOtherUser("remoteAndLocalUser1").copy(name = "updatedNewName", connectionStatus = ConnectionState.NOT_CONNECTED),
             newOtherUser("remoteUser2").copy(
                 teamId = TeamId("otherTeamId"),
                 connectionStatus = ConnectionState.PENDING
+            ),
+            newOtherUser("remoteUser3").copy(
+                teamId = TeamId("otherTeamId"),
+                connectionStatus = ConnectionState.ACCEPTED
             ),
         )
 
@@ -158,8 +162,9 @@ class SearchByHandleUseCaseTest {
 
         val expected = SearchUserResult(
             connected = listOf(
-                newUserSearchDetails("remoteAndLocalUser1").copy(name = "updatedNewName"),
-                newUserSearchDetails("localUser2")
+                newUserSearchDetails("remoteAndLocalUser1").copy(name = "oldName"),
+                newUserSearchDetails("localUser2"),
+                newUserSearchDetails("remoteUser3")
             ),
             notConnected = listOf(
                 newUserSearchDetails("remoteUser2").copy(connectionStatus = ConnectionState.PENDING),


### PR DESCRIPTION
# What's new in this PR?

### Issues

In creating new group conversation: while searching the user and trying to select some private acc (that i have already connected with), the selecting check-box doesn't react on clicks.

### Causes (Optional)

Searching for the user has 2 sources: local storage (for the users that i'm connected with) and API (for remote users, user from another teams, or private users). 
When kalium gets users from API it's `UserProfileDTO` which needs to be mapped into `OtherUser`, as far as `UserProfileDTO` has no `connectionState` field and `OtherUser` needs it, it's mapped like: "if user is in the same team as me -> he's connected, if not -> not_connected". So even if i'm already connected with some private user he'll be "not_connected". 

Later when these 2 sources (local and remote) are merged: there is a check if some user has status "connected" OR he's in local list (checking by user_id) we replace that user in localList by the user from remoteList and remove it from remoteList. 

That is the problem point: as I'm already connected with some private user he should have status "connected" (and he does in localList) but the user data that comes from API always has "Not_connected" status for private users.

The problem becomes visible later in UI when we check if the CheckBox in contacts list should be checked or not (if user was selected for the new group or not), there is comparing: "does SelectedContacts list contain that Contact": SelectedContacts contains user with connected status and "that Contact" has not_connected status so the `selectedContactsList.contains(contact)` always false.  

### Solutions

in merging remote and local SearchResults: 
1. if localList contains user with the same user_id as in remoteList -> just remove that user from remoteList. 
2. If user in remoteList has "Connected" status -> add it to localList and remove from remoteList (was done before changes)
