### PR TITLE
fix: exclude users from other teams when missing-legalhold-consent [WPB-9404]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -649,13 +649,23 @@ internal class ConversationGroupRepositoryImpl(
     }
 
     /**
-     * Filter the initial [userIdList] into valid and invalid users where valid users are only team members.
+     * Filter the initial [userIdList] into valid and invalid users where valid users are only team members and people with consent.
      */
     private suspend fun fetchAndExtractValidUsersForRetryableLegalHoldError(
         userIdList: List<UserId>
     ): Either<CoreFailure, ValidToInvalidUsers> =
-        userRepository.fetchUsersLegalHoldConsent(userIdList.toSet()).map {
-            ValidToInvalidUsers(it.usersWithConsent, it.usersWithoutConsent + it.usersFailed, FailedToAdd.Type.LegalHold)
+        teamIdProvider().flatMap { selfTeamId ->
+            userRepository.fetchUsersLegalHoldConsent(userIdList.toSet()).map {
+                it.usersWithConsent
+                    .partition { (_, teamId) -> teamId == selfTeamId }
+                    .let { (validUsers, membersFromOtherTeam) ->
+                        ValidToInvalidUsers(
+                            validUsers = validUsers.map { (userId, _) -> userId },
+                            failedUsers = membersFromOtherTeam.map { (userId, _) -> userId } + it.usersWithoutConsent + it.usersFailed,
+                            failType = FailedToAdd.Type.LegalHold
+                        )
+                    }
+            }
         }
 
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/legalhold/ListUsersLegalHoldConsent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/legalhold/ListUsersLegalHoldConsent.kt
@@ -17,10 +17,12 @@
  */
 package com.wire.kalium.logic.data.legalhold
 
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.UserId
 
 data class ListUsersLegalHoldConsent(
-    val usersWithConsent: List<UserId>,
+    val usersWithConsent: List<Pair<UserId, TeamId?>>,
     val usersWithoutConsent: List<UserId>,
     val usersFailed: List<UserId>,
 )
+fun List<Pair<UserId, TeamId?>>.ids() = map { (id, _) -> id }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -523,7 +523,7 @@ internal class UserDataSource internal constructor(
                 .partition { it.legalHoldStatus != LegalHoldStatusDTO.NO_CONSENT }
                 .let { (usersWithConsent, usersWithoutConsent) ->
                     ListUsersLegalHoldConsent(
-                        usersWithConsent = usersWithConsent.map { it.id.toModel() },
+                        usersWithConsent = usersWithConsent.map { it.id.toModel() to it.teamId?.let { TeamId(it) } },
                         usersWithoutConsent = usersWithoutConsent.map { it.id.toModel() },
                         usersFailed = listUsersDTO.usersFailed.map { it.toModel() }
                     )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.data.legalhold.ids
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.service.ServiceId
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversation.ADD_MEMBER_TO_CONVERSATION_SUCCESSFUL_RESPONSE

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -22,6 +22,7 @@ import app.cash.turbine.test
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.legalhold.ListUsersLegalHoldConsent
@@ -755,7 +756,7 @@ class UserRepositoryTest {
         val userIdFailed = TestUser.OTHER_USER_ID.copy(value = "idFailed")
         val requestedUserIds = setOf(userIdWithConsent, userIdWithoutConsent, userIdFailed)
         val expectedResult = ListUsersLegalHoldConsent(
-            usersWithConsent = listOf(userIdWithConsent),
+            usersWithConsent = listOf(userIdWithConsent to TeamId("teamId")),
             usersWithoutConsent = listOf(userIdWithoutConsent),
             usersFailed = listOf(userIdFailed),
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9404" title="WPB-9404" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9404</a>  [Android] When creating a group with 2 users, one user under legal hold, group is not created but should
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When creating a group with someone being under legal hold and selecting a member from other team, the app shows "something went wrong" but should create a group just without that specific member.

### Causes (Optional)

It probably happens when this other team also have implicit legal hold consent, which means that legal hold for that team has been configured but not enabled - in that case, when creating group, app still gets `missing-legalhold-consent` error even if there is a consent and when fetching data of members of this team, their legal hold status is not `NO_CONSENT` but just `DISABLED` which means that in theory they already consent, but the backend still returns `missing-legalhold-consent` error in that case. If this other team doesn't have legal hold configured and therefore doesn't have implicit consent, it works because we are able to filter out these members because they have their legal hold status `NO_CONSENT`.

### Solutions

When creating a group or adding members to group under legal hold and backend returns `missing-legalhold-consent` then filter out not only users whose legal hold status is `NO_CONSENT` but also all members of different teams so that only same team members can be added, just like stated in the documentation.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- have team A with user A and B available
- have team B with user C available
- login as user A and B on android
- connect user A and C
- enable legal hold for team A and put user B under legal hold
- as user A, try to create a group with user B and C
- group should be created, but user C should not be added

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
