### PR TITLE
fix: ANRs when getting identities [WPB-8753]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.user.UserRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
@@ -55,6 +56,6 @@ class ObserveConversationMembersUseCaseImpl internal constructor(
             }
         }.flatMapLatest { detailsFlows ->
             combine(detailsFlows) { it.toList() }
-        }
+        }.distinctUntilChanged()
     }
 }


### PR DESCRIPTION
Cherry pick from the original PR: 
- #2718

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ANR when trying to get user or device identities.

### Solutions

`ObserveConversationMembersUseCase` was emitting the same items multiple times, especially when navigating in the app, and it was causing the spam of `getUserIdentities` and probably overloading `CoreCrypto`, so `distinctUntilChanged` worked.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Navigate: group conversation -> details -> participants -> user profile -> 1:1 conversation -> back or conversation details

### Attachments (Optional)

<img width="1505" alt="ANR_getclientidentity" src="https://github.com/wireapp/kalium/assets/30429749/3d9e860b-53da-4278-977b-fe022cf923f9">


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
