### PR TITLE
fix(mls): respect default protocol in one-on-one conversation initialisation (WPB-8975)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1611,7 +1611,8 @@ class UserSessionScope internal constructor(
 
     private val oneOnOneProtocolSelector: OneOnOneProtocolSelector
         get() = OneOnOneProtocolSelectorImpl(
-            userRepository
+            userRepository,
+            userConfigRepository
         )
 
     private val acmeCertificatesSyncWorker: ACMECertificatesSyncWorker by lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1159,7 +1159,7 @@ class UserSessionScope internal constructor(
 
     internal val mlsMigrationManager: MLSMigrationManager = MLSMigrationManagerImpl(
         kaliumConfigs,
-        featureSupport,
+        isMLSEnabled,
         incrementalSyncRepository,
         lazy { clientRepository },
         lazy { users.timestampKeyRepository },

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.feature.TimestampKeyRepository
 import com.wire.kalium.logic.feature.TimestampKeys
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
-import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
@@ -47,7 +46,6 @@ import kotlinx.datetime.Clock
  * Orchestrates the migration from proteus to MLS.
  */
 internal interface MLSMigrationManager
-//todo: fix based on the usecase
 @Suppress("LongParameterList")
 internal class MLSMigrationManagerImpl(
     private val kaliumConfigs: KaliumConfigs,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManager.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.feature.TimestampKeyRepository
 import com.wire.kalium.logic.feature.TimestampKeys
+import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
@@ -46,11 +47,11 @@ import kotlinx.datetime.Clock
  * Orchestrates the migration from proteus to MLS.
  */
 internal interface MLSMigrationManager
-
+//todo: fix based on the usecase
 @Suppress("LongParameterList")
 internal class MLSMigrationManagerImpl(
     private val kaliumConfigs: KaliumConfigs,
-    private val featureSupport: FeatureSupport,
+    private val isMLSEnabledUseCase: IsMLSEnabledUseCase,
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val clientRepository: Lazy<ClientRepository>,
     private val timestampKeyRepository: Lazy<TimestampKeyRepository>,
@@ -73,7 +74,7 @@ internal class MLSMigrationManagerImpl(
             incrementalSyncRepository.incrementalSyncState.collect { syncState ->
                 ensureActive()
                 if (syncState is IncrementalSyncStatus.Live &&
-                    featureSupport.isMLSSupported &&
+                    isMLSEnabledUseCase() &&
                     clientRepository.value.hasRegisteredMLSClient().getOrElse(false)
                 ) {
                     updateMigration()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorker.kt
@@ -42,7 +42,7 @@ internal class MLSMigrationWorkerImpl(
     override suspend fun runMigration() =
         syncMigrationConfigurations().flatMap {
             userConfigRepository.getMigrationConfiguration().getOrNull()?.let { configuration ->
-                if (configuration.hasMigrationStarted()) {
+                if (configuration.status.toBoolean() && configuration.hasMigrationStarted()) {
                     kaliumLogger.i("Running proteus to MLS migration")
                     mlsMigrator.migrateProteusConversations().flatMap {
                         if (configuration.hasMigrationEnded()) {
@@ -57,7 +57,6 @@ internal class MLSMigrationWorkerImpl(
                 }
             } ?: Either.Right(Unit)
         }
-
     private suspend fun syncMigrationConfigurations(): Either<CoreFailure, Unit> =
         featureConfigRepository.getFeatureConfigs().flatMap { configurations ->
             mlsConfigHandler.handle(configurations.mlsModel, duringSlowSync = false)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManagerTest.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.feature.TimestampKeyRepository
 import com.wire.kalium.logic.feature.TimestampKeys
-import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
@@ -123,7 +123,7 @@ class MLSMigrationManagerTest {
         val clientRepository = mock(classOf<ClientRepository>())
 
         @Mock
-        val featureSupport = mock(classOf<FeatureSupport>())
+        val isMLSEnabledUseCase = mock(classOf<IsMLSEnabledUseCase>())
 
         @Mock
         val timestampKeyRepository = mock(classOf<TimestampKeyRepository>())
@@ -153,8 +153,8 @@ class MLSMigrationManagerTest {
         }
 
         fun withIsMLSSupported(supported: Boolean) = apply {
-            given(featureSupport)
-                .invocation { featureSupport.isMLSSupported }
+            given(isMLSEnabledUseCase)
+                .invocation { isMLSEnabledUseCase.invoke() }
                 .thenReturn(supported)
         }
 
@@ -167,7 +167,7 @@ class MLSMigrationManagerTest {
 
         fun arrange() = this to MLSMigrationManagerImpl(
             kaliumConfigs,
-            featureSupport,
+            isMLSEnabledUseCase,
             incrementalSyncRepository,
             lazy { clientRepository },
             lazy { timestampKeyRepository },

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorkerTest.kt
@@ -1,0 +1,293 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.mlsmigration
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigTest
+import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
+import com.wire.kalium.logic.data.featureConfig.MLSModel
+import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.mls.SupportedCipherSuite
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.feature.featureConfig.handler.MLSConfigHandler
+import com.wire.kalium.logic.feature.featureConfig.handler.MLSMigrationConfigHandler
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationWorkerTest.Arrangement.Companion.MIGRATION_CONFIG
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationWorkerTest.Arrangement.Companion.NOT_FOUND_FAILURE
+import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationWorkerTest.Arrangement.Companion.TEST_FAILURE
+import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneOnOnesUseCase
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.left
+import com.wire.kalium.logic.functional.right
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+
+class MLSMigrationWorkerTest {
+    @Test
+    fun givenGettingMigrationConfigurationFails_whenRunningMigration_workerReturnsNoFailure() = runTest {
+        // given
+        val (arrangement, mlsMigrationWorker) = Arrangement().withGetMLSMigrationConfigurationsReturns(NOT_FOUND_FAILURE).arrange()
+
+        // when
+        val result = mlsMigrationWorker.runMigration()
+
+        // then
+        result.shouldSucceed()
+
+        verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+            .wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasNotInvoked()
+    }
+
+    @Test
+    fun givenMigrationIsDisabled_whenRunningMigration_workerReturnsNoFailure() = runTest {
+        // given
+        val (arrangement, mlsMigrationWorker) = Arrangement()
+            .withGetMLSMigrationConfigurationsReturns(MIGRATION_CONFIG.copy(status = Status.DISABLED).right()).arrange()
+
+        // when
+        val result = mlsMigrationWorker.runMigration()
+
+        // then
+        result.shouldSucceed()
+
+        verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+            .wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasNotInvoked()
+    }
+
+    @Test
+    fun givenMigrationIsEnabledButNotStarted_whenRunningMigration_workerReturnsNoFailure() = runTest {
+        // given
+        val (arrangement, mlsMigrationWorker) = Arrangement().withGetMLSMigrationConfigurationsReturns(
+            MIGRATION_CONFIG.copy(startTime = Instant.DISTANT_FUTURE, status = Status.ENABLED).right()
+        ).arrange()
+
+        // when
+        val result = mlsMigrationWorker.runMigration()
+
+        // then
+        result.shouldSucceed()
+
+        verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+            .wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasNotInvoked()
+    }
+
+    @Test
+    fun givenMigrationIsDisabledButStarted_whenRunningMigration_workerReturnsNoFailure() = runTest {
+        // given
+        val (arrangement, mlsMigrationWorker) = Arrangement().withGetMLSMigrationConfigurationsReturns(
+            MIGRATION_CONFIG.copy(startTime = Instant.DISTANT_PAST, status = Status.DISABLED).right()
+        ).arrange()
+
+        // when
+        val result = mlsMigrationWorker.runMigration()
+
+        // then
+        result.shouldSucceed()
+
+        verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+            .wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasNotInvoked()
+    }
+
+    @Test
+    fun givenMigrationIsEnabledAndStartedAndProteusMigrationFails_whenRunningMigration_thenWorkerShouldFail() = runTest {
+        // given
+        val (arrangement, mlsMigrationWorker) = Arrangement().withGetMLSMigrationConfigurationsReturns(
+            MIGRATION_CONFIG.copy(startTime = Instant.DISTANT_PAST, status = Status.ENABLED).right()
+        ).withMigrateProteusConversationsReturn(TEST_FAILURE).arrange()
+
+        // when
+        val result = mlsMigrationWorker.runMigration()
+
+        // then
+        result.shouldFail()
+
+        verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+            .wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseAllProteusConversations).wasNotInvoked()
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseProteusConversations).wasNotInvoked()
+    }
+
+    @Test
+    fun givenProteusMigrationSucceedAndMigrationHasNotEnded_whenRunningMigration_thenWorkerShouldSucceed() = runTest {
+        // given
+        val (arrangement, mlsMigrationWorker) = Arrangement().withGetMLSMigrationConfigurationsReturns(
+            MIGRATION_CONFIG.copy(startTime = Instant.DISTANT_PAST, endTime = Instant.DISTANT_FUTURE, status = Status.ENABLED).right()
+        ).withMigrateProteusConversationsReturn(Unit.right()).withFinaliseProteusConversations(Unit.right()).arrange()
+
+        // when
+        val result = mlsMigrationWorker.runMigration()
+
+        // then
+        result.shouldSucceed()
+
+        verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+            .wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseAllProteusConversations).wasNotInvoked()
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseProteusConversations).wasInvoked(once)
+    }
+
+    @Test
+    fun givenProteusMigrationSucceedAndMigrationHasNotEndedAndFinaliseProteusConversationsFails_whenRunningMigration_thenWorkerShouldFail() =
+        runTest {
+            // given
+            val (arrangement, mlsMigrationWorker) = Arrangement().withGetMLSMigrationConfigurationsReturns(
+                MIGRATION_CONFIG.copy(startTime = Instant.DISTANT_PAST, endTime = Instant.DISTANT_FUTURE, status = Status.ENABLED).right()
+            ).withMigrateProteusConversationsReturn(Unit.right()).withFinaliseProteusConversations(TEST_FAILURE).arrange()
+
+            // when
+            val result = mlsMigrationWorker.runMigration()
+
+            // then
+            result.shouldFail()
+
+            verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+                .wasInvoked(once)
+            verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasInvoked(once)
+            verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseAllProteusConversations).wasNotInvoked()
+            verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseProteusConversations).wasInvoked(once)
+        }
+
+    @Test
+    fun givenProteusMigrationSucceedAndMigrationHasEnded_whenRunningMigration_thenWorkerShouldSucceed() = runTest {
+        // given
+        val (arrangement, mlsMigrationWorker) = Arrangement().withGetMLSMigrationConfigurationsReturns(
+            MIGRATION_CONFIG.copy(startTime = Instant.DISTANT_PAST, endTime = Instant.DISTANT_PAST, status = Status.ENABLED).right()
+        ).withMigrateProteusConversationsReturn(Unit.right()).withFinaliseAllProteusConversations(Unit.right()).arrange()
+
+        // when
+        val result = mlsMigrationWorker.runMigration()
+
+        // then
+        result.shouldSucceed()
+
+        verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+            .wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseAllProteusConversations).wasInvoked(once)
+        verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseProteusConversations).wasNotInvoked()
+    }
+
+    @Test
+    fun givenProteusMigrationSucceedAndMigrationHasEndedAndFinaliseAllProteusConversationsFails_whenRunningMigration_thenWorkerShouldFail() =
+        runTest {
+            // given
+            val (arrangement, mlsMigrationWorker) = Arrangement().withGetMLSMigrationConfigurationsReturns(
+                MIGRATION_CONFIG.copy(startTime = Instant.DISTANT_PAST, endTime = Instant.DISTANT_PAST, status = Status.ENABLED).right()
+            ).withMigrateProteusConversationsReturn(Unit.right()).withFinaliseAllProteusConversations(TEST_FAILURE).arrange()
+
+            // when
+            val result = mlsMigrationWorker.runMigration()
+
+            // then
+            result.shouldFail()
+
+            verify(arrangement.userConfigRepository).suspendFunction(arrangement.userConfigRepository::getMigrationConfiguration)
+                .wasInvoked(once)
+            verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::migrateProteusConversations).wasInvoked(once)
+            verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseAllProteusConversations).wasInvoked(once)
+            verify(arrangement.mlsMigrator).suspendFunction(arrangement.mlsMigrator::finaliseProteusConversations).wasNotInvoked()
+        }
+
+    private class Arrangement {
+        @Mock
+        val userConfigRepository: UserConfigRepository = mock(classOf<UserConfigRepository>())
+
+        @Mock
+        val featureConfigRepository: FeatureConfigRepository = mock(classOf<FeatureConfigRepository>())
+
+        @Mock
+        val updateSupportedProtocolsAndResolveOneOnOnes = mock(classOf<UpdateSupportedProtocolsAndResolveOneOnOnesUseCase>())
+
+        @Mock
+        val mlsMigrator: MLSMigrator = mock(classOf<MLSMigrator>())
+
+        val mlsConfigHandler = MLSConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes)
+
+        val mlsMigrationConfigHandler = MLSMigrationConfigHandler(userConfigRepository, updateSupportedProtocolsAndResolveOneOnOnes)
+
+        fun withGetMLSMigrationConfigurationsReturns(result: Either<StorageFailure, MLSMigrationModel>) = apply {
+            given(userConfigRepository).suspendFunction(userConfigRepository::getMigrationConfiguration).whenInvoked().thenReturn(result)
+        }
+
+        fun withMigrateProteusConversationsReturn(result: Either<CoreFailure, Unit>) = apply {
+            given(mlsMigrator).suspendFunction(mlsMigrator::migrateProteusConversations).whenInvoked().thenReturn(result)
+        }
+
+        fun withFinaliseAllProteusConversations(result: Either<CoreFailure, Unit>) = apply {
+            given(mlsMigrator).suspendFunction(mlsMigrator::finaliseAllProteusConversations).whenInvoked().thenReturn(result)
+        }
+
+        fun withFinaliseProteusConversations(result: Either<CoreFailure, Unit>) = apply {
+            given(mlsMigrator).suspendFunction(mlsMigrator::finaliseProteusConversations).whenInvoked().thenReturn(result)
+        }
+
+        init {
+            given(featureConfigRepository).suspendFunction(featureConfigRepository::getFeatureConfigs).whenInvoked()
+                .thenReturn(FeatureConfigTest.newModel().right())
+            given(userConfigRepository).function(userConfigRepository::setMLSEnabled).whenInvokedWith(any<Boolean>())
+                .thenReturn(Unit.right())
+            given(userConfigRepository).suspendFunction(userConfigRepository::getSupportedProtocols).whenInvoked()
+                .thenReturn(NOT_FOUND_FAILURE)
+            given(userConfigRepository).function(userConfigRepository::setDefaultProtocol).whenInvokedWith(any<SupportedProtocol>())
+                .thenReturn(Unit.right())
+            given(userConfigRepository).suspendFunction(userConfigRepository::setSupportedProtocols)
+                .whenInvokedWith(any<Set<SupportedProtocol>>()).thenReturn(Unit.right())
+            given(userConfigRepository).suspendFunction(userConfigRepository::setSupportedCipherSuite)
+                .whenInvokedWith(any<SupportedCipherSuite>()).thenReturn(Unit.right())
+            given(userConfigRepository).suspendFunction(userConfigRepository::setMigrationConfiguration)
+                .whenInvokedWith(any<MLSMigrationModel>()).thenReturn(Unit.right())
+        }
+
+        fun arrange() = this to MLSMigrationWorkerImpl(
+            userConfigRepository, featureConfigRepository, mlsConfigHandler, mlsMigrationConfigHandler, mlsMigrator
+        )
+
+        companion object {
+            val TEST_FAILURE = CoreFailure.Unknown(Throwable("Testing!")).left()
+            val NOT_FOUND_FAILURE = StorageFailure.DataNotFound.left()
+            val MLS_CONFIG = MLSModel(
+                defaultProtocol = SupportedProtocol.MLS,
+                supportedProtocols = setOf(SupportedProtocol.PROTEUS),
+                status = Status.ENABLED,
+                supportedCipherSuite = null
+            )
+
+            val MIGRATION_CONFIG = MLSMigrationModel(
+                startTime = null, endTime = null, status = Status.ENABLED
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelectorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelectorTest.kt
@@ -22,6 +22,10 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.left
+import com.wire.kalium.logic.functional.right
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
@@ -38,9 +42,11 @@ class OneOnOneProtocolSelectorTest {
 
     @Test
     fun givenSelfUserIsNull_thenShouldReturnFailure() = runTest {
+        val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
             withUserByIdReturning(Either.Right(TestUser.OTHER))
             withSelfUserReturning(null)
+            withGetDefaultProtocolReturning(failure.left())
         }
 
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
@@ -55,7 +61,8 @@ class OneOnOneProtocolSelectorTest {
         val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
             withSelfUserReturning(TestUser.SELF)
-            withUserByIdReturning(Either.Left(failure))
+            withUserByIdReturning(failure.left())
+            withGetDefaultProtocolReturning(failure.left())
         }
 
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
@@ -70,6 +77,7 @@ class OneOnOneProtocolSelectorTest {
         val (arrangement, oneOnOneProtocolSelector) = arrange {
             withSelfUserReturning(TestUser.SELF)
             withUserByIdReturning(Either.Left(failure))
+            withGetDefaultProtocolReturning(failure.left())
         }
         val otherUserId = TestUser.USER_ID
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
@@ -82,10 +90,12 @@ class OneOnOneProtocolSelectorTest {
 
     @Test
     fun givenBothUsersSupportProteusAndMLS_thenShouldPreferMLS() = runTest {
+        val failure = StorageFailure.DataNotFound
         val supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)
         val (arrangement, oneOnOneProtocolSelector) = arrange {
             withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = supportedProtocols))
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = supportedProtocols)))
+            withGetDefaultProtocolReturning(failure.left())
         }
 
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
@@ -97,9 +107,11 @@ class OneOnOneProtocolSelectorTest {
     @Test
     fun givenBothUsersSupportProteusAndOnlyOneSupportsMLS_thenShouldPreferProteus() = runTest {
         val bothProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)
+        val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
             withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = bothProtocols))
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.PROTEUS))))
+            withGetDefaultProtocolReturning(failure.left())
         }
 
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
@@ -110,10 +122,12 @@ class OneOnOneProtocolSelectorTest {
 
     @Test
     fun givenBothUsersSupportMLS_thenShouldPreferMLS() = runTest {
+        val failure = StorageFailure.DataNotFound
         val mlsSet = setOf(SupportedProtocol.MLS)
         val (_, oneOnOneProtocolSelector) = arrange {
             withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = mlsSet))
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = mlsSet)))
+            withGetDefaultProtocolReturning(failure.left())
         }
 
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
@@ -124,9 +138,11 @@ class OneOnOneProtocolSelectorTest {
 
     @Test
     fun givenUsersHaveNoProtocolInCommon_thenShouldReturnNoCommonProtocol() = runTest {
+        val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
             withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS)))
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.PROTEUS))))
+            withGetDefaultProtocolReturning(failure.left())
         }
 
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
@@ -135,11 +151,68 @@ class OneOnOneProtocolSelectorTest {
             }
     }
 
