### PR TITLE
ci: allow parallel merge queue builds [WPB-9914]

### DIFF
--- a/.github/workflows/benchmarks-check.yml
+++ b/.github/workflows/benchmarks-check.yml
@@ -6,7 +6,7 @@ on:
     workflow_dispatch:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gradle-android-instrumented-tests.yml
+++ b/.github/workflows/gradle-android-instrumented-tests.yml
@@ -6,7 +6,7 @@ on:
         types: [ opened, synchronize ] # Don't rerun on `edited` to save time
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gradle-android-unit-tests.yml
+++ b/.github/workflows/gradle-android-unit-tests.yml
@@ -6,7 +6,7 @@ on:
         types: [ opened, synchronize ] # Don't rerun on `edited` to save time
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -6,7 +6,7 @@ on:
     types: [ opened, synchronize ] # Don't rerun on `edited` to save time
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -9,7 +9,7 @@ on:
         - 'develop'
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9914" title="WPB-9914" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9914</a>  Merge Queues - Use them to their fullest
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [X] contains a reference JIRA issue number like `SQPIT-764`
    - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Current concurrency strategy doesn't allow multiple builds in parallel for the merge queue.

What we're currently doing:

```mermaid
%%{ init: { 'gitGraph': { 'mainBranchName': 'develop' }} }%%
gitGraph
commit
branch PR1
commit
commit id: "BUILD PR1" type: HIGHLIGHT
checkout develop
merge PR1
branch PR2
commit
commit id: "BUILD PR2" type: HIGHLIGHT
checkout develop
merge PR2
branch PR3
commit
commit id: "BUILD PR3" type: HIGHLIGHT
checkout develop
merge PR3
```

What we **could** be doing:

```mermaid
%%{ init: { 'gitGraph': { 'mainBranchName': 'develop' }} }%%
gitGraph
commit
branch PR1
commit
branch PR2
checkout PR1
commit id: "BUILD PR1" type: HIGHLIGHT
checkout PR2
commit
branch PR3
checkout PR2
commit id: "BUILD PR2" type: HIGHLIGHT
checkout PR3
commit
commit id: "BUILD PR3" type: HIGHLIGHT
checkout develop
merge PR1
checkout develop
merge PR2
checkout develop
merge PR3
```

### Causes

When running the merge queue, the `github.event.pull_request` is empty. So it means that builds from multiple PRs will have the same concurrency group.

### Solutions

If the PR number is null, use the `merge_group.head_sha`.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

- [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
