### PR TITLE
fix: strongbox unavailable on galaxy s24 [WPB-9639]

### DIFF
--- a/persistence/src/androidInstrumentedTest/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsBuilderTest.kt
+++ b/persistence/src/androidInstrumentedTest/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsBuilderTest.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -51,7 +50,7 @@ class EncryptedSettingsBuilderTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         (1..5000).map {
             launch() {
-                EncryptedSettingsBuilder.build(
+                buildSettings(
                     options = SettingOptions.UserSettings(
                         shouldEncryptData = true,
                         userIDEntity = UserIDEntity(

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -75,10 +75,12 @@ private fun encryptedSharedPref(
         if (isRetry) {
             throw e
         } else runBlocking {
-            delay(200)
+            delay(RETRY_DELAY)
             encryptedSharedPref(options, param, true)
         }
     }
 }
 
 internal actual class EncryptedSettingsPlatformParam(val appContext: Context)
+
+private const val RETRY_DELAY = 200L

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -24,54 +24,58 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 
 private fun SettingOptions.keyAlias(): String = when (this) {
     is SettingOptions.AppSettings -> "_app_settings_master_key_"
     is SettingOptions.UserSettings -> "_${this.fileName}_master_key_"
 }
 
-internal actual object EncryptedSettingsBuilder {
-    private fun getOrCreateMasterKey(
-        context: Context,
-        keyAlias: String
-    ): MasterKey =
-        MasterKey
-            .Builder(context, keyAlias)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .setRequestStrongBoxBacked(true)
-            .build()
+private val lock = Object()
 
-    actual fun build(
-        options: SettingOptions,
-        param: EncryptedSettingsPlatformParam
-    ): Settings = synchronized(this) {
-        val settings = if (options.shouldEncryptData) {
-            encryptedSharedPref(options, param, false)
-        } else {
-            param.appContext.getSharedPreferences(options.fileName, Context.MODE_PRIVATE)
-        }
-        SharedPreferencesSettings(settings, false)
+internal actual fun buildSettings(
+    options: SettingOptions,
+    param: EncryptedSettingsPlatformParam
+): Settings = synchronized(lock) {
+    val settings = if (options.shouldEncryptData) {
+        encryptedSharedPref(options, param, false)
+    } else {
+        param.appContext.getSharedPreferences(options.fileName, Context.MODE_PRIVATE)
     }
+    SharedPreferencesSettings(settings, false)
+}
 
-    private fun encryptedSharedPref(
-        options: SettingOptions,
-        param: EncryptedSettingsPlatformParam,
-        isRetry: Boolean
-    ): SharedPreferences {
-        @Suppress("TooGenericExceptionCaught")
-        return try {
-            val masterKey = getOrCreateMasterKey(param.appContext, options.keyAlias())
-            EncryptedSharedPreferences.create(
-                param.appContext,
-                options.fileName,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
-        } catch (e: Exception) {
-            if (isRetry) {
-                throw e
-            }
+private fun getOrCreateMasterKey(
+    context: Context,
+    keyAlias: String
+): MasterKey =
+    MasterKey
+        .Builder(context, keyAlias)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .setRequestStrongBoxBacked(true)
+        .build()
+
+private fun encryptedSharedPref(
+    options: SettingOptions,
+    param: EncryptedSettingsPlatformParam,
+    isRetry: Boolean
+): SharedPreferences {
+    @Suppress("TooGenericExceptionCaught")
+    return try {
+        val masterKey = getOrCreateMasterKey(param.appContext, options.keyAlias())
+        EncryptedSharedPreferences.create(
+            param.appContext,
+            options.fileName,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    } catch (e: Exception) {
+        if (isRetry) {
+            throw e
+        } else runBlocking {
+            delay(200)
             encryptedSharedPref(options, param, true)
         }
     }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.persistence.dbPassphrase.PassphraseStorageImpl
 actual class GlobalPrefProvider(context: Context, shouldEncryptData: Boolean = true) {
 
     private val encryptedSettingsHolder: KaliumPreferences = KaliumPreferencesSettings(
-        EncryptedSettingsBuilder.build(SettingOptions.AppSettings(shouldEncryptData), EncryptedSettingsPlatformParam(context))
+        buildSettings(SettingOptions.AppSettings(shouldEncryptData), EncryptedSettingsPlatformParam(context))
     )
 
     actual val authTokenStorage: AuthTokenStorage

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
@@ -32,7 +32,7 @@ actual class UserPrefBuilder(
 ) {
     private val encryptedSettingsHolder =
         KaliumPreferencesSettings(
-            EncryptedSettingsBuilder.build(
+            buildSettings(
                 SettingOptions.UserSettings(shouldEncryptData = shouldEncryptData, userIDEntity = userId),
                 EncryptedSettingsPlatformParam(context)
             )

--- a/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -23,11 +23,9 @@ import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
 
 @OptIn(ExperimentalSettingsImplementation::class)
-internal actual object EncryptedSettingsBuilder {
-    actual fun build(
-        options: SettingOptions,
-        param: EncryptedSettingsPlatformParam
-    ): Settings = KeychainSettings(param.serviceName)
-}
+internal actual fun buildSettings(
+    options: SettingOptions,
+    param: EncryptedSettingsPlatformParam
+): Settings = KeychainSettings(param.serviceName)
 
 internal actual class EncryptedSettingsPlatformParam(val serviceName: String)

--- a/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -31,7 +31,7 @@ actual class GlobalPrefProvider(
 ) {
     private val kaliumPref =
         KaliumPreferencesSettings(
-            EncryptedSettingsBuilder.build(
+            buildSettings(
                 SettingOptions.AppSettings(shouldEncryptData),
                 EncryptedSettingsPlatformParam(rootPath)
             )

--- a/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
+++ b/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
@@ -32,7 +32,7 @@ actual class UserPrefBuilder(
 
     private val kaliumPreferences =
         KaliumPreferencesSettings(
-            EncryptedSettingsBuilder.build(SettingOptions.UserSettings(shouldEncryptData, userId), EncryptedSettingsPlatformParam(rootPath))
+            buildSettings(SettingOptions.UserSettings(shouldEncryptData, userId), EncryptedSettingsPlatformParam(rootPath))
         )
 
     actual val lastRetrievedNotificationEventStorage: LastRetrievedNotificationEventStorage

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -35,7 +35,6 @@ internal sealed class SettingOptions {
     }
 }
 
-internal expect object EncryptedSettingsBuilder {
-    fun build(options: SettingOptions, param: EncryptedSettingsPlatformParam): Settings
-}
+internal expect fun buildSettings(options: SettingOptions, param: EncryptedSettingsPlatformParam): Settings
+
 internal expect class EncryptedSettingsPlatformParam

--- a/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -22,11 +22,9 @@ import com.russhwolf.settings.Settings
 import com.russhwolf.settings.StorageSettings
 import org.w3c.dom.Storage
 
-internal actual object EncryptedSettingsBuilder {
-    actual fun build(
-        options: SettingOptions,
-        param: EncryptedSettingsPlatformParam
-    ): Settings = StorageSettings(param.storage)
-}
+internal actual fun buildSettings(
+    options: SettingOptions,
+    param: EncryptedSettingsPlatformParam
+): Settings = StorageSettings(param.storage)
 
 internal actual class EncryptedSettingsPlatformParam(val storage: Storage)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -47,16 +47,14 @@ private fun createOrLoad(rootPath: String, file: File): Properties {
 /**
  * the java implementation is not yet encrypted
  */
-internal actual object EncryptedSettingsBuilder {
-    actual fun build(
-        options: SettingOptions,
-        param: EncryptedSettingsPlatformParam
-    ): Settings {
-        val file: File = File(Paths.get(param.rootPath, options.fileName).toString())
-        val properties = createOrLoad(param.rootPath, file)
+internal actual fun buildSettings(
+    options: SettingOptions,
+    param: EncryptedSettingsPlatformParam
+): Settings {
+    val file = File(Paths.get(param.rootPath, options.fileName).toString())
+    val properties = createOrLoad(param.rootPath, file)
 
-        return PropertiesSettings(properties) { onModify(it, file) }
-    }
+    return PropertiesSettings(properties) { onModify(it, file) }
 }
 
 internal actual class EncryptedSettingsPlatformParam(val rootPath: String)

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -31,7 +31,7 @@ actual class GlobalPrefProvider(
 ) {
     private val kaliumPref =
         KaliumPreferencesSettings(
-            EncryptedSettingsBuilder.build(
+            buildSettings(
                 SettingOptions.AppSettings(shouldEncryptData),
                 EncryptedSettingsPlatformParam(rootPath)
             )

--- a/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
+++ b/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/kmmSettings/UserPrefBuilder.kt
@@ -32,7 +32,7 @@ actual class UserPrefBuilder(
 
     private val kaliumPref =
         KaliumPreferencesSettings(
-            EncryptedSettingsBuilder.build(
+            buildSettings(
                 SettingOptions.UserSettings(shouldEncryptData, userId),
                 EncryptedSettingsPlatformParam(rootPath)
             )

--- a/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/EncryptedSettingsBuilderTest.kt
+++ b/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/EncryptedSettingsBuilderTest.kt
@@ -19,9 +19,9 @@
 package com.wire.kalium.persistence
 
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
-import com.wire.kalium.persistence.kmmSettings.EncryptedSettingsBuilder
 import com.wire.kalium.persistence.kmmSettings.EncryptedSettingsPlatformParam
 import com.wire.kalium.persistence.kmmSettings.SettingOptions
+import com.wire.kalium.persistence.kmmSettings.buildSettings
 import org.junit.Test
 import java.io.FileInputStream
 import java.nio.file.Files
@@ -37,7 +37,7 @@ class EncryptedSettingsBuilderTest {
         val rootPath = Files.createTempDirectory("test-rootPath").toString()
         val userIDEntity = QualifiedIDEntity("user", "domain")
 
-        val encryptedSettings = EncryptedSettingsBuilder.build(
+        val encryptedSettings = buildSettings(
             SettingOptions.UserSettings(
                 shouldEncryptData = false,
                 userIDEntity
@@ -57,7 +57,7 @@ class EncryptedSettingsBuilderTest {
     fun givenJvmPropertiesSettings_WhenAppSettingsAreChanged_ThenItIsStoredInFile() {
         val rootPath = Files.createTempDirectory("test-rootPath").toString()
 
-        val encryptedSettings = EncryptedSettingsBuilder.build(
+        val encryptedSettings = buildSettings(
             SettingOptions.AppSettings(
                 shouldEncryptData = false
             ),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9639" title="WPB-9639" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9639</a>  [Android] Crash on app login -StrongBoxUnavailableException crash in getOrCreateMasterKey
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On Samsungs Galaxy S24 (regular, plus and ultra) sometimes the app crashes on app login. It occurs for around 40 users, when total install count on S24 is over 6k, so even more strange that it occurs only occasionally. Couldn't reproduce that on real device using Samsung Remote Test Lab.

### Causes (Optional)

The cause from stack trace is that the StrongBox is unavailable, but no idea why, maybe some other app is using it at that moment.

### Solutions

These are not 100% certain solutions, more assumptions, but if the StrongBox is unavailable only temporarily, then applying some delay before retry should improve it. Also, expect/actual object, which is still in beta, is replaced with expect/actual fun which is stable.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
