### PR TITLE
refactor: fetch pending receipt ids within a time window [WPB-9216]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -162,6 +162,8 @@ internal interface MessageRepository {
     suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>>
     suspend fun getPendingConfirmationMessagesByConversationAfterDate(
         conversationId: ConversationId,
+        afterDateTime: Instant,
+        untilDateTime: Instant,
         visibility: List<Message.Visibility> = Message.Visibility.entries
     ): Either<CoreFailure, List<String>>
 
@@ -533,10 +535,14 @@ internal class MessageDataSource internal constructor(
 
     override suspend fun getPendingConfirmationMessagesByConversationAfterDate(
         conversationId: ConversationId,
+        afterDateTime: Instant,
+        untilDateTime: Instant,
         visibility: List<Message.Visibility>
     ): Either<CoreFailure, List<String>> = wrapStorageRequest {
-        messageDAO.getPendingToConfirmMessagesByConversationAndVisibilityAfterDate(
+        messageDAO.getMessageIdsThatExpectReadConfirmationWithinDates(
             conversationId.toDao(),
+            afterDateTime,
+            untilDateTime,
             visibility.map { it.toEntityVisibility() }
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -203,7 +203,8 @@ class ConversationScope internal constructor(
             selfUserId,
             selfConversationIdProvider,
             sendConfirmation,
-            scope
+            scope,
+            kaliumLogger
         )
 
     val updateConversationAccess: UpdateConversationAccessRoleUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -19,20 +19,26 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.benasher44.uuid.uuid4
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.feature.message.SendConfirmationUseCase
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
+import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -52,7 +58,8 @@ class UpdateConversationReadDateUseCase internal constructor(
     private val selfUserId: UserId,
     private val selfConversationIdProvider: SelfConversationIdProvider,
     private val sendConfirmation: SendConfirmationUseCase,
-    private val scope: CoroutineScope
+    private val scope: CoroutineScope,
+    private val logger: KaliumLogger = kaliumLogger
 ) {
 
     /**
@@ -61,11 +68,23 @@ class UpdateConversationReadDateUseCase internal constructor(
      */
     operator fun invoke(conversationId: QualifiedID, time: Instant) {
         scope.launch {
-            sendConfirmation(conversationId)
-            conversationRepository.updateConversationReadDate(conversationId, time)
-            selfConversationIdProvider().flatMap { selfConversationIds ->
-                selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
-                    sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
+            conversationRepository.observeCacheDetailsById(conversationId).flatMap {
+                it.first()?.let { Either.Right(it) } ?: Either.Left(StorageFailure.DataNotFound)
+            }.onFailure {
+                logger.w("Failed to update conversation read date; StorageFailure $it")
+            }.onSuccess { conversation ->
+                launch {
+                    sendConfirmation(conversationId, conversation.lastReadDate, time)
+                }
+                launch {
+                    conversationRepository.updateConversationReadDate(conversationId, time)
+                }
+                launch {
+                    selfConversationIdProvider().flatMap { selfConversationIds ->
+                        selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
+                            sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
+                        }
+                    }
                 }
             }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -579,7 +579,12 @@ class MessageRepositoryTest {
                 messageDAO.getMessagesByConversationAndVisibility(any(), any(), any(), any())
             }.returns(flowOf(messages))
             coEvery {
-                messageDAO.getPendingToConfirmMessagesByConversationAndVisibilityAfterDate(any(), any())
+                messageDAO.getMessageIdsThatExpectReadConfirmationWithinDates(
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
             }.returns(messages.map { it.id })
             return this
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendConfirmationUseCaseTest.kt
@@ -19,9 +19,9 @@
 package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestMessage
@@ -31,20 +31,16 @@ import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.Mock
 import io.mockative.any
-
 import io.mockative.coEvery
-import io.mockative.every
 import io.mockative.coVerify
-import io.mockative.coEvery
-import io.mockative.coEvery
+import io.mockative.eq
 import io.mockative.mock
 import io.mockative.once
-import io.mockative.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SendConfirmationUseCaseTest {
 
     @Test
@@ -57,7 +53,10 @@ class SendConfirmationUseCaseTest {
             .withSendMessageSuccess()
             .arrange()
 
-        val result = sendConfirmation(TestConversation.ID)
+        val after = Instant.DISTANT_PAST
+        val until = after + 10.seconds
+
+        val result = sendConfirmation(TestConversation.ID, after, until)
 
         result.shouldSucceed()
         coVerify {
@@ -75,7 +74,10 @@ class SendConfirmationUseCaseTest {
             .withSendMessageSuccess()
             .arrange()
 
-        val result = sendConfirmation(TestConversation.ID)
+        val after = Instant.DISTANT_PAST
+        val until = after + 10.seconds
+
+        val result = sendConfirmation(TestConversation.ID, after, until)
 
         result.shouldSucceed()
         coVerify {
@@ -83,7 +85,12 @@ class SendConfirmationUseCaseTest {
         }.wasNotInvoked()
 
         coVerify {
-            arrangement.messageRepository.getPendingConfirmationMessagesByConversationAfterDate(any(), any())
+            arrangement.messageRepository.getPendingConfirmationMessagesByConversationAfterDate(
+                any(),
+                eq(after),
+                eq(until),
+                any()
+            )
         }.wasNotInvoked()
     }
 
@@ -133,7 +140,7 @@ class SendConfirmationUseCaseTest {
 
         suspend fun withPendingMessagesResponse() = apply {
             coEvery {
-                messageRepository.getPendingConfirmationMessagesByConversationAfterDate(any(), any())
+                messageRepository.getPendingConfirmationMessagesByConversationAfterDate(any(), any(), any(), any())
             }.returns(Either.Right(listOf(TestMessage.TEXT_MESSAGE.id)))
         }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -518,7 +518,7 @@ SELECT * FROM MessageDetailsView WHERE conversationId = ? AND senderUserId = ? A
 selectByConversationIdAndSenderIdAndType:
 SELECT * FROM MessageDetailsView WHERE conversationId = ? AND senderUserId = ? AND contentType = ?;
 
-selectPendingMessagesIdsByConversationIdAndVisibilityAfterDate:
+selectMessageIdsThatExpectReadConfirmationWithinDates:
 SELECT Message.id
 FROM Message
 LEFT JOIN SelfUser
@@ -527,7 +527,8 @@ WHERE
     Message.conversation_id = ?
     AND Message.visibility IN ?
     AND (Message.expects_read_confirmation = 1)
-    AND Message.creation_date > Conversation.last_read_date
+    AND Message.creation_date > ?
+    AND Message.creation_date <= ?
     AND (Message.sender_user_id != SelfUser.id)
 ORDER BY
     Message.creation_date DESC;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -113,8 +113,10 @@ interface MessageDAO {
         clientId: String,
     )
 
-    suspend fun getPendingToConfirmMessagesByConversationAndVisibilityAfterDate(
+    suspend fun getMessageIdsThatExpectReadConfirmationWithinDates(
         conversationId: QualifiedIDEntity,
+        afterDate: Instant,
+        untilDate: Instant,
         visibility: List<MessageEntity.Visibility> = MessageEntity.Visibility.entries
     ): List<String>
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -405,12 +405,17 @@ internal class MessageDAOImpl internal constructor(
         queries.markMessagesAsDecryptionResolved(userId, clientId)
     }
 
-    override suspend fun getPendingToConfirmMessagesByConversationAndVisibilityAfterDate(
+    override suspend fun getMessageIdsThatExpectReadConfirmationWithinDates(
         conversationId: QualifiedIDEntity,
+        afterDate: Instant,
+        untilDate: Instant,
         visibility: List<MessageEntity.Visibility>
     ): List<String> = withContext(coroutineContext) {
-        queries.selectPendingMessagesIdsByConversationIdAndVisibilityAfterDate(
-            conversationId, visibility
+        queries.selectMessageIdsThatExpectReadConfirmationWithinDates(
+            conversation_id = conversationId,
+            visibility = visibility,
+            creation_date = afterDate,
+            creation_date_ = untilDate
         ).executeAsList()
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9216" title="WPB-9216" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9216</a>  [Android] out of memory exception when scrolling a group chat with long unread history
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Marking messages as read requires performing three actions:
- Getting message IDs / Send receipts to message authors
- Updating Last Read date in the conversation
- Sending new Last Read to other self clients

We can't consistently parallelise these steps, because getting message IDs is currently relying in the `Last Read` information that is stored in the database. What if this is updated before we are able to send receipts? We can't afford having this implicit dependency if we want to parallelise things.

---- 

Also, when we mark messages as read, we are currently sending receipts for _all_ unread messages. Even if the user is just reading some of the unread messages.

### Solutions

This PR adds two parameters to the "get me all the message IDs that we can send read receipts to".

This allows us to:
- Send receipts in smaller chunks as the user scrolls
- Make sure sending receipts and updating LastRead can be done in parallel

### In the future

Next PR should be the final one. In which the logic is removed from the `UpdateConversationReadDateUseCase`, and put into one of the new [ConversationTimeEventWorker](https://github.com/wireapp/kalium/blob/611e9806033e7d7c8a3daf6fd55917633e6e031b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWorker.kt) implementation. This way it can be scheduled and enqueued with debounces and whatnot.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

I've updated one test to cover this new behaviour, and I've removed one test that was duplicated.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
