### PR TITLE
fix: Split NoCommonProtocol error

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -107,7 +107,10 @@ sealed interface CoreFailure {
      * No common Protocol found in order to establish a conversation between parties.
      * Could be, for example, that the desired user only supports Proteus, but we only support MLS.
      */
-    data object NoCommonProtocolFound : FeatureFailure()
+    sealed class NoCommonProtocolFound : FeatureFailure() {
+        data object SelfNeedToUpdate: NoCommonProtocolFound()
+        data object OtherNeedToUpdate: NoCommonProtocolFound()
+    }
 }
 
 sealed class NetworkFailure : CoreFailure {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -108,8 +108,14 @@ sealed interface CoreFailure {
      * Could be, for example, that the desired user only supports Proteus, but we only support MLS.
      */
     sealed class NoCommonProtocolFound : FeatureFailure() {
-        data object SelfNeedToUpdate: NoCommonProtocolFound()
-        data object OtherNeedToUpdate: NoCommonProtocolFound()
+        /**
+         * SelfClient needs to update to support MLS
+         */
+        data object SelfNeedToUpdate : NoCommonProtocolFound()
+        /**
+         * Other User needs to update to support MLS
+         */
+        data object OtherNeedToUpdate : NoCommonProtocolFound()
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelector.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelector.kt
@@ -52,7 +52,8 @@ internal class OneOnOneProtocolSelectorImpl(
             return when {
                 commonProtocols.contains(SupportedProtocol.MLS) -> Either.Right(SupportedProtocol.MLS)
                 commonProtocols.contains(SupportedProtocol.PROTEUS) -> Either.Right(SupportedProtocol.PROTEUS)
-                else -> Either.Left(CoreFailure.NoCommonProtocolFound)
+                selfUserProtocols.contains(SupportedProtocol.MLS) -> Either.Left(CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate)
+                else -> Either.Left(CoreFailure.NoCommonProtocolFound.SelfNeedToUpdate)
             }
         }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -71,7 +71,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         val (_, useCase) = arrange {
             withObserveOneToOneConversationWithOtherUserReturning(Either.Left(StorageFailure.DataNotFound))
             withUserByIdReturning(OTHER_USER.right())
-            withResolveOneOnOneConversationWithUserReturning(Either.Left(CoreFailure.NoCommonProtocolFound))
+            withResolveOneOnOneConversationWithUserReturning(Either.Left(CoreFailure.NoCommonProtocolFound.SelfNeedToUpdate))
         }
 
         // when

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelectorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelectorTest.kt
@@ -147,7 +147,22 @@ class OneOnOneProtocolSelectorTest {
 
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
             .shouldFail {
-                assertIs<CoreFailure.NoCommonProtocolFound>(it)
+                assertIs<CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate>(it)
+            }
+    }
+
+    @Test
+    fun givenUsersHaveNoProtocolInCommon_thenShouldReturnNoCommonProtocol_2() = runTest {
+        val failure = StorageFailure.DataNotFound
+        val (_, oneOnOneProtocolSelector) = arrange {
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.PROTEUS)))
+            withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS))))
+            withGetDefaultProtocolReturning(failure.left())
+        }
+
+        oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
+            .shouldFail {
+                assertIs<CoreFailure.NoCommonProtocolFound.SelfNeedToUpdate>(it)
             }
     }
 


### PR DESCRIPTION
# What's new in this PR?

### Issues

For displaying correct error message in UI we need to split `NoCommonProtocol` error into 
- `SelfNeedToUpdate` means current client is old, doesn't support MLS and needs to update
- `OtherNeedToUpdate` means other user (that we are trying to communicate) has old version, doesn't support MLS and needs to update.

### Causes (Optional)

Was not implemented, was not needed

### Solutions

Just do it. 💪 
and update tests