+    @Test
+    fun givenUsersHaveProtocolInCommonButDiffersWithDefaultProtocol_thenShouldReturnNoCommonProtocol() = runTest {
+        val (_, oneOnOneProtocolSelector) = arrange {
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS)))
+            withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS))))
+            withGetDefaultProtocolReturning(SupportedProtocol.PROTEUS.right())
+        }
+
+        oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
+            .shouldFail {
+                assertIs<CoreFailure.NoCommonProtocolFound>(it)
+            }
+    }
+
+    @Test
+    fun givenSelfUserSupportsDefaultProtocolButOtherUserDoesnt_thenShouldReturnNoCommonProtocol() = runTest {
+        val (_, oneOnOneProtocolSelector) = arrange {
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)))
+            withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS))))
+            withGetDefaultProtocolReturning(SupportedProtocol.PROTEUS.right())
+        }
+
+        oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
+            .shouldFail {
+                assertIs<CoreFailure.NoCommonProtocolFound>(it)
+            }
+    }
+
+    @Test
+    fun givenSelfUserDoesntSupportsDefaultProtocolButOtherUserDoes_thenShouldReturnNoCommonProtocol() = runTest {
+        val (_, oneOnOneProtocolSelector) = arrange {
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS)))
+            withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS))))
+            withGetDefaultProtocolReturning(SupportedProtocol.PROTEUS.right())
+        }
+
+        oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
+            .shouldFail {
+                assertIs<CoreFailure.NoCommonProtocolFound>(it)
+            }
+    }
+
+    @Test
+    fun givenUsersHaveProtocolInCommonIncludingDefaultProtocol_thenShouldReturnDefaultProtocolAsCommonProtocol() = runTest {
+        val (_, oneOnOneProtocolSelector) = arrange {
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)))
+            withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS))))
+            withGetDefaultProtocolReturning(SupportedProtocol.MLS.right())
+        }
+
+        oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
+            .shouldSucceed() {
+                assertEquals(SupportedProtocol.MLS, it)
+            }
+    }
+
     private class Arrangement(private val configure: Arrangement.() -> Unit) :
