### PR TITLE
fix: Wrong E2EI information for other users [WPB-9409]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -393,9 +393,15 @@ AND Conversation.mls_group_state IS 'ESTABLISHED'
 ORDER BY Conversation.type DESC LIMIT 1;
 
 getMLSGroupIdByUserId:
-SELECT Conversation.mls_group_id FROM Member
-JOIN Conversation ON Conversation.qualified_id = Member.conversation
-WHERE Conversation.mls_group_id IS NOT NULL AND mls_group_state IS 'ESTABLISHED' AND Member.user = :userId LIMIT 1;
+SELECT mls_group_id FROM
+	(SELECT COUNT(Member.user) AS users_amout, Conversation.mls_group_id, Conversation.mls_group_state FROM Member
+	JOIN Conversation ON Conversation.qualified_id = Member.conversation
+	WHERE Member.user = :userId OR Member.user = (SELECT SelfUser.id FROM SelfUser LIMIT 1)
+	GROUP BY Conversation.qualified_id)
+WHERE users_amout > 1 -- both (Self and Other users) belongs to that conversation
+AND mls_group_id IS NOT NULL
+AND mls_group_state IS 'ESTABLISHED'
+LIMIT 1;
 
 getMLSGroupIdByConversationId:
 SELECT Conversation.mls_group_id FROM Conversation


### PR DESCRIPTION
# What's new in this PR?

### Issues

Wrong e2ei information for other users after self user is kicked out of the group:

- enable MLS for team on bund-next env
- login with user A, B and C
- create an MLS group with all 3 users
- create a 1:1 between A and C
- enable e2ei for all the users
- generate cert for A and B
- delay generating the cert for C
- remove user C from the group conversation
- now take a look as user C at the 1:1 conversation  with user A > details > devices

Result:
device for user A does not have cert information

### Causes (Optional)

To get Identities for each device of user we need to get Id of MLS group this users belongs to. 
To get MLS group kalium finds the conversation that this user belongs to and get MLSGroupId from it. 

The problem comes out when self user is removed from some group-conversation and when kalium is looking for conversation OtherUser belongs to, finds exactly that group-conversation (it happens not in 100% of cases as there are couple of such conversations in DB, but `LIMIT 1` in query is used). So kalium uses MLSGroupId of the conversation SelfUser doesn't belongs to => doesn't have access to MLS group => no Identities found for OtherUser. 

### Solutions

Update DB-query to get MLSGpoupId of conversation that both (SelfUser and OtherUser) belongs to.
