### PR TITLE
refactor: select only 10 notifications form DB

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -308,9 +308,10 @@ internal class MessageDataSource internal constructor(
                     LocalNotification.Conversation(
                         // todo: needs some clean up!
                         id = conversationId.toModel(),
-                        conversationName = messages.first().conversationName ?: "",
-                        messages = messages.take(messageSizePerConversation)
-                            .mapNotNull { message -> messageMapper.fromMessageToLocalNotificationMessage(message) },
+                        conversationName = messages.first().conversationName,
+                        messages = messages.mapNotNull { message ->
+                            messageMapper.fromMessageToLocalNotificationMessage(message)
+                        },
                         isOneToOneConversation = messages.first().conversationType == ConversationEntity.Type.ONE_ON_ONE
                     )
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -111,7 +111,7 @@ internal interface MessageRepository {
         conversationId: ConversationId,
         limit: Int,
         offset: Int,
-        visibility: List<Message.Visibility> = Message.Visibility.values().toList()
+        visibility: List<Message.Visibility> = Message.Visibility.entries
     ): Flow<List<Message>>
 
     suspend fun getLastMessagesForConversationIds(
@@ -123,7 +123,7 @@ internal interface MessageRepository {
     suspend fun getMessagesByConversationIdAndVisibilityAfterDate(
         conversationId: ConversationId,
         date: String,
-        visibility: List<Message.Visibility> = Message.Visibility.values().toList()
+        visibility: List<Message.Visibility> = Message.Visibility.entries
     ): Flow<List<Message>>
 
     /**
@@ -159,7 +159,7 @@ internal interface MessageRepository {
     suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>>
     suspend fun getPendingConfirmationMessagesByConversationAfterDate(
         conversationId: ConversationId,
-        visibility: List<Message.Visibility> = Message.Visibility.values().toList()
+        visibility: List<Message.Visibility> = Message.Visibility.entries
     ): Either<CoreFailure, List<String>>
 
     suspend fun updateTextMessage(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotification.kt
@@ -30,7 +30,7 @@ import kotlinx.datetime.Instant
 sealed class LocalNotification(open val conversationId: ConversationId) {
     data class Conversation(
         val id: ConversationId,
-        val conversationName: String,
+        val conversationName: String?,
         val messages: List<LocalNotificationMessage>,
         val isOneToOneConversation: Boolean
     ) : LocalNotification(id)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.fold
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCase.kt
@@ -81,7 +81,6 @@ internal class GetNotificationsUseCaseImpl internal constructor(
                         list.filter { it !is LocalNotification.Conversation || it.messages.isNotEmpty() }
                     }
             }
-            .distinctUntilChanged()
             .filter { it.isNotEmpty() }
     }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
@@ -1,29 +1,57 @@
 getNotificationsMessages:
+WITH NumberedMessages AS (
+    SELECT
+        m.id,
+        m.conversation_id AS conversationId,
+        m.content_type AS contentType,
+        m.creation_date AS date,
+        m.sender_user_id AS senderUserId,
+        (m.expire_after_millis IS NOT NULL) AS isSelfDelete,
+        u.name AS senderName,
+        u.preview_asset_id AS senderPreviewAssetId,
+        c.name AS conversationName,
+        tc.text_body AS text,
+        tc.is_quoting_self AS isQuotingSelf,
+        ac.asset_mime_type AS assetMimeType,
+        c.muted_status AS mutedStatus,
+        c.type AS conversationType,
+        ROW_NUMBER() OVER (PARTITION BY m.conversation_id ORDER BY m.creation_date DESC) AS row_num
+    FROM
+        Message m
+    JOIN
+        User u ON m.sender_user_id = u.qualified_id
+    JOIN
+        Conversation c ON m.conversation_id = c.qualified_id
+    LEFT JOIN
+        MessageAssetContent ac ON m.id = ac.message_id AND m.conversation_id = ac.conversation_id
+    LEFT JOIN
+        MessageTextContent tc ON m.id = tc.message_id AND m.conversation_id = tc.conversation_id
+    WHERE
+        m.visibility = 'VISIBLE' AND
+        m.content_type IN ('TEXT', 'RESTRICTED_ASSET', 'ASSET', 'KNOCK', 'MISSED_CALL', 'LOCATION') AND
+        m.creation_date > COALESCE(c.last_notified_date, 0) AND
+        NOT EXISTS (SELECT 1 FROM SelfUser WHERE id = m.sender_user_id) AND
+        c.muted_status != 'ALL_MUTED' AND
+        c.archived = 0
+)
 SELECT
-    Message.id AS id,
-    Message.conversation_id AS conversationId,
-    Message.content_type AS contentType,
-    Message.creation_date AS date,
-    Message.sender_user_id AS senderUserId,
-    (Message.expire_after_millis IS NOT NULL) AS isSelfDelete,
-    User.name AS senderName,
-    User.preview_asset_id AS senderPreviewAssetId,
-    Conversation.name AS conversationName,
-    TextContent.text_body AS text,
-    TextContent.is_quoting_self AS isQuotingSelf,
-    AssetContent.asset_mime_type AS assetMimeType,
-    Conversation.muted_status AS mutedStatus,
-    Conversation.type AS conversationType
-FROM Message
-LEFT JOIN SelfUser
-JOIN User ON Message.sender_user_id = User.qualified_id AND Message.content_type IN  ('TEXT', 'RESTRICTED_ASSET', 'ASSET', 'KNOCK', 'MISSED_CALL', 'LOCATION')
-JOIN Conversation AS Conversation ON Message.conversation_id == Conversation.qualified_id AND (Message.creation_date > IFNULL(Conversation.last_notified_date, 0))
-LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
-LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
+    id,
+    conversationId,
+    contentType,
+    date,
+    senderUserId,
+    isSelfDelete,
+    senderName,
+    senderPreviewAssetId,
+    conversationName,
+    text,
+    isQuotingSelf,
+    assetMimeType,
+    mutedStatus,
+    conversationType
+FROM
+    NumberedMessages
 WHERE
-Message.visibility = 'VISIBLE' AND
-(Message.sender_user_id != SelfUser.id) AND
-(Message.creation_date > IFNULL(Conversation.last_notified_date, 0)) AND
-Conversation.muted_status != 'ALL_MUTED' AND
-Conversation.archived == 0
-ORDER BY Message.creation_date DESC;
+    row_num <= 10 -- there is a bug in sqldelight where you can't use a parameter here
+ORDER BY
+    date DESC;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -70,7 +70,7 @@ interface MessageDAO {
         conversationId: QualifiedIDEntity,
         limit: Int,
         offset: Int,
-        visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.values().toList()
+        visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.entries
     ): Flow<List<MessageEntity>>
 
     suspend fun getLastMessagesByConversations(conversationIds: List<QualifiedIDEntity>): Map<QualifiedIDEntity, MessageEntity>
@@ -80,7 +80,7 @@ interface MessageDAO {
     suspend fun observeMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,
         date: String,
-        visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.values().toList()
+        visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.entries
     ): Flow<List<MessageEntity>>
 
     suspend fun getAllPendingMessagesFromUser(userId: UserIDEntity): List<MessageEntity>
@@ -110,7 +110,7 @@ interface MessageDAO {
 
     suspend fun getPendingToConfirmMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,
-        visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.values().toList()
+        visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.entries
     ): List<String>
 
     suspend fun getReceiptModeFromGroupConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity.ReceiptMode?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -75,7 +75,7 @@ interface MessageDAO {
 
     suspend fun getLastMessagesByConversations(conversationIds: List<QualifiedIDEntity>): Map<QualifiedIDEntity, MessageEntity>
 
-    suspend fun getNotificationMessage(): Flow<List<NotificationMessageEntity>>
+    suspend fun getNotificationMessage(maxNumberOfMessagesPerConversation: Int = 10): Flow<List<NotificationMessageEntity>>
 
     suspend fun observeMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -292,12 +292,11 @@ internal class MessageDAOImpl internal constructor(
                 .associateBy { it.conversationId }
         }
 
-    override suspend fun getNotificationMessage(): Flow<List<NotificationMessageEntity>> =
+    override suspend fun getNotificationMessage(maxNumberOfMessagesPerConversation: Int): Flow<List<NotificationMessageEntity>> =
         notificationQueries.getNotificationsMessages(mapper::toNotificationEntity)
             .asFlow()
             .flowOn(coroutineContext)
             .mapToList()
-            .distinctUntilChanged()
 
     override suspend fun observeMessagesByConversationAndVisibilityAfterDate(
         conversationId: QualifiedIDEntity,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when selecting notifications form DB we fetch all available notifications and filter the first 10 in logic 

### Solutions

use window functions to select only 10 notificaions form the DB

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
