### PR TITLE
fix(mls-migration): set correct CS when Kalium start migration (WPB-9638)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -493,6 +493,7 @@ internal class MLSConversationDataSource(
         allowPartialMemberList: Boolean = false,
     ): Either<CoreFailure, MLSAdditionResult> = withContext(serialDispatcher) {
         commitPendingProposals(groupID).flatMap {
+            kaliumLogger.d("adding $userIdList to MLS group: $groupID")
             produceAndSendCommitWithRetryAndResult(groupID, retryOnStaleMessage = retryOnStaleMessage) {
                 keyPackageRepository.claimKeyPackages(userIdList, cipherSuite).flatMap { result ->
                     if (result.usersWithoutKeyPackagesAvailable.isNotEmpty() && !allowPartialMemberList) {
@@ -619,6 +620,7 @@ internal class MLSConversationDataSource(
         externalSenders: ByteArray,
         allowPartialMemberList: Boolean = false,
     ): Either<CoreFailure, MLSAdditionResult> = withContext(serialDispatcher) {
+        kaliumLogger.d("establish MLS group: $groupID")
         mlsClientProvider.getMLSClient().flatMap { mlsClient ->
             wrapMLSRequest {
                 mlsClient.createConversation(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -25,15 +25,16 @@ import com.wire.kalium.logic.data.conversation.Conversation.Protocol
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.message.SystemMessageInserter
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.flow.first
 
@@ -107,6 +108,7 @@ internal class MLSMigratorImpl(
                         )
                     }
                 }
+                kaliumLogger.i("migrating ${conversationId.toLogString()} to mls")
                 establishConversation(conversationId)
             }.flatMapLeft {
                 kaliumLogger.w("failed to migrate ${conversationId.toLogString()} to mixed: $it")
@@ -135,16 +137,10 @@ internal class MLSMigratorImpl(
             .flatMap { protocolInfo ->
                 when (protocolInfo) {
                     is Conversation.ProtocolInfo.Mixed -> {
-                        mlsConversationRepository.establishMLSGroup(protocolInfo.groupId, emptyList())
-                            .flatMap {
-                                conversationRepository.getConversationMembers(conversationId).flatMap { members ->
-                                    mlsConversationRepository.addMemberToMLSGroup(
-                                        protocolInfo.groupId,
-                                        members,
-                                        protocolInfo.cipherSuite
-                                    )
-                                }
-                            }
+                        conversationRepository.getConversationMembers(conversationId).flatMap { members ->
+                            mlsConversationRepository.establishMLSGroup(protocolInfo.groupId, members)
+                        }
+                        Unit.right()
                     }
                     else -> Either.Right(Unit)
                 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.feature.mlsmigration
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -34,6 +35,8 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestTeam
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.left
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.test_util.TestNetworkResponseError
 import com.wire.kalium.logic.util.arrangement.CallRepositoryArrangementImpl
 import com.wire.kalium.logic.util.shouldSucceed
@@ -68,7 +71,7 @@ class MLSMigratorTest {
             .withFetchConversationSucceeding()
             .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
             .withEstablishGroupSucceeds(Arrangement.SUCCESSFUL_ADDITION_RESULT)
-            .withGetConversationMembersReturning(Arrangement.MEMBERS)
+            .withGetConversationMembersReturning(Arrangement.MEMBERS.right())
             .withAddMembersSucceeds()
             .withoutAnyEstablishedCall()
             .arrange()
@@ -102,7 +105,7 @@ class MLSMigratorTest {
             .withFetchConversationSucceeding()
             .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
             .withEstablishGroupSucceeds(Arrangement.SUCCESSFUL_ADDITION_RESULT)
-            .withGetConversationMembersReturning(Arrangement.MEMBERS)
+            .withGetConversationMembersReturning(Arrangement.MEMBERS.right())
             .withAddMembersSucceeds()
             .withEstablishedCall()
             .arrange()
@@ -143,6 +146,7 @@ class MLSMigratorTest {
             .withUpdateProtocolReturns()
             .withFetchConversationSucceeding()
             .withGetConversationProtocolInfoReturning(Arrangement.MIXED_PROTOCOL_INFO)
+            .withGetConversationMembersReturning(StorageFailure.DataNotFound.left())
             .withEstablishGroupFails()
             .withoutAnyEstablishedCall()
             .arrange()
@@ -244,11 +248,11 @@ class MLSMigratorTest {
                 .thenReturn(Either.Right(protocolInfo))
         }
 
-        fun withGetConversationMembersReturning(members: List<UserId>) = apply {
+        fun withGetConversationMembersReturning(result: Either<StorageFailure, List<UserId>>) = apply {
             given(conversationRepository)
                 .suspendFunction(conversationRepository::getConversationMembers)
                 .whenInvokedWith(anything())
-                .thenReturn(Either.Right(members))
+                .thenReturn(result)
         }
 
         fun withFetchConversationSucceeding() = apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
When Android/Kalium starts the migration flow, we actually creating the MLS Conversation, and due to the agreement that the BE will not set the Correct CS in the Create Conversation Response, we need to ignore that value; in the normal conversation creation this was considered, but not in the migration flow.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

* Have a team without MLS enabled
* Login on android and web
* Create a Proteus group and send some messages
* Enable MLS and set the migration to be started
* Log out and log in on Android, the android app must start the migration to MLS
* Web ( without reloading the web-app) and android app must be able to send and receive messages and the group must be established as MLS

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
