### PR TITLE
chore(docs): jira ticket linking action (WPB-8645)

### DIFF
--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -1,0 +1,19 @@
+name: Link and Lint PR with Jira Ticket Number
+on:
+  merge_group:
+  pull_request:
+    types: [opened, edited, synchronize]
+jobs:
+  add-jira-description:
+    runs-on: ubuntu-latest
+    # Run only if the PR is not from a Fork / external contributor
+    if: (!startsWith(github.ref, 'refs/heads/dependabot/') && github.repository_owner == 'wireapp')
+    steps:
+      - uses: cakeinpanic/jira-description-action@v0.8.0
+        name: jira-description-action
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          jira-token: ${{ secrets.JIRA_TOKEN }}
+          jira-base-url: https://wearezeta.atlassian.net
+          skip-branches: '^(production-release|main|master|release\/v\d+)$' #optional
+          fail-when-jira-issue-not-found: false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

For internal tracking and documentation we need to link JIRA tickets to PRs

### Causes (Optional)

Was not implemented in kalium

### Solutions

Add the GH action.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
