### PR TITLE
feat: add analytics user profile - Part 1 (WPB-8978)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -136,6 +136,7 @@ interface UserConfigRepository {
     suspend fun clearE2EISettings()
     fun setShouldFetchE2EITrustAnchors(shouldFetch: Boolean)
     fun getShouldFetchE2EITrustAnchor(): Boolean
+    suspend fun setTrackingIdentifier(identifier: String)
 }
 
 @Suppress("TooManyFunctions")
@@ -495,4 +496,10 @@ internal class UserConfigDataSource internal constructor(
     }
 
     override fun getShouldFetchE2EITrustAnchor(): Boolean = userConfigStorage.getShouldFetchE2EITrustAnchorHasRun()
+
+    override suspend fun setTrackingIdentifier(identifier: String) {
+        wrapStorageRequest {
+            userConfigDAO.setTrackingIdentifier(identifier = identifier)
+        }
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -180,7 +180,7 @@ sealed interface Message {
             return "${toLogMap().toJsonElement()}"
         }
 
-        @Suppress("LongMethod")
+        @Suppress("LongMethod", "CyclomaticComplexMethod")
         override fun toLogMap(): Map<String, Any?> {
             val typeKey = "type"
 
@@ -239,6 +239,11 @@ sealed interface Message {
 
                 is MessageContent.ButtonActionConfirmation -> mutableMapOf(
                     typeKey to "buttonActionConfirmation"
+                )
+
+                is MessageContent.DataTransfer -> mutableMapOf(
+                    typeKey to "dataTransfer",
+                    "content" to content.toLogMap(),
                 )
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -192,7 +192,6 @@ sealed interface MessageContent {
         )
     }
 
-
     data class DeleteMessage(val messageId: String) : Signaling
 
     data class TextEdited(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -180,6 +180,19 @@ sealed interface MessageContent {
         )
     }
 
+    data class DataTransfer(
+        var trackingIdentifier: TrackingIdentifier? = null
+    ) : Signaling {
+        fun toLogMap(): Map<String, Any> = mapOf(
+            "identifier" to (trackingIdentifier?.identifier?.obfuscateId() ?: "null")
+        )
+
+        data class TrackingIdentifier(
+            val identifier: String
+        )
+    }
+
+
     data class DeleteMessage(val messageId: String) : Signaling
 
     data class TextEdited(
@@ -440,6 +453,7 @@ fun MessageContent?.getType() = when (this) {
     is MessageContent.LegalHold.ForConversation.Enabled -> "LegalHold.ForConversation.Enabled"
     is MessageContent.LegalHold.ForMembers.Disabled -> "LegalHold.ForMembers.Disabled"
     is MessageContent.LegalHold.ForMembers.Enabled -> "LegalHold.ForMembers.Enabled"
+    is MessageContent.DataTransfer -> "DataTransfer"
     null -> "null"
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
@@ -40,4 +40,5 @@ inline fun MessageContent.FromProto.typeDescription(): String = when (this) {
     is MessageContent.Reaction -> "Reaction"
     is MessageContent.Receipt -> "Receipt"
     is MessageContent.TextEdited -> "TextEdited"
+    is MessageContent.DataTransfer -> "DataTransfer"
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -126,6 +126,7 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.LegalHold -> false
             is MessageContent.MemberChange.RemovedFromTeam -> false
             is MessageContent.TeamMemberRemoved -> false
+            is MessageContent.DataTransfer -> false
         }
 
     @Suppress("ComplexMethod")
@@ -179,6 +180,7 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.ConversationStartedUnverifiedWarning,
             is MessageContent.LegalHold,
             is MessageContent.MemberChange.RemovedFromTeam,
-            is MessageContent.TeamMemberRemoved -> false
+            is MessageContent.TeamMemberRemoved,
+            is MessageContent.DataTransfer -> false
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -411,6 +411,8 @@ import com.wire.kalium.logic.sync.receiver.handler.CodeDeletedHandler
 import com.wire.kalium.logic.sync.receiver.handler.CodeDeletedHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.CodeUpdateHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.CodeUpdatedHandler
+import com.wire.kalium.logic.sync.receiver.handler.DataTransferEventHandler
+import com.wire.kalium.logic.sync.receiver.handler.DataTransferEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.DeleteForMeHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.DeleteMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.LastReadContentHandlerImpl
@@ -1290,6 +1292,12 @@ class UserSessionScope internal constructor(
     private val buttonActionConfirmationHandler: ButtonActionConfirmationHandler
         get() = ButtonActionConfirmationHandlerImpl(compositeMessageRepository, messageMetadataRepository)
 
+    private val dataTransferEventHandler: DataTransferEventHandler
+        get() = DataTransferEventHandlerImpl(
+            userId,
+            userConfigRepository
+        )
+
     private val applicationMessageHandler: ApplicationMessageHandler
         get() = ApplicationMessageHandlerImpl(
             userRepository,
@@ -1315,6 +1323,7 @@ class UserSessionScope internal constructor(
             messageEncoder,
             receiptMessageHandler,
             buttonActionConfirmationHandler,
+            dataTransferEventHandler,
             userId
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
@@ -208,5 +208,6 @@ internal class PersistMigratedMessagesUseCaseImpl(
         is MessageContent.ButtonAction -> MessageEntity.Visibility.HIDDEN
         is MessageContent.ButtonActionConfirmation -> MessageEntity.Visibility.HIDDEN
         is MessageContent.Location -> MessageEntity.Visibility.VISIBLE
+        is MessageContent.DataTransfer -> MessageEntity.Visibility.HIDDEN
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.asset.AssetMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandler
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandler
+import com.wire.kalium.logic.sync.receiver.handler.DataTransferEventHandler
 import com.wire.kalium.logic.sync.receiver.handler.DeleteForMeHandler
 import com.wire.kalium.logic.sync.receiver.handler.DeleteMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.LastReadContentHandler
@@ -86,6 +87,7 @@ internal class ApplicationMessageHandlerImpl(
     private val messageEncoder: MessageContentEncoder,
     private val receiptMessageHandler: ReceiptMessageHandler,
     private val buttonActionConfirmationHandler: ButtonActionConfirmationHandler,
+    private val dataTransferEventHandler: DataTransferEventHandler,
     private val selfUserId: UserId
 ) : ApplicationMessageHandler {
 
@@ -161,6 +163,7 @@ internal class ApplicationMessageHandlerImpl(
         }
     }
 
+    @Suppress("CyclomaticComplexMethod")
     private suspend fun processSignaling(signaling: Message.Signaling) {
         when (val content = signaling.content) {
             MessageContent.Ignored -> {
@@ -215,6 +218,8 @@ internal class ApplicationMessageHandlerImpl(
                 signaling.senderUserId,
                 content
             )
+
+            is MessageContent.DataTransfer -> dataTransferEventHandler.handle(signaling, content)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/DataTransferEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/DataTransferEventHandler.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.kaliumLogger
+
+internal interface DataTransferEventHandler {
+    suspend fun handle(
+        message: Message.Signaling,
+        messageContent: MessageContent.DataTransfer
+    )
+}
+
+internal class DataTransferEventHandlerImpl(
+    private val selfUserId: UserId,
+    private val userConfigRepository: UserConfigRepository
+) : DataTransferEventHandler {
+
+    override suspend fun handle(
+        message: Message.Signaling,
+        messageContent: MessageContent.DataTransfer
+    ) {
+        kaliumLogger.d("MessageContent.DataTransfer | with Identifier : ${messageContent.trackingIdentifier?.identifier} |end|")
+        // DataTransfer from another user or null tracking identifier shouldn't happen,
+        // If it happens, it's unnecessary
+        // and we can squish some performance by skipping it completely
+        if (message.senderUserId != selfUserId || messageContent.trackingIdentifier == null) return
+
+        userConfigRepository.setTrackingIdentifier(
+            identifier = messageContent.trackingIdentifier!!.identifier
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/DataTransferEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/DataTransferEventHandlerTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
+import io.mockative.any
+import io.mockative.coVerify
+import io.mockative.once
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+
+class DataTransferEventHandlerTest {
+
+    @Test
+    fun givenSelfUserDataTransferContent_whenHandlingEvent_thenSetTrackingIdentifier() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement().arrange {
+            withSetTrackingIdentifier()
+        }
+
+        // when
+        handler.handle(
+            message = MESSAGE,
+            messageContent = MESSAGE_CONTENT
+        )
+
+        // then
+        coVerify {
+            arrangement.userConfigRepository.setTrackingIdentifier(any())
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenOtherUserSentDataTransferContent_whenHandlingEvent_thenTrackingIdentifierIsNotSet() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement().arrange {
+            withSetTrackingIdentifier()
+        }
+
+        // when
+        handler.handle(
+            message = MESSAGE.copy(senderUserId = OTHER_USER_ID),
+            messageContent = MESSAGE_CONTENT
+        )
+
+        // then
+        coVerify {
+            arrangement.userConfigRepository.setTrackingIdentifier(any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenSelfUserDataTransferContentWithNullIdentifier_whenHandlingEvent_thenTrackingIdentifierIsNotSet() = runTest {
+        // given
+        val (arrangement, handler) = Arrangement().arrange {
+            withSetTrackingIdentifier()
+        }
+
+        // when
+        handler.handle(
+            message = MESSAGE,
+            messageContent = MESSAGE_CONTENT.copy(trackingIdentifier = null)
+        )
+
+        // then
+        coVerify {
+            arrangement.userConfigRepository.setTrackingIdentifier(any())
+        }.wasNotInvoked()
+    }
+
+    private companion object {
+        val CONVERSATION_ID = ConversationId("conversationId", "domain")
+        val SELF_USER_ID = UserId("selfUserId", "domain")
+        val OTHER_USER_ID = UserId("otherUserId", "domain")
+
+        val MESSAGE_CONTENT = MessageContent.DataTransfer(
+            trackingIdentifier = MessageContent.DataTransfer.TrackingIdentifier(
+                identifier = "abcd-1234-efgh-5678"
+            )
+        )
+        val MESSAGE = Message.Signaling(
+            id = "messageId",
+            content = MESSAGE_CONTENT,
+            conversationId = CONVERSATION_ID,
+            date = Instant.DISTANT_PAST,
+            senderUserId = SELF_USER_ID,
+            senderClientId = ClientId("deviceId"),
+            status = Message.Status.Sent,
+            isSelfMessage = false,
+            expirationData = null,
+        )
+    }
+
+    private class Arrangement : UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl() {
+        private val handler: DataTransferEventHandler = DataTransferEventHandlerImpl(
+            selfUserId = SELF_USER_ID,
+            userConfigRepository = userConfigRepository
+        )
+
+        fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, DataTransferEventHandler> {
+            runBlocking { block() }
+            return this to handler
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserConfigRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserConfigRepositoryArrangement.kt
@@ -41,6 +41,7 @@ internal interface UserConfigRepositoryArrangement {
     suspend fun withGetMigrationConfigurationReturning(result: Either<StorageFailure, MLSMigrationModel>)
     suspend fun withSetSupportedCipherSuite(result: Either<StorageFailure, Unit>)
     suspend fun withGetSupportedCipherSuitesReturning(result: Either<StorageFailure, SupportedCipherSuite>)
+    suspend fun withSetTrackingIdentifier()
 }
 
 internal class UserConfigRepositoryArrangementImpl : UserConfigRepositoryArrangement {
@@ -93,5 +94,9 @@ internal class UserConfigRepositoryArrangementImpl : UserConfigRepositoryArrange
 
     override suspend fun withSetSupportedCipherSuite(result: Either<StorageFailure, Unit>) {
         coEvery { userConfigRepository.setSupportedCipherSuite(any()) }.returns(result)
+    }
+
+    override suspend fun withSetTrackingIdentifier() {
+        coEvery { userConfigRepository.setTrackingIdentifier(any()) }.returns(Unit)
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/unread/UserConfigDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/unread/UserConfigDAO.kt
@@ -60,6 +60,7 @@ interface UserConfigDAO {
     suspend fun observeShouldNotifyForRevokedCertificate(): Flow<Boolean?>
     suspend fun setDefaultCipherSuite(cipherSuite: SupportedCipherSuiteEntity)
     suspend fun getDefaultCipherSuite(): SupportedCipherSuiteEntity?
+    suspend fun setTrackingIdentifier(identifier: String)
 }
 
 @Suppress("TooManyFunctions")
@@ -186,6 +187,13 @@ internal class UserConfigDAOImpl internal constructor(
     override suspend fun getDefaultCipherSuite(): SupportedCipherSuiteEntity? =
         metadataDAO.getSerializable(DEFAULT_CIPHER_SUITE_KEY, SupportedCipherSuiteEntity.serializer())
 
+    override suspend fun setTrackingIdentifier(identifier: String) {
+        metadataDAO.insertValue(
+            key = ANALYTICS_TRACKING_IDENTIFIER_KEY,
+            value = identifier
+        )
+    }
+
     private companion object {
         private const val DEFAULT_CIPHER_SUITE_KEY = "DEFAULT_CIPHER_SUITE"
         private const val SELF_DELETING_MESSAGES_KEY = "SELF_DELETING_MESSAGES"
@@ -196,5 +204,6 @@ internal class UserConfigDAOImpl internal constructor(
         const val LEGAL_HOLD_CHANGE_NOTIFIED = "legal_hold_change_notified"
         const val SHOULD_UPDATE_CLIENT_LEGAL_HOLD_CAPABILITY =
             "should_update_client_legal_hold_capability"
+        private const val ANALYTICS_TRACKING_IDENTIFIER_KEY = "analytics_tracking_identifier"
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8978" title="WPB-8978" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8978</a>  [Android] Countly analytics ID and user properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no common identifier between same user logged in different devices.

### Causes (Optional)

Not implemented.

### Solutions

This is only Part 1, which solves:
- Receiving the event for `DataTransfer` with tracking identifier
- Saving this value into user metadata table (saving it from Kalium and on a table because it will later be used in the frontend client, and if in the future Kalium is also used by other platforms, only a small tweak on frontend clients will need to be made for receiving/setting the current identifier - from sharedPreferences (Android) to this metadata table)

### Dependencies (Optional)

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- Run this branch with AR
- Login from AR and watch metadata table for logged in user
- Login from web (fresh login)
- Metadata table should now have an entry for `analytics_tracking_identifier`

### Notes (Optional)

This is only Part 1