### PR TITLE
refactor!: use Instant instead of string in most places [WPB-9216]

### DIFF
--- a/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -49,6 +49,8 @@ import kotlin.test.Ignore
 import kotlin.test.Test
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.network.NetworkStateObserver
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.datetime.Instant
 
 class CallManagerTest {
 
@@ -160,7 +162,7 @@ class CallManagerTest {
             id = "id",
             content = CALL_CONTENT,
             conversationId = ConversationId(value = "value", domain = "domain"),
-            date = "2022-03-30T15:36:00.000Z",
+            date = Instant.parse("2022-03-30T15:36:00.000Z"),
             senderUserId = UserId(value = "value", domain = "domain"),
             senderClientId = ClientId(value = "value"),
             status = Message.Status.Sent,

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -76,7 +76,6 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.util.toInt
 import com.wire.kalium.network.NetworkStateObserver
-import com.wire.kalium.util.DateTimeUtil.toEpochMillis
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import io.ktor.util.encodeBase64
@@ -243,7 +242,6 @@ class CallManagerImpl internal constructor(
 
         if (callingValue.type != REMOTE_MUTE_TYPE || shouldRemoteMute) {
             val currTime = System.currentTimeMillis()
-            val msgTime = message.date.toEpochMillis()
 
             val targetConversationId = if (message.isSelfMessage) {
                 content.conversationId ?: message.conversationId
@@ -260,7 +258,7 @@ class CallManagerImpl internal constructor(
                 msg = msg,
                 len = msg.size,
                 curr_time = Uint32_t(value = currTime / 1000),
-                msg_time = Uint32_t(value = msgTime / 1000),
+                msg_time = Uint32_t(value = message.date.epochSeconds),
                 convId = federatedIdMapper.parseToFederatedId(targetConversationId),
                 userId = federatedIdMapper.parseToFederatedId(message.senderUserId),
                 clientId = message.senderClientId.value,

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnHttpRequest.kt
@@ -35,10 +35,10 @@ import com.wire.kalium.logic.data.message.MessageTarget
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 
 internal class OnHttpRequest(
     private val handle: Deferred<Handle>,
@@ -111,7 +111,7 @@ internal class OnHttpRequest(
         selfConversationId: ConversationId? = null
     ): Either<CoreFailure, Unit> {
         val messageContent = MessageContent.Calling(data, conversationId)
-        val date = DateTimeUtil.currentIsoDateTimeString()
+        val date = Clock.System.now()
         val message = Message.Signaling(
             id = uuid4().toString(),
             content = messageContent,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapper.kt
@@ -30,10 +30,6 @@ import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionDTO
 import com.wire.kalium.persistence.dao.ConnectionEntity
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
-import com.wire.kalium.util.time.UNIX_FIRST_DATE
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 
 interface ConnectionMapper {
     fun fromApiToDao(state: ConnectionDTO): ConnectionEntity
@@ -52,7 +48,7 @@ internal class ConnectionMapperImpl(
     override fun fromApiToDao(state: ConnectionDTO): ConnectionEntity = ConnectionEntity(
         conversationId = state.conversationId,
         from = state.from,
-        lastUpdateDate = state.lastUpdate.safeDateToInstant(),
+        lastUpdateDate = state.lastUpdate,
         qualifiedConversationId = idMapper.fromApiToDao(state.qualifiedConversationId),
         qualifiedToId = idMapper.fromApiToDao(state.qualifiedToId),
         status = statusMapper.fromApiToDao(state.status),
@@ -63,7 +59,7 @@ internal class ConnectionMapperImpl(
         Connection(
             conversationId = conversationId,
             from = from,
-            lastUpdate = lastUpdateDate.toIsoDateTimeString(),
+            lastUpdate = lastUpdateDate,
             qualifiedConversationId = qualifiedConversationId.toModel(),
             qualifiedToId = qualifiedToId.toModel(),
             status = statusMapper.fromDaoModel(status),
@@ -79,7 +75,7 @@ internal class ConnectionMapperImpl(
             conversationId = qualifiedConversationId.toModel(),
             otherUser = otherUser?.let { userMapper.fromUserEntityToOtherUser(it) },
             userType = otherUser?.let { userTypeMapper.fromUserTypeEntity(it.userType) } ?: UserType.GUEST,
-            lastModifiedDate = lastUpdateDate.toIsoDateTimeString(),
+            lastModifiedDate = lastUpdateDate,
             connection = fromDaoToModel(this),
             protocolInfo = ProtocolInfo.Proteus,
             // TODO(qol): need to be refactored
@@ -101,12 +97,10 @@ internal class ConnectionMapperImpl(
     override fun modelToDao(state: Connection): ConnectionEntity = ConnectionEntity(
         conversationId = state.conversationId,
         from = state.from,
-        lastUpdateDate = state.lastUpdate.safeDateToInstant(),
+        lastUpdateDate = state.lastUpdate,
         qualifiedConversationId = state.qualifiedConversationId.toDao(),
         qualifiedToId = state.qualifiedToId.toDao(),
         status = statusMapper.toDaoModel(state.status),
         toId = state.toId,
     )
-
-    private fun String.safeDateToInstant() = takeIf { it.isNotBlank() }?.toInstant() ?: Instant.UNIX_FIRST_DATE
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -64,7 +64,6 @@ import com.wire.kalium.persistence.dao.member.MemberDAO
 import com.wire.kalium.persistence.dao.member.MemberEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.datetime.toInstant
 
 interface ConnectionRepository {
     suspend fun fetchSelfUserConnections(): Either<CoreFailure, Unit>
@@ -238,8 +237,8 @@ internal class ConnectionDataSource(
                         protocolInfo = ConversationEntity.ProtocolInfo.Proteus,
                         creatorId = connection.from,
                         lastNotificationDate = null,
-                        lastModifiedDate = connection.lastUpdate.toInstant(),
-                        lastReadDate = connection.lastUpdate.toInstant(),
+                        lastModifiedDate = connection.lastUpdate,
+                        lastReadDate = connection.lastUpdate,
                         access = emptyList(),
                         accessRole = emptyList(),
                         receiptMode = ConversationEntity.ReceiptMode.DISABLED,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.data.user.User
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.util.serialization.toJsonElement
-import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
 
@@ -66,9 +65,9 @@ data class Conversation(
     val protocol: ProtocolInfo,
     val mutedStatus: MutedConversationStatus,
     val removedBy: UserId?,
-    val lastNotificationDate: String?,
-    val lastModifiedDate: String?,
-    val lastReadDate: String,
+    val lastNotificationDate: Instant?,
+    val lastModifiedDate: Instant?,
+    val lastReadDate: Instant,
     val access: List<Access>,
     val accessRole: List<AccessRole>,
     val creatorId: String?,
@@ -310,27 +309,27 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         val conversationId: ConversationId,
         val otherUser: OtherUser?,
         val userType: UserType,
-        val lastModifiedDate: String,
+        val lastModifiedDate: Instant,
         val connection: com.wire.kalium.logic.data.user.Connection,
-        val protocolInfo: Conversation.ProtocolInfo,
-        val access: List<Conversation.Access>,
-        val accessRole: List<Conversation.AccessRole>
+        val protocolInfo: ProtocolInfo,
+        val access: List<Access>,
+        val accessRole: List<AccessRole>
     ) : ConversationDetails(
         Conversation(
             id = conversationId,
             name = otherUser?.name,
-            type = Conversation.Type.CONNECTION_PENDING,
+            type = Type.CONNECTION_PENDING,
             teamId = otherUser?.teamId,
             protocol = protocolInfo,
             mutedStatus = MutedConversationStatus.AllAllowed,
             removedBy = null,
             lastNotificationDate = null,
             lastModifiedDate = lastModifiedDate,
-            lastReadDate = UNIX_FIRST_DATE,
+            lastReadDate = Instant.DISTANT_PAST,
             access = access,
             accessRole = accessRole,
             creatorId = null,
-            receiptMode = Conversation.ReceiptMode.DISABLED,
+            receiptMode = ReceiptMode.DISABLED,
             messageTimer = null,
             userMessageTimer = null,
             archived = false,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -16,6 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 @file:Suppress("TooManyFunctions")
+
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.cryptography.E2EIConversationState
@@ -50,7 +51,6 @@ import com.wire.kalium.persistence.dao.conversation.ConversationViewEntity
 import com.wire.kalium.persistence.dao.conversation.ProposalTimerEntity
 import com.wire.kalium.persistence.util.requireField
 import com.wire.kalium.util.DateTimeUtil
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
@@ -129,8 +129,8 @@ internal class ConversationMapperImpl(
     )
 
     override fun fromDaoModel(daoModel: ConversationViewEntity): Conversation = with(daoModel) {
-        val lastReadDateEntity = if (type == ConversationEntity.Type.CONNECTION_PENDING) UNIX_FIRST_DATE
-        else lastReadDate.toIsoDateTimeString()
+        val lastReadDateEntity = if (type == ConversationEntity.Type.CONNECTION_PENDING) Instant.UNIX_FIRST_DATE
+        else lastReadDate
 
         Conversation(
             id = id.toModel(),
@@ -140,8 +140,8 @@ internal class ConversationMapperImpl(
             protocol = protocolInfoMapper.fromEntity(protocolInfo),
             mutedStatus = conversationStatusMapper.fromMutedStatusDaoModel(mutedStatus),
             removedBy = removedBy?.let { conversationStatusMapper.fromRemovedByToLogicModel(it) },
-            lastNotificationDate = lastNotificationDate?.toIsoDateTimeString(),
-            lastModifiedDate = lastModifiedDate?.toIsoDateTimeString(),
+            lastNotificationDate = lastNotificationDate,
+            lastModifiedDate = lastModifiedDate,
             lastReadDate = lastReadDateEntity,
             access = accessList.map { it.toDAO() },
             accessRole = accessRoleList.map { it.toDAO() },
@@ -158,8 +158,8 @@ internal class ConversationMapperImpl(
     }
 
     override fun fromDaoModel(daoModel: ConversationEntity): Conversation = with(daoModel) {
-        val lastReadDateEntity = if (type == ConversationEntity.Type.CONNECTION_PENDING) UNIX_FIRST_DATE
-        else lastReadDate.toIsoDateTimeString()
+        val lastReadDateEntity = if (type == ConversationEntity.Type.CONNECTION_PENDING) Instant.UNIX_FIRST_DATE
+        else lastReadDate
         Conversation(
             id = id.toModel(),
             name = name,
@@ -168,8 +168,8 @@ internal class ConversationMapperImpl(
             protocol = protocolInfoMapper.fromEntity(protocolInfo),
             mutedStatus = conversationStatusMapper.fromMutedStatusDaoModel(mutedStatus),
             removedBy = removedBy?.let { conversationStatusMapper.fromRemovedByToLogicModel(it) },
-            lastNotificationDate = lastNotificationDate?.toIsoDateTimeString(),
-            lastModifiedDate = lastModifiedDate?.toIsoDateTimeString(),
+            lastNotificationDate = lastNotificationDate,
+            lastModifiedDate = lastModifiedDate,
             lastReadDate = lastReadDateEntity,
             access = access.map { it.toDAO() },
             accessRole = accessRole.map { it.toDAO() },
@@ -260,11 +260,11 @@ internal class ConversationMapperImpl(
                         conversationId = id.toModel(),
                         otherUser = otherUser,
                         userType = domainUserTypeMapper.fromUserTypeEntity(userType),
-                        lastModifiedDate = lastModifiedDate?.toIsoDateTimeString().orEmpty(),
+                        lastModifiedDate = lastModifiedDate ?: Instant.UNIX_FIRST_DATE,
                         connection = Connection(
                             conversationId = id.value,
                             from = "",
-                            lastUpdate = "",
+                            lastUpdate = Instant.UNIX_FIRST_DATE,
                             qualifiedConversationId = id.toModel(),
                             qualifiedToId = otherUserId.requireField("otherUserID in Connection").toModel(),
                             status = connectionStatusMapper.fromDaoModel(connectionStatus),
@@ -367,9 +367,9 @@ internal class ConversationMapperImpl(
             mutedTime = 0,
             removedBy = null,
             creatorId = creatorId.orEmpty(),
-            lastNotificationDate = (conversation.lastNotificationDate ?: "1970-01-01T00:00:00.000Z").toInstant(),
-            lastModifiedDate = (conversation.lastModifiedDate ?: "1970-01-01T00:00:00.000Z").toInstant(),
-            lastReadDate = conversation.lastReadDate.toInstant(),
+            lastNotificationDate = conversation.lastNotificationDate,
+            lastModifiedDate = conversation.lastModifiedDate ?: Instant.UNIX_FIRST_DATE,
+            lastReadDate = conversation.lastReadDate,
             access = conversation.access.map { it.toDAO() },
             accessRole = conversation.accessRole.map { it.toDAO() },
             receiptMode = receiptModeMapper.toDaoModel(conversation.receiptMode),
@@ -471,6 +471,7 @@ internal fun ConversationResponse.toConversationType(selfUserTeamId: TeamId?): C
                 ConversationEntity.Type.GROUP
             }
         }
+
         ConversationResponse.Type.ONE_TO_ONE -> ConversationEntity.Type.ONE_ON_ONE
         ConversationResponse.Type.WAIT_FOR_CONNECTION -> ConversationEntity.Type.CONNECTION_PENDING
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -45,7 +45,9 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.serialization.toJsonElement
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.JsonNull
 
 /**
@@ -139,7 +141,7 @@ sealed class Event(open val id: String) {
             override val conversationId: ConversationId,
             val senderUserId: UserId,
             val senderClientId: ClientId,
-            val timestampIso: String,
+            val messageInstant: Instant,
             val content: String,
             val encryptedExternalContent: EncryptedData?
         ) : Conversation(id, conversationId) {
@@ -150,7 +152,7 @@ sealed class Event(open val id: String) {
                 conversationIdKey to conversationId.toLogString(),
                 senderUserIdKey to senderUserId.toLogString(),
                 "senderClientId" to senderClientId.value.obfuscateId(),
-                timestampIsoKey to timestampIso
+                timestampIsoKey to messageInstant
             )
         }
 
@@ -159,7 +161,7 @@ sealed class Event(open val id: String) {
             override val conversationId: ConversationId,
             val subconversationId: SubconversationId?,
             val senderUserId: UserId,
-            val timestampIso: String,
+            val messageInstant: Instant,
             val content: String
         ) : Conversation(id, conversationId) {
 
@@ -168,7 +170,7 @@ sealed class Event(open val id: String) {
                 idKey to id.obfuscateId(),
                 conversationIdKey to conversationId.toLogString(),
                 senderUserIdKey to senderUserId.toLogString(),
-                timestampIsoKey to timestampIso
+                timestampIsoKey to messageInstant.toIsoDateTimeString()
             )
         }
 
@@ -176,7 +178,7 @@ sealed class Event(open val id: String) {
             override val id: String,
             override val conversationId: ConversationId,
             val senderUserId: UserId,
-            val timestampIso: String,
+            val dateTime: Instant,
             val conversation: ConversationResponse
         ) : Conversation(id, conversationId) {
 
@@ -184,7 +186,7 @@ sealed class Event(open val id: String) {
                 typeKey to "Conversation.NewConversation",
                 idKey to id.obfuscateId(),
                 conversationIdKey to conversationId.toLogString(),
-                timestampIsoKey to timestampIso
+                timestampIsoKey to dateTime
             )
         }
 
@@ -193,7 +195,7 @@ sealed class Event(open val id: String) {
             override val conversationId: ConversationId,
             val addedBy: UserId,
             val members: List<Member>,
-            val timestampIso: String
+            val dateTime: Instant
         ) : Conversation(id, conversationId) {
 
             override fun toLogMap(): Map<String, Any?> = mapOf(
@@ -202,7 +204,7 @@ sealed class Event(open val id: String) {
                 conversationIdKey to conversationId.toLogString(),
                 "addedBy" to addedBy.toLogString(),
                 "members" to members.map { it.toMap() },
-                timestampIsoKey to timestampIso
+                timestampIsoKey to dateTime.toIsoDateTimeString()
             )
         }
 
@@ -211,7 +213,7 @@ sealed class Event(open val id: String) {
             override val conversationId: ConversationId,
             val removedBy: UserId,
             val removedList: List<UserId>,
-            val timestampIso: String,
+            val dateTime: Instant,
             val reason: MemberLeaveReason
         ) : Conversation(id, conversationId) {
 
@@ -220,7 +222,7 @@ sealed class Event(open val id: String) {
                 idKey to id.obfuscateId(),
                 conversationIdKey to conversationId.toLogString(),
                 "removedBy" to removedBy.toLogString(),
-                timestampIsoKey to timestampIso
+                timestampIsoKey to dateTime
             )
         }
 
@@ -331,7 +333,7 @@ sealed class Event(open val id: String) {
             override val conversationId: ConversationId,
             val conversationName: String,
             val senderUserId: UserId,
-            val timestampIso: String,
+            val dateTime: Instant,
         ) : Conversation(id, conversationId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Conversation.RenamedConversation",
@@ -339,7 +341,7 @@ sealed class Event(open val id: String) {
                 conversationIdKey to conversationId.toLogString(),
                 senderUserIdKey to senderUserId.toLogString(),
                 "conversationName" to conversationName,
-                timestampIsoKey to timestampIso,
+                timestampIsoKey to dateTime.toIsoDateTimeString(),
             )
         }
 
@@ -364,7 +366,7 @@ sealed class Event(open val id: String) {
             override val conversationId: ConversationId,
             val messageTimer: Long?,
             val senderUserId: UserId,
-            val timestampIso: String
+            val dateTime: Instant
         ) : Conversation(id, conversationId) {
 
             override fun toLogMap() = mapOf(
@@ -373,7 +375,7 @@ sealed class Event(open val id: String) {
                 conversationIdKey to conversationId.toLogString(),
                 "messageTime" to messageTimer,
                 senderUserIdKey to senderUserId.toLogString(),
-                timestampIsoKey to timestampIso
+                timestampIsoKey to dateTime.toIsoDateTimeString()
             )
         }
 
@@ -436,13 +438,13 @@ sealed class Event(open val id: String) {
             override val id: String,
             override val teamId: String,
             val memberId: String,
-            val timestampIso: String,
+            val dateTime: Instant,
         ) : Team(id, teamId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "Team.MemberLeave",
                 idKey to id.obfuscateId(),
                 teamIdKey to teamId.obfuscateId(),
-                timestampIsoKey to timestampIso,
+                timestampIsoKey to dateTime.toIsoDateTimeString(),
                 memberIdKey to memberId.obfuscateId(),
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -191,7 +191,7 @@ class EventMapper(
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         messageTimer = eventContentDTO.data.messageTimer,
         senderUserId = eventContentDTO.qualifiedFrom.toModel(),
-        timestampIso = eventContentDTO.time
+        dateTime = eventContentDTO.time
     )
 
     private fun conversationReceiptModeUpdate(
@@ -288,7 +288,7 @@ class EventMapper(
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         subconversationId = eventContentDTO.subconversation?.let { SubconversationId(it) },
         senderUserId = eventContentDTO.qualifiedFrom.toModel(),
-        timestampIso = eventContentDTO.time,
+        messageInstant = eventContentDTO.time,
         content = eventContentDTO.message
     )
 
@@ -375,7 +375,7 @@ class EventMapper(
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         addedBy = eventContentDTO.qualifiedFrom.toModel(),
         members = eventContentDTO.members.users.map { memberMapper.fromApiModel(it) },
-        timestampIso = eventContentDTO.time,
+        dateTime = eventContentDTO.time,
     )
 
     fun conversationMemberLeave(
@@ -386,7 +386,7 @@ class EventMapper(
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         removedBy = eventContentDTO.qualifiedFrom.toModel(),
         removedList = eventContentDTO.removedUsers.qualifiedUserIds.map { it.toModel() },
-        timestampIso = eventContentDTO.time,
+        dateTime = eventContentDTO.time,
         reason = eventContentDTO.removedUsers.reason.toModel()
     )
 
@@ -521,7 +521,7 @@ class EventMapper(
         conversationId = event.qualifiedConversation.toModel(),
         senderUserId = event.qualifiedFrom.toModel(),
         conversationName = event.updateNameData.conversationName,
-        timestampIso = event.time,
+        dateTime = event.time,
     )
 
     private fun teamMemberLeft(
@@ -531,7 +531,7 @@ class EventMapper(
         id = id,
         teamId = event.teamId,
         memberId = event.teamMember.nonQualifiedUserId,
-        timestampIso = event.time
+        dateTime = event.time
     )
 
     private fun userUpdate(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/BroadcastMessage.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/BroadcastMessage.kt
@@ -21,11 +21,12 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.util.serialization.toJsonElement
+import kotlinx.datetime.Instant
 
 data class BroadcastMessage(
     val id: String,
     val content: MessageContent.Signaling,
-    val date: String,
+    val date: Instant,
     val senderUserId: UserId,
     val status: Message.Status,
     val isSelfMessage: Boolean,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -38,7 +38,7 @@ sealed interface Message {
     val id: String
     val content: MessageContent
     val conversationId: ConversationId
-    val date: String
+    val date: Instant
     val senderUserId: UserId
     val status: Status
     val expirationData: ExpirationData?
@@ -76,7 +76,7 @@ sealed interface Message {
         override val id: String,
         override val content: MessageContent.Regular,
         override val conversationId: ConversationId,
-        override val date: String,
+        override val date: Instant,
         override val senderUserId: UserId,
         override val status: Status,
         override val visibility: Visibility = Visibility.VISIBLE,
@@ -166,7 +166,7 @@ sealed interface Message {
         override val id: String,
         override val content: MessageContent.Signaling,
         override val conversationId: ConversationId,
-        override val date: String,
+        override val date: Instant,
         override val senderUserId: UserId,
         override val senderClientId: ClientId,
         override val status: Status,
@@ -260,7 +260,7 @@ sealed interface Message {
         override val id: String,
         override val content: MessageContent.System,
         override val conversationId: ConversationId,
-        override val date: String,
+        override val date: Instant,
         override val senderUserId: UserId,
         override val status: Status,
         override val visibility: Visibility = Visibility.VISIBLE,
@@ -388,7 +388,7 @@ sealed interface Message {
             val standardProperties = mapOf(
                 "id" to id.obfuscateId(),
                 "conversationId" to conversationId.toLogString(),
-                "date" to date,
+                "date" to date.toIsoDateTimeString(),
                 "senderUserId" to senderUserId.value.obfuscateId(),
                 "status" to "$status",
                 "visibility" to "$visibility",
@@ -443,11 +443,11 @@ sealed interface Message {
 
     sealed class EditStatus {
         data object NotEdited : EditStatus()
-        data class Edited(val lastTimeStamp: String) : EditStatus()
+        data class Edited(val lastEditInstant: Instant) : EditStatus()
 
         override fun toString(): String = when (this) {
             is NotEdited -> "NOT_EDITED"
-            is Edited -> "EDITED_$lastTimeStamp"
+            is Edited -> "EDITED_${lastEditInstant.toIsoDateTimeString()}"
         }
 
         fun toLogString(): String {
@@ -462,7 +462,7 @@ sealed interface Message {
 
             is Edited -> mutableMapOf(
                 "value" to "EDITED",
-                "time" to this.lastTimeStamp
+                "time" to this.lastEditInstant.toIsoDateTimeString()
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -48,9 +48,7 @@ import com.wire.kalium.persistence.dao.message.MessagePreviewEntity
 import com.wire.kalium.persistence.dao.message.MessagePreviewEntityContent
 import com.wire.kalium.persistence.dao.message.NotificationMessageEntity
 import com.wire.kalium.persistence.dao.message.draft.MessageDraftEntity
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import okio.Path.Companion.toPath
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -84,14 +82,14 @@ class MessageMapperImpl(
         id = message.id,
         content = toMessageEntityContent(message.content),
         conversationId = message.conversationId.toDao(),
-        date = message.date.toInstant(),
+        date = message.date,
         senderUserId = message.senderUserId.toDao(),
         senderClientId = message.senderClientId.value,
         status = message.status.toEntityStatus(),
         readCount = if (message.status is Message.Status.Read) message.status.readCount else 0,
         editStatus = when (message.editStatus) {
             is Message.EditStatus.NotEdited -> MessageEntity.EditStatus.NotEdited
-            is Message.EditStatus.Edited -> MessageEntity.EditStatus.Edited(message.editStatus.lastTimeStamp.toInstant())
+            is Message.EditStatus.Edited -> MessageEntity.EditStatus.Edited(message.editStatus.lastEditInstant)
         },
         expireAfterMs = message.expirationData?.expireAfter?.inWholeMilliseconds,
         selfDeletionEndDate = message.expirationData?.let {
@@ -112,7 +110,7 @@ class MessageMapperImpl(
         id = message.id,
         content = message.content.toMessageEntityContent(),
         conversationId = message.conversationId.toDao(),
-        date = message.date.toInstant(),
+        date = message.date,
         senderUserId = message.senderUserId.toDao(),
         status = message.status.toEntityStatus(),
         visibility = message.visibility.toEntityVisibility(),
@@ -152,13 +150,13 @@ class MessageMapperImpl(
         id = message.id,
         content = message.content.toMessageContent(message.visibility.toModel() == Message.Visibility.HIDDEN, selfUserId),
         conversationId = message.conversationId.toModel(),
-        date = message.date.toIsoDateTimeString(),
+        date = message.date,
         senderUserId = message.senderUserId.toModel(),
         senderClientId = ClientId(message.senderClientId),
         status = message.status.toModel(message.readCount),
         editStatus = when (val editStatus = message.editStatus) {
             MessageEntity.EditStatus.NotEdited -> Message.EditStatus.NotEdited
-            is MessageEntity.EditStatus.Edited -> Message.EditStatus.Edited(editStatus.lastDate.toIsoDateTimeString())
+            is MessageEntity.EditStatus.Edited -> Message.EditStatus.Edited(editStatus.lastDate)
         },
         expirationData = message.expireAfterMs?.let {
             Message.ExpirationData(
@@ -193,7 +191,7 @@ class MessageMapperImpl(
         id = message.id,
         content = message.content.toMessageContent(),
         conversationId = message.conversationId.toModel(),
-        date = message.date.toIsoDateTimeString(),
+        date = message.date,
         senderUserId = message.senderUserId.toModel(),
         status = message.status.toModel(message.readCount),
         visibility = message.visibility.toModel(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -149,7 +149,7 @@ internal interface MessageRepository {
     suspend fun broadcastEnvelope(
         envelope: MessageEnvelope,
         messageOption: BroadcastMessageOption
-    ): Either<CoreFailure, String>
+    ): Either<CoreFailure, Instant>
 
     suspend fun sendMLSMessage(
         conversationId: ConversationId,
@@ -166,7 +166,7 @@ internal interface MessageRepository {
         conversationId: ConversationId,
         messageContent: MessageContent.TextEdited,
         newMessageId: String,
-        editTimeStamp: String
+        editInstant: Instant
     ): Either<CoreFailure, Unit>
 
     suspend fun updateLegalHoldMessageMembers(
@@ -470,7 +470,7 @@ internal class MessageDataSource internal constructor(
     override suspend fun broadcastEnvelope(
         envelope: MessageEnvelope,
         messageOption: BroadcastMessageOption
-    ): Either<CoreFailure, String> {
+    ): Either<CoreFailure, Instant> {
         val recipientMap: Map<NetworkQualifiedId, Map<String, ByteArray>> =
             envelope.recipients.associate { recipientEntry ->
                 recipientEntry.userId.toApi() to recipientEntry.clientPayloads.associate { clientPayload ->
@@ -541,11 +541,11 @@ internal class MessageDataSource internal constructor(
         conversationId: ConversationId,
         messageContent: MessageContent.TextEdited,
         newMessageId: String,
-        editTimeStamp: String
+        editInstant: Instant
     ): Either<CoreFailure, Unit> {
         return wrapStorageRequest {
             messageDAO.updateTextMessageContent(
-                editTimeStamp = editTimeStamp,
+                editInstant = editInstant,
                 conversationId = conversationId.toDao(),
                 currentMessageId = messageContent.editMessageId,
                 newTextContent = MessageEntityContent.Text(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCase.kt
@@ -23,13 +23,14 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.reaction.ReactionRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
+import kotlinx.datetime.Instant
 
 interface PersistReactionUseCase {
     suspend operator fun invoke(
         reaction: MessageContent.Reaction,
         conversationId: ConversationId,
         senderUserId: UserId,
-        date: String
+        date: Instant
     ): Either<CoreFailure, Unit>
 }
 
@@ -40,7 +41,7 @@ internal class PersistReactionUseCaseImpl(
         reaction: MessageContent.Reaction,
         conversationId: ConversationId,
         senderUserId: UserId,
-        date: String
+        date: Instant
     ): Either<CoreFailure, Unit> {
         val emojiSet = reaction.emojiSet.map {
             // If we receive the heavy black heart unicode, we convert it to the emoji version.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedUserIdToClientMap
 import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
+import kotlinx.datetime.Instant
 
 /**
  * Maps the [QualifiedSendMessageResponse] to a [MessageSent] object.
@@ -73,7 +74,7 @@ internal class SendMessagePartialFailureMapperImpl : SendMessagePartialFailureMa
 }
 
 data class MessageSent(
-    val time: String,
+    val time: Instant,
     val failedToConfirmClients: List<UserId> = listOf(),
     val missing: List<UserId> = listOf()
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/reaction/ReactionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/reaction/ReactionRepository.kt
@@ -29,13 +29,14 @@ import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.persistence.dao.reaction.ReactionDAO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Instant
 
 interface ReactionRepository {
     suspend fun persistReaction(
         originalMessageId: String,
         conversationId: ConversationId,
         senderUserId: UserId,
-        date: String,
+        instant: Instant,
         emoji: String
     ): Either<StorageFailure, Unit>
 
@@ -55,7 +56,7 @@ interface ReactionRepository {
         originalMessageId: String,
         conversationId: ConversationId,
         senderUserId: UserId,
-        date: String,
+        instant: Instant,
         userReactions: UserReactions
     ): Either<StorageFailure, Unit>
 
@@ -75,14 +76,14 @@ class ReactionRepositoryImpl(
         originalMessageId: String,
         conversationId: ConversationId,
         senderUserId: UserId,
-        date: String,
+        instant: Instant,
         emoji: String
     ): Either<StorageFailure, Unit> = wrapStorageRequest {
         reactionsDAO.insertReaction(
             originalMessageId = originalMessageId,
             conversationId = conversationId.toDao(),
             senderUserId = senderUserId.toDao(),
-            date = date,
+            instant = instant,
             emoji = emoji
         )
     }
@@ -113,14 +114,14 @@ class ReactionRepositoryImpl(
         originalMessageId: String,
         conversationId: ConversationId,
         senderUserId: UserId,
-        date: String,
+        instant: Instant,
         userReactions: UserReactions
     ): Either<StorageFailure, Unit> = wrapStorageRequest {
         reactionsDAO.updateReactions(
             originalMessageId,
             conversationId.toDao(),
             senderUserId.toDao(),
-            date,
+            instant,
             userReactions
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
@@ -53,7 +53,7 @@ class LocalNotificationMessageMapperImpl : LocalNotificationMessageMapper {
             "",
             author,
             // TODO: change time to Instant
-            connection.lastModifiedDate.toInstant(),
+            connection.lastModifiedDate,
             connection.connection.qualifiedToId
         )
         return LocalNotification.Conversation(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserModel.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.VALUE_DOMAIN_SEPARATOR
 import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
@@ -53,7 +54,7 @@ sealed class User {
 data class Connection(
     val conversationId: String,
     val from: String,
-    val lastUpdate: String,
+    val lastUpdate: Instant,
     val qualifiedConversationId: ConversationId,
     val qualifiedToId: UserId,
     val status: ConnectionState,
@@ -69,7 +70,7 @@ data class Connection(
         return mapOf(
             "conversationId" to conversationId.obfuscateId(),
             "from" to from.obfuscateId(),
-            "lastUpdate" to lastUpdate,
+            "lastUpdate" to lastUpdate.toIsoDateTimeString(),
             "qualifiedConversationId" to "${qId.value.obfuscateId()}@${qId.domain.obfuscateDomain()}",
             "qualifiedToId" to "${qualifiedToId.value.obfuscateId()}@${qualifiedToId.domain.obfuscateDomain()}",
             "status" to status.name,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/web/WebMappers.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MigratedMessage
 import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.ktor.utils.io.core.toByteArray
 import kotlinx.datetime.Instant
 import kotlin.time.DurationUnit
@@ -53,7 +53,7 @@ fun WebEventContent.toMigratedMessage(selfUserDomain: String): MigratedMessage? 
                     ),
                     data.expectsReadConfirmation ?: false,
                     legalHoldStatus = if (data.legalHoldStatus == 2) Conversation.LegalHoldStatus.ENABLED
-                        else Conversation.LegalHoldStatus.DISABLED
+                    else Conversation.LegalHoldStatus.DISABLED
                 ),
                 encryptedProto = null,
                 null,
@@ -132,17 +132,16 @@ private fun toQualifiedId(remoteId: String, domain: String?, selfUserId: UserId)
 
 fun WebConversationContent.toConversation(selfUserId: UserId): Conversation? {
     return mapConversationType(type)?.let {
-        val lastEventTime: String =
-            if (lastEventTimestamp == null || lastEventTimestamp == 0L) {
-                "1970-01-01T00:00:00.000Z"
-            } else {
-                DateTimeUtil.fromEpochMillisToIsoDateTimeString(lastEventTimestamp)
-            }
+        val lastEventTime = if (lastEventTimestamp == null || lastEventTimestamp == 0L) {
+            Instant.UNIX_FIRST_DATE
+        } else {
+            Instant.fromEpochMilliseconds(lastEventTimestamp)
+        }
 
         val conversationLastReadTime = if (lastReadTimestamp == null || lastReadTimestamp == 0L) {
-            "1970-01-01T00:00:00.000Z"
+            Instant.UNIX_FIRST_DATE
         } else {
-            DateTimeUtil.fromEpochMillisToIsoDateTimeString(lastReadTimestamp)
+            Instant.fromEpochMilliseconds(lastReadTimestamp)
         }
         val conversationArchivedTimestamp: Instant? = archivedTimestamp?.let { timestamp ->
             Instant.fromEpochMilliseconds(timestamp)
@@ -174,7 +173,7 @@ fun WebConversationContent.toConversation(selfUserId: UserId): Conversation? {
             mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
             legalHoldStatus = if (legalHoldStatus == 2) Conversation.LegalHoldStatus.ENABLED
-                else Conversation.LegalHoldStatus.DISABLED
+            else Conversation.LegalHoldStatus.DISABLED
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
@@ -54,13 +54,13 @@ import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.fileExtension
 import com.wire.kalium.logic.util.isGreaterThan
 import com.wire.kalium.persistence.dao.message.MessageEntity
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 import okio.Path
 import kotlin.time.Duration
 
@@ -233,7 +233,7 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
                             )
                         ),
                         conversationId = conversationId,
-                        date = DateTimeUtil.currentIsoDateTimeString(),
+                        date = Clock.System.now(),
                         senderUserId = userId,
                         senderClientId = currentClientId,
                         status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 
 /**
  * This use case will clear all messages from a conversation and notify other clients, using the self conversation.
@@ -69,7 +70,7 @@ internal class ClearConversationContentUseCaseImpl(
                             ),
                             // sending the message to clear this conversation
                             conversationId = selfConversationId,
-                            date = DateTimeUtil.currentIsoDateTimeString(),
+                            date = Clock.System.now(),
                             senderUserId = selfUserId,
                             senderClientId = currentClientId,
                             status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -32,9 +32,9 @@ import com.wire.kalium.logic.feature.message.SendConfirmationUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 /**
@@ -87,7 +87,7 @@ class UpdateConversationReadDateUseCase internal constructor(
                     time = time
                 ),
                 conversationId = selfConversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReceiptModeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReceiptModeUseCase.kt
@@ -28,7 +28,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.fold
-import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 
 /**
  * Internal UseCase that updates Group Conversation Receipt Mode value
@@ -75,7 +75,7 @@ internal class UpdateConversationReceiptModeUseCaseImpl(
                 receiptMode = receiptMode == Conversation.ReceiptMode.ENABLED
             ),
             conversationId,
-            DateTimeUtil.currentIsoDateTimeString(),
+            Clock.System.now(),
             selfUserId,
             Message.Status.Sent,
             Message.Visibility.VISIBLE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendBrokenAssetMessageUseCaseImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendBrokenAssetMessageUseCaseImpl.kt
@@ -44,8 +44,8 @@ import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.fileExtension
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Clock
 import okio.Path
 
 @Suppress("MaxLineLength")
@@ -127,7 +127,7 @@ internal class SendBrokenAssetMessageUseCaseImpl(
                     )
                 ),
                 conversationId = conversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = userId,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
@@ -66,7 +66,7 @@ class SendConfirmationUseCase internal constructor(
                 id = generatedMessageUuid,
                 content = MessageContent.Receipt(type, listOf(firstMessageId) + moreMessageIds),
                 conversationId = conversationId,
-                date = Clock.System.now().toString(),
+                date = Clock.System.now(),
                 senderUserId = selfUser.id,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/FetchMLSVerificationStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/FetchMLSVerificationStatusUseCase.kt
@@ -43,7 +43,7 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.wrapMLSRequest
-import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 
 typealias UserToWireIdentity = Map<UserId, List<WireIdentity>>
 
@@ -209,7 +209,7 @@ internal class FetchMLSVerificationStatusUseCaseImpl(
             id = uuid4().toString(),
             content = content,
             conversationId = conversationId,
-            date = DateTimeUtil.currentIsoDateTimeString(),
+            date = Clock.System.now(),
             senderUserId = selfUserId,
             status = Message.Status.Sent,
             visibility = Message.Visibility.VISIBLE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.kaliumLogger
 
-import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 
 /**
  * persist a local system message to all conversations
@@ -47,7 +47,7 @@ class AddSystemMessageToAllConversationsUseCaseImpl internal constructor(
             content = MessageContent.HistoryLost,
             // the conversation id will be ignored in the repo level!
             conversationId = ConversationId("", ""),
-            date = DateTimeUtil.currentIsoDateTimeString(),
+            date = Clock.System.now(),
             senderUserId = selfUserId,
             status = Message.Status.Sent,
             expirationData = null

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -39,11 +39,11 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 
 /**
  * Deletes a message from the conversation
@@ -91,7 +91,7 @@ class DeleteMessageUseCase internal constructor(
                                                 conversationId = conversationId
                                             ),
                                         conversationId = if (deleteForEveryone) conversationId else selfConversationId,
-                                        date = DateTimeUtil.currentIsoDateTimeString(),
+                                        date = Clock.System.now(),
                                         senderUserId = selfUserId,
                                         senderClientId = currentClientId,
                                         status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingInterceptor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendingInterceptor.kt
@@ -49,7 +49,7 @@ internal class MessageSendingInterceptorImpl internal constructor(
         return messageRepository.getMessageById(originalMessage.conversationId, replyMessageContent.quotedMessageReference.quotedMessageId)
             .map { persistedMessage ->
                 val encodedMessageContent = messageContentEncoder.encodeMessageContent(
-                    messageDate = persistedMessage.date,
+                    messageInstant = persistedMessage.date,
                     messageContent = persistedMessage.content
                 )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
@@ -42,10 +42,10 @@ import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.fileExtension
 import com.wire.kalium.persistence.dao.message.MessageEntity
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 
 @Suppress("LongParameterList")
 class RetryFailedMessageUseCase internal constructor(
@@ -130,7 +130,7 @@ class RetryFailedMessageUseCase internal constructor(
                     id = generatedMessageUuid,
                     content = editContent,
                     conversationId = message.conversationId,
-                    date = DateTimeUtil.currentIsoDateTimeString(),
+                    date = Clock.System.now(),
                     senderUserId = message.senderUserId,
                     senderClientId = message.senderClientId,
                     status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCase.kt
@@ -40,7 +40,7 @@ import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.util.serialization.toJsonElement
-import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -84,7 +84,7 @@ internal class SendConfirmationUseCase internal constructor(
                 id = uuid4().toString(),
                 content = MessageContent.Receipt(ReceiptType.READ, messageIds),
                 conversationId = conversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
@@ -34,11 +34,11 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.persistence.dao.message.MessageEntity
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 
 @Suppress("LongParameterList")
 
@@ -87,7 +87,7 @@ class SendEditTextMessageUseCase internal constructor(
                 id = editedMessageId,
                 content = content,
                 conversationId = conversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = clientId,
                 status = Message.Status.Pending,
@@ -100,7 +100,7 @@ class SendEditTextMessageUseCase internal constructor(
                 conversationId = message.conversationId,
                 messageContent = content,
                 newMessageId = originalMessageId,
-                editTimeStamp = message.date
+                editInstant = message.date
             ).flatMap {
                     messageRepository.updateMessageStatus(
                         messageStatus = MessageEntity.Status.PENDING,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -32,11 +32,11 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTim
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 import kotlin.time.Duration
 
 @Suppress("LongParameterList")
@@ -76,7 +76,7 @@ class SendKnockUseCase internal constructor(
                 id = generatedMessageUuid,
                 content = MessageContent.Knock(hotKnock),
                 conversationId = conversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
@@ -32,11 +32,11 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTim
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 import kotlin.time.Duration
 
 /**
@@ -91,7 +91,7 @@ class SendLocationUseCase internal constructor(
                     zoom = zoom
                 ),
                 conversationId = conversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -34,12 +34,12 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTim
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Clock
 import kotlin.time.Duration
 
 @Suppress("LongParameterList")
@@ -92,7 +92,7 @@ class SendTextMessageUseCase internal constructor(
                 ),
                 expectsReadConfirmation = expectsReadConfirmation,
                 conversationId = conversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = clientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionResetSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionResetSender.kt
@@ -33,11 +33,11 @@ import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.message.MessageTarget
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 
 interface SessionResetSender {
     suspend operator fun invoke(conversationId: ConversationId, userId: UserId, clientId: ClientId): Either<CoreFailure, Unit>
@@ -65,7 +65,7 @@ class SessionResetSenderImpl internal constructor(
                 id = generatedMessageUuid,
                 content = MessageContent.ClientAction,
                 conversationId = conversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = selfClientId,
                 status = Message.Status.Sent,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -65,7 +64,7 @@ internal class StaleEpochVerifierImpl(
                 joinExistingMLSConversation(conversationId).flatMap {
                     systemMessageInserter.insertLostCommitSystemMessage(
                         conversationId,
-                        (timestamp ?: Clock.System.now()).toIsoDateTimeString()
+                        Clock.System.now()
                     )
                 }
             } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
@@ -34,11 +34,12 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
 import com.wire.kalium.logic.functional.map
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 /**
  * Toggles a reaction on a message.
@@ -68,7 +69,7 @@ class ToggleReactionUseCase internal constructor(
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }
-        val date = DateTimeUtil.currentIsoDateTimeString()
+        val date = Clock.System.now()
 
         return@withContext reactionRepository.getSelfUserReactionsForMessage(messageId, conversationId)
             .flatMap { reactions ->
@@ -99,15 +100,15 @@ class ToggleReactionUseCase internal constructor(
             }
     }
 
+    @Suppress("LongParameterList")
     private suspend fun addReaction(
         clientId: ClientId,
         conversationId: ConversationId,
-        date: String,
+        date: Instant,
         messageId: String,
         currentReactions: UserReactions,
         newReaction: String
     ): Either<CoreFailure, Unit> {
-
         return reactionRepository
             .persistReaction(messageId, conversationId, userId, date, newReaction).flatMap {
                 val regularMessage = Message.Signaling(
@@ -128,10 +129,11 @@ class ToggleReactionUseCase internal constructor(
             }
     }
 
+    @Suppress("LongParameterList")
     private suspend fun removeReaction(
         clientId: ClientId,
         conversationId: ConversationId,
-        date: String,
+        date: Instant,
         messageId: String,
         removedReaction: String,
         currentReactions: UserReactions

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageUseCase.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.data.message.MessageTarget
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.sync.SyncManager
-import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 
 /**
  * Use case for sending a button action message.
@@ -59,7 +59,7 @@ class SendButtonActionConfirmationMessageUseCase internal constructor(
                         buttonId = buttonId
                     ),
                     conversationId = conversationId,
-                    date = DateTimeUtil.currentIsoDateTimeString(),
+                    date = Clock.System.now(),
                     senderUserId = selfUserId,
                     senderClientId = currentClientId,
                     status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionMessageUseCase.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.logic.data.message.MessageTarget
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.sync.SyncManager
-import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 
 /**
  * Use case for sending a button action message.
@@ -64,7 +64,7 @@ class SendButtonActionMessageUseCase internal constructor(
                         buttonId = buttonId
                     ),
                     conversationId = conversationId,
-                    date = DateTimeUtil.currentIsoDateTimeString(),
+                    date = Clock.System.now(),
                     senderUserId = selfUserId,
                     senderClientId = currentClientId,
                     status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonMessageUseCase.kt
@@ -34,12 +34,12 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Clock
 
 @Suppress("LongParameterList")
 /**
@@ -94,7 +94,7 @@ class SendButtonMessageUseCase internal constructor(
                 content = content,
                 expectsReadConfirmation = expectsReadConfirmation,
                 conversationId = conversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = clientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
@@ -36,7 +36,6 @@ import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.logStructuredJson
 import com.wire.kalium.logic.sync.SyncManager
-import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
@@ -46,6 +45,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
 
 /**
  * Internal: Handles the send of delivery confirmation of messages.
@@ -129,7 +129,7 @@ internal class ConfirmationDeliveryHandlerImpl(
                 id = uuid4().toString(),
                 content = MessageContent.Receipt(ReceiptType.DELIVERED, messages),
                 conversationId = conversation.id,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
@@ -37,7 +37,7 @@ import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 
 /**
  * When the self user is receiver of the self deletion message,
@@ -97,7 +97,7 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
                 id = uuid4().toString(),
                 content = MessageContent.DeleteForMe(messageToDelete, conversationId),
                 conversationId = selfConversationId,
-                date = DateTimeUtil.currentIsoDateTimeString(),
+                date = Clock.System.now(),
                 senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,
@@ -118,7 +118,7 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
         id = uuid4().toString(),
         content = MessageContent.DeleteMessage(messageToDelete),
         conversationId = conversationId,
-        date = DateTimeUtil.currentIsoDateTimeString(),
+        date = Clock.System.now(),
         senderUserId = selfUserId,
         senderClientId = currentClientId,
         status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
@@ -29,10 +29,10 @@ import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.message.BroadcastMessageTarget
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.flatMap
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 
 /**
  * Updates the current user's [UserAvailabilityStatus] status.
@@ -57,7 +57,7 @@ class UpdateSelfAvailabilityStatusUseCase internal constructor(
                 val message = BroadcastMessage(
                     id = id,
                     content = MessageContent.Availability(status),
-                    date = DateTimeUtil.currentIsoDateTimeString(),
+                    date = Clock.System.now(),
                     senderUserId = selfUserId,
                     senderClientId = selfClientId,
                     status = Message.Status.Pending,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiver.kt
@@ -40,11 +40,11 @@ import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.persistence.dao.member.MemberDAO
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
 
 internal interface FederationEventReceiver : EventReceiver<Event.Federation>
 
@@ -175,7 +175,7 @@ class FederationEventReceiverImpl internal constructor(
             id = uuid4().toString(),
             content = MessageContent.MemberChange.FederationRemoved(members = userIDList),
             conversationId = conversationID,
-            date = DateTimeUtil.currentIsoDateTimeString(),
+            date = Clock.System.now(),
             senderUserId = selfUserId,
             status = Message.Status.Read(0),
             visibility = Message.Visibility.VISIBLE,
@@ -189,7 +189,7 @@ class FederationEventReceiverImpl internal constructor(
             id = uuid4().toString(),
             content = MessageContent.FederationStopped.Removed(domain),
             conversationId = conversationID,
-            date = DateTimeUtil.currentIsoDateTimeString(),
+            date = Clock.System.now(),
             senderUserId = selfUserId,
             status = Message.Status.Read(0),
             visibility = Message.Visibility.VISIBLE,
@@ -203,7 +203,7 @@ class FederationEventReceiverImpl internal constructor(
             id = uuid4().toString(),
             content = MessageContent.FederationStopped.ConnectionRemoved(domainList),
             conversationId = conversationID,
-            date = DateTimeUtil.currentIsoDateTimeString(),
+            date = Clock.System.now(),
             senderUserId = selfUserId,
             status = Message.Status.Read(0),
             visibility = Message.Visibility.VISIBLE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
@@ -59,7 +59,7 @@ internal class TeamEventReceiverImpl(
                         id = uuid4().toString(), // We generate a random uuid for this new system message
                         content = MessageContent.MemberChange.RemovedFromTeam(listOf(removedUser)),
                         conversationId = conversationId,
-                        date = event.timestampIso,
+                        date = event.dateTime,
                         senderUserId = removedUser,
                         status = Message.Status.Sent,
                         visibility = Message.Visibility.VISIBLE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandler.kt
@@ -51,7 +51,7 @@ internal class ConversationMessageTimerEventHandlerImpl(
                         messageTimer = event.messageTimer
                     ),
                     event.conversationId,
-                    event.timestampIso,
+                    event.dateTime,
                     event.senderUserId,
                     Message.Status.Sent,
                     Message.Visibility.VISIBLE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -88,7 +88,7 @@ internal class MemberJoinEventHandlerImpl(
             id = event.id.ifEmpty { uuid4().toString() },
             content = MessageContent.MemberChange.Added(members = event.members.map { it.id }),
             conversationId = event.conversationId,
-            date = event.timestampIso,
+            date = event.dateTime,
             senderUserId = event.addedBy,
             status = Message.Status.Sent,
             visibility = Message.Visibility.VISIBLE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandler.kt
@@ -80,7 +80,7 @@ internal class MemberLeaveEventHandlerImpl(
                         id = event.id,
                         content = content,
                         conversationId = event.conversationId,
-                        date = event.timestampIso,
+                        date = event.dateTime,
                         senderUserId = event.removedBy,
                         status = Message.Status.Sent,
                         visibility = Message.Visibility.VISIBLE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -94,16 +94,16 @@ internal class NewConversationEventHandlerImpl(
         event: Event.Conversation.NewConversation
     ) {
         if (isNewUnhandledConversation) {
-            newGroupConversationSystemMessagesCreator.conversationStarted(event.senderUserId, event.conversation, event.timestampIso)
+            newGroupConversationSystemMessagesCreator.conversationStarted(event.senderUserId, event.conversation, event.dateTime)
             newGroupConversationSystemMessagesCreator.conversationResolvedMembersAdded(
                 event.conversationId.toDao(),
                 event.conversation.members.otherMembers.map { it.id.toModel() },
-                event.timestampIso
+                event.dateTime
             )
-            newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(event.conversation, event.timestampIso)
+            newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(event.conversation, event.dateTime)
             newGroupConversationSystemMessagesCreator.conversationStartedUnverifiedWarning(
                 event.conversation.id.toModel(),
-                event.timestampIso
+                event.dateTime
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
-import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Clock
 
 interface ReceiptModeUpdateEventHandler {
     suspend fun handle(event: Event.Conversation.ConversationReceiptMode)
@@ -55,7 +55,7 @@ internal class ReceiptModeUpdateEventHandlerImpl(
                         receiptMode = event.receiptMode == Conversation.ReceiptMode.ENABLED
                     ),
                     event.conversationId,
-                    DateTimeUtil.currentIsoDateTimeString(),
+                    Clock.System.now(),
                     event.senderUserId,
                     Message.Status.Sent,
                     Message.Visibility.VISIBLE,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandler.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
+import kotlinx.datetime.Instant
 
 interface RenamedConversationEventHandler {
     suspend fun handle(event: Event.Conversation.RenamedConversation)
@@ -42,13 +43,13 @@ internal class RenamedConversationEventHandlerImpl(
 
     override suspend fun handle(event: Event.Conversation.RenamedConversation) {
         val logger = kaliumLogger.createEventProcessingLogger(event)
-        updateConversationName(event.conversationId, event.conversationName, event.timestampIso)
+        updateConversationName(event.conversationId, event.conversationName, event.dateTime)
             .onSuccess {
                 val message = Message.System(
                     id = event.id,
                     content = MessageContent.ConversationRenamed(event.conversationName),
                     conversationId = event.conversationId,
-                    date = event.timestampIso,
+                    date = event.dateTime,
                     senderUserId = event.senderUserId,
                     status = Message.Status.Sent,
                     expirationData = null
@@ -62,9 +63,9 @@ internal class RenamedConversationEventHandlerImpl(
     private suspend fun updateConversationName(
         conversationId: ConversationId,
         conversationName: String,
-        timestamp: String
+        dateTime: Instant
     ) =
         wrapStorageRequest {
-            conversationDAO.updateConversationName(conversationId.toDao(), conversationName, timestamp)
+            conversationDAO.updateConversationName(conversationId.toDao(), conversationName, dateTime)
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -45,6 +45,7 @@ import com.wire.kalium.logic.sync.receiver.handler.MessageTextEditHandler
 import com.wire.kalium.logic.sync.receiver.handler.ReceiptMessageHandler
 import com.wire.kalium.logic.util.MessageContentEncoder
 import com.wire.kalium.util.string.toHexString
+import kotlinx.datetime.Instant
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -52,7 +53,7 @@ internal interface ApplicationMessageHandler {
 
     suspend fun handleContent(
         conversationId: ConversationId,
-        timestampIso: String,
+        messageInstant: Instant,
         senderUserId: UserId,
         senderClientId: ClientId,
         content: ProtoContent.Readable,
@@ -62,7 +63,7 @@ internal interface ApplicationMessageHandler {
     suspend fun handleDecryptionError(
         eventId: String,
         conversationId: ConversationId,
-        timestampIso: String,
+        messageInstant: Instant,
         senderUserId: UserId,
         senderClientId: ClientId,
         content: MessageContent.FailedDecryption
@@ -93,7 +94,7 @@ internal class ApplicationMessageHandlerImpl(
     @Suppress("ComplexMethod", "LongMethod")
     override suspend fun handleContent(
         conversationId: ConversationId,
-        timestampIso: String,
+        messageInstant: Instant,
         senderUserId: UserId,
         senderClientId: ClientId,
         content: ProtoContent.Readable
@@ -120,7 +121,7 @@ internal class ApplicationMessageHandlerImpl(
                     id = content.messageUid,
                     content = protoContent,
                     conversationId = conversationId,
-                    date = timestampIso,
+                    date = messageInstant,
                     senderUserId = senderUserId,
                     senderClientId = senderClientId,
                     status = Message.Status.Sent,
@@ -143,7 +144,7 @@ internal class ApplicationMessageHandlerImpl(
                     id = content.messageUid,
                     content = protoContent,
                     conversationId = conversationId,
-                    date = timestampIso,
+                    date = messageInstant,
                     senderUserId = senderUserId,
                     senderClientId = senderClientId,
                     status = Message.Status.Sent,
@@ -282,7 +283,7 @@ internal class ApplicationMessageHandlerImpl(
     override suspend fun handleDecryptionError(
         eventId: String,
         conversationId: ConversationId,
-        timestampIso: String,
+        messageInstant: Instant,
         senderUserId: UserId,
         senderClientId: ClientId,
         content: MessageContent.FailedDecryption
@@ -291,7 +292,7 @@ internal class ApplicationMessageHandlerImpl(
             id = eventId,
             content = content,
             conversationId = conversationId,
-            date = timestampIso,
+            date = messageInstant,
             senderUserId = senderUserId,
             senderClientId = senderClientId,
             status = Message.Status.Sent,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MessageUnpackResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MessageUnpackResult.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.datetime.Instant
 
 /**
  * Result of passing an [Event] through [MLSMessageUnpacker] or [ProteusMessageUnpacker].
@@ -41,7 +42,7 @@ internal sealed interface MessageUnpackResult {
      */
     data class ApplicationMessage(
         val conversationId: ConversationId,
-        val timestampIso: String,
+        val instant: Instant,
         val senderUserId: UserId,
         val senderClientId: ClientId,
         val content: ProtoContent.Readable

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -37,7 +37,6 @@ import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.util.serialization.toJsonElement
-import kotlinx.datetime.toInstant
 
 internal interface NewMessageEventHandler {
     suspend fun handleNewProteusMessage(event: Event.Conversation.NewMessage, deliveryInfo: EventDeliveryInfo)
@@ -78,7 +77,7 @@ internal class NewMessageEventHandlerImpl(
                 applicationMessageHandler.handleDecryptionError(
                     eventId = event.id,
                     conversationId = event.conversationId,
-                    timestampIso = event.timestampIso,
+                    messageInstant = event.messageInstant,
                     senderUserId = event.senderUserId,
                     senderClientId = event.senderClientId,
                     content = MessageContent.FailedDecryption(
@@ -114,7 +113,7 @@ internal class NewMessageEventHandlerImpl(
                         applicationMessageHandler.handleDecryptionError(
                             eventId = event.id,
                             conversationId = event.conversationId,
-                            timestampIso = event.timestampIso,
+                            messageInstant = event.messageInstant,
                             senderUserId = event.senderUserId,
                             senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
                             content = MessageContent.FailedDecryption(
@@ -128,7 +127,7 @@ internal class NewMessageEventHandlerImpl(
                         eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "OUT_OF_SYNC")
                         staleEpochVerifier.verifyEpoch(
                             event.conversationId,
-                            event.timestampIso.toInstant()
+                            event.messageInstant
                         )
                     }
                 }
@@ -182,7 +181,7 @@ internal class NewMessageEventHandlerImpl(
     private suspend fun handleSuccessfulResult(result: MessageUnpackResult.ApplicationMessage) {
         applicationMessageHandler.handleContent(
             conversationId = result.conversationId,
-            timestampIso = result.timestampIso,
+            messageInstant = result.instant,
             senderUserId = result.senderUserId,
             senderClientId = result.senderClientId,
             content = result.content

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
@@ -93,7 +93,7 @@ internal class ProteusMessageUnpackerImpl(
             }.map { readableContent ->
                 MessageUnpackResult.ApplicationMessage(
                     conversationId = event.conversationId,
-                    timestampIso = event.timestampIso,
+                    instant = event.messageInstant,
                     senderUserId = event.senderUserId,
                     senderClientId = event.senderClientId,
                     content = readableContent

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ReceiptMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ReceiptMessageHandler.kt
@@ -25,7 +25,6 @@ import com.wire.kalium.logic.data.message.receipt.ReceiptRepository
 import com.wire.kalium.logic.data.message.receipt.ReceiptsMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
-import kotlinx.datetime.Instant
 
 internal interface ReceiptMessageHandler {
     suspend fun handle(
@@ -55,7 +54,7 @@ internal class ReceiptMessageHandlerImpl(
         receiptRepository.persistReceipts(
             userId = message.senderUserId,
             conversationId = message.conversationId,
-            date = Instant.parse(message.date),
+            date = message.date,
             type = messageContent.type,
             messageIds = messageContent.messageIds
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/MessageContentEncoder.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/MessageContentEncoder.kt
@@ -21,24 +21,24 @@ package com.wire.kalium.logic.util
 import com.wire.kalium.cryptography.utils.calcSHA256
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.util.DateTimeUtil.toEpochMillis
 import com.wire.kalium.util.long.toByteArray
 import com.wire.kalium.util.string.toHexString
 import com.wire.kalium.util.string.toUTF16BEByteArray
+import kotlinx.datetime.Instant
 import kotlin.math.roundToLong
 
 class MessageContentEncoder {
-    fun encodeMessageContent(messageDate: String, messageContent: MessageContent): EncodedMessageContent? {
+    fun encodeMessageContent(messageInstant: Instant, messageContent: MessageContent): EncodedMessageContent? {
         return when (messageContent) {
             is MessageContent.Asset ->
                 encodeMessageAsset(
-                    messageTimeStampInMillis = messageDate.toEpochMillis(),
+                    messageTimeStampInMillis = messageInstant.toEpochMilliseconds(),
                     assetId = messageContent.value.remoteData.assetId
                 )
 
             is MessageContent.Text ->
                 encodeMessageTextBody(
-                    messageTimeStampInMillis = messageDate.toEpochMillis(),
+                    messageTimeStampInMillis = messageInstant.toEpochMilliseconds(),
                     messageTextBody = messageContent.value
                 )
 
@@ -46,7 +46,7 @@ class MessageContentEncoder {
                 encodeLocationCoordinates(
                     latitude = latitude,
                     longitude = longitude,
-                    messageTimeStampInMillis = messageDate.toEpochMillis()
+                    messageTimeStampInMillis = messageInstant.toEpochMilliseconds()
                 )
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionMapperTest.kt
@@ -95,7 +95,7 @@ class ConnectionMapperTest {
         val stubConnectionResponse = ConnectionDTO(
             "someId",
             "from",
-            UNIX_FIRST_DATE,
+            Instant.UNIX_FIRST_DATE,
             ConversationId("someId", "someDomain"),
             UserId("someId", "someDomain"),
             ConnectionStateDTO.ACCEPTED,
@@ -105,7 +105,7 @@ class ConnectionMapperTest {
         val stubConnection = Connection(
             "someId",
             "from",
-            UNIX_FIRST_DATE,
+            Instant.UNIX_FIRST_DATE,
             ModelConversationId("someId", "someDomain"),
             ModelConversationId("someId", "someDomain"),
             ConnectionState.ACCEPTED,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -432,7 +432,7 @@ class ConnectionRepositoryTest {
         val stubConnectionOne = ConnectionDTO(
             conversationId = "conversationId1",
             from = "fromId",
-            lastUpdate = UNIX_FIRST_DATE,
+            lastUpdate = Instant.UNIX_FIRST_DATE,
             qualifiedConversationId = ConversationId("conversationId1", "domain"),
             qualifiedToId = NetworkUserId("connectionId1", "domain"),
             status = ConnectionStateDTO.ACCEPTED,
@@ -441,7 +441,7 @@ class ConnectionRepositoryTest {
         val stubConnectionTwo = ConnectionDTO(
             conversationId = "conversationId2",
             from = "fromId",
-            lastUpdate = UNIX_FIRST_DATE,
+            lastUpdate = Instant.UNIX_FIRST_DATE,
             qualifiedConversationId = ConversationId("conversationId2", "domain"),
             qualifiedToId = NetworkUserId("connectionId2", "domain"),
             status = ConnectionStateDTO.ACCEPTED,
@@ -470,7 +470,7 @@ class ConnectionRepositoryTest {
         val stubConnectionEntity = ConnectionEntity(
             conversationId = "conversationId1",
             from = "fromId",
-            lastUpdateDate = UNIX_FIRST_DATE.toInstant(),
+            lastUpdateDate = Instant.UNIX_FIRST_DATE,
             qualifiedConversationId = ConversationIDEntity("conversationId", "domain"),
             qualifiedToId = ConversationIDEntity("userId", "domain"),
             status = ConnectionEntity.State.ACCEPTED,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -74,6 +74,7 @@ import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationGuestLinkEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationViewEntity
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.ktor.http.HttpStatusCode
 import io.mockative.Mock
 import io.mockative.any
@@ -1140,7 +1141,7 @@ class ConversationGroupRepositoryTest {
             TestConversation.NETWORK_ID,
             ConversationMessageTimerDTO(messageTimer),
             TestConversation.NETWORK_USER_ID1,
-            "2022-03-30T15:36:00.000Z"
+            Instant.UNIX_FIRST_DATE,
         )
 
         val (arrangement, conversationGroupRepository) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -92,6 +92,7 @@ import com.wire.kalium.persistence.dao.message.draft.MessageDraftEntity
 import com.wire.kalium.persistence.dao.unread.ConversationUnreadEventEntity
 import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.ktor.http.HttpStatusCode
 import io.mockative.Mock
 import io.mockative.any
@@ -130,7 +131,7 @@ class ConversationRepositoryTest {
             "id",
             TestConversation.ID,
             TestUser.SELF.id,
-            "time",
+            Instant.UNIX_FIRST_DATE,
             CONVERSATION_RESPONSE
         )
         val selfUserFlow = flowOf(TestUser.SELF)
@@ -158,7 +159,7 @@ class ConversationRepositoryTest {
                 "id",
                 TestConversation.ID,
                 TestUser.SELF.id,
-                "time",
+                Instant.UNIX_FIRST_DATE,
                 CONVERSATION_RESPONSE
             )
             val selfUserFlow = flowOf(TestUser.SELF)
@@ -187,7 +188,7 @@ class ConversationRepositoryTest {
                 "id",
                 TestConversation.ID,
                 TestUser.SELF.id,
-                "time",
+                Instant.UNIX_FIRST_DATE,
                 CONVERSATION_RESPONSE
             )
             val selfUserFlow = flowOf(TestUser.SELF)
@@ -216,7 +217,7 @@ class ConversationRepositoryTest {
                 "id",
                 TestConversation.ID,
                 TestUser.SELF.id,
-                "time",
+                Instant.UNIX_FIRST_DATE,
                 CONVERSATION_RESPONSE.copy(
                     groupId = RAW_GROUP_ID,
                     protocol = MLS,
@@ -1813,7 +1814,7 @@ class ConversationRepositoryTest {
             EventContentDTO.Conversation.ConversationRenameDTO(
                 CONVERSATION_ID.toApi(),
                 USER_ID.toApi(),
-                DateTimeUtil.currentIsoDateTimeString(),
+                Clock.System.now(),
                 ConversationNameUpdateEvent("newName")
             )
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -85,6 +85,7 @@ import com.wire.kalium.persistence.dao.conversation.E2EIConversationClientInfoEn
 import com.wire.kalium.persistence.dao.message.LocalId
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.ktor.util.decodeBase64Bytes
 import io.ktor.util.encodeBase64
 import io.mockative.Mock
@@ -1789,7 +1790,7 @@ class MLSConversationRepositoryTest {
             const val EPOCH = 5UL
             const val RAW_GROUP_ID = "groupId"
             val GROUP_ID = GroupID(RAW_GROUP_ID)
-            val TIME = DateTimeUtil.currentIsoDateTimeString()
+            val TIME = Instant.DISTANT_PAST
             val INVALID_REQUEST_ERROR = KaliumException.InvalidRequestError(ErrorResponse(405, "", ""))
             val MLS_STALE_MESSAGE_ERROR = KaliumException.InvalidRequestError(ErrorResponse(409, "", "mls-stale-message"))
             val MLS_CLIENT_MISMATCH_ERROR = KaliumException.InvalidRequestError(ErrorResponse(409, "", "mls-client-mismatch"))
@@ -1844,14 +1845,14 @@ class MLSConversationRepositoryTest {
             val MEMBER_JOIN_EVENT = EventContentDTO.Conversation.MemberJoinDTO(
                 TestConversation.NETWORK_ID,
                 TestConversation.NETWORK_USER_ID1,
-                "2022-03-30T15:36:00.000Z",
+                Instant.UNIX_FIRST_DATE,
                 ConversationMembers(emptyList(), emptyList()),
                 TestConversation.NETWORK_USER_ID1.value
             )
             val MEMBER_LEAVE_EVENT = EventContentDTO.Conversation.MemberLeaveDTO(
                 TestConversation.NETWORK_ID,
                 TestConversation.NETWORK_USER_ID1,
-                "2022-03-30T15:36:00.000Z",
+                Instant.UNIX_FIRST_DATE,
                 ConversationMemberRemovedDTO(emptyList(), MemberLeaveReasonDTO.LEFT),
                 TestConversation.NETWORK_USER_ID1.value
             )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreatorTest.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ConversationM
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -44,6 +45,8 @@ import io.mockative.matches
 import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 class NewGroupConversationSystemMessagesCreatorTest {
@@ -74,12 +77,12 @@ class NewGroupConversationSystemMessagesCreatorTest {
         val (arrangement, sysMessageCreator) = Arrangement()
             .withPersistMessageSuccess()
             .arrange()
-        val timestampIso = DateTimeUtil.currentIsoDateTimeString()
+        val currentTime = Clock.System.now()
 
         val result = sysMessageCreator.conversationStarted(
             TestUser.USER_ID,
             TestConversation.CONVERSATION_RESPONSE.copy(type = ConversationResponse.Type.GROUP),
-            timestampIso
+            currentTime
         )
 
         result.shouldSucceed()
@@ -87,7 +90,7 @@ class NewGroupConversationSystemMessagesCreatorTest {
         coVerify {
             arrangement.persistMessage.invoke(
                 matches {
-                    (it.content is MessageContent.System && it.content is MessageContent.ConversationCreated && it.date == timestampIso)
+                    (it.content is MessageContent.System && it.content is MessageContent.ConversationCreated && it.date == currentTime)
                 }
             )
         }.wasInvoked(once)
@@ -118,7 +121,7 @@ class NewGroupConversationSystemMessagesCreatorTest {
             .withPersistMessageSuccess()
             .withIsASelfTeamMember()
             .arrange()
-        val timestampIso = DateTimeUtil.currentIsoDateTimeString()
+        val timestampIso = Instant.UNIX_FIRST_DATE
 
         val result = sysMessageCreator.conversationReadReceiptStatus(TestConversation.CONVERSATION_RESPONSE, timestampIso)
 
@@ -137,7 +140,7 @@ class NewGroupConversationSystemMessagesCreatorTest {
             .withPersistMessageSuccess()
             .withIsASelfTeamMember()
             .arrange()
-        val timestampIso = DateTimeUtil.currentIsoDateTimeString()
+        val timestampIso = Instant.UNIX_FIRST_DATE
 
         val result =
             sysMessageCreator.conversationReadReceiptStatus(
@@ -196,7 +199,7 @@ class NewGroupConversationSystemMessagesCreatorTest {
             val (arrangement, sysMessageCreator) = Arrangement()
                 .withPersistMessageSuccess()
                 .arrange()
-            val timestampIso = DateTimeUtil.currentIsoDateTimeString()
+            val timestampIso = Instant.UNIX_FIRST_DATE
 
             val result = sysMessageCreator.conversationReadReceiptStatus(
                 TestConversation.CONVERSATION_RESPONSE.copy(type = ConversationResponse.Type.ONE_TO_ONE),
@@ -221,7 +224,7 @@ class NewGroupConversationSystemMessagesCreatorTest {
                 .withIsASelfTeamMember(false)
                 .withPersistMessageSuccess()
                 .arrange()
-            val timestampIso = DateTimeUtil.currentIsoDateTimeString()
+            val timestampIso = Clock.System.now()
 
             val result = sysMessageCreator.conversationReadReceiptStatus(TestConversation.CONVERSATION_RESPONSE, timestampIso)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.MetadataDAO
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.ktor.http.HttpStatusCode
 import io.mockative.Mock
 import io.mockative.any
@@ -47,6 +48,7 @@ import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -58,7 +60,7 @@ class EventRepositoryTest {
         val pendingEventPayload = EventContentDTO.Conversation.NewMessageDTO(
             TestConversation.NETWORK_ID,
             UserId("value", "domain"),
-            "eventTime",
+            Instant.UNIX_FIRST_DATE,
             MessageEventData("text", "senderId", "recipient")
         )
         val pendingEvent = EventResponse("pendingEventId", listOf(pendingEventPayload))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageMapperTest.kt
@@ -292,7 +292,7 @@ class MessageMapperTest {
             id: String = "someId",
             content: MessageContent.Regular = MessageContent.Text("someText"),
             conversationId: ConversationId = ConversationId("someValue", "someDomain"),
-            date: String = Instant.DISTANT_PAST.toString(),
+            date: Instant = Instant.DISTANT_PAST,
             senderUserId: UserId = UserId(value = "someValue", "someDomain"),
             status: Message.Status = Message.Status.Sent,
             visibility: Message.Visibility = Message.Visibility.VISIBLE,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -49,6 +49,7 @@ import com.wire.kalium.persistence.dao.message.MessageEntity.Status.SENT
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
 import com.wire.kalium.persistence.dao.message.RecipientFailureTypeEntity
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
+
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -164,16 +165,15 @@ class MessageRepositoryTest {
     fun givenAMessage_whenSendingReturnsSuccess_thenSuccessShouldBePropagatedWithServerTime() = runTest {
         val messageEnvelope = MessageEnvelope(TEST_CLIENT_ID, listOf())
         val mappedId: NetworkQualifiedId = TEST_NETWORK_QUALIFIED_ID_ENTITY
-        val timestamp = TEST_DATETIME
 
         val (_, messageRepository) = Arrangement()
-            .withSuccessfulMessageDelivery(timestamp)
+            .withSuccessfulMessageDelivery(TEST_DATETIME)
             .withFailedToSendMapping(emptyList())
             .arrange()
 
         messageRepository.sendEnvelope(TEST_CONVERSATION_ID, messageEnvelope, MessageTarget.Conversation())
             .shouldSucceed {
-                assertSame(it.time, TEST_DATETIME)
+                assertEquals(TEST_DATETIME, it.time)
             }
     }
 
@@ -261,15 +261,14 @@ class MessageRepositoryTest {
     @Test
     fun givenABroadcastMessage_whenBroadcastingReturnsSuccess_thenSuccessShouldBePropagatedWithServerTime() = runTest {
         val messageEnvelope = MessageEnvelope(TEST_CLIENT_ID, listOf())
-        val timestamp = TEST_DATETIME
 
         val (_, messageRepository) = Arrangement()
-            .withSuccessfulMessageBroadcasting(timestamp)
+            .withSuccessfulMessageBroadcasting(TEST_DATETIME)
             .arrange()
 
         messageRepository.broadcastEnvelope(messageEnvelope, BroadcastMessageOption.IgnoreSome(listOf()))
             .shouldSucceed {
-                assertSame(it, TEST_DATETIME)
+                assertSame(TEST_DATETIME, it)
             }
     }
 
@@ -277,15 +276,14 @@ class MessageRepositoryTest {
     fun givenABroadcastMessageWithExternalBlob_whenBroadcasting_thenApiShouldBeCalledWithBlob() = runTest {
         val dataBlob = EncryptedMessageBlob(byteArrayOf(0x42, 0x13, 0x69))
         val messageEnvelope = MessageEnvelope(TEST_CLIENT_ID, listOf(), dataBlob)
-        val timestamp = TEST_DATETIME
 
         val (arrangement, messageRepository) = Arrangement()
-            .withSuccessfulMessageBroadcasting(timestamp)
+            .withSuccessfulMessageBroadcasting(TEST_DATETIME)
             .arrange()
 
         messageRepository.broadcastEnvelope(messageEnvelope, BroadcastMessageOption.IgnoreSome(listOf()))
             .shouldSucceed {
-                assertSame(it, TEST_DATETIME)
+                assertEquals(TEST_DATETIME, it)
             }
 
         with(arrangement) {
@@ -613,11 +611,11 @@ class MessageRepositoryTest {
             return this
         }
 
-        suspend fun withSuccessfulMessageDelivery(timestamp: String): Arrangement {
+        suspend fun withSuccessfulMessageDelivery(dateTime: Instant): Arrangement {
             coEvery { messageApi.qualifiedSendMessage(any(), any()) }
                 .returns(
                     NetworkResponse.Success(
-                        QualifiedSendMessageResponse.MessageSent(timestamp, mapOf(), mapOf(), mapOf()),
+                        QualifiedSendMessageResponse.MessageSent(dateTime, mapOf(), mapOf(), mapOf()),
                         emptyMap(),
                         201
                     )
@@ -657,11 +655,11 @@ class MessageRepositoryTest {
             return this
         }
 
-        suspend fun withSuccessfulMessageBroadcasting(timestamp: String): Arrangement {
+        suspend fun withSuccessfulMessageBroadcasting(dateTime: Instant): Arrangement {
             coEvery { messageApi.qualifiedBroadcastMessage(any()) }
                 .returns(
                     NetworkResponse.Success(
-                        QualifiedSendMessageResponse.MessageSent(timestamp, mapOf(), mapOf(), mapOf()),
+                        QualifiedSendMessageResponse.MessageSent(dateTime, mapOf(), mapOf(), mapOf()),
                         emptyMap(),
                         201
                     )
@@ -756,8 +754,7 @@ class MessageRepositoryTest {
         val TEST_CLIENT_ID = ClientId("clientId")
         val TEST_USER_ID = UserId("userId", "domain")
         val TEST_CONTENT = MessageContent.Text("Ciao!")
-        const val TEST_DATETIME = "2022-04-21T20:56:22.393Z"
-        val INSTANT_TEST_DATETIME = Instant.parse(TEST_DATETIME)
+        val TEST_DATETIME = Instant.parse("2022-04-21T20:56:22.393Z")
         val TEST_MESSAGE = Message.Regular(
             id = "uid",
             content = TEST_CONTENT,
@@ -770,7 +767,7 @@ class MessageRepositoryTest {
             isSelfMessage = false
         )
         val TEST_ASSET_MESSAGE = AssetMessage(
-            time = INSTANT_TEST_DATETIME,
+            time = TEST_DATETIME,
             conversationId = TEST_CONVERSATION_ID,
             username = "username",
             messageId = "messageId",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCaseTest.kt
@@ -28,6 +28,7 @@ import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.mock
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 class PersistReactionUseCaseTest {
@@ -43,7 +44,7 @@ class PersistReactionUseCaseTest {
             ),
             conversationId = TestConversation.ID,
             senderUserId = TestUser.USER_ID,
-            date = "date"
+            date = Instant.DISTANT_PAST
         )
 
         coVerify {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessageFailureMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessageFailureMapperTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.failure.ProteusSendMessageFailure
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
 import com.wire.kalium.network.exceptions.ProteusClientsChangedError
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -38,7 +39,7 @@ class SendMessageFailureMapperTest {
     companion object {
         private val ERROR_DTO = ProteusClientsChangedError(
             errorBody = QualifiedSendMessageResponse.MissingDevicesResponse(
-                time = "some_time",
+                time = Instant.DISTANT_PAST,
                 missing = mapOf("missing_domain" to mapOf(userId(0) to listOf(clientId(0, 0), clientId(0, 1)))),
                 redundant = mapOf("redundant_domain" to mapOf(userId(1) to listOf(clientId(1, 0), clientId(1, 1)))),
                 deleted = mapOf(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapperTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser.OTHER_USER_ID_2
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
 import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -35,7 +36,7 @@ class SendMessagePartialFailureMapperTest {
     @Test
     fun testFromDTOMapping() {
         assertEquals(
-            MessageSent("2022-04-21T20:56:22.393Z", listOf(TEST_USER_ID, OTHER_USER_ID_2)), mapper.fromDTO(RESULT_DTO)
+            MessageSent(Instant.parse("2022-04-21T20:56:22.393Z"), listOf(TEST_USER_ID, OTHER_USER_ID_2)), mapper.fromDTO(RESULT_DTO)
         )
     }
 
@@ -43,9 +44,9 @@ class SendMessagePartialFailureMapperTest {
     fun testFromMlsDTOMapping() {
         val expectedUsersFailedToSend = listOf(TEST_USER_ID, OTHER_USER_ID_2)
         assertEquals(
-            MessageSent("2022-04-21T20:56:22.393Z", expectedUsersFailedToSend),
+            MessageSent(Instant.parse("2022-04-21T20:56:22.393Z"), expectedUsersFailedToSend),
             mapper.fromMlsDTO(
-                SendMLSMessageResponse("2022-04-21T20:56:22.393Z",
+                SendMLSMessageResponse(Instant.parse("2022-04-21T20:56:22.393Z"),
                     emptyList(),
                     expectedUsersFailedToSend.map { it.toApi() })
             )
@@ -54,7 +55,7 @@ class SendMessagePartialFailureMapperTest {
 
     companion object {
         private val RESULT_DTO = QualifiedSendMessageResponse.MessageSent(
-            time = "2022-04-21T20:56:22.393Z",
+            time = Instant.parse("2022-04-21T20:56:22.393Z"),
             missing = mapOf(),
             redundant = mapOf(),
             deleted = mapOf(),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest.kt
@@ -59,7 +59,7 @@ class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest {
             id = messageId,
             content = MessageContent.Text("text"),
             conversationId = conversationId,
-            date = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            date = Instant.DISTANT_FUTURE,
             senderUserId = senderUserID,
             senderClientId = currentClientId,
             status = Message.Status.Pending,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/reaction/ReactionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/reaction/ReactionRepositoryTest.kt
@@ -27,8 +27,8 @@ import com.wire.kalium.logic.util.IgnoreIOS
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.persistence.TestUserDatabase
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -53,7 +53,7 @@ class ReactionRepositoryTest {
     fun givenSelfUserReactionWasPersisted_whenGettingSelfUserReactions_thenShouldReturnPreviouslyStored() = runTest {
         insertInitialData()
         val emoji = "🫡"
-        reactionRepository.persistReaction(TEST_MESSAGE_ID, TEST_CONVERSATION_ID, SELF_USER_ID, "Date", emoji)
+        reactionRepository.persistReaction(TEST_MESSAGE_ID, TEST_CONVERSATION_ID, SELF_USER_ID, Instant.DISTANT_PAST, emoji)
 
         val result = reactionRepository.getSelfUserReactionsForMessage(TEST_MESSAGE_ID, TEST_CONVERSATION_ID)
 
@@ -64,13 +64,12 @@ class ReactionRepositoryTest {
     }
 
     @IgnoreIOS // TODO investigate why test is flaky
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun givenSelfUserReactionWasPersisted_whenObservingMessageReactions_thenShouldReturnReactionsPreviouslyStored() = runTest {
         insertInitialData()
 
-        reactionRepository.persistReaction(TEST_MESSAGE_ID, TEST_CONVERSATION_ID, SELF_USER_ID, "Date", "🤯")
-        reactionRepository.persistReaction(TEST_MESSAGE_ID, TEST_CONVERSATION_ID, SELF_USER_ID, "Date2", "❤️")
+        reactionRepository.persistReaction(TEST_MESSAGE_ID, TEST_CONVERSATION_ID, SELF_USER_ID, Instant.DISTANT_PAST, "🤯")
+        reactionRepository.persistReaction(TEST_MESSAGE_ID, TEST_CONVERSATION_ID, SELF_USER_ID, Instant.DISTANT_PAST, "❤️")
 
             reactionRepository.observeMessageReactions(
                 messageId = TEST_MESSAGE_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/GetMessageAssetUseCaseTest.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.network.api.base.model.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -49,6 +50,7 @@ import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import okio.Path
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -323,7 +325,7 @@ class GetMessageAssetUseCaseTest {
                 id = msgId,
                 content = MessageContent.Asset(mockedImageContent),
                 conversationId = convId,
-                date = "22-03-2022",
+                date = Instant.UNIX_FIRST_DATE,
                 senderUserId = userId,
                 senderClientId = clientId,
                 status = Message.Status.Sent,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -44,6 +44,7 @@ import io.mockative.coVerify
 import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 class EndCallOnConversationChangeUseCaseTest {
@@ -212,7 +213,7 @@ class EndCallOnConversationChangeUseCaseTest {
             lastModifiedDate = null,
             access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
             accessRole = Conversation.defaultGroupAccessRoles.toMutableList().apply { add(Conversation.AccessRole.GUEST) },
-            lastReadDate = "2022-04-04T16:11:28.388Z",
+            lastReadDate = Instant.parse("2022-04-04T16:11:28.388Z"),
             creatorId = null,
             receiptMode = Conversation.ReceiptMode.ENABLED,
             messageTimer = null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCaseTest.kt
@@ -38,6 +38,7 @@ import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -148,7 +149,7 @@ class AcceptConnectionRequestUseCaseTest {
         val CONNECTION = Connection(
             "someId",
             "from",
-            "lastUpdate",
+            Instant.DISTANT_PAST,
             CONVERSATION_ID,
             CONVERSATION_ID,
             ConnectionState.ACCEPTED,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/CancelConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/CancelConnectionRequestUseCaseTest.kt
@@ -32,6 +32,7 @@ import io.mockative.eq
 import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -87,7 +88,7 @@ class CancelConnectionRequestUseCaseTest {
         val connection = Connection(
             "someId",
             "from",
-            "lastUpdate",
+            Instant.DISTANT_PAST,
             ConversationId("someId", "someDomain"),
             ConversationId("someId", "someDomain"),
             ConnectionState.CANCELLED,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCaseTest.kt
@@ -32,6 +32,7 @@ import io.mockative.eq
 import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -87,7 +88,7 @@ class IgnoreConnectionRequestUseCaseTest {
         val connection = Connection(
             "someId",
             "from",
-            "lastUpdate",
+            Instant.DISTANT_PAST,
             ConversationId("someId", "someDomain"),
             ConversationId("someId", "someDomain"),
             ConnectionState.NOT_CONNECTED,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCaseTest.kt
@@ -39,6 +39,7 @@ import io.mockative.eq
 import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertIs
 
@@ -111,7 +112,7 @@ class RenameConversationUseCaseTest {
             EventContentDTO.Conversation.ConversationRenameDTO(
                 ConversationRepositoryTest.CONVERSATION_ID.toApi(),
                 ConversationRepositoryTest.USER_ID.toApi(),
-                DateTimeUtil.currentIsoDateTimeString(),
+                Instant.DISTANT_PAST,
                 ConversationNameUpdateEvent("newName")
             )
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationAccessUseCaseTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.SyncManager
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -41,6 +42,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import okio.IOException
 import kotlin.test.Test
 import kotlin.test.assertIs
@@ -400,7 +402,7 @@ class UpdateConversationAccessUseCaseTest {
                 Conversation.AccessRole.TEAM_MEMBER,
                 Conversation.AccessRole.GUEST
             ),
-            lastReadDate = "2022.01.02",
+            lastReadDate = Instant.UNIX_FIRST_DATE,
             creatorId = "someCreatorId",
             receiptMode = Conversation.ReceiptMode.DISABLED,
             messageTimer = null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/GetNotificationsUseCaseTest.kt
@@ -51,7 +51,6 @@ import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrang
 import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.EphemeralEventsNotificationManagerArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.NotificationEventsManagerArrangement
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -65,6 +64,7 @@ import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.days
 
 class GetNotificationsUseCaseTest {
 
@@ -361,9 +361,9 @@ class GetNotificationsUseCaseTest {
     companion object {
         val SELF_USER_ID = UserId("user-id", "domain")
         private val MY_ID = TestUser.USER_ID
-        private val TIME = Instant.fromEpochMilliseconds(948558215).toIsoDateTimeString()
+        private val TIME = Instant.fromEpochMilliseconds(948558215)
         private val TIME_INSTANCE = Instant.fromEpochMilliseconds(948558215)
-        private const val TIME_EARLIER = "2000-01-23T01:23:30.678+09:00"
+        private val TIME_EARLIER = TIME - 10.days
 
         private fun conversationId(number: Int = 0) =
             QualifiedID("conversation_id_${number}_value", "conversation_id_${number}_domain")
@@ -395,19 +395,18 @@ class GetNotificationsUseCaseTest {
             messageId: String = "message_id",
             content: MessageContent.Regular = MessageContent.Text("test message $messageId"),
             visibility: Message.Visibility = Message.Visibility.VISIBLE
-        ) =
-            Message.Regular(
-                id = messageId,
-                content = content,
-                conversationId = conversationId,
-                date = TIME,
-                senderUserId = senderId,
-                senderClientId = ClientId("client_1"),
-                status = Message.Status.Sent,
-                editStatus = Message.EditStatus.NotEdited,
-                visibility = visibility,
-                isSelfMessage = false
-            )
+        ) = Message.Regular(
+            id = messageId,
+            content = content,
+            conversationId = conversationId,
+            date = TIME,
+            senderUserId = senderId,
+            senderClientId = ClientId("client_1"),
+            status = Message.Status.Sent,
+            editStatus = Message.EditStatus.NotEdited,
+            visibility = visibility,
+            isSelfMessage = false
+        )
 
         private fun entityAssetMessage(
             conversationId: QualifiedID,
@@ -451,7 +450,7 @@ class GetNotificationsUseCaseTest {
                 id = messageId,
                 content = MessageContent.MemberChange.Removed(listOf(senderId)),
                 conversationId = conversationId,
-                date = "some_time",
+                date = Instant.DISTANT_PAST,
                 senderUserId = senderId,
                 status = Message.Status.Sent,
                 expirationData = null

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -65,6 +65,7 @@ import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.api.base.model.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.ktor.utils.io.core.toByteArray
 import io.mockative.Mock
 import io.mockative.any
@@ -413,7 +414,7 @@ class MessageSenderTest {
             id = Arrangement.TEST_MESSAGE_UUID,
             content = MessageContent.Calling(""),
             conversationId = Arrangement.TEST_CONVERSATION_ID,
-            date = TestMessage.TEST_DATE_STRING,
+            date = TestMessage.TEST_DATE,
             senderUserId = UserId("userValue", "userDomain"),
             senderClientId = ClientId("clientId"),
             status = Message.Status.Sent,
@@ -470,7 +471,7 @@ class MessageSenderTest {
             id = Arrangement.TEST_MESSAGE_UUID,
             content = MessageContent.Calling(""),
             conversationId = Arrangement.TEST_CONVERSATION_ID,
-            date = TestMessage.TEST_DATE_STRING,
+            date = TestMessage.TEST_DATE,
             senderUserId = UserId("userValue", "userDomain"),
             senderClientId = ClientId("clientId"),
             status = Message.Status.Sent,
@@ -626,7 +627,7 @@ class MessageSenderTest {
         val message = BroadcastMessage(
             id = Arrangement.TEST_MESSAGE_UUID,
             content = MessageContent.Calling(""),
-            date = TestMessage.TEST_DATE_STRING,
+            date = TestMessage.TEST_DATE,
             senderUserId = UserId("userValue", "userDomain"),
             senderClientId = ClientId("clientId"),
             status = Message.Status.Sent,
@@ -684,7 +685,7 @@ class MessageSenderTest {
         val message = BroadcastMessage(
             id = Arrangement.TEST_MESSAGE_UUID,
             content = MessageContent.Calling(""),
-            date = TestMessage.TEST_DATE_STRING,
+            date = TestMessage.TEST_DATE,
             senderUserId = senderUserId,
             senderClientId = senderClientId,
             status = Message.Status.Sent,
@@ -735,7 +736,7 @@ class MessageSenderTest {
         val message = BroadcastMessage(
             id = Arrangement.TEST_MESSAGE_UUID,
             content = MessageContent.Calling(""),
-            date = TestMessage.TEST_DATE_STRING,
+            date = TestMessage.TEST_DATE,
             senderUserId = senderUserId,
             senderClientId = senderClientId,
             status = Message.Status.Sent,
@@ -778,7 +779,7 @@ class MessageSenderTest {
             id = editedMessageId,
             content = content,
             conversationId = Arrangement.TEST_CONVERSATION_ID,
-            date = TestMessage.TEST_DATE_STRING,
+            date = TestMessage.TEST_DATE,
             senderUserId = UserId("userValue", "userDomain"),
             senderClientId = ClientId("clientId"),
             status = Message.Status.Pending,
@@ -939,7 +940,7 @@ class MessageSenderTest {
             withSendProteusMessage()
             withAllRecipients(listOf(Arrangement.TEST_RECIPIENT_1) to listOf())
             withCreateOutgoingBroadcastEnvelope()
-            withBroadcastEnvelope(Either.Left(failure), Either.Right(TestMessage.TEST_DATE_STRING)) // to avoid loop - fail then succeed
+            withBroadcastEnvelope(Either.Left(failure), Either.Right(TestMessage.TEST_DATE)) // to avoid loop - fail then succeed
             withHandleLegalHoldMessageSendFailure(Either.Right(false))
             withHandleClientsHaveChangedFailure()
         }
@@ -1123,13 +1124,13 @@ class MessageSenderTest {
             }.returns(if (failing) Either.Left(TEST_CORE_FAILURE) else Either.Right(TEST_MESSAGE_ENVELOPE))
         }
 
-        suspend fun withBroadcastEnvelope(result: Either<CoreFailure, String> = Either.Right(TestMessage.TEST_DATE_STRING)) = apply {
+        suspend fun withBroadcastEnvelope(result: Either<CoreFailure, Instant> = Either.Right(TestMessage.TEST_DATE)) = apply {
             coEvery {
                 messageRepository.broadcastEnvelope(any(), any())
             }.returns(result)
         }
 
-        suspend fun withBroadcastEnvelope(vararg result: Either<CoreFailure, String>) = apply {
+        suspend fun withBroadcastEnvelope(vararg result: Either<CoreFailure, Instant>) = apply {
             coEvery {
                 messageRepository.broadcastEnvelope(any(), any())
             }.thenReturnSequentially(*result)
@@ -1262,7 +1263,7 @@ class MessageSenderTest {
 
             val TEST_CONVERSATION_ID = TestConversation.ID
             const val TEST_MESSAGE_UUID = "messageUuid"
-            val MESSAGE_SENT_TIME = DateTimeUtil.currentIsoDateTimeString()
+            val MESSAGE_SENT_TIME = Instant.UNIX_FIRST_DATE
             val TEST_MLS_MESSAGE = MLSMessageApi.Message("message".toByteArray())
             val TEST_CORE_FAILURE = CoreFailure.Unknown(Throwable("an error"))
             val TEST_PROTOCOL_INFO_FAILURE = StorageFailure.DataNotFound

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCaseTest.kt
@@ -35,7 +35,7 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCa
 import com.wire.kalium.logic.feature.asset.UpdateTransferStatusResult
 import com.wire.kalium.logic.framework.TestAsset.mockedLongAssetData
 import com.wire.kalium.logic.framework.TestMessage.ASSET_CONTENT
-import com.wire.kalium.logic.framework.TestMessage.TEST_DATE_STRING
+import com.wire.kalium.logic.framework.TestMessage.TEST_DATE
 import com.wire.kalium.logic.framework.TestMessage.TEXT_MESSAGE
 import com.wire.kalium.logic.framework.TestMessage.assetMessage
 import com.wire.kalium.logic.functional.Either
@@ -47,16 +47,11 @@ import io.mockative.Mock
 import io.mockative.any
 
 import io.mockative.coEvery
-import io.mockative.every
 import io.mockative.coVerify
 import io.mockative.eq
-import io.mockative.coEvery
 import io.mockative.matches
-import io.mockative.coVerify
-import io.mockative.coEvery
 import io.mockative.mock
 import io.mockative.once
-import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -140,7 +135,7 @@ class RetryFailedMessageUseCaseTest {
     fun givenAValidFailedEditedMessage_whenRetryingFailedMessage_thenShouldSendAsSignalingWithNewId() =
         runTest(testDispatcher.default) {
             // given
-            val message = TEXT_MESSAGE.copy(status = Message.Status.Failed, editStatus = Message.EditStatus.Edited(TEST_DATE_STRING))
+            val message = TEXT_MESSAGE.copy(status = Message.Status.Failed, editStatus = Message.EditStatus.Edited(TEST_DATE))
             val (arrangement, useCase) = Arrangement()
                 .withGetMessageById(Either.Right(message))
                 .withUpdateMessageStatus(Either.Right(Unit))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCaseTest.kt
@@ -45,6 +45,7 @@ import io.mockative.matches
 import io.mockative.mock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -134,7 +135,7 @@ class ToggleReactionUseCaseTest {
                 originalMessageId: String,
                 conversationId: ConversationId,
                 senderUserId: UserId,
-                date: String,
+                instant: Instant,
                 emoji: String
             ): Either<StorageFailure, Unit> {
                 persistCallCount++

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConnection.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConnection.kt
@@ -20,12 +20,13 @@ package com.wire.kalium.logic.framework
 
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
+import kotlinx.datetime.Instant
 
 object TestConnection {
     val CONNECTION = Connection(
         TestConversation.ID.value,
         "FROM",
-        "2022-03-30T15:36:00.000Z",
+        Instant.DISTANT_PAST,
         TestConversation.ID,
         TestUser.USER_ID,
         ConnectionState.SENT,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -69,7 +69,7 @@ object TestConversation {
         null,
         null,
         null,
-        lastReadDate = "2022-03-30T15:36:00.000Z",
+        lastReadDate = Instant.parse("2022-03-30T15:36:00.000Z"),
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         creatorId = null,
@@ -93,7 +93,7 @@ object TestConversation {
         null,
         null,
         null,
-        lastReadDate = "2022-03-30T15:36:00.000Z",
+        lastReadDate = Instant.parse("2022-03-30T15:36:00.000Z"),
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         creatorId = null,
@@ -117,7 +117,7 @@ object TestConversation {
         null,
         null,
         null,
-        lastReadDate = "2022-03-30T15:36:00.000Z",
+        lastReadDate = Instant.parse("2022-03-30T15:36:00.000Z"),
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         creatorId = null,
@@ -188,7 +188,7 @@ object TestConversation {
         null,
         null,
         null,
-        lastReadDate = "2022-03-30T15:36:00.000Z",
+        lastReadDate = Instant.parse("2022-03-30T15:36:00.000Z"),
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
         creatorId = null,
@@ -243,7 +243,7 @@ object TestConversation {
             EventContentDTO.Conversation.MemberJoinDTO(
                 NETWORK_ID,
                 NETWORK_USER_ID1,
-                "2022-03-30T15:36:00.000Z",
+                Instant.UNIX_FIRST_DATE,
                 ConversationMembers(emptyList(), emptyList()),
                 NETWORK_ID.value
             )
@@ -254,7 +254,7 @@ object TestConversation {
             EventContentDTO.Conversation.MemberJoinDTO(
                 NETWORK_ID,
                 NETWORK_USER_ID1,
-                "2022-03-30T15:36:00.000Z",
+                Instant.UNIX_FIRST_DATE,
                 ConversationMembers(emptyList(), emptyList()),
                 NETWORK_ID.value
             )
@@ -265,7 +265,7 @@ object TestConversation {
             EventContentDTO.Conversation.MemberLeaveDTO(
                 NETWORK_ID,
                 NETWORK_USER_ID1,
-                "2022-03-30T15:36:00.000Z",
+                Instant.UNIX_FIRST_DATE,
                 ConversationMemberRemovedDTO(emptyList(), MemberLeaveReasonDTO.LEFT),
                 NETWORK_USER_ID1.value
             )
@@ -369,7 +369,7 @@ object TestConversation {
         null,
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
-        lastReadDate = "2022-03-30T15:36:00.000Z",
+        lastReadDate = Instant.parse("2022-03-30T15:36:00.000Z"),
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,
@@ -393,7 +393,7 @@ object TestConversation {
         null,
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
         accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
-        lastReadDate = "2022-03-30T15:36:00.000Z",
+        lastReadDate = Instant.parse("2022-03-30T15:36:00.000Z"),
         creatorId = null,
         receiptMode = Conversation.ReceiptMode.DISABLED,
         messageTimer = null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.user.type.UserType
+import kotlinx.datetime.Instant
 
 object TestConversationDetails {
 
@@ -29,7 +30,7 @@ object TestConversationDetails {
         TestConversation.ID,
         TestUser.OTHER,
         UserType.EXTERNAL,
-        "2022-03-30T15:36:00.000Z",
+        Instant.parse("2022-03-30T15:36:00.000Z"),
         TestConnection.CONNECTION,
         protocolInfo = ProtocolInfo.Proteus,
         access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.sync.incremental.EventSource
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.ktor.util.encodeBase64
 import kotlinx.datetime.Instant
 
@@ -44,15 +44,15 @@ object TestEvent {
         TestConversation.ID,
         TestUser.USER_ID,
         members,
-        "2022-03-30T15:36:00.000Z"
+        Instant.UNIX_FIRST_DATE,
     )
 
-    fun memberLeave(eventId: String = "eventId", members: List<Member> = listOf()) = Event.Conversation.MemberLeave(
+    fun memberLeave(eventId: String = "eventId", members: List<UserId> = listOf()) = Event.Conversation.MemberLeave(
         eventId,
         TestConversation.ID,
         TestUser.USER_ID,
-        listOf(),
-        "2022-03-30T15:36:00.000Z",
+        members,
+        Instant.UNIX_FIRST_DATE,
         reason = MemberLeaveReason.Left
     )
 
@@ -109,7 +109,7 @@ object TestEvent {
         Connection(
             conversationId = "conversationId",
             from = "from",
-            lastUpdate = "lastUpdate",
+            lastUpdate = Instant.UNIX_FIRST_DATE,
             qualifiedConversationId = TestConversation.ID,
             qualifiedToId = TestUser.USER_ID,
             status = status,
@@ -129,7 +129,7 @@ object TestEvent {
         TestConversation.ID,
         "newName",
         TestUser.USER_ID,
-        "2022-03-30T15:36:00.000Z"
+        Instant.UNIX_FIRST_DATE,
     )
 
     fun receiptModeUpdate(eventId: String = "eventId") = Event.Conversation.ConversationReceiptMode(
@@ -143,7 +143,7 @@ object TestEvent {
         eventId,
         teamId = "teamId",
         memberId = "memberId",
-        timestampIso = "2022-03-30T15:36:00.000Z",
+        Instant.UNIX_FIRST_DATE,
     )
 
     fun timerChanged(eventId: String = "eventId") = Event.Conversation.ConversationMessageTimer(
@@ -151,7 +151,7 @@ object TestEvent {
         conversationId = TestConversation.ID,
         messageTimer = 3000,
         senderUserId = TestUser.USER_ID,
-        timestampIso = "2022-03-30T15:36:00.000Z"
+        Instant.UNIX_FIRST_DATE,
     )
 
     fun userPropertyReadReceiptMode(eventId: String = "eventId") = Event.UserProperty.ReadReceiptModeSet(
@@ -168,26 +168,26 @@ object TestEvent {
         TestConversation.ID,
         senderUserId,
         TestClient.CLIENT_ID,
-        "time",
+        Instant.UNIX_FIRST_DATE,
         encryptedContent,
         encryptedExternalContent
     )
 
     fun newMLSMessageEvent(
-        timestamp: Instant
+        dateTime: Instant
     ) = Event.Conversation.NewMLSMessage(
         "eventId",
         TestConversation.ID,
         null,
         TestUser.USER_ID,
-        timestamp.toIsoDateTimeString(),
+        dateTime,
         "content".encodeBase64(),
     )
 
     fun newConversationEvent() = Event.Conversation.NewConversation(
         id = "eventId",
         conversationId = TestConversation.ID,
-        timestampIso = "timestamp",
+        dateTime = Instant.UNIX_FIRST_DATE,
         conversation = TestConversation.CONVERSATION_RESPONSE,
         senderUserId = TestUser.SELF.id
     )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
@@ -27,13 +27,13 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.message.MessageSent
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
-import kotlinx.datetime.toInstant
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 object TestMessage {
     const val TEST_MESSAGE_ID = "messageId"
-    const val TEST_DATE_STRING = "2000-01-01T12:00:00.000Z"
-    val TEST_MESSAGE_SENT = MessageSent(TEST_DATE_STRING)
-    val TEST_DATE = TEST_DATE_STRING.toInstant()
+    val TEST_DATE = Instant.parse("2023-02-01T12:34:50Z")
+    val TEST_MESSAGE_SENT = MessageSent(TEST_DATE)
     val TEST_SENDER_USER_ID = TestUser.USER_ID
     val TEST_SENDER_CLIENT_ID = TestClient.CLIENT_ID
     val TEXT_CONTENT = MessageContent.Text("Ciao!")
@@ -57,7 +57,7 @@ object TestMessage {
         id = TEST_MESSAGE_ID,
         content = TEXT_CONTENT,
         conversationId = TestConversation.ID,
-        date = TEST_DATE_STRING,
+        date = TEST_DATE,
         senderUserId = TEST_SENDER_USER_ID,
         senderClientId = TEST_SENDER_CLIENT_ID,
         status = Message.Status.Pending,
@@ -69,7 +69,7 @@ object TestMessage {
         id = TEST_MESSAGE_ID,
         content = MessageContent.MissedCall,
         conversationId = ConversationId("conv", "id"),
-        date = TEST_DATE_STRING,
+        date = TEST_DATE,
         senderUserId = TEST_SENDER_USER_ID,
         status = Message.Status.Pending,
         expirationData = null
@@ -79,7 +79,7 @@ object TestMessage {
         id = TEST_MESSAGE_ID,
         content = ASSET_CONTENT,
         conversationId = ConversationId("conv", "id"),
-        date = TEST_DATE_STRING,
+        date = TEST_DATE,
         senderUserId = TEST_SENDER_USER_ID,
         senderClientId = TEST_SENDER_CLIENT_ID,
         status = Message.Status.Pending,
@@ -104,7 +104,7 @@ object TestMessage {
     val BROADCAST_MESSAGE = BroadcastMessage(
         id = TEST_MESSAGE_ID,
         content = MessageContent.Availability(UserAvailabilityStatus.AVAILABLE),
-        date = TEST_DATE_STRING,
+        date = TEST_DATE,
         senderUserId = TEST_SENDER_USER_ID,
         senderClientId = TEST_SENDER_CLIENT_ID,
         status = Message.Status.Pending,
@@ -117,7 +117,7 @@ object TestMessage {
         id = TEST_MESSAGE_ID,
         content = content,
         conversationId = TestConversation.ID,
-        date = "currentDate",
+        date = Clock.System.now(),
         senderUserId = TEST_SENDER_USER_ID,
         senderClientId = TEST_SENDER_CLIENT_ID,
         status = Message.Status.Sent,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/stub/ReactionRepositoryStub.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/stub/ReactionRepositoryStub.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Instant
 
 open class ReactionRepositoryStub : ReactionRepository {
 
@@ -34,7 +35,7 @@ open class ReactionRepositoryStub : ReactionRepository {
         originalMessageId: String,
         conversationId: ConversationId,
         senderUserId: UserId,
-        date: String,
+        instant: Instant,
         emoji: String
     ): Either<StorageFailure, Unit> = Either.Right(Unit)
 
@@ -63,7 +64,7 @@ open class ReactionRepositoryStub : ReactionRepository {
         originalMessageId: String,
         conversationId: ConversationId,
         senderUserId: UserId,
-        date: String,
+        instant: Instant,
         userReactions: UserReactions
     ): Either<StorageFailure, Unit> = Either.Right(Unit)
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MessageTextEditHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MessageTextEditHandlerTest.kt
@@ -29,13 +29,16 @@ import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrang
 import com.wire.kalium.logic.util.arrangement.usecase.NotificationEventsManagerArrangement
 import com.wire.kalium.logic.util.arrangement.usecase.EphemeralEventsNotificationManagerArrangementImpl
 import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.minutes
 
 class MessageTextEditHandlerTest {
 
@@ -77,7 +80,7 @@ class MessageTextEditHandlerTest {
     @Test
     fun givenEditIsNewerThanLocalPendingStoredEdit_whenHandling_thenShouldUpdateTheWholeMessageDataAndStatus() = runTest {
         val originalContent = TestMessage.TEXT_CONTENT
-        val originalEditStatus = Message.EditStatus.Edited("2000-01-01T12:00:00.000Z")
+        val originalEditStatus = Message.EditStatus.Edited(Instant.UNIX_FIRST_DATE)
         val originalMessage = ORIGINAL_MESSAGE.copy(
             editStatus = originalEditStatus,
             content = originalContent,
@@ -85,7 +88,7 @@ class MessageTextEditHandlerTest {
         )
         val editContent = EDIT_CONTENT
         val editMessage = EDIT_MESSAGE.copy(
-            date = "2000-01-01T12:00:00.001Z",
+            date = Instant.UNIX_FIRST_DATE,
             content = editContent
         )
         val (arrangement, messageTextEditHandler) = arrange {
@@ -115,7 +118,7 @@ class MessageTextEditHandlerTest {
     @Test
     fun givenEditIsOlderThanLocalPendingStoredEdit_whenHandling_thenShouldUpdateOnlyMessageIdAndDate() = runTest {
         val originalContent = TestMessage.TEXT_CONTENT
-        val originalEditStatus = Message.EditStatus.Edited("2000-01-01T12:00:00.001Z")
+        val originalEditStatus = Message.EditStatus.Edited(Instant.UNIX_FIRST_DATE)
         val originalMessage = ORIGINAL_MESSAGE.copy(
             editStatus = originalEditStatus,
             content = originalContent,
@@ -124,7 +127,7 @@ class MessageTextEditHandlerTest {
         )
         val editContent = EDIT_CONTENT
         val editMessage = EDIT_MESSAGE.copy(
-            date = "2000-01-01T12:00:00.000Z",
+            date = EDIT_MESSAGE.date - 10.minutes,
             content = editContent
         )
         val expectedContent = MessageContent.TextEdited(
@@ -140,7 +143,7 @@ class MessageTextEditHandlerTest {
 
         with(arrangement) {
             coVerify {
-                messageRepository.updateTextMessage(any(), eq(expectedContent), eq(editMessage.id), eq(originalEditStatus.lastTimeStamp))
+                messageRepository.updateTextMessage(any(), eq(expectedContent), eq(editMessage.id), eq(originalEditStatus.lastEditInstant))
             }.wasInvoked(exactly = once)
             coVerify {
                 messageRepository.updateMessageStatus(any(), any(), any())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ConversationMessageTimerEventHandlerTest.kt
@@ -57,7 +57,7 @@ class ConversationMessageTimerEventHandlerTest {
                         messageTimer = event.messageTimer
                     ),
                     event.conversationId,
-                    event.timestampIso,
+                    event.dateTime,
                     event.senderUserId,
                     Message.Status.Sent,
                     Message.Visibility.VISIBLE,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangeme
 import com.wire.kalium.logic.util.arrangement.usecase.PersistMessageUseCaseArrangement
 import com.wire.kalium.logic.util.arrangement.usecase.PersistMessageUseCaseArrangementImpl
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -48,6 +49,7 @@ import io.mockative.matches
 import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 class MemberLeaveEventHandlerTest {
@@ -294,7 +296,7 @@ class MemberLeaveEventHandlerTest {
             conversationId = conversationId,
             removedBy = userId,
             removedList = listOf(userId),
-            timestampIso = "timestampIso",
+            dateTime = Instant.UNIX_FIRST_DATE,
             reason = reason
         )
 
@@ -302,7 +304,7 @@ class MemberLeaveEventHandlerTest {
             id = event.id,
             content = MessageContent.MemberChange.Removed(members = event.removedList),
             conversationId = event.conversationId,
-            date = event.timestampIso,
+            date = event.dateTime,
             senderUserId = event.removedBy,
             status = Message.Status.Sent,
             visibility = Message.Visibility.VISIBLE,
@@ -313,7 +315,7 @@ class MemberLeaveEventHandlerTest {
             id = event.id,
             content = MessageContent.MemberChange.RemovedFromTeam(members = event.removedList),
             conversationId = event.conversationId,
-            date = event.timestampIso,
+            date = event.dateTime,
             senderUserId = event.removedBy,
             status = Message.Status.Sent,
             visibility = Message.Visibility.VISIBLE,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.test_util.wasInTheLastSecond
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ReceiptMode
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -50,6 +51,7 @@ import io.mockative.matches
 import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 class NewConversationEventHandlerTest {
@@ -157,21 +159,21 @@ class NewConversationEventHandlerTest {
             arrangement.newGroupConversationSystemMessagesCreator.conversationResolvedMembersAdded(
                 eq(event.conversationId.toDao()),
                 eq(event.conversation.members.otherMembers.map { it.id.toModel() }),
-                eq(event.timestampIso)
+                eq(event.dateTime)
             )
         }.wasInvoked(exactly = once)
 
         coVerify {
             arrangement.newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(
                 eq(event.conversation),
-                eq(event.timestampIso)
+                eq(event.dateTime)
             )
         }.wasInvoked(exactly = once)
 
         coVerify {
             arrangement.newGroupConversationSystemMessagesCreator.conversationStartedUnverifiedWarning(
                 eq(event.conversation.id.toModel()),
-                eq(event.timestampIso)
+                eq(event.dateTime)
             )
         }.wasInvoked(exactly = once)
     }
@@ -216,14 +218,14 @@ class NewConversationEventHandlerTest {
                 arrangement.newGroupConversationSystemMessagesCreator.conversationResolvedMembersAdded(
                     eq(event.conversationId.toDao()),
                     eq(event.conversation.members.otherMembers.map { it.id.toModel() }),
-                    eq(event.timestampIso)
+                    eq(event.dateTime)
                 )
             }.wasNotInvoked()
 
             coVerify {
                 arrangement.newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(
                     eq(event.conversation),
-                    eq(event.timestampIso)
+                    eq(event.dateTime)
                 )
             }.wasNotInvoked()
         }
@@ -368,7 +370,7 @@ class NewConversationEventHandlerTest {
 
         suspend fun withReadReceiptsSystemMessage() = apply {
             coEvery {
-                newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(any<ConversationResponse>(), any<String>())
+                newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(any<ConversationResponse>(), any<Instant>())
             }.returns(Either.Right(Unit))
         }
 
@@ -393,7 +395,7 @@ class NewConversationEventHandlerTest {
         ) = Event.Conversation.NewConversation(
             id = "eventId",
             conversationId = TestConversation.ID,
-            timestampIso = "timestamp",
+            dateTime = Instant.UNIX_FIRST_DATE,
             conversation = conversation,
             senderUserId = TestUser.SELF.id
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
@@ -85,7 +85,7 @@ class ApplicationMessageHandlerTest {
         val messageEvent = TestEvent.newMessageEvent(encodedEncryptedContent.decodeToString())
         messageHandler.handleContent(
             messageEvent.conversationId,
-            messageEvent.timestampIso,
+            messageEvent.messageInstant,
             messageEvent.senderUserId,
             messageEvent.senderClientId,
             protoContent
@@ -122,7 +122,7 @@ class ApplicationMessageHandlerTest {
         val messageEvent = TestEvent.newMessageEvent(encodedEncryptedContent.decodeToString())
         messageHandler.handleContent(
             messageEvent.conversationId,
-            messageEvent.timestampIso,
+            messageEvent.messageInstant,
             messageEvent.senderUserId,
             messageEvent.senderClientId,
             protoContent

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -355,7 +355,7 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewMLSMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.staleEpochVerifier.verifyEpoch(eq(newMessageEvent.conversationId), eq(newMessageEvent.timestampIso.toInstant()))
+            arrangement.staleEpochVerifier.verifyEpoch(eq(newMessageEvent.conversationId), eq(newMessageEvent.messageInstant))
         }.wasInvoked(exactly = once)
     }
 
@@ -450,7 +450,7 @@ class NewMessageEventHandlerTest {
         val SELF_USER_ID = UserId("selfUserId", "selfDomain")
         val applicationMessage = MessageUnpackResult.ApplicationMessage(
             ConversationId("conversationID", "domain"),
-            Instant.DISTANT_PAST.toIsoDateTimeString(),
+            Instant.DISTANT_PAST,
             SELF_USER_ID,
             ClientId("clientID"),
             ProtoContent.Readable(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
@@ -198,7 +198,7 @@ class ReceiptMessageHandlerTest {
                 id = "signalingId",
                 content = content,
                 conversationId = CONVERSATION_ID,
-                date = date.toIsoDateTimeString(),
+                date = date,
                 senderUserId = senderUserId,
                 senderClientId = ClientId("SomeClientId"),
                 status = Message.Status.Sent,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
@@ -44,9 +44,8 @@ import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.logic.util.thenReturnSequentially
-import com.wire.kalium.util.DateTimeUtil.minusMilliseconds
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -68,6 +67,7 @@ import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
 
 class LegalHoldHandlerTest {
 
@@ -435,7 +435,7 @@ class LegalHoldHandlerTest {
         coVerify {
             arrangement.legalHoldSystemMessagesHandler.handleEnabledForConversation(
                 eq(TestConversation.CONVERSATION.id),
-                eq(minusMilliseconds(message.timestampIso, 1))
+                eq(message.instant - 1.milliseconds)
             )
         }.wasInvoked()
     }
@@ -495,12 +495,12 @@ class LegalHoldHandlerTest {
         // given
         val conversationId = TestConversation.CONVERSATION.id
         val failure = CoreFailure.Unknown(null)
-        val timestampIso = "2022-03-30T15:36:00.000Z"
+        val dateTime = Instant.UNIX_FIRST_DATE
         val handleFailure: () -> Either<CoreFailure, Unit> = { Either.Left(failure) }
         val (_, handler) = Arrangement()
             .arrange()
         // when
-        val result = handler.handleMessageSendFailure(conversationId, timestampIso, handleFailure)
+        val result = handler.handleMessageSendFailure(conversationId, dateTime, handleFailure)
         // then
         result.shouldFail {
             assertEquals(failure, it)
@@ -511,7 +511,7 @@ class LegalHoldHandlerTest {
     fun givenLegalHoldEnabledForConversation_whenHandlingMessageSendFailure_thenHandleItProperlyAndReturnTrue() = runTest {
         // given
         val conversationId = TestConversation.CONVERSATION.id
-        val timestampIso = "2022-03-30T15:36:00.000Z"
+        val dateTime = Instant.UNIX_FIRST_DATE
         val handleFailure: () -> Either<CoreFailure, Unit> = { Either.Right(Unit) }
         val membersHavingLegalHoldClientBefore = emptyList<UserId>()
         val membersHavingLegalHoldClientAfter = listOf(TestUser.OTHER_USER_ID)
@@ -521,7 +521,7 @@ class LegalHoldHandlerTest {
             .withUpdateLegalHoldStatusSuccess(true)
             .arrange()
         // when
-        val result = handler.handleMessageSendFailure(conversationId, timestampIso, handleFailure)
+        val result = handler.handleMessageSendFailure(conversationId, dateTime, handleFailure)
         // then
         result.shouldSucceed {
             assertEquals(true, it)
@@ -535,7 +535,7 @@ class LegalHoldHandlerTest {
     fun givenLegalHoldDisabledForConversation_whenHandlingMessageSendFailure_thenHandleItProperlyAndReturnFalse() = runTest {
         // given
         val conversationId = TestConversation.CONVERSATION.id
-        val timestampIso = "2022-03-30T15:36:00.000Z"
+        val dateTime = Instant.UNIX_FIRST_DATE
         val handleFailure: () -> Either<CoreFailure, Unit> = { Either.Right(Unit) }
         val membersHavingLegalHoldClientBefore = listOf(TestUser.OTHER_USER_ID)
         val membersHavingLegalHoldClientAfter = emptyList<UserId>()
@@ -545,7 +545,7 @@ class LegalHoldHandlerTest {
             .withUpdateLegalHoldStatusSuccess(true)
             .arrange()
         // when
-        val result = handler.handleMessageSendFailure(conversationId, timestampIso, handleFailure)
+        val result = handler.handleMessageSendFailure(conversationId, dateTime, handleFailure)
         // then
         result.shouldSucceed {
             assertEquals(false, it)
@@ -559,7 +559,7 @@ class LegalHoldHandlerTest {
     fun givenLegalHoldChangedForConversation_whenHandlingMessageSendFailure_thenUseTimestampOfMessageMinus1msForSystemMessage() = runTest {
         // given
         val conversationId = TestConversation.CONVERSATION.id
-        val timestampIso = "2022-03-30T15:36:00.000Z"
+        val dateTime = Instant.UNIX_FIRST_DATE
         val handleFailure: () -> Either<CoreFailure, Unit> = { Either.Right(Unit) }
         val membersHavingLegalHoldClientBefore = emptyList<UserId>()
         val membersHavingLegalHoldClientAfter = listOf(TestUser.OTHER_USER_ID)
@@ -569,12 +569,12 @@ class LegalHoldHandlerTest {
             .withUpdateLegalHoldStatusSuccess(true)
             .arrange()
         // when
-        handler.handleMessageSendFailure(conversationId, timestampIso, handleFailure)
+        handler.handleMessageSendFailure(conversationId, dateTime, handleFailure)
         // then
         coVerify {
             arrangement.legalHoldSystemMessagesHandler.handleEnabledForConversation(
                 eq(conversationId),
-                eq(minusMilliseconds(timestampIso, 1))
+                eq(dateTime - 1.milliseconds)
             )
         }.wasInvoked()
     }
@@ -583,7 +583,7 @@ class LegalHoldHandlerTest {
     fun givenLegalHoldNotChangedForConversation_whenHandlingMessageSendFailure_thenHandleItProperlyAndReturnFalse() = runTest {
         // given
         val conversationId = TestConversation.CONVERSATION.id
-        val timestampIso = "2022-03-30T15:36:00.000Z"
+        val dateTime = Instant.UNIX_FIRST_DATE
         val handleFailure: () -> Either<CoreFailure, Unit> = { Either.Right(Unit) }
         val membersHavingLegalHoldClientBefore = listOf(TestUser.OTHER_USER_ID)
         val membersHavingLegalHoldClientAfter = listOf(TestUser.OTHER_USER_ID)
@@ -593,7 +593,7 @@ class LegalHoldHandlerTest {
             .withUpdateLegalHoldStatusSuccess(false)
             .arrange()
         // when
-        val result = handler.handleMessageSendFailure(conversationId, timestampIso, handleFailure)
+        val result = handler.handleMessageSendFailure(conversationId, dateTime, handleFailure)
         // then
         result.shouldSucceed {
             assertEquals(false, it)
@@ -610,7 +610,7 @@ class LegalHoldHandlerTest {
     fun givenLegalHoldChangedForMembers_whenHandlingMessageSendFailure_thenHandleItProperly() = runTest {
         // given
         val conversationId = TestConversation.CONVERSATION.id
-        val timestampIso = "2022-03-30T15:36:00.000Z"
+        val dateTime = Instant.UNIX_FIRST_DATE
         val handleFailure: () -> Either<CoreFailure, Unit> = { Either.Right(Unit) }
         val membersHavingLegalHoldClientBefore = listOf(TestUser.OTHER_USER_ID)
         val membersHavingLegalHoldClientAfter = listOf(TestUser.OTHER_USER_ID_2)
@@ -620,7 +620,7 @@ class LegalHoldHandlerTest {
             .withUpdateLegalHoldStatusSuccess()
             .arrange()
         // when
-        val result = handler.handleMessageSendFailure(conversationId, timestampIso, handleFailure)
+        val result = handler.handleMessageSendFailure(conversationId, dateTime, handleFailure)
         // then
         result.shouldSucceed()
         coVerify {
@@ -707,7 +707,7 @@ class LegalHoldHandlerTest {
         val conversationId = TestConversation.CONVERSATION.id
         val selfUserId = TestUser.SELF.id
         val otherUserId = TestUser.OTHER_USER_ID
-        val membersHavingLegalHoldClient =  listOf(otherUserId)
+        val membersHavingLegalHoldClient = listOf(otherUserId)
         val conversationLegalHoldStatusBefore = Conversation.LegalHoldStatus.ENABLED
         val (arrangement, handler) = Arrangement()
             .withMembersHavingLegalHoldClientSuccess(membersHavingLegalHoldClient)
@@ -920,7 +920,7 @@ class LegalHoldHandlerTest {
             coVerify {
                 arrangement.legalHoldSystemMessagesHandler.handleEnabledForUser(any(), any())
             }.wasInvoked()
-    }
+        }
 
     private class Arrangement {
 
@@ -1070,7 +1070,7 @@ class LegalHoldHandlerTest {
 
         private fun applicationMessage(legalHoldStatus: Conversation.LegalHoldStatus) = MessageUnpackResult.ApplicationMessage(
             conversationId = TestConversation.CONVERSATION.id,
-            timestampIso = Instant.DISTANT_PAST.toIsoDateTimeString(),
+            instant = Instant.DISTANT_PAST,
             senderUserId = TestUser.SELF.id,
             senderClientId = ClientId("clientID"),
             content = ProtoContent.Readable(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/MessageContentEncoderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/MessageContentEncoderTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.util
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.util.string.toHexString
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -33,7 +34,7 @@ class MessageContentEncoderTest {
     fun givenAMessageBodyWithEmoji_whenEncoding_ThenResultHasExpectedHexResult() = runTest {
         // given / when
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = textWithEmoji.first.second,
+            messageInstant = textWithEmoji.first.second,
             messageContent = MessageContent.Text(textWithEmoji.first.first)
         )
         // then
@@ -44,7 +45,7 @@ class MessageContentEncoderTest {
     @Test
     fun givenAMessageBodyWithUrl_whenEncoding_ThenResultHasExpectedHexResult() = runTest {
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = url.first.second,
+            messageInstant = url.first.second,
             messageContent = MessageContent.Text(url.first.first)
         )
 
@@ -56,7 +57,7 @@ class MessageContentEncoderTest {
     @Test
     fun givenAMessageBodyWithArabic_whenEncoding_ThenResultHasExpectedHexResult() = runTest {
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = arabic.first.second,
+            messageInstant = arabic.first.second,
             messageContent = MessageContent.Text(arabic.first.first)
         )
 
@@ -68,7 +69,7 @@ class MessageContentEncoderTest {
     @Test
     fun givenAMessageBodyWithMarkDown_whenEncoding_ThenResultHasExpectedHexResult() = runTest {
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = markDown.first.second,
+            messageInstant = markDown.first.second,
             messageContent = MessageContent.Text(markDown.first.first)
         )
 
@@ -81,7 +82,7 @@ class MessageContentEncoderTest {
     fun givenAMessageBodyWithEmoji_whenEncoding_ThenResultHasExpectedSHA256HashResult() = runTest {
         // given / when
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = textWithEmoji.first.second,
+            messageInstant = textWithEmoji.first.second,
             messageContent = MessageContent.Text(textWithEmoji.first.first)
         )
 
@@ -93,7 +94,7 @@ class MessageContentEncoderTest {
     @Test
     fun givenAMessageBodyWithUrl_whenEncoding_ThenResultHasExpectedSHA256HashResult() = runTest {
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = url.first.second,
+            messageInstant = url.first.second,
             messageContent = MessageContent.Text(url.first.first)
         )
 
@@ -105,7 +106,7 @@ class MessageContentEncoderTest {
     @Test
     fun givenAMessageBodyWithArabic_whenEncoding_ThenResultHasExpectedSHA256HashResult() = runTest {
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = arabic.first.second,
+            messageInstant = arabic.first.second,
             messageContent = MessageContent.Text(arabic.first.first)
         )
 
@@ -117,7 +118,7 @@ class MessageContentEncoderTest {
     @Test
     fun givenAMessageBodyWithMarkDown_whenEncoding_ThenResultHasExpectedSHA256HashResult() = runTest {
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = markDown.first.second,
+            messageInstant = markDown.first.second,
             messageContent = MessageContent.Text(markDown.first.first)
         )
 
@@ -130,7 +131,7 @@ class MessageContentEncoderTest {
     fun givenALocationMessage_whenEncoding_ThenResultHasExpectedSHA256HashResult() = runTest {
         val (locationMessage, messageDate, expectedHash) = location
         val result = messageContentEncoder.encodeMessageContent(
-            messageDate = messageDate,
+            messageInstant = messageDate,
             messageContent = locationMessage
         )
 
@@ -143,7 +144,7 @@ class MessageContentEncoderTest {
         val textWithEmoji =
             (
                     "Hello \uD83D\uDC69\u200D\uD83D\uDCBB\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67!" to
-                            "2018-10-22T15:09:29.000+02:00"
+                            Instant.parse("2018-10-22T15:09:29.000+02:00")
                     ) to
                     (
                             "feff00480065006c006c006f0020d83ddc69200dd83ddcbbd83ddc68200dd83ddc69200dd83ddc670021000000005bcdcc09" to
@@ -152,7 +153,7 @@ class MessageContentEncoderTest {
 
         val url = (
                 "https://www.youtube.com/watch?v=DLzxrzFCyOs" to
-                        "2018-10-22T15:09:29.000+02:00"
+                        Instant.parse("2018-10-22T15:09:29.000+02:00")
                 ) to
                 ("feff00680074007400700073003a002f002f007700770077002e" +
                         "0079006f00750074007500620065002e0063006f006d002f007700610" +
@@ -163,7 +164,7 @@ class MessageContentEncoderTest {
 
         val arabic = (
                 "بغداد" to
-                        "2018-10-22T15:12:45.000+02:00"
+                        Instant.parse("2018-10-22T15:12:45.000+02:00")
                 ) to
                 (
                         "feff0628063a062f0627062f000000005bcdcccd" to
@@ -172,7 +173,7 @@ class MessageContentEncoderTest {
 
         val markDown = (
                 "This has **markdown**" to
-                        "2018-10-22T15:12:45.000+02:00"
+                        Instant.parse("2018-10-22T15:12:45.000+02:00")
                 ) to ("feff005400680069007300200068006100730020002a" +
                 "002a006d00610072006b0064006f0077006e002a002a00000" +
                 "0005bcdcccd" to
@@ -181,7 +182,7 @@ class MessageContentEncoderTest {
 
         val location = Triple(
             MessageContent.Location(52.516666f, 13.4f, "someLocation", 10),
-            "2018-10-22T15:09:29.000+02:00",
+            Instant.parse("2018-10-22T15:09:29.000+02:00"),
             "56a5fa30081bc16688574fdfbbe96c2eee004d1fb37dc714eec6efb340192816"
         )
     }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandlerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandlerTest.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.logic.feature.asset.ValidateAssetMimeTypeUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.sync.receiver.conversation.message.hasValidData
 import com.wire.kalium.logic.sync.receiver.conversation.message.hasValidRemoteData
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -45,6 +46,7 @@ import io.mockative.once
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import org.junit.Test
 
 class AssetMessageHandlerTest {
@@ -330,7 +332,7 @@ class AssetMessageHandlerTest {
             id = "uid-complete",
             content = COMPLETE_ASSET_CONTENT,
             conversationId = ConversationId("some-value", "some-domain.com"),
-            date = "1970-01-01T00:00:01.000Z",
+            date = Instant.UNIX_FIRST_DATE,
             senderUserId = UserId("some-sender-value", "some-sender-domain.com"),
             senderClientId = ClientId("some-client-value"),
             status = Message.Status.Sent,
@@ -339,7 +341,7 @@ class AssetMessageHandlerTest {
         )
         val PREVIEW_ASSET_MESSAGE = COMPLETE_ASSET_MESSAGE.copy(
             content = PREVIEW_ASSET_CONTENT,
-            date = "1970-01-01T00:00:00.000Z",
+            date = Instant.UNIX_FIRST_DATE,
         )
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/connection/ConnectionResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/connection/ConnectionResponse.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.network.api.base.authenticated.connection
 
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.UserId
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -34,7 +35,7 @@ data class ConnectionResponse(
 data class ConnectionDTO(
     @SerialName("conversation") val conversationId: String,
     @SerialName("from") val from: String,
-    @SerialName("last_update") val lastUpdate: String,
+    @SerialName("last_update") val lastUpdate: Instant,
     @SerialName("qualified_conversation") val qualifiedConversationId: ConversationId,
     @SerialName("qualified_to") val qualifiedToId: UserId,
     @SerialName("status") val status: ConnectionStateDTO,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/QualifiedSendMessageResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/QualifiedSendMessageResponse.kt
@@ -18,13 +18,14 @@
 
 package com.wire.kalium.network.api.base.authenticated.message
 
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 sealed class QualifiedSendMessageResponse {
     @SerialName("time")
-    abstract val time: String
+    abstract val time: Instant
 
     @SerialName("missing")
     abstract val missing: QualifiedUserIdToClientMap
@@ -41,7 +42,7 @@ sealed class QualifiedSendMessageResponse {
     @Serializable
     data class MissingDevicesResponse(
         @SerialName("time")
-        override val time: String,
+        override val time: Instant,
         @SerialName("missing")
         override val missing: QualifiedUserIdToClientMap,
         @SerialName("redundant")
@@ -55,7 +56,7 @@ sealed class QualifiedSendMessageResponse {
     @Serializable
     data class MessageSent(
         @SerialName("time")
-        override val time: String,
+        override val time: Instant,
         @SerialName("missing")
         override val missing: QualifiedUserIdToClientMap,
         @SerialName("redundant")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/SendMLSMessageResponse.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/SendMLSMessageResponse.kt
@@ -20,13 +20,14 @@ package com.wire.kalium.network.api.base.authenticated.message
 
 import com.wire.kalium.network.api.base.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.model.QualifiedID
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class SendMLSMessageResponse(
     @SerialName("time")
-    val time: String,
+    val time: Instant,
     @SerialName("events")
     val events: List<EventContentDTO>,
     @SerialName("failed_to_send")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/EventContentDTO.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.network.api.base.model.TeamId
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.kaliumLogger
 import com.wire.kalium.util.serialization.toJsonElement
+import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
@@ -139,7 +140,7 @@ sealed class EventContentDTO {
         data class NewConversationDTO(
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
-            @SerialName("time") val time: String,
+            @SerialName("time") val time: Instant,
             @SerialName("data") val data: ConversationResponse,
         ) : Conversation()
 
@@ -156,7 +157,7 @@ sealed class EventContentDTO {
         data class ConversationRenameDTO(
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
-            @SerialName("time") val time: String,
+            @SerialName("time") val time: Instant,
             @SerialName("data") val updateNameData: ConversationNameUpdateEvent,
         ) : Conversation()
 
@@ -165,7 +166,7 @@ sealed class EventContentDTO {
         data class MemberJoinDTO(
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
-            @SerialName("time") val time: String,
+            @SerialName("time") val time: Instant,
             @SerialName("data") val members: ConversationMembers,
             @Deprecated("use qualifiedFrom", replaceWith = ReplaceWith("this.qualifiedFrom")) @SerialName("from") val from: String
         ) : Conversation()
@@ -175,7 +176,7 @@ sealed class EventContentDTO {
         data class MemberLeaveDTO(
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
-            @SerialName("time") val time: String,
+            @SerialName("time") val time: Instant,
             @SerialName("data") val removedUsers: ConversationMemberRemovedDTO,
             @SerialName("from") val from: String
         ) : Conversation()
@@ -205,7 +206,7 @@ sealed class EventContentDTO {
         data class NewMessageDTO(
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
-            @SerialName("time") val time: String,
+            @SerialName("time") val time: Instant,
             @SerialName("data") val data: MessageEventData,
         ) : Conversation()
 
@@ -246,7 +247,7 @@ sealed class EventContentDTO {
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("data") val data: ConversationMessageTimerDTO,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
-            val time: String
+            @SerialName("time") val time: Instant
         ) : Conversation()
 
         @Serializable
@@ -254,7 +255,7 @@ sealed class EventContentDTO {
         data class NewMLSMessageDTO(
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
-            @SerialName("time") val time: String,
+            @SerialName("time") val time: Instant,
             @SerialName("data") val message: String,
             @SerialName("subconv") val subconversation: String?,
         ) : Conversation()
@@ -285,7 +286,7 @@ sealed class EventContentDTO {
         data class MemberLeave(
             @SerialName("data") val teamMember: TeamMemberIdData,
             @SerialName("team") val teamId: TeamId,
-            val time: String,
+            @SerialName("time") val time: Instant,
         ) : Team()
     }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/conversation/ConversationApiV0Test.kt
@@ -45,10 +45,8 @@ import com.wire.kalium.network.api.base.model.ConversationAccessDTO
 import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.JoinConversationRequestV0
-import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
 import com.wire.kalium.network.api.base.model.UserId
 import com.wire.kalium.network.api.v0.authenticated.ConversationApiV0
-import com.wire.kalium.network.api.v0.authenticated.SelfApiV0
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
@@ -261,7 +259,8 @@ internal class ConversationApiV0Test : ApiTest() {
         val serviceId = AddServiceRequest("service_id", "service_provider")
 
         val networkClient = mockAuthenticatedNetworkClient(
-            AddServiceResponseJson.valid.rawJson, statusCode = HttpStatusCode.Created,
+            responseBody = AddServiceResponseJson.valid.rawJson,
+            statusCode = HttpStatusCode.Created,
             assertion = {
                 assertPost()
                 assertPathEqual("conversations/${conversationId.value}/bots")

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/AddServiceResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/AddServiceResponseJson.kt
@@ -25,7 +25,10 @@ import com.wire.kalium.network.api.base.authenticated.notification.EventContentD
 import com.wire.kalium.network.api.base.model.AddServiceResponse
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.UserId
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.serialization.toJsonElement
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -45,7 +48,7 @@ object AddServiceResponseJson {
                     put("id", serializable.event.qualifiedFrom.value.toJsonElement())
                     put("domain", serializable.event.qualifiedFrom.domain.toJsonElement())
                 }
-                put("time", serializable.event.time.toJsonElement())
+                put("time", serializable.event.time.toIsoDateTimeString().toJsonElement())
                 putJsonObject("data") {
                     putJsonArray("user_ids") {
                         serializable.event.members.userIds.forEach {
@@ -86,7 +89,7 @@ object AddServiceResponseJson {
                     value = "value2",
                     domain = "domain2"
                 ),
-                time = "some_time",
+                time = Instant.UNIX_FIRST_DATE,
                 members = ConversationMembers(
                     userIds = listOf("value3@domain3"),
                     users = listOf(

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/EventContentDTOJson.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.network.api.base.model.ConversationAccessRoleDTO
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.UserId
+import kotlinx.datetime.Instant
 
 object EventContentDTOJson {
 
@@ -192,7 +193,7 @@ object EventContentDTOJson {
             qualifiedConversation = ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             qualifiedFrom = UserId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             from = "ebafd3d4-1548-49f2-ac4e-b2757e6ca44b",
-            time = "2021-05-31T10:52:02.671Z",
+            time = Instant.parse("2021-05-31T10:52:02.671Z"),
             members = ConversationMembers(emptyList(), emptyList())
         ),
         jsonProviderMemberJoin
@@ -203,7 +204,7 @@ object EventContentDTOJson {
             qualifiedConversation = ConversationId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             qualifiedFrom = UserId("ebafd3d4-1548-49f2-ac4e-b2757e6ca44b", "anta.wire.link"),
             from = "ebafd3d4-1548-49f2-ac4e-b2757e6ca44b",
-            time = "2021-05-31T10:52:02.671Z",
+            time = Instant.parse("2021-05-31T10:52:02.671Z"),
             removedUsers = ConversationMemberRemovedDTO(emptyList(), MemberLeaveReasonDTO.LEFT)
         ),
         jsonProviderMemberLeave

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/NotificationEventsResponseJson.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.network.api.base.authenticated.notification.NotificationR
 import com.wire.kalium.network.api.base.model.ConversationId
 import com.wire.kalium.network.api.base.model.QualifiedID
 import com.wire.kalium.network.api.base.model.SupportedProtocolDTO
+import kotlinx.datetime.Instant
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -135,7 +136,7 @@ object NotificationEventsResponseJson {
         EventContentDTO.Conversation.NewMLSMessageDTO(
             ConversationId("e16babfa-308b-414e-b6e0-c59517f723db", "staging.zinfra.io"),
             QualifiedID("76ebeb16-a849-4be4-84a7-157654b492cf", "staging.zinfra.io"),
-            "2022-04-12T13:57:02.414Z",
+            Instant.parse("2022-04-12T13:57:02.414Z"),
             "AiDyKXJ/yTKaq4fIO2SXXkQIBVhU0uOiDHIfVP3Yb6HoWAAAAAAAAAABAQAAAAAo6sj3pAQr7tXmljXYG4+sRsn" +
                     "R2IKQVhhUIOSopJZ7N2wIVH3nh1Az0AAAAJBQsRZJea8cnIeR/DKmixvos3AHWHchXr5PvXModBjxTVx7wcbT4w" +
                     "CTBVXtZqcYJwySIoKxokYhUUE2+zMKGg96+CV7jdQvqYG/fxk/dSm4TdQypanbSuu7VsYXZSPKPV0E1wChqpLit" +
@@ -168,7 +169,7 @@ object NotificationEventsResponseJson {
         EventContentDTO.Conversation.NewConversationDTO(
             ConversationId("e16babfa-308b-414e-b6e0-c59517f723db", "staging.zinfra.io"),
             QualifiedID("76ebeb16-a849-4be4-84a7-157654b492cf", "staging.zinfra.io"),
-            "2022-04-12T13:57:02.414Z",
+            Instant.parse("2022-04-12T13:57:02.414Z"),
             ConversationResponseJson.v3.serializableData
         ),
         newConversationSerializer

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/QualifiedSendMessageResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/QualifiedSendMessageResponseJson.kt
@@ -20,10 +20,11 @@ package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
 import com.wire.kalium.network.api.base.authenticated.message.QualifiedSendMessageResponse
+import kotlinx.datetime.Instant
 
 object QualifiedSendMessageResponseJson {
 
-    private const val TIME = "2021-05-31T10:52:02.671Z"
+    private val TIME = Instant.parse("2021-05-31T10:52:02.671Z")
 
     private const val USER_1 = "user10d0-000b-9c1a-000d-a4130002c221"
     private const val USER_1_client_1 = "60f85e4b15ad3786"

--- a/network/src/commonTest/kotlin/com/wire/kalium/model/SendMLSMessageResponseJson.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/model/SendMLSMessageResponseJson.kt
@@ -20,10 +20,11 @@ package com.wire.kalium.model
 
 import com.wire.kalium.api.json.ValidJsonProvider
 import com.wire.kalium.network.api.base.authenticated.message.SendMLSMessageResponse
+import kotlinx.datetime.Instant
 
 object SendMLSMessageResponseJson {
 
-    private const val TIME = "2021-05-31T10:52:02.671Z"
+    private val TIME = Instant.parse("2021-05-31T10:52:02.671Z")
 
     private val emptyResponse = { response: SendMLSMessageResponse ->
         """

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -94,7 +94,7 @@ interface ConversationDAO {
     suspend fun clearProposalTimer(groupID: String)
     suspend fun getProposalTimers(): Flow<List<ProposalTimerEntity>>
     suspend fun whoDeletedMeInConversation(conversationId: QualifiedIDEntity, selfUserIdString: String): UserIDEntity?
-    suspend fun updateConversationName(conversationId: QualifiedIDEntity, conversationName: String, timestamp: String)
+    suspend fun updateConversationName(conversationId: QualifiedIDEntity, conversationName: String, dateTime: Instant)
     suspend fun updateConversationType(conversationID: QualifiedIDEntity, type: ConversationEntity.Type)
     suspend fun updateConversationProtocolAndCipherSuite(
         conversationId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -348,9 +348,9 @@ internal class ConversationDAOImpl internal constructor(
             conversationQueries.whoDeletedMeInConversation(conversationId, selfUserIdString).executeAsOneOrNull()
         }
 
-    override suspend fun updateConversationName(conversationId: QualifiedIDEntity, conversationName: String, timestamp: String) =
+    override suspend fun updateConversationName(conversationId: QualifiedIDEntity, conversationName: String, dateTime: Instant) =
         withContext(coroutineContext) {
-            conversationQueries.updateConversationName(conversationName, timestamp.toInstant(), conversationId)
+            conversationQueries.updateConversationName(conversationName, dateTime, conversationId)
         }
 
     override suspend fun updateConversationType(conversationID: QualifiedIDEntity, type: ConversationEntity.Type) =

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -89,7 +89,7 @@ interface MessageDAO {
 
     suspend fun getAllPendingMessagesFromUser(userId: UserIDEntity): List<MessageEntity>
     suspend fun updateTextMessageContent(
-        editTimeStamp: String,
+        editInstant: Instant,
         conversationId: QualifiedIDEntity,
         currentMessageId: String,
         newTextContent: MessageEntityContent.Text,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -325,14 +325,14 @@ internal class MessageDAOImpl internal constructor(
         }
 
     override suspend fun updateTextMessageContent(
-        editTimeStamp: String,
+        editInstant: Instant,
         conversationId: QualifiedIDEntity,
         currentMessageId: String,
         newTextContent: MessageEntityContent.Text,
         newMessageId: String
     ): Unit = withContext(coroutineContext) {
         queries.transaction {
-            queries.markMessageAsEdited(editTimeStamp.toInstant(), currentMessageId, conversationId)
+            queries.markMessageAsEdited(editInstant, currentMessageId, conversationId)
             reactionsQueries.deleteAllReactionsForMessage(currentMessageId, conversationId)
             queries.deleteMessageMentions(currentMessageId, conversationId)
             queries.updateMessageTextContent(newTextContent.messageBody, currentMessageId, conversationId)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/reaction/ReactionDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/reaction/ReactionDAO.kt
@@ -24,10 +24,12 @@ import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.util.mapToList
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Instant
 import kotlin.coroutines.CoroutineContext
 
 interface ReactionDAO {
@@ -36,7 +38,7 @@ interface ReactionDAO {
         originalMessageId: String,
         conversationId: ConversationIDEntity,
         senderUserId: UserIDEntity,
-        date: String,
+        instant: Instant,
         reactions: UserReactionsEntity
     )
 
@@ -44,7 +46,7 @@ interface ReactionDAO {
         originalMessageId: String,
         conversationId: ConversationIDEntity,
         senderUserId: UserIDEntity,
-        date: String,
+        instant: Instant,
         emoji: String
     )
 
@@ -76,14 +78,14 @@ class ReactionDAOImpl(
         originalMessageId: String,
         conversationId: ConversationIDEntity,
         senderUserId: UserIDEntity,
-        date: String,
+        instant: Instant,
         reactions: UserReactionsEntity
     ) = withContext(queriesContext) {
         reactionsQueries.transaction {
             reactionsQueries.doesMessageExist(originalMessageId, conversationId).executeAsOneOrNull()?.let {
                 reactionsQueries.deleteAllReactionsOnMessageFromUser(originalMessageId, conversationId, senderUserId)
                 reactions.forEach {
-                    reactionsQueries.insertReaction(originalMessageId, conversationId, senderUserId, it, date)
+                    reactionsQueries.insertReaction(originalMessageId, conversationId, senderUserId, it, instant.toIsoDateTimeString())
                 }
             }
         }
@@ -93,11 +95,15 @@ class ReactionDAOImpl(
         originalMessageId: String,
         conversationId: ConversationIDEntity,
         senderUserId: UserIDEntity,
-        date: String,
+        instant: Instant,
         emoji: String
     ) = withContext(queriesContext) {
         reactionsQueries.insertReaction(
-            originalMessageId, conversationId, senderUserId, emoji, date
+            message_id = originalMessageId,
+            conversation_id = conversationId,
+            sender_id = senderUserId,
+            emoji = emoji,
+            date = instant.toIsoDateTimeString()
         )
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -794,7 +794,11 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user1, conversationEntity3.id)
 
         // when
-        conversationDAO.updateConversationName(conversationEntity3.id, "NEW-NAME", "2023-11-22T15:36:00.000Z")
+        conversationDAO.updateConversationName(
+            conversationEntity3.id,
+            "NEW-NAME",
+            Instant.parse("2023-11-22T15:36:00.000Z")
+        )
         val updatedConversation = conversationDAO.getConversationByQualifiedID(conversationEntity3.id)
 
         // then

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageReactionsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageReactionsTest.kt
@@ -19,8 +19,10 @@
 package com.wire.kalium.persistence.dao.message
 
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -68,9 +70,27 @@ class MessageReactionsTest : BaseMessageTest() {
             firstEmoji to 2,
             secondEmoji to 1
         )
-        reactionDAO.insertReaction(initialMessageEntity.id, initialMessageEntity.conversationId, SELF_USER_ID, "date", firstEmoji)
-        reactionDAO.insertReaction(initialMessageEntity.id, initialMessageEntity.conversationId, OTHER_USER.id, "date", firstEmoji)
-        reactionDAO.insertReaction(initialMessageEntity.id, initialMessageEntity.conversationId, SELF_USER_ID, "date", secondEmoji)
+        reactionDAO.insertReaction(
+            initialMessageEntity.id,
+            initialMessageEntity.conversationId,
+            SELF_USER_ID,
+            Instant.UNIX_FIRST_DATE,
+            firstEmoji
+        )
+        reactionDAO.insertReaction(
+            initialMessageEntity.id,
+            initialMessageEntity.conversationId,
+            OTHER_USER.id,
+            Instant.UNIX_FIRST_DATE,
+            firstEmoji
+        )
+        reactionDAO.insertReaction(
+            initialMessageEntity.id,
+            initialMessageEntity.conversationId,
+            SELF_USER_ID,
+            Instant.UNIX_FIRST_DATE,
+            secondEmoji
+        )
 
         // When
         val result = queryMessageEntity()
@@ -87,10 +107,34 @@ class MessageReactionsTest : BaseMessageTest() {
         val firstEmoji = "🫡"
         val secondEmoji = "🫥"
         val expectedReactionCounts = setOf(firstEmoji, secondEmoji)
-        reactionDAO.insertReaction(initialMessageEntity.id, initialMessageEntity.conversationId, SELF_USER_ID, "date", firstEmoji)
-        reactionDAO.insertReaction(initialMessageEntity.id, initialMessageEntity.conversationId, OTHER_USER.id, "date", firstEmoji)
-        reactionDAO.insertReaction(initialMessageEntity.id, initialMessageEntity.conversationId, SELF_USER_ID, "date", secondEmoji)
-        reactionDAO.insertReaction(initialMessageEntity.id, initialMessageEntity.conversationId, OTHER_USER.id, "date", "😡")
+        reactionDAO.insertReaction(
+            initialMessageEntity.id,
+            initialMessageEntity.conversationId,
+            SELF_USER_ID,
+            Instant.DISTANT_PAST,
+            firstEmoji
+        )
+        reactionDAO.insertReaction(
+            initialMessageEntity.id,
+            initialMessageEntity.conversationId,
+            OTHER_USER.id,
+            Instant.DISTANT_PAST,
+            firstEmoji
+        )
+        reactionDAO.insertReaction(
+            initialMessageEntity.id,
+            initialMessageEntity.conversationId,
+            SELF_USER_ID,
+            Instant.DISTANT_PAST,
+            secondEmoji
+        )
+        reactionDAO.insertReaction(
+            initialMessageEntity.id,
+            initialMessageEntity.conversationId,
+            OTHER_USER.id,
+            Instant.DISTANT_PAST,
+            "😡"
+        )
 
         // When
         val result = queryMessageEntity()

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageTextEditTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageTextEditTest.kt
@@ -22,7 +22,7 @@ import app.cash.turbine.test
 import com.wire.kalium.persistence.dao.receipt.ReceiptTypeEntity
 import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -46,7 +46,7 @@ class MessageTextEditTest : BaseMessageTest() {
         insertInitialData()
 
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(messageBody = "Howdy"),
@@ -60,13 +60,13 @@ class MessageTextEditTest : BaseMessageTest() {
     @Test
     fun givenTextWasInsertedAndReacted_whenUpdatingMessageBody_thenContentShouldHaveNewMessageBody() = runTest {
         insertInitialData()
-        reactionDAO.insertReaction(ORIGINAL_MESSAGE_ID, CONVERSATION_ID, SELF_USER_ID, "Date", "💁‍♂️")
-        reactionDAO.insertReaction(ORIGINAL_MESSAGE_ID, CONVERSATION_ID, OTHER_USER_2.id, "Date", "🤌️")
+        reactionDAO.insertReaction(ORIGINAL_MESSAGE_ID, CONVERSATION_ID, SELF_USER_ID, Instant.UNIX_FIRST_DATE, "💁‍♂️")
+        reactionDAO.insertReaction(ORIGINAL_MESSAGE_ID, CONVERSATION_ID, OTHER_USER_2.id, Instant.UNIX_FIRST_DATE, "🤌️")
 
         val newMessageBody = "newBody"
 
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(messageBody = newMessageBody),
@@ -89,7 +89,7 @@ class MessageTextEditTest : BaseMessageTest() {
         val newMessageBody = "newBody"
 
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(messageBody = newMessageBody),
@@ -110,7 +110,7 @@ class MessageTextEditTest : BaseMessageTest() {
 
         val mentions = listOf(MessageEntity.Mention(0, 1, OTHER_USER_2.id))
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(
@@ -133,7 +133,7 @@ class MessageTextEditTest : BaseMessageTest() {
         insertInitialData()
 
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(messageBody = "Howdy"),
@@ -153,7 +153,7 @@ class MessageTextEditTest : BaseMessageTest() {
         receiptDAO.insertReceipts(OTHER_USER.id, CONVERSATION_ID, instant, ReceiptTypeEntity.READ, listOf(ORIGINAL_MESSAGE_ID))
 
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(messageBody = "Howdy"),
@@ -175,7 +175,7 @@ class MessageTextEditTest : BaseMessageTest() {
 
         val editDate = Instant.DISTANT_FUTURE
         messageDAO.updateTextMessageContent(
-            editTimeStamp = editDate.toIsoDateTimeString(),
+            editInstant = editDate,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(messageBody = "Howdy"),
@@ -198,7 +198,7 @@ class MessageTextEditTest : BaseMessageTest() {
         // When
         val mentions = listOf(MessageEntity.Mention(0, 1, SELF_USER_ID))
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(
@@ -228,7 +228,7 @@ class MessageTextEditTest : BaseMessageTest() {
         // When
         val mentions = listOf(MessageEntity.Mention(0, 1, OTHER_USER.id))
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(
@@ -262,7 +262,7 @@ class MessageTextEditTest : BaseMessageTest() {
         // When
         val mentions = listOf(MessageEntity.Mention(0, 1, OTHER_USER.id))
         messageDAO.updateTextMessageContent(
-            editTimeStamp = Instant.DISTANT_FUTURE.toIsoDateTimeString(),
+            editInstant = Instant.DISTANT_FUTURE,
             conversationId = CONVERSATION_ID,
             currentMessageId = ORIGINAL_MESSAGE_ID,
             newTextContent = ORIGINAL_CONTENT.copy(

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/reaction/ReactionDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/reaction/ReactionDAOTest.kt
@@ -25,7 +25,9 @@ import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.utils.stubs.newConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -56,7 +58,7 @@ class ReactionDAOTest : BaseDatabaseTest() {
         messageDAO.insertOrIgnoreMessage(TEST_MESSAGE)
         val expectedReaction = "🐻"
 
-        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, "date", expectedReaction)
+        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, expectedReaction)
 
         // When
         val result = reactionDAO.getReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID)
@@ -73,7 +75,7 @@ class ReactionDAOTest : BaseDatabaseTest() {
         messageDAO.insertOrIgnoreMessage(TEST_MESSAGE)
         val expectedReaction = "🐻"
 
-        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, "date", expectedReaction)
+        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, expectedReaction)
         reactionDAO.deleteReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, expectedReaction)
 
         // When
@@ -94,9 +96,9 @@ class ReactionDAOTest : BaseDatabaseTest() {
         val expectedReactions = setOf("🐻", "🧱", "🍻")
 
         expectedReactions.forEach {
-            reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, wantedUserId, "date", it)
+            reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, wantedUserId, Instant.UNIX_FIRST_DATE, it)
         }
-        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, otherUserId, "date", "🪵")
+        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, otherUserId, Instant.UNIX_FIRST_DATE, "🪵")
 
         // When
         val result = reactionDAO.getReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, wantedUserId)
@@ -117,9 +119,9 @@ class ReactionDAOTest : BaseDatabaseTest() {
         val expectedReactions = setOf("🐻", "🧱", "🍻")
 
         expectedReactions.forEach {
-            reactionDAO.insertReaction(wantedMessageId, TEST_MESSAGE.conversationId, SELF_USER_ID, "date", it)
+            reactionDAO.insertReaction(wantedMessageId, TEST_MESSAGE.conversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, it)
         }
-        reactionDAO.insertReaction(otherMessageId, TEST_MESSAGE.conversationId, SELF_USER_ID, "date", "🪵")
+        reactionDAO.insertReaction(otherMessageId, TEST_MESSAGE.conversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, "🪵")
 
         // When
         val result = reactionDAO.getReaction(wantedMessageId, TEST_MESSAGE.conversationId, SELF_USER_ID)
@@ -141,9 +143,9 @@ class ReactionDAOTest : BaseDatabaseTest() {
         val expectedReactions = setOf("🐻", "🧱", "🍻")
 
         expectedReactions.forEach {
-            reactionDAO.insertReaction(TEST_MESSAGE.id, wantedConversationId, SELF_USER_ID, "date", it)
+            reactionDAO.insertReaction(TEST_MESSAGE.id, wantedConversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, it)
         }
-        reactionDAO.insertReaction(TEST_MESSAGE.id, otherConversationId, SELF_USER_ID, "date", "🪵")
+        reactionDAO.insertReaction(TEST_MESSAGE.id, otherConversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, "🪵")
 
         // When
         val result = reactionDAO.getReaction(TEST_MESSAGE.id, wantedConversationId, SELF_USER_ID)
@@ -161,10 +163,10 @@ class ReactionDAOTest : BaseDatabaseTest() {
         val initialReaction = "😎"
         val expectedReactions = setOf("🐻", "🧱", "🍻")
 
-        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, "Date", initialReaction)
+        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, initialReaction)
 
         // Given
-        reactionDAO.updateReactions(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, "Date", expectedReactions)
+        reactionDAO.updateReactions(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, expectedReactions)
 
         // Then
         val result = reactionDAO.getReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID)
@@ -181,10 +183,10 @@ class ReactionDAOTest : BaseDatabaseTest() {
         val initialReaction = "😎"
         val expectedReactions = setOf("😎", "🐻", "🧱", "🍻")
 
-        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, "Date", initialReaction)
+        reactionDAO.insertReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, initialReaction)
 
         // Given
-        reactionDAO.updateReactions(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, "Date", expectedReactions)
+        reactionDAO.updateReactions(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID, Instant.UNIX_FIRST_DATE, expectedReactions)
 
         // Then
         val result = reactionDAO.getReaction(TEST_MESSAGE.id, TEST_MESSAGE.conversationId, SELF_USER_ID)

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/time/TimeConstants.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/time/TimeConstants.kt
@@ -20,6 +20,4 @@ package com.wire.kalium.util.time
 
 import kotlinx.datetime.Instant
 
-const val UNIX_FIRST_DATE: String = "1970-01-01T00:00:00.000Z"
-
 val Instant.Companion.UNIX_FIRST_DATE get() = fromEpochMilliseconds(0L)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9216" title="WPB-9216" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9216</a>  [Android] out of memory exception when scrolling a group chat with long unread history
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We're using String for date representation in multiple core places, like messages, conversations, events, etc.
This is bad because:
- We can't be sure at compile time that the format is correct
- We do unnecessary operations, considering that the database is storing the dates/times as unix millis, as parsing to String is slower than just instantiating an Instant
- In many places, we need to sum/subtract/compare times, and this requires parsing the string back to a time data format and then back to string

### Solutions

Use Kotlin's date-time Instant.
When receiving from backend -> parse to Instant.
When reading from database -> create an Instant.

Bubble it up all the way to the Android app. Avoid String as much as possible until actually necessary to display in the UI.

Kalium only deals with Instant now 🎉 

### Testing

Not really _added_ tests, but had to adjust some. Should still be alright.

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
