### PR TITLE
fix: stuck while processing messages [WPB-9814]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.logStructuredJson
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -66,7 +67,7 @@ internal class ConfirmationDeliveryHandlerImpl(
 ) : ConfirmationDeliveryHandler {
 
     private val kaliumLogger = kaliumLogger.withTextTag("ConfirmationDeliveryHandler")
-    private val holder = MutableSharedFlow<Unit>()
+    private val holder = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     private val mutex = Mutex()
 
     override suspend fun enqueueConfirmationDelivery(conversationId: ConversationId, messageId: String) = mutex.withLock {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9814" title="WPB-9814" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9814</a>  [Android] Stuck on message decryption
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App is getting stuck while processing some messages

### Causes

When `ConfirmationDeliveryHandlerImpl$enqueueConfirmationDelivery` is called, it will emit to a collector, that eventually is going to work on pending delivery receipts.

This worker _waits_ until Sync is done.

`ConfirmationDeliveryHandlerImpl$enqueueConfirmationDelivery` emits to a `SharedFlow` that has no buffer and `SUSPEND` strategy (default values).
This means that it will _wait_ until the collector is able to collect it. However, the collector is busy waiting for sync.

It leads to a deadlock.

### Solutions

Make it so the flow has a buffer size = 1, and it drops the oldest emitted value. This way, the emitter will never wait for the collector, whatever it does.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
