### PR TITLE
chore: support v21 web backup

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
@@ -74,8 +74,8 @@ internal class RestoreWebBackupUseCaseImpl(
 
     override suspend operator fun invoke(backupRootPath: Path, metadata: BackupMetadata): RestoreBackupResult =
         withContext(dispatchers.io) {
-            // currently we will support only latest version for testing purposes
-            if (metadata.version == "19") {
+            val version = metadata.version.toIntOrNull()
+            if (version != null && version in OLDEST_SUPPORTED_WEB_VERSION..NEWEST_SUPPORTED_WEB_VERSION) {
                 importWebBackup(backupRootPath, this)
             } else {
                 Either.Left(IncompatibleBackup("invoke: The provided backup format is not supported"))
@@ -155,5 +155,7 @@ internal class RestoreWebBackupUseCaseImpl(
     private companion object {
         const val TAG = "[RestoreWebBackupUseCase]"
         private const val MESSAGES_BATCH_SIZE = 1000
+        private const val OLDEST_SUPPORTED_WEB_VERSION = 19
+        private const val NEWEST_SUPPORTED_WEB_VERSION = 21
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCaseTest.kt
@@ -43,7 +43,6 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 @IgnoreIOS // TODO re-enable when BackupUtils is implemented on Darwin
-@OptIn(ExperimentalCoroutinesApi::class)
 class RestoreWebBackupUseCaseTest {
 
     private val fakeFileSystem = FakeKaliumFileSystem()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

There is new version 21 of web backup which adds `initial_protocol` variable not used on Android. Updated supported web backup versions.