-        UserRepositoryArrangement by UserRepositoryArrangementImpl() {
+        UserRepositoryArrangement by UserRepositoryArrangementImpl(),
+        UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl() {
         fun arrange(): Pair<Arrangement, OneOnOneProtocolSelector> = run {
             configure()
-            this@Arrangement to OneOnOneProtocolSelectorImpl(userRepository)
+            this@Arrangement to OneOnOneProtocolSelectorImpl(userRepository, userConfigRepository)
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserConfigRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserConfigRepositoryArrangement.kt
@@ -34,6 +34,7 @@ internal interface UserConfigRepositoryArrangement {
     fun withGetSupportedProtocolsReturning(result: Either<StorageFailure, Set<SupportedProtocol>>)
     fun withSetSupportedProtocolsSuccessful()
     fun withSetDefaultProtocolSuccessful()
+    fun withGetDefaultProtocolReturning(result: Either<StorageFailure, SupportedProtocol>)
     fun withSetMLSEnabledSuccessful()
     fun withSetMigrationConfigurationSuccessful()
     fun withGetMigrationConfigurationReturning(result: Either<StorageFailure, MLSMigrationModel>)
@@ -64,6 +65,13 @@ internal class UserConfigRepositoryArrangementImpl : UserConfigRepositoryArrange
             .function(userConfigRepository::setDefaultProtocol)
             .whenInvokedWith(any())
             .thenReturn(Either.Right(Unit))
+    }
+
+    override fun withGetDefaultProtocolReturning(result: Either<StorageFailure, SupportedProtocol>) {
+        given(userConfigRepository)
+            .function(userConfigRepository::getDefaultProtocol)
+            .whenInvoked()
+            .thenReturn(result)
     }
 
     override fun withSetMLSEnabledSuccessful() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
- Respect default protocol comes from team-settings when we want to create/start a one-on-one conversation.
- Respect if mls-migration is enabled or not addition to start-end date of the migration when we start the mls-migration

### Causes (Optional)

- Default protocol in one-on-one conversations was not respected
- MLSMigrationWorkers was not covered by tests

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test
- Have an MLS Capable backend
- Have team with disabled MLS and default protocol as Proteus
- Login with two users on Android MLS capable app
- Start a conversation between those two users, the conversation must be Proteus

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
