### PR TITLE
fix: remove duplicate execution of avsSyncStateReporter

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2047,10 +2047,6 @@ class UserSessionScope internal constructor(
         }
 
         launch {
-            avsSyncStateReporter.execute()
-        }
-
-        launch {
             observeE2EIConversationsVerificationStatuses.invoke()
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

During a cherry pick we ended up calling `avsSyncStateReporter.execute()` twice from `UserSessionScope`

### Causes (Optional)

This caused the Calling Manager to try to get the clientId before it was properly set on `currentClientIdProvider`

### Solutions

Remove duplicate and only execute `avsSyncStateReporter` when clientId is set