### PR TITLE
fix: asset restriction [WPB-9947] (#2831)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1320,7 +1320,6 @@ class UserSessionScope internal constructor(
             conversationRepository,
             userRepository,
             logout,
-            oneOnOneResolver,
             userId,
             clientIdProvider,
             lazy { conversations.newGroupConversationSystemMessagesCreator }
@@ -1541,6 +1540,7 @@ class UserSessionScope internal constructor(
             protoContentMapper,
             observeSelfDeletingMessages,
             messageMetadataRepository,
+            observeFileSharingStatus,
             staleEpochVerifier,
             this
         )
@@ -1564,7 +1564,7 @@ class UserSessionScope internal constructor(
             e2eiRepository,
             mlsConversationRepository,
             team.isSelfATeamMember,
-            updateSupportedProtocols
+            e2eiRepository
         )
     private val clearUserData: ClearUserDataUseCase get() = ClearUserDataUseCaseImpl(userStorage)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1320,6 +1320,7 @@ class UserSessionScope internal constructor(
             conversationRepository,
             userRepository,
             logout,
+            oneOnOneResolver,
             userId,
             clientIdProvider,
             lazy { conversations.newGroupConversationSystemMessagesCreator }
@@ -1540,8 +1541,8 @@ class UserSessionScope internal constructor(
             protoContentMapper,
             observeSelfDeletingMessages,
             messageMetadataRepository,
-            observeFileSharingStatus,
             staleEpochVerifier,
+            observeFileSharingStatus,
             this
         )
     val users: UserScope
@@ -1564,7 +1565,7 @@ class UserSessionScope internal constructor(
             e2eiRepository,
             mlsConversationRepository,
             team.isSelfATeamMember,
-            e2eiRepository
+            updateSupportedProtocols
         )
     private val clearUserData: ClearUserDataUseCase get() = ClearUserDataUseCaseImpl(userStorage)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.cryptography.utils.AES256Key
 import com.wire.kalium.cryptography.utils.SHA256Key
 import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.asset.UploadedAssetId
 import com.wire.kalium.logic.data.asset.isAudioMimeType
@@ -43,6 +44,7 @@ import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
+import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
@@ -107,12 +109,14 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
     private val userPropertyRepository: UserPropertyRepository,
     private val selfDeleteTimer: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     private val scope: CoroutineScope,
+    private val observeFileSharingStatus: ObserveFileSharingStatusUseCase,
+    private val validateAssetMimeTypeUseCase: ValidateAssetMimeTypeUseCase,
     private val dispatcher: KaliumDispatcher,
 ) : ScheduleNewAssetMessageUseCase {
 
     private var outGoingAssetUploadJob: Job? = null
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "ReturnCount")
     override suspend fun invoke(
         conversationId: ConversationId,
         assetDataPath: Path,
@@ -123,6 +127,19 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
         assetHeight: Int?,
         audioLengthInMs: Long
     ): ScheduleNewAssetMessageResult {
+        observeFileSharingStatus().first().also {
+            when (it.state) {
+                FileSharingStatus.Value.Disabled -> return ScheduleNewAssetMessageResult.Failure.DisabledByTeam
+                FileSharingStatus.Value.EnabledAll -> { /* no-op*/
+                }
+
+                is FileSharingStatus.Value.EnabledSome -> if (!validateAssetMimeTypeUseCase(assetMimeType, it.state.allowedType)) {
+                    kaliumLogger.e("The asset message trying to be processed has invalid content data")
+                    return ScheduleNewAssetMessageResult.Failure.RestrictedFileType
+                }
+            }
+        }
+
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }
@@ -175,7 +192,7 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
                 }
             }
         }.fold({
-            ScheduleNewAssetMessageResult.Failure(it)
+            ScheduleNewAssetMessageResult.Failure.Generic(it)
         }, { (_, message) ->
             ScheduleNewAssetMessageResult.Success(message.id)
         })
@@ -346,9 +363,13 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
     }
 }
 
-sealed class ScheduleNewAssetMessageResult {
-    class Success(val messageId: String) : ScheduleNewAssetMessageResult()
-    class Failure(val coreFailure: CoreFailure) : ScheduleNewAssetMessageResult()
+sealed interface ScheduleNewAssetMessageResult {
+    data class Success(val messageId: String) : ScheduleNewAssetMessageResult
+    sealed interface Failure : ScheduleNewAssetMessageResult {
+        data class Generic(val coreFailure: CoreFailure) : Failure
+        data object DisabledByTeam : Failure
+        data object RestrictedFileType : Failure
+    }
 }
 
 private data class AssetMessageMetadata(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -50,6 +50,8 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCa
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageDownloadStatusUseCaseImpl
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageUploadStatusUseCase
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageUploadStatusUseCaseImpl
+import com.wire.kalium.logic.feature.asset.ValidateAssetMimeTypeUseCase
+import com.wire.kalium.logic.feature.asset.ValidateAssetMimeTypeUseCaseImpl
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
@@ -60,6 +62,7 @@ import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionH
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCaseImpl
+import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCase
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.util.MessageContentEncoder
 import com.wire.kalium.util.KaliumDispatcher
@@ -92,6 +95,7 @@ class MessageScope internal constructor(
     private val observeSelfDeletingMessages: ObserveSelfDeletionTimerSettingsForConversationUseCase,
     private val messageMetadataRepository: MessageMetadataRepository,
     private val staleEpochVerifier: StaleEpochVerifier,
+    private val observeFileSharingStatusUseCase: ObserveFileSharingStatusUseCase,
     private val scope: CoroutineScope,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
@@ -121,6 +125,9 @@ class MessageScope internal constructor(
             selfUserId = selfUserId,
             protoContentMapper = protoContentMapper
         )
+
+    private val validateAssetMimeTypeUseCase: ValidateAssetMimeTypeUseCase
+        get() = ValidateAssetMimeTypeUseCaseImpl()
 
     private val messageContentEncoder = MessageContentEncoder()
     private val messageSendingInterceptor: MessageSendingInterceptor
@@ -214,6 +221,8 @@ class MessageScope internal constructor(
             userPropertyRepository,
             observeSelfDeletingMessages,
             scope,
+            observeFileSharingStatusUseCase,
+            validateAssetMimeTypeUseCase,
             dispatcher
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCaseTest.kt
@@ -41,7 +41,6 @@ import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
-import com.wire.kalium.logic.feature.selfDeletingMessages.SelfDeletionTimer
 import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCase
 import com.wire.kalium.logic.framework.TestAsset.dummyUploadedAssetId
 import com.wire.kalium.logic.framework.TestAsset.mockedLongAssetData


### PR DESCRIPTION
* fix: asset sending restriction

* add test

* add error messages and detekt

* fist test service

* detekt

* chore: update gradle-ios-tests.yml for runner at that time

---------

Co-authored-by: Yamil Medina <yamilmedina@users.noreply.github.com>

(cherry picked from commit ebcc9f88367c29e75fd582d5b1d06d64d3d9ddb7)
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When sending a new file, assets restrictions are not considered.

### Solutions

check the file restrictions status and return the correct error based on that 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
