### PR TITLE
fix: creating a group with users under LH and users who have not consent to LH [WPB-9404]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -131,7 +131,7 @@ internal class ConversationGroupRepositoryImpl(
 
             when (apiResult) {
                 is Either.Left -> {
-                    val canRetryOnce = apiResult.value.hasUnreachableDomainsError && lastUsersAttempt is LastUsersAttempt.None
+                    val canRetryOnce = apiResult.value.isRetryable && lastUsersAttempt is LastUsersAttempt.None
                     if (canRetryOnce) {
                         extractValidUsersForRetryableError(apiResult.value, usersList)
                             .flatMap { (validUsers, failedUsers, failType) ->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9404" title="WPB-9404" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9404</a>  [Android] When creating a group with 2 users, one user under legal hold, group is not created but should
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Creating group fails with unknown error (dialog with information that something went wrong) when there are users with legal hold enabled and users who has not consent to legal hold.

### Solutions

Fix check if the request is retryable to make a request again with only valid members and add a system message saying that some users could not be added.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create a group with users under legal hold and users who has not consent to legal hold.

### Attachments (Optional)


| Before | After |
| ----------- | ------------ |
| <video width="400" src="https://github.com/wireapp/kalium/assets/30429749/8c4c3a41-58d7-4e60-bb13-40114e431164"/> | <video width="400" src="https://github.com/wireapp/kalium/assets/30429749/58afb4fa-19f3-4e78-948a-40a9d67f1894"/> |


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.