### PR TITLE
fix: app crashing when accepting call (WPB-6973)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -60,7 +60,7 @@ actual class CoreLogic(
     override fun getSessionScope(userId: UserId): UserSessionScope =
         userSessionScopeProvider.value.getOrCreate(userId)
 
-    override fun deleteSessionScope(userId: UserId) {
+    override suspend fun deleteSessionScope(userId: UserId) {
         userSessionScopeProvider.value.get(userId)?.cancel()
         userSessionScopeProvider.value.delete(userId)
     }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -68,7 +68,7 @@ actual class CoreLogic(
     override fun getSessionScope(userId: UserId): UserSessionScope =
         userSessionScopeProvider.value.getOrCreate(userId)
 
-    override fun deleteSessionScope(userId: UserId) {
+    override suspend fun deleteSessionScope(userId: UserId) {
         userSessionScopeProvider.value.get(userId)?.cancel()
         userSessionScopeProvider.value.delete(userId)
     }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -75,4 +75,8 @@ class CallManagerImpl : CallManager {
     override suspend fun reportProcessNotifications(isStarted: Boolean) {
         TODO("Not yet implemented")
     }
+
+    override suspend fun cancelJobs() {
+        TODO("Not yet implemented")
+    }
 }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -53,7 +53,7 @@ actual class GlobalCallManager {
         return CallManagerImpl()
     }
 
-    actual fun removeInMemoryCallingManagerForUser(userId: UserId) {
+    actual suspend fun removeInMemoryCallingManagerForUser(userId: UserId) {
         TODO("Not yet implemented")
     }
 

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -108,7 +108,7 @@ class CallManagerImpl internal constructor(
     kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) : CallManager {
 
-    private val job = SupervisorJob() // TODO(calling): clear job method
+    private val job = SupervisorJob()
     private val scope = CoroutineScope(job + kaliumDispatchers.io)
     private val deferredHandle: Deferred<Handle> = startHandleAsync()
 

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -82,6 +82,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -561,6 +562,12 @@ class CallManagerImpl internal constructor(
         withCalling {
             wcall_process_notifications(it, isStarted)
         }
+    }
+
+    override suspend fun cancelJobs() {
+        deferredHandle.cancel()
+        scope.cancel()
+        job.cancel()
     }
 
     companion object {

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -105,7 +105,8 @@ actual class GlobalCallManager(
         }
     }
 
-    actual fun removeInMemoryCallingManagerForUser(userId: UserId) {
+    actual suspend fun removeInMemoryCallingManagerForUser(userId: UserId) {
+        callManagerHolder[userId]?.cancelJobs()
         callManagerHolder.remove(userId)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -88,7 +88,7 @@ abstract class CoreLogicCommon internal constructor(
     @Suppress("MemberVisibilityCanBePrivate") // Can be used by other targets like iOS and JS
     abstract fun getSessionScope(userId: UserId): UserSessionScope
 
-    abstract fun deleteSessionScope(userId: UserId) // TODO remove when proper use case is ready
+    abstract suspend fun deleteSessionScope(userId: UserId) // TODO remove when proper use case is ready
 
     // TODO: make globalScope a singleton
     inline fun <T> globalScope(action: GlobalKaliumScope.() -> T): T = getGlobalScope().action()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
@@ -27,7 +27,7 @@ interface UserSessionScopeProvider {
     fun get(userId: UserId): UserSessionScope?
     fun getOrCreate(userId: UserId): UserSessionScope
     fun <T> getOrCreate(userId: UserId, action: UserSessionScope.() -> T): T
-    fun delete(userId: UserId)
+    suspend fun delete(userId: UserId)
 }
 
 abstract class UserSessionScopeProviderCommon(
@@ -49,7 +49,7 @@ abstract class UserSessionScopeProviderCommon(
 
     override fun get(userId: UserId): UserSessionScope? = userScopeStorage.get(userId)
 
-    override fun delete(userId: UserId) {
+    override suspend fun delete(userId: UserId) {
         globalCallManager.removeInMemoryCallingManagerForUser(userId)
         userScopeStorage.remove(userId)
         userStorageProvider.clearInMemoryUserStorage(userId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -46,4 +46,5 @@ interface CallManager {
     suspend fun updateEpochInfo(conversationId: ConversationId, epochInfo: EpochInfo)
     suspend fun updateConversationClients(conversationId: ConversationId, clients: String)
     suspend fun reportProcessNotifications(isStarted: Boolean)
+    suspend fun cancelJobs()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -52,7 +52,7 @@ expect class GlobalCallManager {
         kaliumConfigs: KaliumConfigs
     ): CallManager
 
-    fun removeInMemoryCallingManagerForUser(userId: UserId)
+    suspend fun removeInMemoryCallingManagerForUser(userId: UserId)
     fun getFlowManager(): FlowManagerService
     fun getMediaManager(): MediaManagerService
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -91,7 +91,7 @@ class LogoutUseCaseTest {
                 .with(any())
                 .wasNotInvoked()
             verify(arrangement.userSessionScopeProvider)
-                .function(arrangement.userSessionScopeProvider::delete)
+                .suspendFunction(arrangement.userSessionScopeProvider::delete)
                 .with(any())
                 .wasInvoked(exactly = once)
             verify(arrangement.userConfigRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/DeleteSessionUseCaseTest.kt
@@ -87,7 +87,7 @@ class DeleteSessionUseCaseTest {
             .wasInvoked(exactly = once)
 
         verify(arrange.userSessionScopeProvider)
-            .function(arrange.userSessionScopeProvider::delete)
+            .suspendFunction(arrange.userSessionScopeProvider::delete)
             .with(any())
             .wasNotInvoked()
     }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -58,7 +58,7 @@ actual class CoreLogic(
     override fun getSessionScope(userId: UserId): UserSessionScope =
         userSessionScopeProvider.value.getOrCreate(userId)
 
-    override fun deleteSessionScope(userId: UserId) {
+    override suspend fun deleteSessionScope(userId: UserId) {
         userSessionScopeProvider.value.get(userId)?.cancel()
         userSessionScopeProvider.value.delete(userId)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user logs out and login again (without closing the app) and joins or starts(and taps on any of the call options buttons [mute, video, speaker]) a call, the app crashes

### Causes (Optional)

Couldn't open already closed database due to the Jobs/Scopes still being held from previous login

### Solutions

Properly cancel Jobs/Scopes from CallManager when doing logout.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

**Flow 1:**
- Login
- Start a call and wait for it to be properly established
- End call
- Log out
- Login again
- Start a call and wait for it to be properly established
- Mute/Unmute yourself | turn video on/off | turn speakers on/off
- app should not crash


**Flow 2:**
- Login
- Receive a call and accept it and wait for it to be properly established
- End call
- Log out
- Login again
- Join call through Join button and:
- You should be self muted (as from joining a group call)
- call should be properly established and not crash
