### PR TITLE
fix: parse sft url when connecting

### DIFF
--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/call/CallApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/call/CallApiV0Test.kt
@@ -89,6 +89,60 @@ internal class CallApiV0Test : ApiTest() {
         )
     }
 
+    @Test
+    fun givenSftUrlWithHttpProtocol_whenConnecting_thenReplaceItWithHttps() = runTest {
+        val sftConnectionURL = "http://sft.connection.url1/test/endpoint?param1=value1"
+        val sftConnectionData = """
+            |{
+            |   "sft":"connection"
+            |}
+        """.trimIndent()
+
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = GET_CALL_SFT.rawJson,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertJson()
+                assertPost()
+                assertUrlEqual("https://sft.connection.url1/test/endpoint?param1=value1")
+                assertJsonBodyContent(sftConnectionData)
+            }
+        )
+
+        val callApi: CallApi = CallApiV0(networkClient)
+        callApi.connectToSFT(
+            url = sftConnectionURL,
+            data = sftConnectionData
+        )
+    }
+
+    @Test
+    fun givenSftUrlWithNotProtocol_whenConnecting_thenAddHttps() = runTest {
+        val sftConnectionURL = "sft.connection.url1/test/endpoint?param1=value1"
+        val sftConnectionData = """
+            |{
+            |   "sft":"connection"
+            |}
+        """.trimIndent()
+
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = GET_CALL_SFT.rawJson,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertJson()
+                assertPost()
+                assertUrlEqual("https://sft.connection.url1/test/endpoint?param1=value1")
+                assertJsonBodyContent(sftConnectionData)
+            }
+        )
+
+        val callApi: CallApi = CallApiV0(networkClient)
+        callApi.connectToSFT(
+            url = sftConnectionURL,
+            data = sftConnectionData
+        )
+    }
+
     private companion object {
 
         const val PATH_CALLS = "calls"

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/call/CallApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/call/CallApiV0Test.kt
@@ -143,6 +143,33 @@ internal class CallApiV0Test : ApiTest() {
         )
     }
 
+    @Test
+    fun givenSftUrlWithHttpsProtocol_whenConnecting_thenDoNotChangeIt() = runTest {
+        val sftConnectionURL = "https://sft.connection.url1/test/endpoint?param1=value1"
+        val sftConnectionData = """
+            |{
+            |   "sft":"connection"
+            |}
+        """.trimIndent()
+
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = GET_CALL_SFT.rawJson,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertJson()
+                assertPost()
+                assertUrlEqual("https://sft.connection.url1/test/endpoint?param1=value1")
+                assertJsonBodyContent(sftConnectionData)
+            }
+        )
+
+        val callApi: CallApi = CallApiV0(networkClient)
+        callApi.connectToSFT(
+            url = sftConnectionURL,
+            data = sftConnectionData
+        )
+    }
+
     private companion object {
 
         const val PATH_CALLS = "calls"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

sft urls are taken as they received and the app tries connecting

### Solutions

parse the url string and hard code the protocol to https

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
