### PR TITLE
fix: Restrain sending delivery confirmation apart from Regular Messages (WPB-9920)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -166,7 +166,7 @@ internal class NewMessageEventHandlerImpl(
         }
 
     private suspend fun onMessageInserted(result: MessageUnpackResult.ApplicationMessage) {
-        if (result.senderUserId != selfUserId) {
+        if (result.senderUserId != selfUserId && result.content.messageContent is MessageContent.Regular) {
             enqueueConfirmationDelivery(result.conversationId, result.content.messageUid)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.ProtoContent
+import com.wire.kalium.logic.data.message.receipt.ReceiptType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.StaleEpochVerifier
 import com.wire.kalium.logic.feature.message.confirmation.ConfirmationDeliveryHandler
@@ -260,6 +261,21 @@ class NewMessageEventHandlerTest {
     }
 
     @Test
+    fun givenAMessage_whenHandlingSignalingMessage_thenEnqueueDeliveryConfirmationShouldNotHappen() = runTest {
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withHandleLegalHoldSuccess()
+            .withProteusUnpackerReturning(Either.Right(signalingMessage))
+            .arrange()
+
+        val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
+        newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
+
+        coVerify { arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent)) }.wasInvoked(exactly = once)
+        coVerify { arrangement.applicationMessageHandler.handleDecryptionError(any(), any(), any(), any(), any(), any()) }.wasNotInvoked()
+        coVerify { arrangement.confirmationDeliveryHandler.enqueueConfirmationDelivery(any(), any()) }.wasNotInvoked()
+    }
+
+    @Test
     fun givenAProteusMessage_whenHandling_thenEnqueueDeliveryConfirmation() = runTest {
         val (arrangement, newMessageEventHandler) = Arrangement()
             .withHandleLegalHoldSuccess()
@@ -448,6 +464,22 @@ class NewMessageEventHandlerTest {
 
     private companion object {
         val SELF_USER_ID = UserId("selfUserId", "selfDomain")
+        val signalingMessage = MessageUnpackResult.ApplicationMessage(
+            conversationId = ConversationId("conversationID", "domain"),
+            instant = Instant.DISTANT_PAST,
+            senderUserId = UserId("otherUserId", "otherUserDomain"),
+            senderClientId = ClientId("otherUserClientId"),
+            content = ProtoContent.Readable(
+                messageUid = "otherMessageUID",
+                messageContent = MessageContent.Receipt(
+                    type = ReceiptType.READ,
+                    messageIds = listOf("messageId1", "messageId2")
+                ),
+                expectsReadConfirmation = false,
+                legalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
+                expiresAfterMillis = null
+            )
+        )
         val applicationMessage = MessageUnpackResult.ApplicationMessage(
             ConversationId("conversationID", "domain"),
             Instant.DISTANT_PAST,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9920" title="WPB-9920" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9920</a>  [Android] Restrain Sending delivery confirmation to Regular Messages only
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were sending delivery confirmation for all types of messages (System, Signaling, etc)

### Solutions

Only send delivery confirmation if message content is of type `Regular`
