### PR TITLE
fix: end call update status (WPB-9878)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
@@ -55,8 +55,12 @@ internal class EndCallUseCaseImpl(
     override suspend operator fun invoke(conversationId: ConversationId) = withContext(dispatchers.default) {
         callRepository.callsFlow().first().find {
             // This use case can be invoked while joining the call or when the call is established.
-            it.conversationId == conversationId &&
-                    (it.status == CallStatus.STILL_ONGOING || it.status == CallStatus.ESTABLISHED)
+            it.conversationId == conversationId && it.status in listOf(
+                CallStatus.STARTED,
+                CallStatus.INCOMING,
+                CallStatus.STILL_ONGOING,
+                CallStatus.ESTABLISHED
+            )
         }?.let {
             if (it.conversationType == Conversation.Type.GROUP) {
                 callingLogger.d("[EndCallUseCase] -> Updating call status to CLOSED_INTERNALLY")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCaseTest.kt
@@ -108,7 +108,58 @@ class EndCallUseCaseTest {
         coVerify {
             callRepository.updateCallStatusById(eq(conversationId), eq(CallStatus.CLOSED_INTERNALLY))
         }.wasInvoked(once)
+    }
 
+    @Test
+    fun givenStartedOutgoingCall_whenEndCallIsInvoked_thenUpdateStatusAndInvokeEndCallOnce() = runTest(TestKaliumDispatcher.main) {
+        val stillOngoingCall = call.copy(
+            status = CallStatus.STARTED,
+            conversationType = Conversation.Type.GROUP
+        )
+
+        coEvery {
+            callRepository.callsFlow()
+        }.returns(flowOf(listOf(stillOngoingCall)))
+
+        endCall.invoke(conversationId)
+
+        coVerify {
+            callManager.endCall(eq(conversationId))
+        }.wasInvoked(once)
+
+        verify {
+            callRepository.updateIsCameraOnById(eq(conversationId), eq(false))
+        }.wasInvoked(once)
+
+        coVerify {
+            callRepository.updateCallStatusById(eq(conversationId), eq(CallStatus.CLOSED_INTERNALLY))
+        }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenIncomingCall_whenEndCallIsInvoked_thenUpdateStatusAndInvokeEndCallOnce() = runTest(TestKaliumDispatcher.main) {
+        val stillOngoingCall = call.copy(
+            status = CallStatus.INCOMING,
+            conversationType = Conversation.Type.GROUP
+        )
+
+        coEvery {
+            callRepository.callsFlow()
+        }.returns(flowOf(listOf(stillOngoingCall)))
+
+        endCall.invoke(conversationId)
+
+        coVerify {
+            callManager.endCall(eq(conversationId))
+        }.wasInvoked(once)
+
+        verify {
+            callRepository.updateIsCameraOnById(eq(conversationId), eq(false))
+        }.wasInvoked(once)
+
+        coVerify {
+            callRepository.updateCallStatusById(eq(conversationId), eq(CallStatus.CLOSED_INTERNALLY))
+        }.wasInvoked(once)
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9878" title="WPB-9878" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9878</a>  [Android] EndCallUseCase doesn't update call when its incoming or outgoing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When ending an incoming/outgoing call, `EndCallUseCase` wouldn't update the database with correct call status (`CLOSED`)

### Causes (Optional)

We were not verifying these 2 status (INCOMING / outgoing(STARTED)) in EndCallUseCase

### Solutions

Add verification of `INCOMING` and outgoing(`STARTED`) when ending a call

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- From AR with this Kalium version:
     1. start a call and end the call 
     2. receive a call and end the call

on both cases, the green top app bar should be dismissed/hidden after call is properly ended.
