### PR TITLE
perf: schedule updating conversation read status [WPB-9216]

### DIFF
--- a/detekt/baseline.xml
+++ b/detekt/baseline.xml
@@ -664,8 +664,6 @@
     <ID>NoUnusedImports:SearchRepositoryArrangement.kt$com.wire.kalium.logic.util.arrangement.repository.SearchRepositoryArrangement.kt</ID>
     <ID>NoUnusedImports:SearchUseCaseTest.kt$com.wire.kalium.logic.feature.search.SearchUseCaseTest.kt</ID>
     <ID>NoUnusedImports:SendButtonActionMessageTest.kt$com.wire.kalium.logic.feature.message.SendButtonActionMessageTest.kt</ID>
-    <ID>NoUnusedImports:SendConfirmationUseCaseTest.kt$com.wire.kalium.logic.feature.message.SendConfirmationUseCaseTest.kt</ID>
-    <ID>NoUnusedImports:SendConfirmationUseCaseTest.kt$import io.mockative.coEvery</ID>
     <ID>NoUnusedImports:ServerConfigDTOJson.kt$util.ServerConfigDTOJson.kt</ID>
     <ID>NoUnusedImports:ServerConfigRepositoryArrangement.kt$com.wire.kalium.logic.util.arrangement.repository.ServerConfigRepositoryArrangement.kt</ID>
     <ID>NoUnusedImports:SessionEstablisherTest.kt$com.wire.kalium.logic.feature.message.SessionEstablisherTest.kt</ID>

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/cache/SelfConversationIdProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/cache/SelfConversationIdProvider.kt
@@ -29,15 +29,15 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.util.DelicateKaliumApi
 
