### PR TITLE
feat: add SetVideoSendStateUseCase (WPB-7114) - cherrypick 4.4

### DIFF
--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -56,7 +56,7 @@ class CallManagerImpl : CallManager {
         TODO("Not yet implemented")
     }
 
-    override suspend fun updateVideoState(conversationId: ConversationId, videoState: VideoState) {
+    override suspend fun setVideoSendState(conversationId: ConversationId, videoState: VideoState) {
         TODO("Not yet implemented")
     }
 

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -344,7 +344,7 @@ class CallManagerImpl internal constructor(
     /**
      * This method should NOT be called while the call is still incoming or outgoing and not established yet.
      */
-    override suspend fun updateVideoState(conversationId: ConversationId, videoState: VideoState) {
+    override suspend fun setVideoSendState(conversationId: ConversationId, videoState: VideoState) {
         withCalling {
             callingLogger.d("$TAG -> changing video state to ${videoState.name}..")
             scope.launch {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -41,7 +41,7 @@ interface CallManager {
     suspend fun endCall(conversationId: ConversationId)
     suspend fun rejectCall(conversationId: ConversationId)
     suspend fun muteCall(shouldMute: Boolean)
-    suspend fun updateVideoState(conversationId: ConversationId, videoState: VideoState)
+    suspend fun setVideoSendState(conversationId: ConversationId, videoState: VideoState)
     suspend fun requestVideoStreams(conversationId: ConversationId, callClients: CallClientList)
     suspend fun updateEpochInfo(conversationId: ConversationId, epochInfo: EpochInfo)
     suspend fun updateConversationClients(conversationId: ConversationId, clients: String)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -63,7 +63,8 @@ import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCaseImpl
-import com.wire.kalium.logic.feature.call.usecase.UpdateVideoStateUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
+import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.util.KaliumDispatcherImpl
@@ -141,7 +142,8 @@ class CallsScope internal constructor(
 
     val unMuteCall: UnMuteCallUseCase get() = UnMuteCallUseCaseImpl(callManager, callRepository)
 
-    val updateVideoState: UpdateVideoStateUseCase get() = UpdateVideoStateUseCase(callManager, callRepository)
+    val updateVideoState: UpdateVideoStateUseCase get() = UpdateVideoStateUseCase(callRepository)
+    val setVideoSendState: SetVideoSendStateUseCase get() = SetVideoSendStateUseCase(callManager)
 
     val setVideoPreview: SetVideoPreviewUseCase get() = SetVideoPreviewUseCase(flowManagerService)
     val flipToFrontCamera: FlipToFrontCameraUseCase get() = FlipToFrontCameraUseCase(flowManagerService)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/video/SetVideoSendStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/video/SetVideoSendStateUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase.video
+
+import com.wire.kalium.logic.data.call.VideoState
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.CallManager
+
+/**
+ * This usecase is responsible for setting the video send state of a call.
+ */
+class SetVideoSendStateUseCase(
+    private val callManager: Lazy<CallManager>,
+) {
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        videoState: VideoState
+    ) {
+        callManager.value.setVideoSendState(conversationId, videoState)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/video/UpdateVideoStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/video/UpdateVideoStateUseCase.kt
@@ -16,20 +16,17 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call.usecase
+package com.wire.kalium.logic.feature.call.usecase.video
 
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.call.CallManager
-import kotlinx.coroutines.flow.first
 
 /**
- * This use case is responsible for updating the video state of a call.
+ * This use case is responsible for updating and caching the video state of a call.
  * @see [VideoState]
  */
 class UpdateVideoStateUseCase(
-    private val callManager: Lazy<CallManager>,
     private val callRepository: CallRepository
 ) {
     /**
@@ -42,12 +39,5 @@ class UpdateVideoStateUseCase(
     ) {
         if (videoState != VideoState.PAUSED)
             callRepository.updateIsCameraOnById(conversationId, videoState == VideoState.STARTED)
-
-        // updateVideoState should be called only when the call is established
-        callRepository.establishedCallsFlow().first().find { call ->
-            call.conversationId == conversationId
-        }?.let {
-            callManager.value.updateVideoState(conversationId, videoState)
-        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/video/SetVideoSendStateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/video/SetVideoSendStateUseCaseTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase.video
+
+import com.wire.kalium.logic.data.call.VideoState
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.framework.TestConversation
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class SetVideoSendStateUseCaseTest {
+
+    @Test
+    fun givenVideoState_whenRunningUsecase_thenInvokeSetVideoSendStateOnce() = runTest {
+        val (arrangement, setVideoSendState) = Arrangement()
+            .arrange()
+
+        setVideoSendState.invoke(TestConversation.ID, VideoState.STARTED)
+
+        verify(arrangement.callManager)
+            .suspendFunction(arrangement.callManager::setVideoSendState)
+            .with(any(), eq(VideoState.STARTED))
+            .wasInvoked(once)
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val callManager = mock(classOf<CallManager>())
+
+        val setVideoSendState = SetVideoSendStateUseCase(lazy { callManager })
+
+        fun arrange() = this to setVideoSendState
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/video/UpdateVideoStateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/video/UpdateVideoStateUseCaseTest.kt
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2023 Wire Swiss GmbH
+ * Copyright (C) 2024 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,17 +16,15 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call.usecase
+package com.wire.kalium.logic.feature.call.usecase.video
 
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.Call
-import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.call.CallStatus
 import io.mockative.Mock
-import io.mockative.any
 import io.mockative.classOf
 import io.mockative.eq
 import io.mockative.given
@@ -42,25 +40,17 @@ import kotlin.test.Test
 class UpdateVideoStateUseCaseTest {
 
     @Mock
-    private val callManager = mock(classOf<CallManager>())
-
-    @Mock
     private val callRepository = mock(classOf<CallRepository>())
 
     private lateinit var updateVideoStateUseCase: UpdateVideoStateUseCase
 
     @BeforeTest
     fun setup() {
-        updateVideoStateUseCase = UpdateVideoStateUseCase(lazy { callManager }, callRepository)
+        updateVideoStateUseCase = UpdateVideoStateUseCase(callRepository)
         given(callRepository)
             .function(callRepository::updateIsCameraOnById)
             .whenInvokedWith(eq(conversationId.toString()), eq(isCameraOn))
             .thenDoNothing()
-
-        given(callManager)
-            .suspendFunction(callManager::updateVideoState)
-            .whenInvokedWith(any(), any())
-            .thenReturn(Unit)
     }
 
     @Test
@@ -77,10 +67,6 @@ class UpdateVideoStateUseCaseTest {
             null,
             null
         )
-        given(callManager)
-            .suspendFunction(callManager::updateVideoState)
-            .whenInvokedWith(eq(conversationId), eq(videoState))
-            .thenDoNothing()
 
         given(callRepository)
             .suspendFunction(callRepository::establishedCallsFlow)
@@ -97,11 +83,6 @@ class UpdateVideoStateUseCaseTest {
         verify(callRepository)
             .function(callRepository::updateIsCameraOnById)
             .with(eq(conversationId), eq(isCameraOn))
-            .wasInvoked(once)
-
-        verify(callManager)
-            .suspendFunction(callManager::updateVideoState)
-            .with(any(), any())
             .wasInvoked(once)
     }
 
@@ -124,11 +105,6 @@ class UpdateVideoStateUseCaseTest {
             .function(callRepository::updateIsCameraOnById)
             .with(eq(conversationId), eq(isCameraOn))
             .wasInvoked(once)
-
-        verify(callManager)
-            .suspendFunction(callManager::updateVideoState)
-            .with(any(), any())
-            .wasNotInvoked()
     }
 
     companion object {


### PR DESCRIPTION
cherry pick of 
- https://github.com/wireapp/kalium/pull/2670

----
# What's new in this PR?

### Description

Moving the logic of updating send state to a separate usecase.
Needed for https://github.com/wireapp/wire-android/pull/3125

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
