### PR TITLE
fix: recreate cache directories in case cache is cleared [WPB-7368]

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/asset/KaliumFileSystemImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/asset/KaliumFileSystemImpl.kt
@@ -103,6 +103,7 @@ actual class KaliumFileSystemImpl actual constructor(
      */
     override fun tempFilePath(pathString: String?): Path {
         val filePath = pathString ?: "temp_file_path"
+        createDirectories(rootCachePath)  // create dir structure in case cache is cleared
         return "$rootCachePath/$filePath".toPath()
     }
 

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/asset/KaliumFileSystemImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/data/asset/KaliumFileSystemImpl.kt
@@ -103,7 +103,7 @@ actual class KaliumFileSystemImpl actual constructor(
      */
     override fun tempFilePath(pathString: String?): Path {
         val filePath = pathString ?: "temp_file_path"
-        createDirectories(rootCachePath)  // create dir structure in case cache is cleared
+        createDirectories(rootCachePath) // create dir structure in case cache is cleared
         return "$rootCachePath/$filePath".toPath()
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7368" title="WPB-7368" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7368</a>  [Android] Playstore crash - Resample Image and File handling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We get multiple crashes when accessing cache files (ENOENT errors) which potentially suggest that the cache is fully cleared and the app cannot find needed directories for the given user in cache to create a temporary file for that user.

### Solutions

Recreate directories when getting a temporary cache file path.

### Testing

#### How to Test

Open the app, clear app cache and try to send or download asset.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