-internal interface SelfConversationIdProvider {
+internal fun interface SelfConversationIdProvider {
     suspend operator fun invoke(): Either<StorageFailure, List<ConversationId>>
 }
 
-internal interface ProteusSelfConversationIdProvider {
+internal fun interface ProteusSelfConversationIdProvider {
     suspend operator fun invoke(): Either<StorageFailure, ConversationId>
 }
 
-internal interface MLSSelfConversationIdProvider {
+internal fun interface MLSSelfConversationIdProvider {
     suspend operator fun invoke(): Either<StorageFailure, ConversationId>
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -61,7 +61,7 @@ import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTime
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.feature.message.MessageSender
-import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCaseImpl
+import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessagesAfterEndDateUseCase
 import com.wire.kalium.logic.feature.message.receipt.ConversationWorkQueue
 import com.wire.kalium.logic.feature.message.receipt.ParallelConversationWorkQueue
@@ -90,7 +90,7 @@ class ConversationScope internal constructor(
     private val persistMessage: PersistMessageUseCase,
     private val updateKeyingMaterialThresholdProvider: UpdateKeyingMaterialThresholdProvider,
     private val selfTeamIdProvider: SelfTeamIdProvider,
-    private val sendConfirmation: SendConfirmationUseCaseImpl,
+    private val sendConfirmation: SendConfirmationUseCase,
     private val renamedConversationHandler: RenamedConversationEventHandler,
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val serverConfigRepository: ServerConfigRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -61,14 +61,17 @@ import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTime
 import com.wire.kalium.logic.feature.conversation.messagetimer.UpdateMessageTimerUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.feature.message.MessageSender
-import com.wire.kalium.logic.feature.message.SendConfirmationUseCase
+import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCaseImpl
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessagesAfterEndDateUseCase
+import com.wire.kalium.logic.feature.message.receipt.ConversationWorkQueue
+import com.wire.kalium.logic.feature.message.receipt.ParallelConversationWorkQueue
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCase
 import com.wire.kalium.logic.feature.team.DeleteTeamConversationUseCaseImpl
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.sync.receiver.conversation.RenamedConversationEventHandler
 import com.wire.kalium.logic.sync.receiver.handler.CodeUpdateHandlerImpl
+import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
 
 @Suppress("LongParameterList")
@@ -87,7 +90,7 @@ class ConversationScope internal constructor(
     private val persistMessage: PersistMessageUseCase,
     private val updateKeyingMaterialThresholdProvider: UpdateKeyingMaterialThresholdProvider,
     private val selfTeamIdProvider: SelfTeamIdProvider,
-    private val sendConfirmation: SendConfirmationUseCase,
+    private val sendConfirmation: SendConfirmationUseCaseImpl,
     private val renamedConversationHandler: RenamedConversationEventHandler,
     private val qualifiedIdMapper: QualifiedIdMapper,
     private val serverConfigRepository: ServerConfigRepository,
@@ -195,6 +198,10 @@ class ConversationScope internal constructor(
     val markConnectionRequestAsNotified: MarkConnectionRequestAsNotifiedUseCase
         get() = MarkConnectionRequestAsNotifiedUseCaseImpl(connectionRepository)
 
+    private val conversationWorkQueue: ConversationWorkQueue by lazy {
+        ParallelConversationWorkQueue(scope, kaliumLogger, KaliumDispatcherImpl.default)
+    }
+
     val updateConversationReadDateUseCase: UpdateConversationReadDateUseCase
         get() = UpdateConversationReadDateUseCase(
             conversationRepository,
@@ -203,7 +210,7 @@ class ConversationScope internal constructor(
             selfUserId,
             selfConversationIdProvider,
             sendConfirmation,
-            scope,
+            conversationWorkQueue,
             kaliumLogger
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -79,6 +79,7 @@ import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletio
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCaseImpl
 import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
 import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
+import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCaseImpl
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCaseImpl
@@ -362,8 +363,8 @@ class MessageScope internal constructor(
             notificationEventsManager = NotificationEventsManagerImpl
         )
 
-    internal val sendConfirmation: SendConfirmationUseCase
-        get() = SendConfirmationUseCase(
+    internal val sendConfirmation: SendConfirmationUseCaseImpl
+        get() = SendConfirmationUseCaseImpl(
             currentClientIdProvider,
             syncManager,
             messageSender,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -79,7 +79,7 @@ import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletio
 import com.wire.kalium.logic.feature.message.ephemeral.EnqueueMessageSelfDeletionUseCaseImpl
 import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandler
 import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionHandlerImpl
-import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCaseImpl
+import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCase
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCaseImpl
@@ -363,8 +363,8 @@ class MessageScope internal constructor(
             notificationEventsManager = NotificationEventsManagerImpl
         )
 
-    internal val sendConfirmation: SendConfirmationUseCaseImpl
-        get() = SendConfirmationUseCaseImpl(
+    internal val sendConfirmation: SendConfirmationUseCase
+        get() = SendConfirmationUseCase(
             currentClientIdProvider,
             syncManager,
             messageSender,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCase.kt
@@ -61,22 +61,20 @@ internal interface SendConfirmationUseCase {
     ): Either<CoreFailure, Unit>
 }
 
-@Suppress("LongParameterList")
-internal class SendConfirmationUseCaseImpl internal constructor(
-    private val currentClientIdProvider: CurrentClientIdProvider,
-    private val syncManager: SyncManager,
-    private val messageSender: MessageSender,
-    private val selfUserId: UserId,
-    private val conversationRepository: ConversationRepository,
-    private val messageRepository: MessageRepository,
-    private val userPropertyRepository: UserPropertyRepository,
-) : SendConfirmationUseCase {
-    private companion object {
-        const val TAG = "SendConfirmation"
-        const val conversationIdKey = "conversationId"
-        const val messageIdsKey = "messageIds"
-        const val statusKey = "status"
-    }
+@Suppress("LongParameterList", "FunctionNaming")
+internal fun SendConfirmationUseCase(
+    currentClientIdProvider: CurrentClientIdProvider,
+    syncManager: SyncManager,
+    messageSender: MessageSender,
+    selfUserId: UserId,
+    conversationRepository: ConversationRepository,
+    messageRepository: MessageRepository,
+    userPropertyRepository: UserPropertyRepository,
+) = object : SendConfirmationUseCase {
+    val TAG = "SendConfirmation"
+    val conversationIdKey = "conversationId"
+    val messageIdsKey = "messageIds"
+    val statusKey = "status"
 
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.MESSAGES) }
 
@@ -180,6 +178,6 @@ internal class SendConfirmationUseCaseImpl internal constructor(
         val jsonLogString = "${properties.toJsonElement()}"
         val logMessage = "$TAG: $jsonLogString"
 
-        logger.i("$logMessage")
+        logger.i(logMessage)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageTarget
+import com.wire.kalium.logic.feature.message.receipt.ConversationWorkQueue
+import com.wire.kalium.logic.feature.message.receipt.InstantConversationWorkQueue
+import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCase
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.arrangement.MessageSenderArrangement
+import com.wire.kalium.logic.util.arrangement.MessageSenderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangement
+import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.matches
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.seconds
+
+class UpdateConversationReadDateUseCaseTest {
+
+    @Test
+    fun givenCurrentStoredLastReadDateIsNewerThanEnqueued_whenWorking_thenShouldNotTryToDoAnyWork() = runTest {
+        val persistedLastRead = Clock.System.now()
+        val conversationId = TestConversation.CONVERSATION.id
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withCachedInfoByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
+            )
+        }
+
+        updateConversationReadDateUseCase(conversationId, persistedLastRead - 1.seconds)
+
+        coVerify {
+            arrangement.sendConfirmation(any(), any(), any())
+        }.wasNotInvoked()
+        coVerify {
+            arrangement.conversationRepository.updateConversationReadDate(any(), any())
+        }.wasNotInvoked()
+        coVerify {
+            arrangement.messageSender.sendMessage(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenProvidedTimeIsNewerThanPersistedLastReadForConversation_whenWorking_thenShouldTryToSendReceipts() = runTest {
+        val persistedLastRead = Clock.System.now()
+        val newLastRead = persistedLastRead + 1.seconds
+        val conversationId = TestConversation.CONVERSATION.id
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withCachedInfoByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
+            )
+        }
+
+        updateConversationReadDateUseCase(conversationId, newLastRead)
+
+        coVerify {
+            arrangement.sendConfirmation(eq(conversationId), eq(persistedLastRead), eq(newLastRead))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProvidedTimeIsNewerThanPersistedLastReadForConversation_whenWorking_thenShouldUpdateLastReadLocally() = runTest {
+        val persistedLastRead = Clock.System.now()
+        val newLastRead = persistedLastRead + 1.seconds
+        val conversationId = TestConversation.CONVERSATION.id
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withCachedInfoByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
+            )
+        }
+
+        updateConversationReadDateUseCase(conversationId, newLastRead)
+
+        coVerify {
+            arrangement.conversationRepository.updateConversationReadDate(eq(conversationId), eq(newLastRead))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProvidedTimeIsNewerThanPersistedLastReadForConversation_whenWorking_thenShouldUpdateLastReadForOtherSelfClients() = runTest {
+        val persistedLastRead = Clock.System.now()
+        val newLastRead = persistedLastRead + 1.seconds
+        val conversationId = TestConversation.CONVERSATION.id
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withCachedInfoByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
+            )
+        }
+
+        updateConversationReadDateUseCase(conversationId, newLastRead)
+
+        coVerify {
+            arrangement.messageSender.sendMessage(
+                message = matches { message ->
+                    val content = message.content
+                    assertIs<MessageContent.LastRead>(content)
+                    assertEquals(conversationId, content.conversationId)
+                    assertEquals(newLastRead, content.time)
+                    assertEquals(arrangement.selfConversationId, message.conversationId)
+                    true
+                },
+                messageTarget = matches { target ->
+                    assertIs<MessageTarget.Conversation>(target)
+                    true
+                }
+            )
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAnyCall_whenInvoking_thenShouldEnqueueWork() = runTest {
+        val expectedId = TestConversation.CONVERSATION.id.copy(value = "potato")
+        val expectedTime = Clock.System.now()
+        lateinit var enqueuedId: ConversationId
+        lateinit var enqueuedInstant: Instant
+        var enqueuedTimes = 0
+        val (_, updateConversationReadDateUseCase) = arrange {
+            workQueue = ConversationWorkQueue { input, _ ->
+                enqueuedTimes += 1
+                enqueuedInstant = input.eventTime
+                enqueuedId = input.conversationId
+            }
+        }
+        updateConversationReadDateUseCase(expectedId, expectedTime)
+
+        assertEquals(1, enqueuedTimes)
+        assertEquals(expectedId, enqueuedId)
+        assertEquals(expectedTime, enqueuedInstant)
+    }
+
+    private class Arrangement(
+        private val configure: suspend Arrangement.() -> Unit
+    ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
+        MessageSenderArrangement by MessageSenderArrangementImpl(),
+        SelfConversationIdProviderArrangement by SelfConversationIdProviderArrangementImpl() {
+
+        var currentClientId = TestClient.CLIENT_ID
+        var selfUserID = TestUser.SELF.id
+        var selfConversationId = TestConversation.SELF().id.copy("SELF")
+
+        @Mock
+        val sendConfirmation = mock(SendConfirmationUseCase::class)
+
+        var workQueue: ConversationWorkQueue = InstantConversationWorkQueue()
+
+        suspend fun arrange(): Pair<Arrangement, UpdateConversationReadDateUseCase> = run {
+            coEvery {
+                sendConfirmation(any(), any(), any())
+            }.returns(Either.Right(Unit))
+            coEvery {
+                conversationRepository.updateConversationReadDate(any(), any())
+            }.returns(Either.Right(Unit))
+            coEvery {
+                messageSender.sendMessage(any(), any())
+            }.returns(Either.Right(Unit))
+            withSelfConversationIds(listOf(selfConversationId))
+            configure()
+            this@Arrangement to UpdateConversationReadDateUseCase(
+                conversationRepository,
+                messageSender,
+                { Either.Right(currentClientId) },
+                selfUserID,
+                selfConversationIdProvider,
+                sendConfirmation,
+                workQueue
+            )
+        }
+    }
+
+    private companion object {
+        suspend fun arrange(configure: suspend Arrangement.() -> Unit) = Arrangement(configure).arrange()
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/InstantConversationWorkQueue.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/InstantConversationWorkQueue.kt
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.receipt
+
+import kotlinx.coroutines.runBlocking
+
+internal class InstantConversationWorkQueue : ConversationWorkQueue {
+    override fun enqueue(
+        input: ConversationTimeEventInput,
+        worker: ConversationTimeEventWorker
+    ) {
+        runBlocking { worker.doWork(input) }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/ParallelConversationWorkQueueTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/ParallelConversationWorkQueueTest.kt
@@ -80,7 +80,6 @@ class ParallelConversationWorkQueueTest {
         assertTrue(endedSecond)
     }
 
-
     @Test
     fun givenWorkThrows_whenEnqueuingAnotherForTheSameConversation_itIsExecutedNormally() = runTest {
         val queue = testSubject()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCaseTest.kt
@@ -16,12 +16,13 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.message
+package com.wire.kalium.logic.feature.message.receipt
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
+import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestMessage
@@ -144,7 +145,7 @@ class SendConfirmationUseCaseTest {
             }.returns(Either.Right(listOf(TestMessage.TEXT_MESSAGE.id)))
         }
 
-        fun arrange() = this to SendConfirmationUseCase(
+        fun arrange() = this to SendConfirmationUseCaseImpl(
             currentClientIdProvider,
             syncManager,
             messageSender,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCaseTest.kt
@@ -145,7 +145,7 @@ class SendConfirmationUseCaseTest {
             }.returns(Either.Right(listOf(TestMessage.TEXT_MESSAGE.id)))
         }
 
-        fun arrange() = this to SendConfirmationUseCaseImpl(
+        fun arrange() = this to SendConfirmationUseCase(
             currentClientIdProvider,
             syncManager,
             messageSender,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
+import io.mockative.eq
 import io.mockative.fake.valueOf
 import io.mockative.matchers.AnyMatcher
 import io.mockative.matchers.Matcher
@@ -85,6 +86,12 @@ internal interface ConversationRepositoryArrangement {
         coEvery {
             conversationRepository.fetchConversationIfUnknown(any())
         }.returns(Either.Right(Unit))
+    }
+
+    suspend fun withCachedInfoByIdReturning(conversation: Conversation) {
+        coEvery {
+            conversationRepository.observeCacheDetailsById(eq(conversation.id))
+        }.returns(Either.Right(flowOf(conversation)))
     }
 
     suspend fun withUpdateGroupStateReturning(result: Either<StorageFailure, Unit>) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9216" title="WPB-9216" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9216</a>  [Android] out of memory exception when scrolling a group chat with long unread history
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, if the Android app calls to update the conversation read date multiple times, there's nothing that Kalium does to protect from overworking.

### Solutions

Instead of just doing it immediately when called, schedule it to be executed using the new `ParallelConversationWorkQueue`, that allows one work to be executed at a time per conversation.

Add a little debounce to the queue, in case the user is scrolling down through the messages.

Before executing work, check if the lastRead is _actually_ being updated forward (new time is newer than persisted time).


With all of these recent changes, some improvements can be seen:
- The conversation is marked as read faster in self client
- For message authors, the receipts are received as the user scrolls down (plus debounce), as seen in the video below. Before the recent changes, when opening the conversation, receipts would be sent for _all_ messages even if the user wouldn't scroll down to the bottom.

#### Video

From the sender point of view, receipts are sent progressively as the reader scrolls.

https://github.com/wireapp/kalium/assets/9389043/61fa6d17-c72e-429e-95bc-6886eb78485b

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
