### PR TITLE
fix: crash on delivery confirmation queue cleanup (WPB-9023) 

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandlerTest.kt
@@ -38,7 +38,9 @@ import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.mock
+import io.mockative.twice
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -153,15 +155,20 @@ class ConfirmationDeliveryHandlerTest {
         advanceUntilIdle()
 
         val messagesCount = 500
-        launch { repeat(messagesCount) { sut.enqueueConfirmationDelivery(TestConversation.ID, uuid4().toString()) } }
+        launch {
+            repeat(messagesCount) { sut.enqueueConfirmationDelivery(TestConversation.ID, uuid4().toString()) }
+            delay(2000)
+        }
         advanceTimeBy(1000L)
-        launch { repeat(messagesCount) { sut.enqueueConfirmationDelivery(TestConversation.ID, uuid4().toString()) } }
+        launch {
+            repeat(messagesCount) { sut.enqueueConfirmationDelivery(TestConversation.ID, uuid4().toString()) }
+            delay(2000)
+        }
         advanceTimeBy(2000L)
-
         job.cancel()
 
         coVerify { arrangement.conversationRepository.observeCacheDetailsById(any()) }.wasInvoked()
-        coVerify { arrangement.messageSender.sendMessage(any(), any()) }.wasInvoked()
+        coVerify { arrangement.messageSender.sendMessage(any(), any()) }.wasInvoked(twice)
         assertTrue(arrangement.pendingConfirmationMessages.isEmpty())
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9023" title="WPB-9023" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9023</a>  [Android] Delivered status of messages not properly propagating
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is a crash while removing from the queue of messages that needs delivery confirmations

### Causes (Optional)

Not thread safe the removal part

### Solutions

Use the `mutex.withBlock`, to safely remove.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
