### PR TITLE
fix: is user speaking mapper causes a flash briefly (#2809) [WPB-9684]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/ActiveSpeakerMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/mapper/ActiveSpeakerMapper.kt
@@ -38,7 +38,7 @@ class ActiveSpeakerMapperImpl : ActiveSpeakerMapper {
                 activeSpeaker.userId == participant.id.toString() && activeSpeaker.clientId == participant.clientId
             }?.let {
                 this[indexOf(it)] = it.copy(
-                    isSpeaking = activeSpeaker.audioLevel > 0 && activeSpeaker.audioLevelNow > 0
+                    isSpeaking = activeSpeaker.audioLevel > 0 || activeSpeaker.audioLevelNow > 0
                 )
             }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/ActiveSpeakerMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/ActiveSpeakerMapperTest.kt
@@ -29,7 +29,7 @@ class ActiveSpeakerMapperTest {
     private val activeSpeakerMapper = ActiveSpeakerMapperImpl()
 
     @Test
-    fun givenCallActiveSpeakers_whenMappingToParticipantsActiveSpeaker_thenReturnParticipantsActiveSpeaker() = runTest {
+    fun givenUserAudioLevelNot0AndaudioLevelNowNot0_whenMapping_thenUserIsSpeaking() = runTest {
         val dummyParticipantWithDifferentClientId = DUMMY_PARTICIPANT.copy(
             clientId = "anotherClientId"
         )
@@ -40,13 +40,110 @@ class ActiveSpeakerMapperTest {
                 dummyParticipantWithDifferentClientId
             ),
             activeSpeakers = CallActiveSpeakers(
-                activeSpeakers = listOf(DUMMY_CALL_ACTIVE_SPEAKER, DUMMY_CALL_ACTIVE_SPEAKER1)
+                activeSpeakers = listOf(
+                    DUMMY_CALL_ACTIVE_SPEAKER.copy(audioLevel = 1, audioLevelNow = 1),
+                    DUMMY_CALL_ACTIVE_SPEAKER1.copy(audioLevel = 1, audioLevelNow = 1)
+                )
             )
         )
 
         val expectedParticipantsActiveSpeaker = listOf(
             DUMMY_PARTICIPANT.copy(
                 isSpeaking = true
+            ),
+            dummyParticipantWithDifferentClientId.copy(
+                isSpeaking = true
+            )
+        )
+
+        assertEquals(expectedParticipantsActiveSpeaker, callActiveSpeakerMap)
+    }
+
+
+    @Test
+    fun givenUserAudioLevelIs0AndaudioLevelNowNot0_whenMapping_thenUserIsSpeaking() = runTest {
+        val dummyParticipantWithDifferentClientId = DUMMY_PARTICIPANT.copy(
+            clientId = "anotherClientId"
+        )
+
+        val callActiveSpeakerMap = activeSpeakerMapper.mapParticipantsActiveSpeaker(
+            participants = listOf(
+                DUMMY_PARTICIPANT,
+                dummyParticipantWithDifferentClientId
+            ),
+            activeSpeakers = CallActiveSpeakers(
+                activeSpeakers = listOf(
+                    DUMMY_CALL_ACTIVE_SPEAKER.copy(audioLevel = 0, audioLevelNow = 1),
+                    DUMMY_CALL_ACTIVE_SPEAKER1.copy(audioLevel = 0, audioLevelNow = 1)
+                )
+            )
+        )
+
+        val expectedParticipantsActiveSpeaker = listOf(
+            DUMMY_PARTICIPANT.copy(
+                isSpeaking = true
+            ),
+            dummyParticipantWithDifferentClientId.copy(
+                isSpeaking = true
+            )
+        )
+
+        assertEquals(expectedParticipantsActiveSpeaker, callActiveSpeakerMap)
+    }
+
+    @Test
+    fun givenUserAudioLevelNot0AndaudioLevelNowIs0_whenMapping_thenUserIsSpeaking() = runTest {
+        val dummyParticipantWithDifferentClientId = DUMMY_PARTICIPANT.copy(
+            clientId = "anotherClientId"
+        )
+
+        val callActiveSpeakerMap = activeSpeakerMapper.mapParticipantsActiveSpeaker(
+            participants = listOf(
+                DUMMY_PARTICIPANT,
+                dummyParticipantWithDifferentClientId
+            ),
+            activeSpeakers = CallActiveSpeakers(
+                activeSpeakers = listOf(
+                    DUMMY_CALL_ACTIVE_SPEAKER.copy(audioLevel = 1, audioLevelNow = 0),
+                    DUMMY_CALL_ACTIVE_SPEAKER1.copy(audioLevel = 1, audioLevelNow = 0)
+                )
+            )
+        )
+
+        val expectedParticipantsActiveSpeaker = listOf(
+            DUMMY_PARTICIPANT.copy(
+                isSpeaking = true
+            ),
+            dummyParticipantWithDifferentClientId.copy(
+                isSpeaking = true
+            )
+        )
+
+        assertEquals(expectedParticipantsActiveSpeaker, callActiveSpeakerMap)
+    }
+
+    @Test
+    fun givenUserAudioLevelIs0AndaudioLevelNowIs0_whenMapping_thenUserIsNotSpeaking() = runTest {
+        val dummyParticipantWithDifferentClientId = DUMMY_PARTICIPANT.copy(
+            clientId = "anotherClientId"
+        )
+
+        val callActiveSpeakerMap = activeSpeakerMapper.mapParticipantsActiveSpeaker(
+            participants = listOf(
+                DUMMY_PARTICIPANT,
+                dummyParticipantWithDifferentClientId
+            ),
+            activeSpeakers = CallActiveSpeakers(
+                activeSpeakers = listOf(
+                    DUMMY_CALL_ACTIVE_SPEAKER.copy(audioLevel = 0, audioLevelNow = 0),
+                    DUMMY_CALL_ACTIVE_SPEAKER1.copy(audioLevel = 0, audioLevelNow = 0)
+                )
+            )
+        )
+
+        val expectedParticipantsActiveSpeaker = listOf(
+            DUMMY_PARTICIPANT.copy(
+                isSpeaking = false
             ),
             dummyParticipantWithDifferentClientId.copy(
                 isSpeaking = false


### PR DESCRIPTION
(cherry picked from commit 94a64c447637c2bd3fc29c2279faa4d292b40f2d)
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

 is user speaking mapper causes a flash briefly

### Solutions

the condition to decide if a user is speaking atm is 

activeSpeaker.audioLevel > 0 && activeSpeaker.audioLevelNow > 0

when it should be

activeSpeaker.audioLevel > 0 || activeSpeaker.audioLevelNow > 0

sice the audioLevelNow can be 0 and cause it to plip whenaudioLevel have a decay

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
