### PR TITLE
fix: Allow creating empty MLS GroupConversation [WPB-7099]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -119,16 +119,9 @@ internal class ConversationGroupRepositoryImpl(
             }
 
             when (apiResult) {
-                is Either.Left -> handleCreateConverstionFailure(apiResult, usersList, failedUsersList, name, options)
+                is Either.Left -> handleCreateConversationFailure(apiResult, usersList, failedUsersList, name, options)
 
-                is Either.Right -> {
-                    handleCreateConversationSuccess(
-                        apiResult,
-                        usersList,
-                        failedUsersList,
-                        selfTeamId
-                    )
-                }
+                is Either.Right -> handleCreateConversationSuccess(apiResult, usersList, failedUsersList, selfTeamId)
             }
         }
 
@@ -176,7 +169,7 @@ internal class ConversationGroupRepositoryImpl(
         }
     }
 
-    private suspend fun handleCreateConverstionFailure(
+    private suspend fun handleCreateConversationFailure(
         apiResult: Either.Left<NetworkFailure>,
         usersList: List<UserId>,
         failedUsersList: List<UserId>,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -78,7 +79,7 @@ class KeyPackageDataSource(
         userIds: List<UserId>,
         cipherSuite: CipherSuite
     ): Either<CoreFailure, KeyPackageClaimResult> =
-        currentClientIdProvider().flatMap { selfClientId ->
+        currentClientIdProvider().map { selfClientId ->
             val failedUsers = mutableSetOf<UserId>()
             val claimedKeyPackages = mutableListOf<KeyPackageDTO>()
             userIds.forEach { userId ->
@@ -99,11 +100,7 @@ class KeyPackageDataSource(
                 }
             }
 
-            if (claimedKeyPackages.isEmpty() && failedUsers.isNotEmpty()) {
-                Either.Left(CoreFailure.MissingKeyPackages(failedUsers))
-            } else {
-                Either.Right(KeyPackageClaimResult(claimedKeyPackages, failedUsers))
-            }
+            KeyPackageClaimResult(claimedKeyPackages, failedUsers)
         }
 
     override suspend fun uploadNewKeyPackages(clientId: ClientId, amount: Int): Either<CoreFailure, Unit> =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -123,7 +123,7 @@ class KeyPackageRepositoryTest {
     }
 
     @Test
-    fun givenAllUsersHaveNoKeyPackagesAvailable_whenClaimingKeyPackagesFromMultipleUsers_thenSuccessFailWithMissingKeyPackages() = runTest {
+    fun givenAllUsersHaveNoKeyPackagesAvailable_whenClaimingKeyPackagesFromMultipleUsers_thenSuccessWitheEmptySuccessKeyPackages() = runTest {
         val usersWithout = setOf(
             Arrangement.USER_ID.copy(value = "missingKP"),
             Arrangement.USER_ID.copy(value = "alsoMissingKP"),
@@ -138,13 +138,14 @@ class KeyPackageRepositoryTest {
 
         val result = keyPackageRepository.claimKeyPackages(usersWithout.toList(), CIPHER_SUITE)
 
-        result.shouldFail { failure ->
-            assertIs<CoreFailure.MissingKeyPackages>(failure)
+        result.shouldSucceed { keyPackages ->
+            assertEquals(emptyList(), keyPackages.successfullyFetchedKeyPackages)
+            assertEquals(usersWithout, keyPackages.usersWithoutKeyPackagesAvailable)
         }
     }
 
     @Test
-    fun givenUserWithNoKeyPackages_whenClaimingKeyPackagesFromSingleUser_thenResultShouldFailWithError() = runTest {
+    fun givenUserWithNoKeyPackages_whenClaimingKeyPackagesFromSingleUser_thenSuccessWitheEmptySuccessKeyPackages() = runTest {
 
         val (_, keyPackageRepository) = Arrangement()
             .withCurrentClientId()
@@ -153,8 +154,9 @@ class KeyPackageRepositoryTest {
 
         val result = keyPackageRepository.claimKeyPackages(listOf(Arrangement.USER_ID), CIPHER_SUITE)
 
-        result.shouldFail { failure ->
-            assertEquals(CoreFailure.MissingKeyPackages(setOf(Arrangement.USER_ID)), failure)
+        result.shouldSucceed { keyPackages ->
+            assertEquals(emptyList(), keyPackages.successfullyFetchedKeyPackages)
+            assertEquals(setOf(Arrangement.USER_ID), keyPackages.usersWithoutKeyPackagesAvailable)
         }
     }
 


### PR DESCRIPTION
# What's new in this PR?

### Issues

When user trying to create a new MLS GroupConversation only with users that has no KeyPackages, then conversation is not created and error is displayed. 
We should allow such a scenario and just create GroupConversation with only 1 (self) user.

### Causes (Optional)

Was not implemented (not obvious requirement)

### Solutions

Just do it.

In `KeyPackageDataSource.claimKeyPackages` remove checking if all the users were failed  (and returning `MissingKeyPackages` in that case). 
So `MLSConversationRepository` will take care about returning such an error in case when partial MemberList is not allowed.
