### PR TITLE
chore: add performance metrics to event processing

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogger.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.network.NetworkUtilLogger
 import com.wire.kalium.persistence.PersistenceLogger
 import com.wire.kalium.util.serialization.toJsonElement
 
-private var kaliumLoggerConfig = KaliumLogger.Config.disabled()
+private var kaliumLoggerConfig = KaliumLogger.Config.DISABLED
 internal var kaliumLogger = KaliumLogger.disabled()
 internal var callingLogger = KaliumLogger.disabled()
 
@@ -43,7 +43,7 @@ object CoreLogger {
     }
 
     fun setLoggingLevel(level: KaliumLogLevel) {
-        kaliumLoggerConfig.setLogLevel(level)
+        kaliumLoggerConfig.logLevel = level
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -762,27 +762,31 @@ internal enum class EventLoggingStatus {
 internal fun KaliumLogger.logEventProcessing(
     status: EventLoggingStatus,
     event: Event,
-    vararg extraInfo: Pair<String, Any>
+    vararg extraInfo: Pair<String, Any>,
+    performanceData: EventProcessingPerformanceData = EventProcessingPerformanceData.None,
 ) {
-    val logMap = mapOf("event" to event.toLogMap()) + extraInfo.toMap()
+    val logMap = event.toLogMap().toMutableMap()
+    logMap += extraInfo
+
+    val performanceEntry = performanceData.logData
+    if (performanceEntry != null) {
+        logMap["eventPerformanceData"] = performanceEntry
+    }
 
     when (status) {
         EventLoggingStatus.SUCCESS -> {
-            val finalMap = logMap.toMutableMap()
-            finalMap["outcome"] = "success"
-            logStructuredJson(KaliumLogLevel.INFO, "Success handling event", finalMap)
+            logMap["outcome"] = "success"
+            logStructuredJson(KaliumLogLevel.INFO, "Success handling event", logMap)
         }
 
         EventLoggingStatus.FAILURE -> {
-            val finalMap = logMap.toMutableMap()
-            finalMap["outcome"] = "failure"
-            logStructuredJson(KaliumLogLevel.ERROR, "Failure handling event", finalMap)
+            logMap["outcome"] = "failure"
+            logStructuredJson(KaliumLogLevel.ERROR, "Failure handling event", logMap)
         }
 
         EventLoggingStatus.SKIPPED -> {
-            val finalMap = logMap.toMutableMap()
-            finalMap["outcome"] = "skipped"
-            logStructuredJson(KaliumLogLevel.WARN, "Skipped handling event", finalMap)
+            logMap["outcome"] = "skipped"
+            logStructuredJson(KaliumLogLevel.WARN, "Skipped handling event", logMap)
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventProcessingPerformanceData.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventProcessingPerformanceData.kt
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.event
+
+import kotlin.time.Duration
+
+/**
+ * Hierarchy to represent possible ways of recording the
+ * performance of event processing.
+ */
+sealed interface EventProcessingPerformanceData {
+
+    /**
+     * Map containing information about the performance,
+     * which can be used for logging and analysis
+     */
+    val logData: Map<String, Any>?
+
+    /**
+     * No performance is recorded for these
+     */
+    data object None : EventProcessingPerformanceData {
+        override val logData: Map<String, Any>?
+            get() = null
+    }
+
+    /**
+     * The measurement of time that it took to process an event
+     */
+    data class TimeTaken(
+        val duration: Duration,
+    ) : EventProcessingPerformanceData {
+        private val durationEntry: Pair<String, Long>
+            get() = "timeTakenInMillis" to duration.inWholeMilliseconds
+
+        override val logData: Map<String, Any>
+            get() = mapOf(durationEntry)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/BroadcastMessage.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/BroadcastMessage.kt
@@ -32,64 +32,21 @@ data class BroadcastMessage(
     val senderClientId: ClientId,
 ) {
 
-    @Suppress("LongMethod")
     fun toLogString(): String {
-        val typeKey = "type"
-
-        val properties: MutableMap<String, Any> = when (content) {
-            is MessageContent.TextEdited -> mutableMapOf(
-                typeKey to "textEdit"
-            )
-
-            is MessageContent.Calling -> mutableMapOf(
-                typeKey to "calling"
-            )
-
-            is MessageContent.ClientAction -> mutableMapOf(
-                typeKey to "clientAction"
-            )
-
-            is MessageContent.DeleteMessage -> mutableMapOf(
-                typeKey to "delete"
-            )
-
+        val extraProperties: MutableMap<String, Any> = when (content) {
             is MessageContent.DeleteForMe -> mutableMapOf(
-                typeKey to "deleteForMe",
                 "messageId" to content.messageId.obfuscateId(),
             )
 
             is MessageContent.LastRead -> mutableMapOf(
-                typeKey to "lastRead",
                 "time" to "${content.time}",
             )
 
-            is MessageContent.Availability -> mutableMapOf(
-                typeKey to "availability",
-            )
-
-            is MessageContent.Cleared -> mutableMapOf(
-                typeKey to "cleared",
-            )
-
-            is MessageContent.Reaction -> mutableMapOf(
-                typeKey to "reaction",
-            )
-
             is MessageContent.Receipt -> mutableMapOf(
-                typeKey to "receipt",
                 "content" to content.toLogMap(),
             )
 
-            MessageContent.Ignored -> mutableMapOf(
-                typeKey to "ignored"
-            )
-
-            is MessageContent.ButtonAction -> mutableMapOf(
-                typeKey to "buttonAction",
-            )
-            is MessageContent.ButtonActionConfirmation -> mutableMapOf(
-                typeKey to "buttonActionConfirmation",
-            )
+            else -> mutableMapOf()
         }
 
         val standardProperties = mapOf(
@@ -98,10 +55,11 @@ data class BroadcastMessage(
             "senderUserId" to senderUserId.value.obfuscateId(),
             "status" to "$status",
             "senderClientId" to senderClientId.value.obfuscateId(),
+            "type" to content.typeDescription(),
         )
 
-        properties.putAll(standardProperties)
+        extraProperties.putAll(standardProperties)
 
-        return "${properties.toMap().toJsonElement()}"
+        return "${extraProperties.toMap().toJsonElement()}"
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.Serializable
 
 typealias DomainToUserIdToClientsMap = Map<String, Map<String, List<String>>>
 
-sealed class MessageContent {
+sealed interface MessageContent {
 
     /**
      * Messages that are not sent between client, but
@@ -45,7 +45,7 @@ sealed class MessageContent {
      * from the backend (_e.g._ users added/removed from a conversation),
      * or our own logic (_e.g._ missed call).
      */
-    sealed class System : MessageContent()
+    sealed interface System : MessageContent
 
     /**
      * Content that can be serialized/deserialized using the
@@ -53,7 +53,7 @@ sealed class MessageContent {
      * other clients.
      * @see ProtoContentMapper
      */
-    sealed class FromProto : MessageContent()
+    sealed interface FromProto : MessageContent
 
     /**
      * Main content of messages created by users/bot,
@@ -63,7 +63,7 @@ sealed class MessageContent {
      *
      * Examples: [Text], [Asset], [Knock], Locations (coordinates).
      */
-    sealed class Regular : FromProto()
+    sealed class Regular : FromProto
 
     /**
      * Content that is transferred between clients, but
@@ -75,7 +75,7 @@ sealed class MessageContent {
      * [DeleteForMe], [TextEdited], [UserAvailabilityStatus],
      * [Calling], [ClientAction] etc.
      */
-    sealed class Signaling : FromProto()
+    sealed interface Signaling : FromProto
 
     // client message content types
     data class Text(
@@ -158,12 +158,12 @@ sealed class MessageContent {
     data class DeleteForMe(
         val messageId: String,
         val conversationId: ConversationId,
-    ) : Signaling()
+    ) : Signaling
 
     data class Calling(
         val value: String,
         val conversationId: ConversationId? = null
-    ) : Signaling() {
+    ) : Signaling {
         @Serializable
         data class CallingValue(
             val type: String,
@@ -178,13 +178,13 @@ sealed class MessageContent {
         )
     }
 
-    data class DeleteMessage(val messageId: String) : Signaling()
+    data class DeleteMessage(val messageId: String) : Signaling
 
     data class TextEdited(
         val editMessageId: String,
         val newContent: String,
         val newMentions: List<MessageMention> = listOf()
-    ) : Signaling()
+    ) : Signaling
 
     data class Knock(val hotKnock: Boolean) : Regular()
 
@@ -215,7 +215,7 @@ sealed class MessageContent {
          * ID of the button that was selected.
          */
         val buttonId: MessageButtonId
-    ) : Signaling()
+    ) : Signaling
 
     /**
      * Message sent by the author of a [Composite] to
@@ -234,7 +234,7 @@ sealed class MessageContent {
          * ID of the selected button. Null if no button should be marked as selected.
          */
         val buttonId: MessageButtonId?,
-    ) : Signaling()
+    ) : Signaling
 
     data class Unknown( // messages that aren't yet handled properly but stored in db in case
         val typeName: String? = null,
@@ -245,11 +245,11 @@ sealed class MessageContent {
     data class Cleared(
         val conversationId: ConversationId,
         val time: Instant
-    ) : Signaling()
+    ) : Signaling
 
     // server message content types
     // TODO: rename members to userList
-    sealed class MemberChange(open val members: List<UserId>) : System() {
+    sealed class MemberChange(open val members: List<UserId>) : System {
         /**
          * A member(s) was added to the conversation.
          */
@@ -289,50 +289,49 @@ sealed class MessageContent {
         val messageId: String,
         val conversationId: ConversationId,
         val time: Instant
-    ) : Signaling()
+    ) : Signaling
 
-    data class ConversationRenamed(val conversationName: String) : System()
+    data class ConversationRenamed(val conversationName: String) : System
 
     @Deprecated("Use MemberChange.RemovedFromTeam instead")
-    data class TeamMemberRemoved(val userName: String) : System()
+    data class TeamMemberRemoved(val userName: String) : System
 
-    data object MissedCall : System()
+    data object MissedCall : System
 
     data class Reaction(
         val messageId: String,
         val emojiSet: Set<String>
-    ) : Signaling()
+    ) : Signaling
 
-    data class Availability(val status: UserAvailabilityStatus) : Signaling()
+    data class Availability(val status: UserAvailabilityStatus) : Signaling
 
-    data class Receipt(val type: ReceiptType, val messageIds: List<String>) : Signaling() {
+    data class Receipt(val type: ReceiptType, val messageIds: List<String>) : Signaling {
         fun toLogMap(): Map<String, Any> = mapOf(
             "type" to "$type",
             "messageIds" to messageIds.map { it.obfuscateId() }
         )
-
     }
 
     data class NewConversationReceiptMode(
         val receiptMode: Boolean
-    ) : System()
+    ) : System
 
     data class ConversationReceiptModeChanged(
         val receiptMode: Boolean
-    ) : System()
+    ) : System
 
     data class ConversationMessageTimerChanged(
         val messageTimer: Long?
-    ) : System()
+    ) : System
 
     data class ConversationProtocolChanged(
         val protocol: Conversation.Protocol
-    ) : System()
+    ) : System
 
-    data object ConversationProtocolChangedDuringACall : System()
+    data object ConversationProtocolChangedDuringACall : System
 
     // we can add other types to be processed, but signaling ones shouldn't be persisted
-    data object Ignored : Signaling() // messages that aren't processed in any way
+    data object Ignored : Signaling // messages that aren't processed in any way
 
     data class FailedDecryption(
         val encodedData: ByteArray? = null,
@@ -348,27 +347,27 @@ sealed class MessageContent {
         val zoom: Int? = null,
     ) : Regular()
 
-    data object MLSWrongEpochWarning : System()
+    data object MLSWrongEpochWarning : System
 
-    data object ClientAction : Signaling()
+    data object ClientAction : Signaling
 
-    data object CryptoSessionReset : System()
+    data object CryptoSessionReset : System
 
-    data object HistoryLostProtocolChanged : System()
+    data object HistoryLostProtocolChanged : System
 
-    data object HistoryLost : System()
-    data object ConversationCreated : System()
-    data object ConversationStartedUnverifiedWarning : System()
-    data object ConversationDegradedMLS : System()
-    data object ConversationVerifiedMLS : System()
-    data object ConversationDegradedProteus : System()
-    data object ConversationVerifiedProteus : System()
-    sealed class FederationStopped : System() {
+    data object HistoryLost : System
+    data object ConversationCreated : System
+    data object ConversationStartedUnverifiedWarning : System
+    data object ConversationDegradedMLS : System
+    data object ConversationVerifiedMLS : System
+    data object ConversationDegradedProteus : System
+    data object ConversationVerifiedProteus : System
+    sealed class FederationStopped : System {
         data class Removed(val domain: String) : FederationStopped()
         data class ConnectionRemoved(val domainList: List<String>) : FederationStopped()
     }
 
-    sealed class LegalHold : System() {
+    sealed class LegalHold : System {
         sealed class ForMembers(open val members: List<UserId>) : LegalHold() {
             data class Enabled(override val members: List<UserId>) : ForMembers(members)
             data class Disabled(override val members: List<UserId>) : ForMembers(members)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.message
+
+@Suppress("CyclomaticComplexMethod")
+inline fun MessageContent.FromProto.typeDescription(): String = when (this) {
+    is MessageContent.Asset -> "Asset"
+    is MessageContent.Composite -> "Composite"
+    is MessageContent.FailedDecryption -> "FailedDecryption"
+    is MessageContent.Knock -> "Knock"
+    is MessageContent.Location -> "Location"
+    is MessageContent.RestrictedAsset -> "RestrictedAsset"
+    is MessageContent.Text -> "Text"
+    is MessageContent.Unknown -> "Unknown"
+    is MessageContent.Availability -> "Availability"
+    is MessageContent.ButtonAction -> "ButtonAction"
+    is MessageContent.ButtonActionConfirmation -> "ButtonActionConfirmation"
+    is MessageContent.Calling -> "Calling"
+    is MessageContent.Cleared -> "Cleared"
+    MessageContent.ClientAction -> "ClientAction"
+    is MessageContent.DeleteForMe -> "DeleteForMe"
+    is MessageContent.DeleteMessage -> "DeleteMessage"
+    MessageContent.Ignored -> "Ignored"
+    is MessageContent.LastRead -> "LastRead"
+    is MessageContent.Reaction -> "Reaction"
+    is MessageContent.Receipt -> "Receipt"
+    is MessageContent.TextEdited -> "TextEdited"
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiver.kt
@@ -23,11 +23,13 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.event.EventLoggingStatus
+import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import kotlinx.datetime.Clock
 
 internal interface UserPropertiesEventReceiver : EventReceiver<Event.UserProperty>
 
@@ -48,14 +50,18 @@ internal class UserPropertiesEventReceiverImpl internal constructor(
 
     private fun handleReadReceiptMode(
         event: Event.UserProperty.ReadReceiptModeSet
-    ): Either<CoreFailure, Unit> =
-        userConfigRepository
+    ): Either<CoreFailure, Unit> {
+        val initialTime = Clock.System.now()
+        return userConfigRepository
             .setReadReceiptsStatus(event.value)
             .onSuccess {
                 kaliumLogger
                     .logEventProcessing(
                         EventLoggingStatus.SUCCESS,
-                        event
+                        event,
+                        performanceData = EventProcessingPerformanceData.TimeTaken(
+                            duration = (Clock.System.now() - initialTime)
+                        )
                     )
             }
             .onFailure {
@@ -66,17 +72,22 @@ internal class UserPropertiesEventReceiverImpl internal constructor(
                         Pair("errorInfo", "$it")
                     )
             }
+    }
 
     private fun handleTypingIndicatorMode(
         event: Event.UserProperty.TypingIndicatorModeSet
-    ): Either<CoreFailure, Unit> =
-        userConfigRepository
+    ): Either<CoreFailure, Unit> {
+        val initialTime = Clock.System.now()
+        return userConfigRepository
             .setTypingIndicatorStatus(event.value)
             .onSuccess {
                 kaliumLogger
                     .logEventProcessing(
                         EventLoggingStatus.SUCCESS,
-                        event
+                        event,
+                        performanceData = EventProcessingPerformanceData.TimeTaken(
+                            duration = (Clock.System.now() - initialTime)
+                        )
                     )
             }
             .onFailure {
@@ -87,4 +98,5 @@ internal class UserPropertiesEventReceiverImpl internal constructor(
                         Pair("errorInfo", "$it")
                     )
             }
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventLoggingStatus
+import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
 import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -36,6 +37,7 @@ import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.util.serialization.toJsonElement
+import kotlinx.datetime.Clock
 
 interface MemberJoinEventHandler {
     suspend fun handle(event: Event.Conversation.MemberJoin): Either<CoreFailure, Unit>
@@ -49,12 +51,13 @@ internal class MemberJoinEventHandlerImpl(
 ) : MemberJoinEventHandler {
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
 
-    override suspend fun handle(event: Event.Conversation.MemberJoin) =
+    override suspend fun handle(event: Event.Conversation.MemberJoin): Either<CoreFailure, Unit> {
+        val initialTime = Clock.System.now()
         // the group info need to be fetched for the following cases:
         // 1. self user is added/re-added to a group and we need to update the group info in case something changed form last time
         // 2. the new member is a bot in that case we need to make the group a bot 1:1
         // 3. fetch group info in case it is not stored in the first place
-        conversationRepository.fetchConversation(event.conversationId)
+        return conversationRepository.fetchConversation(event.conversationId)
             .run {
                 onSuccess {
                     val logMap = mapOf(
@@ -80,7 +83,10 @@ internal class MemberJoinEventHandlerImpl(
                 kaliumLogger
                     .logEventProcessing(
                         EventLoggingStatus.SUCCESS,
-                        event
+                        event,
+                        performanceData = EventProcessingPerformanceData.TimeTaken(
+                            duration = (Clock.System.now() - initialTime),
+                        )
                     )
             }.onFailure {
                 kaliumLogger
@@ -90,6 +96,7 @@ internal class MemberJoinEventHandlerImpl(
                         Pair("errorInfo", "$it")
                     )
             }
+    }
 
     private suspend fun addSystemMessage(event: Event.Conversation.MemberJoin) {
         val message = Message.System(

--- a/network-util/src/commonMain/kotlin/com/wire/kalium/network/NetworkUtilLogger.kt
+++ b/network-util/src/commonMain/kotlin/com/wire/kalium/network/NetworkUtilLogger.kt
@@ -28,5 +28,5 @@ object NetworkUtilLogger {
         kaliumUtilLogger = KaliumLogger(config = config, tag = "NetworkUtil")
     }
 
-    val isRequestLoggingEnabled: Boolean get() = kaliumUtilLogger.logLevel() in setOf(KaliumLogLevel.VERBOSE, KaliumLogLevel.DEBUG)
+    val isRequestLoggingEnabled: Boolean get() = kaliumUtilLogger.logLevel in setOf(KaliumLogLevel.VERBOSE, KaliumLogLevel.DEBUG)
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have no clue what events take more time to process.

### Solutions

Add a structure to represent EventProcessingPerformanceData, which can be used when logging event outcomes.

Add `EventProcessingPerformanceData.TimeTaken` to most processed events (excluding `Unknown`).

Make sure `MessageContent.FromProto` can be translated to a `type` which we can log, to gather metrics between different types of messages.

We can later collect logs, or use Datadog in our private builds to gather all info and see different metrics.


### Attachments

![image](https://github.com/wireapp/kalium/assets/9389043/dbf14532-c113-497b-bd84-d9866118c5b1)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
