### PR TITLE
refactor: simplify event logging [WPB-9788]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -19,8 +19,6 @@
 package com.wire.kalium.logic.data.event
 
 import com.wire.kalium.cryptography.utils.EncryptedData
-import com.wire.kalium.logger.KaliumLogLevel
-import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.client.Client
@@ -44,7 +42,6 @@ import com.wire.kalium.logic.data.legalhold.LastPreKey
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.logStructuredJson
 import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.util.DateTimeUtil
@@ -745,48 +742,6 @@ sealed class Event(open val id: String) {
                 idKey to id.obfuscateId(),
                 "domains" to domains
             )
-        }
-    }
-}
-
-internal enum class EventLoggingStatus {
-    SUCCESS,
-    FAILURE,
-    SKIPPED
-}
-
-/**
- * Logs event processing.
- * Underlying implementation detail is using the common [KaliumLogger.logStructuredJson] to log structured JSON.
- */
-internal fun KaliumLogger.logEventProcessing(
-    status: EventLoggingStatus,
-    event: Event,
-    vararg extraInfo: Pair<String, Any>,
-    performanceData: EventProcessingPerformanceData = EventProcessingPerformanceData.None,
-) {
-    val logMap = event.toLogMap().toMutableMap()
-    logMap += extraInfo
-
-    val performanceEntry = performanceData.logData
-    if (performanceEntry != null) {
-        logMap["eventPerformanceData"] = performanceEntry
-    }
-
-    when (status) {
-        EventLoggingStatus.SUCCESS -> {
-            logMap["outcome"] = "success"
-            logStructuredJson(KaliumLogLevel.INFO, "Success handling event", logMap)
-        }
-
-        EventLoggingStatus.FAILURE -> {
-            logMap["outcome"] = "failure"
-            logStructuredJson(KaliumLogLevel.ERROR, "Failure handling event", logMap)
-        }
-
-        EventLoggingStatus.SKIPPED -> {
-            logMap["outcome"] = "skipped"
-            logStructuredJson(KaliumLogLevel.WARN, "Skipped handling event", logMap)
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -23,9 +23,7 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.event.EventEnvelope
-import com.wire.kalium.logic.data.event.EventLoggingStatus
 import com.wire.kalium.logic.data.event.EventRepository
-import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
@@ -35,6 +33,8 @@ import com.wire.kalium.logic.sync.receiver.FederationEventReceiver
 import com.wire.kalium.logic.sync.receiver.TeamEventReceiver
 import com.wire.kalium.logic.sync.receiver.UserEventReceiver
 import com.wire.kalium.logic.sync.receiver.UserPropertiesEventReceiver
+import com.wire.kalium.logic.util.EventLoggingStatus
+import com.wire.kalium.logic.util.createEventProcessingLogger
 
 /**
  * Handles incoming events from remote.
@@ -90,11 +90,8 @@ internal class EventProcessorImpl(
             is Event.User -> userEventReceiver.onEvent(event, deliveryInfo)
             is Event.FeatureConfig -> featureConfigEventReceiver.onEvent(event, deliveryInfo)
             is Event.Unknown -> {
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.SKIPPED,
-                        event
-                    )
+                kaliumLogger.createEventProcessingLogger(event)
+                    .logComplete(EventLoggingStatus.SKIPPED)
                 // Skipping event = success
                 Either.Right(Unit)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiver.kt
@@ -22,14 +22,11 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventDeliveryInfo
-import com.wire.kalium.logic.data.event.EventLoggingStatus
-import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
-import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
-import kotlinx.datetime.Clock
+import com.wire.kalium.logic.util.createEventProcessingLogger
 
 internal interface UserPropertiesEventReceiver : EventReceiver<Event.UserProperty>
 
@@ -42,6 +39,7 @@ internal class UserPropertiesEventReceiverImpl internal constructor(
             is Event.UserProperty.ReadReceiptModeSet -> {
                 handleReadReceiptMode(event)
             }
+
             is Event.UserProperty.TypingIndicatorModeSet -> {
                 handleTypingIndicatorMode(event)
             }
@@ -51,52 +49,20 @@ internal class UserPropertiesEventReceiverImpl internal constructor(
     private fun handleReadReceiptMode(
         event: Event.UserProperty.ReadReceiptModeSet
     ): Either<CoreFailure, Unit> {
-        val initialTime = Clock.System.now()
+        val logger = kaliumLogger.createEventProcessingLogger(event)
         return userConfigRepository
             .setReadReceiptsStatus(event.value)
-            .onSuccess {
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.SUCCESS,
-                        event,
-                        performanceData = EventProcessingPerformanceData.TimeTaken(
-                            duration = (Clock.System.now() - initialTime)
-                        )
-                    )
-            }
-            .onFailure {
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.FAILURE,
-                        event,
-                        Pair("errorInfo", "$it")
-                    )
-            }
+            .onSuccess { logger.logSuccess() }
+            .onFailure { logger.logFailure(it) }
     }
 
     private fun handleTypingIndicatorMode(
         event: Event.UserProperty.TypingIndicatorModeSet
     ): Either<CoreFailure, Unit> {
-        val initialTime = Clock.System.now()
+        val logger = kaliumLogger.createEventProcessingLogger(event)
         return userConfigRepository
             .setTypingIndicatorStatus(event.value)
-            .onSuccess {
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.SUCCESS,
-                        event,
-                        performanceData = EventProcessingPerformanceData.TimeTaken(
-                            duration = (Clock.System.now() - initialTime)
-                        )
-                    )
-            }
-            .onFailure {
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.FAILURE,
-                        event,
-                        Pair("errorInfo", "$it")
-                    )
-            }
+            .onSuccess { logger.logSuccess() }
+            .onFailure { logger.logFailure(it) }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandler.kt
@@ -20,17 +20,15 @@ package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.event.EventLoggingStatus
-import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
-import com.wire.kalium.logic.data.event.logEventProcessing
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.notification.EphemeralConversationNotification
 import com.wire.kalium.logic.data.notification.NotificationEventsManager
+import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.util.EventLoggingStatus
+import com.wire.kalium.logic.util.createEventProcessingLogger
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.datetime.Clock
 
 interface DeletedConversationEventHandler {
     suspend fun handle(event: Event.Conversation.DeletedConversation)
@@ -43,37 +41,23 @@ internal class DeletedConversationEventHandlerImpl(
 ) : DeletedConversationEventHandler {
 
     override suspend fun handle(event: Event.Conversation.DeletedConversation) {
-        val initialTime = Clock.System.now()
+        val logger = kaliumLogger.createEventProcessingLogger(event)
         val conversation = conversationRepository.getConversationById(event.conversationId)
         if (conversation != null) {
             conversationRepository.deleteConversation(event.conversationId)
-                .onFailure { coreFailure ->
-                    kaliumLogger
-                        .logEventProcessing(
-                            EventLoggingStatus.FAILURE,
-                            event,
-                            Pair("errorInfo", "$coreFailure")
-                        )
-                }.onSuccess {
+                .onFailure { logger.logFailure(it) }.onSuccess {
                     val senderUser = userRepository.observeUser(event.senderUserId).firstOrNull()
                     val dataNotification = EphemeralConversationNotification(event, conversation, senderUser)
                     notificationEventsManager.scheduleDeleteConversationNotification(dataNotification)
-                    kaliumLogger
-                        .logEventProcessing(
-                            status = EventLoggingStatus.SUCCESS,
-                            event = event,
-                            performanceData = EventProcessingPerformanceData.TimeTaken(
-                                duration = (Clock.System.now() - initialTime),
-                            )
-                        )
+                    logger.logSuccess()
                 }
         } else {
-            kaliumLogger
-                .logEventProcessing(
-                    EventLoggingStatus.SKIPPED,
-                    event,
-                    Pair("info", "Conversation delete event already handled?. Conversation is null.")
+            logger.logComplete(
+                EventLoggingStatus.SKIPPED,
+                arrayOf(
+                    "info" to "Conversation delete event already handled?. Conversation is null."
                 )
+            )
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
@@ -21,15 +21,13 @@ package com.wire.kalium.logic.sync.receiver.conversation
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.event.EventLoggingStatus
-import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
-import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.util.EventLoggingStatus
+import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.serialization.toJsonElement
-import kotlinx.datetime.Clock
 
 interface MemberChangeEventHandler {
     suspend fun handle(event: Event.Conversation.MemberChanged)
@@ -41,7 +39,7 @@ internal class MemberChangeEventHandlerImpl(
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
 
     override suspend fun handle(event: Event.Conversation.MemberChanged) {
-        val initialTime = Clock.System.now()
+        val eventLogger = kaliumLogger.createEventProcessingLogger(event)
         when (event) {
             is Event.Conversation.MemberChanged.MemberMutedStatusChanged -> {
                 conversationRepository.updateMutedStatusLocally(
@@ -49,14 +47,7 @@ internal class MemberChangeEventHandlerImpl(
                     event.mutedConversationStatus,
                     DateTimeUtil.currentInstant().toEpochMilliseconds()
                 )
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.SUCCESS,
-                        event,
-                        performanceData = EventProcessingPerformanceData.TimeTaken(
-                            duration = (Clock.System.now() - initialTime),
-                        )
-                    )
+                eventLogger.logSuccess()
             }
 
             is Event.Conversation.MemberChanged.MemberArchivedStatusChanged -> {
@@ -65,13 +56,7 @@ internal class MemberChangeEventHandlerImpl(
                     event.isArchiving,
                     DateTimeUtil.currentInstant().toEpochMilliseconds()
                 )
-                kaliumLogger.logEventProcessing(
-                    EventLoggingStatus.SUCCESS,
-                    event,
-                    performanceData = EventProcessingPerformanceData.TimeTaken(
-                        duration = (Clock.System.now() - initialTime),
-                    )
-                )
+                eventLogger.logSuccess()
             }
 
             is Event.Conversation.MemberChanged.MemberChangedRole -> {
@@ -79,25 +64,21 @@ internal class MemberChangeEventHandlerImpl(
             }
 
             else -> {
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.SKIPPED,
-                        event,
-                        Pair("info", "Ignoring 'conversation.member-update' event, not handled yet")
-                    )
+                eventLogger.logComplete(
+                    EventLoggingStatus.SKIPPED,
+                    arrayOf("info" to "Ignoring 'conversation.member-update' event, not handled yet")
+                )
             }
         }
     }
 
     private suspend fun handleMemberChangedRoleEvent(event: Event.Conversation.MemberChanged.MemberChangedRole) {
-        val initialTime = Clock.System.now()
+        val eventLogger = kaliumLogger.createEventProcessingLogger(event)
         // Attempt to fetch conversation details if needed, as this might be an unknown conversation
         conversationRepository.fetchConversationIfUnknown(event.conversationId)
             .run {
                 onSuccess {
-                    val logMap = mapOf(
-                        "event" to event.toLogMap(),
-                    )
+                    val logMap = mapOf("event" to event.toLogMap())
                     logger.v("Succeeded fetching conversation details on MemberChange Event: ${logMap.toJsonElement()}")
                 }
                 onFailure {
@@ -109,21 +90,8 @@ internal class MemberChangeEventHandlerImpl(
                 }
                 // Even if unable to fetch conversation details, at least attempt updating the member
                 conversationRepository.updateMemberFromEvent(event.member!!, event.conversationId)
-            }.onFailure {
-                val logMap = mapOf(
-                    "event" to event.toLogMap(),
-                    "errorInfo" to "$it"
-                )
-                logger.e("Error Handling Event: ${logMap.toJsonElement()}")
-            }.onSuccess {
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.SUCCESS,
-                        event,
-                        performanceData = EventProcessingPerformanceData.TimeTaken(
-                            duration = (Clock.System.now() - initialTime),
-                        )
-                    )
             }
+            .onFailure { eventLogger.logFailure(it) }
+            .onSuccess { eventLogger.logSuccess() }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -24,9 +24,6 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.event.EventLoggingStatus
-import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
-import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
@@ -36,8 +33,8 @@ import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
+import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.util.serialization.toJsonElement
-import kotlinx.datetime.Clock
 
 interface MemberJoinEventHandler {
     suspend fun handle(event: Event.Conversation.MemberJoin): Either<CoreFailure, Unit>
@@ -52,7 +49,7 @@ internal class MemberJoinEventHandlerImpl(
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
 
     override suspend fun handle(event: Event.Conversation.MemberJoin): Either<CoreFailure, Unit> {
-        val initialTime = Clock.System.now()
+        val eventLogger = logger.createEventProcessingLogger(event)
         // the group info need to be fetched for the following cases:
         // 1. self user is added/re-added to a group and we need to update the group info in case something changed form last time
         // 2. the new member is a bot in that case we need to make the group a bot 1:1
@@ -80,21 +77,9 @@ internal class MemberJoinEventHandlerImpl(
                     if (conversation.type == Conversation.Type.GROUP) addSystemMessage(event)
                 }
                 legalHoldHandler.handleConversationMembersChanged(event.conversationId)
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.SUCCESS,
-                        event,
-                        performanceData = EventProcessingPerformanceData.TimeTaken(
-                            duration = (Clock.System.now() - initialTime),
-                        )
-                    )
+                eventLogger.logSuccess()
             }.onFailure {
-                kaliumLogger
-                    .logEventProcessing(
-                        EventLoggingStatus.FAILURE,
-                        event,
-                        Pair("errorInfo", "$it")
-                    )
+                eventLogger.logFailure(it)
             }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -22,9 +22,6 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.conversation.toConversationType
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.event.EventLoggingStatus
-import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
-import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.toDao
@@ -38,9 +35,9 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.DateTimeUtil
-import kotlinx.datetime.Clock
 
 interface NewConversationEventHandler {
     suspend fun handle(event: Event.Conversation.NewConversation)
@@ -55,7 +52,7 @@ internal class NewConversationEventHandlerImpl(
 ) : NewConversationEventHandler {
 
     override suspend fun handle(event: Event.Conversation.NewConversation) {
-        val initialTime = Clock.System.now()
+        val eventLogger = kaliumLogger.createEventProcessingLogger(event)
         val selfUserTeamId = selfTeamIdProvider().getOrNull()
         conversationRepository
             .persistConversation(event.conversation, selfUserTeamId?.value, true)
@@ -70,15 +67,9 @@ internal class NewConversationEventHandlerImpl(
                     .map { isNewUnhandledConversation }
             }.onSuccess { isNewUnhandledConversation ->
                 createSystemMessagesForNewConversation(isNewUnhandledConversation, event)
-                kaliumLogger.logEventProcessing(
-                    status = EventLoggingStatus.SUCCESS,
-                    event = event,
-                    performanceData = EventProcessingPerformanceData.TimeTaken(
-                        duration = (Clock.System.now() - initialTime),
-                    )
-                )
+                eventLogger.logSuccess()
             }.onFailure {
-                kaliumLogger.logEventProcessing(EventLoggingStatus.FAILURE, event, Pair("errorInfo", "$it"))
+                eventLogger.logFailure(it)
             }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -25,9 +25,6 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventDeliveryInfo
-import com.wire.kalium.logic.data.event.EventLoggingStatus
-import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
-import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.typeDescription
@@ -38,8 +35,8 @@ import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
+import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.util.serialization.toJsonElement
-import kotlinx.datetime.Clock
 import kotlinx.datetime.toInstant
 
 internal interface NewMessageEventHandler {
@@ -61,7 +58,7 @@ internal class NewMessageEventHandlerImpl(
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
 
     override suspend fun handleNewProteusMessage(event: Event.Conversation.NewMessage, deliveryInfo: EventDeliveryInfo) {
-        val initialTime = Clock.System.now()
+        val eventLogger = logger.createEventProcessingLogger(event)
         proteusMessageUnpacker.unpackProteusMessage(event)
             .onFailure {
                 val logMap = mapOf(
@@ -90,39 +87,29 @@ internal class NewMessageEventHandlerImpl(
                         clientId = ClientId(event.senderClientId.value)
                     )
                 )
+                eventLogger.logFailure(it, "protocol" to "Proteus")
             }.onSuccess {
                 if (it is MessageUnpackResult.ApplicationMessage) {
                     processApplicationMessage(it, deliveryInfo)
                 }
-                kaliumLogger.logEventProcessing(
-                    status = EventLoggingStatus.SUCCESS,
-                    event = event,
+                eventLogger.logSuccess(
                     "protocol" to "Proteus",
                     "messageType" to it.messageTypeDescription,
-                    performanceData = EventProcessingPerformanceData.TimeTaken(
-                        duration = (Clock.System.now() - initialTime)
-                    )
                 )
             }
     }
 
     override suspend fun handleNewMLSMessage(event: Event.Conversation.NewMLSMessage, deliveryInfo: EventDeliveryInfo) {
-        var initialTime = Clock.System.now()
+        var eventLogger = logger.createEventProcessingLogger(event)
         mlsMessageUnpacker.unpackMlsMessage(event)
             .onFailure {
-                val logMap = mapOf(
-                    "event" to event.toLogMap(),
-                    "errorInfo" to "$it",
-                    "protocol" to "MLS"
-                )
-
                 when (MLSMessageFailureHandler.handleFailure(it)) {
                     is MLSMessageFailureResolution.Ignore -> {
-                        logger.i("Ignoring event: ${logMap.toJsonElement()}")
+                        eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "IGNORE")
                     }
 
                     is MLSMessageFailureResolution.InformUser -> {
-                        logger.i("Informing users about decryption error: ${logMap.toJsonElement()}")
+                        eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "INFORM_USER")
                         applicationMessageHandler.handleDecryptionError(
                             eventId = event.id,
                             conversationId = event.conversationId,
@@ -137,7 +124,7 @@ internal class NewMessageEventHandlerImpl(
                     }
 
                     is MLSMessageFailureResolution.OutOfSync -> {
-                        logger.i("Epoch out of sync error: ${logMap.toJsonElement()}")
+                        eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "OUT_OF_SYNC")
                         staleEpochVerifier.verifyEpoch(
                             event.conversationId,
                             event.timestampIso.toInstant()
@@ -149,18 +136,13 @@ internal class NewMessageEventHandlerImpl(
                     if (message is MessageUnpackResult.ApplicationMessage) {
                         processApplicationMessage(message, deliveryInfo)
                     }
-                    kaliumLogger.logEventProcessing(
-                        status = EventLoggingStatus.SUCCESS,
-                        event = event,
+                    eventLogger.logSuccess(
                         "protocol" to "MLS",
                         "isPartOfMLSBatch" to (batchResult.size > 1),
-                        "messageType" to message.messageTypeDescription,
-                        performanceData = EventProcessingPerformanceData.TimeTaken(
-                            duration = (Clock.System.now() - initialTime)
-                        )
+                        "messageType" to message.messageTypeDescription
                     )
                     // reset the time for next messages, if this is a batch
-                    initialTime = Clock.System.now()
+                    eventLogger = logger.createEventProcessingLogger(event)
                 }
             }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/TypingIndicatorHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/TypingIndicatorHandler.kt
@@ -17,18 +17,14 @@
  */
 package com.wire.kalium.logic.sync.receiver.handler
 
-import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.TypingIndicatorIncomingRepository
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.event.EventLoggingStatus
-import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
-import com.wire.kalium.logic.data.event.logEventProcessing
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.kaliumLogger
-import kotlinx.datetime.Clock
+import com.wire.kalium.logic.util.createEventProcessingLogger
 
 internal interface TypingIndicatorHandler {
     suspend fun handle(event: Event.Conversation.TypingIndicator): Either<StorageFailure, Unit>
@@ -39,16 +35,9 @@ internal class TypingIndicatorHandlerImpl(
     private val typingIndicatorIncomingRepository: TypingIndicatorIncomingRepository
 ) : TypingIndicatorHandler {
     override suspend fun handle(event: Event.Conversation.TypingIndicator): Either<StorageFailure, Unit> {
-        val initialTime = Clock.System.now()
+        val eventLogger = kaliumLogger.createEventProcessingLogger(event)
         if (event.senderUserId == selfUserId) {
-            kaliumLogger.withFeatureId(EVENT_RECEIVER).logEventProcessing(
-                EventLoggingStatus.SKIPPED,
-                event,
-                "isForSelfUser" to true,
-                performanceData = EventProcessingPerformanceData.TimeTaken(
-                    duration = (Clock.System.now() - initialTime)
-                )
-            )
+            eventLogger.logSuccess("isForSelfUser" to true)
             return Either.Right(Unit)
         }
 
@@ -63,16 +52,7 @@ internal class TypingIndicatorHandlerImpl(
                 event.senderUserId
             )
         }.also {
-            kaliumLogger
-                .withFeatureId(EVENT_RECEIVER)
-                .logEventProcessing(
-                    status = EventLoggingStatus.SUCCESS,
-                    event = event,
-                    "isForSelfUser" to false,
-                    performanceData = EventProcessingPerformanceData.TimeTaken(
-                        duration = (Clock.System.now() - initialTime),
-                    )
-                )
+            eventLogger.logSuccess("isForSelfUser" to false)
         }
 
         return Either.Right(Unit)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/EventProcessingLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/EventProcessingLogger.kt
@@ -1,0 +1,106 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util
+
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventProcessingPerformanceData
+import com.wire.kalium.logic.logStructuredJson
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * The `EventProcessingLogger` class is responsible for logging event processing details.
+ *
+ * @property logger The underlying logging implementation used for logging.
+ * @property event The event being processed.
+ * @property startOfProcessing The start time of event processing. Defaults to the current system time.
+ */
+internal class EventProcessingLogger(
+    private val logger: KaliumLogger,
+    private val event: Event,
+    private val startOfProcessing: Instant
+) {
+
+    /**
+     * Logs event processing.
+     * Will use the difference between the current system time and [startOfProcessing] to log performance data.
+     * Underlying implementation detail is using the common [KaliumLogger.logStructuredJson] to log structured JSON.
+     */
+    fun logComplete(
+        status: EventLoggingStatus,
+        extraInfo: Array<out Pair<String, Any>> = arrayOf()
+    ) = with(logger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER)) {
+        val duration = Clock.System.now() - startOfProcessing
+        val performanceData = EventProcessingPerformanceData.TimeTaken(duration)
+
+        val logMap = event.toLogMap().toMutableMap()
+        logMap += extraInfo
+
+        logMap["eventPerformanceData"] = performanceData.logData
+
+        when (status) {
+            EventLoggingStatus.SUCCESS -> {
+                logMap["outcome"] = "success"
+                logStructuredJson(KaliumLogLevel.INFO, "Success handling event", logMap)
+            }
+
+            EventLoggingStatus.FAILURE -> {
+                logMap["outcome"] = "failure"
+                logStructuredJson(KaliumLogLevel.ERROR, "Failure handling event", logMap)
+            }
+
+            EventLoggingStatus.SKIPPED -> {
+                logMap["outcome"] = "skipped"
+                logStructuredJson(KaliumLogLevel.WARN, "Skipped handling event", logMap)
+            }
+        }
+    }
+
+    /**
+     * Logs the event processing as successful.
+     * Will use the difference between the current system time and [startOfProcessing] to log performance data.
+     */
+    fun logSuccess(vararg extraInfo: Pair<String, Any>) {
+        logComplete(EventLoggingStatus.SUCCESS, extraInfo)
+    }
+
+    /**
+     * Logs the event processing as failed.
+     * Will use the difference between the current system time and [startOfProcessing] to log performance data.
+     */
+    fun logFailure(failure: CoreFailure? = null, vararg extraInfo: Pair<String, Any>) {
+        if (failure != null) {
+            logComplete(EventLoggingStatus.FAILURE, arrayOf("error" to failure, *extraInfo))
+        } else {
+            logComplete(EventLoggingStatus.FAILURE, extraInfo)
+        }
+    }
+}
+
+internal enum class EventLoggingStatus {
+    SUCCESS,
+    FAILURE,
+    SKIPPED
+}
+
+internal fun KaliumLogger.createEventProcessingLogger(
+    event: Event
+) = EventProcessingLogger(this, event, Clock.System.now())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9788" title="WPB-9788" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9788</a>  [Android] Add event processing performance logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Refactored all event logging code across all event handlers to use a helper logger. This allows concise, consistent event logging.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Too much code repetition for logging events, especially after I added performance metrics.

### Solutions

Simplify by creating an logger per event, with log functions for success/failure.
This can also take care of logging the time it took between start and end.

Example of the final result:

#### Before

```kotlin
        val initialTime = Clock.System.now()
        return handleFeatureConfigEvent(event)
            .onSuccess {
                kaliumLogger.logEventProcessing(
                    EventLoggingStatus.SUCCESS,
                    event,
                    performanceData = EventProcessingPerformanceData.TimeTaken(
                        (Clock.System.now() - initialTime)
                    )
                )
            }
            .onFailure {
                kaliumLogger.logEventProcessing(
                    EventLoggingStatus.FAILURE,
                    event,
                    Pair("error", it)
                )
            }
    }
```
#### After

```kotlin
       val logger = kaliumLogger.createEventProcessingLogger(event)
        return handleFeatureConfigEvent(event)
            .onSuccess { logger.logSuccess() }
            .onFailure { logger.logFailure(it) }
```

### Testing

#### How to Test

Play around with the app and open the logs!

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
