### PR TITLE
refactor(receipts): Add a queue to perform work per conversation [WPB-9216]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWork.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWork.kt
@@ -20,11 +20,22 @@ package com.wire.kalium.logic.feature.message.receipt
 import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.datetime.Instant
 
+/**
+ * The input of a conversation time-event.
+ * Used to schedule [ConversationTimeEventWork] through the [ConversationWorkQueue].
+ * @property eventTime that says when the event in question happened.
+ */
 internal data class ConversationTimeEventInput(
     val conversationId: ConversationId,
-    val time: Instant,
+    val eventTime: Instant
 )
 
+/**
+ * Represents a conversation time-event work, consisting of the input and the worker.
+ *
+ * @property conversationTimeEventInput The input of a conversation time-event.
+ * @property worker The responsible for performing the work.
+ */
 internal data class ConversationTimeEventWork(
     val conversationTimeEventInput: ConversationTimeEventInput,
     val worker: ConversationTimeEventWorker

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWork.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWork.kt
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.receipt
+
+import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.datetime.Instant
+
+internal data class ConversationTimeEventInput(
+    val conversationId: ConversationId,
+    val time: Instant,
+)
+
+internal data class ConversationTimeEventWork(
+    val conversationTimeEventInput: ConversationTimeEventInput,
+    val worker: ConversationTimeEventWorker
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWorker.kt
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.receipt
+
+internal fun interface ConversationTimeEventWorker {
+    suspend fun doWork(workParameters: ConversationTimeEventInput)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ParallelConversationWorkQueue.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ParallelConversationWorkQueue.kt
@@ -1,0 +1,104 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.receipt
+
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A work queue that schedules and runs actions for conversations based on a time
+ */
+internal interface ConversationWorkQueue {
+    /**
+     * Enqueue [worker] to perform on the provided [input], to be executed according to the implementation.
+     */
+    suspend fun enqueue(input: ConversationTimeEventInput, worker: ConversationTimeEventWorker)
+}
+
+/**
+ * This implementation of [ConversationWorkQueue] allows parallel work between conversations,
+ * but _only one_ simultaneous work per conversation, _i.e._ each conversation has its own parallel queue.
+ *
+ * If work is being performed for a conversation, allows enqueuing up to _one_ extra work to be done afterward.
+ * When attempting to enqueue multiple works for the same [ConversationTimeEventInput.conversationId],
+ * only the work with most recent [ConversationTimeEventInput.time] parameter will be scheduled.
+ *
+ * This is aimed at things like handling Delivery or Read Receipts.
+ * For Read Receipts, for example, the user may navigate to an unread conversation, and the client might want to mark as read multiple
+ * times in a row as the user scrolls through the unread messages.
+ * This queue solves it by making sure only one event for that conversation is handled at a time, and if multiple calls are made in
+ * rapid succession while one operation is ongoing, only the most recent one will actually be scheduled to be performed.
+ *
+ * @property scope The CoroutineScope used for enqueuing worker coroutines.
+ * @property dispatcher The dispatcher for executing the works.
+ */
+internal class ParallelConversationWorkQueue(
+    private val scope: CoroutineScope,
+    kaliumLogger: KaliumLogger,
+    private val dispatcher: CoroutineDispatcher,
+) : ConversationWorkQueue {
+    private val mutex = Mutex()
+    private val conversationQueueMap = mutableMapOf<ConversationId, MutableStateFlow<ConversationTimeEventWork>>()
+    private val logger = kaliumLogger.withTextTag("ConversationReceiptQueue")
+
+    /**
+     * Enqueues new work parameters for the provided [input].
+     * Will **only** emit a new entry / replacing an existing one for the [ConversationTimeEventInput.conversationId] if
+     * the [ConversationTimeEventInput.time] is more recent than the existing one.
+     * If there's an existing work being done for the same [ConversationTimeEventInput.conversationId], it will wait until it's over.
+     * After that, will start working as soon as the [dispatcher] allows it, while the [scope] is alive.
+     */
+    override suspend fun enqueue(
+        input: ConversationTimeEventInput,
+        worker: ConversationTimeEventWorker
+    ): Unit = mutex.withLock {
+        val conversationId = input.conversationId
+        val time = input.time
+        logger.v("Attempting to enqueue receipt work for conversation '${conversationId.toLogString()}', with time '$time'")
+        val work = ConversationTimeEventWork(input, worker)
+        val existingConversationQueue = conversationQueueMap[conversationId]
+        existingConversationQueue?.let {
+            val isNewWorkMoreRecent = time > it.value.conversationTimeEventInput.time
+            if (isNewWorkMoreRecent) {
+                it.value = work
+            }
+        } ?: createQueueForConversation(work).also {
+            conversationQueueMap[conversationId] = it
+        }
+    }
+
+    private suspend fun createQueueForConversation(initialWork: ConversationTimeEventWork) =
+        MutableStateFlow(initialWork).also {
+            scope.launch(dispatcher) {
+                @Suppress("TooGenericExceptionCaught")
+                it.collect { work ->
+                    try {
+                        work.worker.doWork(work.conversationTimeEventInput)
+                    } catch (t: Throwable) {
+                        logger.w("Failure in conversation work queue", t)
+                    }
+                }
+            }
+        }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/ParallelConversationWorkQueueTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/ParallelConversationWorkQueueTest.kt
@@ -1,0 +1,186 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.receipt
+
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class ParallelConversationWorkQueueTest {
+
+    private val dispatcher = TestKaliumDispatcher
+
+    fun runTest(test: suspend TestScope.() -> Unit) = runTest(dispatcher.main) { test() }
+
+    private fun TestScope.testSubject() = ParallelConversationWorkQueue(
+        scope = backgroundScope, // So it gets automatically cancelled once the runTest block is finished
+        kaliumLogger = KaliumLogger.disabled(),
+        dispatcher = dispatcher.main
+    )
+
+    @Test
+    fun givenWorkIsOngoing_whenEnqueuingAnotherForTheSameConversation_theyAreExecutedInOrder() = runTest {
+        val subject = testSubject()
+        var startedFirst = false
+        var endedFirst = false
+        var startedSecond = false
+        var endedSecond = false
+        subject.enqueue(workInput(time = Instant.DISTANT_PAST)) {
+            startedFirst = true
+            delay(1.minutes)
+            endedFirst = true
+        }
+        advanceTimeBy(50.seconds) // First is still ongoing
+        assertTrue(startedFirst)
+        assertFalse(endedFirst)
+
+        // Enqueue second
+        subject.enqueue(workInput(time = Instant.DISTANT_PAST + 1.seconds)) {
+            assertTrue(endedFirst, "Started second before first was finished")
+            startedSecond = true
+            delay(1.minutes)
+            endedSecond = true
+        }
+        assertFalse(endedSecond)
+
+        advanceTimeBy(50.seconds) // First should have finished and second started
+        assertTrue(endedFirst)
+        assertTrue(startedSecond)
+        assertFalse(endedSecond)
+
+        advanceTimeBy(50.seconds) // Both should have finished
+
+        advanceUntilIdle()
+        assertTrue(endedFirst)
+        assertTrue(endedSecond)
+    }
+
+
+    @Test
+    fun givenWorkThrows_whenEnqueuingAnotherForTheSameConversation_itIsExecutedNormally() = runTest {
+        val subject = testSubject()
+        var startedFirst = false
+        var endedSecond = false
+        subject.enqueue(workInput(time = Instant.DISTANT_PAST)) {
+            startedFirst = true
+            throw IllegalStateException("Oopsie Doopsie! - Expected Test Exception")
+        }
+        advanceTimeBy(50.seconds) // Trigger first
+        assertTrue(startedFirst)
+
+        // Enqueue second
+        subject.enqueue(workInput(time = Instant.DISTANT_PAST + 1.seconds)) {
+            endedSecond = true
+        }
+        advanceTimeBy(50.seconds) // Both should have finished
+        assertTrue(endedSecond)
+    }
+
+    @Test
+    fun givenWorkIsOngoing_whenEnqueuingAnotherForDifferentConversation_theyAreExecutedInParallel() = runTest {
+        val subject = testSubject()
+        var startedFirst = false
+        var endedFirst = false
+        var startedSecond = false
+        var endedSecond = false
+        subject.enqueue(workInput(convIdValue = "A", time = Instant.DISTANT_PAST)) {
+            startedFirst = true
+            delay(1.minutes)
+            endedFirst = true
+        }
+        advanceTimeBy(30.seconds) // First is still ongoing
+        assertTrue(startedFirst)
+        assertFalse(endedFirst)
+
+        // Enqueue second
+        subject.enqueue(workInput(convIdValue = "B", time = Instant.DISTANT_PAST)) {
+            startedSecond = true
+            delay(1.minutes)
+            endedSecond = true
+        }
+        assertFalse(endedSecond)
+
+        advanceTimeBy(5.seconds) // First should still be ongoing, but second should have started
+        assertTrue(startedFirst)
+        assertFalse(endedFirst)
+        assertTrue(startedSecond)
+        assertFalse(endedSecond)
+
+        advanceTimeBy(2.minutes) // Both should have finished
+
+        assertTrue(endedFirst)
+        assertTrue(endedSecond)
+    }
+
+    @Test
+    fun givenWorkIsOngoing_whenEnqueuingMoreEventsForSameConversation_thenOnlyTheOneWithLatestTimeIsExecutedAfterwards() = runTest {
+        val subject = testSubject()
+        var startedFirstCandidate = false
+        var startedExpectedCandidate = false
+        var completedExpectedCandidate = false
+        var startedThirdCandidate = false
+        subject.enqueue(workInput(time = Instant.DISTANT_PAST)) { delay(1.minutes) }
+        advanceTimeBy(30.seconds) // First is still ongoing
+
+        // Enqueue first candidate
+        subject.enqueue(workInput(time = Instant.DISTANT_PAST + 10.seconds)) {
+            startedFirstCandidate = true
+            delay(1.minutes)
+        }
+
+        // Enqueue second candidate - expected one
+        subject.enqueue(workInput(time = Instant.DISTANT_PAST + 15.seconds)) {
+            startedExpectedCandidate = true
+            delay(1.minutes)
+            completedExpectedCandidate = true
+        }
+
+        // enqueue third candidate
+        subject.enqueue(workInput(time = Instant.DISTANT_PAST + 5.seconds)) {
+            startedThirdCandidate = true
+            delay(1.minutes)
+        }
+
+        advanceTimeBy(1.minutes) // Finish first and start one of the candidates
+        assertTrue(startedExpectedCandidate)
+        assertFalse(startedFirstCandidate)
+        assertFalse(startedThirdCandidate)
+
+        advanceTimeBy(10.minutes) // Only the expected should be executed and completed. The rest shouldn't start at all.
+        assertTrue(completedExpectedCandidate)
+        assertFalse(startedFirstCandidate)
+        assertFalse(startedThirdCandidate)
+    }
+
+    private fun workInput(
+        convIdValue: String = "abc",
+        time: Instant = Instant.DISTANT_PAST
+    ) = ConversationTimeEventInput(ConversationId(convIdValue, "domain"), time)
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9216" title="WPB-9216" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9216</a>  [Android] out of memory exception when scrolling a group chat with long unread history
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app is _very_ slow to mark messages/conversations as read.

### Causes

1. We do stuff synchronously: send receipts, update lastReadDate, then send lastRead to other clients.
2. As the user scrolls through unread messages, we call the same `UpdateConversationReadDateUseCase` _multiple_ times in a row. And this use-case is _not_ prepared to only do one thing at a time. If called 30 times, it will launch 30 jobs in parallel for the same conversation. When only the "latest" one could/should be performed.

### Solutions

For this PR, I'm creating a structure that enables enqueuing work based on conversation ID and _only latest_ work will be performed.

If the idea of this PR is approved, I'll continue in next PRs with:

1. Allow fetching unread messages in a time window. Currently, DAOs are too opinionated and only allow fetching messages created _after_ the _lastRead_ – so, they require that _lastRead_ is only updated after sending receipts – which sucks.
2. Implementing a `ConversationReadTimeWorker`, which will do in parallel: gather messages/send receipts, update `lastRead` for the Conversation, send these receipts to the other devices of this user.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
