### PR TITLE
fix(mls-migration): allow skipping users without KeyPackages during MLS migration (WPB-9638)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -493,17 +493,17 @@ internal class MLSConversationDataSource(
         allowPartialMemberList: Boolean = false,
     ): Either<CoreFailure, MLSAdditionResult> = withContext(serialDispatcher) {
         commitPendingProposals(groupID).flatMap {
-            kaliumLogger.w("adding ${userIdList.count()} users to MLS group")
+            kaliumLogger.d("adding ${userIdList.count()} users to MLS group")
             produceAndSendCommitWithRetryAndResult(groupID, retryOnStaleMessage = retryOnStaleMessage) {
                 keyPackageRepository.claimKeyPackages(userIdList, cipherSuite).flatMap { result ->
                     if (result.usersWithoutKeyPackagesAvailable.isNotEmpty() && !allowPartialMemberList) {
-                        kaliumLogger.w(
+                        kaliumLogger.d(
                             "add members to MLS Group: failed " +
                                     "${result.usersWithoutKeyPackagesAvailable.count()} user(s) missing KeyPackages"
                         )
                         Either.Left(CoreFailure.MissingKeyPackages(result.usersWithoutKeyPackagesAvailable))
                     } else {
-                        kaliumLogger.w("add members to MLS Group: claiming KeyPackages succeed")
+                        kaliumLogger.d("add members to MLS Group: claiming KeyPackages succeed")
                         Either.Right(result)
                     }
                 }.flatMap { result ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -493,12 +493,17 @@ internal class MLSConversationDataSource(
         allowPartialMemberList: Boolean = false,
     ): Either<CoreFailure, MLSAdditionResult> = withContext(serialDispatcher) {
         commitPendingProposals(groupID).flatMap {
-            kaliumLogger.d("adding $userIdList to MLS group: $groupID")
+            kaliumLogger.w("adding ${userIdList.count()} users to MLS group")
             produceAndSendCommitWithRetryAndResult(groupID, retryOnStaleMessage = retryOnStaleMessage) {
                 keyPackageRepository.claimKeyPackages(userIdList, cipherSuite).flatMap { result ->
                     if (result.usersWithoutKeyPackagesAvailable.isNotEmpty() && !allowPartialMemberList) {
+                        kaliumLogger.w(
+                            "add members to MLS Group: failed " +
+                                    "${result.usersWithoutKeyPackagesAvailable.count()} user(s) missing KeyPackages"
+                        )
                         Either.Left(CoreFailure.MissingKeyPackages(result.usersWithoutKeyPackagesAvailable))
                     } else {
+                        kaliumLogger.w("add members to MLS Group: claiming KeyPackages succeed")
                         Either.Right(result)
                     }
                 }.flatMap { result ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrator.kt
@@ -138,7 +138,11 @@ internal class MLSMigratorImpl(
                 when (protocolInfo) {
                     is Conversation.ProtocolInfo.Mixed -> {
                         conversationRepository.getConversationMembers(conversationId).flatMap { members ->
-                            mlsConversationRepository.establishMLSGroup(protocolInfo.groupId, members)
+                            mlsConversationRepository.establishMLSGroup(
+                                protocolInfo.groupId,
+                                members,
+                                allowSkippingUsersWithoutKeyPackages = true
+                            )
                         }
                         Unit.right()
                     }


### PR DESCRIPTION
…ls migration

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
When the migration started by android, and it needs to be finalised, we must migrate the groups even if there are users don't have keypackages or mls clients!
In this PR during the migration we set establish mls group with allowing partial member adding enabled.

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
