### PR TITLE
fix: start related managers before CallManager

### DIFF
--- a/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -68,6 +68,12 @@ class CallManagerTest {
     private val currentClientIdProvider = mock(CurrentClientIdProvider::class)
 
     @Mock
+    private val mediaManagerService = mock(MediaManagerService::class)
+
+    @Mock
+    private val flowManagerService = mock(FlowManagerService::class)
+
+    @Mock
     private val selfConversationIdProvider = mock(SelfConversationIdProvider::class)
 
     @Mock
@@ -113,7 +119,9 @@ class CallManagerTest {
             callMapper = callMapper,
             conversationClientsInCallUpdater = conversationClientsInCallUpdater,
             networkStateObserver = networkStateObserver,
-            kaliumConfigs = kaliumConfigs
+            kaliumConfigs = kaliumConfigs,
+            mediaManagerService = mediaManagerService,
+            flowManagerService = flowManagerService,
         )
     }
 

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
@@ -87,4 +87,6 @@ actual class FlowManagerServiceImpl(
             flowManager.await().setUIRotation(rotation)
         }
     }
+
+    override suspend fun startFlowManager() { flowManager.await() }
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/MediaManagerServiceImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/call/MediaManagerServiceImpl.kt
@@ -59,6 +59,10 @@ actual class MediaManagerServiceImpl(
         }
     }
 
+    override suspend fun startMediaManager() {
+        mediaManager.await()
+    }
+
     private val _isLoudSpeakerOnFlow = MutableStateFlow(false)
     private val isLoudSpeakerOnFlow = _isLoudSpeakerOnFlow.asStateFlow().onStart {
         _isLoudSpeakerOnFlow.value = mediaManager.await().isLoudSpeakerOn

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
@@ -40,4 +40,8 @@ actual class FlowManagerServiceImpl(
     override suspend fun setUIRotation(rotation: Int) {
         TODO("Not yet implemented")
     }
+
+    override suspend fun startFlowManager() {
+        TODO("Not yet implemented")
+    }
 }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/MediaManagerServiceImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/MediaManagerServiceImpl.kt
@@ -35,4 +35,8 @@ actual class MediaManagerServiceImpl(
     override fun observeSpeaker(): Flow<Boolean> {
         TODO("Not yet implemented")
     }
+
+    override suspend fun startMediaManager() {
+        TODO("Not yet implemented")
+    }
 }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -106,6 +106,8 @@ actual class GlobalCallManager(
                 videoStateChecker = videoStateChecker,
                 conversationClientsInCallUpdater = conversationClientsInCallUpdater,
                 networkStateObserver = networkStateObserver,
+                mediaManagerService = mediaManager,
+                flowManagerService = flowManager,
                 kaliumConfigs = kaliumConfigs
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerService.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerService.kt
@@ -26,6 +26,12 @@ interface FlowManagerService {
     suspend fun flipToFrontCamera(conversationId: ConversationId)
     suspend fun flipToBackCamera(conversationId: ConversationId)
     suspend fun setUIRotation(rotation: Int)
+
+    /**
+     * Suspends the execution of the current coroutine and starts the flow manager.
+     * If the FlowManager has already started, will return immediately.
+     */
+    suspend fun startFlowManager()
 }
 
 expect class FlowManagerServiceImpl : FlowManagerService

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/MediaManagerService.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/MediaManagerService.kt
@@ -24,6 +24,12 @@ interface MediaManagerService {
     suspend fun turnLoudSpeakerOn()
     suspend fun turnLoudSpeakerOff()
     fun observeSpeaker(): Flow<Boolean>
+
+    /**
+     * Suspends the execution of the current coroutine until the media manager is started.
+     * If it is already started, then it returns instantly.
+     */
+    suspend fun startMediaManager()
 }
 
 expect class MediaManagerServiceImpl : MediaManagerService

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
@@ -44,4 +44,8 @@ actual class FlowManagerServiceImpl(
     override suspend fun setUIRotation(rotation: Int) {
         kaliumLogger.w("setUIRotation for JVM but not supported yet.")
     }
+
+    override suspend fun startFlowManager() {
+        kaliumLogger.w("FlowManager not fully supported on JVM.")
+    }
 }

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/MediaManagerServiceImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/call/MediaManagerServiceImpl.kt
@@ -41,4 +41,8 @@ actual class MediaManagerServiceImpl(
         kaliumLogger.w("observeSpeaker for JVM but not supported yet.")
         return MutableStateFlow(false)
     }
+
+    override suspend fun startMediaManager() {
+        kaliumLogger.w("Media Manager is not supported on JVM.")
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App Sync is freezing when processing calling messages.

### Causes

The refactors making FlowManager and MediaManager lazy were really good. They are so lazy that when CallManager wants them, they're not initialized 😅

### Solutions

Ensured the MediaManager and FlowManager services start before the call handle. Implemented these start procedures across all platforms, marking unsupported platforms with warnings.

### Testing

I wish.
CallManager is far from testable at the moment. We should definitely refactor it.

Tested manually by making sure call manager starts and processes calling messages

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
